### PR TITLE
[#2033, #2080, #2084] Fix various issues with `ParentheticalTerms` in rolls

### DIFF
--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -241,7 +241,7 @@ export default class DamageRoll extends Roll {
 
     // Append a situational bonus term
     if ( form.bonus.value ) {
-      const bonus = new Roll(form.bonus.value, this.data);
+      const bonus = new DamageRoll(form.bonus.value, this.data);
       if ( !(bonus.terms[0] instanceof OperatorTerm) ) this.terms.push(new OperatorTerm({operator: "+"}));
       this.terms = this.terms.concat(bonus.terms);
     }

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -61,8 +61,8 @@ export default class DamageRoll extends Roll {
       const nextTerm = this.terms[i + 1];
       const prevTerm = this.terms[i - 1];
 
-      // Convert shorthand dX terms to 1dX pre-emptively to allow them to be appropriately doubled for criticals.
-      if ( (term instanceof StringTerm) && /^d\d+/.test(term.term) ) {
+      // Convert shorthand dX terms to 1dX preemptively to allow them to be appropriately doubled for criticals
+      if ( (term instanceof StringTerm) && /^d\d+/.test(term.term) && !(prevTerm instanceof ParentheticalTerm) ) {
         const formula = `1${term.term}`;
         const newTerm = new Roll(formula).terms[0];
         this.terms.splice(i, 1, newTerm);
@@ -70,7 +70,7 @@ export default class DamageRoll extends Roll {
       }
 
       // Merge parenthetical terms that follow string terms to build a dice term (to allow criticals)
-      if ( (term instanceof ParentheticalTerm) && (prevTerm instanceof StringTerm)
+      else if ( (term instanceof ParentheticalTerm) && (prevTerm instanceof StringTerm)
         && prevTerm.term.match(/^[0-9]*d$/)) {
         if ( term.isDeterministic ) {
           let newFormula = `${prevTerm.term}${term.evaluate().total}`;

--- a/module/dice/simplify-roll-formula.mjs
+++ b/module/dice/simplify-roll-formula.mjs
@@ -22,7 +22,7 @@ export default function simplifyRollFormula(formula, { preserveFlavor=false } = 
 
   // If the formula contains multiplication or division we cannot easily simplify
   if ( /[*/]/.test(roll.formula) ) {
-    if (( roll.isDeterministic ) && ( !/\[/.test(roll.formula) || !preserveFlavor )) {
+    if ( roll.isDeterministic && !/d\(/.test(roll.formula) && (!/\[/.test(roll.formula) || !preserveFlavor) ) {
       return Roll.safeEval(roll.formula).toString();
     }
     else return roll.constructor.getFormula(roll.terms);


### PR DESCRIPTION
- Ensure situational bonus dice added are preprocessed to allow crits #2033
- Fix bug introduced by resolving un-numbered dice terms (aka `d4`) #2080 
- Fix repeated warnings from `simplifyRollFormula` when multiplication & division are used #2084 