### PR TITLE
[#1777] Check to ensure advancement can be created on item before duplication

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -429,7 +429,7 @@ export default class ItemSheet5e extends ItemSheet {
     }
 
     // Advancement context menu
-    const contextOptions = this.#getAdvancementContextMenuOptions();
+    const contextOptions = this._getAdvancementContextMenuOptions();
     /**
      * A hook event that fires when the context menu for the advancements list is constructed.
      * @function dnd5e.getItemAdvancementContext
@@ -446,9 +446,9 @@ export default class ItemSheet5e extends ItemSheet {
   /**
    * Get the set of ContextMenu options which should be applied for advancement entries.
    * @returns {ContextMenuEntry[]}  Context menu entries.
-   * @private
+   * @protected
    */
-  #getAdvancementContextMenuOptions() {
+  _getAdvancementContextMenuOptions() {
     const condition = li => (this.advancementConfigurationMode || !this.isEmbedded) && this.isEditable;
     return [
       {

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -460,7 +460,11 @@ export default class ItemSheet5e extends ItemSheet {
       {
         name: "DND5E.AdvancementControlDuplicate",
         icon: "<i class='fas fa-copy fa-fw'></i>",
-        condition,
+        condition: li => {
+          const id = li[0].closest(".advancement-item")?.dataset.id;
+          const advancement = this.item.advancement.byId[id];
+          return condition(li) && advancement?.constructor.availableForItem(this.item);
+        },
         callback: li => this._onAdvancementAction(li[0], "duplicate")
       },
       {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1909,6 +1909,10 @@ export default class Item5e extends Item {
     if ( !Advancement ) throw new Error(`${type}Advancement not found in dnd5e.advancement.types`);
     data = foundry.utils.mergeObject(Advancement.defaultData, data);
 
+    if ( !Advancement.metadata.validItemTypes.has(this.type) || !Advancement.availableForItem(this) ) {
+      throw new Error(`${type} advancement cannot be added to ${this.name}`);
+    }
+
     const advancement = this.toObject().system.advancement;
     if ( !data._id ) data._id = foundry.utils.randomID();
     advancement.push(data);


### PR DESCRIPTION
Ensures you cannot use the new Duplicate Advancement method to create invalid configurations, such as two Hit Points Advancements on a single class.