### PR TITLE
Add Devil's Sight as a sense in creature data and on sheets

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -719,6 +719,7 @@
 "DND5E.SensesConfig": "Configure Senses",
 "DND5E.SensesConfigHint": "Configure any special sensory perception abilities that this actor possesses.",
 "DND5E.SenseDarkvision": "Darkvision",
+"DND5E.SenseDevilsSight": "Devil's Sight",
 "DND5E.SenseBlindsight": "Blindsight",
 "DND5E.SenseTremorsense": "Tremorsense",
 "DND5E.SenseTruesight": "Truesight",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -840,6 +840,7 @@ DND5E.hitDieTypes = ["d4", "d6", "d8", "d10", "d12"];
 DND5E.senses = {
   blindsight: "DND5E.SenseBlindsight",
   darkvision: "DND5E.SenseDarkvision",
+  devilsSight: "DND5E.SenseDevilsSight",
   tremorsense: "DND5E.SenseTremorsense",
   truesight: "DND5E.SenseTruesight"
 };

--- a/packs/src/classfeatures/invocation-devils-sight.json
+++ b/packs/src/classfeatures/invocation-devils-sight.json
@@ -73,7 +73,7 @@
       "_id": "3JYlSTG0olbm1FQC",
       "changes": [
         {
-          "key": "system.attributes.senses.darkvision",
+          "key": "system.attributes.senses.devilsSight",
           "mode": 4,
           "value": "120",
           "priority": null

--- a/template.json
+++ b/template.json
@@ -124,6 +124,7 @@
           "senses": {
             "darkvision": 0,
             "blindsight": 0,
+            "devilsSight": 0,
             "tremorsense": 0,
             "truesight": 0,
             "units": "ft",


### PR DESCRIPTION
Closes #1869 

Notes:
- The current senses are all single words, so there was no casing precedent. I went with camel case but am happy to change it to anything else.
- I notice the compendium build results are committed. Should a rebuild be done with this PR or in a followup?