### PR TITLE
[#1443] Set lair action initiative and item activation cost to `null` by default

### DIFF
--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -36,9 +36,7 @@ export default class ActivatedEffectTemplate extends foundry.abstract.DataModel 
     return {
       activation: new foundry.data.fields.SchemaField({
         type: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.ItemActivationType"}),
-        cost: new foundry.data.fields.NumberField({
-          required: true, nullable: false, initial: 0, label: "DND5E.ItemActivationCost"
-        }),
+        cost: new foundry.data.fields.NumberField({required: true, label: "DND5E.ItemActivationCost"}),
         condition: new foundry.data.fields.StringField({required: true, label: "DND5E.ItemActivationCondition"})
       }, {label: "DND5E.ItemActivation"}),
       duration: new foundry.data.fields.SchemaField({

--- a/packs/src/monsters/aberration/chuul.json
+++ b/packs/src/monsters/aberration/chuul.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/aberration/cloaker.json
+++ b/packs/src/monsters/aberration/cloaker.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/aberration/gibbering-mouther.json
+++ b/packs/src/monsters/aberration/gibbering-mouther.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/aberration/otyugh.json
+++ b/packs/src/monsters/aberration/otyugh.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/ape.json
+++ b/packs/src/monsters/beast/ape.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/axe-beak.json
+++ b/packs/src/monsters/beast/axe-beak.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/baboon.json
+++ b/packs/src/monsters/beast/baboon.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/badger.json
+++ b/packs/src/monsters/beast/badger.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/bat.json
+++ b/packs/src/monsters/beast/bat.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/black-bear.json
+++ b/packs/src/monsters/beast/black-bear.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/blood-hawk.json
+++ b/packs/src/monsters/beast/blood-hawk.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/boar.json
+++ b/packs/src/monsters/beast/boar.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/brown-bear.json
+++ b/packs/src/monsters/beast/brown-bear.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/camel.json
+++ b/packs/src/monsters/beast/camel.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/cat.json
+++ b/packs/src/monsters/beast/cat.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/constrictor-snake.json
+++ b/packs/src/monsters/beast/constrictor-snake.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/crab.json
+++ b/packs/src/monsters/beast/crab.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/crocodile.json
+++ b/packs/src/monsters/beast/crocodile.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/deer.json
+++ b/packs/src/monsters/beast/deer.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/dire-wolf.json
+++ b/packs/src/monsters/beast/dire-wolf.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/draft-horse.json
+++ b/packs/src/monsters/beast/draft-horse.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/eagle.json
+++ b/packs/src/monsters/beast/eagle.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/elephant.json
+++ b/packs/src/monsters/beast/elephant.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/elk.json
+++ b/packs/src/monsters/beast/elk.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/flying-snake.json
+++ b/packs/src/monsters/beast/flying-snake.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/frog.json
+++ b/packs/src/monsters/beast/frog.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-ape.json
+++ b/packs/src/monsters/beast/giant-ape.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-badger.json
+++ b/packs/src/monsters/beast/giant-badger.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-bat.json
+++ b/packs/src/monsters/beast/giant-bat.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-boar.json
+++ b/packs/src/monsters/beast/giant-boar.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-centipede.json
+++ b/packs/src/monsters/beast/giant-centipede.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-constrictor-snake.json
+++ b/packs/src/monsters/beast/giant-constrictor-snake.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-crab.json
+++ b/packs/src/monsters/beast/giant-crab.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-crocodile.json
+++ b/packs/src/monsters/beast/giant-crocodile.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-eagle.json
+++ b/packs/src/monsters/beast/giant-eagle.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-elk.json
+++ b/packs/src/monsters/beast/giant-elk.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-fire-beetle.json
+++ b/packs/src/monsters/beast/giant-fire-beetle.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-fly.json
+++ b/packs/src/monsters/beast/giant-fly.json
@@ -370,7 +370,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-frog.json
+++ b/packs/src/monsters/beast/giant-frog.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-goat.json
+++ b/packs/src/monsters/beast/giant-goat.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-hyena.json
+++ b/packs/src/monsters/beast/giant-hyena.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-lizard.json
+++ b/packs/src/monsters/beast/giant-lizard.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-octopus.json
+++ b/packs/src/monsters/beast/giant-octopus.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-owl.json
+++ b/packs/src/monsters/beast/giant-owl.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-poisonous-snake.json
+++ b/packs/src/monsters/beast/giant-poisonous-snake.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-rat-diseased.json
+++ b/packs/src/monsters/beast/giant-rat-diseased.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-rat.json
+++ b/packs/src/monsters/beast/giant-rat.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-scorpion.json
+++ b/packs/src/monsters/beast/giant-scorpion.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-sea-horse.json
+++ b/packs/src/monsters/beast/giant-sea-horse.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-shark.json
+++ b/packs/src/monsters/beast/giant-shark.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-spider.json
+++ b/packs/src/monsters/beast/giant-spider.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-toad.json
+++ b/packs/src/monsters/beast/giant-toad.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-vulture.json
+++ b/packs/src/monsters/beast/giant-vulture.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-wasp.json
+++ b/packs/src/monsters/beast/giant-wasp.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-weasel.json
+++ b/packs/src/monsters/beast/giant-weasel.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/giant-wolf-spider.json
+++ b/packs/src/monsters/beast/giant-wolf-spider.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/goat.json
+++ b/packs/src/monsters/beast/goat.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/hawk.json
+++ b/packs/src/monsters/beast/hawk.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/hunter-shark.json
+++ b/packs/src/monsters/beast/hunter-shark.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/hyena.json
+++ b/packs/src/monsters/beast/hyena.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/jackal.json
+++ b/packs/src/monsters/beast/jackal.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/killer-whale.json
+++ b/packs/src/monsters/beast/killer-whale.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/lion.json
+++ b/packs/src/monsters/beast/lion.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/lizard.json
+++ b/packs/src/monsters/beast/lizard.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/mammoth.json
+++ b/packs/src/monsters/beast/mammoth.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/mastiff.json
+++ b/packs/src/monsters/beast/mastiff.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/mule.json
+++ b/packs/src/monsters/beast/mule.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/octopus.json
+++ b/packs/src/monsters/beast/octopus.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/owl.json
+++ b/packs/src/monsters/beast/owl.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/panther.json
+++ b/packs/src/monsters/beast/panther.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/plesiosaurus.json
+++ b/packs/src/monsters/beast/plesiosaurus.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/poisonous-snake.json
+++ b/packs/src/monsters/beast/poisonous-snake.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/polar-bear.json
+++ b/packs/src/monsters/beast/polar-bear.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/pony.json
+++ b/packs/src/monsters/beast/pony.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/quipper.json
+++ b/packs/src/monsters/beast/quipper.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/rat.json
+++ b/packs/src/monsters/beast/rat.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/raven.json
+++ b/packs/src/monsters/beast/raven.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/reef-shark.json
+++ b/packs/src/monsters/beast/reef-shark.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/rhinoceros.json
+++ b/packs/src/monsters/beast/rhinoceros.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/riding-horse.json
+++ b/packs/src/monsters/beast/riding-horse.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/saber-toothed-tiger.json
+++ b/packs/src/monsters/beast/saber-toothed-tiger.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/scorpion.json
+++ b/packs/src/monsters/beast/scorpion.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/sea-horse.json
+++ b/packs/src/monsters/beast/sea-horse.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/spider.json
+++ b/packs/src/monsters/beast/spider.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/stirge.json
+++ b/packs/src/monsters/beast/stirge.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/swarm-of-bats.json
+++ b/packs/src/monsters/beast/swarm-of-bats.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/swarm-of-beetles.json
+++ b/packs/src/monsters/beast/swarm-of-beetles.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/swarm-of-centipedes.json
+++ b/packs/src/monsters/beast/swarm-of-centipedes.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/swarm-of-insects.json
+++ b/packs/src/monsters/beast/swarm-of-insects.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/swarm-of-poisonous-snakes.json
+++ b/packs/src/monsters/beast/swarm-of-poisonous-snakes.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/swarm-of-quippers.json
+++ b/packs/src/monsters/beast/swarm-of-quippers.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/swarm-of-rats.json
+++ b/packs/src/monsters/beast/swarm-of-rats.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/swarm-of-ravens.json
+++ b/packs/src/monsters/beast/swarm-of-ravens.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/swarm-of-spiders.json
+++ b/packs/src/monsters/beast/swarm-of-spiders.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/swarm-of-wasps.json
+++ b/packs/src/monsters/beast/swarm-of-wasps.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/tiger.json
+++ b/packs/src/monsters/beast/tiger.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/triceratops.json
+++ b/packs/src/monsters/beast/triceratops.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/tyrannosaurus-rex.json
+++ b/packs/src/monsters/beast/tyrannosaurus-rex.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/vulture.json
+++ b/packs/src/monsters/beast/vulture.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/warhorse.json
+++ b/packs/src/monsters/beast/warhorse.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/weasel.json
+++ b/packs/src/monsters/beast/weasel.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/beast/wolf.json
+++ b/packs/src/monsters/beast/wolf.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/celestial/couatl.json
+++ b/packs/src/monsters/celestial/couatl.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/celestial/deva.json
+++ b/packs/src/monsters/celestial/deva.json
@@ -385,7 +385,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/celestial/pegasus.json
+++ b/packs/src/monsters/celestial/pegasus.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/celestial/planetar.json
+++ b/packs/src/monsters/celestial/planetar.json
@@ -385,7 +385,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/celestial/solar.json
+++ b/packs/src/monsters/celestial/solar.json
@@ -388,8 +388,8 @@
         "max": 0
       },
       "lair": {
-        "value": true,
-        "initiative": 0
+        "value": false,
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/celestial/unicorn.json
+++ b/packs/src/monsters/celestial/unicorn.json
@@ -383,8 +383,8 @@
         "max": 0
       },
       "lair": {
-        "value": true,
-        "initiative": 0
+        "value": false,
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/construct/animated-armor.json
+++ b/packs/src/monsters/construct/animated-armor.json
@@ -386,7 +386,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/construct/clay-golem.json
+++ b/packs/src/monsters/construct/clay-golem.json
@@ -391,7 +391,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/construct/flesh-golem.json
+++ b/packs/src/monsters/construct/flesh-golem.json
@@ -392,7 +392,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/construct/flying-sword.json
+++ b/packs/src/monsters/construct/flying-sword.json
@@ -385,7 +385,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/construct/homunculus.json
+++ b/packs/src/monsters/construct/homunculus.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/construct/iron-golem.json
+++ b/packs/src/monsters/construct/iron-golem.json
@@ -391,7 +391,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/construct/rug-of-smothering.json
+++ b/packs/src/monsters/construct/rug-of-smothering.json
@@ -385,7 +385,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/construct/shield-guardian.json
+++ b/packs/src/monsters/construct/shield-guardian.json
@@ -384,7 +384,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/construct/stone-golem.json
+++ b/packs/src/monsters/construct/stone-golem.json
@@ -390,7 +390,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/black-dragon-wyrmling.json
+++ b/packs/src/monsters/dragon/black-dragon-wyrmling.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/blue-dragon-wyrmling.json
+++ b/packs/src/monsters/dragon/blue-dragon-wyrmling.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/brass-dragon-wyrmling.json
+++ b/packs/src/monsters/dragon/brass-dragon-wyrmling.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/bronze-dragon-wyrmling.json
+++ b/packs/src/monsters/dragon/bronze-dragon-wyrmling.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/copper-dragon-wyrmling.json
+++ b/packs/src/monsters/dragon/copper-dragon-wyrmling.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/dragon-turtle.json
+++ b/packs/src/monsters/dragon/dragon-turtle.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/gold-dragon-wyrmling.json
+++ b/packs/src/monsters/dragon/gold-dragon-wyrmling.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/green-dragon-wyrmling.json
+++ b/packs/src/monsters/dragon/green-dragon-wyrmling.json
@@ -380,7 +380,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/pseudodragon.json
+++ b/packs/src/monsters/dragon/pseudodragon.json
@@ -373,7 +373,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/red-dragon-wyrmling.json
+++ b/packs/src/monsters/dragon/red-dragon-wyrmling.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/silver-dragon-wyrmling.json
+++ b/packs/src/monsters/dragon/silver-dragon-wyrmling.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/white-dragon-wyrmling.json
+++ b/packs/src/monsters/dragon/white-dragon-wyrmling.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/wyvern.json
+++ b/packs/src/monsters/dragon/wyvern.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/young-black-dragon.json
+++ b/packs/src/monsters/dragon/young-black-dragon.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/young-blue-dragon.json
+++ b/packs/src/monsters/dragon/young-blue-dragon.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/young-brass-dragon.json
+++ b/packs/src/monsters/dragon/young-brass-dragon.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/young-bronze-dragon.json
+++ b/packs/src/monsters/dragon/young-bronze-dragon.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/young-copper-dragon.json
+++ b/packs/src/monsters/dragon/young-copper-dragon.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/young-gold-dragon.json
+++ b/packs/src/monsters/dragon/young-gold-dragon.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/young-green-dragon.json
+++ b/packs/src/monsters/dragon/young-green-dragon.json
@@ -381,7 +381,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/young-red-dragon.json
+++ b/packs/src/monsters/dragon/young-red-dragon.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/young-silver-dragon.json
+++ b/packs/src/monsters/dragon/young-silver-dragon.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/dragon/young-white-dragon.json
+++ b/packs/src/monsters/dragon/young-white-dragon.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/air-elemental.json
+++ b/packs/src/monsters/elemental/air-elemental.json
@@ -395,7 +395,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/azer.json
+++ b/packs/src/monsters/elemental/azer.json
@@ -381,7 +381,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/djinni.json
+++ b/packs/src/monsters/elemental/djinni.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/dust-mephit.json
+++ b/packs/src/monsters/elemental/dust-mephit.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/earth-elemental.json
+++ b/packs/src/monsters/elemental/earth-elemental.json
@@ -392,7 +392,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/efreeti.json
+++ b/packs/src/monsters/elemental/efreeti.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/fire-elemental.json
+++ b/packs/src/monsters/elemental/fire-elemental.json
@@ -394,7 +394,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/gargoyle.json
+++ b/packs/src/monsters/elemental/gargoyle.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/ice-mephit.json
+++ b/packs/src/monsters/elemental/ice-mephit.json
@@ -385,7 +385,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/invisible-stalker.json
+++ b/packs/src/monsters/elemental/invisible-stalker.json
@@ -393,7 +393,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/magma-mephit.json
+++ b/packs/src/monsters/elemental/magma-mephit.json
@@ -380,7 +380,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/magmin.json
+++ b/packs/src/monsters/elemental/magmin.json
@@ -380,7 +380,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/salamander.json
+++ b/packs/src/monsters/elemental/salamander.json
@@ -386,7 +386,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/steam-mephit.json
+++ b/packs/src/monsters/elemental/steam-mephit.json
@@ -382,7 +382,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/water-elemental.json
+++ b/packs/src/monsters/elemental/water-elemental.json
@@ -394,7 +394,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/elemental/xorn.json
+++ b/packs/src/monsters/elemental/xorn.json
@@ -382,7 +382,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fey/blink-dog.json
+++ b/packs/src/monsters/fey/blink-dog.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fey/dryad.json
+++ b/packs/src/monsters/fey/dryad.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fey/green-hag.json
+++ b/packs/src/monsters/fey/green-hag.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fey/satyr.json
+++ b/packs/src/monsters/fey/satyr.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fey/sea-hag.json
+++ b/packs/src/monsters/fey/sea-hag.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fey/sprite.json
+++ b/packs/src/monsters/fey/sprite.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/balor.json
+++ b/packs/src/monsters/fiend/balor.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/barbed-devil.json
+++ b/packs/src/monsters/fiend/barbed-devil.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/bearded-devil.json
+++ b/packs/src/monsters/fiend/bearded-devil.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/bone-devil.json
+++ b/packs/src/monsters/fiend/bone-devil.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/chain-devil.json
+++ b/packs/src/monsters/fiend/chain-devil.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/dretch.json
+++ b/packs/src/monsters/fiend/dretch.json
@@ -384,7 +384,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/erinyes.json
+++ b/packs/src/monsters/fiend/erinyes.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/glabrezu.json
+++ b/packs/src/monsters/fiend/glabrezu.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/hell-hound.json
+++ b/packs/src/monsters/fiend/hell-hound.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/hezrou.json
+++ b/packs/src/monsters/fiend/hezrou.json
@@ -390,7 +390,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/horned-devil.json
+++ b/packs/src/monsters/fiend/horned-devil.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/ice-devil.json
+++ b/packs/src/monsters/fiend/ice-devil.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/imp.json
+++ b/packs/src/monsters/fiend/imp.json
@@ -390,7 +390,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/lemure.json
+++ b/packs/src/monsters/fiend/lemure.json
@@ -386,7 +386,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/marilith.json
+++ b/packs/src/monsters/fiend/marilith.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/nalfeshnee.json
+++ b/packs/src/monsters/fiend/nalfeshnee.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/night-hag.json
+++ b/packs/src/monsters/fiend/night-hag.json
@@ -390,7 +390,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/nightmare.json
+++ b/packs/src/monsters/fiend/nightmare.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/pit-fiend.json
+++ b/packs/src/monsters/fiend/pit-fiend.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/quasit.json
+++ b/packs/src/monsters/fiend/quasit.json
@@ -390,7 +390,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/rakshasa.json
+++ b/packs/src/monsters/fiend/rakshasa.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/succubus-incubus.json
+++ b/packs/src/monsters/fiend/succubus-incubus.json
@@ -384,7 +384,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/fiend/vrock.json
+++ b/packs/src/monsters/fiend/vrock.json
@@ -389,7 +389,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/giant/cloud-giant.json
+++ b/packs/src/monsters/giant/cloud-giant.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/giant/ettin.json
+++ b/packs/src/monsters/giant/ettin.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/giant/fire-giant.json
+++ b/packs/src/monsters/giant/fire-giant.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/giant/frost-giant.json
+++ b/packs/src/monsters/giant/frost-giant.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/giant/hill-giant.json
+++ b/packs/src/monsters/giant/hill-giant.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/giant/ogre.json
+++ b/packs/src/monsters/giant/ogre.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/giant/oni.json
+++ b/packs/src/monsters/giant/oni.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/giant/stone-giant.json
+++ b/packs/src/monsters/giant/stone-giant.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/giant/storm-giant.json
+++ b/packs/src/monsters/giant/storm-giant.json
@@ -382,7 +382,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/giant/troll.json
+++ b/packs/src/monsters/giant/troll.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/acolyte.json
+++ b/packs/src/monsters/humanoid/acolyte.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/archmage.json
+++ b/packs/src/monsters/humanoid/archmage.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/assassin.json
+++ b/packs/src/monsters/humanoid/assassin.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/bandit-captain.json
+++ b/packs/src/monsters/humanoid/bandit-captain.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/bandit.json
+++ b/packs/src/monsters/humanoid/bandit.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/berserker.json
+++ b/packs/src/monsters/humanoid/berserker.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/bugbear.json
+++ b/packs/src/monsters/humanoid/bugbear.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/commoner.json
+++ b/packs/src/monsters/humanoid/commoner.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/cult-fanatic.json
+++ b/packs/src/monsters/humanoid/cult-fanatic.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/cultist.json
+++ b/packs/src/monsters/humanoid/cultist.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/deep-gnome.json
+++ b/packs/src/monsters/humanoid/deep-gnome.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/drow.json
+++ b/packs/src/monsters/humanoid/drow.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/druid.json
+++ b/packs/src/monsters/humanoid/druid.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/duergar.json
+++ b/packs/src/monsters/humanoid/duergar.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/gladiator.json
+++ b/packs/src/monsters/humanoid/gladiator.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/gnoll.json
+++ b/packs/src/monsters/humanoid/gnoll.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/goblin.json
+++ b/packs/src/monsters/humanoid/goblin.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/grimlock.json
+++ b/packs/src/monsters/humanoid/grimlock.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/guard.json
+++ b/packs/src/monsters/humanoid/guard.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/half-red-dragon-veteran.json
+++ b/packs/src/monsters/humanoid/half-red-dragon-veteran.json
@@ -379,7 +379,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/hobgoblin.json
+++ b/packs/src/monsters/humanoid/hobgoblin.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/knight.json
+++ b/packs/src/monsters/humanoid/knight.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/kobold.json
+++ b/packs/src/monsters/humanoid/kobold.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/lizardfolk.json
+++ b/packs/src/monsters/humanoid/lizardfolk.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/mage.json
+++ b/packs/src/monsters/humanoid/mage.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/merfolk.json
+++ b/packs/src/monsters/humanoid/merfolk.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/noble.json
+++ b/packs/src/monsters/humanoid/noble.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/orc.json
+++ b/packs/src/monsters/humanoid/orc.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/priest.json
+++ b/packs/src/monsters/humanoid/priest.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/sahuagin.json
+++ b/packs/src/monsters/humanoid/sahuagin.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/scout.json
+++ b/packs/src/monsters/humanoid/scout.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/spy.json
+++ b/packs/src/monsters/humanoid/spy.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/thug.json
+++ b/packs/src/monsters/humanoid/thug.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/tribal-warrior.json
+++ b/packs/src/monsters/humanoid/tribal-warrior.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/veteran.json
+++ b/packs/src/monsters/humanoid/veteran.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/werebear.json
+++ b/packs/src/monsters/humanoid/werebear.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/wereboar.json
+++ b/packs/src/monsters/humanoid/wereboar.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/wererat.json
+++ b/packs/src/monsters/humanoid/wererat.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/weretiger.json
+++ b/packs/src/monsters/humanoid/weretiger.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/humanoid/werewolf.json
+++ b/packs/src/monsters/humanoid/werewolf.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/androsphinx.json
+++ b/packs/src/monsters/monstrosity/androsphinx.json
@@ -386,7 +386,7 @@
       },
       "lair": {
         "value": true,
-        "initiative": 0
+        "initiative": 20
       }
     }
   },

--- a/packs/src/monsters/monstrosity/ankheg.json
+++ b/packs/src/monsters/monstrosity/ankheg.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/basilisk.json
+++ b/packs/src/monsters/monstrosity/basilisk.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/behir.json
+++ b/packs/src/monsters/monstrosity/behir.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/bulette.json
+++ b/packs/src/monsters/monstrosity/bulette.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/centaur.json
+++ b/packs/src/monsters/monstrosity/centaur.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/chimera.json
+++ b/packs/src/monsters/monstrosity/chimera.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/cockatrice.json
+++ b/packs/src/monsters/monstrosity/cockatrice.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/darkmantle.json
+++ b/packs/src/monsters/monstrosity/darkmantle.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/death-dog.json
+++ b/packs/src/monsters/monstrosity/death-dog.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/doppelganger.json
+++ b/packs/src/monsters/monstrosity/doppelganger.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/drider.json
+++ b/packs/src/monsters/monstrosity/drider.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/ettercap.json
+++ b/packs/src/monsters/monstrosity/ettercap.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/gorgon.json
+++ b/packs/src/monsters/monstrosity/gorgon.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/grick.json
+++ b/packs/src/monsters/monstrosity/grick.json
@@ -380,7 +380,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/griffon.json
+++ b/packs/src/monsters/monstrosity/griffon.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/guardian-naga.json
+++ b/packs/src/monsters/monstrosity/guardian-naga.json
@@ -382,7 +382,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/gynosphinx.json
+++ b/packs/src/monsters/monstrosity/gynosphinx.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": true,
-        "initiative": 0
+        "initiative": 20
       }
     }
   },

