### PR TITLE
[#1944] Fix bug with displaying updates in AdvancementConfig

### DIFF
--- a/module/applications/advancement/advancement-config.mjs
+++ b/module/applications/advancement/advancement-config.mjs
@@ -12,10 +12,10 @@ export default class AdvancementConfig extends FormApplication {
     super(advancement, options);
 
     /**
-     * The advancement being created or edited.
-     * @type {Advancement}
+     * The ID of the advancement being created or edited.
+     * @type {string}
      */
-    this.advancement = advancement;
+    this._advancementId = advancement.id;
 
     /**
      * Parent item to which this advancement belongs.
@@ -41,10 +41,28 @@ export default class AdvancementConfig extends FormApplication {
 
   /* -------------------------------------------- */
 
+  /**
+   * The advancement being created or edited.
+   * @type {Advancement}
+   */
+  get advancement() {
+    return this.item.advancement.byId[this._advancementId];
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   get title() {
     const type = this.advancement.constructor.metadata.title;
     return `${game.i18n.format("DND5E.AdvancementConfigureTitle", { item: this.item.name })}: ${type}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async close(options={}) {
+    await super.close(options);
+    delete this.advancement.apps[this.appId];
   }
 
   /* -------------------------------------------- */
@@ -104,6 +122,14 @@ export default class AdvancementConfig extends FormApplication {
   /* -------------------------------------------- */
 
   /** @inheritdoc */
+  render(force=false, options={}) {
+    this.advancement.apps[this.appId] = this;
+    return super.render(force, options);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
   async _updateObject(event, formData) {
     let updates = foundry.utils.expandObject(formData);
     if ( updates.data ) {
@@ -118,7 +144,6 @@ export default class AdvancementConfig extends FormApplication {
     }
     if ( updates.configuration ) updates.configuration = this.prepareConfigurationUpdate(updates.configuration);
     await this.advancement.update(updates);
-    this.render();
   }
 
   /* -------------------------------------------- */
@@ -157,7 +182,6 @@ export default class AdvancementConfig extends FormApplication {
       [this.options.dropKeyPath]: items.filter(uuid => uuid !== uuidToDelete)
     }) };
     await this.advancement.update(updates);
-    this.render();
   }
 
   /* -------------------------------------------- */
@@ -201,7 +225,6 @@ export default class AdvancementConfig extends FormApplication {
     }
 
     await this.advancement.update({[`configuration.${this.options.dropKeyPath}`]: [...existingItems, item.uuid]});
-    this.render();
   }
 
   /* -------------------------------------------- */

--- a/module/applications/advancement/advancement-config.mjs
+++ b/module/applications/advancement/advancement-config.mjs
@@ -2,7 +2,7 @@
  * Base configuration application for advancements that can be extended by other types to implement custom
  * editing interfaces.
  *
- * @property {Advancement} advancement         The advancement item being edited.
+ * @param {Advancement} advancement            The advancement item being edited.
  * @param {object} [options={}]                Additional options passed to FormApplication.
  * @param {string} [options.dropKeyPath=null]  Path within advancement configuration where dropped items are stored.
  *                                             If populated, will enable default drop & delete behavior.
@@ -10,19 +10,25 @@
 export default class AdvancementConfig extends FormApplication {
   constructor(advancement, options={}) {
     super(advancement, options);
-
-    /**
-     * The ID of the advancement being created or edited.
-     * @type {string}
-     */
-    this._advancementId = advancement.id;
-
-    /**
-     * Parent item to which this advancement belongs.
-     * @type {Item5e}
-     */
+    this.#advancementId = advancement.id;
     this.item = advancement.item;
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The ID of the advancement being created or edited.
+   * @type {string}
+   */
+  #advancementId;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Parent item to which this advancement belongs.
+   * @type {Item5e}
+   */
+  item;
 
   /* -------------------------------------------- */
 
@@ -46,7 +52,7 @@ export default class AdvancementConfig extends FormApplication {
    * @type {Advancement}
    */
   get advancement() {
-    return this.item.advancement.byId[this._advancementId];
+    return this.item.advancement.byId[this.#advancementId];
   }
 
   /* -------------------------------------------- */

--- a/module/documents/advancement/advancement.mjs
+++ b/module/documents/advancement/advancement.mjs
@@ -23,6 +23,18 @@ export default class Advancement extends BaseAdvancement {
   constructor(data, {parent=null, ...options}={}) {
     if ( parent instanceof Item ) parent = parent.system;
     super(data, {parent, ...options});
+
+    /**
+     * A collection of Application instances which should be re-rendered whenever this document is updated.
+     * The keys of this object are the application ids and the values are Application instances. Each
+     * Application in this object will have its render method called by {@link Document#render}.
+     * @type {Object<Application>}
+     */
+    Object.defineProperty(this, "apps", {
+      value: {},
+      writable: false,
+      enumerable: false
+    });
   }
 
   /* -------------------------------------------- */
@@ -209,6 +221,17 @@ export default class Advancement extends BaseAdvancement {
    */
   summaryForLevel(level, { configMode=false }={}) {
     return "";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Render all of the Application instances which are connected to this advancement.
+   * @param {boolean} [force=false]     Force rendering
+   * @param {object} [context={}]       Optional context
+   */
+  render(force=false, context={}) {
+    for ( const app of Object.values(this.apps) ) app.render(force, context);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2046,7 +2046,7 @@ export default class Item5e extends Item {
 
     const advancementCollection = this.toObject().system.advancement;
     advancementCollection[idx] = advancement.toObject();
-    this.update({"system.advancement": advancementCollection}).then(r => {
+    return this.update({"system.advancement": advancementCollection}).then(r => {
       advancement.render();
       return r;
     });

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2039,10 +2039,17 @@ export default class Item5e extends Item {
 
     const advancement = this.advancement.byId[id];
     advancement.updateSource(updates);
-    if ( source ) return this;
+    if ( source ) {
+      advancement.render();
+      return this;
+    }
+
     const advancementCollection = this.toObject().system.advancement;
     advancementCollection[idx] = advancement.toObject();
-    return this.update({"system.advancement": advancementCollection});
+    this.update({"system.advancement": advancementCollection}).then(r => {
+      advancement.render();
+      return r;
+    });
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Fixes a bug introduced by the interaction between item data models and advancements. Replicates core's app updating behavior using `apps` to automatically re-render config applications when an advancement is updated.