### PR TITLE
[#1293] Suppress unavailable effects on synthetic actors

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -56,20 +56,10 @@ export default class ActiveEffect5e extends ActiveEffect {
    */
   determineSuppression() {
     this.isSuppressed = false;
-    if ( this.disabled || (this.parent.documentName !== "Actor") ) return;
-    const [parentType, parentId, documentType, documentId, syntheticItem, syntheticItemId] = this.origin?.split(".") ?? [];
-    // case 1: linked or sidebar actor
-    if ( parentType === "Actor" ) {
-      if ( (parentId !== this.parent.id) || (documentType !== "Item") ) return;
-    }
-    // case 2: synthetic actor on scene
-    else if ( parentType === "Scene" ) {
-      if ( (documentId !== this.parent.token?.id) || (syntheticItem !== "Item") ) return;
-    }
-    // case 3: not an actor
-    else return;
-    const item = this.parent.items.get(documentId) ?? this.parent.items.get(syntheticItemId);
-    if ( !item ) return;
+    if ( this.disabled || (this.parent.documentName !== "Actor") || !this.origin ) return;
+    // Determine if this is an effect from an item
+    const item = fromUuidSync(this.origin);
+    if ( item?.parent !== this.parent ) return;
     this.isSuppressed = item.areEffectsSuppressed;
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -57,9 +57,18 @@ export default class ActiveEffect5e extends ActiveEffect {
   determineSuppression() {
     this.isSuppressed = false;
     if ( this.disabled || (this.parent.documentName !== "Actor") ) return;
-    const [parentType, parentId, documentType, documentId] = this.origin?.split(".") ?? [];
-    if ( (parentType !== "Actor") || (parentId !== this.parent.id) || (documentType !== "Item") ) return;
-    const item = this.parent.items.get(documentId);
+    const [parentType, parentId, documentType, documentId, syntheticItem, syntheticItemId] = this.origin?.split(".") ?? [];
+    // case 1: linked actor
+    if ( parentType === "Actor" ) {
+      if ( (parentId !== this.parent.id) || (documentType !== "Item") ) return;
+    }
+    // case 2: synthetic actor
+    else if ( parentType === "Scene" ) {
+      if ( (documentId !== this.parent.token?.id) || (syntheticItem !== "Item") ) return;
+    }
+    // case 3: not an actor
+    else return;
+    const item = this.parent.items.get(documentId) ?? this.parent.items.get(syntheticItemId);
     if ( !item ) return;
     this.isSuppressed = item.areEffectsSuppressed;
   }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -58,11 +58,11 @@ export default class ActiveEffect5e extends ActiveEffect {
     this.isSuppressed = false;
     if ( this.disabled || (this.parent.documentName !== "Actor") ) return;
     const [parentType, parentId, documentType, documentId, syntheticItem, syntheticItemId] = this.origin?.split(".") ?? [];
-    // case 1: linked actor
+    // case 1: linked or sidebar actor
     if ( parentType === "Actor" ) {
       if ( (parentId !== this.parent.id) || (documentType !== "Item") ) return;
     }
-    // case 2: synthetic actor
+    // case 2: synthetic actor on scene
     else if ( parentType === "Scene" ) {
       if ( (documentId !== this.parent.token?.id) || (syntheticItem !== "Item") ) return;
     }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -57,10 +57,12 @@ export default class ActiveEffect5e extends ActiveEffect {
   determineSuppression() {
     this.isSuppressed = false;
     if ( this.disabled || (this.parent.documentName !== "Actor") || !this.origin ) return;
-    // Determine if this is an effect from an item
-    const item = fromUuidSync(this.origin);
-    if ( item?.parent !== this.parent ) return;
-    this.isSuppressed = item.areEffectsSuppressed;
+    try {
+      // Determine if this is an effect from an item
+      const item = fromUuidSync(this.origin);
+      if ( item?.parent !== this.parent ) return;
+      this.isSuppressed = item.areEffectsSuppressed;
+    } catch(e) {}
   }
 
   /* --------------------------------------------- */


### PR DESCRIPTION
This is an attempt to resolve #1293, changing the logic of determineSuppression given that uuids for linked and unlinked actors are different.

Updated: Using `fromUuidSync` and getting the item (the origin) immediately, and checking the equality of the effect's and item's (if any) parents, it should be a lot simpler.