### PR TITLE
Add support for "Space Vehicle" tool proficiencies

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -903,6 +903,7 @@
 "DND5E.VehiclePassengers": "Passengers",
 "DND5E.VehicleTypeAir": "Air Vehicle",
 "DND5E.VehicleTypeLand": "Land Vehicle",
+"DND5E.VehicleTypeSpace": "Space Vehicle",
 "DND5E.VehicleTypeWater": "Water Vehicle",
 "DND5E.VehicleUncrewed": "Uncrewed",
 "DND5E.Versatile": "Versatile",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -459,6 +459,7 @@ preLocalize("equipmentTypes", { sort: true });
 DND5E.vehicleTypes = {
   air: "DND5E.VehicleTypeAir",
   land: "DND5E.VehicleTypeLand",
+  space: "DND5E.VehicleTypeSpace",
   water: "DND5E.VehicleTypeWater"
 };
 preLocalize("vehicleTypes", { sort: true });


### PR DESCRIPTION
The newly-released Spelljammer: Adventures in Space contains a new "tool" vehicle proficiency type, for space vehicles.

E.x.: "Wildspacer" background:

> **Tool Proficiencies:** Navigator’s tools, vehicles (space)