### PR TITLE
Fix bug opening TraitSelector for damage types, fix attunement in inventory

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -753,7 +753,9 @@ export default class ActorSheet5e extends ActorSheet {
       options.push({
         name: isAttuned ? "DND5E.ContextMenuActionUnattune" : "DND5E.ContextMenuActionAttune",
         icon: "<i class='fas fa-sun fa-fw'></i>",
-        callback: item.update({"system.attunement": CONFIG.DND5E.attunementTypes[isAttuned ? "ATTUNED" : "REQUIRED"]})
+        callback: () => item.update({
+          "system.attunement": CONFIG.DND5E.attunementTypes[isAttuned ? "REQUIRED" : "ATTUNED"]
+        })
       });
     }
 

--- a/module/applications/actor/trait-selector.mjs
+++ b/module/applications/actor/trait-selector.mjs
@@ -69,7 +69,7 @@ export default class TraitSelector extends DocumentSheet {
       custom: data.custom,
       customPath: "custom" in data ? `${path}.custom` : null,
       bypasses: "bypasses" in data ? Object.entries(CONFIG.DND5E.physicalWeaponProperties).reduce((obj, [k, v]) => {
-        obj[k] = { label: v, chosen: data.bypasses.includes(k) };
+        obj[k] = { label: v, chosen: data.bypasses.has(k) };
         return obj;
       }, {}) : null,
       bypassesPath: "bypasses" in data ? `${path}.bypasses` : null

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -66,9 +66,9 @@
                     {{item.name~}}
                     {{~#if ctx.isStack}} ({{item.system.quantity}}){{/if}}
                 </h4>
-                {{#if item.attunement}}
+                {{#if ctx.attunement}}
                 <div class="item-detail attunement">
-                    <i class="fas {{item.attunement.icon}} {{item.attunement.cls}}" title="{{localize item.attunement.title}}"></i>
+                    <i class="fas {{ctx.attunement.icon}} {{ctx.attunement.cls}}" title="{{localize ctx.attunement.title}}"></i>
                 </div>
                 {{/if}}
                 {{/if}}


### PR DESCRIPTION
- Fix bug in `TraitSelector` which assumes bypasses are an array rather than a set
- Fix paths on character sheet preventing attunement from being displayed
- Fix attunement callback in context menu