### PR TITLE
[#2150] Fix schema typo and kgs abbreviation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -36,7 +36,7 @@
 "DND5E.AbbreviationCR": "CR",
 "DND5E.AbbreviationConc": "Conc.",
 "DND5E.AbbreviationDC": "DC",
-"DND5E.AbbreviationKgs": "kgs",
+"DND5E.AbbreviationKg": "kg",
 "DND5E.AbbreviationLR": "LR",
 "DND5E.AbbreviationLevel": "Lvl.",
 "DND5E.AbbreviationLbs": "lbs.",

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -38,7 +38,7 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
       classLabels: classes.map(c => c.name).join(", "),
       multiclassLabels: classes.map(c => [c.subclass?.name ?? "", c.name, c.system.levels].filterJoin(" ")).join(", "),
       weightUnit: game.i18n.localize(`DND5E.Abbreviation${
-        game.settings.get("dnd5e", "metricWeightUnits") ? "Kgs" : "Lbs"}`),
+        game.settings.get("dnd5e", "metricWeightUnits") ? "Kg" : "Lbs"}`),
       encumbrance: context.system.attributes.encumbrance
     });
   }

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -54,7 +54,7 @@ export default class CreatureTemplate extends CommonTemplate {
       }), {initialKeys: CONFIG.DND5E.skills, initialValue: this._initialSkillValue}),
       spells: new MappingField(new foundry.data.fields.SchemaField({
         value: new foundry.data.fields.NumberField({
-          nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.SpellProfAvailable"
+          nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.SpellProgAvailable"
         }),
         override: new foundry.data.fields.NumberField({
           integer: true, min: 0, label: "DND5E.SpellProgOverride"


### PR DESCRIPTION
Fixed a typo in the schema ("prof" to "prog") and fixed the SI unit to not be "kilogram seconds".

Closes #2150.