### PR TITLE
Prevent refreshCompendium from saving module art

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -71,7 +71,7 @@ export default class Actor5e extends Actor {
   /** @inheritdoc */
   _initializeSource(source, options={}) {
     source = super._initializeSource(source, options);
-    if ( !source._id || !options.pack ) return source;
+    if ( !source._id || !options.pack || dnd5e.moduleArt.suppressArt ) return source;
     const uuid = `Compendium.${options.pack}.${source._id}`;
     const art = game.dnd5e.moduleArt.map.get(uuid);
     if ( art?.actor || art?.token ) {

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -153,6 +153,7 @@ export async function refreshAllCompendiums() {
  */
 export async function refreshCompendium(pack) {
   if ( !pack?.documentName ) return;
+  dnd5e.moduleArt.suppressArt = true;
   const DocumentClass = CONFIG[pack.documentName].documentClass;
   const wasLocked = pack.locked;
   await pack.configure({locked: false});
@@ -166,6 +167,7 @@ export async function refreshCompendium(pack) {
     await DocumentClass.create(data, {keepId: true, keepEmbeddedIds: true, pack: pack.collection});
   }
   await pack.configure({locked: wasLocked});
+  dnd5e.moduleArt.suppressArt = false;
   ui.notifications.info(`Refreshed all documents from Compendium ${pack.collection}`);
 }
 

--- a/module/module-art.mjs
+++ b/module/module-art.mjs
@@ -20,6 +20,14 @@ export class ModuleArt {
   /* -------------------------------------------- */
 
   /**
+   * Set to true to temporarily prevent actors from loading module art.
+   * @type {boolean}
+   */
+  suppressArt = false;
+
+  /* -------------------------------------------- */
+
+  /**
    * Register any art mapping information included in active modules.
    * @returns {Promise<void>}
    */

--- a/utils/packs.mjs
+++ b/utils/packs.mjs
@@ -57,6 +57,12 @@ function cleanPackEntry(data, { clearSourceId=true }={}) {
     if ( Object.keys(contents).length === 0 ) delete data.flags[key];
   });
 
+  // Remove mystery-man.svg from Actors
+  if ( ["character", "npc"].includes(data.type) && data.img === "icons/svg/mystery-man.svg" ) {
+    data.img = "";
+    data.prototypeToken.texture.src = "";
+  }
+
   if ( data.effects ) data.effects.forEach(i => cleanPackEntry(i, { clearSourceId: false }));
   if ( data.items ) data.items.forEach(i => cleanPackEntry(i, { clearSourceId: false }));
   if ( data.system?.description?.value ) data.system.description.value = cleanString(data.system.description.value);


### PR DESCRIPTION
This will prevent `refreshCompendium` from saving any enabled module art and changes our compendium build script to strip out `mystery-man.svg` from actor artwork & token artwork.