### PR TITLE
[#1909] Add units to item weight & properly convert for calculating encumbrance

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1817,6 +1817,25 @@
 "DND5E.WeaponSimpleProficiency": "Simple",
 "DND5E.WeaponSimpleR": "Simple Ranged",
 "DND5E.Weight": "Weight",
+"DND5E.WeightUnit": {
+  "Label": "Weight Units",
+  "Kilograms": {
+    "Label": "Kilograms",
+    "Abbreviation": "kg"
+  },
+  "Megagrams": {
+    "Label": "Tonnes",
+    "Abbreviation": "t"
+  },
+  "Pounds": {
+    "Label": "Pounds",
+    "Abbreviation": "lb"
+  },
+  "Tons": {
+    "Label": "Tons",
+    "Abbreviation": "tn"
+  }
+},
 "DND5E.WhisperedTo": "Whispered to",
 "DND5E.Wiki": "Wiki",
 "DND5E.available": "available",

--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -137,7 +137,7 @@
         font-size: var(--font-size-13);
       }
 
-      [name="system.price.denomination"] {
+      :is([name="system.price.denomination"], [name="system.weight.units"]) {
         border: none;
       }
     }

--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -48,11 +48,6 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
       : CONFIG.DND5E.encumbrance.currencyPerWeight.imperial;
     totalWeight += totalCoins / currencyPerWeight;
 
-    // Vehicle weights are an order of magnitude greater.
-    totalWeight /= game.settings.get("dnd5e", "metricWeightUnits")
-      ? CONFIG.DND5E.encumbrance.vehicleWeightMultiplier.metric
-      : CONFIG.DND5E.encumbrance.vehicleWeightMultiplier.imperial;
-
     // Compute overall encumbrance
     const max = actorData.system.attributes.capacity.cargo;
     const pct = Math.clamped((totalWeight * 100) / max, 0, 100);
@@ -210,11 +205,14 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
         }, {
           label: game.i18n.localize("DND5E.Weight"),
           css: "item-weight",
-          property: "system.weight",
+          property: "system.weight.value",
           editable: "Number"
         }]
       }
     };
+
+    const baseUnits = CONFIG.DND5E.encumbrance.baseUnits[this.actor.type] ?? CONFIG.DND5E.encumbrance.baseUnits.default;
+    const units = game.settings.get("dnd5e", "metricWeightUnits") ? baseUnits.metric : baseUnits.imperial;
 
     // Classify items owned by the vehicle and compute total cargo weight
     let totalWeight = 0;
@@ -225,7 +223,7 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
       // Handle cargo explicitly
       const isCargo = item.flags.dnd5e?.vehicleCargo === true;
       if ( isCargo ) {
-        totalWeight += item.system.totalWeight ?? 0;
+        totalWeight += item.system.totalWeightin?.(units) ?? 0;
         cargo.cargo.items.push(item);
         continue;
       }
@@ -245,7 +243,7 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
           else features.actions.items.push(item);
           break;
         default:
-          totalWeight += item.system.totalWeight ?? 0;
+          totalWeight += item.system.totalWeightIn?.(units) ?? 0;
           cargo.cargo.items.push(item);
       }
     }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1773,7 +1773,7 @@ DND5E.weightUnits = {
     conversion: 2.2046,
     type: "metric"
   },
