### PR TITLE
ci: add Github Actions to replace Gitlab-CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release Creation
+
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+    
+    steps:
+    - uses: actions/checkout@v3
+
+
+    # Set up our some variables for future use
+    # Adapted from https://github.community/t/how-to-get-just-the-tag-name/16241/7
+    # Tag name: ${{ steps.get_names.outputs.TAG_NAME }}
+    # Zip name: ${{ steps.get_names.outputs.ZIP_NAME }}
+    # Expected Release Download URL: ${{ steps.get_names.outputs.RELEASE_DOWNLOAD_URL }}
+    # Stringified system.json contents: ${{ steps.get_names.outputs.SYSTEM_JSON }}
+    - name: Set up variables
+      id: get_names
+      run: |
+        $TAG_NAME=${GITHUB_REF/refs\/tags\//}
+        echo ::set-output name=TAG_NAME::$TAG_NAME
+        echo ::set-output name=ZIP_NAME::dnd5e-$TAG_NAME.zip
+        echo ::set-output name=RELEASE_DOWNLOAD_URL::https://github.com/${{github.repository}}/releases/download/$TAG_NAME/dnd5e-$TAG_NAME.zip
+        JSON=$(cat ./system.json)
+        echo ::set-output name=SYSTEM_JSON::${JSON//'%'/'%25'}
+
+
+    # Run some tests to make sure our `system.json` is correct
+    # Exit before setting up node if not
+    - name: Verify correct naming
+      env:
+        TAG_NAME: ${{ steps.get_names.outputs.TAG_NAME }}
+        RELEASE_DOWNLOAD: ${{steps.get_names.outputs.RELEASE_DOWNLOAD_URL}}
+        # Extract version and download url from system.json
+        # https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
+        PACKAGE_VERSION: ${{fromJSON(${{steps.get_names.outputs.SYSTEM_JSON}}).version}}
+        PACKAGE_DOWNLOAD: ${{fromJSON(${{steps.get_names.outputs.SYSTEM_JSON}}).download}}
+      run: |
+        # Validate that the tag being released matches the package version.
+        if [[ ! $TAG_NAME == release-$PACKAGE_VERSION ]]; then
+          echo "The system.json version does not match tag name."
+          echo "system.json: $PACKAGE_VERSION"
+          echo "tag name: $TAG_NAME"
+          echo "Please fix this and push the tag again."
+          exit 1
+        fi
+
+        # Validate that the package download url matches the release asset that will be created.
+        if [[ ! $RELEASE_DOWNLOAD == $PACKAGE_DOWNLOAD ]]; then
+          echo "The system.json download url does not match the created release asset url."
+          echo "system.json: $PACKAGE_DOWNLOAD"
+          echo "release asset url: $RELEASE_DOWNLOAD"
+          echo "Please fix this and push the tag again."
+          exit 1
+        fi
+
+
+    # Set up Node
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+
+
+    # `npm ci` is recommended:
+    # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+    - name: Install Dependencies
+    - run: npm ci
+
+
+    # Run our `build` script
+    - name: Build All
+    - run: npm run build --if-present
+
+
+    # Create a zip file with all files required by the module to add to the release
+    - run: zip ${{steps.get_names.outputs.ZIP_NAME}} -r icons lang module json packs/*.db templates tokens ui dnd5e.css dnd5e.js LICENSE.txt OGL.txt README.md system.json template.json
+
+
+    # Create a release for this specific version
+    - name: Update Release with Files
+      id: create_version_release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true # Set this to false if you want to prevent updating existing releases
+        name: ${{steps.get_names.outputs.TAG_NAME}}
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './system.json, ./${{steps.get_names.outputs.ZIP_NAME}}'
+        tag: ${{steps.get_names.outputs.TAG_NAME}}
+        body: '**Installation:** To manually install this release, please use the following manifest URL: ${{steps.get_names.outputs.RELEASE_DOWNLOAD_URL}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
         RELEASE_DOWNLOAD: ${{steps.get_names.outputs.RELEASE_DOWNLOAD_URL}}
         # Extract version and download url from system.json
         # https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        PACKAGE_VERSION: ${{fromJSON(${{steps.get_names.outputs.SYSTEM_JSON}}).version}}
-        PACKAGE_DOWNLOAD: ${{fromJSON(${{steps.get_names.outputs.SYSTEM_JSON}}).download}}
+        PACKAGE_VERSION: ${{fromJSON(steps.get_names.outputs.SYSTEM_JSON).version}}
+        PACKAGE_DOWNLOAD: ${{fromJSON(steps.get_names.outputs.SYSTEM_JSON).download}}
       run: |
         # Validate that the tag being released matches the package version.
         if [[ ! $TAG_NAME == release-$PACKAGE_VERSION ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release Creation
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'release-*'
 
 
 jobs:
@@ -75,12 +76,12 @@ jobs:
     # `npm ci` is recommended:
     # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
     - name: Install Dependencies
-    - run: npm ci
+      run: npm ci
 
 
     # Run our `build` script
     - name: Build All
-    - run: npm run build --if-present
+      run: npm run build --if-present
 
 
     # Create a zip file with all files required by the module to add to the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,27 +10,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x, 16.x]
-    
     steps:
     - uses: actions/checkout@v3
 
 
     # Set up our some variables for future use
     # Adapted from https://github.community/t/how-to-get-just-the-tag-name/16241/7
-    # Tag name: ${{ steps.get_names.outputs.TAG_NAME }}
-    # Zip name: ${{ steps.get_names.outputs.ZIP_NAME }}
-    # Expected Release Download URL: ${{ steps.get_names.outputs.RELEASE_DOWNLOAD_URL }}
-    # Stringified system.json contents: ${{ steps.get_names.outputs.SYSTEM_JSON }}
+    # Tag name: ${{ steps.get_vars.outputs.TAG_NAME }}
+    # Zip name: ${{ steps.get_vars.outputs.ZIP_NAME }}
+    # Expected Release Download URL: ${{ steps.get_vars.outputs.RELEASE_DOWNLOAD_URL }}
+    # Expected Release system.json URL: ${{ steps.get_vars.outputs.RELEASE_INSTALL_URL }}
+    # Stringified system.json contents: ${{ steps.get_vars.outputs.SYSTEM_JSON }}
     - name: Set up variables
-      id: get_names
+      id: get_vars
       run: |
-        $TAG_NAME=${GITHUB_REF/refs\/tags\//}
-        echo ::set-output name=TAG_NAME::$TAG_NAME
-        echo ::set-output name=ZIP_NAME::dnd5e-$TAG_NAME.zip
-        echo ::set-output name=RELEASE_DOWNLOAD_URL::https://github.com/${{github.repository}}/releases/download/$TAG_NAME/dnd5e-$TAG_NAME.zip
+        TAG=${GITHUB_REF/refs\/tags\//}
+        echo ::set-output name=TAG_NAME::$TAG
+        echo ::set-output name=ZIP_NAME::dnd5e-$TAG.zip
+        echo ::set-output name=RELEASE_DOWNLOAD_URL::https://github.com/${{github.repository}}/releases/download/$TAG/dnd5e-$TAG.zip
+        echo ::set-output name=RELEASE_INSTALL_URL::https://github.com/${{github.repository}}/releases/download/$TAG/system.json
         JSON=$(cat ./system.json)
         echo ::set-output name=SYSTEM_JSON::${JSON//'%'/'%25'}
 
@@ -39,12 +37,12 @@ jobs:
     # Exit before setting up node if not
     - name: Verify correct naming
       env:
-        TAG_NAME: ${{ steps.get_names.outputs.TAG_NAME }}
-        RELEASE_DOWNLOAD: ${{steps.get_names.outputs.RELEASE_DOWNLOAD_URL}}
+        TAG_NAME: ${{ steps.get_vars.outputs.TAG_NAME }}
+        RELEASE_DOWNLOAD: ${{steps.get_vars.outputs.RELEASE_DOWNLOAD_URL}}
         # Extract version and download url from system.json
         # https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        PACKAGE_VERSION: ${{fromJSON(steps.get_names.outputs.SYSTEM_JSON).version}}
-        PACKAGE_DOWNLOAD: ${{fromJSON(steps.get_names.outputs.SYSTEM_JSON).download}}
+        PACKAGE_VERSION: ${{fromJSON(steps.get_vars.outputs.SYSTEM_JSON).version}}
+        PACKAGE_DOWNLOAD: ${{fromJSON(steps.get_vars.outputs.SYSTEM_JSON).download}}
       run: |
         # Validate that the tag being released matches the package version.
         if [[ ! $TAG_NAME == release-$PACKAGE_VERSION ]]; then
@@ -69,7 +67,7 @@ jobs:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: '16.x'
         cache: 'npm'
 
 
@@ -85,7 +83,7 @@ jobs:
 
 
     # Create a zip file with all files required by the module to add to the release
-    - run: zip ${{steps.get_names.outputs.ZIP_NAME}} -r icons lang module json packs/*.db templates tokens ui dnd5e.css dnd5e.js LICENSE.txt OGL.txt README.md system.json template.json
+    - run: zip ${{steps.get_vars.outputs.ZIP_NAME}} -r icons lang module json packs/*.db templates tokens ui dnd5e.css dnd5e.js LICENSE.txt OGL.txt README.md system.json template.json
 
 
     # Create a release for this specific version
@@ -94,10 +92,10 @@ jobs:
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: true # Set this to false if you want to prevent updating existing releases
-        name: ${{steps.get_names.outputs.TAG_NAME}}
+        name: ${{steps.get_vars.outputs.TAG_NAME}}
         draft: false
         prerelease: false
         token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: './system.json, ./${{steps.get_names.outputs.ZIP_NAME}}'
-        tag: ${{steps.get_names.outputs.TAG_NAME}}
-        body: '**Installation:** To manually install this release, please use the following manifest URL: ${{steps.get_names.outputs.RELEASE_DOWNLOAD_URL}}'
+        artifacts: './system.json, ./${{steps.get_vars.outputs.ZIP_NAME}}'
+        tag: ${{steps.get_vars.outputs.TAG_NAME}}
+        body: '**Installation:** To manually install this release, please use the following manifest URL: ${{steps.get_vars.outputs.RELEASE_INSTALL_URL}}'


### PR DESCRIPTION
This action setup has full parity with the previous gitlab ci configuration:

- Verifies that the `system.json` `version` and `download` fields are correct for the tag that triggers the build.
- Installs `npm` deps, using node 16
- Runs `npm run build` to build everything at once
- Zips up the same file list as is present in `gitlab-ci.yml`
- Attaches that zip file and the `system.json` file to a release which is generated for this tag

Simplifications from the Gitlab CI:
- We no longer need a hacky `/latest` workaround using a "generic package", as github provides a permalink to `foundryvtt/dnd5e/releases/latest` out of the box.

I tested this in my own fork:
- Failure because of `download` url: https://github.com/ElfFriend-DnD/dnd5e/actions/runs/2522296308
- Failure because of `version` mismatch: https://github.com/ElfFriend-DnD/dnd5e/actions/runs/2522300430
- Success: https://github.com/ElfFriend-DnD/dnd5e/actions/runs/2522327283
  - Created Release:  https://github.com/ElfFriend-DnD/dnd5e/releases/tag/release-408