### PR TITLE
[#1532] Displaying toolType in tool sheet header + adding general toolType

### DIFF
--- a/templates/items/tool.html
+++ b/templates/items/tool.html
@@ -16,12 +16,15 @@
 
             <ul class="summary flexrow">
                 <li>
-                    <select name="system.rarity">
-                        {{selectOptions config.itemRarity selected=system.rarity blank=""}}
+                    {{lookup config.toolTypes data.toolType }}
+                </li>
+                <li>
+                    <select name="data.rarity">
+                        {{selectOptions config.itemRarity selected=data.rarity blank="&nbsp;"}}
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+                    <input type="text" name="data.source" value="{{data.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
                 </li>
             </ul>
         </div>
@@ -46,51 +49,51 @@
             {{!-- Tool Type --}}
             <div class="form-group">
                 <label>{{ localize "DND5E.ItemToolType" }}</label>
-                <select name="system.toolType">
-                    {{selectOptions config.toolTypes selected=system.toolType blank=""}}
+                <select name="data.toolType">
+                    {{selectOptions config.toolTypes selected=data.toolType blank=""}}
                 </select>
             </div>
 
             <div class="form-group">
                 <label>{{ localize "DND5E.ItemToolBase" }}</label>
-                <select name="system.baseItem">
-                    {{selectOptions baseItems selected=system.baseItem blank=""}}
+                <select name="data.baseItem">
+                    {{selectOptions baseItems selected=data.baseItem blank=""}}
                 </select>
             </div>
 
             <div class="form-group">
                 <label>{{localize "DND5E.Attunement"}}</label>
-                <select name="system.attunement" data-dtype="Number">
-                    {{selectOptions config.attunements selected=system.attunement}}
+                <select name="data.attunement" data-dtype="Number">
+                    {{selectOptions config.attunements selected=data.attunement}}
                 </select>
             </div>
 
             {{!-- Tool Proficiency --}}
             <div class="form-group">
                 <label>{{ localize "DND5E.ItemToolProficiency" }}</label>
-                 <select name="system.proficient" data-dtype="Number">
-                     {{selectOptions config.proficiencyLevels selected=system.proficient}}
+                 <select name="data.proficient" data-dtype="Number">
+                     {{selectOptions config.proficiencyLevels selected=data.proficient}}
                  </select>
             </div>
 
             {{!-- Ability Check --}}
             <div class="form-group">
                 <label>{{ localize "DND5E.DefaultAbilityCheck" }}</label>
-                <select name="system.ability">
-                    {{selectOptions config.abilities selected=system.ability}}
+                <select name="data.ability">
+                    {{selectOptions config.abilities selected=data.ability}}
                 </select>
             </div>
 
             {{!-- Tool Bonus --}}
             <div class="form-group">
                 <label>{{ localize "DND5E.ItemToolBonus" }}</label>
-                <input type="text" name="system.bonus" value="{{system.bonus}}"/>
+                <input type="text" name="data.bonus" value="{{data.bonus}}"/>
             </div>
 
             {{!-- Chat Message Flavor --}}
             <div class="form-group stacked">
                 <label>{{ localize "DND5E.ChatFlavor" }}</label>
-                <input type="text" name="system.chatFlavor" value="{{system.chatFlavor}}"/>
+                <input type="text" name="data.chatFlavor" value="{{data.chatFlavor}}"/>
             </div>
         </div>
 


### PR DESCRIPTION
[possible solution to #1532]

This PR adds the tool's type [from among Artisan's, Musical Instrument, or Gaming Set] to the tool sheet's header. 

The first commit (3060096a825fa922b4cc80cea0914b0c9228284a) is just a few lines that accomplishes this goal, BUT it leaves a white space in the header for "general tools" not in those 3 categories. 

Removing the white space in the header would require either some sort of conditional logic in-place to remove the white space (kinda gross), or filling that space with a generic type. So:

The second commit (9adaf613adba901b8f5f15416b98f768c1b366be) adds a fourth toolType, called "General Tool", so that every tool has a toolType - so that space in the header is always filled. 

Warning: the second commit is opinionated™ - the SRD rules neither confirm nor deny that non-artisan, non-musical, non-gaming tools fall under an umbrella category, but this commit adds an umbrella category to make tool data more unified and asserts that the category is called "General Tool".

If people are opposed to this opinion, we could either keep just commit 1 (so no umbrella category) or we could rename the umbrella category to something more preferable, maybe like "Miscellaneous Tool". 
