### PR TITLE
[#1622] Rename "backpack" item type to "container"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3,7 +3,7 @@
 "ACTOR.TypeNpc": "Non-Player Character",
 "ACTOR.TypeVehicle": "Vehicle",
 "ITEM.TypeBackground": "Background",
-"ITEM.TypeBackpack": "Backpack",
+"ITEM.TypeBackpack": "Container",
 "ITEM.TypeClass": "Class",
 "ITEM.TypeConsumable": "Consumable",
 "ITEM.TypeEquipment": "Equipment",


### PR DESCRIPTION
Potentially closes issue #1622 (rename backpack item to container)

- Refactors the old "backpack" item type with a new item type "container" - this reduces misnomers like a pouch being a "backpack"
- Updates all relevant compendia items to this new type

[This is my first dnd5e contribution - please review carefully!]
[Note: the actual "Backpack" item is preserved; only the "backpack" item type has been refactored to the new item type "container"]
[Packs were successfully recompiled; linting was unnecessary since syntax was preserved]