-  mg: {
+  Mg: {
     label: "DND5E.WeightUnit.Megagrams.Label",
     abbreviation: "DND5E.WeightUnit.Megagrams.Abbreviation",
     conversion: 2204.6,
@@ -1857,7 +1857,7 @@ DND5E.encumbrance = {
     },
     vehicle: {
       imperial: "tn",
-      metric: "mg"
+      metric: "Mg"
     }
   }
 };

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1770,13 +1770,13 @@ DND5E.weightUnits = {
   kg: {
     label: "DND5E.WeightUnit.Kilograms.Label",
     abbreviation: "DND5E.WeightUnit.Kilograms.Abbreviation",
-    conversion: 2.2046,
+    conversion: 2.5,
     type: "metric"
   },
   Mg: {
     label: "DND5E.WeightUnit.Megagrams.Label",
     abbreviation: "DND5E.WeightUnit.Megagrams.Abbreviation",
-    conversion: 2204.6,
+    conversion: 2500,
     type: "metric"
   }
 };

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1741,17 +1741,62 @@ preLocalize("distanceUnits");
 /* -------------------------------------------- */
 
 /**
+ * Configuration data for a weight unit.
+ *
+ * @typedef {object} WeightUnitConfiguration
+ * @property {string} label         Localized label for the unit.
+ * @property {string} abbreviation  Localized abbreviation for the unit.
+ * @property {number} conversion    Number that by which this unit should be multiplied to arrive at a standard value.
+ * @property {string} type          Whether this is an "imperial" or "metric" unit.
+ */
+
+/**
+ * The valid units for measurement of weight.
+ * @enum {WeightUnitConfiguration}
+ */
+DND5E.weightUnits = {
+  lb: {
+    label: "DND5E.WeightUnit.Pounds.Label",
+    abbreviation: "DND5E.WeightUnit.Pounds.Abbreviation",
+    conversion: 1,
+    type: "imperial"
+  },
+  tn: {
+    label: "DND5E.WeightUnit.Tons.Label",
+    abbreviation: "DND5E.WeightUnit.Tons.Abbreviation",
+    conversion: 2000,
+    type: "imperial"
+  },
+  kg: {
+    label: "DND5E.WeightUnit.Kilograms.Label",
+    abbreviation: "DND5E.WeightUnit.Kilograms.Abbreviation",
+    conversion: 2.2046,
+    type: "metric"
+  },
+  mg: {
+    label: "DND5E.WeightUnit.Megagrams.Label",
+    abbreviation: "DND5E.WeightUnit.Megagrams.Abbreviation",
+    conversion: 2204.6,
+    type: "metric"
+  }
+};
+preLocalize("weightUnits", { keys: ["label", "abbreviation"] });
+
+/* -------------------------------------------- */
+
+/**
  * Encumbrance configuration data.
  *
  * @typedef {object} EncumbranceConfiguration
  * @property {Record<string, number>} currencyPerWeight  Pieces of currency that equal a base weight (lbs or kgs).
- * @property {Record<string, object>} effects            Data used to create encumbrance-replated Active Effects.
+ * @property {Record<string, object>} effects            Data used to create encumbrance-related Active Effects.
  * @property {object} threshold                          Amount to multiply strength to get given capacity threshold.
  * @property {Record<string, number>} threshold.encumbered
  * @property {Record<string, number>} threshold.heavilyEncumbered
  * @property {Record<string, number>} threshold.maximum
  * @property {Record<string, {ft: number, m: number}>} speedReduction  Speed reduction caused by encumbered status.
  * @property {Record<string, number>} vehicleWeightMultiplier  Multiplier used to determine vehicle carrying capacity.
+ * @property {Record<string, Record<string, string>>} baseUnits  Base units used to calculate carrying weight.
  */
 
 /**
@@ -1805,9 +1850,15 @@ DND5E.encumbrance = {
       m: 1.5
     }
   },
-  vehicleWeightMultiplier: {
-    imperial: 2000, // 2000 lbs in an imperial ton
-    metric: 1000 // 1000 kg in a metric ton
+  baseUnits: {
+    default: {
+      imperial: "lb",
+      metric: "kg"
+    },
+    vehicle: {
+      imperial: "tn",
+      metric: "mg"
+    }
   }
 };
 Object.defineProperty(DND5E.encumbrance, "strMultiplier", {

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -199,7 +199,9 @@ export default class ContainerData extends ItemDataModel.mixin(
    */
   get contentsWeight() {
     if ( this.parent?.pack && !this.parent?.isEmbedded ) return this.#contentsWeight();
-    return this.contents.reduce((weight, item) => weight + item.system.totalWeight, this.currencyWeight);
+    return this.contents.reduce((weight, item) =>
+      weight + item.system.totalWeightIn(this.weight.units), this.currencyWeight
+    );
   }
 
   /**
@@ -208,7 +210,9 @@ export default class ContainerData extends ItemDataModel.mixin(
    */
   async #contentsWeight() {
     const contents = await this.contents;
-    return contents.reduce(async (weight, item) => await weight + await item.system.totalWeight, this.currencyWeight);
+    return contents.reduce(async (weight, item) =>
+      await weight + await item.system.totalWeightIn(this.weight.units), this.currencyWeight
+    );
   }
 
   /* -------------------------------------------- */
