### PR TITLE
[#2064] Fix system DataModel migrations causing issues with core migrations, up minimum core version

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -125,8 +125,8 @@ export default class CharacterData extends CreatureTemplate {
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     AttributesFields._migrateInitiative(source.attributes);
-    return super.migrateData(source);
   }
 }
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -123,9 +123,9 @@ export default class NPCData extends CreatureTemplate {
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     NPCData.#migrateTypeData(source);
     AttributesFields._migrateInitiative(source.attributes);
-    return super.migrateData(source);
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -102,7 +102,7 @@ export default class AttributesFields {
    * @internal
    */
   static _migrateInitiative(source) {
-    const init = source.init;
+    const init = source?.init;
     if ( !init?.value ) return;
     if ( init.bonus ) init.bonus += init.value < 0 ? ` - ${init.value * -1}` : ` + ${init.value}`;
     else init.bonus = `${init.value}`;

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -119,8 +119,8 @@ export default class VehicleData extends CommonTemplate {
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     AttributesFields._migrateInitiative(source.attributes);
-    return super.migrateData(source);
   }
 }
 

--- a/module/data/advancement/scale-value.mjs
+++ b/module/data/advancement/scale-value.mjs
@@ -28,9 +28,9 @@ export class ScaleValueConfigurationData extends foundry.abstract.DataModel {
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     if ( source.type === "numeric" ) source.type = "number";
     Object.values(source.scale ?? {}).forEach(v => TYPES[source.type].migrateData(v));
-    super.migrateData(source);
   }
 }
 

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -61,9 +61,9 @@ export default class ClassData extends SystemDataModel.mixin(ItemDescriptionTemp
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     ClassData.#migrateLevels(source);
     ClassData.#migrateSpellcastingData(source);
-    return super.migrateData(source);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -59,9 +59,9 @@ export default class EquipmentData extends SystemDataModel.mixin(
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     EquipmentData.#migrateArmor(source);
     EquipmentData.#migrateStrength(source);
-    return super.migrateData(source);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -41,9 +41,9 @@ export default class FeatData extends SystemDataModel.mixin(
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     FeatData.#migrateType(source);
     FeatData.#migrateRecharge(source);
-    return super.migrateData(source);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -71,9 +71,9 @@ export default class SpellData extends SystemDataModel.mixin(
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     SpellData.#migrateComponentData(source);
     SpellData.#migrateScaling(source);
-    return super.migrateData(source);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -40,8 +40,8 @@ export default class ToolData extends SystemDataModel.mixin(
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     ToolData.#migrateAbility(source);
-    return super.migrateData(source);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -43,10 +43,10 @@ export default class WeaponData extends SystemDataModel.mixin(
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     WeaponData.#migratePropertiesData(source);
     WeaponData.#migrateProficient(source);
     WeaponData.#migrateWeaponType(source);
-    return super.migrateData(source);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2349,16 +2349,4 @@ export default class Item5e extends Item {
     });
     return new this(spellScrollData);
   }
-
-  /* -------------------------------------------- */
-  /*  Compatibility                               */
-  /* -------------------------------------------- */
-
-  /** @inheritdoc */
-  static migrateData(source) {
-    // TODO: Temporary patch until https://github.com/foundryvtt/foundryvtt/issues/8366 is resolved
-    const model = this.schema.get("system").getModelForType(source.type);
-    if ( model ) source.system = model.migrateDataSafe(source.system ?? {});
-    return super.migrateData(source);
-  }
 }

--- a/system.json
+++ b/system.json
@@ -4,7 +4,7 @@
   "description": "A system for playing the fifth edition of the worlds most popular role-playing game in the Foundry Virtual Tabletop environment.",
   "version": "2.1.2",
   "compatibility": {
-    "minimum": "10",
+    "minimum": "10.291",
     "verified": "10"
   },
   "url": "https://github.com/foundryvtt/dnd5e/",


### PR DESCRIPTION
**Note**: I've removed the return statement in out overridden `migrateData` methods. The core JSDoc states that `migrateData` should return `source`, but `migrateDataSafe` just ignores that value. Do we think is will be necessary to add `return source;` to each of these methods or are we good as is?