### PR TITLE
Adjust cogs on actor sheets

### DIFF
--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -53,8 +53,9 @@
             <ul class="attributes flexrow">
                 <li class="attribute health">
                     <h4 class="attribute-name box-title">{{localize "DND5E.HitPoints"}}</h4>
-                    <a class="config-button" data-action="hit-points"
-                        data-tooltip="{{localize 'DND5E.HitPointsConfig'}}"><i class="fas fa-cog"></i></a>
+                    <a class="config-button" data-action="hit-points" data-tooltip="{{localize 'DND5E.HitPointsConfig'}}">
+                        <i class="fas fa-cog"></i>
+                    </a>
                     <div class="attribute-value multiple">
                         <input name="system.attributes.hp.value" type="text" value="{{hp.value}}" placeholder="10"
                             data-tooltip="{{localize 'DND5E.HitPointsCurrent'}}" data-dtype="Number">

--- a/templates/actors/group-sheet.hbs
+++ b/templates/actors/group-sheet.hbs
@@ -21,12 +21,10 @@
                     </div>
                 </li>
                 <li class="attribute movement">
-                    <h4 class="attribute-name box-title">
-                        {{ localize "DND5E.Movement" }}
-                        <a class="action-button config-button" data-action="movementConfig" data-tooltip="{{localize 'DND5E.MovementConfig'}}">
-                            <i class="fas fa-cog"></i>
-                        </a>
-                    </h4>
+                    <h4 class="attribute-name box-title">{{ localize "DND5E.Movement" }}</h4>
+                    <a class="action-button config-button" data-action="movementConfig" data-tooltip="{{localize 'DND5E.MovementConfig'}}">
+                        <i class="fas fa-cog"></i>
+                    </a>
                     <div class="attribute-value">
                         <span>{{movement.primary}}</span>
                     </div>

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -46,10 +46,10 @@
             {{!-- Header Attributes --}}
             <ul class="attributes flexrow">
                 <li class="attribute health">
-                    <h4 class="attribute-name box-title">
-                        {{ localize "DND5E.HitPoints" }}
-                        <a class="config-button" data-action="hit-points" title="{{localize 'DND5E.HitPointsConfig'}}"><i class="fas fa-cog"></i></a>
-                    </h4>
+                    <h4 class="attribute-name box-title">{{ localize "DND5E.HitPoints" }}</h4>
+                    <a class="config-button" data-action="hit-points" title="{{localize 'DND5E.HitPointsConfig'}}">
+                        <i class="fas fa-cog"></i>
+                    </a>
                     <div class="attribute-value multiple">
                         <input name="system.attributes.hp.value" type="text" value="{{hp.value}}" placeholder="10"
                             title="{{localize 'DND5E.HitPointsCurrent'}}" data-dtype="Number">

--- a/templates/actors/vehicle-sheet.hbs
+++ b/templates/actors/vehicle-sheet.hbs
@@ -58,10 +58,10 @@
                     </footer>
                 </li>
                 <li class="attribute movement">
-                    <h4 class="attribute-name box-title">
-                        {{ localize "DND5E.Movement" }}
-                        <a class="config-button" data-action="movement" title="{{localize 'DND5E.MovementConfig'}}"><i class="fas fa-cog"></i></a>
-                    </h4>
+                    <h4 class="attribute-name box-title">{{ localize "DND5E.Movement" }}</h4>
+                    <a class="config-button" data-action="movement" title="{{localize 'DND5E.MovementConfig'}}">
+                        <i class="fas fa-cog"></i>
+                    </a>
                     <div class="attribute-value">
                         <span>{{movement.primary}}</span>
                     </div>


### PR DESCRIPTION
This moves all cog icons out of any `h4` tags on all actor sheets to align with the rest that were already outside them.