### PR TITLE
[#1002] Add hooks to `Actor5e` rolling methods

### DIFF
--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -3,44 +3,56 @@
 /* -------------------------------------------- */
 
 /**
+ * Configuration data for a D20 roll.
+ *
+ * @typedef {object} D20RollConfiguration
+ *
+ * @property {string[]} [parts=[]]  The dice roll component parts, excluding the initial d20.
+ * @property {object} [data={}]     Data that will be used when parsing this roll.
+ * @property {Event} [event]        The triggering event for this roll.
+ *
+ * ## D20 Properties
+ * @property {boolean} [advantage]     Apply advantage to this roll (unless overridden by modifier keys or dialog)?
+ * @property {boolean} [disadvantage]  Apply disadvantage to this roll (unless overridden by modifier keys or dialog)?
+ * @property {number} [critical=20]    The value of the d20 result which represents a critical success.
+ * @property {number} [fumble=1]       The value of the d20 result which represents a critical failure.
+ * @property {number} [targetValue]    The value of the d20 result which should represent a successful roll.
+ *
+ * ## Flags
+ * @property {boolean} [elvenAccuracy]   Allow Elven Accuracy to modify this roll?
+ * @property {boolean} [halflingLucky]   Allow Halfling Luck to modify this roll?
+ * @property {boolean} [reliableTalent]  Allow Reliable Talent to modify this roll?
+ *
+ * ## Roll Configuration Dialog
+ * @property {boolean} [fastForward=false]     Should the roll configuration dialog be skipped?
+ * @property {boolean} [chooseModifier=false]  If the configuration dialog is shown, should the ability modifier be
+ *                                             configurable within that interface?
+ * @property {string} [template]               The HTML template used to display the roll configuration dialog.
+ * @property {string} [title]                  Title of the roll configuration dialog.
+ * @property {object} [dialogOptions]          Additional options passed to the roll configuration dialog.
+ *
+ * ## Chat Message
+ * @property {boolean} [chatMessage=true]  Should a chat message be created for this roll?
+ * @property {object} [messageData={}]     Additional data which is applied to the created chat message.
+ * @property {string} [rollMode]           Value of `CONST.DICE_ROLL_MODES` to apply as default for the chat message.
+ * @property {object} [flavor]             Flavor text to use in the created chat message.
+ */
+
+/**
  * A standardized helper function for managing core 5e d20 rolls.
  * Holding SHIFT, ALT, or CTRL when the attack is rolled will "fast-forward".
  * This chooses the default options of a normal attack with no bonus, Advantage, or Disadvantage respectively
  *
- * @param {object} [config]
- * @param {string[]} [config.parts]          The dice roll component parts, excluding the initial d20
- * @param {object} [config.data]             Actor or item data against which to parse the roll
- *
- * @param {boolean} [config.advantage]       Apply advantage to the roll (unless otherwise specified)
- * @param {boolean} [config.disadvantage]    Apply disadvantage to the roll (unless otherwise specified)
- * @param {number} [config.critical]         The value of d20 result which represents a critical success
- * @param {number} [config.fumble]           The value of d20 result which represents a critical failure
- * @param {number} [config.targetValue]      Assign a target value against which the result of this roll
- *                                           should be compared
- * @param {boolean} [config.elvenAccuracy]   Allow Elven Accuracy to modify this roll?
- * @param {boolean} [config.halflingLucky]   Allow Halfling Luck to modify this roll?
- * @param {boolean} [config.reliableTalent]  Allow Reliable Talent to modify this roll?
- *
- * @param {boolean} [config.chooseModifier=false] Choose the ability modifier that should be used when the roll is made
- * @param {boolean} [config.fastForward=false] Allow fast-forward advantage selection
- * @param {Event} [config.event]             The triggering event which initiated the roll
- * @param {string} [config.template]         The HTML template used to render the roll dialog
- * @param {string} [config.title]            The dialog window title
- * @param {object} [config.dialogOptions]    Modal dialog options
- *
- * @param {boolean} [config.chatMessage=true] Automatically create a Chat Message for the result of this roll
- * @param {object} [config.messageData={}] Additional data which is applied to the created Chat Message, if any
- * @param {string} [config.rollMode]       A specific roll mode to apply as the default for the resulting roll
- * @param {object} [config.speaker]        The ChatMessage speaker to pass when creating the chat
- * @param {string} [config.flavor]         Flavor text to use in the posted chat message
- *
- * @returns {Promise<D20Roll|null>}  The evaluated D20Roll, or null if the workflow was cancelled
+ * @param {D20RollConfiguration} configuration  Configuration data for the D20 roll.
+ * @returns {Promise<D20Roll|null>}             The evaluated D20Roll, or null if the workflow was cancelled.
  */
 export async function d20Roll({
-  parts=[], data={}, // Roll creation
-  advantage, disadvantage, fumble=1, critical=20, targetValue, elvenAccuracy, halflingLucky, reliableTalent, // Roll customization
-  chooseModifier=false, fastForward=false, event, template, title, dialogOptions, // Dialog configuration
-  chatMessage=true, messageData={}, rollMode, speaker, flavor // Chat Message customization
+  parts=[], data={}, event,
+  advantage, disadvantage, critical=20, fumble=1, targetValue,
+  elvenAccuracy, halflingLucky, reliableTalent,
+  fastForward=false, chooseModifier=false, template, title, dialogOptions,
+  chatMessage=true, messageData={}, rollMode, flavor,
+  speaker // Deprecated
 }={}) {
 
   // Handle input arguments
@@ -117,43 +129,51 @@ function _determineAdvantageMode({event, advantage=false, disadvantage=false, fa
 /* -------------------------------------------- */
 
 /**
+ * Configuration data for a damage roll.
+ *
+ * @typedef {object} DamageRollConfiguration
+ *
+ * @property {string[]} [parts=[]]  The dice roll component parts.
+ * @property {object} [data={}]     Data that will be used when parsing this roll.
+ * @property {Event} [event]        The triggering event for this roll.
+ *
+ * ## Critical Handling
+ * @property {boolean} [allowCritical=true]  Is this damage roll allowed to be rolled as critical?
+ * @property {boolean} [critical=false]      Apply critical to this roll (unless overridden by modifier key or dialog)?
+ * @property {number} [criticalBonusDice]    A number of bonus damage dice that are added for critical hits.
+ * @property {number} [criticalMultiplier]   Multiplier to use when calculating critical damage.
+ * @property {boolean} [multiplyNumeric]     Should numeric terms be multiplied when this roll criticals?
+ * @property {boolean} [powerfulCritical]    Should the critical dice be maximized rather than rolled?
+ * @property {string} [criticalBonusDamage]  An extra damage term that is applied only on a critical hit.
+ *
+ * ## Roll Configuration Dialog
+ * @property {boolean} [fastForward=false]  Should the roll configuration dialog be skipped?
+ * @property {string} [template]            The HTML template used to render the roll configuration dialog.
+ * @property {string} [title]               Title of the roll configuration dialog.
+ * @property {object} [dialogOptions]       Additional options passed to the roll configuration dialog.
+ *
+ * ## Chat Message
+ * @property {boolean} [chatMessage=true]  Should a chat message be created for this roll?
+ * @property {object} [messageData={}]     Additional data which is applied to the created chat message.
+ * @property {string} [rollMode]           Value of `CONST.DICE_ROLL_MODES` to apply as default for the chat message.
+ * @property {string} [flavor]             Flavor text to use in the created chat message.
+ */
+
+/**
  * A standardized helper function for managing core 5e damage rolls.
  * Holding SHIFT, ALT, or CTRL when the attack is rolled will "fast-forward".
  * This chooses the default options of a normal attack with no bonus, Critical, or no bonus respectively
  *
- * @param {object} [config]
- * @param {string[]} [config.parts]        The dice roll component parts, excluding the initial d20
- * @param {object} [config.data]           Actor or item data against which to parse the roll
- *
- * @param {boolean} [config.critical=false] Flag this roll as a critical hit for the purposes of
- *                                          fast-forward or default dialog action
- * @param {number} [config.criticalBonusDice=0] A number of bonus damage dice that are added for critical hits
- * @param {number} [config.criticalMultiplier=2] A critical hit multiplier which is applied to critical hits
- * @param {boolean} [config.multiplyNumeric=false] Multiply numeric terms by the critical multiplier
- * @param {boolean} [config.powerfulCritical=false] Apply the "powerful criticals" house rule to critical hits
- * @param {string} [config.criticalBonusDamage] An extra damage term that is applied only on a critical hit
- *
- * @param {boolean} [config.fastForward=false] Allow fast-forward advantage selection
- * @param {Event}[config.event]            The triggering event which initiated the roll
- * @param {boolean} [config.allowCritical=true] Allow the opportunity for a critical hit to be rolled
- * @param {string} [config.template]       The HTML template used to render the roll dialog
- * @param {string} [config.title]          The dice roll UI window title
- * @param {object} [config.dialogOptions]  Configuration dialog options
- *
- * @param {boolean} [config.chatMessage=true] Automatically create a Chat Message for the result of this roll
- * @param {object} [config.messageData={}] Additional data which is applied to the created Chat Message, if any
- * @param {string} [config.rollMode]       A specific roll mode to apply as the default for the resulting roll
- * @param {object} [config.speaker]        The ChatMessage speaker to pass when creating the chat
- * @param {string} [config.flavor]         Flavor text to use in the posted chat message
- *
- * @returns {Promise<DamageRoll|null>} The evaluated DamageRoll, or null if the workflow was canceled
+ * @param {DamageRollConfiguration} configuration  Configuration data for the Damage roll.
+ * @returns {Promise<DamageRoll|null>}             The evaluated DamageRoll, or null if the workflow was canceled.
  */
 export async function damageRoll({
-  parts=[], data, // Roll creation
-  critical=false, criticalBonusDice, criticalMultiplier, multiplyNumeric, powerfulCritical,
-  criticalBonusDamage, // Damage customization
-  fastForward=false, event, allowCritical=true, template, title, dialogOptions, // Dialog configuration
-  chatMessage=true, messageData={}, rollMode, speaker, flavor // Chat Message customization
+  parts=[], data={}, event,
+  allowCritical=true, critical=false, criticalBonusDice, criticalMultiplier,
+  multiplyNumeric, powerfulCritical, criticalBonusDamage,
+  fastForward=false, template, title, dialogOptions,
+  chatMessage=true, messageData={}, rollMode, flavor,
+  speaker // Deprecated
 }={}) {
 
   // Handle input arguments

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -775,7 +775,7 @@ export default class Actor5e extends Actor {
    * @param {object} options      Options which configure how the skill check is rolled
    * @returns {Promise<D20Roll>}  A Promise which resolves to the created Roll instance
    */
-  rollSkill(skillId, options={}) {
+  async rollSkill(skillId, options={}) {
     const skl = this.system.skills[skillId];
     const abl = this.system.abilities[skl.ability];
     const globalBonuses = this.system.bonuses?.abilities ?? {};
@@ -819,7 +819,7 @@ export default class Actor5e extends Actor {
     if ( options.parts?.length > 0 ) parts.push(...options.parts);
 
     // Reliable Talent applies to any skill check we have full or better proficiency in
-    const reliableTalent = (skl.value >= 1 && this.getFlag("dnd5e", "reliableTalent"));
+    const reliableTalent = (skl.value >= 1 && this.getFlag("dnd5e", "reliableTalent")) || undefined;
 
     // Roll and return
     const flavor = game.i18n.format("DND5E.SkillPromptTitle", {skill: CONFIG.DND5E.skills[skillId]});
@@ -830,13 +830,37 @@ export default class Actor5e extends Actor {
       flavor,
       chooseModifier: true,
       halflingLucky: this.getFlag("dnd5e", "halflingLucky"),
-      reliableTalent: reliableTalent,
+      reliableTalent,
       messageData: {
         speaker: options.speaker || ChatMessage.getSpeaker({actor: this}),
         "flags.dnd5e.roll": {type: "skill", skillId }
       }
     });
-    return d20Roll(rollData);
+
+    /**
+     * A hook event that fires before a skill check is rolled for an Actor.
+     * @function dnd5e.preRollSkill
+     * @memberof hookEvents
+     * @param {Actor5e} actor                Actor for which the skill check is being rolled.
+     * @param {D20RollConfiguration} config  Configuration data for the pending roll.
+     * @param {string} skillId               ID of the skill being rolled as defined in `DND5E.skills`.
+     * @returns {boolean}                    Explicitly return false to prevent skill check from being rolled.
+     */
+    if ( Hooks.call("dnd5e.preRollSkill", this, rollData, skillId) === false ) return;
+
+    const roll = await d20Roll(rollData);
+
+    /**
+     * A hook event that fires after a skill check has been rolled for an Actor.
+     * @function dnd5e.rollSkill
+     * @memberof hookEvents
+     * @param {Actor5e} actor   Actor for which the skill check has been rolled.
+     * @param {D20Roll} roll    The resulting roll.
+     * @param {string} skillId  ID of the skill that was rolled as defined in `DND5E.skills`.
+     */
+    if ( roll ) Hooks.callAll("dnd5e.rollSkill", this, roll, skillId);
+
+    return roll;
   }
 
   /* -------------------------------------------- */
@@ -874,7 +898,7 @@ export default class Actor5e extends Actor {
    * @param {object} options      Options which configure how ability tests are rolled
    * @returns {Promise<D20Roll>}  A Promise which resolves to the created Roll instance
    */
-  rollAbilityTest(abilityId, options={}) {
+  async rollAbilityTest(abilityId, options={}) {
     const label = CONFIG.DND5E.abilities[abilityId] ?? "";
     const abl = this.system.abilities[abilityId];
     const globalBonuses = this.system.bonuses?.abilities ?? {};
@@ -920,7 +944,31 @@ export default class Actor5e extends Actor {
         "flags.dnd5e.roll": {type: "ability", abilityId }
       }
     });
-    return d20Roll(rollData);
+
+    /**
+     * A hook event that fires before an ability test is rolled for an Actor.
+     * @function dnd5e.preRollAbilityTest
+     * @memberof hookEvents
+     * @param {Actor5e} actor                Actor for which the ability test is being rolled.
+     * @param {D20RollConfiguration} config  Configuration data for the pending roll.
+     * @param {string} abilityId             ID of the ability being rolled as defined in `DND5E.abilities`.
+     * @returns {boolean}                    Explicitly return false to prevent ability test from being rolled.
+     */
+    if ( Hooks.call("dnd5e.preRollAbilityTest", this, rollData, abilityId) === false ) return;
+
+    const roll = await d20Roll(rollData);
+
+    /**
+     * A hook event that fires after an ability test has been rolled for an Actor.
+     * @function dnd5e.rollAbilityTest
+     * @memberof hookEvents
+     * @param {Actor5e} actor     Actor for which the ability test has been rolled.
+     * @param {D20Roll} roll      The resulting roll.
+     * @param {string} abilityId  ID of the ability that was rolled as defined in `DND5E.abilities`.
+     */
+    if ( roll ) Hooks.callAll("dnd5e.rollAbilityTest", this, roll, abilityId);
+
+    return roll;
   }
 
   /* -------------------------------------------- */
@@ -932,7 +980,7 @@ export default class Actor5e extends Actor {
    * @param {object} options      Options which configure how ability tests are rolled
    * @returns {Promise<D20Roll>}  A Promise which resolves to the created Roll instance
    */
-  rollAbilitySave(abilityId, options={}) {
+  async rollAbilitySave(abilityId, options={}) {
     const label = CONFIG.DND5E.abilities[abilityId] ?? "";
     const abl = this.system.abilities[abilityId];
     const globalBonuses = this.system.bonuses?.abilities ?? {};
@@ -978,7 +1026,31 @@ export default class Actor5e extends Actor {
         "flags.dnd5e.roll": {type: "save", abilityId }
       }
     });
-    return d20Roll(rollData);
+
+    /**
+     * A hook event that fires before an ability save is rolled for an Actor.
+     * @function dnd5e.preRollAbilitySave
+     * @memberof hookEvents
+     * @param {Actor5e} actor                Actor for which the ability save is being rolled.
+     * @param {D20RollConfiguration} config  Configuration data for the pending roll.
+     * @param {string} abilityId             ID of the ability being rolled as defined in `DND5E.abilities`.
+     * @returns {boolean}                    Explicitly return false to prevent ability save from being rolled.
+     */
+    if ( Hooks.call("dnd5e.preRollAbilitySave", this, rollData, abilityId) === false ) return;
+
+    const roll = await d20Roll(rollData);
+
+    /**
+     * A hook event that fires after an ability save has been rolled for an Actor.
+     * @function dnd5e.rollAbilitySave
+     * @memberof hookEvents
+     * @param {Actor5e} actor     Actor for which the ability save has been rolled.
+     * @param {D20Roll} roll      The resulting roll.
+     * @param {string} abilityId  ID of the ability that was rolled as defined in `DND5E.abilities`.
+     */
+    if ( roll ) Hooks.callAll("dnd5e.rollAbilitySave", this, roll, abilityId);
+
+    return roll;
   }
 
   /* -------------------------------------------- */
@@ -992,7 +1064,7 @@ export default class Actor5e extends Actor {
     const death = this.system.attributes.death;
 
     // Display a warning if we are not at zero HP or if we already have reached 3
-    if ( (this.system.attributes.hp.value > 0) || (death.failure >= 3) || (death.success >= 3)) {
+    if ( (this.system.attributes.hp.value > 0) || (death.failure >= 3) || (death.success >= 3) ) {
       ui.notifications.warn(game.i18n.localize("DND5E.DeathSaveUnnecessary"));
       return null;
     }
@@ -1017,7 +1089,7 @@ export default class Actor5e extends Actor {
 
     // Evaluate the roll
     const flavor = game.i18n.localize("DND5E.DeathSavingThrow");
-    const rollData = foundry.utils.mergeObject(options, {
+    const rollData = foundry.utils.mergeObject({
       parts,
       data,
       title: `${flavor}: ${this.name}`,
@@ -1028,55 +1100,79 @@ export default class Actor5e extends Actor {
         speaker: speaker,
         "flags.dnd5e.roll": {type: "death"}
       }
-    });
+    }, options);
+
+    /**
+     * A hook event that fires before a death saving throw is rolled for an Actor.
+     * @function dnd5e.preRollDeathSave
+     * @memberof hookEvents
+     * @param {Actor5e} actor                Actor for which the death saving throw is being rolled.
+     * @param {D20RollConfiguration} config  Configuration data for the pending roll.
+     * @returns {boolean}                    Explicitly return false to prevent death saving throw from being rolled.
+     */
+    if ( Hooks.call("dnd5e.preRollDeathSave", this, rollData) === false ) return;
+
     const roll = await d20Roll(rollData);
     if ( !roll ) return null;
 
     // Take action depending on the result
-    const success = roll.total >= 10;
     const d20 = roll.dice[0].total;
-
-    let chatString;
+    const details = {};
 
     // Save success
-    if ( success ) {
+    if ( roll.total >= (roll.options.targetValue ?? 10) ) {
       let successes = (death.success || 0) + 1;
 
       // Critical Success = revive with 1hp
-      if ( d20 === 20 ) {
-        await this.update({
+      if ( d20 >= (rollData.critical ?? 20) ) {
+        details.updates = {
           "system.attributes.death.success": 0,
           "system.attributes.death.failure": 0,
           "system.attributes.hp.value": 1
-        });
-        chatString = "DND5E.DeathSaveCriticalSuccess";
+        };
+        details.chatString = "DND5E.DeathSaveCriticalSuccess";
       }
 
       // 3 Successes = survive and reset checks
       else if ( successes === 3 ) {
-        await this.update({
+        details.updates = {
           "system.attributes.death.success": 0,
           "system.attributes.death.failure": 0
-        });
-        chatString = "DND5E.DeathSaveSuccess";
+        };
+        details.chatString = "DND5E.DeathSaveSuccess";
       }
 
       // Increment successes
-      else await this.update({"system.attributes.death.success": Math.clamped(successes, 0, 3)});
+      else details.updates = {"system.attributes.death.success": Math.clamped(successes, 0, 3)};
     }
 
     // Save failure
     else {
-      let failures = (death.failure || 0) + (d20 === 1 ? 2 : 1);
-      await this.update({"system.attributes.death.failure": Math.clamped(failures, 0, 3)});
+      let failures = (death.failure || 0) + (d20 <= (roll.options.fumble ?? 1) ? 2 : 1);
+      details.updates = {"system.attributes.death.failure": Math.clamped(failures, 0, 3)};
       if ( failures >= 3 ) {  // 3 Failures = death
-        chatString = "DND5E.DeathSaveFailure";
+        details.chatString = "DND5E.DeathSaveFailure";
       }
     }
 
+    /**
+     * A hook event that fires after a death saving throw has been rolled for an Actor.
+     * @function dnd5e.rollDeathSave
+     * @memberof hookEvents
+     * @param {Actor5e} actor              Actor for which the death saving throw has been rolled.
+     * @param {D20Roll} roll               The resulting roll.
+     * @param {object} details
+     * @param {object} details.updates     Updates that will be applied to the actor as a result of this save.
+     * @param {string} details.chatString  Localizable string displayed in the create chat message. If not set, then
+     *                                     no chat message will be displayed.
+     */
+    if ( Hooks.call("dnd5e.rollDeathSave", this, roll, details) === false ) return roll;
+
+    if ( !foundry.utils.isEmpty(details.updates) ) await this.update(details.updates);
+
     // Display success/failure chat message
-    if ( chatString ) {
-      let chatData = { content: game.i18n.format(chatString, {name: this.name}), speaker };
+    if ( details.chatString ) {
+      let chatData = { content: game.i18n.format(details.chatString, {name: this.name}), speaker };
       ChatMessage.applyRollMode(chatData, roll.options.rollMode);
       await ChatMessage.create(chatData);
     }
@@ -1091,10 +1187,10 @@ export default class Actor5e extends Actor {
    * Roll a hit die of the appropriate type, gaining hit points equal to the die roll plus your CON modifier
    * @param {string} [denomination]       The hit denomination of hit die to roll. Example "d8".
    *                                      If no denomination is provided, the first available HD will be used
-   * @param {boolean} [dialog]            Show a dialog prompt for configuring the hit die roll?
+   * @param {object} options              Additional options which modify the roll.
    * @returns {Promise<DamageRoll|null>}  The created Roll instance, or null if no hit die was rolled
    */
-  async rollHitDie(denomination, {dialog=true}={}) {
+  async rollHitDie(denomination, options={}) {
 
     // If no denomination was provided, choose the first available
     let cls = null;
@@ -1117,29 +1213,58 @@ export default class Actor5e extends Actor {
 
     // Prepare roll data
     const flavor = game.i18n.localize("DND5E.HitDiceRoll");
-
-    // Call the roll helper utility
-    const roll = await damageRoll({
+    if ( options.fastForward === undefined ) options.fastForward = !options.dialog;
+    const rollData = foundry.utils.mergeObject(options, {
       event: new Event("hitDie"),
       parts: [`1${denomination}`, "@abilities.con.mod"],
       data: this.toObject().system,
       title: `${flavor}: ${this.name}`,
       flavor,
       allowCritical: false,
-      fastForward: !dialog,
       dialogOptions: {width: 350},
       messageData: {
         speaker: ChatMessage.getSpeaker({actor: this}),
         "flags.dnd5e.roll": {type: "hitDie"}
       }
     });
-    if ( !roll ) return null;
 
-    // Adjust actor data
-    await cls.update({"system.hitDiceUsed": cls.system.hitDiceUsed + 1});
+    /**
+     * A hook event that fires before a hit die is rolled for an Actor.
+     * @function dnd5e.preRollHitDie
+     * @memberof hookEvents
+     * @param {Actor5e} actor                Actor for which the hit die is to be rolled.
+     * @param {D20RollConfiguration} config  Configuration data for the pending roll.
+     * @param {string} denomination          Size of hit die to be rolled.
+     * @returns {boolean}                    Explicitly return false to prevent hit die from being rolled.
+     */
+    if ( Hooks.call("dnd5e.preRollHitDie", this, rollData, denomination) === false ) return;
+
+    const roll = await damageRoll(rollData);
+    if ( !roll ) return roll;
+
     const hp = this.system.attributes.hp;
     const dhp = Math.min(hp.max + (hp.tempmax ?? 0) - hp.value, roll.total);
-    await this.update({"system.attributes.hp.value": hp.value + dhp});
+    const updates = {
+      actor: {"system.attributes.hp.value": hp.value + dhp},
+      class: {"system.hitDiceUsed": cls.system.hitDiceUsed + 1}
+    };
+
+    /**
+     * A hook event that fires after a hit die has been rolled for an Actor.
+     * @function dnd5e.rollHitDie
+     * @memberof hookEvents
+     * @param {Actor5e} actor        Actor for which the hit die has been rolled.
+     * @param {D20Roll} roll         The resulting roll.
+     * @param {object} updates
+     * @param {object} updates.actor  Updates that will be applied to the actor.
+     * @param {object} updates.class  Updates that will be applied to the class.
+     */
+    if ( Hooks.call("dnd5e.rollHitDie", this, roll, updates) === false ) return roll;
+
+    // Perform updates
+    if ( !foundry.utils.isEmpty(updates.actor) ) this.update(updates.actor);
+    if ( !foundry.utils.isEmpty(updates.class) ) cls.update(updates.class);
+
     return roll;
   }
 
@@ -1180,6 +1305,8 @@ export default class Actor5e extends Actor {
     return roll;
   }
 
+  /* -------------------------------------------- */
+  /*  Resting                                     */
   /* -------------------------------------------- */
 
   /**


### PR DESCRIPTION
Adds a number of hooks to the actor rolling process to allow modules to better customize rolling without having to override or wrap system methods:

- `dnd5e.preRollSkill` & `dnd5e.rollSkill`
- `dnd5e.preRollAbilityTest` & `dnd5e.rollAbilityTest`
- `dnd5e.preRollAbilitySave` & `dnd5e.rollAbilitySave`
- `dnd5e.preRollDeathSave`: Modify normal death save parameters and set the target & critical numbers.
- `dnd5e.rollDeathSave`: Modify or prevent actor changes based on the result of a death save.
- `dnd5e.preRollHitDie` & `dnd5e.rollHitDie`: Modify or prevent actor changes based on a hit die roll.