### PR TITLE
[#1314, #1395] Allow skills to be customized by modules

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -914,10 +914,9 @@
 }
 .dnd5e.sheet.actor ul.skills-list {
   flex: 0 0 180px;
-  height: 440px;
   list-style: none;
   margin: 0 5px 0;
-  padding: 3px 0 2px;
+  padding: 0;
   border: 2px groove #eeede0;
   border-radius: 3px;
 }

--- a/less/actors.less
+++ b/less/actors.less
@@ -294,10 +294,9 @@
 
   ul.skills-list {
     flex: 0 0 180px;
-    height: 440px;
     list-style: none;
     margin: 0 5px 0;
-    padding: 3px 0 2px;
+    padding: 0;
     border: @borderGroove;
     border-radius: 3px;
 

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -49,8 +49,7 @@ export default class ActorSheet5e extends ActorSheet {
       ],
       tabs: [{navSelector: ".tabs", contentSelector: ".sheet-body", initial: "description"}],
       width: 720,
-      height: Math.max(
-        680, Math.max(
+      height: Math.max(680, Math.max(
         237 + (Object.keys(CONFIG.DND5E.abilities).length * 70),
         240 + (Object.keys(CONFIG.DND5E.skills).length * 24)
       ))

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -49,7 +49,11 @@ export default class ActorSheet5e extends ActorSheet {
       ],
       tabs: [{navSelector: ".tabs", contentSelector: ".sheet-body", initial: "description"}],
       width: 720,
-      height: Math.max(680, 237 + (Object.keys(CONFIG.DND5E.abilities).length * 70))
+      height: Math.max(
+        680, Math.max(
+        237 + (Object.keys(CONFIG.DND5E.abilities).length * 70),
+        240 + (Object.keys(CONFIG.DND5E.skills).length * 24)
+      ))
     });
   }
 

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -139,8 +139,8 @@ export default class ActorSheet5e extends ActorSheet {
       skl.ability = CONFIG.DND5E.abilityAbbreviations[skl.ability];
       skl.icon = this._getProficiencyIcon(skl.value);
       skl.hover = CONFIG.DND5E.proficiencyLevels[skl.value];
-      skl.label = CONFIG.DND5E.skills[s];
-      skl.baseValue = source.system.skills[s].value;
+      skl.label = CONFIG.DND5E.skills[s]?.label;
+      skl.baseValue = source.system.skills[s]?.value ?? 0;
     }
 
     // Update traits

