### PR TITLE
Use RAW GP as standard for currency conversions

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -14,7 +14,6 @@ ______      ______ _____ _____
 |___/ \\___/\\/___/ \\____/\\____/
 _______________________________`;
 
-
 /**
  * The set of Ability Scores used within the system.
  * @enum {string}
@@ -627,27 +626,28 @@ preLocalize("consumableTypes", { sort: true });
 DND5E.currencies = {
   pp: {
     label: "DND5E.CurrencyPP",
-    abbreviation: "DND5E.CurrencyAbbrPP"
+    abbreviation: "DND5E.CurrencyAbbrPP",
+    conversion: 0.1
   },
   gp: {
     label: "DND5E.CurrencyGP",
     abbreviation: "DND5E.CurrencyAbbrGP",
-    conversion: {into: "pp", each: 10}
+    conversion: 1
   },
   ep: {
     label: "DND5E.CurrencyEP",
     abbreviation: "DND5E.CurrencyAbbrEP",
-    conversion: {into: "gp", each: 2}
+    conversion: 2
   },
   sp: {
     label: "DND5E.CurrencySP",
     abbreviation: "DND5E.CurrencyAbbrSP",
-    conversion: {into: "ep", each: 5}
+    conversion: 10
   },
   cp: {
     label: "DND5E.CurrencyCP",
     abbreviation: "DND5E.CurrencyAbbrCP",
-    conversion: {into: "sp", each: 10}
+    conversion: 100
   }
 };
 preLocalize("currencies", { keys: ["label", "abbreviation"] });

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -617,10 +617,12 @@ preLocalize("consumableTypes", { sort: true });
 
 /**
  * The valid currency denominations with localized labels, abbreviations, and conversions.
+ * The conversion number defines how many of that currency are equal to one GP (according
+ * to the rules as written).
  * @enum {{
  *   label: string,
  *   abbreviation: string,
- *   [conversion]: {into: string, each: number}
+ *   conversion: number,
  * }}
  */
 DND5E.currencies = {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1783,20 +1783,25 @@ export default class Actor5e extends Actor {
   convertCurrency() {
     const curr = foundry.utils.deepClone(this.system.currency);
     const conversion = Object.entries(CONFIG.DND5E.currencies);
-    conversion.sort((a, b) => a[1].conversion-b[1].conversion);
-    var change = 0
-    for ( let [c, data] of conversion) {
-      const rate = data.conversion
-      if ( !rate ) continue
-      change = change + curr[c] / rate
-      }
+    conversion.sort((a, b) => a[1].conversion - b[1].conversion);
+
+    var change = 0;
     for ( let [c, data] of conversion) {
       const rate = data.conversion;
       if ( !rate ) continue;
+
+      change = change + curr[c] / rate;
+    }
+
+    for ( let [c, data] of conversion) {
+      const rate = data.conversion;
+      if ( !rate ) continue;
+
       let amt = Math.floor(change * rate);
       curr[c] = amt;
       change = (change - amt / rate);
     }
+
     return this.update({"data.currency": curr});
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1793,9 +1793,9 @@ export default class Actor5e extends Actor {
     for ( let [c, data] of conversion) {
       const rate = data.conversion;
       if ( !rate ) continue;
-      let amt = (change * rate).toFixed(8);
-      curr[c] = Math.floor(amt);
-      change = (change - (Math.floor(amt) / rate)) ;
+      let amt = Math.floor(change * rate);
+      curr[c] = amt;
+      change = (change - amt / rate);
     }
     return this.update({"data.currency": curr});
   }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1779,18 +1779,25 @@ export default class Actor5e extends Actor {
    * carried by an Actor.
    * @returns {Promise<Actor5e>}
    */
+
   convertCurrency() {
     const curr = foundry.utils.deepClone(this.system.currency);
     const conversion = Object.entries(CONFIG.DND5E.currencies);
-    conversion.reverse();
-    for ( let [c, data] of conversion ) {
-      const t = data.conversion;
-      if ( !t ) continue;
-      let change = Math.floor(curr[c] / t.each);
-      curr[c] -= (change * t.each);
-      curr[t.into] += change;
+    conversion.sort((a, b) => a[1].conversion-b[1].conversion);
+    var change = 0
+    for ( let [c, data] of conversion) {
+      const rate = data.conversion
+      if ( !rate ) continue
+      change = change + curr[c] / rate
+      }
+    for ( let [c, data] of conversion) {
+      const rate = data.conversion;
+      if ( !rate ) continue;
+      let amt = (change * rate).toFixed(8);
+      curr[c] = Math.floor(amt);
+      change = (change - (Math.floor(amt) / rate)) ;
     }
-    return this.update({"system.currency": curr});
+    return this.update({"data.currency": curr});
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
I'm the maintainer of World Currency 5e, a module that allows for currency customization. This pull request changes the currency conversion schema so that all currencies are defined in terms of GP (according to rules as written).

There are a few problems with the current schema:
- Module creators often hard code their own conversion logic because it's convoluted to use the system conversion numbers to convert a currency to/from GP.
- Completely omitting a currency like Electrum can't be achieved while keeping copper and silver.
- We can't have more than one currency that's worth more than GP.
- Defining new currencies in terms of each other isn't intuitive for most GMs.

I believe that the current schema was designed to make the "Currency Converter" logic straightforward. I have updated the currency converter logic so that it'll work exactly the same as before.