### PR TITLE
[#1977] [#1955] [#1930] [#1979] [#1984] Ammo localization; chatlog deprecation warning; world pack migration; actor spellcasting mod; null limited uses in ability dialog

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -302,7 +302,7 @@
 "DND5E.ConsumeWarningZeroAttribute": "{name} has run out of its designated attribute resource pool!",
 "DND5E.ConsumeResource": "Consume Resource?",
 "DND5E.ConsumeRecharge": "Consume Recharge?",
-"DND5E.ConsumableAmmunition": "Ammunition",
+"DND5E.ConsumableAmmo": "Ammunition",
 "DND5E.ConsumableFood": "Food",
 "DND5E.ConsumablePoison": "Poison",
 "DND5E.ConsumablePotion": "Potion",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -604,7 +604,7 @@ preLocalize("armorClasses", { key: "label" });
  * @enum {string}
  */
 DND5E.consumableTypes = {
-  ammo: "DND5E.ConsumableAmmunition",
+  ammo: "DND5E.ConsumableAmmo",
   potion: "DND5E.ConsumablePotion",
   poison: "DND5E.ConsumablePoison",
   food: "DND5E.ConsumableFood",

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -194,6 +194,8 @@ export default class Actor5e extends Actor {
     data.prof = new Proficiency(this.system.attributes.prof, 1);
     if ( deterministic ) data.prof = data.prof.flat;
 
+    data.attributes.spellmod = data.abilities[data.attributes.spellcasting || "int"]?.mod ?? 0;
+
     data.classes = {};
     for ( const [identifier, cls] of Object.entries(this.classes) ) {
       data.classes[identifier] = foundry.utils.deepClone(cls.system);

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -805,7 +805,7 @@ export default class Item5e extends Item {
       consumeResource: !!resource.target && (!item.hasAttack || (resource.type !== "ammo")),
       consumeSpellLevel: requireSpellSlot ? is.preparation.mode === "pact" ? "pact" : is.level : null,
       consumeSpellSlot: requireSpellSlot,
-      consumeUsage: !!is.uses?.per
+      consumeUsage: !!is.uses?.per && (is.uses?.max > 0)
     }, config);
 
     // Display a configuration dialog to customize the usage

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1907,7 +1907,7 @@ export default class Item5e extends Item {
       case "save":
         targets = this._getChatCardTargets(card);
         for ( let token of targets ) {
-          const speaker = ChatMessage.getSpeaker({scene: canvas.scene, token: token});
+          const speaker = ChatMessage.getSpeaker({scene: canvas.scene, token: token.document});
           await token.actor.rollAbilitySave(button.dataset.ability, { event, speaker });
         }
         break;
@@ -1921,7 +1921,7 @@ export default class Item5e extends Item {
       case "abilityCheck":
         targets = this._getChatCardTargets(card);
         for ( let token of targets ) {
-          const speaker = ChatMessage.getSpeaker({scene: canvas.scene, token: token});
+          const speaker = ChatMessage.getSpeaker({scene: canvas.scene, token: token.document});
           await token.actor.rollAbilityTest(button.dataset.ability, { event, speaker });
         }
         break;

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -69,7 +69,7 @@ export const migrateWorld = async function() {
 
   // Migrate World Compendium Packs
   for ( let p of game.packs ) {
-    if ( p.metadata.package !== "world" ) continue;
+    if ( p.metadata.packageType !== "world" ) continue;
     if ( !["Actor", "Item", "Scene"].includes(p.documentName) ) continue;
     await migrateCompendium(p);
   }


### PR DESCRIPTION
* Changed localization of Ammunition to use 'ammo', matching the key used for the consumable type. To the best of my ability, I've not found any other references to `DND5E.ConsumableAmmunition`.
* Passing the token document to the speaker method instead of the placeable, avoiding the only lingering deprecation warning I've encountered post v10 release.
* For 1930: Weirdly `metadata.package` does exist (as `"world"`) immediately when a compendium is created, but this property disappears when refreshed.
* Added `data.attributes.spellmod = data.abilities[data.attributes.spellcasting || "int"]?.mod ?? 0;` to actor's roll data. This one-liner may be a duplicate of a different issue; if so, I can easily remove it, though supporting a 'default' spellcasting modifier for actors that have none is still worthwhile.
* When determining whether Limited Uses should force the AbilityUseDialog, added a check for `uses.max > 0` rather than just `uses.per`, which is identical to whether the checkbox appears in the dialog.

Related issues:
- #1977
- #1955
- #1930 
- #1979 
- #1984 