### PR TITLE
[#1607] avoid setting NPC weapon proficiency/equipped if already set

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2128,7 +2128,12 @@ export default class Item5e extends Item {
   _onCreateOwnedWeapon(data, isNPC) {
 
     // NPCs automatically equip items and are proficient with them
-    if ( isNPC ) return {"system.equipped": true, "system.proficient": true};
+    if ( isNPC ) {
+      const updates = {};
+      if ( !foundry.utils.hasProperty(data, "system.equipped") ) updates["system.equipped"] = true;
+      if ( !foundry.utils.hasProperty(data, "system.proficient") ) updates["system.proficient"] = true;
+      return updates;
+    }
     if ( data.system?.proficient !== undefined ) return {};
 
     // Some weapon types are always proficient


### PR DESCRIPTION
If the user has specified these directly, then we should not clobber the existing values when creating the item. This matches the check already found in e.g. `_onCreateOwnedTool`

Closes #1607.