### PR TITLE
Centralize fastForward detection for roll configs, allow explicit false

### DIFF
--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -26,7 +26,7 @@
  * @property {boolean} [reliableTalent]  Allow Reliable Talent to modify this roll?
  *
  * ## Roll Configuration Dialog
- * @property {boolean} [fastForward]     Should the roll configuration dialog be skipped?
+ * @property {boolean} [fastForward]           Should the roll configuration dialog be skipped?
  * @property {boolean} [chooseModifier=false]  If the configuration dialog is shown, should the ability modifier be
  *                                             configurable within that interface?
  * @property {string} [template]               The HTML template used to display the roll configuration dialog.
@@ -136,7 +136,7 @@ function _determineAdvantageMode({event, advantage=false, disadvantage=false, fa
  *
  * ## Critical Handling
  * @property {boolean} [allowCritical=true]  Is this damage roll allowed to be rolled as critical?
- * @property {boolean} [critical]      Apply critical to this roll (unless overridden by modifier key or dialog)?
+ * @property {boolean} [critical]            Apply critical to this roll (unless overridden by modifier key or dialog)?
  * @property {number} [criticalBonusDice]    A number of bonus damage dice that are added for critical hits.
  * @property {number} [criticalMultiplier]   Multiplier to use when calculating critical damage.
  * @property {boolean} [multiplyNumeric]     Should numeric terms be multiplied when this roll criticals?
@@ -144,7 +144,7 @@ function _determineAdvantageMode({event, advantage=false, disadvantage=false, fa
  * @property {string} [criticalBonusDamage]  An extra damage term that is applied only on a critical hit.
  *
  * ## Roll Configuration Dialog
- * @property {boolean} [fastForward]  Should the roll configuration dialog be skipped?
+ * @property {boolean} [fastForward]        Should the roll configuration dialog be skipped?
  * @property {string} [template]            The HTML template used to render the roll configuration dialog.
  * @property {string} [title]               Title of the roll configuration dialog.
  * @property {object} [dialogOptions]       Additional options passed to the roll configuration dialog.

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -26,7 +26,7 @@
  * @property {boolean} [reliableTalent]  Allow Reliable Talent to modify this roll?
  *
  * ## Roll Configuration Dialog
- * @property {boolean} [fastForward=false]     Should the roll configuration dialog be skipped?
+ * @property {boolean} [fastForward]     Should the roll configuration dialog be skipped?
  * @property {boolean} [chooseModifier=false]  If the configuration dialog is shown, should the ability modifier be
  *                                             configurable within that interface?
  * @property {string} [template]               The HTML template used to display the roll configuration dialog.
@@ -52,7 +52,7 @@ export async function d20Roll({
   parts=[], data={}, event,
   advantage, disadvantage, critical=20, fumble=1, targetValue,
   elvenAccuracy, halflingLucky, reliableTalent,
-  fastForward=false, chooseModifier=false, template, title, dialogOptions,
+  fastForward, chooseModifier=false, template, title, dialogOptions,
   chatMessage=true, messageData={}, rollMode, flavor
 }={}) {
 
@@ -111,14 +111,14 @@ export async function d20Roll({
  * @param {boolean} [config.fastForward]   Should the roll dialog be skipped?
  * @returns {{isFF: boolean, advantageMode: number}}  Whether the roll is fast-forward, and its advantage mode.
  */
-function _determineAdvantageMode({event, advantage=false, disadvantage=false, fastForward=false}={}) {
-  const isFF = fastForward || (event && (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey));
+function _determineAdvantageMode({event, advantage=false, disadvantage=false, fastForward}={}) {
+  const isFF = fastForward ?? (event && (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey));
   let advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.NORMAL;
   if ( advantage || event?.altKey ) advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
   else if ( disadvantage || event?.ctrlKey || event?.metaKey ) {
     advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
   }
-  return {isFF, advantageMode};
+  return {isFF: !!isFF, advantageMode};
 }
 
 /* -------------------------------------------- */
@@ -136,7 +136,7 @@ function _determineAdvantageMode({event, advantage=false, disadvantage=false, fa
  *
  * ## Critical Handling
  * @property {boolean} [allowCritical=true]  Is this damage roll allowed to be rolled as critical?
- * @property {boolean} [critical=false]      Apply critical to this roll (unless overridden by modifier key or dialog)?
+ * @property {boolean} [critical]      Apply critical to this roll (unless overridden by modifier key or dialog)?
  * @property {number} [criticalBonusDice]    A number of bonus damage dice that are added for critical hits.
  * @property {number} [criticalMultiplier]   Multiplier to use when calculating critical damage.
  * @property {boolean} [multiplyNumeric]     Should numeric terms be multiplied when this roll criticals?
@@ -144,7 +144,7 @@ function _determineAdvantageMode({event, advantage=false, disadvantage=false, fa
  * @property {string} [criticalBonusDamage]  An extra damage term that is applied only on a critical hit.
  *
  * ## Roll Configuration Dialog
- * @property {boolean} [fastForward=false]  Should the roll configuration dialog be skipped?
+ * @property {boolean} [fastForward]  Should the roll configuration dialog be skipped?
  * @property {string} [template]            The HTML template used to render the roll configuration dialog.
  * @property {string} [title]               Title of the roll configuration dialog.
  * @property {object} [dialogOptions]       Additional options passed to the roll configuration dialog.
@@ -166,9 +166,9 @@ function _determineAdvantageMode({event, advantage=false, disadvantage=false, fa
  */
 export async function damageRoll({
   parts=[], data={}, event,
-  allowCritical=true, critical=false, criticalBonusDice, criticalMultiplier,
+  allowCritical=true, critical, criticalBonusDice, criticalMultiplier,
   multiplyNumeric, powerfulCritical, criticalBonusDamage,
-  fastForward=false, template, title, dialogOptions,
+  fastForward, template, title, dialogOptions,
   chatMessage=true, messageData={}, rollMode, flavor
 }={}) {
 
@@ -219,8 +219,8 @@ export async function damageRoll({
  * @param {boolean} [config.fastForward]  Should the roll dialog be skipped?
  * @returns {{isFF: boolean, isCritical: boolean}}  Whether the roll is fast-forward, and whether it is a critical hit
  */
-function _determineCriticalMode({event, critical=false, fastForward=false}={}) {
-  const isFF = fastForward || (event && (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey));
+function _determineCriticalMode({event, critical=false, fastForward}={}) {
+  const isFF = fastForward ?? (event && (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey));
   if ( event?.altKey ) critical = true;
-  return {isFF, isCritical: critical};
+  return {isFF: !!isFF, isCritical: critical};
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1353,7 +1353,6 @@ export default class Item5e extends Item {
    *                                       cannot be performed.
    */
   async rollDamage({critical, event=null, spellLevel=null, versatile=false, options={}}={}) {
-    debugger;
     if ( !this.hasDamage ) throw new Error("You may not make a Damage Roll with this Item.");
     const messageData = {
       "flags.dnd5e.roll": {type: "damage", itemId: this.id},

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1804,7 +1804,6 @@ export default class Item5e extends Item {
       case "damage":
       case "versatile":
         await item.rollDamage({
-          // critical: event.altKey,
           event: event,
           spellLevel: spellLevel,
           versatile: action === "versatile"

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1352,7 +1352,8 @@ export default class Item5e extends Item {
    * @returns {Promise<DamageRoll>}        A Promise which resolves to the created Roll instance, or null if the action
    *                                       cannot be performed.
    */
-  async rollDamage({critical=false, event=null, spellLevel=null, versatile=false, options={}}={}) {
+  async rollDamage({critical, event=null, spellLevel=null, versatile=false, options={}}={}) {
+    debugger;
     if ( !this.hasDamage ) throw new Error("You may not make a Damage Roll with this Item.");
     const messageData = {
       "flags.dnd5e.roll": {type: "damage", itemId: this.id},
@@ -1370,10 +1371,9 @@ export default class Item5e extends Item {
     const title = `${this.name} - ${actionFlavor}`;
     const rollConfig = {
       actor: this.actor,
-      critical: critical ?? event?.altKey ?? false,
+      critical,
       data: rollData,
-      event: event,
-      fastForward: event ? event.shiftKey || event.altKey || event.ctrlKey || event.metaKey : false,
+      event,
       parts: parts,
       title: title,
       flavor: this.labels.damageTypes.length ? `${title} (${this.labels.damageTypes})` : title,
@@ -1804,7 +1804,7 @@ export default class Item5e extends Item {
       case "damage":
       case "versatile":
         await item.rollDamage({
-          critical: event.altKey,
+          // critical: event.altKey,
           event: event,
           spellLevel: spellLevel,
           versatile: action === "versatile"


### PR DESCRIPTION
## Goals
1. Centralize `fastForward` and `critical` detection within the `dice.mjs` helper functions, rather than also have some event key detection within `rollDamage` and similar methods.
    - `_determineCriticalMode` and `_determineAdvantageMode` should be the only methods concerned with determining these roll modifiers to make it easier to refactor those methods later (e.g. in #1591)
2. Respect when `damageRoll` or `d20Roll` is invoked with `fastForward` explicitly set to `false`, showing the roll config dialog as normal.
3. Maintain the current API call signatures and behaviors, except in the case where `fastForward` is explicitly set to false.


### Problem being Solved

> It is not possible to explicitly override a roll config to be `fastForward: false` if the config also has an `event` which would normally fast-forward a roll config.

<details>
<summary>Example scenario</summary>

```javascript
item.rollAttack({ event: { altKey: true }, fastForward: false, advantage: true });
```
As an API consumer I expect the attack roll configuration dialog to appear, but with `advantage` as the default button (This is the current behavior if I leave out the `event`):

![Demonstration of the expectation working with this PR's code changes](https://user-images.githubusercontent.com/7644614/192112005-3d702d8e-9d39-4a34-b0f5-f42e9865b9b6.png)

When the `event` is populated, the `fastForward: false` is ignored because of the `event` handling in various places of the workflow, but most notably the two utility functions `_determineCriticalMode` and `_determineAdvantageMode`.

My assertion is that determining the `fastForward`-ness of a roll should solely be the responsibility of these methods, and that is what this PR makes true. It also uses nullish coalescing, so as not to overwrite an explicit `false`.
</details>

### Methodology

Remove the `event` checking that happened during item damage and attack roll workflows (from `_onChatCardAction` and `rollDamage`).

Remove the defaults for the `critical` and `fastForward` booleans from all methods/configs, allowing them to be `undefined` until `_determineAdvantageMode` and `_determineCriticalMode`'s evaluation (this did not affect `d20Roll`'s `critical` number argument).
