### PR TITLE
Allow drag and drop of effects on items

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -31,7 +31,7 @@ export default class ItemSheet5e extends ItemSheet {
       resizable: true,
       scrollY: [".tab.details"],
       tabs: [{navSelector: ".tabs", contentSelector: ".sheet-body", initial: "description"}],
-      dragDrop: [{dragSelector: "[data-effect-id]", dropSelector: '.effects-list'}],
+      dragDrop: [{dragSelector: "[data-effect-id]", dropSelector: ".effects-list"}],
     });
   }
 
@@ -539,7 +539,7 @@ export default class ItemSheet5e extends ItemSheet {
      * @param {object} data                  The data that has been dropped onto the sheet
      * @returns {boolean}                    Explicitly return `false` to prevent normal drop handling.
      */
-    const allowed = Hooks.call('dnd5e.dropItemSheetData', item, this, data);
+    const allowed = Hooks.call("dnd5e.dropItemSheetData", item, this, data);
     if ( allowed === false ) return;
 
     switch ( data.type ) {
@@ -559,7 +559,7 @@ export default class ItemSheet5e extends ItemSheet {
   async _onDropActiveEffect(event, data) {
     const effect = await ActiveEffect.implementation.fromDropData(data);
     if ( !this.item.isOwner || !effect ) return false;
-    if ( this.item.uuid === effect.parent.uuid || this.item.uuid === effect.origin ) return false;
+    if ( (this.item.uuid === effect.parent.uuid) || (this.item.uuid === effect.origin) ) return false;
     return ActiveEffect.create({
       ...effect.toObject(),
       origin: this.item.uuid,

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -555,6 +555,7 @@ export default class ItemSheet5e extends ItemSheet {
    * @param {DragEvent} event                  The concluding DragEvent which contains drop data
    * @param {object} data                      The data transfer extracted from the event
    * @returns {Promise<ActiveEffect|boolean>}  The created ActiveEffect object or false if it couldn't be created.
+   * @protected
    */
   async _onDropActiveEffect(event, data) {
     const effect = await ActiveEffect.implementation.fromDropData(data);


### PR DESCRIPTION
This change introduces drag and drop handlers for the Item Sheet to allow Effects to be dragged and dropped between items.

This also allows effects to be drag and dropped from an item onto an actor to emulate applying the effect.

### Use Cases:
- Having configured a "Poisoned Dagger" with a "Poisioned" Effect, I would like to be able to quickly copy that effect to a "Poisioned Longsword".
  - Said items would not need to transfer their effect to their parent actor in order for the GM to use them on enemies.
- An item which replicates the effects of a spell that has active effects configured can quickly clone the effect of that spell.

### Methodology
Copies what core does for dropping active effects on Actor Sheets, with one change:
- Sets the `origin` of the created effect to be the `uuid` of the new parent item.

### Research
I've been doing this with with the module: Drop Effects on Items for several months and it's been very useful.