### PR TITLE
[#1997] Add support for preRollInitiative and rollInitiative hooks.

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -92,6 +92,7 @@ Hooks.once("init", function() {
   CONFIG.Dice.DamageRoll = dice.DamageRoll;
   CONFIG.Dice.D20Roll = dice.D20Roll;
   CONFIG.MeasuredTemplate.defaults.angle = 53.13; // 5e cone RAW should be 53.13 degrees
+  CONFIG.ui.combat = applications.combat.CombatTracker5e;
 
   // Register System Settings
   registerSystemSettings();

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -1,5 +1,6 @@
 export * as actor from "./actor/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";
+export * as combat from "./combat/_module.mjs";
 export * as item from "./item/_module.mjs";
 export * as journal from "./journal/_module.mjs";
 

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -229,7 +229,7 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
       case "rollDeathSave":
         return this.actor.rollDeathSave({event: event});
       case "rollInitiative":
-        return this.actor.rollInitiativeDialog();
+        return this.actor.rollInitiativeDialog({event});
     }
   }
 

--- a/module/applications/combat/_module.mjs
+++ b/module/applications/combat/_module.mjs
@@ -1,0 +1,1 @@
+export {default as CombatTracker5e} from "./combat-tracker.mjs";

--- a/module/applications/combat/combat-tracker.mjs
+++ b/module/applications/combat/combat-tracker.mjs
@@ -1,0 +1,14 @@
+/**
+ * An extension of the base CombatTracker class to provide some 5e-specific functionality.
+ * @extends {CombatTracker}
+ */
+export default class CombatTracker5e extends CombatTracker {
+  /** @inheritdoc */
+  async _onCombatantControl(event) {
+    const btn = event.currentTarget;
+    const combatantId = btn.closest(".combatant").dataset.combatantId;
+    const combatant = this.viewed.combatants.get(combatantId);
+    if ( (btn.dataset.control === "rollInitiative") && combatant?.actor ) return combatant.actor.rollInitiativeDialog();
+    return super._onCombatantControl(event);
+  }
+}

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -35,6 +35,26 @@ export default class D20Roll extends Roll {
   /* -------------------------------------------- */
 
   /**
+   * Determine whether a d20 roll should be fast-forwarded, and whether advantage or disadvantage should be applied.
+   * @param {object} [options]
+   * @param {Event} [options.event]                               The Event that triggered the roll.
+   * @param {boolean} [options.advantage]                         Is something granting this roll advantage?
+   * @param {boolean} [options.disadvantage]                      Is something granting this roll disadvantage?
+   * @param {boolean} [options.fastForward]                       Should the roll dialog be skipped?
+   * @returns {{advantageMode: D20Roll.ADV_MODE, isFF: boolean}}  Whether the roll is fast-forwarded, and its advantage
+   *                                                              mode.
+   */
+  static determineAdvantageMode({event, advantage=false, disadvantage=false, fastForward}={}) {
+    const isFF = fastForward ?? (event?.shiftKey || event?.altKey || event?.ctrlKey || event?.metaKey);
+    let advantageMode = this.ADV_MODE.NORMAL;
+    if ( advantage || event?.altKey ) advantageMode = this.ADV_MODE.ADVANTAGE;
+    else if ( disadvantage || event?.ctrlKey || event?.metaKey ) advantageMode = this.ADV_MODE.DISADVANTAGE;
+    return {isFF: !!isFF, advantageMode};
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Advantage mode of a 5e d20 roll
    * @enum {number}
    */

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -110,8 +110,9 @@ export async function d20Roll({
  * @param {boolean} [config.disadvantage]  Is something granting this roll disadvantage?
  * @param {boolean} [config.fastForward]   Should the roll dialog be skipped?
  * @returns {{isFF: boolean, advantageMode: number}}  Whether the roll is fast-forward, and its advantage mode.
+ * @internal
  */
-function _determineAdvantageMode({event, advantage=false, disadvantage=false, fastForward}={}) {
+export function _determineAdvantageMode({event, advantage=false, disadvantage=false, fastForward}={}) {
   const isFF = fastForward ?? (event && (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey));
   let advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.NORMAL;
   if ( advantage || event?.altKey ) advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -58,7 +58,9 @@ export async function d20Roll({
 
   // Handle input arguments
   const formula = ["1d20"].concat(parts).join(" + ");
-  const {advantageMode, isFF} = _determineAdvantageMode({advantage, disadvantage, fastForward, event});
+  const {advantageMode, isFF} = CONFIG.Dice.D20Roll.determineAdvantageMode({
+    advantage, disadvantage, fastForward, event
+  });
   const defaultRollMode = rollMode || game.settings.get("core", "rollMode");
   if ( chooseModifier && !isFF ) {
     data.mod = "@mod";
@@ -98,28 +100,6 @@ export async function d20Roll({
   // Create a Chat Message
   if ( roll && chatMessage ) await roll.toMessage(messageData);
   return roll;
-}
-
-/* -------------------------------------------- */
-
-/**
- * Determines whether this d20 roll should be fast-forwarded, and whether advantage or disadvantage should be applied
- * @param {object} [config]
- * @param {Event} [config.event]           Event that triggered the roll.
- * @param {boolean} [config.advantage]     Is something granting this roll advantage?
- * @param {boolean} [config.disadvantage]  Is something granting this roll disadvantage?
- * @param {boolean} [config.fastForward]   Should the roll dialog be skipped?
- * @returns {{isFF: boolean, advantageMode: number}}  Whether the roll is fast-forward, and its advantage mode.
- * @internal
- */
-export function _determineAdvantageMode({event, advantage=false, disadvantage=false, fastForward}={}) {
-  const isFF = fastForward ?? (event && (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey));
-  let advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.NORMAL;
-  if ( advantage || event?.altKey ) advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
-  else if ( disadvantage || event?.ctrlKey || event?.metaKey ) {
-    advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
-  }
-  return {isFF: !!isFF, advantageMode};
 }
 
 /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1,5 +1,5 @@
 import Proficiency from "./proficiency.mjs";
-import { d20Roll } from "../../dice/dice.mjs";
+import { _determineAdvantageMode, d20Roll } from "../../dice/dice.mjs";
 import { simplifyBonus } from "../../utils.mjs";
 import ShortRestDialog from "../../applications/actor/short-rest.mjs";
 import LongRestDialog from "../../applications/actor/long-rest.mjs";
@@ -1428,7 +1428,7 @@ export default class Actor5e extends Actor {
    * @param {string} [options.flavor]                     Special flavor text to apply
    * @returns {D20Roll}                               The constructed but unevaluated D20Roll
    */
-  getInitiativeRoll({advantageMode, flavor}={}) {
+  getInitiativeRoll(options={}) {
 
     // Use a temporarily cached initiative roll
     if ( this._cachedInitiativeRoll ) return this._cachedInitiativeRoll.clone();
@@ -1438,7 +1438,7 @@ export default class Actor5e extends Actor {
     const abilityId = init?.ability || CONFIG.DND5E.initiativeAbility;
     const data = this.getRollData();
     const flags = this.flags.dnd5e || {};
-    if ( flags.initiativeAdv ) advantageMode ??= dnd5e.dice.D20Roll.ADV_MODE.ADVANTAGE;
+    if ( flags.initiativeAdv ) options.advantageMode ??= dnd5e.dice.D20Roll.ADV_MODE.ADVANTAGE;
 
     // Standard initiative formula
     const parts = ["1d20"];
@@ -1487,15 +1487,27 @@ export default class Actor5e extends Actor {
       if ( Number.isNumeric(abilityValue) ) parts.push(String(abilityValue / 100));
     }
 
-    // Create the d20 roll
-    const formula = parts.join(" + ");
-    return new CONFIG.Dice.D20Roll(formula, data, {
-      flavor: flavor ?? game.i18n.localize("DND5E.Initiative"),
-      advantageMode: advantageMode,
+    options = foundry.utils.mergeObject({
+      flavor: options.flavor ?? game.i18n.localize("DND5E.Initiative"),
       halflingLucky: flags.halflingLucky ?? false,
       critical: null,
       fumble: null
-    });
+    }, options);
+
+    /**
+     * A hook event that fires before initiative is rolled for an Actor.
+     * @function dnd5e.preRollInitiative
+     * @memberof hookEvents
+     * @param {Actor5e} actor                The Actor that is rolling initiative.
+     * @param {object} data                  The roll data.
+     * @param {string[]} parts               The roll parts.
+     * @param {D20RollConfiguration} config  Configuration data for the pending roll.
+     */
+    Hooks.callAll("dnd5e.preRollInitiative", this, data, parts, options);
+
+    // Create the d20 roll
+    const formula = parts.join(" + ");
+    return new CONFIG.Dice.D20Roll(formula, data, options);
   }
 
   /* -------------------------------------------- */
@@ -1506,21 +1518,47 @@ export default class Actor5e extends Actor {
    * @returns {Promise<void>}           A promise which resolves once initiative has been rolled for the Actor
    */
   async rollInitiativeDialog(rollOptions={}) {
+    let {advantageMode, fastForward, event} = rollOptions;
+    const ff = _determineAdvantageMode({fastForward, event});
+    if ( ff.isFF ) advantageMode ??= ff.advantageMode;
+    if ( advantageMode !== undefined ) rollOptions.advantageMode = advantageMode;
+    const defaultRollMode = game.settings.get("core", "rollMode");
 
     // Create and configure the Initiative roll
     const roll = this.getInitiativeRoll(rollOptions);
-    const choice = await roll.configureDialog({
-      title: `${game.i18n.localize("DND5E.InitiativeRoll")}: ${this.name}`,
-      chooseModifier: false,
-      defaultRollMode: game.settings.get("core", "rollMode"),
-      defaultAction: rollOptions.advantageMode ?? dnd5e.dice.D20Roll.ADV_MODE.NORMAL
-    });
-    if ( choice === null ) return; // Closed dialog
+    if ( ff.isFF ) roll.options.rollMode ??= defaultRollMode;
+    else {
+      const choice = await roll.configureDialog({
+        defaultRollMode,
+        title: `${game.i18n.localize("DND5E.InitiativeRoll")}: ${this.name}`,
+        chooseModifier: false,
+        defaultAction: rollOptions.advantageMode ?? dnd5e.dice.D20Roll.ADV_MODE.NORMAL
+      });
+      if ( choice === null ) return; // Closed dialog
+    }
 
     // Temporarily cache the configured roll and use it to roll initiative for the Actor
     this._cachedInitiativeRoll = roll;
     await this.rollInitiative({createCombatants: true});
     delete this._cachedInitiativeRoll;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async rollInitiative(options={}) {
+    const combat = await super.rollInitiative(options);
+    const combatant = this.isToken ? combat.getCombatantByToken(this.token.id) : combat.getCombatantByActor(this.id);
+
+    /**
+     * A hook event that fires after an Actor has rolled for initiative.
+     * @function dnd5e.rollInitiative
+     * @memberof hookEvents
+     * @param {Actor5e} actor        The Actor that rolled initiative.
+     * @param {Combatant} combatant  The associated Combatant in the Combat.
+     */
+    Hooks.callAll("dnd5e.rollInitiative", this, combatant);
+    return combat;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1,5 +1,5 @@
 import Proficiency from "./proficiency.mjs";
-import { _determineAdvantageMode, d20Roll } from "../../dice/dice.mjs";
+import { d20Roll } from "../../dice/dice.mjs";
 import { simplifyBonus } from "../../utils.mjs";
 import ShortRestDialog from "../../applications/actor/short-rest.mjs";
 import LongRestDialog from "../../applications/actor/long-rest.mjs";
@@ -1494,17 +1494,6 @@ export default class Actor5e extends Actor {
       fumble: null
     }, options);
 
-    /**
-     * A hook event that fires before initiative is rolled for an Actor.
-     * @function dnd5e.preRollInitiative
-     * @memberof hookEvents
-     * @param {Actor5e} actor                The Actor that is rolling initiative.
-     * @param {object} data                  The roll data.
-     * @param {string[]} parts               The roll parts.
-     * @param {D20RollConfiguration} config  Configuration data for the pending roll.
-     */
-    Hooks.callAll("dnd5e.preRollInitiative", this, data, parts, options);
-
     // Create the d20 roll
     const formula = parts.join(" + ");
     return new CONFIG.Dice.D20Roll(formula, data, options);
@@ -1518,24 +1507,15 @@ export default class Actor5e extends Actor {
    * @returns {Promise<void>}           A promise which resolves once initiative has been rolled for the Actor
    */
   async rollInitiativeDialog(rollOptions={}) {
-    let {advantageMode, fastForward, event} = rollOptions;
-    const ff = _determineAdvantageMode({fastForward, event});
-    if ( ff.isFF ) advantageMode ??= ff.advantageMode;
-    if ( advantageMode !== undefined ) rollOptions.advantageMode = advantageMode;
-    const defaultRollMode = game.settings.get("core", "rollMode");
-
     // Create and configure the Initiative roll
     const roll = this.getInitiativeRoll(rollOptions);
-    if ( ff.isFF ) roll.options.rollMode ??= defaultRollMode;
-    else {
-      const choice = await roll.configureDialog({
-        defaultRollMode,
-        title: `${game.i18n.localize("DND5E.InitiativeRoll")}: ${this.name}`,
-        chooseModifier: false,
-        defaultAction: rollOptions.advantageMode ?? dnd5e.dice.D20Roll.ADV_MODE.NORMAL
-      });
-      if ( choice === null ) return; // Closed dialog
-    }
+    const choice = await roll.configureDialog({
+      defaultRollMode: game.settings.get("core", "rollMode"),
+      title: `${game.i18n.localize("DND5E.InitiativeRoll")}: ${this.name}`,
+      chooseModifier: false,
+      defaultAction: rollOptions.advantageMode ?? dnd5e.dice.D20Roll.ADV_MODE.NORMAL
+    });
+    if ( choice === null ) return; // Closed dialog
 
     // Temporarily cache the configured roll and use it to roll initiative for the Actor
     this._cachedInitiativeRoll = roll;
@@ -1547,17 +1527,30 @@ export default class Actor5e extends Actor {
 
   /** @inheritdoc */
   async rollInitiative(options={}) {
+    /**
+     * A hook event that fires before initiative is rolled for an Actor.
+     * @function dnd5e.preRollInitiative
+     * @memberof hookEvents
+     * @param {Actor5e} actor  The Actor that is rolling initiative.
+     * @param {D20Roll} roll   The initiative roll.
+     */
+    if ( Hooks.call("dnd5e.preRollInitiative", this, this._cachedInitiativeRoll) === false ) return;
+
     const combat = await super.rollInitiative(options);
-    const combatant = this.isToken ? combat.getCombatantByToken(this.token.id) : combat.getCombatantByActor(this.id);
+    const combatants = this.isToken ? this.getActiveTokens(false, true).reduce((arr, t) => {
+      const combatant = game.combat.getCombatantByToken(t.id);
+      if ( combatant ) arr.push(combatant);
+      return arr;
+    }, []) : [game.combat.getCombatantByActor(this.id)];
 
     /**
      * A hook event that fires after an Actor has rolled for initiative.
      * @function dnd5e.rollInitiative
      * @memberof hookEvents
-     * @param {Actor5e} actor        The Actor that rolled initiative.
-     * @param {Combatant} combatant  The associated Combatant in the Combat.
+     * @param {Actor5e} actor           The Actor that rolled initiative.
+     * @param {Combatant[]} combatants  The associated Combatants in the Combat.
      */
-    Hooks.callAll("dnd5e.rollInitiative", this, combatant);
+    Hooks.callAll("dnd5e.rollInitiative", this, combatants);
     return combat;
   }
 


### PR DESCRIPTION
Some adjustments for things I missed in my initial review that came up in later testing such as missing fast-forward rolls and the advantage button not being highlighted in the roll dialog when 'advantage on initiative' was checked. Also adds rudimentary support for `preRollInitiative` and `rollInitiative` hooks.

- Closes #1997 