### PR TITLE
Fix issues with modifying custom skills

### DIFF
--- a/module/applications/actor/ability-config.mjs
+++ b/module/applications/actor/ability-config.mjs
@@ -34,9 +34,9 @@ export default class ActorAbilityConfig extends DocumentSheet {
 
   /** @override */
   getData(options) {
-    const src = this.object.toObject();
+    const src = this.document.toObject();
     return {
-      ability: src.system.abilities[this._abilityId] || {},
+      ability: src.system.abilities[this._abilityId] ?? this.document.system.abilities[this._abilityId] ?? {},
       labelSaves: game.i18n.format("DND5E.AbilitySaveConfigure", {ability: CONFIG.DND5E.abilities[this._abilityId]}),
       labelChecks: game.i18n.format("DND5E.AbilityCheckConfigure", {ability: CONFIG.DND5E.abilities[this._abilityId]}),
       abilityId: this._abilityId,

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -873,12 +873,11 @@ export default class ActorSheet5e extends ActorSheet {
     event.preventDefault();
     const field = event.currentTarget.previousElementSibling;
     const skillName = field.parentElement.dataset.skill;
-    const source = this.actor._source.system.skills[skillName];
-    if ( !source ) return;
+    const value = this.actor._source.system.skills[skillName]?.value ?? 0;
 
     // Cycle to the next or previous skill level
     const levels = [0, 1, 0.5, 2];
-    let idx = levels.indexOf(source.value);
+    let idx = levels.indexOf(value);
     const next = idx + (event.type === "click" ? 1 : 3);
     field.value = levels[next % 4];
 

--- a/module/applications/actor/skill-config.mjs
+++ b/module/applications/actor/skill-config.mjs
@@ -38,7 +38,7 @@ export default class ActorSkillConfig extends DocumentSheet {
     const src = this.document.toObject();
     return {
       abilities: CONFIG.DND5E.abilities,
-      skill: src.system.skills?.[this._skillId] || {},
+      skill: src.system.skills?.[this._skillId] ?? this.document.system.skills[this._skillId] ?? {},
       skillId: this._skillId,
       proficiencyLevels: CONFIG.DND5E.proficiencyLevels,
       bonusGlobal: src.system.bonuses?.abilities.skill

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -183,6 +183,7 @@
                 <li class="skill flexrow {{#if skill.value}}proficient{{/if}}" data-skill="{{s}}">
                     <input type="hidden" name="system.skills.{{s}}.value"
                            value="{{skill.baseValue}}" data-dtype="Number">
+                    <input type="hidden" name="system.skills.{{s}}.ability" value="{{skill.ability}}">
                     <a class="proficiency-toggle skill-proficiency" data-tooltip="{{skill.hover}}">{{{skill.icon}}}</a>
                     <div class="skill-name-controls">
                       <h4 class="skill-name rollable">{{skill.label}}</h4>

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -145,7 +145,9 @@
             {{#each config.skills as |obj s|}}
             {{#with (lookup ../skills s) as |skill|}}
                 <li class="skill flexrow {{#if skill.value}}proficient{{/if}}" data-skill="{{s}}">
-                    <input type="hidden" name="system.skills.{{s}}.value" value="{{skill.baseValue}}" data-dtype="Number"/>
+                    <input type="hidden" name="system.skills.{{s}}.value"
+                           value="{{skill.baseValue}}" data-dtype="Number">
+                    <input type="hidden" name="system.skills.{{s}}.ability" value="{{skill.ability}}">
                     <a class="proficiency-toggle skill-proficiency" data-tooltip="{{skill.hover}}">{{{skill.icon}}}</a>
                     <div class="skill-name-controls">
                       <h4 class="skill-name rollable">{{skill.label}}</h4>


### PR DESCRIPTION
Split off some of the less major changes from #2087. This should fix a bug preventing the proficiency toggle from working with newly added custom skills, an issue with `SkillConfig` not having the right data for custom skills, and the ability score being lost when other sheet data is saved.