### PR TITLE
[#1839] Provided `parts` array overriding default `parts` in various rolls.

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -860,17 +860,12 @@ export default class Actor5e extends Actor {
       data.skillBonus = Roll.replaceFormulaData(globalBonuses.skill, data);
     }
 
-    // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
-    else options.parts = parts;
-
     // Reliable Talent applies to any skill check we have full or better proficiency in
     const reliableTalent = (skl.value >= 1 && this.getFlag("dnd5e", "reliableTalent"));
 
     // Roll and return
     const flavor = game.i18n.format("DND5E.SkillPromptTitle", {skill: CONFIG.DND5E.skills[skillId]?.label ?? ""});
     const rollData = foundry.utils.mergeObject({
-      parts: parts,
       data: data,
       title: `${flavor}: ${this.name}`,
       flavor,
@@ -882,6 +877,7 @@ export default class Actor5e extends Actor {
         "flags.dnd5e.roll": {type: "skill", skillId }
       }
     }, options);
+    rollData.parts = parts.concat(options.parts ?? []);
 
     /**
      * A hook event that fires before a skill check is rolled for an Actor.
@@ -974,14 +970,9 @@ export default class Actor5e extends Actor {
       data.checkBonus = Roll.replaceFormulaData(globalBonuses.check, data);
     }
 
-    // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
-    else options.parts = parts;
-
     // Roll and return
     const flavor = game.i18n.format("DND5E.AbilityPromptTitle", {ability: label});
     const rollData = foundry.utils.mergeObject({
-      parts,
       data,
       title: `${flavor}: ${this.name}`,
       flavor,
@@ -991,6 +982,7 @@ export default class Actor5e extends Actor {
         "flags.dnd5e.roll": {type: "ability", abilityId }
       }
     }, options);
+    rollData.parts = parts.concat(options.parts ?? []);
 
     /**
      * A hook event that fires before an ability test is rolled for an Actor.
@@ -1057,14 +1049,9 @@ export default class Actor5e extends Actor {
       data.saveBonus = Roll.replaceFormulaData(globalBonuses.save, data);
     }
 
-    // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
-    else options.parts = parts;
-
     // Roll and return
     const flavor = game.i18n.format("DND5E.SavePromptTitle", {ability: label});
     const rollData = foundry.utils.mergeObject({
-      parts,
       data,
       title: `${flavor}: ${this.name}`,
       flavor,
@@ -1074,6 +1061,7 @@ export default class Actor5e extends Actor {
         "flags.dnd5e.roll": {type: "save", abilityId }
       }
     }, options);
+    rollData.parts = parts.concat(options.parts ?? []);
 
     /**
      * A hook event that fires before an ability save is rolled for an Actor.
@@ -1135,14 +1123,9 @@ export default class Actor5e extends Actor {
       data.saveBonus = Roll.replaceFormulaData(globalBonuses.save, data);
     }
 
-    // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
-    else options.parts = parts;
-
     // Evaluate the roll
     const flavor = game.i18n.localize("DND5E.DeathSavingThrow");
     const rollData = foundry.utils.mergeObject({
-      parts,
       data,
       title: `${flavor}: ${this.name}`,
       flavor,
@@ -1153,6 +1136,7 @@ export default class Actor5e extends Actor {
         "flags.dnd5e.roll": {type: "death"}
       }
     }, options);
+    rollData.parts = parts.concat(options.parts ?? []);
 
     /**
      * A hook event that fires before a death saving throw is rolled for an Actor.

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -861,7 +861,7 @@ export default class Actor5e extends Actor {
     }
 
     // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts.push(...parts);
+    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
     else options.parts = parts;
 
     // Reliable Talent applies to any skill check we have full or better proficiency in
@@ -975,7 +975,7 @@ export default class Actor5e extends Actor {
     }
 
     // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts.push(...parts);
+    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
     else options.parts = parts;
 
     // Roll and return
@@ -1058,7 +1058,7 @@ export default class Actor5e extends Actor {
     }
 
     // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts.push(...parts);
+    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
     else options.parts = parts;
 
     // Roll and return
@@ -1136,7 +1136,7 @@ export default class Actor5e extends Actor {
     }
 
     // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts.push(...parts);
+    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
     else options.parts = parts;
 
     // Evaluate the roll

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -861,7 +861,8 @@ export default class Actor5e extends Actor {
     }
 
     // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) parts.push(...options.parts);
+    if ( options.parts?.length > 0 ) options.parts.push(...parts);
+    else options.parts = parts;
 
     // Reliable Talent applies to any skill check we have full or better proficiency in
     const reliableTalent = (skl.value >= 1 && this.getFlag("dnd5e", "reliableTalent"));
@@ -974,7 +975,8 @@ export default class Actor5e extends Actor {
     }
 
     // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) parts.push(...options.parts);
+    if ( options.parts?.length > 0 ) options.parts.push(...parts);
+    else options.parts = parts;
 
     // Roll and return
     const flavor = game.i18n.format("DND5E.AbilityPromptTitle", {ability: label});
@@ -1056,7 +1058,8 @@ export default class Actor5e extends Actor {
     }
 
     // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) parts.push(...options.parts);
+    if ( options.parts?.length > 0 ) options.parts.push(...parts);
+    else options.parts = parts;
 
     // Roll and return
     const flavor = game.i18n.format("DND5E.SavePromptTitle", {ability: label});
@@ -1131,6 +1134,10 @@ export default class Actor5e extends Actor {
       parts.push("@saveBonus");
       data.saveBonus = Roll.replaceFormulaData(globalBonuses.save, data);
     }
+
+    // Add provided extra roll parts now because they will get clobbered by mergeObject below
+    if ( options.parts?.length > 0 ) options.parts.push(...parts);
+    else options.parts = parts;
 
     // Evaluate the roll
     const flavor = game.i18n.localize("DND5E.DeathSavingThrow");

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1326,6 +1326,10 @@ export default class Item5e extends Item {
     const elvenAccuracy = (flags.elvenAccuracy
       && CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(this.abilityMod)) || undefined;
 
+    // Add provided extra roll parts now because they will get clobbered by mergeObject below
+    if ( options.parts?.length > 0 ) options.parts.push(...parts);
+    else options.parts = parts;
+
     // Compose roll options
     const rollConfig = foundry.utils.mergeObject({
       parts,
@@ -1463,6 +1467,10 @@ export default class Item5e extends Item {
 
     // Factor in extra weapon-specific critical damage
     if ( this.system.critical?.damage ) rollConfig.criticalBonusDamage = this.system.critical.damage;
+
+    // Add provided extra roll parts now because they will get clobbered by mergeObject below
+    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
+    else options.parts = parts;
 
     foundry.utils.mergeObject(rollConfig, options);
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1720,6 +1720,10 @@ export default class Item5e extends Item {
       rollData.checkBonus = Roll.replaceFormulaData(globalBonus.check, rollData);
     }
 
+    // Add provided extra roll parts now because they will get clobbered by mergeObject below
+    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
+    else options.parts = parts;
+
     // Compose the roll data
     const rollConfig = foundry.utils.mergeObject({
       parts: parts,

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1326,13 +1326,8 @@ export default class Item5e extends Item {
     const elvenAccuracy = (flags.elvenAccuracy
       && CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(this.abilityMod)) || undefined;
 
-    // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
-    else options.parts = parts;
-
     // Compose roll options
     const rollConfig = foundry.utils.mergeObject({
-      parts,
       actor: this.actor,
       data: rollData,
       critical: this.getCriticalThreshold(),
@@ -1350,6 +1345,7 @@ export default class Item5e extends Item {
         speaker: ChatMessage.getSpeaker({actor: this.actor})
       }
     }, options);
+    rollConfig.parts = parts.concat(options.parts ?? []);
 
     /**
      * A hook event that fires before an attack is rolled for an Item.
@@ -1414,7 +1410,6 @@ export default class Item5e extends Item {
       critical,
       data: rollData,
       event,
-      parts: parts,
       title: title,
       flavor: this.labels.damageTypes.length ? `${title} (${this.labels.damageTypes})` : title,
       dialogOptions: {
@@ -1468,11 +1463,8 @@ export default class Item5e extends Item {
     // Factor in extra weapon-specific critical damage
     if ( this.system.critical?.damage ) rollConfig.criticalBonusDamage = this.system.critical.damage;
 
-    // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
-    else options.parts = parts;
-
     foundry.utils.mergeObject(rollConfig, options);
+    rollConfig.parts = parts.concat(options.parts ?? []);
 
     /**
      * A hook event that fires before a damage is rolled for an Item.
@@ -1720,13 +1712,8 @@ export default class Item5e extends Item {
       rollData.checkBonus = Roll.replaceFormulaData(globalBonus.check, rollData);
     }
 
-    // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
-    else options.parts = parts;
-
     // Compose the roll data
     const rollConfig = foundry.utils.mergeObject({
-      parts: parts,
       data: rollData,
       title: title,
       flavor: title,
@@ -1743,6 +1730,7 @@ export default class Item5e extends Item {
         "flags.dnd5e.roll": {type: "tool", itemId: this.id }
       }
     }, options);
+    rollConfig.parts = parts.concat(options.parts ?? []);
 
     /**
      * A hook event that fires before a tool check is rolled for an Item.

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1327,7 +1327,7 @@ export default class Item5e extends Item {
       && CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(this.abilityMod)) || undefined;
 
     // Add provided extra roll parts now because they will get clobbered by mergeObject below
-    if ( options.parts?.length > 0 ) options.parts.push(...parts);
+    if ( options.parts?.length > 0 ) options.parts = parts.concat(options.parts);
     else options.parts = parts;
 
     // Compose roll options


### PR DESCRIPTION
Merges default and provided `parts` array in the following methods:
- `Actor#rollAbilityTest`, `rollAbilitySave`, `rollDeathSave`, `rollSkill`.
- `Item#rollAttack`, `rollDamage`, `rollToolCheck`.

Closes #1839.