### PR TITLE
[#1140] Fix rolling criticals when number of dice is a formula

### DIFF
--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -81,7 +81,7 @@ export default class DamageRoll extends Roll {
       }
 
       // Merge any parenthetical terms followed by string terms
-      else if ( (term instanceof ParentheticalTerm) && (nextTerm instanceof StringTerm)
+      else if ( (term instanceof ParentheticalTerm || term instanceof MathTerm) && (nextTerm instanceof StringTerm)
         && nextTerm.term.match(/^d[0-9]*$/)) {
         if ( term.isDeterministic ) {
           const newFormula = `${term.evaluate().total}${nextTerm.term}`;


### PR DESCRIPTION
Attempting to fix the issue with rolling critical damage when a parenthetical or math expression is used:

1. `(@details.level)d6` ==> `5d6`
2. `floor(@details.level / 2)d6` ==> `2d6`

It also evaluates properly if a deterministic formula is used for the dice type:

4. `1d(4+floor((@classes.monk.levels+1)/6)*2)` ==> `1d6`
5. `1d(@prof)rr=1` ==> `1d3rr=1`

It does not attempt to simplify things if dice are used on either side of the expression:

6. `(1d4)d6` ==> Nope
7. `1d(2 * 1d10)` ==> Nope