### PR TITLE
[#1667] Fix bug in `ProficiencySelector` and accessibility update

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -1654,10 +1654,12 @@
 .dnd5e.sheet.item .advancement .items-list .items-header .item-checkmark {
   flex: 0 0 44px;
   color: #119111;
+  text-shadow: white 0 0 1px;
 }
 .dnd5e.sheet.item .advancement .items-list .items-header .item-warning {
   flex: 0 0 44px;
   color: #faff23;
+  text-shadow: black 0 0 1px;
 }
 .dnd5e.sheet.item .advancement .items-list .item-name {
   flex: 1 0 10em;

--- a/less/items.less
+++ b/less/items.less
@@ -261,10 +261,12 @@
         .item-checkmark {
           flex: 0 0 44px;
           color: rgb(17 145 17);
+          text-shadow: white 0 0 1px;
         }
         .item-warning {
           flex: 0 0 44px;
           color: rgb(250 255 35);
+          text-shadow: black 0 0 1px;
         }
       }
       .item-name {

--- a/module/applications/proficiency-selector.mjs
+++ b/module/applications/proficiency-selector.mjs
@@ -26,7 +26,7 @@ export default class ProficiencySelector extends TraitSelector {
 
   /** @inheritdoc */
   async getData() {
-    const attr = foundry.utils.getProperty(this.object.data, this.attribute);
+    const attr = foundry.utils.getProperty(this.object, this.attribute);
     const chosen = (this.options.valueKey) ? foundry.utils.getProperty(attr, this.options.valueKey) ?? [] : attr;
 
     const data = super.getData();
@@ -66,7 +66,7 @@ export default class ProficiencySelector extends TraitSelector {
         const item = await this.getBaseItem(id);
         if ( !item ) continue;
 
-        let type = foundry.utils.getProperty(item.data, typeProperty);
+        let type = foundry.utils.getProperty(item.system, typeProperty);
         if ( map && map[type] ) type = map[type];
         const entry = {
           label: item.name,

--- a/utils/javascript.mjs
+++ b/utils/javascript.mjs
@@ -33,7 +33,8 @@ async function compileJavascript() {
   await bundle.write({
     file: "./dnd5e-compiled.mjs",
     format: "es",
-    sourcemap: true
+    sourcemap: true,
+    sourcemapFile: "dnd5e.mjs"
   });
 }
 export const compile = compileJavascript;


### PR DESCRIPTION
- Fix a bug preventing `ProficiencySelector` from showing selected items
- Fix `data` warning in `ProficiencySelector`
- Fix issue with compiled source map pointing to wrong filename
- Add small black outline to improve contrast for warning icon in advancement list

<img width="572" alt="Screen Shot 2022-08-07 at 17 48 03" src="https://user-images.githubusercontent.com/19979839/183318501-3fa5dd34-6983-4744-ba8a-2a4dc132f038.png">
<img width="577" alt="Screen Shot 2022-08-07 at 17 47 51" src="https://user-images.githubusercontent.com/19979839/183318505-d8409870-4b98-4bcd-8076-895ac20a1873.png">

Resolves #1667 