@@ -220,8 +224,8 @@ export default class ContainerData extends ItemDataModel.mixin(
   get totalWeight() {
     if ( this.properties.has("weightlessContents") ) return this.weight;
     const containedWeight = this.contentsWeight;
-    if ( containedWeight instanceof Promise ) return containedWeight.then(c => this.weight + c);
-    return this.weight + containedWeight;
+    if ( containedWeight instanceof Promise ) return containedWeight.then(c => this.weight.value + c);
+    return this.weight.value + containedWeight;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -207,7 +207,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
   /**
    * Calculate the total weight and return it in specific units.
    * @param {string} units  Units in which the weight should be returned.
-   * @returns {number}
+   * @returns {number|Promise<number>}
    */
   totalWeightIn(units) {
     const weight = this.totalWeight;

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -1,3 +1,4 @@
+import { convertWeight } from "../../../utils.mjs";
 import SystemDataModel from "../../abstract.mjs";
 
 /**
@@ -5,7 +6,9 @@ import SystemDataModel from "../../abstract.mjs";
  *
  * @property {string} container           Container within which this item is located.
  * @property {number} quantity            Number of items in a stack.
- * @property {number} weight              Item's weight in pounds or kilograms (depending on system setting).
+ * @property {object} weight
+ * @property {number} weight.value        Item's weight.
+ * @property {string} weight.units        Units used to measure the weight.
  * @property {object} price
  * @property {number} price.value         Item's cost in the specified denomination.
  * @property {string} price.denomination  Currency denomination used to determine price.
@@ -22,9 +25,15 @@ export default class PhysicalItemTemplate extends SystemDataModel {
       quantity: new foundry.data.fields.NumberField({
         required: true, nullable: false, integer: true, initial: 1, min: 0, label: "DND5E.Quantity"
       }),
-      weight: new foundry.data.fields.NumberField({
-        required: true, nullable: false, initial: 0, min: 0, label: "DND5E.Weight"
-      }),
+      weight: new foundry.data.fields.SchemaField({
+        value: new foundry.data.fields.NumberField({
+          required: true, nullable: false, initial: 0, min: 0, label: "DND5E.Weight"
+        }),
+        units: new foundry.data.fields.StringField({
+          required: true, label: "DND5E.WeightUnit.Label",
+          initial: () => game.settings.get("dnd5e", "metricWeightUnits") ? "kg" : "lb"
+        })
+      }, {label: "DND5E.Weight"}),
       price: new foundry.data.fields.SchemaField({
         value: new foundry.data.fields.NumberField({
           required: true, nullable: false, initial: 0, min: 0, label: "DND5E.Price"
@@ -66,7 +75,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
    * @type {number}
    */
   get totalWeight() {
-    return this.quantity * this.weight;
+    return this.quantity * this.weight.value;
   }
 
   /* -------------------------------------------- */
@@ -111,12 +120,15 @@ export default class PhysicalItemTemplate extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
-   * Convert null weights to 0.
+   * Migrate the item's weight from a single field to an object with units & convert null weights to 0.
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateWeight(source) {
-    if ( !("weight" in source) ) return;
-    if ( (source.weight === null) || (source.weight === undefined) ) source.weight = 0;
+    if ( !("weight" in source) || (foundry.utils.getType(source.weight) === "Object") ) return;
+    source.weight = {
+      value: Number.isNumeric(source.weight) ? Number(source.weight) : 0,
+      units: game.settings.get("dnd5e", "metricWeightUnits") ? "kg" : "lb"
+    };
   }
 
   /* -------------------------------------------- */
@@ -188,5 +200,18 @@ export default class PhysicalItemTemplate extends SystemDataModel {
       depth++;
     }
     return containers;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Calculate the total weight and return it in specific units.
+   * @param {string} units  Units in which the weight should be returned.
+   * @returns {number}
+   */
+  totalWeightIn(units) {
+    const weight = this.totalWeight;
+    if ( weight instanceof Promise ) return weight.then(w => convertWeight(w, this.weight.units, units));
+    return convertWeight(weight, this.weight.units, units);
   }
 }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -503,12 +503,11 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const encumbrance = this.system.attributes.encumbrance ??= {};
     const baseUnits = CONFIG.DND5E.encumbrance.baseUnits[this.type] ?? CONFIG.DND5E.encumbrance.baseUnits.default;
     const unitSystem = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
-    const units = unitSystem === "metric" ? baseUnits.metric : baseUnits.imperial;
 
     // Get the total weight from items
     let weight = this.items
       .filter(item => !item.container)
-      .reduce((weight, item) => weight + (item.system.totalWeightIn?.(units) ?? 0), 0);
+      .reduce((weight, item) => weight + (item.system.totalWeightIn?.(baseUnits[unitSystem]) ?? 0), 0);
 
     // [Optional] add Currency Weight (for non-transformed actors)
     const currency = this.system.currency;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -501,18 +501,20 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   _prepareEncumbrance() {
     const config = CONFIG.DND5E.encumbrance;
     const encumbrance = this.system.attributes.encumbrance ??= {};
-    const units = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
+    const baseUnits = CONFIG.DND5E.encumbrance.baseUnits[this.type] ?? CONFIG.DND5E.encumbrance.baseUnits.default;
+    const unitSystem = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
+    const units = unitSystem === "metric" ? baseUnits.metric : baseUnits.imperial;
 
     // Get the total weight from items
     let weight = this.items
       .filter(item => !item.container)
-      .reduce((weight, item) => weight + (item.system.totalWeight ?? 0), 0);
+      .reduce((weight, item) => weight + (item.system.totalWeightIn?.(units) ?? 0), 0);
 
     // [Optional] add Currency Weight (for non-transformed actors)
     const currency = this.system.currency;
     if ( game.settings.get("dnd5e", "currencyWeight") && currency ) {
       const numCoins = Object.values(currency).reduce((val, denom) => val + Math.max(denom, 0), 0);
-      const currencyPerWeight = config.currencyPerWeight[units];
+      const currencyPerWeight = config.currencyPerWeight[unitSystem];
       weight += numCoins / currencyPerWeight;
     }
 
@@ -525,16 +527,16 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const mod = sizeConfig?.capacityMultiplier ?? sizeConfig?.token ?? 1;
 
     const calculateThreshold = multiplier => this.type === "vehicle"
-      ? this.system.attributes.capacity.cargo * config.vehicleWeightMultiplier[units]
+      ? this.system.attributes.capacity.cargo
       : ((this.system.abilities.str?.value ?? 10) * multiplier * mod).toNearest(0.1);
 
     // Populate final Encumbrance values
     encumbrance.mod = mod;
     encumbrance.value = weight.toNearest(0.1);
     encumbrance.thresholds = {
-      encumbered: calculateThreshold(config.threshold.encumbered[units]),
-      heavilyEncumbered: calculateThreshold(config.threshold.heavilyEncumbered[units]),
-      maximum: calculateThreshold(config.threshold.maximum[units])
+      encumbered: calculateThreshold(config.threshold.encumbered[unitSystem]),
+      heavilyEncumbered: calculateThreshold(config.threshold.heavilyEncumbered[unitSystem]),
+      maximum: calculateThreshold(config.threshold.maximum[unitSystem])
     };
     encumbrance.max = encumbrance.thresholds.maximum;
     encumbrance.stops = {

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -213,6 +213,27 @@ export function getSceneTargets() {
 }
 
 /* -------------------------------------------- */
+/*  Conversions                                 */
+/* -------------------------------------------- */
+
+/**
+ * Convert the provided weight to another unit.
+ * @param {number} value  The weight being converted.
+ * @param {string} from   The initial units.
+ * @param {string} to     The final units.
+ * @returns {number}      Weight in the specified units.
+ */
+export function convertWeight(value, from, to) {
+  if ( from === to ) return value;
+  const message = unit => `Weight unit ${unit} not defined in CONFIG.DND5E.weightUnits`;
+  if ( !CONFIG.DND5E.weightUnits[from] ) throw new Error(message(from));
+  if ( !CONFIG.DND5E.weightUnits[to] ) throw new Error(message(to));
+  return value
+    * CONFIG.DND5E.weightUnits[from].conversion
+    / CONFIG.DND5E.weightUnits[to].conversion;
+}
+
+/* -------------------------------------------- */
 /*  Validators                                  */
 /* -------------------------------------------- */
 

--- a/templates/items/parts/item-description.hbs
+++ b/templates/items/parts/item-description.hbs
@@ -15,7 +15,10 @@
 
         <div class="form-group">
             <label>{{ localize "DND5E.Weight" }}</label>
-            {{numberInput system.weight name="system.weight"}}
+            {{ numberInput system.weight.value name="system.weight.value" }}
+            <select name="system.weight.units">
+                {{ selectOptions config.weightUnits selected=system.weight.units labelAttr="abbreviation" }}
+            </select>
         </div>
 
         <div class="form-group">

--- a/templates/shared/inventory.hbs
+++ b/templates/shared/inventory.hbs
@@ -115,7 +115,8 @@
                     <div class="item-detail item-weight">
                         {{#if ctx.totalWeight}}
                         <div class="item-detail">
-                            {{ ctx.totalWeight }} {{ @root.weightUnit }}
+                            {{ ctx.totalWeight }}
+                            {{ lookup (lookup @root.config.weightUnits item.system.weight.units) "abbreviation" }}
                         </div>
                         {{/if}}
                     </div>


### PR DESCRIPTION
Item weights now define a specific unit which will make it possible to have a mixture of imperial and metric object weights, as well as represent large items in vehicle inventories. Defines these weights along with a conversion method in `CONFIG.weightUnits`.

Closes #1909

### To Do
- [ ] Convert SRD items