### PR TITLE
[#1956] fix: include roll flavour in damage rolls

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1397,13 +1397,13 @@ export default class Item5e extends Item {
 
     // Get roll data
     const dmg = this.system.damage;
-    const dmgParts = deepClone(dmg.parts)
+    const dmgParts = deepClone(dmg.parts);
     const rollData = this.getRollData();
     if ( spellLevel ) rollData.item.level = spellLevel;
 
     // Adjust damage from versatile usage
     if ( versatile && dmg.versatile ) {
-      parts[0][0] = dmg.versatile;
+      dmgParts[0][0] = dmg.versatile;
       messageData["flags.dnd5e.roll"].versatile = true;
     }
 


### PR DESCRIPTION
Suggested for for issue #1956

> I have been looking into making an automation module where I want to take damage types into consideration. I wanted to reuse Item5e.rollDamage() but this seems to [omit the flavour texts](https://github.com/foundryvtt/dnd5e/blob/f2c7c99193f5c00d327e9fb515b3759919b86e91/module/documents/item.mjs#L1400), would it be possible to add those to the roll?

I wasn't 100% sure on what the best practice is on merging flavors, but currently flavors seem to be appended so I have copied that behaviour. Example, if I have the damage formula `1d8[if uninjured]` with damage type `fire` it would become `1d8[if uninjured fire]`. An alternative result I could think of (but did not implement) would be `1d8[fire: if uninjured]`

This would be a rather unique case, in 99% of the cases the flavor is simply appended. Example: damage formula `8d6` with damage type `fire` it would become `8d6[fire]`.