### PR TITLE
[#1835] Move equipped and atunement to seperate template

### DIFF
--- a/module/data/item/_module.mjs
+++ b/module/data/item/_module.mjs
@@ -25,6 +25,7 @@ export {
 };
 export {default as ActionTemplate} from "./templates/action.mjs";
 export {default as ActivatedEffectTemplate} from "./templates/activated-effect.mjs";
+export {default as EquippableItemTemplate} from "./templates/equippable-item.mjs";
 export {default as ItemDescriptionTemplate} from "./templates/item-description.mjs";
 export {default as MountableTemplate} from "./templates/mountable.mjs";
 export {default as PhysicalItemTemplate} from "./templates/physical-item.mjs";

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -1,6 +1,7 @@
 import SystemDataModel from "../abstract.mjs";
 import ActionTemplate from "./templates/action.mjs";
 import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
+import EquippableItemTemplate from "./templates/equippable-item.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import PhysicalItemTemplate from "./templates/physical-item.mjs";
 
@@ -8,6 +9,7 @@ import PhysicalItemTemplate from "./templates/physical-item.mjs";
  * Data definition for Consumable items.
  * @mixes ItemDescriptionTemplate
  * @mixes PhysicalItemTemplate
+ * @mixes EquippableItemTemplate
  * @mixes ActivatedEffectTemplate
  * @mixes ActionTemplate
  *
@@ -16,7 +18,7 @@ import PhysicalItemTemplate from "./templates/physical-item.mjs";
  * @property {boolean} uses.autoDestroy  Should this item be destroyed when it runs out of uses.
  */
 export default class ConsumableData extends SystemDataModel.mixin(
-  ItemDescriptionTemplate, PhysicalItemTemplate, ActivatedEffectTemplate, ActionTemplate
+  ItemDescriptionTemplate, PhysicalItemTemplate, EquippableItemTemplate, ActivatedEffectTemplate, ActionTemplate
 ) {
   /** @inheritdoc */
   static defineSchema() {

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -1,4 +1,5 @@
 import SystemDataModel from "../abstract.mjs";
+import EquippableItemTemplate from "./templates/equippable-item.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import PhysicalItemTemplate from "./templates/physical-item.mjs";
 import CurrencyTemplate from "../shared/currency.mjs";
@@ -8,6 +9,7 @@ import CurrencyTemplate from "../shared/currency.mjs";
  * Data definition for Backpack items.
  * @mixes ItemDescriptionTemplate
  * @mixes PhysicalItemTemplate
+ * @mixes EquippableItemTemplate
  * @mixes CurrencyTemplate
  *
  * @property {object} capacity              Information on container's carrying capacity.
@@ -16,7 +18,7 @@ import CurrencyTemplate from "../shared/currency.mjs";
  * @property {boolean} capacity.weightless  Does the weight of the items in the container carry over to the actor?
  */
 export default class ContainerData extends SystemDataModel.mixin(
-  ItemDescriptionTemplate, PhysicalItemTemplate, CurrencyTemplate
+  ItemDescriptionTemplate, PhysicalItemTemplate, EquippableItemTemplate, CurrencyTemplate
 ) {
   /** @inheritdoc */
   static defineSchema() {

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -1,6 +1,7 @@
 import SystemDataModel from "../abstract.mjs";
 import ActionTemplate from "./templates/action.mjs";
 import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
+import EquippableItemTemplate from "./templates/equippable-item.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import PhysicalItemTemplate from "./templates/physical-item.mjs";
 import MountableTemplate from "./templates/mountable.mjs";
@@ -9,6 +10,7 @@ import MountableTemplate from "./templates/mountable.mjs";
  * Data definition for Equipment items.
  * @mixes ItemDescriptionTemplate
  * @mixes PhysicalItemTemplate
+ * @mixes EquippableItemTemplate
  * @mixes ActivatedEffectTemplate
  * @mixes ActionTemplate
  * @mixes MountableTemplate
@@ -27,7 +29,8 @@ import MountableTemplate from "./templates/mountable.mjs";
  * @property {boolean} proficient       Does the owner have proficiency in this piece of equipment?
  */
 export default class EquipmentData extends SystemDataModel.mixin(
-  ItemDescriptionTemplate, PhysicalItemTemplate, ActivatedEffectTemplate, ActionTemplate, MountableTemplate
+  ItemDescriptionTemplate, PhysicalItemTemplate, EquippableItemTemplate,
+  ActivatedEffectTemplate, ActionTemplate, MountableTemplate
 ) {
   /** @inheritdoc */
   static defineSchema() {

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -1,0 +1,36 @@
+/**
+ * Data model template with information on items that can be attuned and equipped.
+ *
+ * @property {number} attunement  Attunement information as defined in `DND5E.attunementTypes`.
+ * @property {boolean} equipped   Is this item equipped on its owning actor.
+ * @mixin
+ */
+export default class EquippableItemTemplate extends foundry.abstract.DataModel {
+  /** @inheritdoc */
+  static defineSchema() {
+    return {
+      attunement: new foundry.data.fields.NumberField({
+        required: true, integer: true, initial: CONFIG.DND5E.attunementTypes.NONE, label: "DND5E.Attunement"
+      }),
+      equipped: new foundry.data.fields.BooleanField({required: true, label: "DND5E.Equipped"})
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static migrateData(source) {
+    this.migrateAttunement(source);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Migrate the item's attuned boolean to attunement string.
+   * @param {object} source  The candidate source data from which the model will be constructed.
+   */
+  static migrateAttunement(source) {
+    if ( (source.attuned === undefined) || (source.attunement !== undefined) ) return;
+    source.attunement = source.attuned ? CONFIG.DND5E.attunementTypes.ATTUNED : CONFIG.DND5E.attunementTypes.NONE;
+  }
+}

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -1,13 +1,13 @@
 /**
  * Data model template with information on physical items.
  *
- * @property {number} quantity     Number of items in a stack.
- * @property {number} weight       Item's weight in pounds or kilograms (depending on system setting).
- * @property {number} price        Item's cost in GP.
- * @property {number} attunement   Attunement information as defined in `DND5E.attunementTypes`.
- * @property {boolean} equipped    Is this item equipped on its owning actor.
- * @property {string} rarity       Item rarity as defined in `DND5E.itemRarity`.
- * @property {boolean} identified  Has this item been identified?
+ * @property {number} quantity            Number of items in a stack.
+ * @property {number} weight              Item's weight in pounds or kilograms (depending on system setting).
+ * @property {object} price
+ * @property {number} price.value         Item's cost in the specified denomination.
+ * @property {string} price.denomination  Currency denomination used to determine price.
+ * @property {string} rarity              Item rarity as defined in `DND5E.itemRarity`.
+ * @property {boolean} identified         Has this item been identified?
  * @mixin
  */
 export default class PhysicalItemTemplate extends foundry.abstract.DataModel {
@@ -28,10 +28,6 @@ export default class PhysicalItemTemplate extends foundry.abstract.DataModel {
           required: true, blank: false, initial: "gp", label: "DND5E.Currency"
         })
       }, {label: "DND5E.Price"}),
-      attunement: new foundry.data.fields.NumberField({
-        required: true, integer: true, initial: CONFIG.DND5E.attunementTypes.NONE, label: "DND5E.Attunement"
-      }),
-      equipped: new foundry.data.fields.BooleanField({required: true, label: "DND5E.Equipped"}),
       rarity: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.Rarity"}),
       identified: new foundry.data.fields.BooleanField({required: true, initial: true, label: "DND5E.Identified"})
     };
@@ -41,20 +37,8 @@ export default class PhysicalItemTemplate extends foundry.abstract.DataModel {
 
   /** @inheritdoc */
   static migrateData(source) {
-    this.migrateAttunement(source);
     this.migratePrice(source);
     this.migrateRarity(source);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Migrate the item's attuned boolean to attunement string.
-   * @param {object} source  The candidate source data from which the model will be constructed.
-   */
-  static migrateAttunement(source) {
-    if ( (source.attuned === undefined) || (source.attunement !== undefined) ) return;
-    source.attunement = source.attuned ? CONFIG.DND5E.attunementTypes.ATTUNED : CONFIG.DND5E.attunementTypes.NONE;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -1,5 +1,6 @@
 import SystemDataModel from "../abstract.mjs";
 import { FormulaField } from "../fields.mjs";
+import EquippableItemTemplate from "./templates/equippable-item.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import PhysicalItemTemplate from "./templates/physical-item.mjs";
 
@@ -7,6 +8,7 @@ import PhysicalItemTemplate from "./templates/physical-item.mjs";
  * Data definition for Tool items.
  * @mixes ItemDescriptionTemplate
  * @mixes PhysicalItemTemplate
+ * @mixes EquippableItemTemplate
  *
  * @property {string} toolType    Tool category as defined in `DND5E.toolTypes`.
  * @property {string} baseItem    Base tool as defined in `DND5E.toolIds` for determining proficiency.
@@ -15,7 +17,9 @@ import PhysicalItemTemplate from "./templates/physical-item.mjs";
  * @property {number} proficient  Level of proficiency in this tool as defined in `DND5E.proficiencyLevels`.
  * @property {string} bonus       Bonus formula added to tool rolls.
  */
-export default class ToolData extends SystemDataModel.mixin(ItemDescriptionTemplate, PhysicalItemTemplate) {
+export default class ToolData extends SystemDataModel.mixin(
+  ItemDescriptionTemplate, PhysicalItemTemplate, EquippableItemTemplate
+) {
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -2,6 +2,7 @@ import SystemDataModel from "../abstract.mjs";
 import { MappingField } from "../fields.mjs";
 import ActionTemplate from "./templates/action.mjs";
 import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
+import EquippableItemTemplate from "./templates/equippable-item.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import PhysicalItemTemplate from "./templates/physical-item.mjs";
 import MountableTemplate from "./templates/mountable.mjs";
@@ -10,6 +11,7 @@ import MountableTemplate from "./templates/mountable.mjs";
  * Data definition for Weapon items.
  * @mixes ItemDescriptionTemplate
  * @mixes PhysicalItemTemplate
+ * @mixes EquippableItemTemplate
  * @mixes ActivatedEffectTemplate
  * @mixes ActionTemplate
  * @mixes MountableTemplate
@@ -20,7 +22,8 @@ import MountableTemplate from "./templates/mountable.mjs";
  * @property {boolean} proficient  Does the weapon's owner have proficiency?
  */
 export default class WeaponData extends SystemDataModel.mixin(
-  ItemDescriptionTemplate, PhysicalItemTemplate, ActivatedEffectTemplate, ActionTemplate, MountableTemplate
+  ItemDescriptionTemplate, PhysicalItemTemplate, EquippableItemTemplate,
+  ActivatedEffectTemplate, ActionTemplate, MountableTemplate
 ) {
   /** @inheritdoc */
   static defineSchema() {


### PR DESCRIPTION
Creates a new `AttunementEquippedTemplate` and moves those values out of `PhysicalItemTemplate` so they don't appear on loot, containers, or consumables.