### PR TITLE
[#1901] Take ammo's critical threshold into account when calculating attack's threshold

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -609,7 +609,7 @@ export default class Item5e extends Item {
    * - the constant '20'
    * @returns {number|null}  The minimum value that must be rolled to be considered a critical hit.
    */
-   getCriticalThreshold() {
+  getCriticalThreshold() {
     const actorFlags = this.actor.flags.dnd5e || {};
     if ( !this.hasAttack ) return null;
     let actorThreshold = null;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -613,14 +613,14 @@ export default class Item5e extends Item {
     const actorFlags = this.actor.flags.dnd5e || {};
     if ( !this.hasAttack ) return null;
     let actorThreshold = null;
-    let it = this.system.critical?.threshold ?? 20;
-    let at = 20;
+    let itemThreshold = this.system.critical?.threshold ?? Infinity;
+    let ammoThreshold = Infinity;
     if ( this.type === "weapon" ) actorThreshold = actorFlags.weaponCriticalThreshold;
     else if ( this.type === "spell" ) actorThreshold = actorFlags.spellCriticalThreshold;
     if ( this.system.consume?.type === "ammo" ) {
-      at = this.actor.items.get(this.system.consume.target)?.system.critical?.threshold ?? 20;
+      ammoThreshold = this.actor.items.get(this.system.consume.target)?.system.critical.threshold ?? Infinity;
     }
-    return Math.min(it, at, actorThreshold ?? 20);
+    return Math.min(itemThreshold, ammoThreshold, actorThreshold ?? 20);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -605,16 +605,22 @@ export default class Item5e extends Item {
    * Retrieve an item's critical hit threshold. Uses the smallest value from among the following sources:
    * - item document
    * - item document's actor (if it has one)
+   * - item document's ammunition (if it has any)
    * - the constant '20'
    * @returns {number|null}  The minimum value that must be rolled to be considered a critical hit.
    */
-  getCriticalThreshold() {
+   getCriticalThreshold() {
     const actorFlags = this.actor.flags.dnd5e || {};
     if ( !this.hasAttack ) return null;
     let actorThreshold = null;
+    let it = this.system.critical?.threshold ?? 20;
+    let at = 20;
     if ( this.type === "weapon" ) actorThreshold = actorFlags.weaponCriticalThreshold;
     else if ( this.type === "spell" ) actorThreshold = actorFlags.spellCriticalThreshold;
-    return Math.min(this.system.critical?.threshold ?? 20, actorThreshold ?? 20);
+    if ( this.system.consume?.type === "ammo" ) {
+      at = this.actor.items.get(this.system.consume.target)?.system.critical?.threshold ?? 20;
+    }
+    return Math.min(it, at, actorThreshold ?? 20);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Added ammunition's critical threshold to an item's `getCriticalThreshold`. Resolves #1901.