### PR TITLE
[#1013] Add max to ability scores

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -94,6 +94,7 @@
 "DND5E.AbilitySan": "Sanity",
 "DND5E.AbilitySanAbbr": "san",
 "DND5E.AbilityScore": "Ability Score",
+"DND5E.AbilityScoreMax": "Maximum Ability Score",
 "DND5E.AbilityModifier": "Ability Modifier",
 "DND5E.AbilityPromptText": "What type of {ability} check?",
 "DND5E.AbilityPromptTitle": "{ability} Ability Check",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1541,6 +1541,12 @@ preLocalize("languages", { sort: true });
 DND5E.maxLevel = 20;
 
 /**
+ * Maximum ability score value allowed by default.
+ * @type {number}
+ */
+DND5E.maxAbilityScore = 20;
+
+/**
  * XP required to achieve each character level.
  * @type {number[]}
  */

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -6,6 +6,7 @@ import CurrencyTemplate from "../../shared/currency.mjs";
  * @typedef {object} AbilityData
  * @property {number} value          Ability score.
  * @property {number} proficient     Proficiency value for saves.
+ * @property {number} max            Maximum possible score for the ability.
  * @property {object} bonuses        Bonuses that modify ability checks and saves.
  * @property {string} bonuses.check  Numeric or dice bonus to ability checks.
  * @property {string} bonuses.save   Numeric or dice bonus to ability saving throws.
@@ -26,7 +27,12 @@ export default class CommonTemplate extends SystemDataModel.mixin(CurrencyTempla
         value: new foundry.data.fields.NumberField({
           required: true, nullable: false, integer: true, min: 0, initial: 10, label: "DND5E.AbilityScore"
         }),
-        proficient: new foundry.data.fields.NumberField({required: true, initial: 0, label: "DND5E.ProficiencyLevel"}),
+        proficient: new foundry.data.fields.NumberField({
+          required: true, integer: true, min: 0, max: 1, initial: 0, label: "DND5E.ProficiencyLevel"
+        }),
+        max: new foundry.data.fields.NumberField({
+          required: true, integer: true, min: 0, initial: 20, label: "DND5E.AbilityScoreMax"
+        }),
         bonuses: new foundry.data.fields.SchemaField({
           check: new FormulaField({required: true, label: "DND5E.AbilityCheckBonus"}),
           save: new FormulaField({required: true, label: "DND5E.SaveBonus"})

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -31,7 +31,7 @@ export default class CommonTemplate extends SystemDataModel.mixin(CurrencyTempla
           required: true, integer: true, min: 0, max: 1, initial: 0, label: "DND5E.ProficiencyLevel"
         }),
         max: new foundry.data.fields.NumberField({
-          required: true, integer: true, min: 0, initial: 20, label: "DND5E.AbilityScoreMax"
+          required: true, integer: true, nullable: true, min: 0, initial: null, label: "DND5E.AbilityScoreMax"
         }),
         bonuses: new foundry.data.fields.SchemaField({
           check: new FormulaField({required: true, label: "DND5E.AbilityCheckBonus"}),

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -359,6 +359,8 @@ export default class Actor5e extends Actor {
       if ( Number.isNumeric(abl.saveProf.term) ) abl.save += abl.saveProf.flat;
       abl.dc = 8 + abl.mod + this.system.attributes.prof + dcBonus;
 
+      if ( !Number.isFinite(abl.max) ) abl.max = CONFIG.DND5E.maxAbilityScore;
+
       // If we merged saves when transforming, take the highest bonus here.
       if ( originalSaves && abl.proficient ) abl.save = Math.max(abl.save, originalSaves[id].save);
     }

--- a/template.json
+++ b/template.json
@@ -7,6 +7,7 @@
           "str": {
             "value": 10,
             "proficient": 0,
+            "max": 20,
             "bonuses": {
               "check": "",
               "save": ""
@@ -15,6 +16,7 @@
           "dex": {
             "value": 10,
             "proficient": 0,
+            "max": 20,
             "bonuses": {
               "check": "",
               "save": ""
@@ -23,6 +25,7 @@
           "con": {
             "value": 10,
             "proficient": 0,
+            "max": 20,
             "bonuses": {
               "check": "",
               "save": ""
@@ -31,6 +34,7 @@
           "int": {
             "value": 10,
             "proficient": 0,
+            "max": 20,
             "bonuses": {
               "check": "",
               "save": ""
@@ -39,6 +43,7 @@
           "wis": {
             "value": 10,
             "proficient": 0,
+            "max": 20,
             "bonuses": {
               "check": "",
               "save": ""
@@ -47,6 +52,7 @@
           "cha": {
             "value": 10,
             "proficient": 0,
+            "max": 20,
             "bonuses": {
               "check": "",
               "save": ""

--- a/template.json
+++ b/template.json
@@ -7,7 +7,7 @@
           "str": {
             "value": 10,
             "proficient": 0,
-            "max": 20,
+            "max": null,
             "bonuses": {
               "check": "",
               "save": ""
@@ -16,7 +16,7 @@
           "dex": {
             "value": 10,
             "proficient": 0,
-            "max": 20,
+            "max": null,
             "bonuses": {
               "check": "",
               "save": ""
@@ -25,7 +25,7 @@
           "con": {
             "value": 10,
             "proficient": 0,
-            "max": 20,
+            "max": null,
             "bonuses": {
               "check": "",
               "save": ""
@@ -34,7 +34,7 @@
           "int": {
             "value": 10,
             "proficient": 0,
-            "max": 20,
+            "max": null,
             "bonuses": {
               "check": "",
               "save": ""
@@ -43,7 +43,7 @@
           "wis": {
             "value": 10,
             "proficient": 0,
-            "max": 20,
+            "max": null,
             "bonuses": {
               "check": "",
               "save": ""
@@ -52,7 +52,7 @@
           "cha": {
             "value": 10,
             "proficient": 0,
-            "max": 20,
+            "max": null,
             "bonuses": {
               "check": "",
               "save": ""

--- a/templates/apps/ability-config.hbs
+++ b/templates/apps/ability-config.hbs
@@ -8,6 +8,10 @@
     </select>
   </div>
   <div class="form-group">
+    <label>{{ localize "DND5E.AbilityScoreMax" }}</label>
+    <input name="system.abilities.{{abilityId}}.max" type="number" value="{{ability.max}}">
+  </div>
+  <div class="form-group">
     <label>{{localize "DND5E.SaveBonus"}}</label>
     <input name="system.abilities.{{abilityId}}.bonuses.save" type="text" value="{{ability.bonuses.save}}">
   </div>


### PR DESCRIPTION
Split the maximum ability score from #2158 for separate review.

Adds `max` to abilities that defaults to `20` to allow `AbilityScoreImprovementAdvancement` and other uses to cap an ability score.

- Currently doesn't prevent entering a value over the max on the character sheet
- This ends up also adding `max` to NPCs and vehicles where it isn't useful, should the data models be modified so it is only included on characters?

Resolves #1013