### PR TITLE
[#1949] Prevent dropping unwanted items onto group actor, fix getRollData & inventory bugs

### DIFF
--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -354,7 +354,7 @@ export default class GroupActorSheet extends ActorSheet {
 
   /** @override */
   async _onDropItemCreate(itemData) {
-    let items = itemData instanceof Array ? itemData : [itemData];
+    const items = itemData instanceof Array ? itemData : [itemData];
 
     const toCreate = [];
     for ( const item of items ) {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -204,6 +204,7 @@ export default class Actor5e extends Actor {
    */
   getRollData({ deterministic=false }={}) {
     const data = {...super.getRollData()};
+    if ( this.type === "group" ) return data;
     data.prof = new Proficiency(this.system.attributes.prof, 1);
     if ( deterministic ) data.prof = data.prof.flat;
     data.attributes = foundry.utils.deepClone(data.attributes);


### PR DESCRIPTION
Ideally other actors sheets and the group sheet would inherit from a new base type to remove the code duplication, but this will work well for the moment.