### PR TITLE
[#1983] Allow class to be level 0 to prevent advancement issue

### DIFF
--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -26,7 +26,7 @@ export default class ClassData extends SystemDataModel.mixin(ItemDescriptionTemp
     return this.mergeSchema(super.defineSchema(), {
       identifier: new IdentifierField({required: true, label: "DND5E.Identifier"}),
       levels: new foundry.data.fields.NumberField({
-        required: true, nullable: false, integer: true, positive: true, initial: 1, label: "DND5E.ClassLevels"
+        required: true, nullable: false, integer: true, min: 0, initial: 1, label: "DND5E.ClassLevels"
       }),
       hitDice: new foundry.data.fields.StringField({
         required: true, initial: "d6", blank: false, label: "DND5E.HitDice",


### PR DESCRIPTION
The advancement system sets classes to level 0 when first created and adjust them down to 0 during the deletion process, but the data model requiring `levels` to be positive causes this to thrown an error.