### PR TITLE
Move proficiency calculating into Proficiency class

### DIFF
--- a/module/applications/journal/class-sheet.mjs
+++ b/module/applications/journal/class-sheet.mjs
@@ -1,4 +1,5 @@
 import Actor5e from "../../documents/actor/actor.mjs";
+import Proficiency from "../../documents/actor/proficiency.mjs";
 import JournalEditor from "./journal-editor.mjs";
 
 /**
@@ -151,7 +152,7 @@ export default class JournalClassPageSheet extends JournalPageSheet {
 
       // Level & proficiency bonus
       const cells = [{class: "level", content: level.ordinalString()}];
-      if ( item.type === "class" ) cells.push({class: "prof", content: `+${Math.floor((level + 7) / 4)}`});
+      if ( item.type === "class" ) cells.push({class: "prof", content: `+${Proficiency.calculateMod(level)}`});
       if ( hasFeatures ) cells.push({class: "features", content: features.join(", ")});
       scaleValues.forEach(s => cells.push({class: "scale", content: s.valueForLevel(level)?.display}));
       const spellCells = spellProgression?.rows[rows.length];

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -310,7 +310,7 @@ export default class Actor5e extends Actor {
     }
 
     // Character proficiency bonus
-    this.system.attributes.prof = Math.floor((this.system.details.level + 7) / 4);
+    this.system.attributes.prof = Proficiency.calculateMod(this.system.details.level);
 
     // Experience required for next level
     const xp = this.system.details.xp;
@@ -341,7 +341,7 @@ export default class Actor5e extends Actor {
     this.system.details.xp.value = this.getCRExp(cr);
 
     // Proficiency
-    this.system.attributes.prof = Math.floor((Math.max(cr, 1) + 7) / 4);
+    this.system.attributes.prof = Proficiency.calculateMod(Math.max(cr, 1));
 
     // Spellcaster Level
     if ( this.system.attributes.spellcasting && !Number.isNumeric(this.system.details.spellLevel) ) {

--- a/module/documents/actor/proficiency.mjs
+++ b/module/documents/actor/proficiency.mjs
@@ -28,6 +28,19 @@ export default class Proficiency {
     this.rounding = roundDown ? "down" : "up";
   }
 
+  /* -------------------------------------------- */
+
+  /**
+   * Calculate an actor's proficiency modifier based on level or CR.
+   * @param {number} level  Level or CR To use for calculating proficiency modifier.
+   * @returns {number}      Proficiency modifier.
+   */
+  static calculateMod(level) {
+    return Math.floor((level + 7) / 4);
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Flat proficiency value regardless of proficiency mode.
    * @type {number}
@@ -36,6 +49,8 @@ export default class Proficiency {
     const roundMethod = (this.rounding === "down") ? Math.floor : Math.ceil;
     return roundMethod(this.multiplier * this._baseProficiency);
   }
+
+  /* -------------------------------------------- */
 
   /**
    * Dice-based proficiency value regardless of proficiency mode.
@@ -51,6 +66,8 @@ export default class Proficiency {
     }
   }
 
+  /* -------------------------------------------- */
+
   /**
    * Either flat or dice proficiency term based on configured setting.
    * @type {string}
@@ -59,6 +76,8 @@ export default class Proficiency {
     return (game.settings.get("dnd5e", "proficiencyModifier") === "dice") ? this.dice : String(this.flat);
   }
 
+  /* -------------------------------------------- */
+
   /**
    * Whether the proficiency is greater than zero.
    * @type {boolean}
@@ -66,6 +85,8 @@ export default class Proficiency {
   get hasProficiency() {
     return (this._baseProficiency > 0) && (this.multiplier > 0);
   }
+
+  /* -------------------------------------------- */
 
   /**
    * Override the default `toString` method to return flat proficiency for backwards compatibility in formula.


### PR DESCRIPTION
Consolidates the code for calculating proficiency into the `Proficiency` class to avoid duplicating this formula. Should also allow for any modules that want to mess with how proficiency is calculated to be able to do it by replacing this single method.