### PR TITLE
[#1276, #1531] Implement variant encumbrance option rule

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -1210,26 +1210,12 @@
   position: relative;
 }
 .dnd5e.sheet.actor .encumbrance .encumbrance-bar {
-  --encumbered-0-color: #6c8aa5;
-  --encumbered-33-color: #7e8197;
-  --encumbered-66-color: #907789;
-  --encumbered-max-color: #a56c79;
   position: absolute;
   top: 1px;
   left: 1px;
-  background: var(--encumbered-0-color);
   height: 8px;
   border: 1px solid #cde4ff;
   border-radius: 2px;
-}
-.dnd5e.sheet.actor .encumbrance.encumbered-33 .encumbrance-bar {
-  background: var(--encumbered-33-color);
-}
-.dnd5e.sheet.actor .encumbrance.encumbered-66 .encumbrance-bar {
-  background: var(--encumbered-66-color);
-}
-.dnd5e.sheet.actor .encumbrance.encumbered-max .encumbrance-bar {
-  background: var(--encumbered-max-color);
 }
 .dnd5e.sheet.actor .encumbrance .encumbrance-label {
   height: 10px;
@@ -1247,12 +1233,6 @@
   display: block;
   position: absolute;
 }
-.dnd5e.sheet.actor .encumbrance .encumbrance-breakpoint.encumbrance-33 {
-  left: 33%;
-}
-.dnd5e.sheet.actor .encumbrance .encumbrance-breakpoint.encumbrance-66 {
-  left: 66%;
-}
 .dnd5e.sheet.actor .encumbrance .arrow-up {
   bottom: 0;
   width: 0;
@@ -1260,6 +1240,9 @@
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
   border-bottom: 4px solid #666;
+}
+.dnd5e.sheet.actor .encumbrance .arrow-up.encumbered {
+  border-bottom: 4px solid #000;
 }
 .dnd5e.sheet.actor .encumbrance .arrow-down {
   top: 0;
@@ -1269,22 +1252,7 @@
   border-right: 4px solid transparent;
   border-top: 4px solid #666;
 }
