### PR TITLE
[#532] Allow for editing the quantity of an item directly on the character sheet

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -1172,6 +1172,9 @@ h5 {
 .dnd5e.sheet.actor .inventory-list .item-detail.item-action {
   flex: 0 0 100px;
 }
+.dnd5e.sheet.actor .inventory-list .item-detail.item-quantity {
+  flex: 0 0 40px;
+}
 .dnd5e.sheet.actor .inventory-list .item-detail.attunement {
   flex: 0 0 24px;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -789,6 +789,7 @@
 "DND5E.PropertyBase": "Base",
 "DND5E.PropertyTotal": "Total",
 "DND5E.Quantity": "Quantity",
+"DND5E.QuantityAbbr": "Qty",
 "DND5E.Race": "Race",
 "DND5E.RacialTraits": "Racial Traits",
 "DND5E.Range": "Range",

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -123,7 +123,7 @@ export default class ActorSheet5e extends ActorSheet {
     /** @deprecated */
     Object.defineProperty(context, "data", {
       get() {
-        const msg = `You are accessing the "data" attribute within the rendering context provided by the ActorSheet5e
+        const msg = `You are accessing the "data" attribute within the rendering context provided by the ActorSheet5e 
         class. This attribute has been deprecated in favor of "system" and will be removed in a future release`;
         foundry.utils.logCompatibilityWarning(msg, { since: "DnD5e 2.0", until: "DnD5e 2.2" });
         return context.system;

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -123,7 +123,7 @@ export default class ActorSheet5e extends ActorSheet {
     /** @deprecated */
     Object.defineProperty(context, "data", {
       get() {
-        const msg = `You are accessing the "data" attribute within the rendering context provided by the ActorSheet5e 
+        const msg = `You are accessing the "data" attribute within the rendering context provided by the ActorSheet5e
         class. This attribute has been deprecated in favor of "system" and will be removed in a future release`;
         foundry.utils.logCompatibilityWarning(msg, { since: "DnD5e 2.0", until: "DnD5e 2.2" });
         return context.system;
@@ -641,6 +641,7 @@ export default class ActorSheet5e extends ActorSheet {
       html.find(".item-create").click(this._onItemCreate.bind(this));
       html.find(".item-delete").click(this._onItemDelete.bind(this));
       html.find(".item-uses input").click(ev => ev.target.select()).change(this._onUsesChange.bind(this));
+      html.find(".item-quantity input").click(ev => ev.target.select()).change(this._onQuantityChange.bind(this));
       html.find(".slot-max-override").click(this._onSpellSlotOverride.bind(this));
 
       // Active Effect management
@@ -1152,6 +1153,23 @@ export default class ActorSheet5e extends ActorSheet {
     const uses = Math.clamped(0, parseInt(event.target.value), item.system.uses.max);
     event.target.value = uses;
     return item.update({"system.uses.value": uses});
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Change the quantity of an Owned Item within the actor.
+   * @param {Event} event        The triggering click event.
+   * @returns {Promise<Item5e>}  Updated item.
+   * @private
+   */
+  async _onQuantityChange(event) {
+    event.preventDefault();
+    const itemId = event.currentTarget.closest(".item").dataset.itemId;
+    const item = this.actor.items.get(itemId);
+    const quantity = Math.max(0, parseInt(event.target.value));
+    event.target.value = quantity;
+    return item.update({"system.quantity": quantity});
   }
 
   /* -------------------------------------------- */

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -38,7 +38,7 @@
             {{#if ../isCharacter}}
                 <div class="item-detail item-weight">{{localize "DND5E.Weight"}}</div>
             {{/if}}
-            <div class="item-detail item-quantity">{{localize "DND5E.Quantity"}}</div>
+            <div class="item-detail item-quantity">{{localize "DND5E.QuantityAbbr"}}</div>
             <div class="item-detail item-uses">{{localize "DND5E.Charges"}}</div>
             <div class="item-detail item-action">{{localize "DND5E.Usage"}}</div>
         {{/if}}
@@ -63,7 +63,10 @@
                 <input type="text" value="{{item.name}}">
                 {{else}}
                 <div class="item-image" tabindex="0" role="button" aria-label="{{item.name}}" style="background-image: url('{{item.img}}')"></div>
-                <h4>{{item.name}}</h4>
+                <h4>
+                    {{item.name~}}
+                    {{~#if ctx.isStack}} ({{item.system.quantity}}){{/if}}
+                </h4>
                 {{#if ctx.attunement}}
                 <div class="item-detail attunement">
                     <i class="fas {{ctx.attunement.icon}} {{ctx.attunement.cls}}"

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -38,7 +38,7 @@
             {{#if ../isCharacter}}
                 <div class="item-detail item-weight">{{localize "DND5E.Weight"}}</div>
             {{/if}}
-
+            <div class="item-detail item-quantity">{{localize "DND5E.Quantity"}}</div>
             <div class="item-detail item-uses">{{localize "DND5E.Charges"}}</div>
             <div class="item-detail item-action">{{localize "DND5E.Usage"}}</div>
         {{/if}}
@@ -63,10 +63,7 @@
                 <input type="text" value="{{item.name}}">
                 {{else}}
                 <div class="item-image" tabindex="0" role="button" aria-label="{{item.name}}" style="background-image: url('{{item.img}}')"></div>
-                <h4>
-                    {{item.name~}}
-                    {{~#if ctx.isStack}} ({{item.system.quantity}}){{/if}}
-                </h4>
+                <h4>{{item.name}}</h4>
                 {{#if ctx.attunement}}
                 <div class="item-detail attunement">
                     <i class="fas {{ctx.attunement.icon}} {{ctx.attunement.cls}}"
@@ -97,6 +94,10 @@
                     {{/if}}
                 </div>
                 {{/if}}
+
+                <div class="item-detail item-quantity">
+                    <input type="text" value="{{item.system.quantity}}" placeholder="0">
+                </div>
 
                 <div class="item-detail item-uses">
                     {{#if ctx.hasUses }}


### PR DESCRIPTION
Note that this touches the `character` sheet only, but by extension also the `group` sheet, where it is currently non-functional.

![image](https://user-images.githubusercontent.com/50169243/215532109-fda1198c-9dd8-4b10-b76b-c03b03cdbdd2.png)
