### PR TITLE
[#1620, #1626, #1689] Add spell config & type restriction to ItemGrant advancement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -118,6 +118,7 @@
 "DND5E.AdvancementItemGrantRecursiveWarning": "You cannot grant an item in its own advancement.",
 "DND5E.AdvancementItemGrantOptional": "Optional",
 "DND5E.AdvancementItemGrantOptionalHint": "If optional, players will be given the option to opt out of any of the following items, otherwise all of them are granted.",
+"DND5E.AdvancementItemTypeInvalidWarning": "{type} items cannot be added with this advancement type.",
 "DND5E.AdvancementLevelHeader": "Level {level}",
 "DND5E.AdvancementLevelAnyHeader": "Any Level",
 "DND5E.AdvancementLevelNoneHeader": "No Level",

--- a/module/advancement/advancement-config.mjs
+++ b/module/advancement/advancement-config.mjs
@@ -192,6 +192,7 @@ export default class AdvancementConfig extends FormApplication {
    * if the item is invalid.
    * @param {Event} event  Triggering drop event.
    * @param {Item5e} item  The materialized Item that was dropped.
+   * @throws An error if the item is invalid.
    * @protected
    */
   _validateDroppedItem(event, item) {}

--- a/module/advancement/advancement.mjs
+++ b/module/advancement/advancement.mjs
@@ -318,4 +318,31 @@ export default class Advancement {
    * @abstract
    */
   async reverse(level) { }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Helper method to prepare spell customizations.
+   * @param {object} spell  Spell configuration object.
+   * @returns {object}      Object of updates to apply to item.
+   * @protected
+   */
+  _prepareSpellChanges(spell) {
+    const updates = {};
+    if ( spell.ability ) updates["system.ability"] = spell.ability;
+    if ( spell.preparation ) updates["system.preparation.mode"] = spell.preparation;
+    if ( spell.uses?.max ) {
+      updates["system.uses.max"] = spell.uses.max;
+      if ( Number.isNumeric(spell.uses.max) ) updates["system.uses.value"] = parseInt(spell.uses.max);
+      else {
+        try {
+          const rollData = this.actor.getRollData({ deterministic: true });
+          const formula = Roll.replaceFormulaData(spell.uses.max, rollData, {missing: 0});
+          updates["system.uses.value"] = Roll.safeEval(formula);
+        } catch(e) { }
+      }
+    }
+    if ( spell.uses?.per ) updates["system.uses.per"] = spell.uses.per;
+    return updates;
+  }
 }

--- a/module/advancement/types/item-grant.mjs
+++ b/module/advancement/types/item-grant.mjs
@@ -92,7 +92,7 @@ export class ItemGrantAdvancement extends Advancement {
           "flags.dnd5e.advancementOrigin": `${this.item.id}.${this.id}`
         }, {keepId: true}).toObject();
       }
-      foundry.utils.mergeObject(itemData, spellChanges);
+      if ( itemData.type === "spell" ) foundry.utils.mergeObject(itemData, spellChanges);
 
       items.push(itemData);
       // TODO: Trigger any additional advancement steps for added items

