### PR TITLE
[#1470] Allow migration version to be set via world manifest flag

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -189,7 +189,7 @@ Hooks.once("ready", function() {
 
   // Determine whether a system migration is required and feasible
   if ( !game.user.isGM ) return;
-  const cv = game.settings.get("dnd5e", "systemMigrationVersion");
+  const cv = game.settings.get("dnd5e", "systemMigrationVersion") || game.world.data.flags.dnd5e?.version;
   const totalDocuments = game.actors.size + game.scenes.size + game.items.size;
   if ( !cv && totalDocuments === 0 ) return game.settings.set("dnd5e", "systemMigrationVersion", game.system.version);
   if ( cv && !isNewerVersion(game.system.flags.needsMigrationVersion, cv) ) return;


### PR DESCRIPTION
Closes #1470

This allows world distributors to set a manifest flag to let the dnd5e system know that this world has already been migrated to a certain version. Normally, the `settings.db` serves this purpose, but sharing that is often undesirable (e.g. in a git repo) since it may contain sensitive info such as API keys for certain modules.

For example, you may find this in a world's manifest file to indicate that the world has been migrated to v1.6.3 of dnd5e:
```json
"flags": {
    "dnd5e": {
        "version": "1.6.3"
     }
}
```