### PR TITLE
Refactor actor & item sheet getData methods

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -79,6 +79,9 @@
 .dnd5e .window-content {
   font-size: 13px;
 }
+.dnd5e h3 {
+  border-bottom: none;
+}
 .dnd5e input[type="text"],
 .dnd5e input[type="number"],
 .dnd5e select {
@@ -511,7 +514,6 @@
   font-weight: 700;
   text-align: left;
   font-size: 16px;
-  border-bottom: 0;
 }
 .dnd5e .effects .item .effect-source,
 .dnd5e .effects .item .effect-duration,

--- a/less/apps.less
+++ b/less/apps.less
@@ -17,6 +17,10 @@
   /*  Element Styles                           */
   /* ----------------------------------------- */
 
+  h3 {
+    border-bottom: none;
+  }
+
   // Item Sheet form fields
   input[type="text"],
   input[type="number"],
@@ -488,7 +492,6 @@
         .modesto();
         text-align: left;
         font-size: 16px;
-        border-bottom: 0;
       }
     }
   }

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -83,6 +83,7 @@ export default class ActorSheet5e extends ActorSheet {
     // Basic data
     const context = {
       actor: actorData,
+      source: source.system,
       system: actorData.system,
       items: actorData.items,
       labels: this._getLabels(actorData.system),

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -37,9 +37,8 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
       disableExperience: game.settings.get("dnd5e", "disableExperienceTracking"),
       classLabels: classes.map(c => c.name).join(", "),
       multiclassLabels: classes.map(c => [c.subclass?.name ?? "", c.name, c.system.levels].filterJoin(" ")).join(", "),
-      weightUnit: game.settings.get("dnd5e", "metricWeightUnits")
-        ? game.i18n.localize("DND5E.AbbreviationKgs")
-        : game.i18n.localize("DND5E.AbbreviationLbs")
+      weightUnit: game.i18n.localize(`DND5E.Abbreviation${
+        game.settings.get("dnd5e", "metricWeightUnits") ? "Kgs" : "Lbs"}`)
     });
   }
 

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -15,6 +15,8 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
   }
 
   /* -------------------------------------------- */
+  /*  Context Preparation                         */
+  /* -------------------------------------------- */
 
   /** @inheritDoc */
   async getData(options={}) {
@@ -30,18 +32,15 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
       return arr.concat([res]);
     }, []);
 
-    // Experience Tracking
-    context.disableExperience = game.settings.get("dnd5e", "disableExperienceTracking");
-    context.classLabels = this.actor.itemTypes.class.map(c => c.name).join(", ");
-    context.multiclassLabels = this.actor.itemTypes.class.map(c => {
-      return [c.system.subclass, c.name, c.system.levels].filterJoin(" ");
-    }).join(", ");
-
-    // Weight unit
-    context.weightUnit = game.settings.get("dnd5e", "metricWeightUnits")
-      ? game.i18n.localize("DND5E.AbbreviationKgs")
-      : game.i18n.localize("DND5E.AbbreviationLbs");
-    return context;
+    const classes = this.actor.itemTypes.class;
+    return foundry.utils.mergeObject(context, {
+      disableExperience: game.settings.get("dnd5e", "disableExperienceTracking"),
+      classLabels: classes.map(c => c.name).join(", "),
+      multiclassLabels: classes.map(c => [c.subclass?.name ?? "", c.name, c.system.levels].filterJoin(" ")).join(", "),
+      weightUnit: game.settings.get("dnd5e", "metricWeightUnits")
+        ? game.i18n.localize("DND5E.AbbreviationKgs")
+        : game.i18n.localize("DND5E.AbbreviationLbs")
+    });
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -19,6 +19,27 @@ export default class ActorSheet5eNPC extends ActorSheet5e {
   static unsupportedItemTypes = new Set(["background", "class", "subclass"]);
 
   /* -------------------------------------------- */
+  /*  Context Preparation                         */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async getData(options) {
+    const context = await super.getData(options);
+
+    // Challenge Rating
+    const cr = parseFloat(context.system.details.cr ?? 0);
+    const crLabels = {0: "0", 0.125: "1/8", 0.25: "1/4", 0.5: "1/2"};
+
+    return foundry.utils.mergeObject(context, {
+      labels: {
+        cr: cr >= 1 ? String(cr) : crLabels[cr] ?? 1,
+        type: this.actor.constructor.formatCreatureType(context.system.details.type),
+        armorType: this.getArmorLabel()
+      }
+    });
+  }
+
+  /* -------------------------------------------- */
 
   /** @override */
   _prepareItems(context) {
@@ -67,25 +88,6 @@ export default class ActorSheet5eNPC extends ActorSheet5e {
     // Assign and return
     context.features = Object.values(features);
     context.spellbook = spellbook;
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritdoc */
-  async getData(options) {
-    const context = await super.getData(options);
-
-    // Challenge Rating
-    const cr = parseFloat(context.actor.system.details.cr || 0);
-    const crLabels = {0: "0", 0.125: "1/8", 0.25: "1/4", 0.5: "1/2"};
-    context.labels.cr = cr >= 1 ? String(cr) : crLabels[cr] || 1;
-
-    // Creature Type
-    context.labels.type = this.actor.constructor.formatCreatureType(this.actor.system.details.type);
-
-    // Armor Type
-    context.labels.armorType = this.getArmorLabel();
-    return context;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -28,6 +28,8 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
   }
 
   /* -------------------------------------------- */
+  /*  Context Preparation                         */
+  /* -------------------------------------------- */
 
   /**
    * Compute the total weight of the vehicle's cargo.
@@ -245,7 +247,7 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
     // Update the rendering context data
     context.features = Object.values(features);
     context.cargo = Object.values(cargo);
-    context.actor.system.attributes.encumbrance = this._computeEncumbrance(totalWeight, context);
+    context.system.attributes.encumbrance = this._computeEncumbrance(totalWeight, context);
   }
 
   /* -------------------------------------------- */

--- a/templates/items/parts/item-activation.html
+++ b/templates/items/parts/item-activation.html
@@ -119,7 +119,7 @@
     <div class="form-fields">
         <input type="number" step="any" name="system.uses.value" value="{{system.uses.value}}">
         <span class="sep">{{ localize "DND5E.of" }}</span>
-        <input type="text" name="system.uses.max" value="{{system.uses.max}}">
+        <input type="text" name="system.uses.max" value="{{source.uses.max}}">
         <span class="sep">{{ localize "DND5E.per" }}</span>
         <select name="system.uses.per">
             {{#select system.uses.per}}


### PR DESCRIPTION
- Refactor the `getData` methods for all of the sheets to use a merge-strategy rather than individually setting each property on context
- Fix bug with `multiclassLabel` in character sheet context caused by the new subclass type
- Remove more unwanted `h3` underlines that was missed in the last PR