### PR TITLE
[#2094] Move Item getters into system data models

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -63,7 +63,6 @@ export default class ItemSheet5e extends ItemSheet {
     const context = await super.getData(options);
     const item = context.item;
     const source = item.toObject();
-    const isMountable = this._isItemMountable(item);
 
     // Game system configuration
     context.config = CONFIG.DND5E;
@@ -84,22 +83,15 @@ export default class ItemSheet5e extends ItemSheet {
       baseItems: await this._getItemBaseTypes(),
       isPhysical: item.system.hasOwnProperty("quantity"),
 
-      // Activation Details
-      hasScalarTarget: ![null, "", "self"].includes(item.system.target.type),
-
       // Action Details
-      hasAttackRoll: item.hasAttack,
       isHealing: item.system.actionType === "heal",
       isFlatDC: item.system.save?.scaling === "flat",
       isLine: ["line", "wall"].includes(item.system.target?.type),
 
       // Vehicles
       isCrewed: item.system.activation?.type === "crew",
-      isMountable,
 
       // Armor Class
-      isArmor: item.isArmor,
-      hasAC: item.isArmor || isMountable,
       hasDexModifier: item.isArmor && (item.system.armor?.type !== "shield"),
 
       // Advancement
@@ -330,7 +322,7 @@ export default class ItemSheet5e extends ItemSheet {
     switch ( this.item.type ) {
       case "equipment":
         props.push(CONFIG.DND5E.equipmentTypes[this.item.system.armor.type]);
-        if ( this.item.isArmor || this._isItemMountable(this.item) ) props.push(labels.armor);
+        if ( this.item.isArmor || this.item.isMountable ) props.push(labels.armor);
         break;
       case "feat":
         props.push(labels.featType);
@@ -355,20 +347,6 @@ export default class ItemSheet5e extends ItemSheet {
       props.push(labels.activation, labels.range, labels.target, labels.duration);
     }
     return props.filter(p => !!p);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Is this item a separate large object like a siege engine or vehicle component that is
-   * usually mounted on fixtures rather than equipped, and has its own AC and HP.
-   * @param {object} item  Copy of item data being prepared for display.
-   * @returns {boolean}    Is item siege weapon or vehicle equipment?
-   * @private
-   */
-  _isItemMountable(item) {
-    return ((item.type === "weapon") && (item.system.weaponType === "siege"))
-      || (item.type === "equipment" && (item.system.armor.type === "vehicle"));
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -58,6 +58,8 @@ export default class ClassData extends SystemDataModel.mixin(ItemDescriptionTemp
   }
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -31,4 +31,14 @@ export default class ConsumableData extends SystemDataModel.mixin(
       }, {label: "DND5E.LimitedUses"})
     });
   }
+
+  /* -------------------------------------------- */
+  /*  Getters                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  get _typeAbilityMod() {
+    if ( this.consumableType !== "scroll" ) return null;
+    return this.parent?.actor?.system.attributes.spellcasting || "int";
+  }
 }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -56,6 +56,8 @@ export default class EquipmentData extends SystemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {
@@ -91,4 +93,17 @@ export default class EquipmentData extends SystemDataModel.mixin(
     if ( source.strength === "" ) source.strength = null;
     if ( Number.isNumeric(source.strength) ) source.strength = Number(source.strength);
   }
+
+  /* -------------------------------------------- */
+  /*  Getters                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Is this Item any of the armor subtypes?
+   * @type {boolean}
+   */
+  get isArmor() {
+    return this.armor.type in CONFIG.DND5E.armorTypes;
+  }
+
 }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -106,4 +106,15 @@ export default class EquipmentData extends SystemDataModel.mixin(
     return this.armor.type in CONFIG.DND5E.armorTypes;
   }
 
+  /* -------------------------------------------- */
+
+  /**
+   * Is this item a separate large object like a siege engine or vehicle component that is
+   * usually mounted on fixtures rather than equipped, and has its own AC and HP?
+   * @type {boolean}
+   */
+  get isMountable() {
+    return this.armor.type === "vehicle";
+  }
+
 }

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -38,6 +38,8 @@ export default class FeatData extends SystemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {
@@ -68,5 +70,14 @@ export default class FeatData extends SystemDataModel.mixin(
     if ( (value === 0) || (value === "") ) source.recharge.value = null;
     else if ( (typeof value === "string") && Number.isNumeric(value) ) source.recharge.value = Number(value);
     if ( source.recharge.charged === null ) source.recharge.charged = false;
+  }
+
+  /* -------------------------------------------- */
+  /*  Getters                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  get hasLimitedUses() {
+    return !!this.recharge.value || super.hasLimitedUses;
   }
 }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -68,6 +68,8 @@ export default class SpellData extends SystemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {
@@ -99,4 +101,21 @@ export default class SpellData extends SystemDataModel.mixin(
     if ( !("scaling" in source) ) return;
     if ( (source.scaling.mode === "") || (source.scaling.mode === null) ) source.scaling.mode = "none";
   }
+
+  /* -------------------------------------------- */
+  /*  Getters                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  get _typeAbilityMod() {
+    return this.parent?.actor?.system.attributes.spellcasting || "int";
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  get _typeCriticalThreshold() {
+    return this.parent?.actor?.flags.dnd5e?.spellCriticalThreshold ?? Infinity;
+  }
+
 }

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -217,7 +217,7 @@ export default class ActionTemplate extends foundry.abstract.DataModel {
    * @type {boolean}
    */
   get hasDamage() {
-    return this.damage.parts.length > 0;
+    return this.actionType && (this.damage.parts.length > 0);
   }
 
   /* -------------------------------------------- */
@@ -227,7 +227,7 @@ export default class ActionTemplate extends foundry.abstract.DataModel {
    * @type {boolean}
    */
   get hasSave() {
-    return !!(this.save.ability && this.save.scaling);
+    return this.actionType && !!(this.save.ability && this.save.scaling);
   }
 
   /* -------------------------------------------- */
@@ -247,7 +247,7 @@ export default class ActionTemplate extends foundry.abstract.DataModel {
    * @type {boolean}
    */
   get isVersatile() {
-    return !!(this.hasDamage && this.damage.versatile);
+    return this.actionType && !!(this.hasDamage && this.damage.versatile);
   }
 
 }

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -58,6 +58,8 @@ export default class ActionTemplate extends foundry.abstract.DataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {
@@ -129,4 +131,123 @@ export default class ActionTemplate extends foundry.abstract.DataModel {
     if ( !("damage" in source) ) return;
     source.damage.parts ??= [];
   }
+
+  /* -------------------------------------------- */
+  /*  Getters                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Which ability score modifier is used by this item?
+   * @type {string|null}
+   */
+  get abilityMod() {
+    return this.ability || this._typeAbilityMod || {
+      mwak: "str",
+      rwak: "dex",
+      msak: this.parent?.actor?.system.attributes.spellcasting || "int",
+      rsak: this.parent?.actor?.system.attributes.spellcasting || "int"
+    }[this.actionType] || null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Default ability key defined for this type.
+   * @type {string|null}
+   * @internal
+   */
+  get _typeAbilityMod() {
+    return null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * What is the critical hit threshold for this item? Uses the smallest value from among the following sources:
+   *  - `critical.threshold` defined on the item
+   *  - `critical.threshold` defined on ammunition, if consumption mode is set to ammo
+   *  - Type-specific critical threshold
+   * @type {number|null}
+   */
+  get criticalThreshold() {
+    if ( !this.hasAttack ) return null;
+    let ammoThreshold = Infinity;
+    if ( this.consume?.type === "ammo" ) {
+      ammoThreshold = this.parent?.actor?.items.get(this.consume.target).system.critical.threshold ?? Infinity;
+    }
+    const threshold = Math.min(this.critical.threshold ?? Infinity, this._typeCriticalThreshold, ammoThreshold);
+    return threshold < Infinity ? threshold : 20;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Default critical threshold for this type.
+   * @type {number}
+   * @internal
+   */
+  get _typeCriticalThreshold() {
+    return Infinity;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item implement an ability check as part of its usage?
+   * @type {boolean}
+   */
+  get hasAbilityCheck() {
+    return (this.actionType === "abil") && !!this.ability;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item implement an attack roll as part of its usage?
+   * @type {boolean}
+   */
+  get hasAttack() {
+    return ["mwak", "rwak", "msak", "rsak"].includes(this.actionType);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item implement a damage roll as part of its usage?
+   * @type {boolean}
+   */
+  get hasDamage() {
+    return this.damage.parts.length > 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item implement a saving throw as part of its usage?
+   * @type {boolean}
+   */
+  get hasSave() {
+    return !!(this.save.ability && this.save.scaling);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item provide an amount of healing instead of conventional damage?
+   * @type {boolean}
+   */
+  get isHealing() {
+    return (this.actionType === "heal") && this.hasDamage;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item implement a versatile damage roll as part of its usage?
+   * @type {boolean}
+   */
+  get isVersatile() {
+    return !!(this.hasDamage && this.damage.versatile);
+  }
+
 }

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -87,6 +87,8 @@ export default class ActivatedEffectTemplate extends foundry.abstract.DataModel 
   };
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {
@@ -178,4 +180,47 @@ export default class ActivatedEffectTemplate extends foundry.abstract.DataModel 
       else if ( Number.isNumeric(amount) ) source.consume.amount = Number(amount);
     }
   }
+
+  /* -------------------------------------------- */
+  /*  Getters                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item have an area of effect target?
+   * @type {boolean}
+   */
+  get hasAreaTarget() {
+    return this.target.type in CONFIG.DND5E.areaTargetTypes;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item target one or more distinct targets?
+   * @type {boolean}
+   */
+  get hasIndividualTarget() {
+    return this.target.type in CONFIG.DND5E.individualTargetTypes;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this Item limited in its ability to be used by charges or by recharge?
+   * @type {boolean}
+   */
+  get hasLimitedUses() {
+    return !!this.uses.per && (this.uses.max > 0);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item have a target?
+   * @type {boolean}
+   */
+  get hasTarget() {
+    return !["", null].includes(this.target.type);
+  }
+
 }

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -216,6 +216,36 @@ export default class ActivatedEffectTemplate extends foundry.abstract.DataModel 
   /* -------------------------------------------- */
 
   /**
+   * Does the Item duration accept an associated numeric value or formula?
+   * @type {boolean}
+   */
+  get hasScalarDuration() {
+    return this.duration.units in CONFIG.DND5E.scalarTimePeriods;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item range accept an associated numeric value?
+   * @type {boolean}
+   */
+  get hasScalarRange() {
+    return this.range.units in CONFIG.DND5E.movementUnits;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item target accept an associated numeric value?
+   * @type {boolean}
+   */
+  get hasScalarTarget() {
+    return ![null, "", "self"].includes(this.target.type);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Does the Item have a target?
    * @type {boolean}
    */

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -17,6 +17,8 @@ export default class EquippableItemTemplate extends foundry.abstract.DataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {

--- a/module/data/item/templates/item-description.mjs
+++ b/module/data/item/templates/item-description.mjs
@@ -24,6 +24,8 @@ export default class ItemDescriptionTemplate extends foundry.abstract.DataModel 
   }
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -34,6 +34,8 @@ export default class PhysicalItemTemplate extends foundry.abstract.DataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -37,6 +37,8 @@ export default class ToolData extends SystemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {
@@ -52,5 +54,17 @@ export default class ToolData extends SystemDataModel.mixin(
    */
   static #migrateAbility(source) {
     if ( Array.isArray(source.ability) ) source.ability = source.ability[0];
+  }
+
+  /* -------------------------------------------- */
+  /*  Getters                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Which ability score modifier is used by this item?
+   * @type {string|null}
+   */
+  get abilityMod() {
+    return this.ability || "int";
   }
 }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -108,4 +108,15 @@ export default class WeaponData extends SystemDataModel.mixin(
   get _typeCriticalThreshold() {
     return this.parent?.actor?.flags.dnd5e?.weaponCriticalThreshold ?? Infinity;
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this item a separate large object like a siege engine or vehicle component that is
+   * usually mounted on fixtures rather than equipped, and has its own AC and HP?
+   * @type {boolean}
+   */
+  get isMountable() {
+    return this.weaponType === "siege";
+  }
 }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -90,10 +90,8 @@ export default class WeaponData extends SystemDataModel.mixin(
 
   /** @inheritdoc */
   get _typeAbilityMod() {
-    // Ranged weapons - Dex (PHB pg. 194)
     if ( ["simpleR", "martialR"].includes(this.weaponType) ) return "dex";
 
-    // Finesse weapons - Str or Dex (PHB pg. 147)
     const abilities = this.parent?.actor?.system.abilities;
     if ( this.properties.fin && abilities ) {
       return (abilities.dex?.mod ?? 0) >= (abilities.str?.mod ?? 0) ? "dex" : "str";

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -40,6 +40,8 @@ export default class WeaponData extends SystemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   static migrateData(source) {
@@ -80,5 +82,30 @@ export default class WeaponData extends SystemDataModel.mixin(
    */
   static #migrateWeaponType(source) {
     if ( source.weaponType === null ) source.weaponType = "simpleM";
+  }
+
+  /* -------------------------------------------- */
+  /*  Getters                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  get _typeAbilityMod() {
+    // Ranged weapons - Dex (PHB pg. 194)
+    if ( ["simpleR", "martialR"].includes(this.weaponType) ) return "dex";
+
+    // Finesse weapons - Str or Dex (PHB pg. 147)
+    const abilities = this.parent?.actor?.system.abilities;
+    if ( this.properties.fin && abilities ) {
+      return (abilities.dex?.mod ?? 0) >= (abilities.str?.mod ?? 0) ? "dex" : "str";
+    }
+
+    return null;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  get _typeCriticalThreshold() {
+    return this.parent?.actor?.flags.dnd5e?.weaponCriticalThreshold ?? Infinity;
   }
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -174,6 +174,19 @@ export default class Item5e extends Item {
   /* -------------------------------------------- */
 
   /**
+   * Is this item a separate large object like a siege engine or vehicle component that is
+   * usually mounted on fixtures rather than equipped, and has its own AC and HP?
+   * @type {boolean}
+   * @see {@link EquipmentData#isMountable}
+   * @see {@link WeaponData#isMountable}
+   */
+  get isMountable() {
+    return this.system.isMountable ?? false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Is this class item the original class for the containing actor? If the item is not a class or it is not
    * embedded in an actor then this will return `null`.
    * @type {boolean|null}

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -23,57 +23,32 @@ export default class Item5e extends Item {
   /**
    * Which ability score modifier is used by this item?
    * @type {string|null}
+   * @see {@link ActionTemplate#abilityMod}
    */
   get abilityMod() {
-
-    // Case 1 - defined directly by the item
-    if ( this.system.ability ) return this.system.ability;
-
-    // Case 2 - inferred from a parent actor
-    if ( this.actor && ("abilities" in this.actor.system) ) {
-      const abilities = this.actor.system.abilities;
-      const spellcasting = this.actor.system.attributes.spellcasting;
-
-      // Special rules per item type
-      switch ( this.type ) {
-        case "consumable":
-          if ( this.system.consumableType === "scroll" ) return spellcasting || "int";
-          break;
-        case "spell":
-          return spellcasting || "int";
-        case "tool":
-          return "int";
-        case "weapon":
-          // Finesse weapons - Str or Dex (PHB pg. 147)
-          if ( this.system.properties.fin === true ) {
-            return abilities.dex.mod >= abilities.str.mod ? "dex" : "str";
-          }
-          // Ranged weapons - Dex (PH p.194)
-          if ( ["simpleR", "martialR"].includes(this.system.weaponType) ) return "dex";
-          break;
-      }
-
-      // If a specific attack type is defined
-      if ( this.hasAttack ) return {
-        mwak: "str",
-        rwak: "dex",
-        msak: spellcasting || "int",
-        rsak: spellcasting || "int"
-      }[this.system.actionType];
-    }
-
-    // Case 3 - unknown
-    return null;
+    return this.system.abilityMod ?? null;
   }
 
-  /* -------------------------------------------- */
+  /* --------------------------------------------- */
 
   /**
-   * Return an item's identifier.
-   * @type {string}
+   * What is the critical hit threshold for this item, if applicable?
+   * @type {number|null}
+   * @see {@link ActionTemplate#criticalThreshold}
    */
-  get identifier() {
-    return this.system.identifier || this.name.slugify({strict: true});
+  get criticalThreshold() {
+    return this.system.criticalThreshold ?? null;
+  }
+
+  /* --------------------------------------------- */
+
+  /**
+   * Does the Item implement an ability check as part of its usage?
+   * @type {boolean}
+   * @see {@link ActionTemplate#hasAbilityCheck}
+   */
+  get hasAbilityCheck() {
+    return this.system.hasAbilityCheck ?? false;
   }
 
   /* -------------------------------------------- */
@@ -89,11 +64,23 @@ export default class Item5e extends Item {
   /* -------------------------------------------- */
 
   /**
+   * Does the Item have an area of effect target?
+   * @type {boolean}
+   * @see {@link ActivatedEffectTemplate#hasAreaTarget}
+   */
+  get hasAreaTarget() {
+    return this.system.hasAreaTarget ?? false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Does the Item implement an attack roll as part of its usage?
    * @type {boolean}
+   * @see {@link ActionTemplate#hasAttack}
    */
   get hasAttack() {
-    return ["mwak", "rwak", "msak", "rsak"].includes(this.system.actionType);
+    return this.system.hasAttack ?? false;
   }
 
   /* -------------------------------------------- */
@@ -101,19 +88,76 @@ export default class Item5e extends Item {
   /**
    * Does the Item implement a damage roll as part of its usage?
    * @type {boolean}
+   * @see {@link ActionTemplate#hasDamage}
    */
   get hasDamage() {
-    return !!(this.system.damage && this.system.damage.parts.length);
+    return this.system.hasDamage ?? false;
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Does the Item implement a versatile damage roll as part of its usage?
+   * Does the Item target one or more distinct targets?
    * @type {boolean}
+   * @see {@link ActivatedEffectTemplate#hasIndividualTarget}
    */
-  get isVersatile() {
-    return !!(this.hasDamage && this.system.damage.versatile);
+  get hasIndividualTarget() {
+    return this.system.hasIndividualTarget ?? false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this Item limited in its ability to be used by charges or by recharge?
+   * @type {boolean}
+   * @see {@link ActivatedEffectTemplate#hasLimitedUses}
+   * @see {@link FeatData#hasLimitedUses}
+   */
+  get hasLimitedUses() {
+    return this.system.hasLimitedUses ?? false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item implement a saving throw as part of its usage?
+   * @type {boolean}
+   * @see {@link ActionTemplate#hasSave}
+   */
+  get hasSave() {
+    return this.system.hasSave ?? false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item have a target?
+   * @type {boolean}
+   * @see {@link ActivatedEffectTemplate#hasTarget}
+   */
+  get hasTarget() {
+    return this.system.hasTarget ?? false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Return an item's identifier.
+   * @type {string}
+   */
+  get identifier() {
+    return this.system.identifier || this.name.slugify({strict: true});
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this item any of the armor subtypes?
+   * @type {boolean}
+   * @see {@link EquipmentTemplate#isArmor}
+   */
+  get isArmor() {
+    return this.system.isArmor ?? false;
   }
 
   /* -------------------------------------------- */
@@ -121,9 +165,10 @@ export default class Item5e extends Item {
   /**
    * Does the item provide an amount of healing instead of conventional damage?
    * @type {boolean}
+   * @see {@link ActionTemplate#isHealing}
    */
   get isHealing() {
-    return (this.system.actionType === "heal") && this.system.damage.parts.length;
+    return this.system.isHealing ?? false;
   }
 
   /* -------------------------------------------- */
@@ -136,6 +181,17 @@ export default class Item5e extends Item {
   get isOriginalClass() {
     if ( this.type !== "class" || !this.isEmbedded ) return null;
     return this.id === this.parent.system.details.originalClass;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item implement a versatile damage roll as part of its usage?
+   * @type {boolean}
+   * @see {@link ActionTemplate#isVersatile}
+   */
+  get isVersatile() {
+    return this.system.isVersatile ?? false;
   }
 
   /* -------------------------------------------- */
@@ -161,71 +217,6 @@ export default class Item5e extends Item {
     const items = this.parent.items;
     const cid = this.identifier;
     return this._classLink ??= items.find(i => (i.type === "subclass") && (i.system.classIdentifier === cid));
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Does the Item implement a saving throw as part of its usage?
-   * @type {boolean}
-   */
-  get hasSave() {
-    const save = this.system.save || {};
-    return !!(save.ability && save.scaling);
-  }
-
-  /* --------------------------------------------- */
-
-  /**
-   * Does the Item implement an ability check as part of its usage?
-   * @type {boolean}
-   */
-  get hasAbilityCheck() {
-    return (this.system.actionType === "abil") && this.system.ability;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Does the Item have a target?
-   * @type {boolean}
-   */
-  get hasTarget() {
-    const target = this.system.target;
-    return target && !["none", ""].includes(target.type);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Does the Item have an area of effect target?
-   * @type {boolean}
-   */
-  get hasAreaTarget() {
-    const target = this.system.target;
-    return target && (target.type in CONFIG.DND5E.areaTargetTypes);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Is this Item limited in its ability to be used by charges or by recharge?
-   * @type {boolean}
-   */
-  get hasLimitedUses() {
-    let recharge = this.system.recharge || {};
-    let uses = this.system.uses || {};
-    return !!recharge.value || (uses.per && (uses.max > 0));
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Is this item any of the armor subtypes?
-   * @type {boolean}
-   */
-  get isArmor() {
-    return this.system.armor?.type in CONFIG.DND5E.armorTypes;
   }
 
   /* -------------------------------------------- */
@@ -615,30 +606,6 @@ export default class Item5e extends Item {
     const formula = simplifyRollFormula(roll.formula) || "0";
     this.labels.toHit = !/^[+-]/.test(formula) ? `+ ${formula}` : formula;
     return {rollData, parts};
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Retrieve an item's critical hit threshold. Uses the smallest value from among the following sources:
-   * - item document
-   * - item document's actor (if it has one)
-   * - item document's ammunition (if it has any)
-   * - the constant '20'
-   * @returns {number|null}  The minimum value that must be rolled to be considered a critical hit.
-   */
-  getCriticalThreshold() {
-    const actorFlags = this.actor.flags.dnd5e || {};
-    if ( !this.hasAttack ) return null;
-    let actorThreshold = null;
-    let itemThreshold = this.system.critical?.threshold ?? Infinity;
-    let ammoThreshold = Infinity;
-    if ( this.type === "weapon" ) actorThreshold = actorFlags.weaponCriticalThreshold;
-    else if ( this.type === "spell" ) actorThreshold = actorFlags.spellCriticalThreshold;
-    if ( this.system.consume?.type === "ammo" ) {
-      ammoThreshold = this.actor.items.get(this.system.consume.target)?.system.critical.threshold ?? Infinity;
-    }
-    return Math.min(itemThreshold, ammoThreshold, actorThreshold ?? 20);
   }
 
   /* -------------------------------------------- */
@@ -2348,5 +2315,26 @@ export default class Item5e extends Item {
       }
     });
     return new this(spellScrollData);
+  }
+
+  /* -------------------------------------------- */
+  /*  Deprecations                                */
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieve an item's critical hit threshold. Uses the smallest value from among the following sources:
+   * - item document
+   * - item document's actor (if it has one)
+   * - item document's ammunition (if it has any)
+   * - the constant '20'
+   * @returns {number|null}  The minimum value that must be rolled to be considered a critical hit.
+   * @deprecated since dnd5e 2.2, targeted for removal in 2.4
+   */
+  getCriticalThreshold() {
+    foundry.utils.logCompatibilityWarning(
+      "Item5e#getCriticalThreshold has been replaced with the Item5e#criticalThreshold getter.",
+      { since: "DnD5e 2.2", until: "DnD5e 2.4" }
+    );
+    return this.criticalThreshold;
   }
 }

--- a/templates/items/class.hbs
+++ b/templates/items/class.hbs
@@ -109,7 +109,7 @@
             <div class="form-group">
                 <label>
                     {{localize "DND5E.ClassSkillsEligible"}}
-                    {{#if editable }}
+                    {{#if editable}}
                     <a class="trait-selector class-skills" data-target="system.skills.choices" data-options="skills.choices">
                         <i class="fas fa-edit"></i>
                     </a>
@@ -127,7 +127,7 @@
             <div class="form-group">
                 <label>
                     {{localize "DND5E.ClassSkillsChosen"}}
-                    {{#if editable }}
+                    {{#if editable}}
                     <a class="trait-selector class-skills" data-target="system.skills" data-options="skills">
                         <i class="fas fa-edit"></i>
                     </a>

--- a/templates/items/equipment.hbs
+++ b/templates/items/equipment.hbs
@@ -66,7 +66,7 @@
                 </select>
             </div>
 
-            {{#unless isMountable}}
+            {{#unless system.isMountable}}
             <div class="form-group">
                 <label>{{localize "DND5E.Attunement"}}</label>
                 <select name="system.attunement" data-dtype="Number">
@@ -90,7 +90,7 @@
             {{/unless}}
 
             {{!-- Armor Class --}}
-            {{#if hasAC}}
+            {{#if (or system.isArmor system.isMountable)}}
             <div class="form-group">
                 <label>{{ localize "DND5E.ArmorClass" }}</label>
                 <div class="form-fields">
@@ -109,7 +109,7 @@
             </div>
             {{/if}}
 
-            {{#if isArmor}}
+            {{#if system.isArmor}}
             {{!-- Required Strength --}}
             <div class="form-group">
                 <label>{{ localize "DND5E.ItemRequiredStr" }}</label>
@@ -125,7 +125,7 @@
             </div>
             {{/if}}
 
-            {{#if isMountable}}
+            {{#if system.isMountable}}
             {{> "dnd5e.item-mountable"}}
             <div class="form-group">
                 <label>{{localize 'DND5E.Speed'}}</label>

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -2,12 +2,7 @@
 <div class="form-group select">
     <label>{{ localize "DND5E.ItemActionType" }}</label>
     <select name="system.actionType">
-        {{#select system.actionType}}
-        <option value=""></option>
-        {{#each config.itemActionTypes as |name type|}}
-        <option value="{{type}}">{{name}}</option>
-        {{/each}}
-        {{/select}}
+        {{selectOptions config.itemActionTypes selected=system.actionType blank=""}}
     </select>
 </div>
 {{#if system.actionType}}
@@ -16,37 +11,28 @@
 <div class="form-group select">
     <label>{{ localize "DND5E.AbilityModifier" }}</label>
     <select name="system.ability">
-        {{#select system.ability}}
-        <option value="">{{ localize "DND5E.Default" }}</option>
-        {{#each config.abilities as |ability a|}}
-        <option value="{{a}}">{{ability}}</option>
-        {{/each}}
-        {{/select}}
+        {{selectOptions config.abilities selected=system.ability labelAttr="label" blank=(localize "DND5E.Default")}}
     </select>
 </div>
 
+{{#if system.hasAttack}}
 {{!-- Attack Roll Bonus --}}
-{{#if hasAttackRoll }}
 <div class="form-group">
     <label>{{ localize "DND5E.ItemAttackBonus" }}</label>
     <div class="form-fields">
         <input type="text" name="system.attackBonus" value="{{system.attackBonus}}" data-formula-editor/>
     </div>
 </div>
-{{/if}}
 
 {{!-- Critical Hit Threshold --}}
-{{#if hasAttackRoll }}
 <div class="form-group">
     <label>{{ localize "DND5E.ItemCritThreshold" }}</label>
     <div class="form-fields">
-        {{ numberInput system.critical.threshold name="system.critical.threshold" placeholder="20" max=20 min=1 step=1 }}
+        {{numberInput system.critical.threshold name="system.critical.threshold" placeholder="20" max=20 min=1 step=1}}
     </div>
 </div>
-{{/if}}
 
 {{!-- Critical Hit Damage --}}
-{{#if hasAttackRoll }}
 <div class="form-group">
     <label>{{ localize "DND5E.ItemCritExtraDamage" }}</label>
     <div class="form-fields">
@@ -57,7 +43,8 @@
 
 {{!-- Damage Formula --}}
 <h4 class="damage-header">
-    {{#unless isHealing }}{{ localize "DND5E.Damage" }}{{ else }}{{ localize "DND5E.Healing" }}{{/unless}} {{ localize "DND5E.Formula" }}
+    {{#unless isHealing}}{{ localize "DND5E.Damage" }}{{ else }}{{ localize "DND5E.Healing" }}{{/unless}}
+    {{ localize "DND5E.Formula" }}
     <a class="damage-control add-damage"><i class="fas fa-plus"></i></a>
 </h4>
 <ol class="damage-parts form-group">
@@ -65,14 +52,14 @@
     <li class="damage-part flexrow" data-damage-part="{{i}}">
         <input type="text" name="system.damage.parts.{{i}}.0" value="{{lookup this "0"}}" data-formula-editor/>
         <select name="system.damage.parts.{{i}}.1">
-            {{#select (lookup this "1") }}
-            <option value="">{{ localize "DND5E.None" }}</option>
-            {{#each ../config.damageTypes as |name type|}}
-            <option value="{{type}}">{{name}}</option>
-            {{/each}}
-            {{#each ../config.healingTypes as |name type|}}
-            <option value="{{type}}">{{name}}</option>
-            {{/each}}
+            {{#select (lookup this "1")}}
+                <option value="">{{ localize "DND5E.None" }}</option>
+                <optgroup label="{{localize 'DND5E.Damage'}}">
+                    {{selectOptions @root.config.damageTypes}}
+                </optgroup>
+                <optgroup label="{{localize 'DND5E.Healing'}}">
+                    {{selectOptions @root.config.healingTypes}}
+                </optgroup>
             {{/select}}
         </select>
         <a class="damage-control delete-damage"><i class="fas fa-minus"></i></a>
@@ -86,7 +73,7 @@
     <label>{{ localize "DND5E.VersatileDamage" }}</label>
     <div class="form-fields">
         <input type="text" name="system.damage.versatile" value="{{system.damage.versatile}}"
-               placeholder="{{ localize 'DND5E.Formula' }}" data-formula-editor/>
+               placeholder="{{ localize 'DND5E.Formula' }}" data-formula-editor>
     </div>
 </div>
 {{/if}}
@@ -95,8 +82,8 @@
 <div class="form-group">
     <label>{{ localize "DND5E.OtherFormula" }}</label>
     <div class="form-fields">
-        <input type="text" name="system.formula" value="{{system.formula}}" placeholder="{{ localize 'DND5E.Formula' }}"
-        data-formula-editor/>
+        <input type="text" name="system.formula" value="{{system.formula}}"
+               placeholder="{{ localize 'DND5E.Formula' }}" data-formula-editor>
     </div>
 </div>
 
@@ -105,12 +92,7 @@
     <label>{{ localize "DND5E.ActionSave" }}</label>
     <div class="form-fields">
         <select name="system.save.ability">
-            {{#select system.save.ability}}
-            <option value=""></option>
-            {{#each config.abilities as |ability a|}}
-            <option value="{{a}}">{{ability}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOptions config.abilities selected=system.save.ability labelAttr="label" blank=""}}
         </select>
         <span>{{ localize "DND5E.VsDC" }}</span>
         <input type="number" step="any" name="system.save.dc"
@@ -118,11 +100,9 @@
             placeholder="{{ localize 'DND5E.AbbreviationDC' }}" {{#unless isFlatDC}}disabled{{/unless}}>
         <select name="system.save.scaling">
             {{#select system.save.scaling}}
-            <option value="spell">{{ localize "DND5E.Spellcasting" }}</option>
-            {{#each config.abilities as |ability a|}}
-            <option value="{{a}}">{{ability}}</option>
-            {{/each}}
-            <option value="flat">{{ localize "DND5E.Flat" }}</option>
+                <option value="spell">{{ localize "DND5E.Spellcasting" }}</option>
+                {{selectOptions config.abilities labelAttr="label"}}
+                <option value="flat">{{ localize "DND5E.Flat" }}</option>
             {{/select}}
         </select>
     </div>

--- a/templates/items/parts/item-activation.hbs
+++ b/templates/items/parts/item-activation.hbs
@@ -37,11 +37,11 @@
 <div class="form-group input-select-select">
     <label>{{ localize "DND5E.Target" }}</label>
     <div class="form-fields">
-        {{#if hasScalarTarget}}
+        {{#if system.hasScalarTarget}}
             <input type="number" step="any" name="system.target.value"
                    value="{{system.target.value}}" placeholder="&mdash;">
         {{/if}}
-        {{#if item.hasAreaTarget}}
+        {{#if system.hasAreaTarget}}
             <select name="system.target.units" data-tooltip="DND5E.TargetUnits">
                 {{selectOptions config.movementUnits selected=system.target.units blank=""}}
             </select>
@@ -75,7 +75,7 @@
 <div class="form-group input-select">
     <label>{{ localize "DND5E.Range" }}</label>
     <div class="form-fields">
-        {{#if (lookup config.movementUnits system.range.units)}}
+        {{#if system.hasScalarRange}}
             <input type="number" step="any" name="system.range.value" value="{{system.range.value}}"
                    placeholder="{{localize 'DND5E.Normal'}}" data-tooltip="DND5E.RangeNormal">
             <span class="sep">/</span>
@@ -98,7 +98,7 @@
 <div class="form-group input-select">
     <label>{{ localize "DND5E.Duration" }}</label>
     <div class="form-fields">
-        {{#if (lookup config.scalarTimePeriods system.duration.units)}}
+        {{#if system.hasScalarDuration}}
             <input type="text" name="system.duration.value" value="{{source.duration.value}}"
                    placeholder="&mdash;" data-tooltip="DND5E.DurationValue" data-formula-editor>
         {{/if}}

--- a/templates/items/weapon.hbs
+++ b/templates/items/weapon.hbs
@@ -62,7 +62,7 @@
                 </select>
             </div>
 
-            {{#unless isMountable}}
+            {{#unless system.isMountable}}
             <div class="form-group">
                 <label>{{localize "DND5E.Attunement"}}</label>
                 <select name="system.attunement" data-dtype="Number">
@@ -97,7 +97,7 @@
                 {{/each}}
             </div>
 
-            {{#if isMountable}}
+            {{#if system.isMountable}}
             <div class="form-group">
                 <label>{{localize 'DND5E.ArmorClass'}}</label>
                 <div class="form-fields">


### PR DESCRIPTION
Moves most of the getter logic from `Item5e` into the various system data models and splits up `abilityMod` and `criticalThreshold` so that each individual type can handle their own type-specific logic.

Adjust the logic of `hasDamage`, `hasSave`, and `isVersatile` to require that `actionType` be set.

Adds `isMountable`, `hasScalarDuration`, `hasScalarRange`, and `hasScalarTarget` getters.

This also refactors `ItemSheet5e` & templates to make more use of getters directly and reorders the getters in `Item5e` to be in alphabetical order.