### PR TITLE
[#1605] Prepare scale values earlier to allow them to be modified by active effects

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -124,17 +124,9 @@ export default class Actor5e extends Actor {
 
   /* --------------------------------------------- */
 
-  /** @override */
-  prepareEmbeddedDocuments() {
-    super.prepareEmbeddedDocuments();
-    this._prepareScaleValues();
-    this.applyActiveEffects();
-  }
-
-  /* --------------------------------------------- */
-
   /** @inheritDoc */
   applyActiveEffects() {
+    this._prepareScaleValues();
     // The Active Effects do not have access to their parent at preparation time, so we wait until this stage to
     // determine whether they are suppressed or not.
     this.effects.forEach(e => e.determineSuppression());

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -93,6 +93,7 @@ export default class Actor5e extends Actor {
   prepareData() {
     this._classes = undefined;
     this._preparationWarnings = [];
+    this.items.forEach(item => item.prepareInitialAttributes());
     super.prepareData();
     this.items.forEach(item => item.prepareFinalAttributes());
   }
@@ -110,6 +111,7 @@ export default class Actor5e extends Actor {
     this._prepareBaseAbilities();
     this._prepareBaseSkills();
     this._prepareBaseArmorClass();
+    this._prepareScaleValues();
 
     // Type-specific preparation
     switch ( this.type ) {
@@ -167,7 +169,6 @@ export default class Actor5e extends Actor {
     this._prepareEncumbrance();
     this._prepareHitPoints(rollData);
     this._prepareInitiative(rollData, checkBonus);
-    this._prepareScaleValues();
     this._prepareSpellcasting();
   }
 
@@ -280,6 +281,21 @@ export default class Actor5e extends Actor {
     const ac = this.system.attributes.ac;
     ac.armor = 10;
     ac.shield = ac.bonus = ac.cover = 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Derive any values that have been scaled by the Advancement system.
+   * Mutates the value of the `system.scale` object.
+   * @protected
+   */
+  _prepareScaleValues() {
+    this.system.scale = Object.entries(this.classes).reduce((scale, [identifier, cls]) => {
+      scale[identifier] = cls.scaleValues;
+      if ( cls.subclass ) scale[cls.subclass.identifier] = cls.subclass.scaleValues;
+      return scale;
+    }, {});
   }
 
   /* -------------------------------------------- */
@@ -631,21 +647,6 @@ export default class Actor5e extends Actor {
     init.total = init.mod + initBonus + abilityBonus + globalCheckBonus
       + (flags.initiativeAlert ? 5 : 0)
       + (Number.isNumeric(init.prof.term) ? init.prof.flat : 0);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Derive any values that have been scaled by the Advancement system.
-   * Mutates the value of the `system.scale` object.
-   * @protected
-   */
-  _prepareScaleValues() {
-    this.system.scale = Object.entries(this.classes).reduce((scale, [identifier, cls]) => {
-      scale[identifier] = cls.scaleValues;
-      if ( cls.subclass ) scale[cls.subclass.identifier] = cls.subclass.scaleValues;
-      return scale;
-    }, {});
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -93,7 +93,6 @@ export default class Actor5e extends Actor {
   prepareData() {
     this._classes = undefined;
     this._preparationWarnings = [];
-    this.items.forEach(item => item.prepareInitialAttributes());
     super.prepareData();
     this.items.forEach(item => item.prepareFinalAttributes());
   }
@@ -111,7 +110,6 @@ export default class Actor5e extends Actor {
     this._prepareBaseAbilities();
     this._prepareBaseSkills();
     this._prepareBaseArmorClass();
-    this._prepareScaleValues();
 
     // Type-specific preparation
     switch ( this.type ) {
@@ -122,6 +120,15 @@ export default class Actor5e extends Actor {
       case "vehicle":
         return this._prepareVehicleData();
     }
+  }
+
+  /* --------------------------------------------- */
+
+  /** @override */
+  prepareEmbeddedDocuments() {
+    super.prepareEmbeddedDocuments();
+    this._prepareScaleValues();
+    this.applyActiveEffects();
   }
 
   /* --------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -299,25 +299,16 @@ export default class Item5e extends Item {
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 
-  /**
-   * Initial preparation steps that performed before other actor data preparation. If the item is not embedded
-   * these steps will be called at the start of `Item5e#prepareDerivedData`.
-   */
-  prepareInitialAttributes() {
-    this._prepareAdvancement();
-  }
-
-  /* -------------------------------------------- */
-
   /** @inheritDoc */
   prepareDerivedData() {
-    if ( !this.isOwned ) this.prepareInitialAttributes();
-
     super.prepareDerivedData();
     this.labels = {};
 
     // Clear out linked item cache
     this._classLink = undefined;
+
+    // Advancement
+    this._prepareAdvancement();
 
     // Specialized preparation per Item type
     switch ( this.type ) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -299,16 +299,25 @@ export default class Item5e extends Item {
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 
+  /**
+   * Initial preparation steps that performed before other actor data preparation. If the item is not embedded
+   * these steps will be called at the start of `Item5e#prepareDerivedData`.
+   */
+  prepareInitialAttributes() {
+    this._prepareAdvancement();
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   prepareDerivedData() {
+    if ( !this.isOwned ) this.prepareInitialAttributes();
+
     super.prepareDerivedData();
     this.labels = {};
 
     // Clear out linked item cache
     this._classLink = undefined;
-
-    // Advancement
-    this._prepareAdvancement();
 
     // Specialized preparation per Item type
     switch ( this.type ) {


### PR DESCRIPTION
Moves the data preparation for scale value between when item data is prepared but before active effects are applied so they can be modified by active effects. This also allows them to be used as in input for an active effect if a player is using a module like DAE.

Resolves #1605 