### PR TITLE
[#1835] Create system data model for containers (aka backpacks)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -557,6 +557,7 @@
 "DND5E.ItemConsumableType": "Consumable Type",
 "DND5E.ItemContainerCapacity": "Capacity",
 "DND5E.ItemContainerCapacityItems": "Items",
+"DND5E.ItemContainerCapacityMax": "Max Capacity",
 "DND5E.ItemContainerCapacityType": "Capacity Type",
 "DND5E.ItemContainerCapacityWeight": "Weight",
 "DND5E.ItemContainerDetails": "Container Details",

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -5,3 +5,4 @@ export * as actor from "./actor/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";
 export * as item from "./item/_module.mjs";
 export * as journal from "./journal/_module.mjs";
+export * as shared from "./shared/_module.mjs";

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -1,6 +1,9 @@
+import SystemDataModel from "../abstract.mjs";
+import CurrencyTemplate from "../shared/currency.mjs";
 
 /**
  * A data model and API layer which handles the schema and functionality of "group" type Actors in the dnd5e system.
+ * @mixes CurrencyTemplate
  *
  * @example Create a new Group
  * const g = new dnd5e.documents.Actor5e({
@@ -11,9 +14,8 @@
  *  }
  * });
  */
-export default class GroupActor extends foundry.abstract.DataModel {
-
-  /** @override */
+export default class GroupActor extends SystemDataModel.mixin(CurrencyTemplate) {
+  /** @inheritdoc */
   static defineSchema() {
     const fields = foundry.data.fields;
     return {

--- a/module/data/item/_module.mjs
+++ b/module/data/item/_module.mjs
@@ -1,6 +1,7 @@
 import BackgroundData from "./background.mjs";
 import ClassData from "./class.mjs";
 import ConsumableData from "./consumable.mjs";
+import ContainerData from "./container.mjs";
 import EquipmentData from "./equipment.mjs";
 import FeatData from "./feat.mjs";
 import LootData from "./loot.mjs";
@@ -13,6 +14,7 @@ export {
   BackgroundData,
   ClassData,
   ConsumableData,
+  ContainerData,
   EquipmentData,
   FeatData,
   LootData,
@@ -29,6 +31,7 @@ export {default as PhysicalItemTemplate} from "./templates/physical-item.mjs";
 
 export const config = {
   background: BackgroundData,
+  backpack: ContainerData,
   class: ClassData,
   consumable: ConsumableData,
   equipment: EquipmentData,

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -1,0 +1,35 @@
+import SystemDataModel from "../abstract.mjs";
+import ItemDescriptionTemplate from "./templates/item-description.mjs";
+import PhysicalItemTemplate from "./templates/physical-item.mjs";
+import CurrencyTemplate from "../shared/currency.mjs";
+
+
+/**
+ * Data definition for Backpack items.
+ * @mixes ItemDescriptionTemplate
+ * @mixes PhysicalItemTemplate
+ * @mixes CurrencyTemplate
+ *
+ * @property {object} capacity              Information on container's carrying capacity.
+ * @property {string} capacity.type         Method for tracking max capacity as defined in `DND5E.itemCapacityTypes`.
+ * @property {number} capacity.value        Total amount of the type this container can carry.
+ * @property {boolean} capacity.weightless  Does the weight of the items in the container carry over to the actor?
+ */
+export default class ContainerData extends SystemDataModel.mixin(
+  ItemDescriptionTemplate, PhysicalItemTemplate, CurrencyTemplate
+) {
+  /** @inheritdoc */
+  static defineSchema() {
+    return this.mergeSchema(super.defineSchema(), {
+      capacity: new foundry.data.fields.SchemaField({
+        type: new foundry.data.fields.StringField({
+          required: true, initial: "weight", blank: false, label: "DND5E.ItemContainerCapacityType"
+        }),
+        value: new foundry.data.fields.NumberField({
+          required: true, nullable: false, initial: 0, min: 0, label: "DND5E.ItemContainerCapacityMax"
+        }),
+        weightless: new foundry.data.fields.BooleanField({required: true, label: "DND5E.ItemContainerWeightless"})
+      }, {label: "DND5E.ItemContainerCapacity"})
+    });
+  }
+}

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -21,6 +21,7 @@ import { FormulaField } from "../../fields.mjs";
  * @mixin
  */
 export default class ActionTemplate extends foundry.abstract.DataModel {
+  /** @inheritdoc */
   static defineSchema() {
     return {
       ability: new foundry.data.fields.StringField({

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -31,6 +31,7 @@ import { FormulaField } from "../../fields.mjs";
  * @mixin
  */
 export default class ActivatedEffectTemplate extends foundry.abstract.DataModel {
+  /** @inheritdoc */
   static defineSchema() {
     return {
       activation: new foundry.data.fields.SchemaField({

--- a/module/data/item/templates/item-description.mjs
+++ b/module/data/item/templates/item-description.mjs
@@ -9,6 +9,7 @@
  * @mixin
  */
 export default class ItemDescriptionTemplate extends foundry.abstract.DataModel {
+  /** @inheritdoc */
   static defineSchema() {
     return {
       description: new foundry.data.fields.SchemaField({

--- a/module/data/item/templates/mountable.mjs
+++ b/module/data/item/templates/mountable.mjs
@@ -11,6 +11,7 @@
  * @mixin
  */
 export default class MountableTemplate extends foundry.abstract.DataModel {
+  /** @inheritdoc */
   static defineSchema() {
     return {
       armor: new foundry.data.fields.SchemaField({

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -11,6 +11,7 @@
  * @mixin
  */
 export default class PhysicalItemTemplate extends foundry.abstract.DataModel {
+  /** @inheritdoc */
   static defineSchema() {
     return {
       quantity: new foundry.data.fields.NumberField({

--- a/module/data/shared/_module.mjs
+++ b/module/data/shared/_module.mjs
@@ -1,0 +1,1 @@
+export {default as CurrencyTemplate} from "./currency.mjs";

--- a/module/data/shared/currency.mjs
+++ b/module/data/shared/currency.mjs
@@ -1,0 +1,18 @@
+import { MappingField } from "../fields.mjs";
+
+/**
+ * A template for currently held currencies.
+ *
+ * @property {object} currency  Object containing currencies as numbers.
+ * @mixin
+ */
+export default class CurrencyTemplate extends foundry.abstract.DataModel {
+  /** @inheritdoc */
+  static defineSchema() {
+    return {
+      currency: new MappingField(new foundry.data.fields.NumberField({
+        required: true, nullable: false, integer: true, min: 0, initial: 0
+      }), {initialKeys: CONFIG.DND5E.currencies, label: "DND5E.Currency"})
+    };
+  }
+}


### PR DESCRIPTION
I named it `ContainerData` in expectation of an eventual renaming of the `backpack` item type to `container` (#1622). If that seems too confusing, I can rename it to `BackpackData` and we can change it later.

Also, I moved the currency data to its own template so it can eventually contain currency conversion methods so they are available on containers in addition to actors. More work can be done on that once #1829 is integrated.