### PR TITLE
[#1743] Fix stealth input having a value

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1156,7 +1156,7 @@ export default class Item5e extends Item {
     props.push(
       CONFIG.DND5E.equipmentTypes[data.armor.type],
       labels.armor || null,
-      data.stealth.value ? game.i18n.localize("DND5E.StealthDisadvantage") : null
+      data.stealth ? game.i18n.localize("DND5E.StealthDisadvantage") : null
     );
   }
 

--- a/templates/items/equipment.hbs
+++ b/templates/items/equipment.hbs
@@ -121,7 +121,7 @@
             {{!-- Stealth Disadvantage --}}
             <div class="form-group">
                 <label>{{ localize "DND5E.ItemEquipmentStealthDisav" }}</label>
-                <input type="checkbox" name="system.stealth" value="1" {{checked system.stealth}}/>
+                <input type="checkbox" name="system.stealth" {{checked system.stealth}}/>
             </div>
             {{/if}}
 


### PR DESCRIPTION
Resolves #1743 

The `stealth` field of an equipment item document should be a boolean, but the input has a `value="1"` attribute, causing it to be saved incorrectly when the item is edited.

This in turn causes a problem when attempting to get `_equipmentChatData`, since `value` isn't necessary to check the boolean toggle.