### PR TITLE
[#1795] Add ability for items added with through advancement to trigger their own advancements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -292,7 +292,10 @@
   "Subclass": {
     "Title": "Subclass",
     "Hint": "Specify what level this class receives its subclass.",
-    "FlowHint": "Select a subclass in the Features tab after level up has completed."
+    "FlowHint": "Select a subclass in the Features tab after level up has completed.",
+    "Warning": {
+      "InvalidType": "Only subclasses may be selected."
+    }
   }
 },
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -292,7 +292,6 @@
   "Subclass": {
     "Title": "Subclass",
     "Hint": "Specify what level this class receives its subclass.",
-    "FlowHint": "Select a subclass in the Features tab after level up has completed.",
     "Warning": {
       "InvalidType": "Only subclasses may be selected."
     }

--- a/less/dnd5e.less
+++ b/less/dnd5e.less
@@ -22,6 +22,7 @@
 @import "v2/sheets.less";
 @import "v2/activities.less";
 @import "v2/actors.less";
+@import "v2/advancement.less";
 @import "v2/items.less";
 @import "v2/character.less";
 @import "v2/npc.less";

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -1,0 +1,22 @@
+.advancement-visualizer {
+  .step {
+    position: relative;
+    padding: 4px;
+
+    &.current {
+      border-color: rebeccapurple;
+      &::before {
+        content: "➧";
+        position: absolute;
+        inset-inline-start: -12px;
+        inset-block: 0;
+        align-content: center;
+        color: rebeccapurple;
+        font-size: 18px;
+      }
+    }
+    .icons {
+      i:not(.enabled) { opacity: 15%; }
+    }
+  }
+}

--- a/module/applications/advancement/advancement-manager.mjs
+++ b/module/applications/advancement/advancement-manager.mjs
@@ -652,7 +652,7 @@ export default class AdvancementManager extends Application {
         // Find spots where the level increases
         const thisLevel = this.steps[idx].flow?.level || this.steps[idx].class?.level;
         const nextLevel = this.steps[idx + 1]?.flow?.level || this.steps[idx + 1]?.class?.level;
-        if ( (thisLevel <= handledLevel) || (thisLevel === nextLevel) ) continue;
+        if ( (thisLevel < handledLevel) || (thisLevel === nextLevel) ) continue;
 
         // Determine if there is any advancement to be done for the added item to this level
         // from the previously handled level
@@ -747,8 +747,7 @@ export default class AdvancementManager extends Application {
     // Create a disjoint union of the before and after items
     const preIds = new Set(preEmbeddedItems.map(i => i.id));
     const postIds = new Set(this.clone.items.map(i => i.id));
-    const modifiedIds = postIds.difference(preIds);
-    preIds.difference(postIds).forEach(id => modifiedIds.add(id));
+    const modifiedIds = postIds.symmetricDifference(preIds);
 
     // Remove any synthetic steps after the current step if their item has been modified
     for ( const [idx, element] of Array.from(this.steps.entries()).reverse() ) {

--- a/module/applications/advancement/advancement-manager.mjs
+++ b/module/applications/advancement/advancement-manager.mjs
@@ -828,6 +828,7 @@ export default class AdvancementManager extends Application {
 
 /**
  * Debug application for visualizing advancement steps.
+ * Note: Intentionally not localized due to its nature as a debug application.
  */
 class AdvancementVisualizer extends Application5e {
   /** @override */
@@ -839,7 +840,7 @@ class AdvancementVisualizer extends Application5e {
     position: {
       top: 50,
       left: 50,
-      width: 350
+      width: 440
     },
     manager: null
   };

--- a/module/applications/advancement/subclass-flow.mjs
+++ b/module/applications/advancement/subclass-flow.mjs
@@ -116,7 +116,7 @@ export default class SubclassFlow extends AdvancementFlow {
 
     // Ensure the dropped item is a subclass
     if ( item.type !== "subclass" ) {
-      ui.notifications.warn(game.i18n.localize("DND5E.ADVANCEMENT.Subclass.Warning.InvalidType"));
+      ui.notifications.warn("DND5E.ADVANCEMENT.Subclass.Warning.InvalidType", { localize: true });
       return;
     }
 

--- a/module/applications/advancement/subclass-flow.mjs
+++ b/module/applications/advancement/subclass-flow.mjs
@@ -1,13 +1,133 @@
+import Advancement from "../../documents/advancement/advancement.mjs";
+import CompendiumBrowser from "../compendium-browser.mjs";
 import AdvancementFlow from "./advancement-flow.mjs";
 
 /**
- * Inline application that presents the player with the subclass hint.
+ * Inline application that presents the player with a choice of subclass.
  */
 export default class SubclassFlow extends AdvancementFlow {
-  /** @inheritDoc */
-  async getData() {
-    return foundry.utils.mergeObject(super.getData(), {
-      hint: `${this.advancement.hint ?? ""} ${game.i18n.localize("DND5E.ADVANCEMENT.Subclass.FlowHint")}`
+
+  /**
+   * Cached subclass dropped onto the advancement.
+   * @type {Item5e|false}
+   */
+  subclass;
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      dragDrop: [{ dropSelector: "form" }],
+      template: "systems/dnd5e/templates/advancement/subclass-flow.hbs"
     });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async retainData(data) {
+    await super.retainData(data);
+    const uuid = foundry.utils.getProperty(data, "flags.dnd5e.sourceId");
+    if ( uuid ) this.subclass = await fromUuid(uuid);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async getData() {
+    const context = await super.getData();
+    context.subclass = this.subclass;
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  activateListeners(jQuery) {
+    super.activateListeners(jQuery);
+    const [html] = jQuery;
+    html.querySelector("a[data-uuid]")?.addEventListener("click", this._onClickFeature.bind(this));
+    html.querySelector('[data-action="browse"]')?.addEventListener("click", this._onBrowseCompendium.bind(this));
+    html.querySelector('[data-action="deleteItem"]')?.addEventListener("click", this._onItemDelete.bind(this));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle opening the compendium browser and displaying the result.
+   * @param {Event} event  The originating click event.
+   * @protected
+   */
+  async _onBrowseCompendium(event) {
+    event.preventDefault();
+    const filters = {
+      locked: {
+        additional: { class: { [this.item.identifier]: 1 } },
+        types: new Set(["subclass"])
+      }
+    };
+    const result = await CompendiumBrowser.selectOne({ filters });
+    if ( result ) this.subclass = await fromUuid(result);
+    this.render();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle clicking on a feature during item grant to preview the feature.
+   * @param {MouseEvent} event  The triggering event.
+   * @protected
+   */
+  async _onClickFeature(event) {
+    event.preventDefault();
+    const uuid = event.currentTarget.dataset.uuid;
+    const item = await fromUuid(uuid);
+    item?.sheet.render(true);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle deleting a dropped item.
+   * @param {Event} event  The originating click event.
+   * @protected
+   */
+  async _onItemDelete(event) {
+    event.preventDefault();
+    this.subclass = false;
+    this.render();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onDrop(event) {
+    // Try to extract the data
+    let data;
+    try {
+      data = JSON.parse(event.dataTransfer.getData("text/plain"));
+    } catch(err) {
+      return false;
+    }
+
+    if ( data.type !== "Item" ) return false;
+    const item = await Item.implementation.fromDropData(data);
+
+    // Ensure the dropped item is a subclass
+    if ( item.type !== "subclass" ) {
+      ui.notifications.warn(game.i18n.localize("DND5E.ADVANCEMENT.Subclass.Warning.InvalidType"));
+      return;
+    }
+
+    this.subclass = item;
+    this.render();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async _updateObject(event, formData) {
+    if ( this.subclass ) await this.advancement.apply(this.level, { uuid: this.subclass.uuid }, this.retainedData);
   }
 }

--- a/module/applications/advancement/subclass-flow.mjs
+++ b/module/applications/advancement/subclass-flow.mjs
@@ -1,4 +1,3 @@
-import Advancement from "../../documents/advancement/advancement.mjs";
 import CompendiumBrowser from "../compendium-browser.mjs";
 import AdvancementFlow from "./advancement-flow.mjs";
 

--- a/module/data/advancement/_module.mjs
+++ b/module/data/advancement/_module.mjs
@@ -6,4 +6,5 @@ export * from "./item-choice.mjs";
 export {default as ItemGrantConfigurationData} from "./item-grant.mjs";
 export * as scaleValue from "./scale-value.mjs";
 export * from "./size.mjs";
-export {TraitConfigurationData, TraitValueData} from "./trait.mjs";
+export * from "./trait.mjs";
+export * from "./subclass.mjs";

--- a/module/data/advancement/subclass.mjs
+++ b/module/data/advancement/subclass.mjs
@@ -1,0 +1,18 @@
+import LocalDocumentField from "../fields/local-document-field.mjs";
+
+const { DocumentUUIDField } = foundry.data.fields;
+
+/**
+ * Value data for Subclass advancement.
+ * @property {Item5e} document  Copy of the subclass on the actor.
+ * @property {string} uuid      UUID of the remote subclass source.
+ */
+export class SubclassValueData extends foundry.abstract.DataModel {
+  /** @override */
+  static defineSchema() {
+    return {
+      document: new LocalDocumentField(foundry.documents.BaseItem),
+      uuid: new DocumentUUIDField()
+    };
+  }
+}

--- a/module/data/fields/local-document-field.mjs
+++ b/module/data/fields/local-document-field.mjs
@@ -57,10 +57,23 @@ export default class LocalDocumentField extends foundry.data.fields.DocumentIdFi
 
   /* -------------------------------------------- */
 
+  /**
+   * Step up through model's parents to find the specified collection.
+   * @param {DataModel} model
+   * @param {string} collection
+   * @returns {EmbeddedCollection|void}
+   */
+  _findCollection(model, collection) {
+    if ( !model.parent ) return;
+    return model.parent[collection] ?? this._findCollection(model.parent, collection);
+  }
+
+  /* -------------------------------------------- */
+
   /** @override */
   initialize(value, model, options={}) {
     if ( this.idOnly ) return this.options.fallback || foundry.data.validators.isValidId(value) ? value : null;
-    const collection = model.parent?.[this.model.metadata.collection];
+    const collection = this._findCollection(model, this.model.metadata.collection);
     return () => {
       const document = collection?.get(value);
       if ( !document ) return this.options.fallback ? value : null;

--- a/module/data/fields/local-document-field.mjs
+++ b/module/data/fields/local-document-field.mjs
@@ -65,7 +65,11 @@ export default class LocalDocumentField extends foundry.data.fields.DocumentIdFi
    */
   _findCollection(model, collection) {
     if ( !model.parent ) return;
-    return model.parent[collection] ?? this._findCollection(model.parent, collection);
+    try {
+      return model.parent.getEmbeddedCollection(collection);
+    } catch(err) {
+      return model.parent[collection] ?? this._findCollection(model.parent, collection);
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/documents/advancement/subclass.mjs
+++ b/module/documents/advancement/subclass.mjs
@@ -1,14 +1,19 @@
-import Advancement from "./advancement.mjs";
 import SubclassFlow from "../../applications/advancement/subclass-flow.mjs";
+import { SubclassValueData } from "../../data/advancement/subclass.mjs";
+import Advancement from "./advancement.mjs";
 
 /**
- * Advancement that indicates when a class takes a subclass. Only allowed on class items and can only be taken once.
+ * Advancement that allows the player to select a subclass for their class. Only allowed on class items
+ * and can only be taken once.
  */
 export default class SubclassAdvancement extends Advancement {
 
   /** @inheritDoc */
   static get metadata() {
     return foundry.utils.mergeObject(super.metadata, {
+      dataModels: {
+        value: SubclassValueData
+      },
       order: 70,
       icon: "icons/skills/trades/mining-pickaxe-yellow-blue.webp",
       typeIcon: "systems/dnd5e/icons/svg/subclass.svg",
@@ -24,7 +29,14 @@ export default class SubclassAdvancement extends Advancement {
   /*  Display Methods                             */
   /* -------------------------------------------- */
 
-  /** @inheritDoc */
+  /** @inheritdoc */
+  configuredForLevel(level) {
+    return !foundry.utils.isEmpty(this.value);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
   summaryforLevel(level, { configMode=false }={}) {
     const subclass = this.item.subclass;
     if ( configMode || !subclass ) return "";
@@ -38,5 +50,40 @@ export default class SubclassAdvancement extends Advancement {
   /** @inheritDoc */
   static availableForItem(item) {
     return !item.advancement.byType.Subclass?.length;
+  }
+
+  /* -------------------------------------------- */
+  /*  Application Methods                         */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async apply(level, data, retainedData) {
+    const useRetained = data.uuid === foundry.utils.getProperty(retainedData, "flags.dnd5e.sourceId");
+    let itemData = useRetained ? retainedData : null;
+    if ( !itemData ) {
+      itemData = await this.createItemData(data.uuid);
+      foundry.utils.setProperty(itemData, "system.classIdentifier", this.item.identifier);
+    }
+    this.actor.updateSource({ items: [itemData] });
+    this.updateSource({ value: { document: itemData._id, uuid: data.uuid } });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async restore(level, data) {
+    this.actor.updateSource({ items: [data] });
+    this.updateSource({ value: { document: data._id, uuid: data.flags.dnd5e.sourceId } });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async reverse(level) {
+    const item = this.value.document ?? this.item.subclass;
+    if ( !item ) return;
+    this.actor.items.delete(item.id);
+    this.updateSource({ value: { document: null, uuid: null } });
+    return item.toObject();
   }
 }

--- a/templates/advancement/advancement-visualizer.hbs
+++ b/templates/advancement/advancement-visualizer.hbs
@@ -1,0 +1,18 @@
+<ol class="unlist">
+    {{#each steps}}
+    <li class="card flexrow step {{~#if current}} current{{/if}}" data-type="{{ type }}">
+        <div class="flexcol">
+            <span class="type"><strong>Item:</strong> {{#if flow.item}}{{ flow.item.name }}{{else}}—{{/if}}</span>
+            <span class="flow"><strong>Flow:</strong> {{#if flow}}{{ flow.advancement.type }}, {{ flow.level }}{{else}}—{{/if}}</span>
+        </div>
+        <div class="flexcol">
+            <span class="class"><strong>Class:</strong> {{#if class}}{{ class.item.name }}, {{ class.level }}{{else}}—{{/if}}</span>
+            <div class="icons">
+                <i class="fa-solid fa-forward-fast {{~#if automatic}} enabled{{/if}}" data-tooltip="Automatic"></i>
+                <i class="fa-solid fa-robot {{~#if synthetic}} enabled{{/if}}" data-tooltip="Synthetic"></i>
+                &nbsp;
+            </div>
+        </div>
+    </li>
+    {{/each}}
+</ol>

--- a/templates/advancement/subclass-flow.hbs
+++ b/templates/advancement/subclass-flow.hbs
@@ -8,7 +8,7 @@
             <div class="item-image" style="background-image: url({{ subclass.img }});"></div>
             <label class="flexrow">
                 <h4><a data-uuid="{{ subclass.uuid }}">{{ subclass.name }}</a></h4>
-                <a class="item-control item-delete" title="{{ localize 'DND5E.ItemDelete' }}">
+                <a class="item-control item-delete" title="{{ localize 'DND5E.ItemDelete' }}" data-action="deleteItem">
                   <i class="fas fa-trash" inert></i>
                 </a>
                 <input type="hidden" name="uuid" value="{{ subclass.uuid }}">

--- a/templates/advancement/subclass-flow.hbs
+++ b/templates/advancement/subclass-flow.hbs
@@ -1,0 +1,24 @@
+<form id="{{ appId }}" data-level="{{ level }}" data-id="{{ advancement.id }}" data-type="{{ type }}">
+    <h3>{{{ title }}}</h3>
+    {{#if advancement.hint}}<p>{{ advancement.hint }}</p>{{/if}}
+
+    <div class="drop-target">
+        {{#if subclass}}
+        <div class="item-name flexrow">
+            <div class="item-image" style="background-image: url({{ subclass.img }});"></div>
+            <label class="flexrow">
+                <h4><a data-uuid="{{ subclass.uuid }}">{{ subclass.name }}</a></h4>
+                <a class="item-control item-delete" title="{{ localize 'DND5E.ItemDelete' }}">
+                  <i class="fas fa-trash" inert></i>
+                </a>
+                <input type="hidden" name="uuid" value="{{ subclass.uuid }}">
+            </label>
+        </div>
+        {{else}}
+        <button type="button" data-action="browse">
+            <i class="fa-solid fa-book-open-reader" inert></i>
+            {{ localize "DND5E.CompendiumBrowser.Action.Open" }}
+        </button>
+        {{/if}}
+    </div>
+</form>


### PR DESCRIPTION
Detects items added or removed during the advancement process and adds "synthetic" advancement steps if necessary for those items. This fixes the issue that prevents subclasses from automatically adding their initial features.

Adds a `AdvancementVisualizer` application that can be used to help debugging the advancement steps.

Changes subclass advancement to allow for selection of the subclass during the advancement process.

Resolves #1795 