### PR TITLE
Migrate old effect icons in compendium data

### DIFF
--- a/packs/src/monsters/celestial/couatl.json
+++ b/packs/src/monsters/celestial/couatl.json
@@ -1024,7 +1024,7 @@
             "seconds": 60,
             "rounds": 10
           },
-          "icon": "systems/dnd5e/icons/spells/haste-sky-1.jpg",
+          "icon": "icons/magic/control/buff-flight-wings-blue.webp",
           "label": "Bless",
           "origin": "Item.kZZAZ6kp9YzgPQEe",
           "tint": null,
@@ -1549,7 +1549,7 @@
             "startTime": null,
             "rounds": 1
           },
-          "icon": "systems/dnd5e/icons/spells/protect-magenta-1.jpg",
+          "icon": "icons/magic/defensive/shield-barrier-glowing-triangle-magenta.webp",
           "label": "Shield",
           "origin": "Item.FlLKKv7bQBlIAs11",
           "tint": null,

--- a/packs/src/monsters/fey/dryad.json
+++ b/packs/src/monsters/fey/dryad.json
@@ -1088,7 +1088,7 @@
             "startTime": null,
             "seconds": 3600
           },
-          "icon": "systems/dnd5e/icons/spells/protect-orange-2.jpg",
+          "icon": "icons/magic/defensive/shield-barrier-flaming-diamond-orange.webp",
           "label": "Barkskin",
           "origin": "Item.VQMKMnQDw5rzL0zp",
           "tint": null,

--- a/packs/src/monsters/humanoid/acolyte.json
+++ b/packs/src/monsters/humanoid/acolyte.json
@@ -1101,7 +1101,7 @@
             "seconds": 60,
             "rounds": 10
           },
-          "icon": "systems/dnd5e/icons/spells/haste-sky-1.jpg",
+          "icon": "icons/magic/control/buff-flight-wings-blue.webp",
           "label": "Bless",
           "origin": "Item.kZZAZ6kp9YzgPQEe",
           "tint": null,

--- a/packs/src/monsters/humanoid/archmage.json
+++ b/packs/src/monsters/humanoid/archmage.json
@@ -1558,7 +1558,7 @@
           "duration": {
             "startTime": null
           },
-          "icon": "systems/dnd5e/icons/spells/protect-blue-1.jpg",
+          "icon": "icons/magic/defensive/shield-barrier-glowing-triangle-blue.webp",
           "label": "Mage Armor",
           "origin": "Compendium.dnd5e.spells.CKZTpZlxj7hjjo2H",
           "transfer": true,
@@ -2491,7 +2491,7 @@
             "startTime": null,
             "seconds": 600
           },
-          "icon": "systems/dnd5e/icons/spells/protect-red-3.jpg",
+          "icon": "icons/magic/defensive/shield-barrier-flaming-pentagon-red.webp",
           "label": "Warm Shield",
           "origin": "Item.OtcTsffCQaOFkr9K",
           "tint": null,
@@ -2512,7 +2512,7 @@
             "startTime": null,
             "seconds": 600
           },
-          "icon": "systems/dnd5e/icons/spells/protect-blue-3.jpg",
+          "icon": "icons/magic/defensive/shield-barrier-flaming-pentagon-blue.webp",
           "label": "Chill Shield",
           "origin": "Item.OtcTsffCQaOFkr9K",
           "tint": null,

--- a/packs/src/monsters/humanoid/druid.json
+++ b/packs/src/monsters/humanoid/druid.json
@@ -1587,7 +1587,7 @@
             "startTime": null,
             "seconds": 3600
           },
-          "icon": "systems/dnd5e/icons/spells/protect-orange-2.jpg",
+          "icon": "icons/magic/defensive/shield-barrier-flaming-diamond-orange.webp",
           "label": "Barkskin",
           "origin": "Item.VQMKMnQDw5rzL0zp",
           "tint": null,

--- a/packs/src/monsters/humanoid/mage.json
+++ b/packs/src/monsters/humanoid/mage.json
@@ -1202,7 +1202,7 @@
           "duration": {
             "startTime": null
           },
-          "icon": "systems/dnd5e/icons/spells/protect-blue-1.jpg",
+          "icon": "icons/magic/defensive/shield-barrier-glowing-triangle-blue.webp",
           "label": "Mage Armor",
           "origin": "Compendium.dnd5e.spells.CKZTpZlxj7hjjo2H",
           "transfer": true,
@@ -1428,7 +1428,7 @@
             "startTime": null,
             "rounds": 1
           },
-          "icon": "systems/dnd5e/icons/spells/protect-magenta-1.jpg",
+          "icon": "icons/magic/defensive/shield-barrier-glowing-triangle-magenta.webp",
           "label": "Shield",
           "origin": "Item.FlLKKv7bQBlIAs11",
           "tint": null,

--- a/packs/src/monsters/monstrosity/gynosphinx.json
+++ b/packs/src/monsters/monstrosity/gynosphinx.json
@@ -1430,7 +1430,7 @@
             "startTime": null,
             "rounds": 1
           },
-          "icon": "systems/dnd5e/icons/spells/protect-magenta-1.jpg",
+          "icon": "icons/magic/defensive/shield-barrier-glowing-triangle-magenta.webp",
           "label": "Shield",
           "origin": "Item.FlLKKv7bQBlIAs11",
           "tint": null,

--- a/packs/src/monsters/undead/lich.json
+++ b/packs/src/monsters/undead/lich.json
@@ -1223,7 +1223,7 @@
             "startTime": null,
             "rounds": 1
           },
-          "icon": "systems/dnd5e/icons/spells/protect-magenta-1.jpg",
+          "icon": "icons/magic/defensive/shield-barrier-glowing-triangle-magenta.webp",
           "label": "Shield",
           "origin": "Item.FlLKKv7bQBlIAs11",
           "tint": null,


### PR DESCRIPTION
Runs the migration from #1739 and only keeps the `icon` changes. These icons currently are broken references as the images were removed in 2.0.0-alpha3