### PR TITLE
[#1926] Add try-catch handling to placeTemplate case of Item5e._onChatCardAction

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1907,8 +1907,9 @@ export default class Item5e extends Item {
       case "toolCheck":
         await item.rollToolCheck({event}); break;
       case "placeTemplate":
-        const template = dnd5e.canvas.AbilityTemplate.fromItem(item);
-        if ( template ) template.drawPreview();
+        try {
+          await (dnd5e.canvas.AbilityTemplate.fromItem(item))?.drawPreview();
+        } catch(err) {}
         break;
       case "abilityCheck":
         targets = this._getChatCardTargets(card);

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1908,7 +1908,7 @@ export default class Item5e extends Item {
         await item.rollToolCheck({event}); break;
       case "placeTemplate":
         try {
-          await (dnd5e.canvas.AbilityTemplate.fromItem(item))?.drawPreview();
+          await dnd5e.canvas.AbilityTemplate.fromItem(item)?.drawPreview();
         } catch(err) {}
         break;
       case "abilityCheck":


### PR DESCRIPTION
This pull request adds try-catch handling to the placeTemplate case of the `_onChatCardAction` method of the `Item5e` class. The absence of handling the rejection case of the promise from the `drawPreview` method of the created `AbilityTemplate` resulted in an uncaught error. The code within the placeTemplate case has also been refactored so as to resemble the code responsible for the creation of the initial `AbilityTemplate`.

Closes #1926