### PR TITLE
Fix various issues with custom abilities caused by V10 transition

### DIFF
--- a/templates/apps/ability-config.html
+++ b/templates/apps/ability-config.html
@@ -3,7 +3,7 @@
   <h3 class="form-header">{{labelSaves}}</h3>
   <div class="form-group">
     <label>{{ localize "DND5E.ProficiencyLevel" }}</label>
-    <select name="system.abilities.{{abilityId}}.proficient">
+    <select name="system.abilities.{{abilityId}}.proficient" data-dtype="Number">
       {{selectOptions proficiencyLevels selected=ability.proficient}}
     </select>
   </div>


### PR DESCRIPTION
- Fix issue with custom abilities still appearing on character sheet after they are disabled
- Fix issue with ability data not being persisted to the database when added, resulting in properties like `"bonuses"` not existing for custom abilities unless the user explicitly sets them in the configuration window
- Fix issue with ability proficiency value being set to a string rather than a number via the configuration interface