### PR TITLE
[#1438] Add Mythic Actions to ability activation types

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -756,6 +756,7 @@
 "DND5E.ModuleArtConfigN": "Module-provided Art",
 "DND5E.ModuleArtConfigPortraits": "Portraits",
 "DND5E.ModuleArtConfigTokens": "Tokens",
+"DND5E.MythicActionLabel": "Mythic Action",
 "DND5E.Name": "Character Name",
 "DND5E.NoCharges": "No Charges",
 "DND5E.None": "None",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -389,6 +389,7 @@ DND5E.abilityActivationTypes = {
   day: DND5E.timePeriods.day,
   special: DND5E.timePeriods.spec,
   legendary: "DND5E.LegendaryActionLabel",
+  mythic: "DND5E.MythicActionLabel",
   lair: "DND5E.LairActionLabel",
   crew: "DND5E.VehicleCrewAction"
 };


### PR DESCRIPTION
Adds new "Mythic Action" activation type listed just below "Legendary Action".

Resolves #1438