### PR TITLE
Move distance units in range dropdown to top

### DIFF
--- a/templates/items/parts/item-activation.hbs
+++ b/templates/items/parts/item-activation.hbs
@@ -85,10 +85,10 @@
         <select name="system.range.units" data-tooltip="DND5E.RangeUnits">
             {{#select system.range.units}}
                 <option value="">{{localize "DND5E.None"}}</option>
-                {{selectOptions config.rangeTypes}}
                 <optgroup label="{{localize 'DND5E.RangeDistance'}}">
                     {{selectOptions config.movementUnits}}
                 </optgroup>
+                {{selectOptions config.rangeTypes}}
             {{/select}}
         </select>
     </div>


### PR DESCRIPTION
A minor usability change that moves the location of the distance types in the range dropdown to the top just below "None".

Current:
<img width="370" alt="Screenshot 2023-01-29 at 10 40 10" src="https://user-images.githubusercontent.com/19979839/215348520-cae546e0-7534-4b2a-a821-da4b4cb6deb7.png">

Adjusted:
<img width="370" alt="Screenshot 2023-01-29 at 10 39 54" src="https://user-images.githubusercontent.com/19979839/215348533-79fe2bc5-7ff5-4cab-885a-9c12a951d5fa.png">