--- a/module/applications/actor/skill-config.mjs
+++ b/module/applications/actor/skill-config.mjs
@@ -27,7 +27,8 @@ export default class ActorSkillConfig extends DocumentSheet {
 
   /** @inheritdoc */
   get title() {
-    return `${game.i18n.format("DND5E.SkillConfigureTitle", {skill: CONFIG.DND5E.skills[this._skillId]})}: ${this.document.name}`;
+    const label = CONFIG.DND5E.skills[this._skillId]?.label ?? "";
+    return `${game.i18n.format("DND5E.SkillConfigureTitle", {skill: label})}: ${this.document.name}`;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/skill-config.mjs
+++ b/module/applications/actor/skill-config.mjs
@@ -27,7 +27,7 @@ export default class ActorSkillConfig extends DocumentSheet {
 
   /** @inheritdoc */
   get title() {
-    const label = CONFIG.DND5E.skills[this._skillId]?.label ?? "";
+    const label = CONFIG.DND5E.skills[this._skillId].label;
     return `${game.i18n.format("DND5E.SkillConfigureTitle", {skill: label})}: ${this.document.name}`;
   }
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -792,30 +792,33 @@ preLocalize("senses", { sort: true });
 /* -------------------------------------------- */
 
 /**
- * The set of skill which can be trained.
- * @enum {string}
+ * The set of skill which can be trained with their default ability scores.
+ * @enum {{
+ *   label: string,
+ *   ability: string
+ * }}
  */
 DND5E.skills = {
-  acr: "DND5E.SkillAcr",
-  ani: "DND5E.SkillAni",
-  arc: "DND5E.SkillArc",
-  ath: "DND5E.SkillAth",
-  dec: "DND5E.SkillDec",
-  his: "DND5E.SkillHis",
-  ins: "DND5E.SkillIns",
-  itm: "DND5E.SkillItm",
-  inv: "DND5E.SkillInv",
-  med: "DND5E.SkillMed",
-  nat: "DND5E.SkillNat",
-  prc: "DND5E.SkillPrc",
-  prf: "DND5E.SkillPrf",
-  per: "DND5E.SkillPer",
-  rel: "DND5E.SkillRel",
-  slt: "DND5E.SkillSlt",
-  ste: "DND5E.SkillSte",
-  sur: "DND5E.SkillSur"
+  acr: { label: "DND5E.SkillAcr", ability: "dex" },
+  ani: { label: "DND5E.SkillAni", ability: "wis" },
+  arc: { label: "DND5E.SkillArc", ability: "int" },
+  ath: { label: "DND5E.SkillAth", ability: "str" },
+  dec: { label: "DND5E.SkillDec", ability: "cha" },
+  his: { label: "DND5E.SkillHis", ability: "int" },
+  ins: { label: "DND5E.SkillIns", ability: "wis" },
+  itm: { label: "DND5E.SkillItm", ability: "cha" },
+  inv: { label: "DND5E.SkillInv", ability: "int" },
+  med: { label: "DND5E.SkillMed", ability: "wis" },
+  nat: { label: "DND5E.SkillNat", ability: "int" },
+  prc: { label: "DND5E.SkillPrc", ability: "wis" },
+  prf: { label: "DND5E.SkillPrf", ability: "cha" },
+  per: { label: "DND5E.SkillPer", ability: "cha" },
+  rel: { label: "DND5E.SkillRel", ability: "int" },
+  slt: { label: "DND5E.SkillSlt", ability: "dex" },
+  ste: { label: "DND5E.SkillSte", ability: "dex" },
+  sur: { label: "DND5E.SkillSur", ability: "wis" }
 };
-preLocalize("skills", { sort: true });
+preLocalize("skills", { key: "label", sort: true });
 
 /* -------------------------------------------- */
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -50,6 +50,43 @@ preLocalize("abilityAbbreviations");
 /* -------------------------------------------- */
 
 /**
+ * Configuration data for skills.
+ *
+ * @typedef {object} SkillConfiguration
+ * @property {string} label    Localized label.
+ * @property {string} ability  Key for the default ability used by this skill.
+ */
+
+/**
+ * The set of skill which can be trained with their default ability scores.
+ * @enum {SkillConfiguration}
+ */
+DND5E.skills = {
+  acr: { label: "DND5E.SkillAcr", ability: "dex" },
+  ani: { label: "DND5E.SkillAni", ability: "wis" },
+  arc: { label: "DND5E.SkillArc", ability: "int" },
+  ath: { label: "DND5E.SkillAth", ability: "str" },
+  dec: { label: "DND5E.SkillDec", ability: "cha" },
+  his: { label: "DND5E.SkillHis", ability: "int" },
+  ins: { label: "DND5E.SkillIns", ability: "wis" },
+  itm: { label: "DND5E.SkillItm", ability: "cha" },
+  inv: { label: "DND5E.SkillInv", ability: "int" },
+  med: { label: "DND5E.SkillMed", ability: "wis" },
+  nat: { label: "DND5E.SkillNat", ability: "int" },
+  prc: { label: "DND5E.SkillPrc", ability: "wis" },
+  prf: { label: "DND5E.SkillPrf", ability: "cha" },
+  per: { label: "DND5E.SkillPer", ability: "cha" },
+  rel: { label: "DND5E.SkillRel", ability: "int" },
+  slt: { label: "DND5E.SkillSlt", ability: "dex" },
+  ste: { label: "DND5E.SkillSte", ability: "dex" },
+  sur: { label: "DND5E.SkillSur", ability: "wis" }
+};
+preLocalize("skills", { key: "label", sort: true });
+patchConfig("skills", "label", { since: 2.0, until: 2.2 });
+
+/* -------------------------------------------- */
+
+/**
  * Character alignment options.
  * @enum {string}
  */
@@ -792,37 +829,6 @@ preLocalize("senses", { sort: true });
 /* -------------------------------------------- */
 
 /**
- * The set of skill which can be trained with their default ability scores.
- * @enum {{
- *   label: string,
- *   ability: string
- * }}
- */
-DND5E.skills = {
-  acr: { label: "DND5E.SkillAcr", ability: "dex" },
-  ani: { label: "DND5E.SkillAni", ability: "wis" },
-  arc: { label: "DND5E.SkillArc", ability: "int" },
-  ath: { label: "DND5E.SkillAth", ability: "str" },
-  dec: { label: "DND5E.SkillDec", ability: "cha" },
-  his: { label: "DND5E.SkillHis", ability: "int" },
-  ins: { label: "DND5E.SkillIns", ability: "wis" },
-  itm: { label: "DND5E.SkillItm", ability: "cha" },
-  inv: { label: "DND5E.SkillInv", ability: "int" },
-  med: { label: "DND5E.SkillMed", ability: "wis" },
-  nat: { label: "DND5E.SkillNat", ability: "int" },
-  prc: { label: "DND5E.SkillPrc", ability: "wis" },
-  prf: { label: "DND5E.SkillPrf", ability: "cha" },
-  per: { label: "DND5E.SkillPer", ability: "cha" },
-  rel: { label: "DND5E.SkillRel", ability: "int" },
-  slt: { label: "DND5E.SkillSlt", ability: "dex" },
-  ste: { label: "DND5E.SkillSte", ability: "dex" },
-  sur: { label: "DND5E.SkillSur", ability: "wis" }
-};
-preLocalize("skills", { key: "label", sort: true });
-
-/* -------------------------------------------- */
-
-/**
  * Various different ways a spell can be prepared.
  */
 DND5E.spellPreparationModes = {
@@ -1306,5 +1312,28 @@ preLocalize("characterFlags", { keys: ["name", "hint", "section"] });
  * @type {string[]}
  */
 DND5E.allowedActorFlags = ["isPolymorphed", "originalActor"].concat(Object.keys(DND5E.characterFlags));
+
+/* -------------------------------------------- */
+
+/**
+ * Patch an existing config enum to allow conversion from string values to object values without
+ * breaking existing modules that are expecting strings.
+ * @param {string} key          Key within DND5E that has been replaced with an enum of objects.
+ * @param {string} fallbackKey  Key within the new config object from which to get the fallback value.
+ * @param {object} [options]    Additional options passed through to logCompatibilityWarning.
+ */
+function patchConfig(key, fallbackKey, options) {
+  /** @override */
+  function toString() {
+    const message = `The value of CONFIG.DND5E.${key} has been changed to an object.`
+      +` The former value can be acccessed from .${fallbackKey}.`;
+    foundry.utils.logCompatibilityWarning(message, options);
+    return this[fallbackKey];
+  }
+
+  Object.values(DND5E[key]).forEach(o => o.toString = toString);
+}
+
+/* -------------------------------------------- */
 
 export default DND5E;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -84,6 +84,7 @@ export default class Actor5e extends Actor {
   prepareBaseData() {
     const updates = {};
     this._prepareBaseAbilities(updates);
+    this._prepareBaseSkills(updates);
     if ( !foundry.utils.isEmpty(updates) ) {
       if ( !this.id ) this.updateSource(updates);
       else this.update(updates);
@@ -220,6 +221,28 @@ export default class Actor5e extends Actor {
       }
     }
     this.system.abilities = abilities;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Update the actor's skill list to match the skills configured in `DND5E.skills`.
+   * Mutates the system.skills object.
+   * @param {object} updates  Updates to be applied to the actor. *Will be mutated*.
+   * @private
+   */
+  _prepareBaseSkills(updates) {
+    if ( this.type === "vehicle") return;
+    const skills = {};
+    for ( const [key, skill] of Object.entries(CONFIG.DND5E.skills) ) {
+      skills[key] = this.system.skills[key];
+      if ( !skills[key] ) {
+        skills[key] = foundry.utils.deepClone(game.system.template.Actor.templates.creature.skills.acr);
+        skills[key].ability = skill.ability;
+        updates[`data.skills.${key}`] = foundry.utils.deepClone(skills[key]);
+      }
+    }
+    this.system.skills = skills;
   }
 
   /* -------------------------------------------- */
@@ -822,7 +845,7 @@ export default class Actor5e extends Actor {
     const reliableTalent = (skl.value >= 1 && this.getFlag("dnd5e", "reliableTalent"));
 
     // Roll and return
-    const flavor = game.i18n.format("DND5E.SkillPromptTitle", {skill: CONFIG.DND5E.skills[skillId]});
+    const flavor = game.i18n.format("DND5E.SkillPromptTitle", {skill: CONFIG.DND5E.skills[skillId]?.label ?? ""});
     const rollData = foundry.utils.mergeObject({
       parts: parts,
       data: data,

--- a/template.json
+++ b/template.json
@@ -51,22 +51,6 @@
               "check": "",
               "save": ""
             }
-          },
-          "hon": {
-            "value": 10,
-            "proficient": 0,
-            "bonuses": {
-              "check": "",
-              "save": ""
-            }
-          },
-          "san": {
-            "value": 10,
-            "proficient": 0,
-            "bonuses": {
-              "check": "",
-              "save": ""
-            }
           }
         },
         "attributes": {

--- a/template.json
+++ b/template.json
@@ -51,6 +51,22 @@
               "check": "",
               "save": ""
             }
+          },
+          "hon": {
+            "value": 10,
+            "proficient": 0,
+            "bonuses": {
+              "check": "",
+              "save": ""
+            }
+          },
+          "san": {
+            "value": 10,
+            "proficient": 0,
+            "bonuses": {
+              "check": "",
+              "save": ""
+            }
           }
         },
         "attributes": {

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -174,7 +174,7 @@
                     <input type="hidden" name="system.skills.{{s}}.value" value="{{skill.baseValue}}" data-dtype="Number"/>
                     <a class="proficiency-toggle skill-proficiency" title="{{skill.hover}}">{{{skill.icon}}}</a>
                     <div class="skill-name-controls">
-                      <h4 class="skill-name rollable">{{label}}</h4>
+                      <h4 class="skill-name rollable">{{skill.label}}</h4>
                       <a class="config-button" data-action="skill" title="{{localize 'DND5E.SkillConfigure'}}"><i class="fas fa-cog"></i></a>
                     </div>
                     <span class="skill-ability">{{skill.ability}}</span>

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -168,7 +168,7 @@
 
             {{!-- Skills --}}
             <ul class="skills-list">
-            {{#each config.skills as |label s|}}
+            {{#each config.skills as |obj s|}}
             {{#with (lookup ../system.skills s) as |skill|}}
                 <li class="skill flexrow {{#if skill.value}}proficient{{/if}}" data-skill="{{s}}">
                     <input type="hidden" name="system.skills.{{s}}.value" value="{{skill.baseValue}}" data-dtype="Number"/>
@@ -178,8 +178,12 @@
                       <a class="config-button" data-action="skill" title="{{localize 'DND5E.SkillConfigure'}}"><i class="fas fa-cog"></i></a>
                     </div>
                     <span class="skill-ability">{{skill.ability}}</span>
-                    <span class="skill-mod" title="{{ localize 'DND5E.SkillModifierHint' skill=label }}">{{numberFormat skill.total decimals=0 sign=true}}</span>
-                    <span class="skill-passive" title="{{ localize 'DND5E.SkillPassiveHint' skill=label }}">({{skill.passive}})</span>
+                    <span class="skill-mod" title="{{ localize 'DND5E.SkillModifierHint' skill=skill.label }}">
+                        {{numberFormat skill.total decimals=0 sign=true}}
+                    </span>
+                    <span class="skill-passive" title="{{ localize 'DND5E.SkillPassiveHint' skill=skill.label }}">
+                        ({{skill.passive}})
+                    </span>
                 </li>
             {{/with}}
             {{/each}}

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -136,7 +136,7 @@
                     <input type="hidden" name="system.skills.{{s}}.value" value="{{skill.baseValue}}" data-dtype="Number"/>
                     <a class="proficiency-toggle skill-proficiency" title="{{skill.hover}}">{{{skill.icon}}}</a>
                     <div class="skill-name-controls">
-                      <h4 class="skill-name rollable">{{label}}</h4>
+                      <h4 class="skill-name rollable">{{skill.label}}</h4>
                       <a class="config-button" data-action="skill" title="{{localize 'DND5E.SkillConfigure'}}"><i class="fas fa-cog"></i></a>
                     </div>
                     <span class="skill-ability">{{skill.ability}}</span>

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -130,7 +130,7 @@
 
             {{!-- Skills --}}
             <ul class="skills-list">
-            {{#each config.skills as |label s|}}
+            {{#each config.skills as |obj s|}}
             {{#with (lookup ../system.skills s) as |skill|}}
                 <li class="skill flexrow {{#if skill.value}}proficient{{/if}}" data-skill="{{s}}">
                     <input type="hidden" name="system.skills.{{s}}.value" value="{{skill.baseValue}}" data-dtype="Number"/>
@@ -140,8 +140,12 @@
                       <a class="config-button" data-action="skill" title="{{localize 'DND5E.SkillConfigure'}}"><i class="fas fa-cog"></i></a>
                     </div>
                     <span class="skill-ability">{{skill.ability}}</span>
-                    <span class="skill-mod" title="{{ localize 'DND5E.SkillModifierHint' skill=label }}">{{numberFormat skill.total decimals=0 sign=true}}</span>
-                    <span class="skill-passive" title="{{ localize 'DND5E.SkillPassiveHint' skill=label }}">({{skill.passive}})</span>
+                    <span class="skill-mod" title="{{ localize 'DND5E.SkillModifierHint' skill=skill.label }}">
+                        {{numberFormat skill.total decimals=0 sign=true}}
+                    </span>
+                    <span class="skill-passive" title="{{ localize 'DND5E.SkillPassiveHint' skill=skill.label }}">
+                        ({{skill.passive}})
+                    </span>
                 </li>
             {{/with}}
             {{/each}}

--- a/templates/apps/skill-config.hbs
+++ b/templates/apps/skill-config.hbs
@@ -2,7 +2,7 @@
   <p class="notes">{{localize "DND5E.SkillConfigurationHint"}}</p>
   <div class="form-group">
     <label>{{ localize "DND5E.ProficiencyLevel" }}</label>
-    <select name="system.skills.{{skillId}}.value">
+    <select name="system.skills.{{skillId}}.value" data-dtype="Number">
       {{selectOptions proficiencyLevels selected=skill.value}}
     </select>
   </div>


### PR DESCRIPTION
Similar to the changes made in !443, this adds the ability for modules to easily introduce new skills simply by modifying `CONFIG.DND5E.skills`. This involves three major changes:

1. `DND5E.skills` has been modified to contain the default ability associated with this skill:

```javascript
DND5E.skills = {
  acr: { label: "DND5E.SkillAcr", ability: "dex" },
  ani: { label: "DND5E.SkillAni", ability: "wis" },
  arc: { label: "DND5E.SkillArc", ability: "int" },
  ath: { label: "DND5E.SkillAth", ability: "str" },
  …
};
```

A `patchConfig` method has been added that allows any sheets or modules that are expecting the old format to continue functioning without the dreaded `"[object Object]"` showing up everywhere.

2. Introduction of `Actor5e#_prepareBaseSkills` to ensure the proper skills are contained in the actor's data.

3. A few minor changes in `rollSkill` to harden it against errors.

Resolves #1314
Resolves #1395 