### PR TITLE
[#2071] Default to metric length units for movement and senses

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -587,6 +587,21 @@ Hooks.on("renderJournalPageSheet", applications.journal.JournalSheet5e.onRenderJ
 
 Hooks.on("targetToken", canvas.Token5e.onTargetToken);
 
+Hooks.on("preCreateScene", (doc, createData, options, userId) => {
+  // Set default grid units based on metric length setting
+  const units = utils.defaultUnits("length");
+  if ( (units !== dnd5e.grid.units) && !foundry.utils.getProperty(createData, "grid.distance")
+    && !foundry.utils.getProperty(createData, "grid.units") ) {
+    const C = CONFIG.DND5E.movementUnits;
+    doc.updateSource({
+      grid: {
+        // TODO: Replace with `convertLength` method once added
+        distance: dnd5e.grid.distance * (C[dnd5e.grid.units]?.conversion ?? 1) / (C[units]?.conversion ?? 1), units
+      }
+    });
+  }
+});
+
 // TODO: Generalize this logic and make it available in the re-designed transform application.
 Hooks.on("dnd5e.transformActor", (subject, target, d, options) => {
   const isLegacy = game.settings.get("dnd5e", "rulesVersion") === "legacy";

--- a/lang/en.json
+++ b/lang/en.json
@@ -4008,8 +4008,6 @@
 "SETTINGS.5eHonorN": "Honor Ability Score",
 "SETTINGS.5eInitTBL": "Append the raw Dexterity ability score to break ties in Initiative.",
 "SETTINGS.5eInitTBN": "Initiative Dexterity Tiebreaker",
-"SETTINGS.5eMetricN": "Use Metric Weight Units",
-"SETTINGS.5eMetricL": "Replaces all reference to lbs with kgs and updates the encumbrance calculations to use metric weight units.",
 "SETTINGS.5eNoAdvancementsN": "Disable level-up automation",
 "SETTINGS.5eNoAdvancementsL": "Do not prompt for level-up or character creation choices.",
 "SETTINGS.5eNoConcentrationN": "Disable concentration tracking",
@@ -4069,6 +4067,16 @@
     "NoXP": "Level Advancement without XP",
     "XP": "Experience Points",
     "XPBoons": "Experience Points with Epic Boons"
+  },
+  "METRIC": {
+    "LengthUnits": {
+      "Name": "Use Metric Length Units",
+      "Hint": "Defaults to using meters instead of feet for movement and senses."
+    },
+    "WeightUnits": {
+      "Name": "Use Metric Weight Units",
+      "Hint": "Replaces all reference to lbs with kgs and updates the encumbrance calculations to use metric weight units."
+    }
   },
   "THEME": {
     "Name": "Theme",

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1,6 +1,6 @@
 import * as Trait from "../../documents/actor/trait.mjs";
 import Item5e from "../../documents/item.mjs";
-import { formatDistance, splitSemicolons } from "../../utils.mjs";
+import { defaultUnits, formatDistance, splitSemicolons } from "../../utils.mjs";
 import EffectsElement from "../components/effects.mjs";
 import MovementSensesConfig from "../shared/movement-senses-config.mjs";
 import CreatureTypeConfig from "../shared/creature-type-config.mjs";
@@ -253,7 +253,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
 
     // Filter and sort speeds on their values
     speeds = speeds.filter(s => s[0]).sort((a, b) => b[0] - a[0]);
-    const units = movement.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
+    const units = movement.units ?? defaultUnits("length");
 
     // Case 1: Largest as primary
     if ( largestPrimary ) {
@@ -284,7 +284,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
   _getSenses(systemData) {
     const senses = systemData.attributes.senses ?? {};
     const tags = {};
-    const units = senses.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
+    const units = senses.units ?? defaultUnits("length");
     for ( let [k, label] of Object.entries(CONFIG.DND5E.senses) ) {
       const v = senses[k] ?? 0;
       if ( v === 0 ) continue;

--- a/module/applications/shared/movement-senses-config.mjs
+++ b/module/applications/shared/movement-senses-config.mjs
@@ -1,3 +1,4 @@
+import { defaultUnits } from "../../utils.mjs";
 import BaseConfigSheet from "../actor/api/base-config-sheet.mjs";
 
 /**
@@ -83,11 +84,9 @@ export default class MovementSensesConfig extends BaseConfigSheet {
       placeholder: placeholderData?.[key] ?? ""
     }));
 
-    const automaticUnit = CONFIG.DND5E.movementUnits[
-      placeholderData?.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0]
-    ]?.label?.toLowerCase();
+    const automaticUnit = CONFIG.DND5E.movementUnits[placeholderData?.units ?? defaultUnits("length")]?.label ?? "";
     context.unitsOptions = [
-      { value: "", label: game.i18n.format("DND5E.AutomaticValue", { value: automaticUnit }) },
+      { value: "", label: game.i18n.format("DND5E.AutomaticValue", { value: automaticUnit.toLowerCase() }) },
       { rule: true },
       ...Object.entries(CONFIG.DND5E.movementUnits).map(([value, { label }]) => ({ value, label }))
     ];

--- a/module/applications/shared/movement-senses-config.mjs
+++ b/module/applications/shared/movement-senses-config.mjs
@@ -84,12 +84,14 @@ export default class MovementSensesConfig extends BaseConfigSheet {
       placeholder: placeholderData?.[key] ?? ""
     }));
 
-    const automaticUnit = CONFIG.DND5E.movementUnits[placeholderData?.units ?? defaultUnits("length")]?.label ?? "";
-    context.unitsOptions = [
-      { value: "", label: game.i18n.format("DND5E.AutomaticValue", { value: automaticUnit.toLowerCase() }) },
-      { rule: true },
-      ...Object.entries(CONFIG.DND5E.movementUnits).map(([value, { label }]) => ({ value, label }))
-    ];
+    context.unitsOptions = Object.entries(CONFIG.DND5E.movementUnits).map(([value, { label }]) => ({ value, label }));
+    if ( this.document instanceof Actor ) {
+      const automaticUnit = CONFIG.DND5E.movementUnits[placeholderData?.units ?? defaultUnits("length")]?.label ?? "";
+      context.unitsOptions.unshift(
+        { value: "", label: game.i18n.format("DND5E.AutomaticValue", { value: automaticUnit.toLowerCase() }) },
+        { rule: true }
+      );
+    }
 
     return context;
   }

--- a/module/applications/shared/movement-senses-config.mjs
+++ b/module/applications/shared/movement-senses-config.mjs
@@ -85,7 +85,7 @@ export default class MovementSensesConfig extends BaseConfigSheet {
     }));
 
     context.unitsOptions = Object.entries(CONFIG.DND5E.movementUnits).map(([value, { label }]) => ({ value, label }));
-    if ( this.document instanceof Actor ) {
+    if ( (this.document.type === "pc") || ((this.document.type === "npc") && placeholderData) ) {
       const automaticUnit = CONFIG.DND5E.movementUnits[placeholderData?.units ?? defaultUnits("length")]?.label ?? "";
       context.unitsOptions.unshift(
         { value: "", label: game.i18n.format("DND5E.AutomaticValue", { value: automaticUnit.toLowerCase() }) },

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2350,6 +2350,23 @@ preLocalize("movementTypes", { sort: true });
 /* -------------------------------------------- */
 
 /**
+ * Default units used for imperial & metric settings.
+ * @enum {{ imperial: string, metric: string }}
+ */
+DND5E.defaultUnits = {
+  length: {
+    imperial: "ft",
+    metric: "m"
+  },
+  weight: {
+    imperial: "lb",
+    metric: "kg"
+  }
+};
+
+/* -------------------------------------------- */
+
+/**
  * @typedef {object} UnitConfiguration
  * @property {string} label              Localized label for the unit.
  * @property {string} abbreviation       Localized abbreviation for the unit.

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -1,6 +1,6 @@
 import HitDice from "../../documents/actor/hit-dice.mjs";
 import Proficiency from "../../documents/actor/proficiency.mjs";
-import { simplifyBonus } from "../../utils.mjs";
+import { defaultUnits, simplifyBonus } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import LocalDocumentField from "../fields/local-document-field.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
@@ -238,8 +238,8 @@ export default class CharacterData extends CreatureTemplate {
     }
     for ( const key of Object.keys(CONFIG.DND5E.movementTypes) ) this.attributes.movement[key] ??= 0;
     for ( const key of Object.keys(CONFIG.DND5E.senses) ) this.attributes.senses[key] ??= 0;
-    this.attributes.movement.units ??= Object.keys(CONFIG.DND5E.movementUnits)[0];
-    this.attributes.senses.units ??= Object.keys(CONFIG.DND5E.movementUnits)[0];
+    this.attributes.movement.units ??= defaultUnits("length");
+    this.attributes.senses.units ??= defaultUnits("length");
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -1,7 +1,7 @@
 import Actor5e from "../../documents/actor/actor.mjs";
 import Proficiency from "../../documents/actor/proficiency.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
-import { formatCR, formatNumber, splitSemicolons } from "../../utils.mjs";
+import { defaultUnits, formatCR, formatNumber, splitSemicolons } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
 import RollConfigField from "../shared/roll-config-field.mjs";
@@ -342,8 +342,8 @@ export default class NPCData extends CreatureTemplate {
     }
     for ( const key of Object.keys(CONFIG.DND5E.movementTypes) ) this.attributes.movement[key] ??= 0;
     for ( const key of Object.keys(CONFIG.DND5E.senses) ) this.attributes.senses[key] ??= 0;
-    this.attributes.movement.units ??= Object.keys(CONFIG.DND5E.movementUnits)[0];
-    this.attributes.senses.units ??= Object.keys(CONFIG.DND5E.movementUnits)[0];
+    this.attributes.movement.units ??= defaultUnits("length");
+    this.attributes.senses.units ??= defaultUnits("length");
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -31,8 +31,8 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
       advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" }),
-      movement: new MovementField(),
-      senses: new SensesField(),
+      movement: new MovementField({}, { initialUnits: defaultUnits("length") }),
+      senses: new SensesField({}, { initialUnits: defaultUnits("length") }),
       type: new CreatureTypeField({ swarm: false }, { initial: { value: "humanoid" } })
     });
   }

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -1,5 +1,5 @@
 import Actor5e from "../../documents/actor/actor.mjs";
-import { formatDistance, splitSemicolons } from "../../utils.mjs";
+import { defaultUnits, formatDistance, splitSemicolons } from "../../utils.mjs";
 import { ItemDataModel } from "../abstract.mjs";
 import AdvancementField from "../fields/advancement-field.mjs";
 import { CreatureTypeField, MovementField, SensesField } from "../shared/_module.mjs";
@@ -71,7 +71,7 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
    * @returns {Object<string>}
    */
   get movementLabels() {
-    const units = this.movement.units || Object.keys(CONFIG.DND5E.movementUnits)[0];
+    const units = this.movement.units || defaultUnits("length");
     return Object.entries(CONFIG.DND5E.movementTypes).reduce((obj, [k, label]) => {
       const value = this.movement[k];
       if ( value ) obj[k] = `${label} ${formatDistance(value, units)}`;
@@ -86,7 +86,7 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
    * @returns {Object<string>}
    */
   get sensesLabels() {
-    const units = this.senses.units || Object.keys(CONFIG.DND5E.movementUnits)[0];
+    const units = this.senses.units || defaultUnits("length");
     return Object.entries(CONFIG.DND5E.senses).reduce((arr, [k, label]) => {
       const value = this.senses[k];
       if ( value ) arr.push(`${label} ${formatDistance(value, units)}`);

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -1,4 +1,4 @@
-import { convertWeight } from "../../../utils.mjs";
+import { convertWeight, defaultUnits } from "../../../utils.mjs";
 import SystemDataModel from "../../abstract.mjs";
 
 const { ForeignDocumentField, NumberField, SchemaField, StringField } = foundry.data.fields;
@@ -32,8 +32,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
           required: true, nullable: false, initial: 0, min: 0, label: "DND5E.Weight"
         }),
         units: new StringField({
-          required: true, label: "DND5E.UNITS.WEIGHT.Label",
-          initial: () => game.settings.get("dnd5e", "metricWeightUnits") ? "kg" : "lb"
+          required: true, label: "DND5E.UNITS.WEIGHT.Label", initial: () => defaultUnits("weight")
         })
       }, {label: "DND5E.Weight"}),
       price: new SchemaField({
@@ -195,7 +194,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
     if ( !("weight" in source) || (foundry.utils.getType(source.weight) === "Object") ) return;
     source.weight = {
       value: Number.isNumeric(source.weight) ? Number(source.weight) : 0,
-      units: game.settings.get("dnd5e", "metricWeightUnits") ? "kg" : "lb"
+      units: defaultUnits("weight")
     };
   }
 

--- a/module/data/shared/movement-field.mjs
+++ b/module/data/shared/movement-field.mjs
@@ -4,7 +4,7 @@ const { BooleanField, NumberField, StringField } = foundry.data.fields;
  * Field for storing movement data.
  */
 export default class MovementField extends foundry.data.fields.SchemaField {
-  constructor(fields={}, options={}) {
+  constructor(fields={}, { initialUnits=null, ...options }={}) {
     const numberConfig = { required: true, nullable: true, min: 0, step: 0.1, initial: null };
     fields = {
       burrow: new NumberField({ ...numberConfig, label: "DND5E.MovementBurrow" }),
@@ -13,7 +13,7 @@ export default class MovementField extends foundry.data.fields.SchemaField {
       swim: new NumberField({ ...numberConfig, label: "DND5E.MovementSwim" }),
       walk: new NumberField({ ...numberConfig, label: "DND5E.MovementWalk" }),
       units: new StringField({
-        required: true, nullable: true, blank: false, initial: null, label: "DND5E.MovementUnits"
+        required: true, nullable: true, blank: false, initial: initialUnits, label: "DND5E.MovementUnits"
       }),
       hover: new BooleanField({ required: true, label: "DND5E.MovementHover" }),
       ...fields

--- a/module/data/shared/senses-field.mjs
+++ b/module/data/shared/senses-field.mjs
@@ -4,7 +4,7 @@ const { NumberField, StringField } = foundry.data.fields;
  * Field for storing senses data.
  */
 export default class SensesField extends foundry.data.fields.SchemaField {
-  constructor(fields={}, options={}) {
+  constructor(fields={}, { initialUnits=null, ...options }={}) {
     const numberConfig = { required: true, nullable: true, integer: true, min: 0, initial: null };
     fields = {
       darkvision: new NumberField({ ...numberConfig, label: "DND5E.SenseDarkvision" }),
@@ -12,7 +12,7 @@ export default class SensesField extends foundry.data.fields.SchemaField {
       tremorsense: new NumberField({ ...numberConfig, label: "DND5E.SenseTremorsense" }),
       truesight: new NumberField({ ...numberConfig, label: "DND5E.SenseTruesight" }),
       units: new StringField({
-        required: true, nullable: true, blank: false, initial: null, label: "DND5E.SenseUnits"
+        required: true, nullable: true, blank: false, initial: initialUnits, label: "DND5E.SenseUnits"
       }),
       special: new StringField({ required: true, label: "DND5E.SenseSpecial" }),
       ...fields

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -1,4 +1,4 @@
-import { formatDistance, formatNumber, getPluralRules, prepareFormulaValue } from "../../utils.mjs";
+import { defaultUnits, formatDistance, formatNumber, getPluralRules, prepareFormulaValue } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { BooleanField, SchemaField, StringField } = foundry.data.fields;
@@ -33,7 +33,7 @@ export default class TargetField extends SchemaField {
         size: new FormulaField({ deterministic: true }),
         width: new FormulaField({ deterministic: true }),
         height: new FormulaField({ deterministic: true }),
-        units: new StringField({ initial: "ft" })
+        units: new StringField({ initial: () => defaultUnits("length") })
       }),
       affects: new SchemaField({
         count: new FormulaField({ deterministic: true }),

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -4,7 +4,7 @@ import SkillToolRollConfigurationDialog from "../../applications/dice/skill-tool
 import PropertyAttribution from "../../applications/property-attribution.mjs";
 import { _applyDeprecatedD20Configs, _createDeprecatedD20Config } from "../../dice/d20-roll.mjs";
 import { createRollLabel } from "../../enrichers.mjs";
-import { replaceFormulaData, simplifyBonus, staticID } from "../../utils.mjs";
+import { defaultUnits, replaceFormulaData, simplifyBonus, staticID } from "../../utils.mjs";
 import ActiveEffect5e from "../active-effect.mjs";
 import Item5e from "../item.mjs";
 import SystemDocumentMixin from "../mixins/document.mjs";
@@ -2900,7 +2900,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   _prepareMovementAttribution() {
     const { movement } = this.system.attributes;
-    const units = movement.units || Object.keys(CONFIG.DND5E.movementUnits)[0];
+    const units = movement.units || defaultUnits("length");
     return Object.entries(CONFIG.DND5E.movementTypes).reduce((html, [k, label]) => {
       const value = movement[k];
       if ( value || (k === "walk") ) html += `

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -345,10 +345,20 @@ export function registerSystemSettings() {
     type: Boolean
   });
 
+  // Metric Length Weights
+  game.settings.register("dnd5e", "metricLengthUnits", {
+    name: "SETTINGS.DND5E.METRIC.LengthUnits.Name",
+    hint: "SETTINGS.DND5E.METRIC.LengthUnits.Hint",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false
+  });
+
   // Metric Unit Weights
   game.settings.register("dnd5e", "metricWeightUnits", {
-    name: "SETTINGS.5eMetricN",
-    hint: "SETTINGS.5eMetricL",
+    name: "SETTINGS.DND5E.METRIC.WeightUnits.Name",
+    hint: "SETTINGS.DND5E.METRIC.WeightUnits.Hint",
     scope: "world",
     config: true,
     type: Boolean,

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -519,6 +519,19 @@ export function convertWeight(value, from, to) {
 }
 
 /* -------------------------------------------- */
+
+/**
+ * Default units to use depending on system setting.
+ * @param {"length"|"weight"} type  Type of units to select.
+ * @returns {string}
+ */
+export function defaultUnits(type) {
+  return CONFIG.DND5E.defaultUnits[type]?.[
+    game.settings.get("dnd5e", `metric${type.capitalize()}Units`) ? "metric" : "imperial"
+  ];
+}
+
+/* -------------------------------------------- */
 /*  Validators                                  */
 /* -------------------------------------------- */
 


### PR DESCRIPTION
Sets the default value for movement, senses, and grid units to meters if metric length units are enabled in settings.

Updates newly created scenes setting them to the correct units and adjusting the grid distance (so using default settings, scenes in metric mode will be created with a grid of 1.5 m, instead of 5 ft).

Resolves #2071 