### PR TITLE
[#1610] Apply temp HP from context menu on dice rolls

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -222,7 +222,7 @@
 "DND5E.Charges": "Charges",
 "DND5E.ChatContextDamage": "Apply Damage",
 "DND5E.ChatContextHealing": "Apply Healing",
-"DND5E.ChatContextTempHP": "Apply Temp HP",
+"DND5E.ChatContextTempHP": "Apply Temporary HP",
 "DND5E.ChatContextDoubleDamage": "Apply Double Damage",
 "DND5E.ChatContextHalfDamage": "Apply Half Damage",
 "DND5E.ChatFlavor": "Chat Message Flavor",

--- a/lang/en.json
+++ b/lang/en.json
@@ -222,6 +222,7 @@
 "DND5E.Charges": "Charges",
 "DND5E.ChatContextDamage": "Apply Damage",
 "DND5E.ChatContextHealing": "Apply Healing",
+"DND5E.ChatContextTempHP": "Apply Temp HP",
 "DND5E.ChatContextDoubleDamage": "Apply Double Damage",
 "DND5E.ChatContextHalfDamage": "Apply Half Damage",
 "DND5E.ChatFlavor": "Chat Message Flavor",

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -753,18 +753,20 @@ export default class Actor5e extends Actor {
     return allowed !== false ? this.update(updates, {dhp: -amount}) : this;
   }
 
+  /* -------------------------------------------- */
+ 
   /**
-   * Apply a certain amount of tempoary hit point, but only if it's more then the actor currently has.
+   * Apply a certain amount of temporary hit point, but only if it's more than the actor currently has.
    * @param {number} amount       An amount of temporary hit points to set
    * @returns {Promise<Actor5e>}  A Promise which resolves once the temp HP has been applied
    */
-  async applyTempHp(amount = 0) {
+  async applyTempHP(amount=0) {
     amount = parseInt(amount);
-    const hp = this.data.data.attributes.hp;
+    const hp = this.system.attributes.hp;
 
     // Update the actor if the new amount is greater than the current
     const tmp = parseInt(hp.temp) || 0;
-    return amount > tmp ? this.update({ "data.attributes.hp.temp": amount }) : this;
+    return amount > tmp ? this.update({"system.attributes.hp.temp": amount}) : this;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -753,6 +753,20 @@ export default class Actor5e extends Actor {
     return allowed !== false ? this.update(updates, {dhp: -amount}) : this;
   }
 
+  /**
+   * Apply a certain amount of tempoary hit point, but only if it's more then the actor currently has.
+   * @param {number} amount       An amount of temporary hit points to set
+   * @returns {Promise<Actor5e>}  A Promise which resolves once the temp HP has been applied
+   */
+  async applyTempHp(amount = 0) {
+    amount = parseInt(amount);
+    const hp = this.data.data.attributes.hp;
+
+    // Update the actor if the new amount is greater than the current
+    const tmp = parseInt(hp.temp) || 0;
+    return amount > tmp ? this.update({ "data.attributes.hp.temp": amount }) : this;
+  }
+
   /* -------------------------------------------- */
 
   /**

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -86,6 +86,12 @@ export function addChatMessageContextOptions(html, options) {
       callback: li => applyChatCardDamage(li, -1)
     },
     {
+      name: game.i18n.localize("DND5E.ChatContextTempHP"),
+      icon: `<i class="fas fa-user-clock"></i>`,
+      condition: canApply,
+      callback: li => applyChatCardTemp(li)
+    },
+    {
       name: game.i18n.localize("DND5E.ChatContextDoubleDamage"),
       icon: '<i class="fas fa-user-injured"></i>',
       condition: canApply,
@@ -117,6 +123,20 @@ function applyChatCardDamage(li, multiplier) {
   return Promise.all(canvas.tokens.controlled.map(t => {
     const a = t.actor;
     return a.applyDamage(roll.total, multiplier);
+  }));
+}
+
+/**
+ * Apply rolled dice as tempoary hit points to the controled token(s).
+ * @param {HTMLElement} li The chat entry which contains the roll data
+ * @returns {Promise}
+ */
+function applyChatCardTemp(li) {
+  const message = game.messages.get(li.data("messageId"));
+  const roll = message.roll;
+  return Promise.all(canvas.tokens.controlled.map(t => {
+    const a = t.actor;
+    return a.applyTempHp(roll.total);
   }));
 }
 

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -87,7 +87,7 @@ export function addChatMessageContextOptions(html, options) {
     },
     {
       name: game.i18n.localize("DND5E.ChatContextTempHP"),
-      icon: `<i class="fas fa-user-clock"></i>`,
+      icon: '<i class="fas fa-user-clock"></i>',
       condition: canApply,
       callback: li => applyChatCardTemp(li)
     },
@@ -126,17 +126,19 @@ function applyChatCardDamage(li, multiplier) {
   }));
 }
 
+/* -------------------------------------------- */
+ 
 /**
- * Apply rolled dice as tempoary hit points to the controled token(s).
- * @param {HTMLElement} li The chat entry which contains the roll data
+ * Apply rolled dice as temporary hit points to the controlled token(s).
+ * @param {HTMLElement} li  The chat entry which contains the roll data
  * @returns {Promise}
  */
 function applyChatCardTemp(li) {
   const message = game.messages.get(li.data("messageId"));
-  const roll = message.roll;
+  const roll = message.rolls[0];
   return Promise.all(canvas.tokens.controlled.map(t => {
     const a = t.actor;
-    return a.applyTempHp(roll.total);
+    return a.applyTempHP(roll.total);
   }));
 }
 


### PR DESCRIPTION
Also adds an `applyTempHp` function to `Actor5e`. I could have just done that inside the chat function, but I figured it could be useful for macros and module developers to have the function.