### PR TITLE
[#1741] Fix ability consumption display in item sheets

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -80,9 +80,6 @@ export default class ItemSheet5e extends ItemSheet {
         async: true
       }),
 
-      // Potential consumption targets
-      abilityConsumptionTargets: this._getItemConsumptionTargets(item),
-
       // Action Details
       hasAttackRoll: item.hasAttack,
       isHealing: item.system.actionType === "heal",
@@ -104,6 +101,9 @@ export default class ItemSheet5e extends ItemSheet {
       // Prepare Active Effects
       effects: ActiveEffect5e.prepareActiveEffectCategories(item.effects)
     });
+
+    // Potential consumption targets
+    context.abilityConsumptionTargets = this._getItemConsumptionTargets(item);
 
     /** @deprecated */
     Object.defineProperty(context, "data", {


### PR DESCRIPTION
Resolves #1741

### Problem
The output of `_getItemConsumptionTargets` is an object with keys that look like paths to user data:
```js
{
  'resources.primary.value': 'resources.primary.value'
  // etc
}
```

When `mergeObject` encounters such a thing, it expands the path into an object.

```js
{
  resources: { primary: { value: 'resources.primary.value' } }
}
```

### Solution
Instead of using `mergeObject` to apply abilityConsumptionTargets, mutate `context` directly, as we did pre-v10-refactor.