### PR TITLE
[#1550, #1575] Refactor spellcasting preparation & add support for custom progressions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -854,6 +854,7 @@
 "DND5E.SpellProgArt": "Artificer",
 "DND5E.SpellProgFull": "Full Caster",
 "DND5E.SpellProgHalf": "Half Caster",
+"DND5E.SpellProgLeveled": "Leveled Magic",
 "DND5E.SpellProgOverride": "Override slots",
 "DND5E.SpellProgPact": "Pact Magic",
 "DND5E.SpellProgThird": "Third Caster",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -903,6 +903,38 @@ DND5E.senses = {
 preLocalize("senses", { sort: true });
 
 /* -------------------------------------------- */
+/*  Spellcasting                                */
+/* -------------------------------------------- */
+
+/**
+ * Define the standard slot progression by character level.
+ * The entries of this array represent the spell slot progression for a full spell-caster.
+ * @type {number[][]}
+ */
+DND5E.SPELL_SLOT_TABLE = [
+  [2],
+  [3],
+  [4, 2],
+  [4, 3],
+  [4, 3, 2],
+  [4, 3, 3],
+  [4, 3, 3, 1],
+  [4, 3, 3, 2],
+  [4, 3, 3, 3, 1],
+  [4, 3, 3, 3, 2],
+  [4, 3, 3, 3, 2, 1],
+  [4, 3, 3, 3, 2, 1],
+  [4, 3, 3, 3, 2, 1, 1],
+  [4, 3, 3, 3, 2, 1, 1],
+  [4, 3, 3, 3, 2, 1, 1, 1],
+  [4, 3, 3, 3, 2, 1, 1, 1],
+  [4, 3, 3, 3, 2, 1, 1, 1, 1],
+  [4, 3, 3, 3, 3, 1, 1, 1, 1],
+  [4, 3, 3, 3, 3, 2, 1, 1, 1],
+  [4, 3, 3, 3, 3, 2, 2, 1, 1]
+];
+
+/* -------------------------------------------- */
 
 /**
  * Various different ways a spell can be prepared.
@@ -916,25 +948,61 @@ DND5E.spellPreparationModes = {
 };
 preLocalize("spellPreparationModes");
 
+/* -------------------------------------------- */
+
 /**
  * Subset of `DND5E.spellPreparationModes` that consume spell slots.
  * @type {boolean[]}
  */
 DND5E.spellUpcastModes = ["always", "pact", "prepared"];
 
+/* -------------------------------------------- */
+
+/**
+ * Configuration data for different types of spellcasting progression.
+ *
+ * @typedef {object} SpellProgressionConfiguration
+ * @property {string} label       Localized label.
+ * @property {string} type        How progression is calculated, currently supports "leveled" or "pact".
+ * @property {number} [divisor]   Amount class level is divided by for leveled progression.
+ * @property {boolean} [roundUp]  Should fractional values should be rounded up by default?
+ */
+
 /**
  * Ways in which a class can contribute to spellcasting levels.
- * @enum {string}
+ * @enum {SpellProgressionConfiguration}
  */
 DND5E.spellProgression = {
-  none: "DND5E.SpellNone",
-  full: "DND5E.SpellProgFull",
-  half: "DND5E.SpellProgHalf",
-  third: "DND5E.SpellProgThird",
-  pact: "DND5E.SpellProgPact",
-  artificer: "DND5E.SpellProgArt"
+  none: {
+    label: "DND5E.SpellNone"
+  },
+  full: {
+    label: "DND5E.SpellProgFull",
+    type: "leveled",
+    divisor: 1
+  },
+  half: {
+    label: "DND5E.SpellProgHalf",
+    type: "leveled",
+    divisor: 2
+  },
+  third: {
+    label: "DND5E.SpellProgThird",
+    type: "leveled",
+    divisor: 3
+  },
+  pact: {
+    label: "DND5E.SpellProgPact",
+    type: "pact"
+  },
+  artificer: {
+    label: "DND5E.SpellProgArt",
+    type: "leveled",
+    divisor: 2,
+    roundUp: true
+  }
 };
-preLocalize("spellProgression");
+preLocalize("spellProgression", { key: "label" });
 
 /* -------------------------------------------- */
 
@@ -1105,34 +1173,6 @@ DND5E.spellScrollIds = {
 DND5E.sourcePacks = {
   ITEMS: "dnd5e.items"
 };
-
-/**
- * Define the standard slot progression by character level.
- * The entries of this array represent the spell slot progression for a full spell-caster.
- * @type {number[][]}
- */
-DND5E.SPELL_SLOT_TABLE = [
-  [2],
-  [3],
-  [4, 2],
-  [4, 3],
-  [4, 3, 2],
-  [4, 3, 3],
-  [4, 3, 3, 1],
-  [4, 3, 3, 2],
-  [4, 3, 3, 3, 1],
-  [4, 3, 3, 3, 2],
-  [4, 3, 3, 3, 2, 1],
-  [4, 3, 3, 3, 2, 1],
-  [4, 3, 3, 3, 2, 1, 1],
-  [4, 3, 3, 3, 2, 1, 1],
-  [4, 3, 3, 3, 2, 1, 1, 1],
-  [4, 3, 3, 3, 2, 1, 1, 1],
-  [4, 3, 3, 3, 2, 1, 1, 1, 1],
-  [4, 3, 3, 3, 3, 1, 1, 1, 1],
-  [4, 3, 3, 3, 3, 2, 1, 1, 1],
-  [4, 3, 3, 3, 3, 2, 2, 1, 1]
-];
 
 /* -------------------------------------------- */
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -959,58 +959,71 @@ DND5E.spellUpcastModes = ["always", "pact", "prepared"];
 /* -------------------------------------------- */
 
 /**
- * Configuration data for different types of spellcasting progression.
+ * Configuration data for different types of spellcasting supported.
  *
- * @typedef {object} SpellProgressionConfiguration
- * @property {string} label       Localized label.
- * @property {string} [type]      How progression is calculated as defined in `DND5E.spellProgressionTypes`.
- * @property {number} [divisor]   Amount class level is divided by for leveled progression.
- * @property {boolean} [roundUp]  Should fractional values should be rounded up by default?
+ * @typedef {object} SpellcastingTypeConfiguration
+ * @property {string} label                                                        Localized label.
+ * @property {Object<string, SpellcastingProgressionConfiguration>} [progression]  Any progression modes for this type.
  */
 
 /**
- * Ways in which a class can contribute to spellcasting levels.
- * @enum {SpellProgressionConfiguration}
+ * Configuration data for a spellcasting progression mode.
+ *
+ * @typedef {object} SpellcastingProgressionConfiguration
+ * @property {string} label             Localized label.
+ * @property {number} [divisor=1]       Value by which the class levels are divided to determine spellcasting level.
+ * @property {boolean} [roundUp=false]  Should fractional values should be rounded up by default?
  */
-DND5E.spellProgression = {
-  none: {
-    label: "DND5E.SpellNone"
-  },
-  full: {
-    label: "DND5E.SpellProgFull",
-    type: "leveled",
-    divisor: 1
-  },
-  half: {
-    label: "DND5E.SpellProgHalf",
-    type: "leveled",
-    divisor: 2
-  },
-  third: {
-    label: "DND5E.SpellProgThird",
-    type: "leveled",
-    divisor: 3
+
+/**
+ * Different spellcasting types and their progression.
+ * @type {SpellcastingTypeConfiguration}
+ */
+DND5E.spellcastingTypes = {
+  leveled: {
+    label: "DND5E.SpellProgLeveled",
+    progression: {
+      full: {
+        label: "DND5E.SpellProgFull",
+        divisor: 1
+      },
+      half: {
+        label: "DND5E.SpellProgHalf",
+        divisor: 2
+      },
+      third: {
+        label: "DND5E.SpellProgThird",
+        divisor: 3
+      },
+      artificer: {
+        label: "DND5E.SpellProgArt",
+        divisor: 2,
+        roundUp: true
+      }
+    }
   },
   pact: {
-    label: "DND5E.SpellProgPact",
-    type: "pact"
-  },
-  artificer: {
-    label: "DND5E.SpellProgArt",
-    type: "leveled",
-    divisor: 2,
-    roundUp: true
+    label: "DND5E.SpellProgPact"
   }
 };
-preLocalize("spellProgression", { key: "label" });
+preLocalize("spellcastingTypes", { key: "label", sort: true });
+preLocalize("spellcastingTypes.leveled.progression", { key: "label" });
 
 /* -------------------------------------------- */
 
 /**
- * Spell progression categories that can be used within `DND5E.spellProgression`.
- * @type {string[]}
+ * Ways in which a class can contribute to spellcasting levels.
+ * @enum {string}
  */
-DND5E.spellProgressionTypes = ["leveled", "pact"];
+DND5E.spellProgression = {
+  none: "DND5E.SpellNone",
+  full: "DND5E.SpellProgFull",
+  half: "DND5E.SpellProgHalf",
+  third: "DND5E.SpellProgThird",
+  pact: "DND5E.SpellProgPact",
+  artificer: "DND5E.SpellProgArt"
+};
+preLocalize("spellProgression", { key: "label" });
 
 /* -------------------------------------------- */
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -963,7 +963,7 @@ DND5E.spellUpcastModes = ["always", "pact", "prepared"];
  *
  * @typedef {object} SpellProgressionConfiguration
  * @property {string} label       Localized label.
- * @property {string} type        How progression is calculated, currently supports "leveled" or "pact".
+ * @property {string} [type]      How progression is calculated as defined in `DND5E.spellProgressionTypes`.
  * @property {number} [divisor]   Amount class level is divided by for leveled progression.
  * @property {boolean} [roundUp]  Should fractional values should be rounded up by default?
  */
@@ -1003,6 +1003,14 @@ DND5E.spellProgression = {
   }
 };
 preLocalize("spellProgression", { key: "label" });
+
+/* -------------------------------------------- */
+
+/**
+ * Spell progression categories that can be used within `DND5E.spellProgression`.
+ * @type {string[]}
+ */
+DND5E.spellProgressionTypes = ["leveled", "pact"];
 
 /* -------------------------------------------- */
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1015,6 +1015,26 @@ DND5E.spellProgressionTypes = ["leveled", "pact"];
 /* -------------------------------------------- */
 
 /**
+ * Valid spell levels.
+ * @enum {string}
+ */
+DND5E.spellLevels = {
+  0: "DND5E.SpellLevel0",
+  1: "DND5E.SpellLevel1",
+  2: "DND5E.SpellLevel2",
+  3: "DND5E.SpellLevel3",
+  4: "DND5E.SpellLevel4",
+  5: "DND5E.SpellLevel5",
+  6: "DND5E.SpellLevel6",
+  7: "DND5E.SpellLevel7",
+  8: "DND5E.SpellLevel8",
+  9: "DND5E.SpellLevel9"
+};
+preLocalize("spellLevels");
+
+/* -------------------------------------------- */
+
+/**
  * The available choices for how spell damage scaling may be computed.
  * @enum {string}
  */
@@ -1024,6 +1044,83 @@ DND5E.spellScalingModes = {
   level: "DND5E.SpellLevel"
 };
 preLocalize("spellScalingModes", { sort: true });
+
+/* -------------------------------------------- */
+
+/**
+ * Types of components that can be required when casting a spell.
+ * @enum {object}
+ */
+DND5E.spellComponents = {
+  vocal: {
+    label: "DND5E.ComponentVerbal",
+    abbr: "DND5E.ComponentVerbalAbbr"
+  },
+  somatic: {
+    label: "DND5E.ComponentSomatic",
+    abbr: "DND5E.ComponentSomaticAbbr"
+  },
+  material: {
+    label: "DND5E.ComponentMaterial",
+    abbr: "DND5E.ComponentMaterialAbbr"
+  }
+};
+preLocalize("spellComponents", {keys: ["label", "abbr"]});
+
+/* -------------------------------------------- */
+
+/**
+ * Supplementary rules keywords that inform a spell's use.
+ * @enum {object}
+ */
+DND5E.spellTags = {
+  concentration: {
+    label: "DND5E.Concentration",
+    abbr: "DND5E.ConcentrationAbbr"
+  },
+  ritual: {
+    label: "DND5E.Ritual",
+    abbr: "DND5E.RitualAbbr"
+  }
+};
+preLocalize("spellTags", {keys: ["label", "abbr"]});
+
+/* -------------------------------------------- */
+
+/**
+ * Schools to which a spell can belong.
+ * @enum {string}
+ */
+DND5E.spellSchools = {
+  abj: "DND5E.SchoolAbj",
+  con: "DND5E.SchoolCon",
+  div: "DND5E.SchoolDiv",
+  enc: "DND5E.SchoolEnc",
+  evo: "DND5E.SchoolEvo",
+  ill: "DND5E.SchoolIll",
+  nec: "DND5E.SchoolNec",
+  trs: "DND5E.SchoolTrs"
+};
+preLocalize("spellSchools", { sort: true });
+
+/* -------------------------------------------- */
+
+/**
+ * Spell scroll item ID within the `DND5E.sourcePacks` compendium for each level.
+ * @enum {string}
+ */
+DND5E.spellScrollIds = {
+  0: "rQ6sO7HDWzqMhSI3",
+  1: "9GSfMg0VOA2b4uFN",
+  2: "XdDp6CKh9qEvPTuS",
+  3: "hqVKZie7x9w3Kqds",
+  4: "DM7hzgL836ZyUFB1",
+  5: "wa1VF8TXHmkrrR35",
+  6: "tI3rWx4bxefNCexS",
+  7: "mtyw4NS1s7j2EJaD",
+  8: "aOrinPg7yuDZEuWr",
+  9: "O4YbkJkLlnsgUszZ"
+};
 
 /* -------------------------------------------- */
 /*  Weapon Details                              */
@@ -1084,95 +1181,6 @@ DND5E.weaponProperties = {
 preLocalize("weaponProperties", { sort: true });
 
 /* -------------------------------------------- */
-/*  Spell Details                               */
-/* -------------------------------------------- */
-
-/**
- * Types of components that can be required when casting a spell.
- * @enum {object}
- */
-DND5E.spellComponents = {
-  vocal: {
-    label: "DND5E.ComponentVerbal",
-    abbr: "DND5E.ComponentVerbalAbbr"
-  },
-  somatic: {
-    label: "DND5E.ComponentSomatic",
-    abbr: "DND5E.ComponentSomaticAbbr"
-  },
-  material: {
-    label: "DND5E.ComponentMaterial",
-    abbr: "DND5E.ComponentMaterialAbbr"
-  }
-};
-preLocalize("spellComponents", {keys: ["label", "abbr"]});
-
-/**
- * Supplementary rules keywords that inform a spell's use.
- * @enum {object}
- */
-DND5E.spellTags = {
-  concentration: {
-    label: "DND5E.Concentration",
-    abbr: "DND5E.ConcentrationAbbr"
-  },
-  ritual: {
-    label: "DND5E.Ritual",
-    abbr: "DND5E.RitualAbbr"
-  }
-};
-preLocalize("spellTags", {keys: ["label", "abbr"]});
-
-/**
- * Schools to which a spell can belong.
- * @enum {string}
- */
-DND5E.spellSchools = {
-  abj: "DND5E.SchoolAbj",
-  con: "DND5E.SchoolCon",
-  div: "DND5E.SchoolDiv",
-  enc: "DND5E.SchoolEnc",
-  evo: "DND5E.SchoolEvo",
-  ill: "DND5E.SchoolIll",
-  nec: "DND5E.SchoolNec",
-  trs: "DND5E.SchoolTrs"
-};
-preLocalize("spellSchools", { sort: true });
-
-/**
- * Valid spell levels.
- * @enum {string}
- */
-DND5E.spellLevels = {
-  0: "DND5E.SpellLevel0",
-  1: "DND5E.SpellLevel1",
-  2: "DND5E.SpellLevel2",
-  3: "DND5E.SpellLevel3",
-  4: "DND5E.SpellLevel4",
-  5: "DND5E.SpellLevel5",
-  6: "DND5E.SpellLevel6",
-  7: "DND5E.SpellLevel7",
-  8: "DND5E.SpellLevel8",
-  9: "DND5E.SpellLevel9"
-};
-preLocalize("spellLevels");
-
-/**
- * Spell scroll item ID within the `DND5E.sourcePacks` compendium for each level.
- * @enum {string}
- */
-DND5E.spellScrollIds = {
-  0: "rQ6sO7HDWzqMhSI3",
-  1: "9GSfMg0VOA2b4uFN",
-  2: "XdDp6CKh9qEvPTuS",
-  3: "hqVKZie7x9w3Kqds",
-  4: "DM7hzgL836ZyUFB1",
-  5: "wa1VF8TXHmkrrR35",
-  6: "tI3rWx4bxefNCexS",
-  7: "mtyw4NS1s7j2EJaD",
-  8: "aOrinPg7yuDZEuWr",
-  9: "O4YbkJkLlnsgUszZ"
-};
 
 /**
  * Compendium packs used for localized items.

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -626,7 +626,7 @@ export default class Actor5e extends Actor {
       // Grab all classes with spellcasting
       const classes = this.items.filter(c => {
         if ( c.type !== "class" ) return false;
-        const prog = config[c.system.spellcasting.progression];
+        const prog = config[c.spellcasting.progression];
         if ( !prog.type ) return false;
         types[prog.type] ??= 0;
         types[prog.type] += 1;
@@ -634,7 +634,7 @@ export default class Actor5e extends Actor {
       });
 
       for ( const cls of classes ) {
-        const type = config[cls.system.spellcasting.progression].type;
+        const type = config[cls.spellcasting.progression].type;
 
         /**
          * A hook event that fires while computing the spellcasting progression for each class on each actor.
@@ -684,7 +684,7 @@ export default class Actor5e extends Actor {
    */
   static _computeLeveledProgression(progression, actor, cls, count) {
     const levels = cls.system.levels;
-    const prog = CONFIG.DND5E.spellProgression[cls.system.spellcasting.progression];
+    const prog = CONFIG.DND5E.spellProgression[cls.spellcasting.progression];
     if ( !prog ) return;
 
     const rounder = ( (count === 1) || prog.roundUp) ? Math.ceil : Math.floor;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -255,10 +255,17 @@ export default class Item5e extends Item {
     const spellcasting = this.system.spellcasting;
     if ( !spellcasting ) return spellcasting;
     const isSubclass = this.type === "subclass";
-    const classSpellcasting = isSubclass ? this.class?.system.spellcasting : spellcasting;
-    const subclassSpellcasting = isSubclass ? spellcasting : this.subclass?.system.spellcasting;
-    if ( subclassSpellcasting && subclassSpellcasting.progression !== "none" ) return subclassSpellcasting;
-    return classSpellcasting;
+    const classSC = isSubclass ? this.class?.system.spellcasting : spellcasting;
+    const subclassSC = isSubclass ? spellcasting : this.subclass?.system.spellcasting;
+    const finalSC = ( subclassSC && (subclassSC.progression !== "none") ) ? subclassSC : classSC;
+
+    // Temp method for determining spellcasting type until this data is available directly using advancement
+    if ( CONFIG.DND5E.spellcastingTypes[finalSC.progression] ) finalSC.type = finalSC.progression;
+    else finalSC.type = Object.entries(CONFIG.DND5E.spellcastingTypes).find(([type, data]) => {
+      return !!data.progression?.[finalSC.progression];
+    })?.[0];
+
+    return finalSC;
   }
 
   /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -186,7 +186,7 @@ export function preLocalize(configKeyPath, { key, keys=[], sort=false }={}) {
  */
 export function performPreLocalization(config) {
   for ( const [keyPath, settings] of Object.entries(_preLocalizationRegistrations) ) {
-    let target = foundry.utils.getProperty(config, keyPath);
+    const target = foundry.utils.getProperty(config, keyPath);
     _localizeObject(target, settings.keys);
     if ( settings.sort ) foundry.utils.setProperty(config, keyPath, sortObjectEntries(target, settings.keys[0]));
   }

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -165,7 +165,7 @@ const _preLocalizationRegistrations = {};
 
 /**
  * Mark the provided config key to be pre-localized during the init stage.
- * @param {string} configKey              Key within `CONFIG.DND5E` to localize.
+ * @param {string} configKeyPath          Key path within `CONFIG.DND5E` to localize.
  * @param {object} [options={}]
  * @param {string} [options.key]          If each entry in the config enum is an object,
  *                                        localize and sort using this property.
@@ -173,9 +173,9 @@ const _preLocalizationRegistrations = {};
  *                                        if multiple are provided.
  * @param {boolean} [options.sort=false]  Sort this config enum, using the key if set.
  */
-export function preLocalize(configKey, { key, keys=[], sort=false }={}) {
+export function preLocalize(configKeyPath, { key, keys=[], sort=false }={}) {
   if ( key ) keys.unshift(key);
-  _preLocalizationRegistrations[configKey] = { keys, sort };
+  _preLocalizationRegistrations[configKeyPath] = { keys, sort };
 }
 
 /* -------------------------------------------- */
@@ -185,9 +185,10 @@ export function preLocalize(configKey, { key, keys=[], sort=false }={}) {
  * @param {object} config  The `CONFIG.DND5E` object to localize and sort. *Will be mutated.*
  */
 export function performPreLocalization(config) {
-  for ( const [key, settings] of Object.entries(_preLocalizationRegistrations) ) {
-    _localizeObject(config[key], settings.keys);
-    if ( settings.sort ) config[key] = sortObjectEntries(config[key], settings.keys[0]);
+  for ( const [keyPath, settings] of Object.entries(_preLocalizationRegistrations) ) {
+    let target = foundry.utils.getProperty(config, keyPath);
+    _localizeObject(target, settings.keys);
+    if ( settings.sort ) foundry.utils.setProperty(config, keyPath, sortObjectEntries(target, settings.keys[0]));
   }
 }
 

--- a/templates/items/parts/item-spellcasting.hbs
+++ b/templates/items/parts/item-spellcasting.hbs
@@ -2,7 +2,7 @@
   <label>{{localize "DND5E.SpellProgression"}}</label>
   <div class="form-fields">
     <select name="system.spellcasting.progression">
-      {{selectOptions config.spellProgression selected=system.spellcasting.progression}}
+      {{selectOptions config.spellProgression selected=system.spellcasting.progression labelAttr="label"}}
     </select>
   </div>
 </div>

--- a/templates/items/parts/item-spellcasting.hbs
+++ b/templates/items/parts/item-spellcasting.hbs
@@ -2,7 +2,7 @@
   <label>{{localize "DND5E.SpellProgression"}}</label>
   <div class="form-fields">
     <select name="system.spellcasting.progression">
-      {{selectOptions config.spellProgression selected=system.spellcasting.progression labelAttr="label"}}
+      {{selectOptions config.spellProgression selected=system.spellcasting.progression}}
     </select>
   </div>
 </div>


### PR DESCRIPTION
- Refactors `_prepareSpellcasting` method to make the spellcasting preparation process clearer and remove special cases
- Adds `_computeLeveledProgression` & `_computePactProgression` methods for build progression object from classes
- Adds `dnd5e.computeLeveledProgression` & `dnd5e.computePactProgression` hooks to allow for overriding the default behavior
- Adds `_prepareLeveledSlots` & `_preparePactSlots` and related hooks to allow for customizing slot creation behavior

This also introduces a `CONFIG.DND5E.spellcastingTypes` object that will eventually replace `spellProgression`. It defines two top-level types (`leveled` and `pact`) with the option for new additions by modules. Individual progressions (`full`, `half`, `third`, `artificer`) are defined underneath that top-level type. The type determines which hooks are called, so if you add a third type for psionics then the `dnd5e.computePsionicProgression` & `dnd5e.preparePsionicSlots` hooks will be called to allow for configuring that new spellcasting type.

Eventually when #1540 is implemented it would store `type` & `progression` as two separate configuration values rather than a single one like now. For the moment this simply derives the necessary information from the single `progression` value.