### PR TITLE
Move Source Input field

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -365,6 +365,9 @@
 .dnd5e.sheet .sheet-header .summary li:last-child {
   border-right: none;
 }
+.dnd5e.sheet.npc .sheet-header .summary li:first-child {
+  flex:0.5;
+}
 .dnd5e.sheet .sheet-navigation {
   flex: 0 0 30px;
   margin-bottom: 5px;
@@ -909,7 +912,7 @@
   border-radius: 3px;
 }
 .dnd5e.sheet.actor .ability-scores .ability {
-  height: 70px;
+  height: 72.5px;
   text-align: center;
   border-bottom: 2px groove #eeede0;
   position: relative;

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -38,9 +38,6 @@
                     <span title="{{labels.type}}">{{labels.type}}</span>
                     <a class="config-button" data-action="type" title="{{localize 'DND5E.CreatureTypeConfig'}}"><i class="fas fa-cog"></i></a>
                 </li>
-                <li>
-                    <input type="text" name="system.details.source" value="{{system.details.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
-                </li>
             </ul>
 
             {{!-- Header Attributes --}}

--- a/templates/actors/parts/actor-traits.hbs
+++ b/templates/actors/parts/actor-traits.hbs
@@ -139,4 +139,12 @@
         </a>
     </div>
     {{/unless}}
+
+    {{#unless isCharacter}}
+    <div class="form-group ">
+        <label>{{localize "DND5E.Source"}}</label>
+        <input type="text" name="system.details.source" value="{{system.details.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+    </div>
+    {{/unless}}
+
 </div>

--- a/templates/actors/vehicle-sheet.hbs
+++ b/templates/actors/vehicle-sheet.hbs
@@ -21,10 +21,6 @@
                     <input type="text" name="system.traits.dimensions" value="{{system.traits.dimensions}}"
                            placeholder="{{localize 'DND5E.Dimensions'}}">
                 </li>
-                <li>
-                    <input type="text" name="system.details.source" value="{{system.details.source}}"
-                           placeholder="{{localize 'DND5E.Source'}}">
-                </li>
             </ul>
             <ul class="attributes flexrow">
                 <li class="attribute health">


### PR DESCRIPTION
Within the current NPC actor sheet I find that the upper list elements used directly underneath the actors name to use inefficient spacing, and the text is rather cramped. For this example below, we can see that the most NPCs who have both a type and a subtype will likely not have enough space to full display both words as one is cut off, along with any other additional text within the alignment text field that isn't part of the core nine. 
Furthermore the only reason there is enough space in the Source field is because acronyms are being used,  Which is fine for any core material, since the community has a shared core glossary, there is just not enough space to easily display the sources for 3rd party content.

![default](https://user-images.githubusercontent.com/58280840/193423047-2cac51e4-95a3-4c99-9181-dde9745a5b5c.JPG)


The basic changes within this PR is to move the location of the source field from the upper list, to the form groups near the bottom of the page. This dramatically increases the amount of space to display information at the top of the page, making the type + subtype, field of an NPC readable from a glance, and so the users does not need to move their mouse cursor over and read the hover title text. Any additional text in the alignment field is also more accessibly read further from a simple change to the flex css on the size display which has been limited in its flex width by 50%.
The source text input field also has significantly more space for text, there is now enough room that acronyms are no longer a necessity, core acronyms  should still be used, but this creates more space for 3rd party creators to have their names properly displayed.

Another small change that I made to the sheet, was ever so slightly changing the height of the ability attributes boxes, so that the bottom of their list aligns with the bottom of the skills list.

![image](https://user-images.githubusercontent.com/58280840/193423696-e4a2d917-ad0a-434e-811f-8b2320b89377.png)