-.dnd5e.sheet.actor .encumbrance.encumbered-33 .encumbrance-33.arrow-up {
-  border-bottom: 4px solid #000;
-}
-.dnd5e.sheet.actor .encumbrance.encumbered-33 .encumbrance-33.arrow-down {
-  border-top: 4px solid #000;
-}
-.dnd5e.sheet.actor .encumbrance.encumbered-66 .arrow-up {
-  border-bottom: 4px solid #000;
-}
-.dnd5e.sheet.actor .encumbrance.encumbered-66 .arrow-down {
-  border-top: 4px solid #000;
-}
-.dnd5e.sheet.actor .encumbrance.encumbered-max .arrow-up {
-  border-bottom: 4px solid #000;
-}
-.dnd5e.sheet.actor .encumbrance.encumbered-max .arrow-down {
+.dnd5e.sheet.actor .encumbrance .arrow-down.encumbered {
   border-top: 4px solid #000;
 }
 .dnd5e.sheet.actor .spellcasting-ability {

--- a/dnd5e.css
+++ b/dnd5e.css
@@ -1210,13 +1210,26 @@
   position: relative;
 }
 .dnd5e.sheet.actor .encumbrance .encumbrance-bar {
+  --encumbered-0-color: #6c8aa5;
+  --encumbered-33-color: #7e8197;
+  --encumbered-66-color: #907789;
+  --encumbered-max-color: #a56c79;
   position: absolute;
   top: 1px;
   left: 1px;
-  background: #6c8aa5;
+  background: var(--encumbered-0-color);
   height: 8px;
   border: 1px solid #cde4ff;
   border-radius: 2px;
+}
+.dnd5e.sheet.actor .encumbrance.encumbered-33 .encumbrance-bar {
+  background: var(--encumbered-33-color);
+}
+.dnd5e.sheet.actor .encumbrance.encumbered-66 .encumbrance-bar {
+  background: var(--encumbered-66-color);
+}
+.dnd5e.sheet.actor .encumbrance.encumbered-max .encumbrance-bar {
+  background: var(--encumbered-max-color);
 }
 .dnd5e.sheet.actor .encumbrance .encumbrance-label {
   height: 10px;
@@ -1256,10 +1269,22 @@
   border-right: 4px solid transparent;
   border-top: 4px solid #666;
 }
-.dnd5e.sheet.actor .encumbrance.encumbered .arrow-up {
+.dnd5e.sheet.actor .encumbrance.encumbered-33 .encumbrance-33.arrow-up {
   border-bottom: 4px solid #000;
 }
-.dnd5e.sheet.actor .encumbrance.encumbered .arrow-down {
+.dnd5e.sheet.actor .encumbrance.encumbered-33 .encumbrance-33.arrow-down {
+  border-top: 4px solid #000;
+}
+.dnd5e.sheet.actor .encumbrance.encumbered-66 .arrow-up {
+  border-bottom: 4px solid #000;
+}
+.dnd5e.sheet.actor .encumbrance.encumbered-66 .arrow-down {
+  border-top: 4px solid #000;
+}
+.dnd5e.sheet.actor .encumbrance.encumbered-max .arrow-up {
+  border-bottom: 4px solid #000;
+}
+.dnd5e.sheet.actor .encumbrance.encumbered-max .arrow-down {
   border-top: 4px solid #000;
 }
 .dnd5e.sheet.actor .spellcasting-ability {

--- a/lang/en.json
+++ b/lang/en.json
@@ -961,6 +961,10 @@
 "DND5E.of": "of",
 "DND5E.per": "per",
 "DND5E.spell": "spell",
+"DND5E.Unencumbered": "Unencumbered",
+"DND5E.Encumbered": "Encumbered",
+"DND5E.HeavilyEncumbered": "Heavily Encumbered",
+"DND5E.ExceedingCarryingCapacity": "Exceeding Carrying Capacity",
 
 "MACRO.5eMissingTargetWarn": "Your controlled actor '{actor}' does not have an {type} with name '{name}'.",
 "MACRO.5eMultipleTargetsWarn": "Your controlled actor '{actor}' has more than one {type} with name '{name}'. The first match will be chosen.",
@@ -1010,5 +1014,7 @@
 "SETTINGS.5eRestEpic": "Epic Heroism (LR: 1 hour, SR: 1 min)",
 "SETTINGS.5eSanityL": "Enable the use of the optional Sanity ability score. Requires the world to be reloaded.",
 "SETTINGS.5eSanityN": "Sanity Ability Score",
-"SETTINGS.5eUndoChanges": "Undo Changes"
+"SETTINGS.5eUndoChanges": "Undo Changes",
+"SETTINGS.5eVarEncumbranceL": "Use the variant encumbrance rules from the PHB pg. 176.",
+"SETTINGS.5eVarEncumbranceN": "Use Variant Encumbrance Rules"
 }

--- a/less/actors.less
+++ b/less/actors.less
@@ -583,29 +583,12 @@
     position: relative;
 
     .encumbrance-bar {
-      --encumbered-0-color: #6c8aa5;
-      --encumbered-33-color: #7e8197;
-      --encumbered-66-color: #907789;
-      --encumbered-max-color: #a56c79;
       position: absolute;
       top: 1px;
       left: 1px;
-      background: var(--encumbered-0-color);
       height: 8px;
       border: 1px solid #cde4ff;
       border-radius: 2px;
-    }
-
-    &.encumbered-33 .encumbrance-bar {
-      background: var(--encumbered-33-color);
-    }
-
-    &.encumbered-66 .encumbrance-bar {
-      background: var(--encumbered-66-color);
-    }
-
-    &.encumbered-max .encumbrance-bar {
-      background: var(--encumbered-max-color);
     }
 
     .encumbrance-label {
@@ -624,8 +607,6 @@
     .encumbrance-breakpoint {
       display: block;
       position: absolute;
-      &.encumbrance-33 { left: 33% }
-      &.encumbrance-66 { left: 66% }
     }
 
     .arrow-up {
@@ -635,6 +616,10 @@
       border-left: 4px solid transparent;
       border-right: 4px solid transparent;
       border-bottom: 4px solid #666;
+
+      &.encumbered {
+        border-bottom: 4px solid #000;
+      }
     }
 
     .arrow-down {
@@ -644,21 +629,10 @@
       border-left: 4px solid transparent;
       border-right: 4px solid transparent;
       border-top: 4px solid #666;
-    }
 
-    &.encumbered-33 {
-      .encumbrance-33.arrow-up { border-bottom: 4px solid #000; }
-      .encumbrance-33.arrow-down { border-top: 4px solid #000; }
-    }
-
-    &.encumbered-66 {
-      .arrow-up { border-bottom: 4px solid #000; }
-      .arrow-down { border-top: 4px solid #000; }
-    }
-
-    &.encumbered-max {
-      .arrow-up { border-bottom: 4px solid #000; }
-      .arrow-down { border-top: 4px solid #000; }
+      &.encumbered {
+        border-top: 4px solid #000;
+      }
     }
   }
 

--- a/less/actors.less
+++ b/less/actors.less
@@ -583,13 +583,29 @@
     position: relative;
 
     .encumbrance-bar {
+      --encumbered-0-color: #6c8aa5;
+      --encumbered-33-color: #7e8197;
+      --encumbered-66-color: #907789;
+      --encumbered-max-color: #a56c79;
       position: absolute;
       top: 1px;
       left: 1px;
-      background: #6c8aa5;
+      background: var(--encumbered-0-color);
       height: 8px;
       border: 1px solid #cde4ff;
       border-radius: 2px;
+    }
+
+    &.encumbered-33 .encumbrance-bar {
+      background: var(--encumbered-33-color);
+    }
+
+    &.encumbered-66 .encumbrance-bar {
+      background: var(--encumbered-66-color);
+    }
+
+    &.encumbered-max .encumbrance-bar {
+      background: var(--encumbered-max-color);
     }
 
     .encumbrance-label {
@@ -630,7 +646,17 @@
       border-top: 4px solid #666;
     }
 
-    &.encumbered {
+    &.encumbered-33 {
+      .encumbrance-33.arrow-up { border-bottom: 4px solid #000; }
+      .encumbrance-33.arrow-down { border-top: 4px solid #000; }
+    }
+
+    &.encumbered-66 {
+      .arrow-up { border-bottom: 4px solid #000; }
+      .arrow-down { border-top: 4px solid #000; }
+    }
+
+    &.encumbered-max {
       .arrow-up { border-bottom: 4px solid #000; }
       .arrow-down { border-top: 4px solid #000; }
     }

--- a/module/applications/actor/type-config.mjs
+++ b/module/applications/actor/type-config.mjs
@@ -67,7 +67,7 @@ export default class ActorTypeConfig extends FormApplication {
       subtype: attr.subtype,
       swarm: attr.swarm,
       sizes: Array.from(Object.entries(CONFIG.DND5E.actorSizes)).reverse().reduce((obj, e) => {
-        obj[e[0]] = e[1];
+        obj[e[0]] = e[1].label;
         return obj;
       }, {}),
       preview: Actor5e.formatCreatureType(attr) || "–"

--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -56,7 +56,17 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
     // Compute overall encumbrance
     const max = actorData.system.attributes.capacity.cargo;
     const pct = Math.clamped((totalWeight * 100) / max, 0, 100);
-    return {value: totalWeight.toNearest(0.1), max, pct};
+
+    let { tooltip, color } = CONFIG.DND5E.encumbrance.bar;
+    if ( totalWeight > max ) {
+      ({ tooltip, color } = CONFIG.DND5E.encumbrance.maxCapacity);
+    }
+
+    return {
+      breakpoints: [33, 66],
+      color, max, pct, tooltip,
+      value: totalWeight.toNearest(0.1)
+    };
   }
 
   /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -324,18 +324,41 @@ preLocalize("abilityConsumptionTypes", { sort: true });
 /* -------------------------------------------- */
 
 /**
- * Creature sizes.
- * @enum {string}
+ * Various sizes that an actor can be.
+ * @enum {ActorSizeConfiguration}
  */
 DND5E.actorSizes = {
-  tiny: "DND5E.SizeTiny",
-  sm: "DND5E.SizeSmall",
-  med: "DND5E.SizeMedium",
-  lg: "DND5E.SizeLarge",
-  huge: "DND5E.SizeHuge",
-  grg: "DND5E.SizeGargantuan"
+  tiny: {
+    label: "DND5E.SizeTiny",
+    encumbranceMultiplier: 0.5,
+    next: "small"
+  },
+  small: {
+    label: "DND5E.SizeSmall",
+    encumbranceMultiplier: 1,
+    next: "med"
+  },
+  med: {
+    label: "DND5E.SizeMedium",
+    encumbranceMultiplier: 1,
+    next: "lg"
+  },
+  lg: {
+    label: "DND5E.SizeLarge",
+    encumbranceMultiplier: 2,
+    next: "huge"
+  },
+  huge: {
+    label: "DND5E.SizeHuge",
+    encumbranceMultiplier: 4,
+    next: "grg"
+  },
+  grg: {
+    label: "DND5E.SizeGargantuan",
+    encumbranceMultiplier: 8
+  }
 };
-preLocalize("actorSizes");
+preLocalize("actorSizes", { key: "label" });
 
 /**
  * Default token image size for the values of `DND5E.actorSizes`.
@@ -761,6 +784,32 @@ DND5E.encumbrance = {
   strMultiplier: {
     imperial: 15,
     metric: 6.8
+  },
+  variant: {
+    0: {
+      name: "DND5E.Unencumbered"
+    },
+    33: {
+      name: "DND5E.Encumbered",
+      strMultiplier: {
+        imperial: 5,
+        metric: 2.2
+      }
+    },
+    66: {
+      name: "DND5E.HeavilyEncumbered",
+      strMultiplier: {
+        imperial: 10,
+        metric: 4.5
+      }
+    },
+    max: {
+      name: "DND5E.ExceedingCarryingCapacity",
+      strMultiplier: {
+        imperial: 15,
+        metric: 6.8
+      }
+    }
   },
   vehicleWeightMultiplier: {
     imperial: 2000, // 2000 lbs in an imperial ton

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -781,36 +781,36 @@ DND5E.encumbrance = {
     imperial: 50,
     metric: 110
   },
-  strMultiplier: {
-    imperial: 15,
-    metric: 6.8
+  bar: {
+    tooltip: "DND5E.Unencumbered",
+    color: "#6c8aa5"
   },
-  variant: {
-    0: {
-      name: "DND5E.Unencumbered"
-    },
-    33: {
-      name: "DND5E.Encumbered",
+  maxCapacity: {
+    tooltip: "DND5E.ExceedingCarryingCapacity",
+    color: "#a56c79",
+    strMultiplier: {
+      imperial: 15,
+      metric: 6.8
+    }
+  },
+  variant: [ // these should be defined in ascending order of strMultiplier
+    {
+      tooltip: "DND5E.Encumbered",
+      color: "#7f8096",
       strMultiplier: {
         imperial: 5,
         metric: 2.2
       }
     },
-    66: {
-      name: "DND5E.HeavilyEncumbered",
+    {
+      tooltip: "DND5E.HeavilyEncumbered",
+      color: "#927688",
       strMultiplier: {
         imperial: 10,
         metric: 4.5
       }
-    },
-    max: {
-      name: "DND5E.ExceedingCarryingCapacity",
-      strMultiplier: {
-        imperial: 15,
-        metric: 6.8
-      }
     }
-  },
+  ],
   vehicleWeightMultiplier: {
     imperial: 2000, // 2000 lbs in an imperial ton
     metric: 1000 // 1000 kg in a metric ton

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -521,14 +521,7 @@ export default class Actor5e extends Actor {
     const encumbrance = this.system.attributes.encumbrance ??= {};
     const units = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
 
-    // Get the total weight from items
-    const physicalItems = ["weapon", "equipment", "consumable", "tool", "backpack", "loot"];
-    let weight = this.items.reduce((weight, i) => {
-      if ( !physicalItems.includes(i.type) ) return weight;
-      const q = i.system.quantity || 0;
-      const w = i.system.weight || 0;
-      return weight + (q * w);
-    }, 0);
+    let weight = this._tallyInventoryEncumbrance();
 
     // [Optional] add Currency Weight (for non-transformed actors)
     const currency = this.system.currency;
@@ -537,7 +530,7 @@ export default class Actor5e extends Actor {
       weight += numCoins / CONFIG.DND5E.encumbrance.currencyPerWeight[units];
     }
 
-    weight = weight.toNearest(0.1);
+    weight = weight.toNearest(0.1)
 
     let size = CONFIG.DND5E.actorSizes[this.system.traits.size]
       || CONFIG.DND5E.actorSizes.med;
@@ -578,6 +571,22 @@ export default class Actor5e extends Actor {
     encumbrance.pct = Math.clamped((weight * 100) / max, 0, 100);
     encumbrance.level = level;
     encumbrance.name = name;
+  }
+
+  /** Tally the total weight of Items that the Actor is carrying, excluding
+   * currency and any items types that shouldn't contribute to encumbrance.
+   * @protected
+   * @returns {number} the total weight
+   */
+  _tallyInventoryEncumbrance() {
+    const physicalItems = ["weapon", "equipment", "consumable", "tool", "backpack", "loot"];
+
+    return this.items.reduce((weight, i) => {
+      if ( !physicalItems.includes(i.type) ) return weight;
+      const q = i.system.quantity || 0;
+      const w = i.system.weight || 0;
+      return weight + (q * w);
+    }, 0);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -518,6 +518,7 @@ export default class Actor5e extends Actor {
    * @protected
    */
   _prepareEncumbrance() {
+    const config = CONFIG.DND5E.encumbrance;
     const encumbrance = this.system.attributes.encumbrance ??= {};
     const units = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
 
@@ -527,10 +528,10 @@ export default class Actor5e extends Actor {
     const currency = this.system.currency;
     if ( game.settings.get("dnd5e", "currencyWeight") && currency ) {
       const numCoins = Object.values(currency).reduce((val, denom) => val + Math.max(denom, 0), 0);
-      weight += numCoins / CONFIG.DND5E.encumbrance.currencyPerWeight[units];
+      weight += numCoins / config.currencyPerWeight[units];
     }
 
-    weight = weight.toNearest(0.1)
+    weight = weight.toNearest(0.1);
 
     let size = CONFIG.DND5E.actorSizes[this.system.traits.size]
       || CONFIG.DND5E.actorSizes.med;
@@ -540,37 +541,38 @@ export default class Actor5e extends Actor {
     }
 
     const sizeMultiplier = size.encumbranceMultiplier || 1;
+    const strMultiplier = config.maxCapacity.strMultiplier[units];
     const strValue = this.system.abilities.str.value ?? 10;
+    const max = (strValue * strMultiplier * sizeMultiplier).toNearest(0.1);
 
-    let max = 0;
-    let level = "0";
-    let name = "DND5E.Unencumbered";
+    let breakpoints = [33, 66];
+    let { tooltip, color } = config.bar;
 
     if ( game.settings.get("dnd5e", "variantEncumbrance") ) {
-      const levels = CONFIG.DND5E.encumbrance.variant;
-      for ( const l of ["33", "66", "max"] ) {
-        const strMultiplier = levels[l].strMultiplier[units];
-        max = (strValue * strMultiplier * sizeMultiplier).toNearest(0.1);
-        if ( weight > max ) {
-          level = l;
-          name = levels[l].name;
+      breakpoints = [];
+      for ( const level of config.variant ) {
+        const strMultiplier = level.strMultiplier[units];
+        const limit = (strValue * strMultiplier * sizeMultiplier).toNearest(0.1);
+        if ( weight > limit ) {
+          ({ tooltip, color } = level);
         }
+        breakpoints.push(Math.clamped((limit * 100) / max, 0, 100).toNearest(1));
       }
     } else {
-      const strMultiplier = CONFIG.DND5E.encumbrance.strMultiplier[units];
-      max = (strValue * strMultiplier * sizeMultiplier).toNearest(0.1);
-      if ( weight > max ) {
-        level = "max";
-        name = "DND5E.Encumbered";
-      }
+      tooltip = null;
+    }
+
+    if ( weight > max ) {
+      ({ tooltip, color } = config.maxCapacity);
     }
 
     // Populate final Encumbrance values
     encumbrance.value = weight;
+    encumbrance.tooltip = tooltip;
     encumbrance.max = max;
     encumbrance.pct = Math.clamped((weight * 100) / max, 0, 100);
-    encumbrance.level = level;
-    encumbrance.name = name;
+    encumbrance.breakpoints = breakpoints;
+    encumbrance.color = color;
   }
 
   /** Tally the total weight of Items that the Actor is carrying, excluding

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -519,6 +519,7 @@ export default class Actor5e extends Actor {
    */
   _prepareEncumbrance() {
     const encumbrance = this.system.attributes.encumbrance ??= {};
+    const units = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
 
     // Get the total weight from items
     const physicalItems = ["weapon", "equipment", "consumable", "tool", "backpack", "loot"];
@@ -533,25 +534,50 @@ export default class Actor5e extends Actor {
     const currency = this.system.currency;
     if ( game.settings.get("dnd5e", "currencyWeight") && currency ) {
       const numCoins = Object.values(currency).reduce((val, denom) => val + Math.max(denom, 0), 0);
-      const currencyPerWeight = game.settings.get("dnd5e", "metricWeightUnits")
-        ? CONFIG.DND5E.encumbrance.currencyPerWeight.metric
-        : CONFIG.DND5E.encumbrance.currencyPerWeight.imperial;
-      weight += numCoins / currencyPerWeight;
+      weight += numCoins / CONFIG.DND5E.encumbrance.currencyPerWeight[units];
     }
 
-    // Determine the Encumbrance size class
-    let mod = {tiny: 0.5, sm: 1, med: 1, lg: 2, huge: 4, grg: 8}[this.system.traits.size] || 1;
-    if ( this.flags.dnd5e?.powerfulBuild ) mod = Math.min(mod * 2, 8);
+    weight = weight.toNearest(0.1);
 
-    const strengthMultiplier = game.settings.get("dnd5e", "metricWeightUnits")
-      ? CONFIG.DND5E.encumbrance.strMultiplier.metric
-      : CONFIG.DND5E.encumbrance.strMultiplier.imperial;
+    let size = CONFIG.DND5E.actorSizes[this.system.traits.size]
+      || CONFIG.DND5E.actorSizes.med;
+
+    if ( this.getFlag("dnd5e", "powerfulBuild") ) {
+      size = CONFIG.DND5E.actorSizes[size.next];
+    }
+
+    const sizeMultiplier = size.encumbranceMultiplier || 1;
+    const strValue = this.system.abilities.str.value ?? 10;
+
+    let max = 0;
+    let level = "0";
+    let name = "DND5E.Unencumbered";
+
+    if ( game.settings.get("dnd5e", "variantEncumbrance") ) {
+      const levels = CONFIG.DND5E.encumbrance.variant;
+      for ( const l of ["33", "66", "max"] ) {
+        const strMultiplier = levels[l].strMultiplier[units];
+        max = (strValue * strMultiplier * sizeMultiplier).toNearest(0.1);
+        if ( weight > max ) {
+          level = l;
+          name = levels[l].name;
+        }
+      }
+    } else {
+      const strMultiplier = CONFIG.DND5E.encumbrance.strMultiplier[units];
+      max = (strValue * strMultiplier * sizeMultiplier).toNearest(0.1);
+      if ( weight > max ) {
+        level = "max";
+        name = "DND5E.Encumbered";
+      }
+    }
 
     // Populate final Encumbrance values
-    encumbrance.value = weight.toNearest(0.1);
-    encumbrance.max = ((this.system.abilities.str?.value ?? 10) * strengthMultiplier * mod).toNearest(0.1);
-    encumbrance.pct = Math.clamped((encumbrance.value * 100) / encumbrance.max, 0, 100);
-    encumbrance.encumbered = encumbrance.pct > (200 / 3);
+    encumbrance.value = weight;
+    encumbrance.max = max;
+    encumbrance.pct = Math.clamped((weight * 100) / max, 0, 100);
+    encumbrance.level = level;
+    encumbrance.name = name;
   }
 
   /* -------------------------------------------- */
@@ -2065,7 +2091,7 @@ export default class Actor5e extends Actor {
     let type = localizedType;
     if ( typeData.swarm ) {
       type = game.i18n.format("DND5E.CreatureSwarmPhrase", {
-        size: game.i18n.localize(CONFIG.DND5E.actorSizes[typeData.swarm]),
+        size: game.i18n.localize(CONFIG.DND5E.actorSizes[typeData.swarm].label),
         type: localizedType
       });
     }

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -127,7 +127,7 @@ function applyChatCardDamage(li, multiplier) {
 }
 
 /* -------------------------------------------- */
- 
+
 /**
  * Apply rolled dice as temporary hit points to the controlled token(s).
  * @param {HTMLElement} li  The chat entry which contains the roll data

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -515,7 +515,7 @@ function _migrateActorType(actor, updateData) {
     if ( match.groups.size || isNamedSwarm ) {
       const sizeLc = match.groups.size ? match.groups.size.trim().toLowerCase() : "tiny";
       const sizeMatch = Object.entries(CONFIG.DND5E.actorSizes).find(([k, v]) => {
-        return (sizeLc === k) || (sizeLc === game.i18n.localize(v).toLowerCase());
+        return (sizeLc === k) || (sizeLc === game.i18n.localize(v.label).toLowerCase());
       });
       actorTypeData.swarm = sizeMatch ? sizeMatch[0] : "tiny";
     }

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -171,6 +171,15 @@ export default function registerSystemSettings() {
     default: false
   });
 
+  game.settings.register("dnd5e", "variantEncumbrance", {
+    name: "SETTINGS.5eVarEncumbranceN",
+    hint: "SETTINGS.5eVarEncumbranceL",
+    scope: "world",
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
   // Critical Damage Modifiers
   game.settings.register("dnd5e", "criticalDamageModifiers", {
     name: "SETTINGS.5eCriticalModifiersN",

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -29,7 +29,7 @@
             {{!-- Character Summary --}}
             <ul class="summary flexrow">
                 <li>
-                    <span>{{lookup config.actorSizes system.traits.size}}</span>
+                    <span>{{#with (lookup config.actorSizes system.traits.size)}}{{label}}{{/with}}</span>
                 </li>
                 <li>
                     <input type="text" name="system.details.alignment" value="{{system.details.alignment}}" placeholder="{{ localize 'DND5E.Alignment' }}"/>

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -129,13 +129,13 @@
 
 {{#unless isNPC}}
 {{#with system.attributes.encumbrance}}
-<div class="encumbrance encumbered-{{level}}">
-    <span class="encumbrance-bar" style="width:{{pct}}%" data-tooltip="{{localize name}}"></span>
+<div class="encumbrance">
+    <span class="encumbrance-bar" style="width:{{pct}}%; background: {{color}};" {{#if tooltip}}data-tooltip="{{localize tooltip}}"{{/if}}></span>
     <span class="encumbrance-label">{{value}} / {{max}}</span>
-    <i class="encumbrance-breakpoint encumbrance-33 arrow-up"></i>
-    <i class="encumbrance-breakpoint encumbrance-33 arrow-down"></i>
-    <i class="encumbrance-breakpoint encumbrance-66 arrow-up"></i>
-    <i class="encumbrance-breakpoint encumbrance-66 arrow-down"></i>
+    {{#each breakpoints}}
+    <i class="encumbrance-breakpoint arrow-up{{#if (gt ../pct this)}} encumbered{{/if}}" style="left: {{this}}%"></i>
+    <i class="encumbrance-breakpoint arrow-down{{#if (gt ../pct this)}} encumbered{{/if}}" style="left: {{this}}%"></i>
+    {{/each}}
 </div>
 {{/with}}
 {{/unless}}

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -129,8 +129,8 @@
 
 {{#unless isNPC}}
 {{#with system.attributes.encumbrance}}
-<div class="encumbrance {{#if encumbered}}encumbered{{/if}}">
-    <span class="encumbrance-bar" style="width:{{pct}}%"></span>
+<div class="encumbrance encumbered-{{level}}">
+    <span class="encumbrance-bar" style="width:{{pct}}%" data-tooltip="{{localize name}}"></span>
     <span class="encumbrance-label">{{value}} / {{max}}</span>
     <i class="encumbrance-breakpoint encumbrance-33 arrow-up"></i>
     <i class="encumbrance-breakpoint encumbrance-33 arrow-down"></i>

--- a/templates/actors/parts/actor-traits.hbs
+++ b/templates/actors/parts/actor-traits.hbs
@@ -3,8 +3,8 @@
         <label>{{localize "DND5E.Size"}}</label>
         <select class="actor-size" name="system.traits.size">
             {{#select system.traits.size}}
-            {{#each config.actorSizes as |label size|}}
-                <option value="{{size}}">{{label}}</option>
+            {{#each config.actorSizes as |data size|}}
+                <option value="{{size}}">{{data.label}}</option>
             {{/each}}
             {{/select}}
         </select>

--- a/templates/actors/vehicle-sheet.hbs
+++ b/templates/actors/vehicle-sheet.hbs
@@ -10,7 +10,7 @@
             </h1>
             <ul class="summary flexrow">
                 <li>
-                    <span>{{lookup config.actorSizes system.traits.size}}</span>
+                    <span>{{#with (lookup config.actorSizes system.traits.size)}}{{label}}{{/with}}</span>
                 </li>
                 <li>
                     <select name="system.vehicleType">


### PR DESCRIPTION
This adds a toggle to the DnD5E system settings called "Use Variant Encumbrance Rules". If enabled, the encumbrance bar starts to turn from the default blue to a more purple/red as it passes the various thresholds. Please suggest better colours! A tooltip is also added to the entire encumbrance bar at each stage.

![image](https://user-images.githubusercontent.com/487715/188706701-f36e924a-16b1-4587-8e98-97908180c724.png)

The rules don't have defined terms for "below 'Encumbered' (<5 times STR score) or "above 'heavily encumbered'" (>15 times STR score), so I used the words "Unencumbered" and "Over Encumbered" for the tooltip on those stages.

I have another commit that consolidates `tokenSizes` into `actorSizes` as recommended [here](https://github.com/foundryvtt/dnd5e/pull/1623#discussion_r912129520), and can add it to the PR if that's still a desirable change.

I'm also trying to sneak in a whitespace fix that was annoying me every time I ran the linter with `--fix`. I can open another PR for it if you'd rather.

----------------

I'd like to consider also adding status effects for the encumbrance levels above "Unencumbered" in this PR, but I'm unsure if they should be active effects or not. The speed modifications should be easy, the only question is if they should apply to all speeds or just walking/land speed. I'm pretty sure the former, but it's up for debate. However, if I understand the current state of active effects correctly, then we can't add the second effect of "Heavily Encumbered" (which is "disadvantage on d20 tests involving the 3 physical attributes"), right?

----------------

Closes [#1276]. May also fix [#1531].