### PR TITLE
feat: add control to skip initiative dialog using modifier keys

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1194,6 +1194,8 @@
 "SETTINGS.5eHonorN": "Honor Ability Score",
 "SETTINGS.5eInitTBL": "Append the raw Dexterity ability score to break ties in Initiative.",
 "SETTINGS.5eInitTBN": "Initiative Dexterity Tiebreaker",
+"SETTINGS.5eInitKBDN": "Initiative Advantage/Disadvantage Keyboard Control",
+"SETTINGS.5eInitKBDL": "Use keyboard modifier keys to control Advantage/Disadvantage when rolling from the Combat Tracker",
 "SETTINGS.5eMetricN": "Use Metric Weight Units",
 "SETTINGS.5eMetricL": "Replaces all reference to lbs with kgs and updates the encumbrance calculations to use metric weight units.",
 "SETTINGS.5eNoAdvancementsN": "Disable level-up automation",

--- a/module/applications/combat/combat-tracker.mjs
+++ b/module/applications/combat/combat-tracker.mjs
@@ -1,3 +1,5 @@
+import D20Roll from "../../dice/d20-roll.mjs";
+
 /**
  * An extension of the base CombatTracker class to provide some 5e-specific functionality.
  * @extends {CombatTracker}
@@ -8,10 +10,8 @@ export default class CombatTracker5e extends CombatTracker {
     const btn = event.currentTarget;
     const combatantId = btn.closest(".combatant").dataset.combatantId;
     const combatant = this.viewed.combatants.get(combatantId);
-    const advantageKeyboardControl = game.settings.get("dnd5e", "initiativeAdvantageKeyboardControl");
-    const advantageMode = advantageKeyboardControl ? (event.altKey ? dnd5e.dice.D20Roll.ADV_MODE.ADVANTAGE
-      : event.shiftKey ? dnd5e.dice.D20Roll.ADV_MODE.DISADVANTAGE : dnd5e.dice.D20Roll.ADV_MODE.NORMAL) : null;
-    if ( (btn.dataset.control === "rollInitiative") && combatant?.actor ) return combatant.actor.rollInitiativeDialog({advantageMode});
+    const rollOptions = game.settings.get("dnd5e", "initiativeAdvantageKeyboardControl") ? D20Roll.determineAdvantageMode({event: event, advantage: false, disadvantage: false, fastForward: false}) : {};
+    if ( (btn.dataset.control === "rollInitiative") && combatant?.actor ) return combatant.actor.rollInitiativeDialog(rollOptions);
     return super._onCombatantControl(event);
   }
 }

--- a/module/applications/combat/combat-tracker.mjs
+++ b/module/applications/combat/combat-tracker.mjs
@@ -8,7 +8,10 @@ export default class CombatTracker5e extends CombatTracker {
     const btn = event.currentTarget;
     const combatantId = btn.closest(".combatant").dataset.combatantId;
     const combatant = this.viewed.combatants.get(combatantId);
-    if ( (btn.dataset.control === "rollInitiative") && combatant?.actor ) return combatant.actor.rollInitiativeDialog();
+    const advantageKeyboardControl = game.settings.get("dnd5e", "initiativeAdvantageKeyboardControl");
+    const advantageMode = advantageKeyboardControl ? (event.altKey ? dnd5e.dice.D20Roll.ADV_MODE.ADVANTAGE
+      : event.shiftKey ? dnd5e.dice.D20Roll.ADV_MODE.DISADVANTAGE : dnd5e.dice.D20Roll.ADV_MODE.NORMAL) : null;
+    if ( (btn.dataset.control === "rollInitiative") && combatant?.actor ) return combatant.actor.rollInitiativeDialog({advantageMode});
     return super._onCombatantControl(event);
   }
 }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1512,13 +1512,16 @@ export default class Actor5e extends Actor {
   async rollInitiativeDialog(rollOptions={}) {
     // Create and configure the Initiative roll
     const roll = this.getInitiativeRoll(rollOptions);
-    const choice = await roll.configureDialog({
-      defaultRollMode: game.settings.get("core", "rollMode"),
-      title: `${game.i18n.localize("DND5E.InitiativeRoll")}: ${this.name}`,
-      chooseModifier: false,
-      defaultAction: rollOptions.advantageMode ?? dnd5e.dice.D20Roll.ADV_MODE.NORMAL
-    });
-    if ( choice === null ) return; // Closed dialog
+
+    if (rollOptions.advantageMode === null) {
+      const choice = await roll.configureDialog({
+        defaultRollMode: game.settings.get("core", "rollMode"),
+        title: `${game.i18n.localize("DND5E.InitiativeRoll")}: ${this.name}`,
+        chooseModifier: false,
+        defaultAction: rollOptions.advantageMode ?? dnd5e.dice.D20Roll.ADV_MODE.NORMAL
+      });
+      if ( choice === null ) return; // Closed dialog
+    }
 
     // Temporarily cache the configured roll and use it to roll initiative for the Actor
     this._cachedInitiativeRoll = roll;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1513,7 +1513,7 @@ export default class Actor5e extends Actor {
     // Create and configure the Initiative roll
     const roll = this.getInitiativeRoll(rollOptions);
 
-    if (rollOptions.advantageMode === null) {
+    if (!rollOptions.isFF) {
       const choice = await roll.configureDialog({
         defaultRollMode: game.settings.get("core", "rollMode"),
         title: `${game.i18n.localize("DND5E.InitiativeRoll")}: ${this.name}`,

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -90,6 +90,16 @@ export default function registerSystemSettings() {
     type: Boolean
   });
 
+  // Use keyboard controls to set initiative advantage
+  game.settings.register("dnd5e", "initiativeAdvantageKeyboardControl", {
+    name: "SETTINGS.5eInitKBDN",
+    hint: "SETTINGS.5eInitKBDL",
+    scope: "client",
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
   // Record Currency Weight
   game.settings.register("dnd5e", "currencyWeight", {
     name: "SETTINGS.5eCurWtN",


### PR DESCRIPTION
# What?

This PR adds a control that is defaulted to false that can be configured per client to enable the alt/shift processing of initiative rolls via the combat tracker.

## Feedback

I'm a BE dev by trade, so JS is outside my comfort zone, so I am ok with (gentle) feedback on the code.


## TODO

The one missing piece to this PR is that I think the modifiers should be configurable. Right now it's hard-coded, but if someone can point me to documentation or code that explains how to create a new keybinding entry and use it within the system, that would be great.

## Discussion

I realize this may be a point of contention, given [this comment by @arbron ](https://discord.com/channels/170995199584108546/670336046164213761/1066629882639044658)

The rationale here is that having a dialog box pop up every time, at least for me and for many others, is disruptive to the workflow. Players can easily be trained on using alt/shift if they find it annoying, and can toggle the feature on. Additionally, modules like midi-qol automate a lot of things precisely to be able to avoid having lots of pop-ups for people to click for things to happen. The current implementation removed the ability for the `advantageMode` to be calculated and set by a module. I'm not sure this PR fixes that; maybe we should have an event that can be hooked for this purpose.

I can probably make this a module if we're absolutely set on not having this feature, but I still would argue strongly at the very least for a hook so `_onCombatantControl()` doesn't need to be wrapped by a module.