### PR TITLE
Provide an event option to `item#use` from character sheet usage

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -991,7 +991,7 @@ export default class ActorSheet5e extends ActorSheet {
     event.preventDefault();
     const itemId = event.currentTarget.closest(".item").dataset.itemId;
     const item = this.actor.items.get(itemId);
-    if ( item ) return item.use();
+    if ( item ) return item.use({}, {event});
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -699,6 +699,7 @@ export default class Item5e extends Item {
    * @property {boolean} createMessage    Whether to automatically create a chat message (if true) or simply return
    *                                      the prepared chat message data (if false).
    * @property {object} flags             Additional flags added to the chat message.
+   * @property {Event} event              The browser event which triggered the item usage, if any.
    */
 
   /**


### PR DESCRIPTION
The `event` from `ActorSheet5e#_onItemUse` can contain useful information for modules listening to the `Item5e#use` hooks. This PR changes the `ItemUseOptions` to provide that `event` as well as the existing options, and ensures that this event is passed through to the use method from actor sheet usage.

### Rationale

A module such as [Faster Rolling By Default](https://github.com/ElfFriend-DnD/foundryvtt-faster-rolling-by-default-5e) can make use of the PointerEvent which triggered the item usage. Instead of swallowing it during `_onItemUse`, we can simply put it on `options` even though we do not use it ourself.

Additionally, other modules which offer ways to `use` items can adopt this pattern to improve intercompatibility.