### PR TITLE
[#1082] Add automatic proficiency updates for items when the owning actor's proficiency list changes

### DIFF
--- a/module/actor/entity.js
+++ b/module/actor/entity.js
@@ -2060,6 +2060,28 @@ export default class Actor5e extends Actor {
   _onUpdate(data, options, userId) {
     super._onUpdate(data, options, userId);
     this._displayScrollingDamage(options.dhp);
+    this._updateOwnedProficiencies(data);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * When an update is handled, update the proficiencies of all relevant items
+   * if a proficiency was updated.
+   *
+   * @param {object} updates          Object containing the update data.
+   */
+  _updateOwnedProficiencies(updates) {
+
+    if (updates.data.traits?.weaponProf) {
+      for (const item of this.itemTypes.weapon) item.updateProficiency();
+    }
+    if (updates.data.traits?.armorProf) {
+      for (const item of this.itemTypes.equipment) item.updateProficiency();
+    }
+    if (updates.data.traits?.toolProf) {
+      for (const item of this.itemTypes.tool) item.updateProficiency();
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -634,6 +634,38 @@ export default class Item5e extends Item {
   /* -------------------------------------------- */
 
   /**
+   * Updates this item's proficiency based on its owner's proficiencies.
+   */
+  async updateProficiency() {
+    const updates = {};
+    let profType = "";
+    let actorProfs = [];
+    switch ( this.type ) {
+      case "weapon":
+        profType = CONFIG.DND5E.weaponProficienciesMap[this.data.data.weaponType];
+        actorProfs = this.actor.data.data.traits?.weaponProf?.value || [];
+        break;
+      case "equipment":
+        profType = CONFIG.DND5E.armorProficienciesMap[this.data.data.armor?.type];
+        actorProfs = this.actor.data.data.traits?.armorProf?.value || [];
+        break;
+      case "tool": // TODO: When actor's tool proficiencies can include expertise etc., update this calculation.
+        profType = this.data.data.toolType;
+        actorProfs = this.actor.data.data.traits?.toolProf?.value || [];
+        break;
+    }
+    if (profType === true)
+      updates["data.proficient"] = true; // "true" => natural weapons and armor => always proficient
+    else {
+      updates["data.proficient"] =
+          actorProfs.includes(profType) || actorProfs.includes(this.data.data.baseItem);
+    }
+    this.data.update(updates);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Roll the item to Chat, creating a chat card which contains follow up attack or damage roll options
    * @param {object} [options]
    * @param {boolean} [options.configureDialog]     Display a configuration dialog for the item roll, if applicable?


### PR DESCRIPTION
[Potentially solves #1082]

Whenever _onUpdate is triggered on an Actor, update the proficiencies of any items related to the original update. 

Note: There might be a better place to attach this than "_onUpdate", but I couldn't find a less frequent method that gets called every time the actor's proficiencies change. The current slowdown is small (checks if weaponProf, armorProf, or toolProf is included in every update), but there might be a more efficient location for this.

Note: When we get working tool proficiencies in 1.8.x (see #774), this section should be updated to handle non-binary tool proficiencies like expertise and half-proficiency.