### PR TITLE
[#2054] Fix crew & passengers sections not displaying on vehicle sheet

### DIFF
--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -145,12 +145,34 @@ export async function preloadHandlebarsTemplates() {
 /* -------------------------------------------- */
 
 /**
+ * A helper that fetch the appropriate item context from root and adds it to the first block parameter.
+ * @param {object} context  Current evaluation context.
+ * @param {object} options  Handlebars options.
+ * @returns {string}
+ */
+function itemContext(context, options) {
+  if ( arguments.length !== 2 ) throw new Error("#dnd5e-with requires exactly one argument");
+  if ( foundry.utils.getType(context) === "function" ) context = context.call(this);
+
+  const ctx = options.data.root.itemContext?.[context.id];
+  if ( !ctx ) {
+    const inverse = options.inverse(this);
+    if ( inverse ) return options.inverse(this);
+  }
+
+  return options.fn(context, { data: options.data, blockParams: [ctx] });
+}
+
+/* -------------------------------------------- */
+
+/**
  * Register custom Handlebars helpers used by 5e.
  */
 export function registerHandlebarsHelpers() {
   Handlebars.registerHelper({
     getProperty: foundry.utils.getProperty,
-    "dnd5e-linkForUuid": linkForUuid
+    "dnd5e-linkForUuid": linkForUuid,
+    "dnd5e-itemContext": itemContext
   });
 }
 

--- a/templates/actors/parts/actor-features.hbs
+++ b/templates/actors/parts/actor-features.hbs
@@ -35,7 +35,7 @@
 
     <ol class="item-list">
     {{#each section.items as |item iid|}}
-    {{#with (lookup @root.itemContext item.id) as |ctx|}}
+    {{#dnd5e-itemContext item as |ctx|}}
         <li class="item flexrow {{#if ctx.isDepleted}}depleted{{/if}}" data-item-id="{{item.id}}">
             <div class="item-name flexrow rollable">
                 <div class="item-image" tabindex="0" role="button" aria-label="{{item.name}}" style="background-image: url('{{item.img}}')"></div>
@@ -103,7 +103,7 @@
             </div>
             {{/if}}
         </li>
-    {{/with}}
+    {{/dnd5e-itemContext}}
     {{/each}}
     </ol>
 {{/each}}

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -54,7 +54,7 @@
 
     <ol class="item-list">
     {{#each section.items as |item iid|}}
-    {{#with (lookup @root.itemContext item.id) as |ctx|}}
+    {{#dnd5e-itemContext item as |ctx|}}
         <li class="item flexrow {{section.css}}" data-item-id="{{item.id}}"
             {{#if section.editableName}}data-item-index="{{iid}}"{{/if}}>
             <div class="item-name flexrow {{@root.rollableClass}}">
@@ -128,7 +128,7 @@
             </div>
             {{/if}}
         </li>
-    {{/with}}
+    {{/dnd5e-itemContext}}
     {{/each}}
     </ol>
 {{/each}}

--- a/templates/actors/parts/actor-spellbook.hbs
+++ b/templates/actors/parts/actor-spellbook.hbs
@@ -68,7 +68,7 @@
 
     <ol class="item-list">
     {{#each section.spells as |item i|}}
-    {{#with (lookup @root.itemContext item.id) as |ctx|}}
+    {{#dnd5e-itemContext item as |ctx|}}
         <li class="item flexrow" data-item-id="{{item.id}}">
             <div class="item-name flexrow rollable">
                 <div class="item-image" tabindex="0" role="button" aria-label="{{item.name}}" style="background-image: url('{{item.img}}')"></div>
@@ -101,7 +101,7 @@
             </div>
             {{/if}}
         </li>
-    {{/with}}
+    {{/dnd5e-itemContext}}
     {{/each}}
     </ol>
 {{else}}


### PR DESCRIPTION
- Fix issue with crew & passenger sections not displaying on vehicle sheets by adding a new version of the `{{with}}` handlebars helper that can handle the context not being found #2054 