### PR TITLE
[#1882] Fix new Character's token prototypes not having vision enabled by default

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -689,8 +689,8 @@ export default class Actor5e extends Actor {
     // Configure prototype token settings
     const s = CONFIG.DND5E.tokenSizes[this.system.traits.size || "med"];
     const prototypeToken = {width: s, height: s};
-    if ( this.type === "character" ) Object.assign(prototypeToken, {vision: true, actorLink: true, disposition: 1});
-    this.updateSource({prototypeToken});
+    if ( this.type === "character" ) Object.assign(prototypeToken, {sight: { enabled: true }, actorLink: true, disposition: 1});
+    this.updateSource({prototypeToken}); 
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -689,7 +689,9 @@ export default class Actor5e extends Actor {
     // Configure prototype token settings
     const s = CONFIG.DND5E.tokenSizes[this.system.traits.size || "med"];
     const prototypeToken = {width: s, height: s};
-    if ( this.type === "character" ) Object.assign(prototypeToken, {sight: { enabled: true }, actorLink: true, disposition: 1});
+    if ( this.type === "character" ) Object.assign(prototypeToken, {
+      sight: { enabled: true }, actorLink: true, disposition: 1
+    });
     this.updateSource({prototypeToken});
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -690,7 +690,7 @@ export default class Actor5e extends Actor {
     const s = CONFIG.DND5E.tokenSizes[this.system.traits.size || "med"];
     const prototypeToken = {width: s, height: s};
     if ( this.type === "character" ) Object.assign(prototypeToken, {sight: { enabled: true }, actorLink: true, disposition: 1});
-    this.updateSource({prototypeToken}); 
+    this.updateSource({prototypeToken});
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Fixed it so new characters have vision by default. Fixes #1882 