### PR TITLE
[#1615] Update readme install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://raw.githubusercontent.com/foundryvtt/dnd5e/master/system.json
 
 If you wish to manually install the system, you must clone or extract it into the ``Data/systems/dnd5e`` folder. You
 may do this by cloning the repository or downloading a zip archive from the
-[Releases Page](https://gitlab.com/foundrynet/dnd5e/-/releases).
+[Releases Page](https://github.com/foundryvtt/dnd5e/releases).
 
 ## Community Contribution
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The software component of this system is distributed under the MIT license.
 To install and use the DnD5e system for Foundry Virtual Tabletop, simply paste the following URL into the 
 **Install System** dialog on the Setup menu of the application.
 
-https://gitlab.com/foundrynet/dnd5e/raw/master/system.json
+https://raw.githubusercontent.com/foundryvtt/dnd5e/master/system.json
 
 If you wish to manually install the system, you must clone or extract it into the ``Data/systems/dnd5e`` folder. You
 may do this by cloning the repository or downloading a zip archive from the


### PR DESCRIPTION
Seemed to have been left over from the move from git lab. I've just copy and pasted the URL from https://foundryvtt.com/packages/dnd5e (which worked better than either the thing I replaced or the one listed in the application)

Closes #1615