### PR TITLE
Enable typescript mode for JSDoc comments, fix linting issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -198,6 +198,7 @@
   },
   "settings": {
     "jsdoc": {
+      "mode": "typescript",
       "preferredTypes": {
         ".<>": "<>"
       },

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -763,11 +763,10 @@ export default class ActorSheet5e extends ActorSheet {
     if ( ("attunement" in item.system) && (item.system.attunement !== CONFIG.DND5E.attunementTypes.NONE) ) {
       const isAttuned = item.system.attunement === CONFIG.DND5E.attunementsTypes.ATTUNED;
       options.push({
-          name: isAttuned ? "DND5E.ContextMenuActionUnattune" : "DND5E.ContextMenuActionAttune",
-          icon: "<i class='fas fa-sun fa-fw'></i>",
-          callback: item.update({"system.attunement": CONFIG.DND5E.attunementTypes[isAttuned ? "ATTUNED" : "REQUIRED"]})
-        }
-      );
+        name: isAttuned ? "DND5E.ContextMenuActionUnattune" : "DND5E.ContextMenuActionAttune",
+        icon: "<i class='fas fa-sun fa-fw'></i>",
+        callback: item.update({"system.attunement": CONFIG.DND5E.attunementTypes[isAttuned ? "ATTUNED" : "REQUIRED"]})
+      });
     }
 
     // Toggle Equipped State

--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -324,7 +324,7 @@ export default class GroupActorSheet extends ActorSheet {
    * @protected
    */
   _onClickItemName(event) {
-    return game.system.applications.actor.ActorSheet5e.prototype._onItemSummary.call(this, event);
+    game.system.applications.actor.ActorSheet5e.prototype._onItemSummary.call(this, event);
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/movement-config.mjs
+++ b/module/applications/actor/movement-config.mjs
@@ -44,7 +44,7 @@ export default class ActorMovementConfig extends DocumentSheet {
       climb: "DND5E.MovementClimb",
       fly: "DND5E.MovementFly",
       swim: "DND5E.MovementSwim"
-    }
+    };
 
     // Return rendering context
     return {

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -188,18 +188,6 @@ export default class ItemSheet5e extends ItemSheet {
   /* -------------------------------------------- */
 
   /**
-   * Get the item type label which is shown next to the name on the top-right corner of the sheet.
-   * @returns {string}  Localized item type.
-   * @protected
-   */
-  _getItemType() {
-
-    return ;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
    * Get the base weapons and tools based on the selected type.
    * @returns {Promise<object>}  Object with base items for this type formatted for selectOptions.
    * @protected

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1484,7 +1484,7 @@ DND5E.CR_EXP_LEVELS = [
  * @property {string} name
  * @property {string} hint
  * @property {string} section
- * @property {typeof Boolean|String|Number} type
+ * @property {typeof boolean|string|number} type
  * @property {string} placeholder
  * @property {string[]} [abilities]
  * @property {Object<string, string>} [choices]

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -403,15 +403,15 @@ export default class Item5e extends Item {
     if ( ["none", ""].includes(tgt.type) ) tgt.type = null;   // Backwards compatibility
     if ( [null, "self"].includes(tgt.type) ) tgt.value = tgt.units = null;
     else if ( tgt.units === "touch" ) tgt.value = null;
-    this.labels.target = tgt.type ?
-      [tgt.value, C.distanceUnits[tgt.units], C.targetTypes[tgt.type]].filterJoin(" ") : "";
+    this.labels.target = tgt.type
+      ? [tgt.value, C.distanceUnits[tgt.units], C.targetTypes[tgt.type]].filterJoin(" ") : "";
 
     // Range Label
     let rng = this.system.range ?? {};
     if ( ["none", ""].includes(rng.units) ) rng.units = null; // Backwards compatibility
     if ( [null, "touch", "self"].includes(rng.units) ) rng.value = rng.long = null;
-    this.labels.range = rng.units ?
-      [rng.value, rng.long ? `/ ${rng.long}` : null, C.distanceUnits[rng.units]].filterJoin(" ") : "";
+    this.labels.range = rng.units
+      ? [rng.value, rng.long ? `/ ${rng.long}` : null, C.distanceUnits[rng.units]].filterJoin(" ") : "";
 
     // Recharge Label
     let chg = this.system.recharge ?? {};

--- a/module/module-art.mjs
+++ b/module/module-art.mjs
@@ -32,7 +32,7 @@ export class ModuleArt {
       try {
         const mapping = await foundry.utils.fetchJsonWithTimeout(artPath);
         await this.#parseArtMapping(module.id, mapping, flags["dnd5e-art-credit"]);
-      } catch ( e ) {
+      } catch( e ) {
         console.error(e);
       }
     }
@@ -47,7 +47,7 @@ export class ModuleArt {
         </em>
       `;
       await this.#parseArtMapping(game.system.id, mapping, credit);
-    } catch ( e ) {
+    } catch( e ) {
       console.error(e);
     }
   }


### PR DESCRIPTION
Enables typescript mode in our JSDoc linter to prevent warnings when we use `@internal` and fix a variety of linting issues that have crept in recently.