### PR TITLE
Determine ActiveEffect suppression on all actor types

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -56,13 +56,21 @@ export default class ActiveEffect5e extends ActiveEffect {
    */
   determineSuppression() {
     this.isSuppressed = false;
-    if ( this.disabled || (this.parent.documentName !== "Actor") || !this.origin ) return;
-    try {
-      // Determine if this is an effect from an item
-      const item = fromUuidSync(this.origin);
-      if ( item?.parent !== this.parent ) return;
-      this.isSuppressed = item.areEffectsSuppressed;
-    } catch(e) {}
+    if ( this.disabled || (this.parent.documentName !== "Actor") ) return;
+    const [parentType, parentId, documentType, documentId, syntheticItem, syntheticItemId] = this.origin?.split(".") ?? [];
+    // Case 1: This is a linked or sidebar actor
+    if ( parentType === "Actor" ) {
+      if ( (parentId !== this.parent.id) || (documentType !== "Item") ) return;
+    }
+    // Case 2: This is a synthetic actor on the scene
+    else if ( parentType === "Scene" ) {
+      if ( (documentId !== this.parent.token?.id) || (syntheticItem !== "Item") ) return;
+    }
+    // Case 3: This is not an actor
+    else return;
+    const item = this.parent.items.get(documentId) ?? this.parent.items.get(syntheticItemId);
+    if ( !item ) return;
+    this.isSuppressed = item.areEffectsSuppressed;
   }
 
   /* --------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -56,20 +56,10 @@ export default class ActiveEffect5e extends ActiveEffect {
    */
   determineSuppression() {
     this.isSuppressed = false;
-    if ( this.disabled || (this.parent.documentName !== "Actor") ) return;
-    const [parentType, parentId, documentType, documentId, syntheticItem, syntheticItemId] = this.origin?.split(".") ?? [];
-    // case 1: linked or sidebar actor
-    if ( parentType === "Actor" ) {
-      if ( (parentId !== this.parent.id) || (documentType !== "Item") ) return;
-    }
-    // case 2: synthetic actor on scene
-    else if ( parentType === "Scene" ) {
-      if ( (documentId !== this.parent.token?.id) || (syntheticItem !== "Item") ) return;
-    }
-    // case 3: not an actor
-    else return;
-    const item = this.parent.items.get(documentId) ?? this.parent.items.get(syntheticItemId);
-    if ( !item ) return;
+    if ( this.disabled || (this.parent.documentName !== "Actor") || !this.origin ) return;
+    // Determine if this is an effect from an item
+    const item = fromUuidSync(this.origin);
+    if ( item?.parent !== this.parent ) return;
     this.isSuppressed = item.areEffectsSuppressed;
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -58,11 +58,11 @@ export default class ActiveEffect5e extends ActiveEffect {
     this.isSuppressed = false;
     if ( this.disabled || (this.parent.documentName !== "Actor") ) return;
     const [parentType, parentId, documentType, documentId, syntheticItem, syntheticItemId] = this.origin?.split(".") ?? [];
-    // case 1: linked actor
+    // case 1: linked or sidebar actor
     if ( parentType === "Actor" ) {
       if ( (parentId !== this.parent.id) || (documentType !== "Item") ) return;
     }
-    // case 2: synthetic actor
+    // case 2: synthetic actor on scene
     else if ( parentType === "Scene" ) {
       if ( (documentId !== this.parent.token?.id) || (syntheticItem !== "Item") ) return;
     }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -56,13 +56,21 @@ export default class ActiveEffect5e extends ActiveEffect {
    */
   determineSuppression() {
     this.isSuppressed = false;
-    if ( this.disabled || (this.parent.documentName !== "Actor") || !this.origin ) return;
-    try {
-      // Determine if this is an effect from an item
-      const item = fromUuidSync(this.origin);
-      if ( item?.parent !== this.parent ) return;
-      this.isSuppressed = item.areEffectsSuppressed;
-    } catch(e) {}
+    if ( this.disabled || (this.parent.documentName !== "Actor") ) return;
+    const [parentType, parentId, documentType, documentId, syntheticItem, syntheticItemId] = this.origin?.split(".") ?? [];
+    // case 1: linked actor
+    if ( parentType === "Actor" ) {
+      if ( (parentId !== this.parent.id) || (documentType !== "Item") ) return;
+    }
+    // case 2: synthetic actor
+    else if ( parentType === "Scene" ) {
+      if ( (documentId !== this.parent.token?.id) || (syntheticItem !== "Item") ) return;
+    }
+    // case 3: not an actor
+    else return;
+    const item = this.parent.items.get(documentId) ?? this.parent.items.get(syntheticItemId);
+    if ( !item ) return;
+    this.isSuppressed = item.areEffectsSuppressed;
   }
 
   /* --------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -57,18 +57,19 @@ export default class ActiveEffect5e extends ActiveEffect {
   determineSuppression() {
     this.isSuppressed = false;
     if ( this.disabled || (this.parent.documentName !== "Actor") ) return;
-    const [parentType, parentId, documentType, documentId, syntheticItem, syntheticItemId] = this.origin?.split(".") ?? [];
+    const parts = this.origin?.split(".") ?? [];
+    const [parentType, parentId, documentType, documentId, syntheticItem, syntheticItemId] = parts;
+    let item;
     // Case 1: This is a linked or sidebar actor
     if ( parentType === "Actor" ) {
       if ( (parentId !== this.parent.id) || (documentType !== "Item") ) return;
+      item = this.parent.items.get(documentId);
     }
     // Case 2: This is a synthetic actor on the scene
     else if ( parentType === "Scene" ) {
       if ( (documentId !== this.parent.token?.id) || (syntheticItem !== "Item") ) return;
+      item = this.parent.items.get(syntheticItemId);
     }
-    // Case 3: This is not an actor
-    else return;
-    const item = this.parent.items.get(documentId) ?? this.parent.items.get(syntheticItemId);
     if ( !item ) return;
     this.isSuppressed = item.areEffectsSuppressed;
   }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -57,10 +57,12 @@ export default class ActiveEffect5e extends ActiveEffect {
   determineSuppression() {
     this.isSuppressed = false;
     if ( this.disabled || (this.parent.documentName !== "Actor") || !this.origin ) return;
-    // Determine if this is an effect from an item
-    const item = fromUuidSync(this.origin);
-    if ( item?.parent !== this.parent ) return;
-    this.isSuppressed = item.areEffectsSuppressed;
+    try {
+      // Determine if this is an effect from an item
+      const item = fromUuidSync(this.origin);
+      if ( item?.parent !== this.parent ) return;
+      this.isSuppressed = item.areEffectsSuppressed;
+    } catch(e) {}
   }
 
   /* --------------------------------------------- */


### PR DESCRIPTION
A new PR to revert a change made in #1913, going back to not using `fromUuidSync` since it was found to be able to cause an error despite the try/catch.