### PR TITLE
[#1776, #1810, #1811] Fix various bugs

### DIFF
--- a/module/applications/actor/skill-config.mjs
+++ b/module/applications/actor/skill-config.mjs
@@ -40,7 +40,7 @@ export default class ActorSkillConfig extends DocumentSheet {
       skill: src.system.skills?.[this._skillId] || {},
       skillId: this._skillId,
       proficiencyLevels: CONFIG.DND5E.proficiencyLevels,
-      bonusGlobal: src.system.bonuses?.skill
+      bonusGlobal: src.system.bonuses?.abilities.skill
     };
   }
 

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -401,7 +401,7 @@ export default class ItemSheet5e extends ItemSheet {
       const match = formData.system.identifier.match(dataRgx);
       if ( !match ) {
         formData.system.identifier = this.item._source.system.identifier;
-        this.form.querySelector("input[name='data.identifier']").value = formData.system.identifier;
+        this.form.querySelector("input[name='system.identifier']").value = formData.system.identifier;
         return ui.notifications.error(game.i18n.localize("DND5E.IdentifierError"));
       }
     }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -745,6 +745,7 @@ export default class Item5e extends Item {
       if ( upcastLevel && (upcastLevel !== is.level) ) {
         item = item.clone({"system.level": upcastLevel}, {keepId: true});
         item.prepareData();
+        item.prepareFinalAttributes();
       }
     }
 


### PR DESCRIPTION
- Fix bug with Global Skill Check Bonus not appearing in Skill Config dialog (resolves #1776)
- Fix bug with `prepareFinalAttributes` not being called on upcast spells (resolves #1810)
- Fix bug when invalid identifier is set on class or subclass sheet (resolves #1811)