### PR TITLE
WIP: Refactor roll pipeline to dynamically re-prepare roll data

### DIFF
--- a/module/applications/dice/_module.mjs
+++ b/module/applications/dice/_module.mjs
@@ -1,0 +1,1 @@
+export {default as D20RollConfig} from "./d20-roll-config.mjs";

--- a/module/applications/dice/d20-roll-config.mjs
+++ b/module/applications/dice/d20-roll-config.mjs
@@ -1,0 +1,157 @@
+/**
+ * A class responsible for displaying roll configuration options to the user.
+ * @extends {FormApplication}
+ */
+export default class D20RollConfig extends FormApplication {
+  /**
+   * @param {D20RollBuilder} buildRoll              A function that constructs the appropriate D20Roll.
+   * @param {D20RollConfiguration} [rollConfig={}]  Options forwarded to the D20Roll constructor.
+   * @param {D20DialogConfiguration} [options={}]   Options to configure the behavior of this dialog.
+   */
+  constructor(buildRoll, rollConfig={}, options={}) {
+    const roll = buildRoll(rollConfig);
+    super(roll, options);
+
+    /**
+     * A function that constructs the appropriate D20Roll.
+     * @type {D20RollBuilder}
+     */
+    Object.defineProperty(this, "buildRoll", {value: buildRoll, writable: false, enumerable: true});
+
+    /**
+     * Options forwarded to the D20Roll constructor.
+     * @type {D20RollConfiguration}
+     */
+    Object.defineProperty(this, "rollConfig", {value: rollConfig, writable: false, enumerable: true});
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      width: 400,
+      submitOnChange: false,
+      closeOnSubmit: false
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  get template() {
+    return this.options.template ?? "systems/dnd5e/templates/chat/roll-dialog.hbs";
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  getData(options={}) {
+    return foundry.utils.mergeObject(super.getData(), {
+      formula: this._getFormulaForDisplay(),
+      rollModes: CONFIG.Dice.rollModes,
+      abilities: CONFIG.DND5E.abilities,
+      chooseModifier: this.options.chooseModifier,
+      defaultRollMode: this.object.options.rollMode ?? this.options.defaultRollMode,
+      defaultAbility: this.object.data.ability ?? this.options.defaultAbility,
+      bonus: this.object.data.bonus
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  activateListeners(html) {
+    super.activateListeners(html);
+    html.find(".action-button").on("click", this._onAction.bind(this));
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  _getSubmitData(updateData={}) {
+    const formData = super._getSubmitData(updateData);
+    const parts = [];
+    const data = {};
+
+    if ( formData.bonus ) {
+      parts.push("@bonus");
+      data.bonus = formData.bonus;
+    }
+
+    return {
+      parts, data,
+      ability: formData.ability,
+      rollMode: formData.rollMode
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onChangeInput(event) {
+    if ( event.currentTarget.name === "ability" ) {
+      // Recalculate the roll if the ability used changes.
+      this.object = this.#buildRoll();
+      this.form.elements.formula.value = this._getFormulaForDisplay();
+    }
+    return super._onChangeInput(event);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async close(options={}) {
+    this.options.resolve?.(null);
+    return super.close(options);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle clicking one of the action buttons to submit the sheet.
+   * @param {PointerEvent} event  The triggering event.
+   * @protected
+   */
+  _onAction(event) {
+    const action = event.currentTarget.dataset.action;
+    const modes = CONFIG.Dice.D20Roll.ADV_MODE;
+    let advantageMode = modes.NORMAL;
+    switch ( action ) {
+      case "advantage": advantageMode = modes.ADVANTAGE; break;
+      case "disadvantage": advantageMode = modes.DISADVANTAGE; break;
+    }
+    const roll = this.#buildRoll(advantageMode);
+    this.options.resolve?.(roll);
+    return this.close({submit: false, force: true});
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Format the roll's formula for display.
+   * @returns {string}
+   * @protected
+   */
+  _getFormulaForDisplay() {
+    let formula = this.object.formula;
+    if ( !this.object.data.bonus ) formula += " + @bonus";
+    return formula;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare a D20Roll based on the configured roll information, plus the fields present in the dialog.
+   * @param {number} [advantageMode]  An optional advantage mode to build the roll with.
+   * @returns {D20Roll}
+   */
+  #buildRoll(advantageMode) {
+    let {parts=[], data={}, ...config} = this._getSubmitData();
+    parts = (this.rollConfig.parts || []).concat(parts);
+    data = foundry.utils.mergeObject(this.rollConfig.data || {}, data, {inplace: false});
+    const rollConfig = {...this.rollConfig, ...config, parts, data};
+    if ( advantageMode !== undefined ) rollConfig.advantageMode = advantageMode;
+    return this.buildRoll(rollConfig);
+  }
+}

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -3,102 +3,23 @@
 /* -------------------------------------------- */
 
 /**
- * Configuration data for a D20 roll.
- *
- * @typedef {object} D20RollConfiguration
- *
- * @property {string[]} [parts=[]]  The dice roll component parts, excluding the initial d20.
- * @property {object} [data={}]     Data that will be used when parsing this roll.
- * @property {Event} [event]        The triggering event for this roll.
- *
- * ## D20 Properties
- * @property {boolean} [advantage]     Apply advantage to this roll (unless overridden by modifier keys or dialog)?
- * @property {boolean} [disadvantage]  Apply disadvantage to this roll (unless overridden by modifier keys or dialog)?
- * @property {number|null} [critical=20]  The value of the d20 result which represents a critical success,
- *                                     `null` will prevent critical successes.
- * @property {number|null} [fumble=1]  The value of the d20 result which represents a critical failure,
- *                                     `null` will prevent critical failures.
- * @property {number} [targetValue]    The value of the d20 result which should represent a successful roll.
- *
- * ## Flags
- * @property {boolean} [elvenAccuracy]   Allow Elven Accuracy to modify this roll?
- * @property {boolean} [halflingLucky]   Allow Halfling Luck to modify this roll?
- * @property {boolean} [reliableTalent]  Allow Reliable Talent to modify this roll?
- *
- * ## Roll Configuration Dialog
- * @property {boolean} [fastForward]           Should the roll configuration dialog be skipped?
- * @property {boolean} [chooseModifier=false]  If the configuration dialog is shown, should the ability modifier be
- *                                             configurable within that interface?
- * @property {string} [template]               The HTML template used to display the roll configuration dialog.
- * @property {string} [title]                  Title of the roll configuration dialog.
- * @property {object} [dialogOptions]          Additional options passed to the roll configuration dialog.
- *
- * ## Chat Message
- * @property {boolean} [chatMessage=true]  Should a chat message be created for this roll?
- * @property {object} [messageData={}]     Additional data which is applied to the created chat message.
- * @property {string} [rollMode]           Value of `CONST.DICE_ROLL_MODES` to apply as default for the chat message.
- * @property {object} [flavor]             Flavor text to use in the created chat message.
+ * @typedef {object} D20MessageOptions
+ * @property {boolean} [chatMessage=true]  Whether to display a chat message for the roll.
+ * @property {object} [messageData={}]     Additional message data for the chat message.
  */
 
 /**
- * A standardized helper function for managing core 5e d20 rolls.
- * Holding SHIFT, ALT, or CTRL when the attack is rolled will "fast-forward".
- * This chooses the default options of a normal attack with no bonus, Advantage, or Disadvantage respectively
- *
- * @param {D20RollConfiguration} configuration  Configuration data for the D20 roll.
- * @returns {Promise<D20Roll|null>}             The evaluated D20Roll, or null if the workflow was cancelled.
+ * A helper function for making d20 rolls.
+ * @param {D20Roll} roll                        The d20 roll to evaluate.
+ * @param {D20MessageOptions} [messageOptions]  Additional options to configure the chat message.
+ * @returns {Promise<D20Roll>}                  The evaluated D20Roll.
  */
-export async function d20Roll({
-  parts=[], data={}, event,
-  advantage, disadvantage, critical=20, fumble=1, targetValue,
-  elvenAccuracy, halflingLucky, reliableTalent,
-  fastForward, chooseModifier=false, template, title, dialogOptions,
-  chatMessage=true, messageData={}, rollMode, flavor
-}={}) {
-
-  // Handle input arguments
-  const formula = ["1d20"].concat(parts).join(" + ");
-  const {advantageMode, isFF} = CONFIG.Dice.D20Roll.determineAdvantageMode({
-    advantage, disadvantage, fastForward, event
-  });
-  const defaultRollMode = rollMode || game.settings.get("core", "rollMode");
-  if ( chooseModifier && !isFF ) {
-    data.mod = "@mod";
-    if ( "abilityCheckBonus" in data ) data.abilityCheckBonus = "@abilityCheckBonus";
-  }
-
-  // Construct the D20Roll instance
-  const roll = new CONFIG.Dice.D20Roll(formula, data, {
-    flavor: flavor || title,
-    advantageMode,
-    defaultRollMode,
-    rollMode,
-    critical,
-    fumble,
-    targetValue,
-    elvenAccuracy,
-    halflingLucky,
-    reliableTalent
-  });
-
-  // Prompt a Dialog to further configure the D20Roll
-  if ( !isFF ) {
-    const configured = await roll.configureDialog({
-      title,
-      chooseModifier,
-      defaultRollMode,
-      defaultAction: advantageMode,
-      defaultAbility: data?.item?.ability || data?.defaultAbility,
-      template
-    }, dialogOptions);
-    if ( configured === null ) return null;
-  } else roll.options.rollMode ??= defaultRollMode;
-
-  // Evaluate the configured roll
+export async function d20Roll(roll, {chatMessage=true, messageData={}}={}) {
+  // Evaluate the roll.
   await roll.evaluate({async: true});
 
-  // Create a Chat Message
-  if ( roll && chatMessage ) await roll.toMessage(messageData);
+  // Create a Chat Message.
+  if ( chatMessage ) await roll.toMessage(messageData);
   return roll;
 }
 

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -7,13 +7,13 @@
     <div class="form-group">
         <label>{{ localize "DND5E.AbilityModifier" }}</label>
         <select name="ability">
-            {{selectOptions abilities selected=defaultAbility}}
+            {{selectOptions abilities selected=defaultAbility labelAttr="label"}}
         </select>
     </div>
     {{/if}}
     <div class="form-group">
         <label>{{ localize "DND5E.RollSituationalBonus" }}</label>
-        <input type="text" name="bonus" value="" placeholder="{{ localize 'DND5E.RollExample' }}"/>
+        <input type="text" name="bonus" value="{{bonus}}" placeholder="{{ localize 'DND5E.RollExample' }}"/>
     </div>
     <div class="form-group">
         <label>{{ localize "DND5E.RollMode" }}</label>
@@ -21,4 +21,15 @@
             {{selectOptions rollModes selected=defaultRollMode localize=true}}
         </select>
     </div>
+    <footer class="sheet-footer flexrow">
+        <button type="button" class="action-button" data-action="advantage">
+            {{localize "DND5E.Advantage"}}
+        </button>
+        <button type="button" class="action-button" data-action="normal">
+            {{localize "DND5E.Normal"}}
+        </button>
+        <button type="button" class="action-button" data-action="disadvantage">
+            {{localize "DND5E.Disadvantage"}}
+        </button>
+    </footer>
 </form>


### PR DESCRIPTION
- Closes #2138 

This version operates on the same principle as Jeff's callback solution to the Remarkable Athlete bug, but adds some more API rigour around the passing of the callback. Logic for preparing a particular type of roll is factored out into its own method that can be called on-demand with various options to produce an unevaluated `D20Roll` for the required roll. This method is then passed to the dialog so that the formula can be updated dynamically as the user makes changes, before finally making the roll.

This also deprecates `D20Roll#configureDialog` (replacing it with the static `D20Roll.configureDialog`), and `D20Roll#_onSubmitDialog`.

https://user-images.githubusercontent.com/207433/215591927-1d9c0ed2-59bb-484e-9d5b-114c5ca06ebb.mp4