### PR TITLE
Add support for data models in TokenDocument.getTrackedAttributes.

### DIFF
--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -1,3 +1,5 @@
+import { MappingField } from "../data/fields.mjs";
+
 /**
  * Extend the base TokenDocument class to implement system-specific HP bar logic.
  */
@@ -18,10 +20,44 @@ export default class TokenDocument5e extends TokenDocument {
 
   /** @inheritdoc */
   static getTrackedAttributes(data, _path=[]) {
+    if ( data instanceof foundry.abstract.DataModel ) return this._getTrackedAttributesFromSchema(data.schema, _path);
     const attributes = super.getTrackedAttributes(data, _path);
     if ( _path.length ) return attributes;
     const allowed = CONFIG.DND5E.trackableAttributes;
     attributes.value = attributes.value.filter(attrs => this._isAllowedAttribute(allowed, attrs));
+    return attributes;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static _getTrackedAttributesFromSchema(schema, _path=[]) {
+    const isSchema = field => field instanceof foundry.data.fields.SchemaField;
+    const isModel = field => field instanceof foundry.data.fields.EmbeddedDataField;
+    const attributes = {bar: [], value: []};
+    for ( const [name, field] of Object.entries(schema.fields) ) {
+      const p = _path.concat([name]);
+      if ( field instanceof foundry.data.fields.NumberField ) attributes.value.push(p);
+      if ( isSchema(field) || isModel(field) ) {
+        const schema = isModel(field) ? field.model.schema : field;
+        const isBar = schema.has("value") && schema.has("max");
+        if ( isBar ) attributes.bar.push(p);
+        else {
+          const inner = this._getTrackedAttributesFromSchema(schema, p);
+          attributes.bar.push(...inner.bar);
+          attributes.value.push(...inner.value);
+        }
+      }
+      if ( !(field instanceof MappingField) ) continue;
+      if ( foundry.utils.isEmpty(field.initialKeys) ) continue;
+      if ( !isSchema(field.model) && !isModel(field.model) ) continue;
+      const keys = Array.isArray(field.initialKeys) ? field.initialKeys : Object.keys(field.initialKeys);
+      for ( const key of keys ) {
+        const inner = this._getTrackedAttributesFromSchema(field.model, p.concat([key]));
+        attributes.bar.push(...inner.bar);
+        attributes.value.push(...inner.value);
+      }
+    }
     return attributes;
   }
 


### PR DESCRIPTION
I have a branch for support for this as part of the core software also, but here we have overridden the (pending) core methods in order to support the custom `MappingField` that we have in the `dnd5e` system.