### PR TITLE
[#1629] Adds confirmation prompt to item deletion.

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1112,7 +1112,7 @@ export default class ActorSheet5e extends ActorSheet {
       }
     }
 
-    return item.delete();
+    return item.deleteDialog();
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Changes deletion to be a delete dialog instead.
- While testing with classes and subclasses, there is no double-up on confirmation dialogs unless you choose to not remove the items granted.

Closes #1629.