--- a/packs/src/monsters/monstrosity/harpy.json
+++ b/packs/src/monsters/monstrosity/harpy.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/hippogriff.json
+++ b/packs/src/monsters/monstrosity/hippogriff.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/hydra.json
+++ b/packs/src/monsters/monstrosity/hydra.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/kraken.json
+++ b/packs/src/monsters/monstrosity/kraken.json
@@ -384,7 +384,7 @@
       },
       "lair": {
         "value": true,
-        "initiative": 0
+        "initiative": 20
       }
     }
   },

--- a/packs/src/monsters/monstrosity/lamia.json
+++ b/packs/src/monsters/monstrosity/lamia.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/manticore.json
+++ b/packs/src/monsters/monstrosity/manticore.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/medusa.json
+++ b/packs/src/monsters/monstrosity/medusa.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/merrow.json
+++ b/packs/src/monsters/monstrosity/merrow.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/mimic.json
+++ b/packs/src/monsters/monstrosity/mimic.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/minotaur.json
+++ b/packs/src/monsters/monstrosity/minotaur.json
@@ -376,7 +376,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/owlbear.json
+++ b/packs/src/monsters/monstrosity/owlbear.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/phase-spider.json
+++ b/packs/src/monsters/monstrosity/phase-spider.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/purple-worm.json
+++ b/packs/src/monsters/monstrosity/purple-worm.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/remorhaz.json
+++ b/packs/src/monsters/monstrosity/remorhaz.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/roc.json
+++ b/packs/src/monsters/monstrosity/roc.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/roper.json
+++ b/packs/src/monsters/monstrosity/roper.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/rust-monster.json
+++ b/packs/src/monsters/monstrosity/rust-monster.json
@@ -374,7 +374,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/spirit-naga.json
+++ b/packs/src/monsters/monstrosity/spirit-naga.json
@@ -382,7 +382,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/tarrasque.json
+++ b/packs/src/monsters/monstrosity/tarrasque.json
@@ -386,8 +386,8 @@
         "max": 3
       },
       "lair": {
-        "value": true,
-        "initiative": 0
+        "value": false,
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/winter-wolf.json
+++ b/packs/src/monsters/monstrosity/winter-wolf.json
@@ -380,7 +380,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/monstrosity/worg.json
+++ b/packs/src/monsters/monstrosity/worg.json
@@ -377,7 +377,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/ooze/black-pudding.json
+++ b/packs/src/monsters/ooze/black-pudding.json
@@ -386,7 +386,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/ooze/gelatinous-cube.json
+++ b/packs/src/monsters/ooze/gelatinous-cube.json
@@ -381,7 +381,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/ooze/gray-ooze.json
+++ b/packs/src/monsters/ooze/gray-ooze.json
@@ -385,7 +385,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/ooze/ochre-jelly.json
+++ b/packs/src/monsters/ooze/ochre-jelly.json
@@ -386,7 +386,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/plant/awakened-shrub.json
+++ b/packs/src/monsters/plant/awakened-shrub.json
@@ -380,7 +380,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/plant/awakened-tree.json
+++ b/packs/src/monsters/plant/awakened-tree.json
@@ -381,7 +381,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/plant/shambling-mound.json
+++ b/packs/src/monsters/plant/shambling-mound.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/plant/shrieker.json
+++ b/packs/src/monsters/plant/shrieker.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/plant/treant.json
+++ b/packs/src/monsters/plant/treant.json
@@ -384,7 +384,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/plant/violet-fungus.json
+++ b/packs/src/monsters/plant/violet-fungus.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/avatar-of-death.json
+++ b/packs/src/monsters/undead/avatar-of-death.json
@@ -380,7 +380,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/ghast.json
+++ b/packs/src/monsters/undead/ghast.json
@@ -384,7 +384,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/ghost.json
+++ b/packs/src/monsters/undead/ghost.json
@@ -394,7 +394,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/ghoul.json
+++ b/packs/src/monsters/undead/ghoul.json
@@ -382,7 +382,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/lich.json
+++ b/packs/src/monsters/undead/lich.json
@@ -394,7 +394,7 @@
       },
       "lair": {
         "value": true,
-        "initiative": 0
+        "initiative": 20
       }
     }
   },

