### PR TITLE
[#244] Preserve expanded state of items on actor sheets across re-render

### DIFF
--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -78,6 +78,9 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
         }
       }[item.system.attunement];
 
+      // Prepare data needed to display expanded sections
+      ctx.isExpanded = this._expanded.has(item.id);
+
       // Item usage
       ctx.hasUses = uses && (uses.max > 0);
       ctx.isOnCooldown = recharge && !!recharge.value && (recharge.charged === false);

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -59,6 +59,7 @@ export default class ActorSheet5eNPC extends ActorSheet5e {
       const {quantity, uses, recharge, target} = item.system;
       const ctx = context.itemContext[item.id] ??= {};
       ctx.isStack = Number.isNumeric(quantity) && (quantity !== 1);
+      ctx.isExpanded = this._expanded.has(item.id);
       ctx.hasUses = uses && (uses.max > 0);
       ctx.isOnCooldown = recharge && !!recharge.value && (recharge.charged === false);
       ctx.isDepleted = item.isOnCooldown && (uses.per && (uses.value > 0));

--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -169,6 +169,7 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
       const {uses, recharge} = item.system;
       const ctx = context.itemContext[item.id] ??= {};
       ctx.canToggle = false;
+      ctx.isExpanded = this._expanded.has(item.id);
       ctx.hasUses = uses && (uses.max > 0);
       ctx.isOnCooldown = recharge && !!recharge.value && (recharge.charged === false);
       ctx.isDepleted = item.isOnCooldown && (uses.per && (uses.value > 0));

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -124,6 +124,7 @@ export async function preloadHandlebarsTemplates() {
     "systems/dnd5e/templates/items/parts/item-description.hbs",
     "systems/dnd5e/templates/items/parts/item-mountable.hbs",
     "systems/dnd5e/templates/items/parts/item-spellcasting.hbs",
+    "systems/dnd5e/templates/items/parts/item-summary.hbs",
 
     // Journal Partials
     "systems/dnd5e/templates/journal/parts/journal-table.hbs",

--- a/templates/actors/parts/actor-features.hbs
+++ b/templates/actors/parts/actor-features.hbs
@@ -37,7 +37,8 @@
     <ol class="item-list">
     {{#each section.items as |item iid|}}
     {{#dnd5e-itemContext item as |ctx|}}
-        <li class="item flexrow {{#if ctx.isDepleted}}depleted{{/if}}" data-item-id="{{item.id}}">
+        <li class="item flexrow {{#if ctx.isDepleted}}depleted{{/if}} {{#if ctx.isExpanded}}expanded{{/if}}"
+            data-item-id="{{item.id}}">
             <div class="item-name flexrow rollable">
                 <div class="item-image" tabindex="0" role="button" aria-label="{{item.name}}" style="background-image: url('{{item.img}}')"></div>
                 <h4>
@@ -107,6 +108,10 @@
                     <i class="fas fa-trash"></i>
                 </a>
             </div>
+            {{/if}}
+
+            {{#if ctx.isExpanded}}
+                {{> "dnd5e.item-summary" (lookup @root.expandedData item.id)}}
             {{/if}}
         </li>
     {{/dnd5e-itemContext}}

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -56,7 +56,7 @@
     <ol class="item-list">
     {{#each section.items as |item iid|}}
     {{#dnd5e-itemContext item as |ctx|}}
-        <li class="item flexrow {{section.css}}" data-item-id="{{item.id}}"
+        <li class="item flexrow {{section.css}} {{#if ctx.isExpanded}}expanded{{/if}}" data-item-id="{{item.id}}"
             {{#if section.editableName}}data-item-index="{{iid}}"{{/if}}>
             <div class="item-name flexrow {{@root.rollableClass}}">
                 {{#if section.editableName}}
@@ -128,6 +128,10 @@
                     <i class="fas fa-trash"></i>
                 </a>
             </div>
+            {{/if}}
+
+            {{#if ctx.isExpanded}}
+                {{> "dnd5e.item-summary" (lookup @root.expandedData item.id)}}
             {{/if}}
         </li>
     {{/dnd5e-itemContext}}

--- a/templates/actors/parts/actor-spellbook.hbs
+++ b/templates/actors/parts/actor-spellbook.hbs
@@ -70,7 +70,7 @@
     <ol class="item-list">
     {{#each section.spells as |item i|}}
     {{#dnd5e-itemContext item as |ctx|}}
-        <li class="item flexrow" data-item-id="{{item.id}}">
+        <li class="item flexrow {{#if ctx.isExpanded}}expanded{{/if}}" data-item-id="{{item.id}}">
             <div class="item-name flexrow rollable">
                 <div class="item-image" tabindex="0" role="button" aria-label="{{item.name}}" style="background-image: url('{{item.img}}')"></div>
                 <h4>{{item.name}}</h4>
@@ -106,6 +106,10 @@
                     <i class="fas fa-trash"></i>
                 </a>
             </div>
+            {{/if}}
+
+            {{#if ctx.isExpanded}}
+                {{> "dnd5e.item-summary" (lookup @root.expandedData item.id)}}
             {{/if}}
         </li>
     {{/dnd5e-itemContext}}

--- a/templates/items/parts/item-summary.hbs
+++ b/templates/items/parts/item-summary.hbs
@@ -1,0 +1,7 @@
+<div class="item-summary">
+  {{{description.value}}}
+  
+  <div class="item-properties">
+    {{#each properties}}<span class="tag">{{this}}</span>{{/each}}
+  </div>
+</div>


### PR DESCRIPTION
Tracks which sections are expanded using the new `ActorSheet5e#_expanded` property.

Moves the actual HTML for the expanded sections into its own template so it can be easily rendered with the other templates.

Resolves #244