--- a/module/advancement/types/item-grant.mjs
+++ b/module/advancement/types/item-grant.mjs
@@ -161,11 +161,10 @@ export class ItemGrantConfig extends AdvancementConfig {
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  _verifyDroppedItem(event, item) {
+  _validateDroppedItem(event, item) {
     if ( this.advancement.constructor.VALID_TYPES.has(item.type) ) return true;
     const type = game.i18n.localize(`ITEM.Type${item.type.capitalize()}`);
-    ui.notifications.warn(game.i18n.format("DND5E.AdvancementItemTypeInvalidWarning", { type }));
-    return false;
+    throw new Error(game.i18n.format("DND5E.AdvancementItemTypeInvalidWarning", { type }));
   }
 }
 

--- a/module/advancement/types/item-grant.mjs
+++ b/module/advancement/types/item-grant.mjs
@@ -151,11 +151,10 @@ export class ItemGrantConfig extends AdvancementConfig {
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  async getData() {
-    const data = super.getData();
-    data.items = data.data.configuration.items.map(fromUuidSync);
-    data.showSpellConfig = data.items.some(i => i.type === "spell");
-    return data;
+  getData() {
+    const context = super.getData();
+    context.showSpellConfig = context.data.configuration.items.map(fromUuidSync).some(i => i.type === "spell");
+    return context;
   }
 
   /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -110,7 +110,8 @@ export async function preloadHandlebarsTemplates() {
     "systems/dnd5e/templates/items/parts/item-spellcasting.hbs",
 
     // Advancement Partials
-    "systems/dnd5e/templates/advancement/parts/advancement-controls.hbs"
+    "systems/dnd5e/templates/advancement/parts/advancement-controls.hbs",
+    "systems/dnd5e/templates/advancement/parts/advancement-spell-config.hbs"
   ];
 
   const paths = {};

--- a/templates/advancement/item-grant-config.hbs
+++ b/templates/advancement/item-grant-config.hbs
@@ -8,6 +8,10 @@
     <p class="hint">{{localize "DND5E.AdvancementItemGrantOptionalHint"}}</p>
   </div>
 
+  {{#if showSpellConfig}}
+    {{> "dnd5e.advancement-spell-config"}}
+  {{/if}}
+
   <div class="drop-target">
     <ol class="items-list">
       <li class="items-header flexrow"><h3 class="item-name">{{localize "DOCUMENT.Items"}}</h3></li>
@@ -16,7 +20,9 @@
         <li class="item flexrow" data-item-uuid="{{this}}">
           <div class="item-name">{{{dnd5e-linkForUuid this}}}</div>
           <div class="item-controls flexrow">
-            <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+            <a class="item-control item-delete" title="{{localize 'DND5E.ItemDelete'}}">
+              <i class="fas fa-trash"></i>
+            </a>
           </div>
         </li>
       {{/each}}

--- a/templates/advancement/item-grant-config.hbs
+++ b/templates/advancement/item-grant-config.hbs
@@ -20,7 +20,7 @@
         <li class="item flexrow" data-item-uuid="{{this}}">
           <div class="item-name">{{{dnd5e-linkForUuid this}}}</div>
           <div class="item-controls flexrow">
-            <a class="item-control item-delete" title="{{localize 'DND5E.ItemDelete'}}">
+            <a class="item-control item-action" data-action="delete" title="{{localize 'DND5E.ItemDelete'}}">
               <i class="fas fa-trash"></i>
             </a>
           </div>

--- a/templates/advancement/parts/advancement-spell-config.hbs
+++ b/templates/advancement/parts/advancement-spell-config.hbs
@@ -1,0 +1,28 @@
+<div class="form-group">
+  {{log this}}
+  <label>{{localize "DND5E.AbilityModifier"}}</label>
+  <div class="form-fields">
+    <select name="data.configuration.spell.ability">
+      {{selectOptions CONFIG.abilities selected=data.configuration.spell.ability blank="&mdash;"}}
+    </select>
+  </div>
+</div>
+
+<div class="form-group">
+  <label>{{localize "DND5E.SpellPreparationMode"}}</label>
+  <div class="form-fields">
+    <select name="data.configuration.spell.preparation">
+      {{selectOptions CONFIG.spellPreparationModes selected=data.configuration.spell.preparation blank="&mdash;"}}
+    </select>
+  </div>
+</div>
+
+<div class="form-group">
+  <label>{{localize "DND5E.LimitedUses"}}</label>
+  <div class="form-fields">
+    <input type="text" name="data.configuration.spell.uses.max" value="{{data.configuration.spell.uses.max}}">
+    <select name="data.configuration.spell.uses.per">
+      {{selectOptions CONFIG.limitedUsePeriods selected=data.configuration.spell.uses.per blank="&mdash;"}}
+    </select>
+  </div>
+</div>


### PR DESCRIPTION
- Add ability to override spellcasting ability, preparation mode, and max uses for spells added using item grant advancement (resolves #1626)
- Prevent `class`, `subclass`, or `background` items from being added using item grant to avoid issues caused by the use of the advancement system in a way that isn't yet supported (existing advancements that do this won't break, but new ones can't be created through the interface) (resolves #1689)
- Localize delete title that was missed (resolves #1620)
- Move drag & drop code into `AdvancementConfig` to prepare for sharing with `ItemChoiceAdvancement`