### PR TITLE
Fix several bugs in item grant advancement

### DIFF
--- a/module/advancement/advancement.mjs
+++ b/module/advancement/advancement.mjs
@@ -259,8 +259,8 @@ export default class Advancement {
     const advancement = foundry.utils.deepClone(this.item.system.advancement);
     const idx = advancement.findIndex(a => a._id === this.id);
     if ( idx < 0 ) throw new Error(`Advancement of ID ${this.id} could not be found to update`);
-    foundry.utils.mergeObject(this.data, updates);
-    foundry.utils.mergeObject(advancement[idx], updates);
+    foundry.utils.mergeObject(this.data, updates, { performDeletions: true });
+    foundry.utils.mergeObject(advancement[idx], updates, { performDeletions: true });
     this.item.updateSource({"system.advancement": advancement});
     return this;
   }

--- a/module/advancement/types/item-grant.mjs
+++ b/module/advancement/types/item-grant.mjs
@@ -71,19 +71,17 @@ export class ItemGrantAdvancement extends Advancement {
     for ( const [uuid, selected] of Object.entries(data) ) {
       if ( !selected ) continue;
 
-      const ri = retainedData[uuid];
-      if ( ri && !ri._id ) ri._id = foundry.utils.randomID();
-      const item = ri ? new Item.implementation(ri) : (await fromUuid(uuid))?.clone();
-      if ( !item ) continue;
-
-      item.updateSource({
+      const itemData = retainedData[uuid] ?? (await fromUuid(uuid))?.clone().toObject();
+      if ( !itemData ) continue;
+      if ( !itemData._id ) itemData._id = foundry.utils.randomID();
+      foundry.utils.mergeObject(itemData, {
         "flags.dnd5e.sourceId": uuid,
         "flags.dnd5e.advancementOrigin": `${this.item.id}.${this.id}`
       });
 
-      items.push(item.toObject());
+      items.push(itemData);
       // TODO: Trigger any additional advancement steps for added items
-      updates[item.id] = uuid;
+      updates[itemData._id] = uuid;
     }
     this.actor.updateSource({items});
     this.updateSource({"value.added": updates});

--- a/module/advancement/types/item-grant.mjs
+++ b/module/advancement/types/item-grant.mjs
@@ -49,7 +49,7 @@ export class ItemGrantAdvancement extends Advancement {
     else {
       return Object.keys(this.data.value.added).map(id => {
         const item = this.actor.items.get(id);
-        return item?.toAnchor({classes: ["content-link", "actor-item-link"]}) || "";
+        return item?.toAnchor({classes: ["content-link", "actor-item-link"]}).outerHTML || "";
       }).join("");
     }
   }
@@ -71,13 +71,16 @@ export class ItemGrantAdvancement extends Advancement {
     for ( const [uuid, selected] of Object.entries(data) ) {
       if ( !selected ) continue;
 
-      const itemData = retainedData[uuid] ?? (await fromUuid(uuid))?.clone().toObject();
-      if ( !itemData ) continue;
-      if ( !itemData._id ) itemData._id = foundry.utils.randomID();
-      foundry.utils.mergeObject(itemData, {
-        "flags.dnd5e.sourceId": uuid,
-        "flags.dnd5e.advancementOrigin": `${this.item.id}.${this.id}`
-      });
+      let itemData = retainedData[uuid];
+      if ( !itemData ) {
+        const source = await fromUuid(uuid);
+        if ( !source ) continue;
+        itemData = source.clone({
+          _id: foundry.utils.randomID(),
+          "flags.dnd5e.sourceId": uuid,
+          "flags.dnd5e.advancementOrigin": `${this.item.id}.${this.id}`
+        }, {keepId: true}).toObject();
+      }
 
       items.push(itemData);
       // TODO: Trigger any additional advancement steps for added items

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1705,7 +1705,7 @@ export default class Item5e extends Item {
     const idx = this.system.advancement.findIndex(a => a._id === id);
     if ( idx === -1 ) throw new Error(`Advancement of ID ${id} could not be found to update`);
     const advancement = this.toObject().system.advancement;
-    foundry.utils.mergeObject(advancement[idx], updates);
+    foundry.utils.mergeObject(advancement[idx], updates, { performDeletions: true });
     return this.update({"system.advancement": advancement});
   }
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -78,7 +78,7 @@ export function indexFromUuid(uuid) {
  * @private
  */
 export function _linkForUuid(uuid) {
-  return TextEditor._createContentLink(["", "UUID", uuid]);
+  return TextEditor._createContentLink(["", "UUID", uuid]).outerHTML;
 }
 
 /* -------------------------------------------- */


### PR DESCRIPTION
- Fix issue with item grant choices not appearing in advancement list or advancement config due to `TextEditor._createContentLink` returning node rather than raw HTML
- Fix issue with advancement values not being unset when leveling down due to `mergeObject` no long performing deletions by default
- Fix issue with granted item ID not being stored in advancement data