### PR TITLE
[#2108] Fix issue with localized ability abbreviations causing issues with skills

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -149,7 +149,7 @@ export default class ActorSheet5e extends ActorSheet {
 
     // Skills
     for ( const [s, skl] of Object.entries(context.skills) ) {
-      skl.ability = CONFIG.DND5E.abilityAbbreviations[skl.ability];
+      skl.abbreviation = CONFIG.DND5E.abilityAbbreviations[skl.ability];
       skl.icon = this._getProficiencyIcon(skl.value);
       skl.hover = CONFIG.DND5E.proficiencyLevels[skl.value];
       skl.label = CONFIG.DND5E.skills[s]?.label;

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -191,7 +191,7 @@
                           <i class="fas fa-cog"></i>
                       </a>
                     </div>
-                    <span class="skill-ability">{{skill.ability}}</span>
+                    <span class="skill-ability">{{skill.abbreviation}}</span>
                     <span class="skill-mod" data-tooltip="{{localize 'DND5E.SkillModifierHint' skill=skill.label}}">
                         {{numberFormat skill.total decimals=0 sign=true}}
                     </span>

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -155,7 +155,7 @@
                           <i class="fas fa-cog"></i>
                       </a>
                     </div>
-                    <span class="skill-ability">{{skill.ability}}</span>
+                    <span class="skill-ability">{{skill.abbreviation}}</span>
                     <span class="skill-mod" data-tooltip="{{localize 'DND5E.SkillModifierHint' skill=skill.label}}">
                         {{numberFormat skill.total decimals=0 sign=true}}
                     </span>


### PR DESCRIPTION
Fixes a critical bug causing skills to lose their associated abilities if the ability abbreviations are localized.

Resolves #2108 