### PR TITLE
Fix v10 macro & token migration issues

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -50,7 +50,7 @@ Hooks.once("init", function() {
     get() {
       const msg = `You are referencing the 'dnd5e.entities' property which has been deprecated and renamed to 
       'dnd5e.documents'. Support for this old path will be removed in a future version.`;
-      foundry.utils.logCompatibilityWarning(msg, {from: "DnD5e 2.0", until: "DnD5e 2.2"});
+      foundry.utils.logCompatibilityWarning(msg, { since: "DnD5e 2.0", until: "DnD5e 2.2" });
       return dnd5e.documents;
     }
   });

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -33,7 +33,6 @@ globalThis.dnd5e = {
   dice,
   documents,
   migrations,
-  rollItemMacro: documents.macros.rollItem,
   utils
 };
 
@@ -48,10 +47,36 @@ Hooks.once("init", function() {
   /** @deprecated */
   Object.defineProperty(dnd5e, "entities", {
     get() {
-      const msg = `You are referencing the 'dnd5e.entities' property which has been deprecated and renamed to 
-      'dnd5e.documents'. Support for this old path will be removed in a future version.`;
-      foundry.utils.logCompatibilityWarning(msg, { since: "DnD5e 2.0", until: "DnD5e 2.2" });
+      foundry.utils.logCompatibilityWarning(
+        "You are referencing the 'dnd5e.entities' property which has been deprecated and renamed to "
+        + "'dnd5e.documents'. Support for this old path will be removed in a future version.",
+        { since: "DnD5e 2.0", until: "DnD5e 2.2" }
+      );
       return dnd5e.documents;
+    }
+  });
+
+  /** @deprecated */
+  Object.defineProperty(dnd5e, "rollItemMacro", {
+    get() {
+      foundry.utils.logCompatibilityWarning(
+        "You are referencing the 'dnd5e.rollItemMacro' method which has been deprecated and renamed to "
+        + "'dnd5e.documents.macro.rollItem'. Support for this old path will be removed in a future version.",
+        { since: "DnD5e 2.0", until: "DnD5e 2.2" }
+      );
+      return dnd5e.documents.macro.rollItem;
+    }
+  });
+
+  /** @deprecated */
+  Object.defineProperty(dnd5e, "macros", {
+    get() {
+      foundry.utils.logCompatibilityWarning(
+        "You are referencing the 'dnd5e.macros' property which has been deprecated and renamed to "
+        + "'dnd5e.documents.macro'. Support for this old path will be removed in a future version.",
+        { since: "DnD5e 2.0", until: "DnD5e 2.2" }
+      );
+      return dnd5e.documents.macro;
     }
   });
 
@@ -160,7 +185,7 @@ Hooks.once("i18nInit", () => utils.performPreLocalization(CONFIG.DND5E));
 Hooks.once("ready", function() {
 
   // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
-  Hooks.on("hotbarDrop", (bar, data, slot) => documents.macros.create5eMacro(data, slot));
+  Hooks.on("hotbarDrop", (bar, data, slot) => documents.macro.create5eMacro(data, slot));
 
   // Determine whether a system migration is required and feasible
   if ( !game.user.isGM ) return;

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -102,7 +102,7 @@ export default class ActorSheet5e extends ActorSheet {
       get() {
         const msg = `You are accessing the "data" attribute within the rendering context provided by the ItemSheet5e 
         class. This attribute has been deprecated in favor of "system" and will be removed in a future release`;
-        foundry.utils.logCompatibilityWarning(msg, {from: "DnD5e 2.0", until: "DnD5e 2.2"});
+        foundry.utils.logCompatibilityWarning(msg, { since: "DnD5e 2.0", until: "DnD5e 2.2" });
         return context.system;
       }
     });

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -902,7 +902,7 @@ export default class ActorSheet5e extends ActorSheet {
   async _onSpellSlotOverride(event) {
     const span = event.currentTarget.parentElement;
     const level = span.dataset.level;
-    const override = this.actor.systema.spells[level].override || span.dataset.slots;
+    const override = this.actor.system.spells[level].override || span.dataset.slots;
     const input = document.createElement("INPUT");
     input.type = "text";
     input.name = `system.spells.${level}.override`;

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -62,7 +62,7 @@ export default class ItemSheet5e extends ItemSheet {
       get() {
         const msg = `You are accessing the "data" attribute within the rendering context provided by the ItemSheet5e 
         class. This attribute has been deprecated in favor of "system" and will be removed in a future release`;
-        foundry.utils.logCompatibilityWarning(msg, {from: "DnD5e 2.0", until: "DnD5e 2.2"});
+        foundry.utils.logCompatibilityWarning(msg, { since: "DnD5e 2.0", until: "DnD5e 2.2" });
         return context.system;
       }
     });

--- a/module/documents/_module.mjs
+++ b/module/documents/_module.mjs
@@ -8,4 +8,4 @@ export {default as TokenDocument5e} from "./token.mjs";
 export {default as Proficiency} from "./actor/proficiency.mjs";
 export * as chat from "./chat-message.mjs";
 export * as combat from "./combat.mjs";
-export * as macros from "./macro.mjs";
+export * as macro from "./macro.mjs";

--- a/module/documents/macro.mjs
+++ b/module/documents/macro.mjs
@@ -1,6 +1,6 @@
 /**
  * Attempt to create a macro from the dropped data. Will use an existing macro if one exists.
- * @param {object} dropData         The dropped data
+ * @param {object} dropData     The dropped data
  * @param {number} slot         The hotbar slot to use
  * @returns {Promise<boolean>}
  */
@@ -8,22 +8,22 @@ export async function create5eMacro(dropData, slot) {
   const macroData = { type: "script", scope: "actor" };
   switch ( dropData.type ) {
     case "Item":
-      const itemData = dropData.data;
+      const itemData = await Item.implementation.fromDropData(dropData);
       if ( !itemData ) return ui.notifications.warn(game.i18n.localize("MACRO.5eUnownedWarn"));
       foundry.utils.mergeObject(macroData, {
         name: itemData.name,
         img: itemData.img,
-        command: `dnd5e.macros.rollItem("${itemData.name}")`,
+        command: `dnd5e.documents.macro.rollItem("${itemData.name}")`,
         flags: {"dnd5e.itemMacro": true}
       });
       break;
     case "ActiveEffect":
-      const effectData = dropData.data;
+      const effectData = await ActiveEffect.implementation.fromDropData(dropData);
       if ( !effectData ) return ui.notifications.warn(game.i18n.localize("MACRO.5eUnownedWarn"));
       foundry.utils.mergeObject(macroData, {
         name: effectData.label,
         img: effectData.icon,
-        command: `dnd5e.macros.toggleEffect("${effectData.label}")`,
+        command: `dnd5e.documents.macro.toggleEffect("${effectData.label}")`,
         flags: {"dnd5e.effectMacro": true}
       });
       break;
@@ -54,7 +54,7 @@ function getMacroTarget(name, documentType) {
   if ( !actor ) return ui.notifications.warn(game.i18n.localize("MACRO.5eNoActorSelected"));
 
   const collection = (documentType === "Item") ? actor.items : actor.effects;
-  const nameKeyPath = (documentType === "Item") ? "name" : "data.label";
+  const nameKeyPath = (documentType === "Item") ? "name" : "label";
 
   // Find item in collection
   const documents = collection.filter(i => foundry.utils.getProperty(i, nameKeyPath) === name);


### PR DESCRIPTION
- Adjust macro export to match filename (`dnd5e.documents.macro` rather than `dnd5e.documents.macros`)
- Add compatibility exports for `game.dnd5e.rollItemMacro` & `game.dnd5e.macros`
- Add migration to convert existing macros from using the old paths to the new paths
- Fix issue with migrations being unable to be created by dropping on macro bar
- Fix issue with token image migrations pointing to old `img` rather than `texture.src`
- Fix a few instances where `logComptabilityWarning` were provided with `from` rather than `since`