### PR TITLE
Add spell level to attack rolls' options.

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1356,6 +1356,7 @@ export default class Item5e extends Item {
 
     // Get the parts and rollData for this item's attack
     const {parts, rollData} = this.getAttackToHit();
+    if ( options.spellLevel ) rollData.item.level = options.spellLevel;
 
     // Handle ammunition consumption
     delete this._ammo;
@@ -1893,7 +1894,11 @@ export default class Item5e extends Item {
     let targets;
     switch ( action ) {
       case "attack":
-        await item.rollAttack({event}); break;
+        await item.rollAttack({
+          event: event,
+          spellLevel: spellLevel
+        });
+        break;
       case "damage":
       case "versatile":
         await item.rollDamage({


### PR DESCRIPTION
When an item (a spell) is cast at a level higher than its base, the attack roll does not take its current level into account. That's fine, unless you give the spell an AttackBonus of `@item.level`, in which the base level is always used. This PR changes it so the spellLevel from the chat message is used, identical to the way `rollDamage` is performed.

`Item5e#rollAttack` accepts `spellLevel` as an option now, same as `Item5e#rollDamage`.

I have tested it on attack rolls with
- leveled spells at a base level,
- leveled spells cast at a higher level,
- cantrips,
- weapons