--- a/packs/src/monsters/undead/minotaur-skeleton.json
+++ b/packs/src/monsters/undead/minotaur-skeleton.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/mummy-lord.json
+++ b/packs/src/monsters/undead/mummy-lord.json
@@ -390,7 +390,7 @@
       },
       "lair": {
         "value": true,
-        "initiative": 0
+        "initiative": 20
       }
     }
   },

--- a/packs/src/monsters/undead/mummy.json
+++ b/packs/src/monsters/undead/mummy.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/ogre-zombie.json
+++ b/packs/src/monsters/undead/ogre-zombie.json
@@ -380,7 +380,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/shadow.json
+++ b/packs/src/monsters/undead/shadow.json
@@ -399,7 +399,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/skeleton.json
+++ b/packs/src/monsters/undead/skeleton.json
@@ -381,7 +381,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/specter.json
+++ b/packs/src/monsters/undead/specter.json
@@ -398,7 +398,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/vampire-spawn.json
+++ b/packs/src/monsters/undead/vampire-spawn.json
@@ -383,7 +383,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/vampire.json
+++ b/packs/src/monsters/undead/vampire.json
@@ -380,8 +380,8 @@
         "max": 3
       },
       "lair": {
-        "value": true,
-        "initiative": 0
+        "value": false,
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/warhorse-skeleton.json
+++ b/packs/src/monsters/undead/warhorse-skeleton.json
@@ -381,7 +381,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/wight.json
+++ b/packs/src/monsters/undead/wight.json
@@ -387,7 +387,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/will-o-wisp.json
+++ b/packs/src/monsters/undead/will-o-wisp.json
@@ -396,7 +396,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/wraith.json
+++ b/packs/src/monsters/undead/wraith.json
@@ -398,7 +398,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/packs/src/monsters/undead/zombie.json
+++ b/packs/src/monsters/undead/zombie.json
@@ -378,7 +378,7 @@
       },
       "lair": {
         "value": false,
-        "initiative": 0
+        "initiative": null
       }
     }
   },

--- a/template.json
+++ b/template.json
@@ -456,7 +456,7 @@
         },
         "lair": {
           "value": false,
-          "initiative": 0
+          "initiative": null
         }
       }
     },


### PR DESCRIPTION
Also fixes a number of monsters that had lair action incorrectly set.

Resolves #1443 