### PR TITLE
[#1846] Allow ability type & defaults to be defined in config

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -104,14 +104,8 @@ Hooks.once("init", function() {
   game.dnd5e.moduleArt = new ModuleArt();
 
   // Remove honor & sanity from configuration if they aren't enabled
-  if ( !game.settings.get("dnd5e", "honorScore") ) {
-    delete DND5E.abilities.hon;
-    delete DND5E.abilityAbbreviations.hon;
-  }
-  if ( !game.settings.get("dnd5e", "sanityScore") ) {
-    delete DND5E.abilities.san;
-    delete DND5E.abilityAbbreviations.san;
-  }
+  if ( !game.settings.get("dnd5e", "honorScore") ) delete DND5E.abilities.hon;
+  if ( !game.settings.get("dnd5e", "sanityScore") ) delete DND5E.abilities.san;
 
   // Patch Core Functions
   Combatant.prototype.getInitiativeRoll = documents.combat.getInitiativeRoll;

--- a/module/applications/actor/ability-config.mjs
+++ b/module/applications/actor/ability-config.mjs
@@ -29,7 +29,8 @@ export default class ActorAbilityConfig extends BaseConfigSheet {
 
   /** @override */
   get title() {
-    return `${game.i18n.format("DND5E.AbilityConfigureTitle", {ability: CONFIG.DND5E.abilities[this._abilityId]})}: ${this.document.name}`;
+    return `${game.i18n.format("DND5E.AbilityConfigureTitle", {
+      ability: CONFIG.DND5E.abilities[this._abilityId].label})}: ${this.document.name}`;
   }
 
   /* -------------------------------------------- */
@@ -37,10 +38,11 @@ export default class ActorAbilityConfig extends BaseConfigSheet {
   /** @override */
   getData(options) {
     const src = this.document.toObject();
+    const ability = CONFIG.DND5E.abilities[this._abilityId].label;
     return {
       ability: src.system.abilities[this._abilityId] ?? this.document.system.abilities[this._abilityId] ?? {},
-      labelSaves: game.i18n.format("DND5E.AbilitySaveConfigure", {ability: CONFIG.DND5E.abilities[this._abilityId]}),
-      labelChecks: game.i18n.format("DND5E.AbilityCheckConfigure", {ability: CONFIG.DND5E.abilities[this._abilityId]}),
+      labelSaves: game.i18n.format("DND5E.AbilitySaveConfigure", {ability}),
+      labelChecks: game.i18n.format("DND5E.AbilityCheckConfigure", {ability}),
       abilityId: this._abilityId,
       proficiencyLevels: {
         0: CONFIG.DND5E.proficiencyLevels[0],

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -143,13 +143,13 @@ export default class ActorSheet5e extends ActorSheet {
     for ( const [a, abl] of Object.entries(context.abilities) ) {
       abl.icon = this._getProficiencyIcon(abl.proficient);
       abl.hover = CONFIG.DND5E.proficiencyLevels[abl.proficient];
-      abl.label = CONFIG.DND5E.abilities[a];
+      abl.label = CONFIG.DND5E.abilities[a]?.label;
       abl.baseProf = source.system.abilities[a]?.proficient ?? 0;
     }
 
     // Skills
     for ( const [s, skl] of Object.entries(context.skills) ) {
-      skl.abbreviation = CONFIG.DND5E.abilityAbbreviations[skl.ability];
+      skl.abbreviation = CONFIG.DND5E.abilities[skl.ability]?.abbreviation;
       skl.icon = this._getProficiencyIcon(skl.value);
       skl.hover = CONFIG.DND5E.proficiencyLevels[skl.value];
       skl.label = CONFIG.DND5E.skills[s]?.label;

--- a/module/applications/property-attribution.mjs
+++ b/module/applications/property-attribution.mjs
@@ -82,9 +82,9 @@ export default class PropertyAttribution extends Application {
   getPropertyLabel(property) {
     const parts = property.split(".");
     if ( parts[0] === "abilities" && parts[1] ) {
-      return CONFIG.DND5E.abilities[parts[1]] ?? property;
+      return CONFIG.DND5E.abilities[parts[1]]?.label ?? property;
     } else if ( (property === "attributes.ac.dex") && CONFIG.DND5E.abilities.dex ) {
-      return CONFIG.DND5E.abilities.dex;
+      return CONFIG.DND5E.abilities.dex.label;
     } else if ( (parts[0] === "prof") || (property === "attributes.prof") ) {
       return game.i18n.localize("DND5E.Proficiency");
     }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -16,35 +16,57 @@ _______________________________`;
 
 /**
  * The set of Ability Scores used within the system.
- * @enum {string}
+ * @enum {{
+ *  label: string,
+ *  abbreviation: string
+ * }}
  */
 DND5E.abilities = {
-  str: "DND5E.AbilityStr",
-  dex: "DND5E.AbilityDex",
-  con: "DND5E.AbilityCon",
-  int: "DND5E.AbilityInt",
-  wis: "DND5E.AbilityWis",
-  cha: "DND5E.AbilityCha",
-  hon: "DND5E.AbilityHon",
-  san: "DND5E.AbilitySan"
+  str: {
+    label: "DND5E.AbilityStr",
+    abbreviation: "DND5E.AbilityStrAbbr"
+  },
+  dex: {
+    label: "DND5E.AbilityDex",
+    abbreviation: "DND5E.AbilityDexAbbr"
+  },
+  con: {
+    label: "DND5E.AbilityCon",
+    abbreviation: "DND5E.AbilityConAbbr"
+  },
+  int: {
+    label: "DND5E.AbilityInt",
+    abbreviation: "DND5E.AbilityIntAbbr"
+  },
+  wis: {
+    label: "DND5E.AbilityWis",
+    abbreviation: "DND5E.AbilityWisAbbr"
+  },
+  cha: {
+    label: "DND5E.AbilityCha",
+    abbreviation: "DND5E.AbilityChaAbbr"
+  },
+  hon: {
+    label: "DND5E.AbilityHon",
+    abbreviation: "DND5E.AbilityHonAbbr"
+  },
+  san: {
+    label: "DND5E.AbilitySan",
+    abbreviation: "DND5E.AbilitySanAbbr"
+  }
 };
-preLocalize("abilities");
+preLocalize("abilities", { keys: ["label", "abbreviation"] });
+patchConfig("abilities", "label", { since: 2.2, until: 2.4 });
 
-/**
- * Localized abbreviations for Ability Scores.
- * @enum {string}
- */
-DND5E.abilityAbbreviations = {
-  str: "DND5E.AbilityStrAbbr",
-  dex: "DND5E.AbilityDexAbbr",
-  con: "DND5E.AbilityConAbbr",
-  int: "DND5E.AbilityIntAbbr",
-  wis: "DND5E.AbilityWisAbbr",
-  cha: "DND5E.AbilityChaAbbr",
-  hon: "DND5E.AbilityHonAbbr",
-  san: "DND5E.AbilitySanAbbr"
-};
-preLocalize("abilityAbbreviations");
+Object.defineProperty(DND5E, "abilityAbbreviations", {
+  get() {
+    foundry.utils.logCompatibilityWarning(
+      "The `abilityAbbreviations` configuration object has been merged with `abilities`.",
+      { since: "DnD5e 2.2", until: "DnD5e 2.4" }
+    );
+    return Object.fromEntries(Object.entries(DND5E.abilities).map(([k, v]) => [k, v.abbreviation]));
+  }
+});
 
 /**
  * Configure which ability score is used as the default modifier for initiative rolls.

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -18,11 +18,12 @@ _______________________________`;
  * Configuration data for abilities.
  *
  * @typedef {object} AbilityConfiguration
- * @property {string} label         Localized label.
- * @property {string} abbreviation  Localized abbreviation.
- * @property {Object<string, number|string>}  defaults  Default values for this ability based on actor type.
- *                                  If a string is used, the system will attempt to fetch the value of the
- *                                  specified ability.
+ * @property {string} label                               Localized label.
+ * @property {string} abbreviation                        Localized abbreviation.
+ * @property {string} [type]                              Whether this is a "physical" or "mental" ability.
+ * @property {Object<string, number|string>}  [defaults]  Default values for this ability based on actor type.
+ *                                                        If a string is used, the system will attempt to fetch.
+ *                                                        the value of the specified ability.
  */
 
 /**
@@ -32,39 +33,47 @@ _______________________________`;
 DND5E.abilities = {
   str: {
     label: "DND5E.AbilityStr",
-    abbreviation: "DND5E.AbilityStrAbbr"
+    abbreviation: "DND5E.AbilityStrAbbr",
+    type: "physical"
   },
   dex: {
     label: "DND5E.AbilityDex",
-    abbreviation: "DND5E.AbilityDexAbbr"
+    abbreviation: "DND5E.AbilityDexAbbr",
+    type: "physical"
   },
   con: {
     label: "DND5E.AbilityCon",
-    abbreviation: "DND5E.AbilityConAbbr"
+    abbreviation: "DND5E.AbilityConAbbr",
+    type: "physical"
   },
   int: {
     label: "DND5E.AbilityInt",
     abbreviation: "DND5E.AbilityIntAbbr",
+    type: "mental",
     defaults: { vehicle: 0 }
   },
   wis: {
     label: "DND5E.AbilityWis",
     abbreviation: "DND5E.AbilityWisAbbr",
+    type: "mental",
     defaults: { vehicle: 0 }
   },
   cha: {
     label: "DND5E.AbilityCha",
     abbreviation: "DND5E.AbilityChaAbbr",
+    type: "mental",
     defaults: { vehicle: 0 }
   },
   hon: {
     label: "DND5E.AbilityHon",
     abbreviation: "DND5E.AbilityHonAbbr",
+    type: "mental",
     defaults: { npc: "cha", vehicle: 0 }
   },
   san: {
     label: "DND5E.AbilitySan",
     abbreviation: "DND5E.AbilitySanAbbr",
+    type: "mental",
     defaults: { npc: "wis", vehicle: 0 }
   }
 };

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -15,11 +15,19 @@ ______      ______ _____ _____
 _______________________________`;
 
 /**
+ * Configuration data for abilities.
+ *
+ * @typedef {object} AbilityConfiguration
+ * @property {string} label         Localized label.
+ * @property {string} abbreviation  Localized abbreviation.
+ * @property {Object<string, number|string>}  defaults  Default values for this ability based on actor type.
+ *                                  If a string is used, the system will attempt to fetch the value of the
+ *                                  specified ability.
+ */
+
+/**
  * The set of Ability Scores used within the system.
- * @enum {{
- *  label: string,
- *  abbreviation: string
- * }}
+ * @enum {AbilityConfiguration}
  */
 DND5E.abilities = {
   str: {
@@ -36,23 +44,28 @@ DND5E.abilities = {
   },
   int: {
     label: "DND5E.AbilityInt",
-    abbreviation: "DND5E.AbilityIntAbbr"
+    abbreviation: "DND5E.AbilityIntAbbr",
+    defaults: { vehicle: 0 }
   },
   wis: {
     label: "DND5E.AbilityWis",
-    abbreviation: "DND5E.AbilityWisAbbr"
+    abbreviation: "DND5E.AbilityWisAbbr",
+    defaults: { vehicle: 0 }
   },
   cha: {
     label: "DND5E.AbilityCha",
-    abbreviation: "DND5E.AbilityChaAbbr"
+    abbreviation: "DND5E.AbilityChaAbbr",
+    defaults: { vehicle: 0 }
   },
   hon: {
     label: "DND5E.AbilityHon",
-    abbreviation: "DND5E.AbilityHonAbbr"
+    abbreviation: "DND5E.AbilityHonAbbr",
+    defaults: { npc: "cha", vehicle: 0 }
   },
   san: {
     label: "DND5E.AbilitySan",
-    abbreviation: "DND5E.AbilitySanAbbr"
+    abbreviation: "DND5E.AbilitySanAbbr",
+    defaults: { npc: "wis", vehicle: 0 }
   }
 };
 preLocalize("abilities", { keys: ["label", "abbreviation"] });

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -289,7 +289,7 @@ export default class D20Roll extends Roll {
         }
         return t;
       });
-      this.options.flavor += ` (${CONFIG.DND5E.abilities[form.ability.value]})`;
+      this.options.flavor += ` (${CONFIG.DND5E.abilities[form.ability.value]?.label ?? ""})`;
     }
 
     // Apply advantage or disadvantage

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -229,22 +229,16 @@ export default class Actor5e extends Actor {
   _prepareBaseAbilities() {
     if ( !("abilities" in this.system) ) return;
     const abilities = {};
-    for ( const key of Object.keys(CONFIG.DND5E.abilities) ) {
+    for ( const [key, config] of Object.entries(CONFIG.DND5E.abilities) ) {
       abilities[key] = this.system.abilities[key];
       if ( !abilities[key] ) {
         abilities[key] = foundry.utils.deepClone(game.system.template.Actor.templates.common.abilities.cha);
 
-        // Honor: Charisma for NPC, 0 for vehicles
-        if ( key === "hon" ) {
-          if ( this.type === "vehicle" ) abilities[key].value = 0;
-          else if ( this.type === "npc" ) abilities[key].value = this.system.abilities.cha?.value ?? 10;
+        let defaultValue = config.defaults?.[this.type] ?? 10;
+        if ( typeof defaultValue === "string" ) {
+          defaultValue = abilities[defaultValue].value ?? this.system.abilities[defaultValue] ?? 10;
         }
-
-        // Sanity: Wisdom for NPC, 0 for vehicles
-        else if ( key === "san" ) {
-          if ( this.type === "vehicle" ) abilities[key].value = 0;
-          else if ( this.type === "npc" ) abilities[key].value = this.system.abilities.wis?.value ?? 10;
-        }
+        abilities[key].value = defaultValue;
       }
     }
     this.system.abilities = abilities;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2302,8 +2302,9 @@ export default class Actor5e extends Actor {
       for ( let k of Object.keys(abilities) ) {
         const oa = o.system.abilities[k];
         const prof = abilities[k].proficient;
-        if ( keepPhysical && (CONFIG.DND5E.abilities[k]?.type === "physical") ) abilities[k] = oa;
-        else if ( keepMental && (CONFIG.DND5E.abilities[k]?.type === "mental") ) abilities[k] = oa;
+        const type = CONFIG.DND5E.abilities[k]?.type;
+        if ( keepPhysical && (type === "physical") ) abilities[k] = oa;
+        else if ( keepMental && (type === "mental") ) abilities[k] = oa;
         if ( keepSaves ) abilities[k].proficient = oa.proficient;
         else if ( mergeSaves ) abilities[k].proficient = Math.max(prof, oa.proficient);
       }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1118,7 +1118,7 @@ export default class Actor5e extends Actor {
    * @param {object} options      Options which configure how ability tests or saving throws are rolled
    */
   rollAbility(abilityId, options={}) {
-    const label = CONFIG.DND5E.abilities[abilityId] ?? "";
+    const label = CONFIG.DND5E.abilities[abilityId]?.label ?? "";
     new Dialog({
       title: `${game.i18n.format("DND5E.AbilityPromptTitle", {ability: label})}: ${this.name}`,
       content: `<p>${game.i18n.format("DND5E.AbilityPromptText", {ability: label})}</p>`,
@@ -1145,7 +1145,7 @@ export default class Actor5e extends Actor {
    * @returns {Promise<D20Roll>}  A Promise which resolves to the created Roll instance
    */
   async rollAbilityTest(abilityId, options={}) {
-    const label = CONFIG.DND5E.abilities[abilityId] ?? "";
+    const label = CONFIG.DND5E.abilities[abilityId]?.label ?? "";
     const abl = this.system.abilities[abilityId];
     const globalBonuses = this.system.bonuses?.abilities ?? {};
     const parts = [];
@@ -1224,7 +1224,7 @@ export default class Actor5e extends Actor {
    * @returns {Promise<D20Roll>}  A Promise which resolves to the created Roll instance
    */
   async rollAbilitySave(abilityId, options={}) {
-    const label = CONFIG.DND5E.abilities[abilityId] ?? "";
+    const label = CONFIG.DND5E.abilities[abilityId]?.label ?? "";
     const abl = this.system.abilities[abilityId];
     const globalBonuses = this.system.bonuses?.abilities ?? {};
     const parts = [];

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2302,8 +2302,8 @@ export default class Actor5e extends Actor {
       for ( let k of Object.keys(abilities) ) {
         const oa = o.system.abilities[k];
         const prof = abilities[k].proficient;
-        if ( keepPhysical && ["str", "dex", "con"].includes(k) ) abilities[k] = oa;
-        else if ( keepMental && ["int", "wis", "cha"].includes(k) ) abilities[k] = oa;
+        if ( keepPhysical && (CONFIG.DND5E.abilities[k]?.type === "physical") ) abilities[k] = oa;
+        else if ( keepMental && (CONFIG.DND5E.abilities[k]?.type === "mental") ) abilities[k] = oa;
         if ( keepSaves ) abilities[k].proficient = oa.proficient;
         else if ( mergeSaves ) abilities[k].proficient = Math.max(prof, oa.proficient);
       }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -485,7 +485,7 @@ export default class Item5e extends Item {
     // Action usage
     if ( "actionType" in this.system ) {
       this.labels.abilityCheck = game.i18n.format("DND5E.AbilityPromptTitle", {
-        ability: CONFIG.DND5E.abilities[this.system.ability]
+        ability: CONFIG.DND5E.abilities[this.system.ability]?.label ?? ""
       });
 
       // Saving throws
@@ -552,7 +552,7 @@ export default class Item5e extends Item {
     }
 
     // Update labels
-    const abl = CONFIG.DND5E.abilities[save.ability] ?? "";
+    const abl = CONFIG.DND5E.abilities[save.ability]?.label ?? "";
     this.labels.save = game.i18n.format("DND5E.SaveDC", {dc: save.dc || "", ability: abl});
     return save.dc;
   }
@@ -1318,7 +1318,7 @@ export default class Item5e extends Item {
    */
   _toolChatData(data, labels, props) {
     props.push(
-      CONFIG.DND5E.abilities[data.ability] || null,
+      CONFIG.DND5E.abilities[data.ability]?.label || null,
       CONFIG.DND5E.proficiencyLevels[data.proficient || 0]
     );
   }


### PR DESCRIPTION
- Merge `DND5E.abilities` & `DND5E.abilityAbbreviations` into single object
- Add `type` to abilities to specify whether they are `"mental"` or `"physical"` and adjust polymorphing to make use of those types rather than hardcoded values (resolves #1848)
- Add a `defaults` object to those where different default values can be specified for different actor types and adjust `Actor5e#_prepareBaseAbilities` to make use of these defaults rather than hardcoding values (resolves #1846)