### PR TITLE
WIP: Refactor roll pipeline to spawn the dialog before roll data preparation

### DIFF
--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -3,102 +3,29 @@
 /* -------------------------------------------- */
 
 /**
- * Configuration data for a D20 roll.
- *
- * @typedef {object} D20RollConfiguration
- *
- * @property {string[]} [parts=[]]  The dice roll component parts, excluding the initial d20.
- * @property {object} [data={}]     Data that will be used when parsing this roll.
- * @property {Event} [event]        The triggering event for this roll.
- *
- * ## D20 Properties
- * @property {boolean} [advantage]     Apply advantage to this roll (unless overridden by modifier keys or dialog)?
- * @property {boolean} [disadvantage]  Apply disadvantage to this roll (unless overridden by modifier keys or dialog)?
- * @property {number|null} [critical=20]  The value of the d20 result which represents a critical success,
- *                                     `null` will prevent critical successes.
- * @property {number|null} [fumble=1]  The value of the d20 result which represents a critical failure,
- *                                     `null` will prevent critical failures.
- * @property {number} [targetValue]    The value of the d20 result which should represent a successful roll.
- *
- * ## Flags
- * @property {boolean} [elvenAccuracy]   Allow Elven Accuracy to modify this roll?
- * @property {boolean} [halflingLucky]   Allow Halfling Luck to modify this roll?
- * @property {boolean} [reliableTalent]  Allow Reliable Talent to modify this roll?
- *
- * ## Roll Configuration Dialog
- * @property {boolean} [fastForward]           Should the roll configuration dialog be skipped?
- * @property {boolean} [chooseModifier=false]  If the configuration dialog is shown, should the ability modifier be
- *                                             configurable within that interface?
- * @property {string} [template]               The HTML template used to display the roll configuration dialog.
- * @property {string} [title]                  Title of the roll configuration dialog.
- * @property {object} [dialogOptions]          Additional options passed to the roll configuration dialog.
- *
- * ## Chat Message
- * @property {boolean} [chatMessage=true]  Should a chat message be created for this roll?
- * @property {object} [messageData={}]     Additional data which is applied to the created chat message.
- * @property {string} [rollMode]           Value of `CONST.DICE_ROLL_MODES` to apply as default for the chat message.
- * @property {object} [flavor]             Flavor text to use in the created chat message.
+ * @typedef {object} D20MessageOptions
+ * @property {boolean} [chatMessage=true]  Whether to display a chat message for the roll.
+ * @property {object} [messageData={}]     Additional message data for the chat message.
  */
 
 /**
- * A standardized helper function for managing core 5e d20 rolls.
- * Holding SHIFT, ALT, or CTRL when the attack is rolled will "fast-forward".
- * This chooses the default options of a normal attack with no bonus, Advantage, or Disadvantage respectively
- *
- * @param {D20RollConfiguration} configuration  Configuration data for the D20 roll.
- * @returns {Promise<D20Roll|null>}             The evaluated D20Roll, or null if the workflow was cancelled.
+ * A helper function to create d20 rolls.
+ * @param {string[]} [parts=[]]                        Bonuses to apply to the roll.
+ * @param {object} [data={}]                           The data to retrieve the bonus values from.
+ * @param {D20RollConfiguration} [rollConfig]          Additional options to configure the roll.
+ * @param {D20MessageOptions} [messageOptions]         Additional options to configure the chat message.
+ * @returns {Promise<D20Roll>}                         The evaluated D20Roll.
  */
-export async function d20Roll({
-  parts=[], data={}, event,
-  advantage, disadvantage, critical=20, fumble=1, targetValue,
-  elvenAccuracy, halflingLucky, reliableTalent,
-  fastForward, chooseModifier=false, template, title, dialogOptions,
-  chatMessage=true, messageData={}, rollMode, flavor
-}={}) {
-
-  // Handle input arguments
+export async function d20Roll(parts=[], data={}, rollConfig={}, {chatMessage=true, messageData={}}={}) {
+  parts = parts.filter(p => data[p.slice(1)]);
   const formula = ["1d20"].concat(parts).join(" + ");
-  const {advantageMode, isFF} = CONFIG.Dice.D20Roll.determineAdvantageMode({
-    advantage, disadvantage, fastForward, event
-  });
-  const defaultRollMode = rollMode || game.settings.get("core", "rollMode");
-  if ( chooseModifier && !isFF ) {
-    data.mod = "@mod";
-    if ( "abilityCheckBonus" in data ) data.abilityCheckBonus = "@abilityCheckBonus";
-  }
-
-  // Construct the D20Roll instance
-  const roll = new CONFIG.Dice.D20Roll(formula, data, {
-    flavor: flavor || title,
-    advantageMode,
-    defaultRollMode,
-    rollMode,
-    critical,
-    fumble,
-    targetValue,
-    elvenAccuracy,
-    halflingLucky,
-    reliableTalent
-  });
-
-  // Prompt a Dialog to further configure the D20Roll
-  if ( !isFF ) {
-    const configured = await roll.configureDialog({
-      title,
-      chooseModifier,
-      defaultRollMode,
-      defaultAction: advantageMode,
-      defaultAbility: data?.item?.ability || data?.defaultAbility,
-      template
-    }, dialogOptions);
-    if ( configured === null ) return null;
-  } else roll.options.rollMode ??= defaultRollMode;
+  const roll = new CONFIG.Dice.D20Roll(formula, data, rollConfig);
 
   // Evaluate the configured roll
   await roll.evaluate({async: true});
 
   // Create a Chat Message
-  if ( roll && chatMessage ) await roll.toMessage(messageData);
+  if ( chatMessage ) await roll.toMessage(messageData);
   return roll;
 }
 

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -7,7 +7,7 @@
     <div class="form-group">
         <label>{{ localize "DND5E.AbilityModifier" }}</label>
         <select name="ability">
-            {{selectOptions abilities selected=defaultAbility}}
+            {{selectOptions abilities selected=defaultAbility labelAttr="label"}}
         </select>
     </div>
     {{/if}}


### PR DESCRIPTION
- Closes #2138 

This version rearranges the roll pipeline to bring the intermediary roll dialog first, then prepares roll data based on the options the user has chosen. This deprecates `D20Roll#configureDialog` (replacing it with the static version `D20Roll.configureDialog), and `D20Roll#_onDialogSubmit`.

In this version, the preview roll formula cannot be accurately shown since we don't create the `D20Roll` instance first. I considered just removing the roll formula preview, since it would simplify the implementation, but I don't know how controversial that change would be, so I've made an attempt to provide some sort of formula preview here.