### PR TITLE
[#1506] Add a copy button next to Scalar variable name 

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -425,6 +425,8 @@
 "DND5E.EffectNew": "New Effect",
 "DND5E.EffectUnavailable": "Unavailable Effects",
 "DND5E.EffectUnavailableInfo": "Source item must be equipped or attuned to activate these",
+"DND5E.IdentifierCopy": "Copy Identifier",
+"DND5E.IdentifierCopied": "Copied!",
 "DND5E.ItemRarityCommon": "common",
 "DND5E.ItemRarityUncommon": "uncommon",
 "DND5E.ItemRarityRare": "rare",

--- a/module/advancement/types/scale-value.mjs
+++ b/module/advancement/types/scale-value.mjs
@@ -262,7 +262,7 @@ export class ScaleValueConfig extends AdvancementConfig {
    */
   _onIdentifierHintCopy(event) {
     let data = this.getData();
-    navigator.clipboard.writeText(`@scale.${data.classIdentifier}.${data.previewIdentifier}`);
+    game.clipboard.copyPlainText(`@scale.${data.classIdentifier}.${data.previewIdentifier}`);
     game.tooltip.activate(event.target, {text: game.i18n.localize("DND5E.IdentifierCopied"), direction: "UP"});
   }
 

--- a/module/advancement/types/scale-value.mjs
+++ b/module/advancement/types/scale-value.mjs
@@ -252,7 +252,7 @@ export class ScaleValueConfig extends AdvancementConfig {
   activateListeners(html) {
     super.activateListeners(html);
     this.form.querySelector("input[name='data.title']").addEventListener("input", this._onChangeTitle.bind(this));
-    this.form.querySelector("i[name='identifier-hint-copy']").addEventListener("click", this._onIdentifyerHintCopy.bind(this));
+    this.form.querySelector(".identifier-hint-copy").addEventListener("click", this._onIdentifierHintCopy.bind(this));
   }
 
   /* -------------------------------------------- */
@@ -260,9 +260,10 @@ export class ScaleValueConfig extends AdvancementConfig {
   /**
    * Copies the full scale identifier hint to the clipboard.
    */
-  _onIdentifyerHintCopy() {
+  _onIdentifierHintCopy(event) {
     let data = this.getData();
     navigator.clipboard.writeText(`@scale.${data.classIdentifier}.${data.previewIdentifier}`);
+    game.tooltip.activate(event.target, {text: game.i18n.localize("DND5E.IdentifierCopied"), direction: "UP"});
   }
 
   /* -------------------------------------------- */

--- a/module/advancement/types/scale-value.mjs
+++ b/module/advancement/types/scale-value.mjs
@@ -261,7 +261,7 @@ export class ScaleValueConfig extends AdvancementConfig {
    * Copies the full scale identifier hint to the clipboard.
    */
   _onIdentifierHintCopy(event) {
-    let data = this.getData();
+    const data = this.getData();
     game.clipboard.copyPlainText(`@scale.${data.classIdentifier}.${data.previewIdentifier}`);
     game.tooltip.activate(event.target, {text: game.i18n.localize("DND5E.IdentifierCopied"), direction: "UP"});
   }

--- a/module/advancement/types/scale-value.mjs
+++ b/module/advancement/types/scale-value.mjs
@@ -259,6 +259,7 @@ export class ScaleValueConfig extends AdvancementConfig {
 
   /**
    * Copies the full scale identifier hint to the clipboard.
+   * @protected
    */
   _onIdentifierHintCopy(event) {
     const data = this.getData();

--- a/module/advancement/types/scale-value.mjs
+++ b/module/advancement/types/scale-value.mjs
@@ -252,6 +252,17 @@ export class ScaleValueConfig extends AdvancementConfig {
   activateListeners(html) {
     super.activateListeners(html);
     this.form.querySelector("input[name='data.title']").addEventListener("input", this._onChangeTitle.bind(this));
+    this.form.querySelector("i[name='identifier-hint-copy']").addEventListener("click", this._onIdentifyerHintCopy.bind(this));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Copies the full scale identifier hint to the clipboard.
+   */
+  _onIdentifyerHintCopy() {
+    let data = this.getData();
+    navigator.clipboard.writeText(`@scale.${data.classIdentifier}.${data.previewIdentifier}`);
   }
 
   /* -------------------------------------------- */

--- a/templates/advancement/scale-value-config.hbs
+++ b/templates/advancement/scale-value-config.hbs
@@ -26,6 +26,7 @@
       </div>
       <p class="hint identifier-hint">
         {{{localize "DND5E.AdvancementScaleValueIdentifierHint" class=classIdentifier identifier=previewIdentifier}}}
+        <i name="identifier-hint-copy" class="far fa-clipboard"></i>
       </p>
     </div>
   </div>

--- a/templates/advancement/scale-value-config.hbs
+++ b/templates/advancement/scale-value-config.hbs
@@ -26,7 +26,9 @@
       </div>
       <p class="hint identifier-hint">
         {{{localize "DND5E.AdvancementScaleValueIdentifierHint" class=classIdentifier identifier=previewIdentifier}}}
-        <i name="identifier-hint-copy" class="far fa-clipboard"></i>
+        <a class="identifier-hint-copy" title="{{localize 'DND5E.IdentifierCopy'}}">
+          <i class="far fa-clipboard"></i>
+        </a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
Added a simple icon to copy the whole scalar variable.
![copy-icon](https://user-images.githubusercontent.com/55275506/174316988-e3a9ae43-a2a8-4dcd-9ba5-e2930ce3be21.png)
![ksnip_20220829-171713](https://user-images.githubusercontent.com/55275506/187237564-665f3761-0146-45fb-8c72-93cbd32568f5.png)
![ksnip_20220829-171840](https://user-images.githubusercontent.com/55275506/187237567-a4823ecb-c950-4067-97f7-6465dfb763a0.png)

~~There is currently no indication that the info is copied to the clipboard, this could be fixed using a notification. Should this also be added?~~

closes #1506  