### PR TITLE
[#2053] Fix spellcasting not being prepared if no class exists with spellcasting type

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -659,7 +659,7 @@ export default class Actor5e extends Actor {
    * @protected
    */
   _prepareSpellcasting() {
-    if ( this.type === "vehicle" ) return;
+    if ( !this.system.spells ) return;
 
     // Spellcasting DC
     const spellcastingAbility = this.system.abilities[this.system.attributes.spellcasting];
@@ -691,7 +691,7 @@ export default class Actor5e extends Actor {
       );
     }
 
-    for ( const type of Object.keys(types) ) {
+    for ( const type of Object.keys(CONFIG.DND5E.spellcastingTypes) ) {
       this.constructor.prepareSpellcastingSlots(this.system.spells, type, progression, { actor: this });
     }
   }


### PR DESCRIPTION
Ensures spellcasting is prepared for all spellcasting types regardless of whether the character has a class with that type. Also prevents spellcasting from being prepared on Group actors.