### PR TITLE
[#1002, #1543, #1677] Add hooks to `Item5e#roll` & `Item5e#displayCard` to allow modules to enhance that workflow

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -614,7 +614,7 @@ export default class ActorSheet5e extends ActorSheet {
       html.find(".skill-name").click(this._onRollSkillCheck.bind(this));
 
       // Item Rolling
-      html.find(".rollable .item-image").click(event => this._onItemRoll(event));
+      html.find(".rollable .item-image").click(event => this._onItemUse(event));
       html.find(".item .item-recharge").click(event => this._onItemRecharge(event));
     }
 
@@ -944,16 +944,16 @@ export default class ActorSheet5e extends ActorSheet {
   /* -------------------------------------------- */
 
   /**
-   * Handle rolling an item from the Actor sheet, obtaining the Item instance, and dispatching to its roll method.
+   * Handle using an item from the Actor sheet, obtaining the Item instance, and dispatching to its use method.
    * @param {Event} event  The triggering click event.
-   * @returns {Promise}    Results of the roll.
-   * @private
+   * @returns {Promise}    Results of the usage.
+   * @protected
    */
-  _onItemRoll(event) {
+  _onItemUse(event) {
     event.preventDefault();
     const itemId = event.currentTarget.closest(".item").dataset.itemId;
     const item = this.actor.items.get(itemId);
-    if ( item ) return item.roll();
+    if ( item ) return item.use();
   }
 
   /* -------------------------------------------- */

--- a/module/canvas/ability-template.mjs
+++ b/module/canvas/ability-template.mjs
@@ -6,7 +6,7 @@ export default class AbilityTemplate extends MeasuredTemplate {
   /**
    * A factory method to create an AbilityTemplate instance using provided data from an Item5e instance
    * @param {Item5e} item               The Item object for which to construct the template
-   * @returns {AbilityTemplate|null}     The template object, or null if the item does not produce a template
+   * @returns {AbilityTemplate|null}    The template object, or null if the item does not produce a template
    */
   static fromItem(item) {
     const target = item.system.target || {};
@@ -21,7 +21,8 @@ export default class AbilityTemplate extends MeasuredTemplate {
       direction: 0,
       x: 0,
       y: 0,
-      fillColor: game.user.color
+      fillColor: game.user.color,
+      flags: { dnd5e: { origin: item.uuid } }
     };
 
     // Additional type-specific data

--- a/module/canvas/ability-template.mjs
+++ b/module/canvas/ability-template.mjs
@@ -53,7 +53,8 @@ export default class AbilityTemplate extends MeasuredTemplate {
   /* -------------------------------------------- */
 
   /**
-   * Creates a preview of the spell template
+   * Creates a preview of the spell template.
+   * @returns {Promise}  A promise that resolves with the final measured template if created.
    */
   drawPreview() {
     const initialLayer = canvas.activeLayer;
@@ -67,7 +68,7 @@ export default class AbilityTemplate extends MeasuredTemplate {
     this.actorSheet?.minimize();
 
     // Activate interactivity
-    this.activatePreviewListeners(initialLayer);
+    return this.activatePreviewListeners(initialLayer);
   }
 
   /* -------------------------------------------- */
@@ -75,57 +76,66 @@ export default class AbilityTemplate extends MeasuredTemplate {
   /**
    * Activate listeners for the template preview
    * @param {CanvasLayer} initialLayer  The initially active CanvasLayer to re-activate after the workflow is complete
+   * @returns {Promise}                 A promise that resolves with the final measured template if created.
    */
   activatePreviewListeners(initialLayer) {
-    const handlers = {};
-    let moveTime = 0;
+    return new Promise((resolve, reject) => {
+      const handlers = {};
+      let moveTime = 0;
 
-    // Update placement (mouse-move)
-    handlers.mm = event => {
-      event.stopPropagation();
-      let now = Date.now(); // Apply a 20ms throttle
-      if ( now - moveTime <= 20 ) return;
-      const center = event.data.getLocalPosition(this.layer);
-      const snapped = canvas.grid.getSnappedPosition(center.x, center.y, 2);
-      this.document.updateSource({x: snapped.x, y: snapped.y});
-      this.refresh();
-      moveTime = now;
-    };
+      // Update placement (mouse-move)
+      handlers.mm = event => {
+        event.stopPropagation();
+        let now = Date.now(); // Apply a 20ms throttle
+        if ( now - moveTime <= 20 ) return;
+        const center = event.data.getLocalPosition(this.layer);
+        const snapped = canvas.grid.getSnappedPosition(center.x, center.y, 2);
+        this.document.updateSource({x: snapped.x, y: snapped.y});
+        this.refresh();
+        moveTime = now;
+      };
 
-    // Cancel the workflow (right-click)
-    handlers.rc = event => {
-      this.layer._onDragLeftCancel(event);
-      canvas.stage.off("mousemove", handlers.mm);
-      canvas.stage.off("mousedown", handlers.lc);
-      canvas.app.view.oncontextmenu = null;
-      canvas.app.view.onwheel = null;
-      initialLayer.activate();
-      this.actorSheet?.maximize();
-    };
+      // Shared cancelation code
+      handlers.cancel = async event => {
+        this.layer._onDragLeftCancel(event);
+        canvas.stage.off("mousemove", handlers.mm);
+        canvas.stage.off("mousedown", handlers.lc);
+        canvas.app.view.oncontextmenu = null;
+        canvas.app.view.onwheel = null;
+        initialLayer.activate();
+        await this.actorSheet?.maximize();
+      };
 
-    // Confirm the workflow (left-click)
-    handlers.lc = event => {
-      handlers.rc(event);
-      const destination = canvas.grid.getSnappedPosition(this.document.x, this.document.y, 2);
-      this.document.updateSource(destination);
-      canvas.scene.createEmbeddedDocuments("MeasuredTemplate", [this.document.toObject()]);
-    };
+      // Cancel the workflow (right-click)
+      handlers.rc = async event => {
+        await handlers.cancel(event);
+        reject();
+      };
 
-    // Rotate the template by 3 degree increments (mouse-wheel)
-    handlers.mw = event => {
-      if ( event.ctrlKey ) event.preventDefault(); // Avoid zooming the browser window
-      event.stopPropagation();
-      let delta = canvas.grid.type > CONST.GRID_TYPES.SQUARE ? 30 : 15;
-      let snap = event.shiftKey ? delta : 5;
-      const update = {direction: this.document.direction + (snap * Math.sign(event.deltaY))};
-      this.document.updateSource(update);
-      this.refresh();
-    };
+      // Confirm the workflow (left-click)
+      handlers.lc = async event => {
+        await handlers.cancel(event);
+        const destination = canvas.grid.getSnappedPosition(this.document.x, this.document.y, 2);
+        this.document.updateSource(destination);
+        resolve(canvas.scene.createEmbeddedDocuments("MeasuredTemplate", [this.document.toObject()]));
+      };
 
-    // Activate listeners
-    canvas.stage.on("mousemove", handlers.mm);
-    canvas.stage.on("mousedown", handlers.lc);
-    canvas.app.view.oncontextmenu = handlers.rc;
-    canvas.app.view.onwheel = handlers.mw;
+      // Rotate the template by 3 degree increments (mouse-wheel)
+      handlers.mw = event => {
+        if ( event.ctrlKey ) event.preventDefault(); // Avoid zooming the browser window
+        event.stopPropagation();
+        let delta = canvas.grid.type > CONST.GRID_TYPES.SQUARE ? 30 : 15;
+        let snap = event.shiftKey ? delta : 5;
+        const update = {direction: this.document.direction + (snap * Math.sign(event.deltaY))};
+        this.document.updateSource(update);
+        this.refresh();
+      };
+
+      // Activate listeners
+      canvas.stage.on("mousemove", handlers.mm);
+      canvas.stage.on("mousedown", handlers.lc);
+      canvas.app.view.oncontextmenu = handlers.rc;
+      canvas.app.view.onwheel = handlers.mw;
+    });
   }
 }

--- a/module/canvas/ability-template.mjs
+++ b/module/canvas/ability-template.mjs
@@ -4,6 +4,30 @@
 export default class AbilityTemplate extends MeasuredTemplate {
 
   /**
+   * Track the timestamp when the last mouse move event was captured.
+   * @type {number}
+   */
+  #moveTime = 0;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The initially active CanvasLayer to re-activate after the workflow is complete.
+   * @type {CanvasLayer}
+   */
+  #initialLayer;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Track the bound event handlers so they can be properly canceled later.
+   * @type {object}
+   */
+  #events;
+
+  /* -------------------------------------------- */
+
+  /**
    * A factory method to create an AbilityTemplate instance using provided data from an Item5e instance
    * @param {Item5e} item               The Item object for which to construct the template
    * @returns {AbilityTemplate|null}    The template object, or null if the item does not produce a template
@@ -81,62 +105,95 @@ export default class AbilityTemplate extends MeasuredTemplate {
    */
   activatePreviewListeners(initialLayer) {
     return new Promise((resolve, reject) => {
-      const handlers = {};
-      let moveTime = 0;
-
-      // Update placement (mouse-move)
-      handlers.mm = event => {
-        event.stopPropagation();
-        let now = Date.now(); // Apply a 20ms throttle
-        if ( now - moveTime <= 20 ) return;
-        const center = event.data.getLocalPosition(this.layer);
-        const snapped = canvas.grid.getSnappedPosition(center.x, center.y, 2);
-        this.document.updateSource({x: snapped.x, y: snapped.y});
-        this.refresh();
-        moveTime = now;
-      };
-
-      // Shared cancelation code
-      handlers.cancel = async event => {
-        this.layer._onDragLeftCancel(event);
-        canvas.stage.off("mousemove", handlers.mm);
-        canvas.stage.off("mousedown", handlers.lc);
-        canvas.app.view.oncontextmenu = null;
-        canvas.app.view.onwheel = null;
-        initialLayer.activate();
-        await this.actorSheet?.maximize();
-      };
-
-      // Cancel the workflow (right-click)
-      handlers.rc = async event => {
-        await handlers.cancel(event);
-        reject();
-      };
-
-      // Confirm the workflow (left-click)
-      handlers.lc = async event => {
-        await handlers.cancel(event);
-        const destination = canvas.grid.getSnappedPosition(this.document.x, this.document.y, 2);
-        this.document.updateSource(destination);
-        resolve(canvas.scene.createEmbeddedDocuments("MeasuredTemplate", [this.document.toObject()]));
-      };
-
-      // Rotate the template by 3 degree increments (mouse-wheel)
-      handlers.mw = event => {
-        if ( event.ctrlKey ) event.preventDefault(); // Avoid zooming the browser window
-        event.stopPropagation();
-        let delta = canvas.grid.type > CONST.GRID_TYPES.SQUARE ? 30 : 15;
-        let snap = event.shiftKey ? delta : 5;
-        const update = {direction: this.document.direction + (snap * Math.sign(event.deltaY))};
-        this.document.updateSource(update);
-        this.refresh();
+      this.#initialLayer = initialLayer;
+      this.#events = {
+        cancel: this._onCancelPlacement.bind(this),
+        confirm: this._onConfirmPlacement.bind(this),
+        move: this._onMovePlacement.bind(this),
+        resolve,
+        reject,
+        rotate: this._onRotatePlacement.bind(this)
       };
 
       // Activate listeners
-      canvas.stage.on("mousemove", handlers.mm);
-      canvas.stage.on("mousedown", handlers.lc);
-      canvas.app.view.oncontextmenu = handlers.rc;
-      canvas.app.view.onwheel = handlers.mw;
+      canvas.stage.on("mousemove", this.#events.move);
+      canvas.stage.on("mousedown", this.#events.confirm);
+      canvas.app.view.oncontextmenu = this.#events.cancel;
+      canvas.app.view.onwheel = this.#events.rotate;
     });
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Shared code for when template placement ends by being confirmed or canceled.
+   * @param {Event} event  Triggering event that ended the placement.
+   */
+  async _finishPlacement(event) {
+    this.layer._onDragLeftCancel(event);
+    canvas.stage.off("mousemove", this.#events.move);
+    canvas.stage.off("mousedown", this.#events.confirm);
+    canvas.app.view.oncontextmenu = null;
+    canvas.app.view.onwheel = null;
+    this.#initialLayer.activate();
+    await this.actorSheet?.maximize();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Move the template preview when the mouse moves.
+   * @param {Event} event  Triggering mouse event.
+   */
+  _onMovePlacement(event) {
+    event.stopPropagation();
+    let now = Date.now(); // Apply a 20ms throttle
+    if ( now - this.#moveTime <= 20 ) return;
+    const center = event.data.getLocalPosition(this.layer);
+    const snapped = canvas.grid.getSnappedPosition(center.x, center.y, 2);
+    this.document.updateSource({x: snapped.x, y: snapped.y});
+    this.refresh();
+    this.#moveTime = now;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Rotate the template preview by 3˚ increments when the mouse wheel is rotated.
+   * @param {Event} event  Triggering mouse event.
+   */
+  _onRotatePlacement(event) {
+    if ( event.ctrlKey ) event.preventDefault(); // Avoid zooming the browser window
+    event.stopPropagation();
+    let delta = canvas.grid.type > CONST.GRID_TYPES.SQUARE ? 30 : 15;
+    let snap = event.shiftKey ? delta : 5;
+    const update = {direction: this.document.direction + (snap * Math.sign(event.deltaY))};
+    this.document.updateSource(update);
+    this.refresh();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Confirm placement when the left mouse button is clicked.
+   * @param {Event} event  Triggering mouse event.
+   */
+  async _onConfirmPlacement(event) {
+    await this._finishPlacement(event);
+    const destination = canvas.grid.getSnappedPosition(this.document.x, this.document.y, 2);
+    this.document.updateSource(destination);
+    this.#events.resolve(canvas.scene.createEmbeddedDocuments("MeasuredTemplate", [this.document.toObject()]));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Cancel placement when the right mouse button is clicked.
+   * @param {Event} event  Triggering mouse event.
+   */
+  async _onCancelPlacement(event) {
+    await this._finishPlacement(event);
+    this.#events.reject();
+  }
+
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -669,11 +669,26 @@ export default class Item5e extends Item {
   /**
    * Trigger an item usage, optionally creating a chat message with followup actions.
    * @param {ItemUseOptions} [options]           Options used for configuring item usage.
+   * @returns {Promise<ChatMessage|object|void>} Chat message if options.createMessage is true, message data if it is
+   *                                             false, and nothing if the roll wasn't performed.
+   * @deprecated since 2.0 in favor of `Item5e#use`, targeted for removal in 2.4
+   */
+  async roll(options={}) {
+    foundry.utils.logCompatibilityWarning(
+      "Item5e#roll has been renamed Item5e#use. Support for the old name will be removed in future versions.",
+      { since: "DnD5e 2.0", until: "DnD5e 2.4" }
+    );
+    return this.use(undefined, options);
+  }
+
+  /**
+   * Trigger an item usage, optionally creating a chat message with followup actions.
    * @param {ItemUseConfiguration} [config]      Initial configuration data for the usage.
+   * @param {ItemUseOptions} [options]           Options used for configuring item usage.
    * @returns {Promise<ChatMessage|object|void>} Chat message if options.createMessage is true, message data if it is
    *                                             false, and nothing if the roll wasn't performed.
    */
-  async roll(options={}, config={}) {
+  async use(config={}, options={}) {
     let item = this;
     const is = item.system;
     const as = item.actor.system;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -758,10 +758,13 @@ export default class Item5e extends Item {
     if ( !foundry.utils.isEmpty(actorUpdates) ) await this.actor.update(actorUpdates);
     if ( resourceUpdates.length ) await this.actor.updateEmbeddedDocuments("Item", resourceUpdates);
 
+    // Prepare card data & display it if options.createMessage is true
+    const cardData = item.displayCard(options);
+
     // Initiate measured template creation
     if ( config.createMeasuredTemplate ) {
       const template = dnd5e.canvas.AbilityTemplate.fromItem(item);
-      if ( template ) template.drawPreview();
+      if ( template ) await template.drawPreview();
     }
 
     /**
@@ -774,8 +777,7 @@ export default class Item5e extends Item {
      */
     Hooks.callAll("dnd5e.roll", item, config, options);
 
-    // Create or return the Chat Message data
-    return item.displayCard(options);
+    return cardData;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1001,6 +1001,9 @@ export default class Item5e extends Item {
       chatData.flags["dnd5e.itemData"] = templateData.item;
     }
 
+    // Merge in the flags from options
+    chatData.flags = foundry.utils.mergeObject(chatData.flags, options.flags);
+
     /**
      * A hook event that fires before an item chat card is displayed.
      * @function dnd5e.preDisplayCard
@@ -1010,9 +1013,6 @@ export default class Item5e extends Item {
      * @param {ItemRollOptions} options  Options which configure the display of the item chat card.
      */
     Hooks.callAll("dnd5e.preDisplayCard", this, chatData, options);
-
-    // Merge in the flags from options
-    chatData.flags = foundry.utils.mergeObject(chatData.flags, options.flags);
 
     // Apply the roll mode to adjust message visibility
     ChatMessage.applyRollMode(chatData, options.rollMode ?? game.settings.get("core", "rollMode"));

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -721,8 +721,9 @@ export default class Item5e extends Item {
     }
 
     // Handle spell upcasting
-    if ( isSpell && config.consumeSpellSlot ) {
-      const upcastLevel = config.consumeSpellLevel === "pact" ? as.spells.pact.level : config.consumeSpellLevel;
+    if ( isSpell && (config.consumeSpellSlot || config.consumeSpellLevel) ) {
+      const upcastLevel = config.consumeSpellLevel === "pact" ? as.spells.pact.level
+        : parseInt(config.consumeSpellLevel);
       if ( upcastLevel && (upcastLevel !== is.level) ) {
         item = item.clone({"system.level": upcastLevel}, {keepId: true});
         item.prepareData();
@@ -798,7 +799,9 @@ export default class Item5e extends Item {
    * @returns {object|boolean}              A set of data changes to apply when the item is used, or false.
    * @protected
    */
-  _getUsageUpdates({consumeQuantity, consumeRecharge, consumeResource, consumeSpellLevel, consumeUsage}) {
+  _getUsageUpdates({
+    consumeQuantity, consumeRecharge, consumeResource, consumeSpellSlot,
+    consumeSpellLevel, consumeUsage}) {
     const actorUpdates = {};
     const itemUpdates = {};
     const resourceUpdates = [];
@@ -820,7 +823,7 @@ export default class Item5e extends Item {
     }
 
     // Consume Spell Slots
-    if ( consumeSpellLevel ) {
+    if ( consumeSpellSlot && consumeSpellLevel ) {
       if ( Number.isNumeric(consumeSpellLevel) ) consumeSpellLevel = `spell${consumeSpellLevel}`;
       const level = this.actor?.system.spells[consumeSpellLevel];
       const spells = Number(level?.value ?? 0);

--- a/module/documents/macro.mjs
+++ b/module/documents/macro.mjs
@@ -76,7 +76,7 @@ function getMacroTarget(name, documentType) {
  * @returns {Promise<ChatMessage|object>}  Roll result.
  */
 export function rollItem(itemName) {
-  return getMacroTarget(itemName, "Item")?.roll();
+  return getMacroTarget(itemName, "Item")?.use();
 }
 
 /* -------------------------------------------- */

--- a/templates/apps/ability-use.hbs
+++ b/templates/apps/ability-use.hbs
@@ -9,7 +9,7 @@
     <div class="form-group">
         <label>{{ localize "DND5E.SpellCastUpcast" }}</label>
         <div class="form-fields">
-            <select name="level">
+            <select name="consumeSpellLevel">
                 {{#select item.system.level}}
                 {{#each spellLevels as |l|}}
                 <option value="{{l.level}}" {{disabled (not l.canCast)}}>{{l.label}}</option>

--- a/templates/apps/ability-use.hbs
+++ b/templates/apps/ability-use.hbs
@@ -1,5 +1,5 @@
 <form id="ability-use-form">
-    <p>{{ title }}</p>
+    <p>{{title}}</p>
     <p class="notes">{{note}}</p>
     {{#each errors}}
     <p class="notification error">{{this}}</p>
@@ -12,7 +12,7 @@
             <select name="level">
                 {{#select item.system.level}}
                 {{#each spellLevels as |l|}}
-                <option value="{{l.level}}" {{#unless l.canCast}}disabled{{/unless}}>{{l.label}}</option>
+                <option value="{{l.level}}" {{disabled (not l.canCast)}}>{{l.label}}</option>
                 {{/each}}
                 {{/select}}
             </select>
@@ -20,33 +20,40 @@
     </div>
 
     <div class="form-group">
-        <label class="checkbox"><input type="checkbox" name="consumeSlot" checked/>{{ localize "DND5E.SpellCastConsume" }}</label>
+        <label class="checkbox">
+            <input type="checkbox" name="consumeSpellSlot" checked>{{localize "DND5E.SpellCastConsume"}}
+        </label>
     </div>
     {{/if}}
 
     {{#if consumeUses}}
     <div class="form-group">
-        <label class="checkbox"><input type="checkbox" name="consumeUse" checked/>{{ localize "DND5E.AbilityUseConsume" }}</label>
+        <label class="checkbox">
+            <input type="checkbox" name="consumeUsage" checked>{{localize "DND5E.AbilityUseConsume"}}
+        </label>
     </div>
     {{/if}}
 
     {{#if consumeResource}}
     <div class="form-group">
-        <label class="checkbox"><input type="checkbox" name="consumeResource" checked/>{{ localize "DND5E.ConsumeResource" }}</label>
+        <label class="checkbox">
+            <input type="checkbox" name="consumeResource" checked>{{localize "DND5E.ConsumeResource"}}
+        </label>
     </div>
     {{/if}}
 
     {{#if consumeRecharge}}
     <div class="form-group">
-        <label class="checkbox"><input type="checkbox" name="consumeRecharge" checked/>{{ localize "DND5E.ConsumeRecharge" }}</label>
+        <label class="checkbox">
+            <input type="checkbox" name="consumeRecharge" checked>{{localize "DND5E.ConsumeRecharge"}}
+        </label>
     </div>
     {{/if}}
 
     {{#if createTemplate}}
     <div class="form-group">
         <label class="checkbox">
-            <input type="checkbox" name="placeTemplate" checked/>
-            {{ localize "DND5E.PlaceTemplate" }}
+            <input type="checkbox" name="createMeasuredTemplate" checked>{{localize "DND5E.PlaceTemplate"}}
         </label>
     </div>
     {{/if}}


### PR DESCRIPTION
Adds a number of hooks to the item usage process to allow modules to better customize that workflow without having to override or wrap system methods:

- `dnd5e.preUseItem`: Called before the item is configured, allows changing configuration data, controlling whether the dialog should be displayed, and upcasting spells even if the dialog isn't shown
- `dnd5e.preItemUsageConsumption`: Called before usage updates are calculated
- `dnd5e.itemUsageConsumption`: Called after resource consumption is calculated to allow any modifications before those changes are applied to the actor or other items
- `dnd5e.preDisplayCard`: Called before the chat card is created with the chat data that will be used to display the card to allow for any changes before the creation occurs
- `dnd5e.displayCard`: Called after the chat card is created to allow for any changes now that the card is saved to the database
- `dnd5e.useItem`: Called after consumption updates, the chat card is created, and any measured template is created to respond to the effects of the usage (e.g. auto applying damage to all creatures within the template)

This also makes the process for placing a measured template async so that it can be awaited and sets the creating item's UUID as a flag so their origin can be tracked.