### PR TITLE
Support an initiative roll configuration Dialog for characters

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -110,8 +110,7 @@ Hooks.once("init", function() {
   }
 
   // Patch Core Functions
-  CONFIG.Combat.initiative.formula = "1d20 + @attributes.init.mod + @attributes.init.prof + @attributes.init.bonus + @abilities.dex.bonuses.check + @bonuses.abilities.check";
-  Combatant.prototype._getInitiativeFormula = documents.combat._getInitiativeFormula;
+  Combatant.prototype.getInitiativeRoll = documents.combat.getInitiativeRoll;
 
   // Register Roll Extensions
   CONFIG.Dice.rolls.push(dice.D20Roll);

--- a/lang/en.json
+++ b/lang/en.json
@@ -573,6 +573,7 @@
 "DND5E.Identifier": "Identifier",
 "DND5E.IdentifierError": "Identifier can only contain letters (a-z), numbers (0-9), dashes (-), and underscores (_).",
 "DND5E.Initiative": "Initiative",
+"DND5E.InitiativeRoll": "Initiative Roll",
 "DND5E.Inspiration": "Inspiration",
 "DND5E.Inventory": "Inventory",
 "DND5E.ItemActionType": "Action Type",

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -228,7 +228,7 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
       case "rollDeathSave":
         return this.actor.rollDeathSave({event: event});
       case "rollInitiative":
-        return this.actor.rollInitiative({createCombatants: true});
+        return this.actor.rollInitiativeDialog();
     }
   }
 

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -1,39 +1,10 @@
 /**
- * Override the default Initiative formula to customize special behaviors of the system.
- * Apply advantage, proficiency, or bonuses where appropriate
- * Apply the dexterity score as a decimal tiebreaker if requested
- * See Combat._getInitiativeFormula for more detail.
- * @returns {string}  Final initiative formula for the actor.
+ * Override the core method for obtaining a Roll instance used for the Combatant.
+ * @see {Actor5e#getInitiativeRoll}
+ * @param {string} [formula]  A formula to use if no Actor is defined
+ * @returns {D20Roll}         The D20Roll instance which is used to determine initiative for the Combatant
  */
-export function _getInitiativeFormula() {
-  const actor = this.actor;
-  if ( !actor || (actor.type === "group") ) return "1d20";
-  const init = actor.system.attributes.init;
-  const rollData = actor.getRollData();
-
-  // Construct initiative formula parts
-  let nd = 1;
-  let mods = "";
-  if ( actor.getFlag("dnd5e", "halflingLucky") ) mods += "r1=1";
-  if ( actor.getFlag("dnd5e", "initiativeAdv") ) {
-    nd = 2;
-    mods += "kh";
-  }
-  const parts = [
-    `${nd}d20${mods}`,
-    init.mod,
-    (init.prof.term !== "0") ? init.prof.term : null,
-    (init.bonus !== 0) ? init.bonus : null
-  ];
-
-  // Ability Check Bonuses
-  const dexCheckBonus = actor.system.abilities.dex?.bonuses?.check;
-  const globalCheckBonus = actor.system.bonuses?.abilities?.check;
-  if ( dexCheckBonus ) parts.push(Roll.replaceFormulaData(dexCheckBonus, rollData));
-  if ( globalCheckBonus ) parts.push(Roll.replaceFormulaData(globalCheckBonus, rollData));
-
-  // Optionally apply Dexterity tiebreaker
-  const tiebreaker = game.settings.get("dnd5e", "initiativeDexTiebreaker");
-  if ( tiebreaker ) parts.push((actor.system.abilities.dex?.value ?? 0) / 100);
-  return parts.filter(p => p !== null).join(" + ");
+export function getInitiativeRoll(formula="1d20") {
+  if ( !this.actor ) return CONFIG.Dice.D20Roll(formula, {});
+  return this.actor.getInitiativeRoll();
 }


### PR DESCRIPTION
Closes Issues:
- https://github.com/foundryvtt/dnd5e/issues/1632
- https://github.com/foundryvtt/dnd5e/issues/1069
- https://github.com/foundryvtt/dnd5e/issues/811 (wontfix)

Closes PRs:
- https://github.com/foundryvtt/dnd5e/pull/1894 (close without merging)
- https://github.com/foundryvtt/dnd5e/issues/1632 (close without merging)

## Objectives
- Ensure that initiative formula includes bonuses that are currently absent but should be included
- Enable a d20 roll dialog when rolling initiative off the character sheet to support circumstances where initiative can be conditionally rolled with a bonus or advantage/disadvantage