### PR TITLE
[#1532] Displaying toolType in tool sheet header

### DIFF
--- a/templates/items/tool.hbs
+++ b/templates/items/tool.hbs
@@ -16,7 +16,11 @@
 
             <ul class="summary flexrow">
                 <li>
-                    {{lookup config.toolTypes system.toolType}}
+                    {{#if system.toolType}}
+                      {{lookup config.toolTypes system.toolType}}
+                    {{else}}
+                      {{localize "DND5E.ItemTypeTool"}}
+                    {{/if}}
                 </li>
                 <li>
                     <select name="system.rarity">

--- a/templates/items/tool.hbs
+++ b/templates/items/tool.hbs
@@ -16,6 +16,9 @@
 
             <ul class="summary flexrow">
                 <li>
+                    {{lookup config.toolTypes system.toolType}}
+                </li>
+                <li>
                     <select name="system.rarity">
                         {{selectOptions config.itemRarity selected=system.rarity blank=""}}
                     </select>


### PR DESCRIPTION
[possible solution to #1532]

This PR adds the tool's type [from among Artisan's, Musical Instrument, or Gaming Set] to the tool sheet's header.