### PR TITLE
[#2166] Fix bug with equipment details not displaying on vehicle sheet

### DIFF
--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -394,8 +394,8 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
     event.preventDefault();
     const itemID = event.currentTarget.closest(".item").dataset.itemId;
     const item = this.actor.items.get(itemID);
-    const hp = Math.clamped(0, parseInt(event.currentTarget.value), item.system.hp.max);
-    event.currentTarget.value = hp;
+    let hp = Math.clamped(0, parseInt(event.currentTarget.value), item.system.hp.max);
+    if ( Number.isNaN(hp) ) hp = 0;
     return item.update({"system.hp.value": hp});
   }
 
@@ -411,8 +411,8 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
     event.preventDefault();
     const itemID = event.currentTarget.closest(".item").dataset.itemId;
     const item = this.actor.items.get(itemID);
-    const qty = parseInt(event.currentTarget.value);
-    event.currentTarget.value = qty;
+    let qty = parseInt(event.currentTarget.value);
+    if ( Number.isNaN(qty) ) qty = 0;
     return item.update({"system.quantity": qty});
   }
 

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -11,6 +11,7 @@ import { FormulaField } from "../../fields.mjs";
  * @property {object} duration              Effect's duration.
  * @property {number} duration.value        How long the effect lasts.
  * @property {string} duration.units        Time duration period as defined in `DND5E.timePeriods`.
+ * @property {number} cover                 Amount of cover does this item affords to its crew on a vehicle.
  * @property {object} target                Effect's valid targets.
  * @property {number} target.value          Length or radius of target depending on targeting mode selected.
  * @property {number} target.width          Width of line when line type is selected.
@@ -43,6 +44,9 @@ export default class ActivatedEffectTemplate extends foundry.abstract.DataModel 
         value: new FormulaField({required: true, deterministic: true, label: "DND5E.Duration"}),
         units: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.DurationType"})
       }, {label: "DND5E.Duration"}),
+      cover: new foundry.data.fields.NumberField({
+        required: true, nullable: true, min: 0, max: 1, label: "DND5E.Cover"
+      }),
       target: new foundry.data.fields.SchemaField({
         value: new foundry.data.fields.NumberField({required: true, min: 0, label: "DND5E.TargetValue"}),
         width: new foundry.data.fields.NumberField({required: true, min: 0, label: "DND5E.TargetWidth"}),

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -47,6 +47,7 @@ export default class ActivatedEffectTemplate extends foundry.abstract.DataModel 
       cover: new foundry.data.fields.NumberField({
         required: true, nullable: true, min: 0, max: 1, label: "DND5E.Cover"
       }),
+      crewed: new foundry.data.fields.BooleanField({label: "DND5E.Crewed"}),
       target: new foundry.data.fields.SchemaField({
         value: new foundry.data.fields.NumberField({required: true, min: 0, label: "DND5E.TargetValue"}),
         width: new foundry.data.fields.NumberField({required: true, min: 0, label: "DND5E.TargetWidth"}),

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -152,7 +152,7 @@ export async function preloadHandlebarsTemplates() {
  * @returns {string}
  */
 function itemContext(context, options) {
-  if ( arguments.length !== 2 ) throw new Error("#dnd5e-with requires exactly one argument");
+  if ( arguments.length !== 2 ) throw new Error("#dnd5e-itemContext requires exactly one argument");
   if ( foundry.utils.getType(context) === "function" ) context = context.call(this);
 
   const ctx = options.data.root.itemContext?.[context.id];

--- a/template.json
+++ b/template.json
@@ -570,6 +570,7 @@
           "units": ""
         },
         "cover": null,
+        "crewed": false,
         "target": {
           "value": null,
           "width": null,

--- a/templates/actors/parts/actor-features.hbs
+++ b/templates/actors/parts/actor-features.hbs
@@ -85,10 +85,15 @@
                 {{#each section.columns}}
                     <div class="item-detail {{css}}">
                         {{#if editable}}
-                            <input type="text" value="{{getProperty item property}}" placeholder="&mdash;"
-                                   data-dtype="{{editable}}">
+                            <input type="text" data-dtype="{{editable}}" data-property="{{property}}"
+                                   value="{{#if (getProperty item property)}}{{getProperty item property}}
+                                   {{~else}}{{getProperty ctx property}}{{/if}}" placeholder="&mdash;">
                         {{else}}
-                            {{getProperty item property}}
+                            {{#if (getProperty item property)}}
+                                {{getProperty item property}}
+                            {{else}}
+                                {{getProperty ctx property}}
+                            {{/if}}
                         {{/if}}
                     </div>
                 {{/each}}

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -80,10 +80,15 @@
                 {{#each section.columns}}
                     <div class="item-detail {{css}}">
                         {{#if editable}}
-                            <input type="text" value="{{getProperty item property}}" placeholder="&mdash;"
-                                   data-dtype="{{editable}}" data-property="{{property}}">
+                            <input type="text" data-dtype="{{editable}}" data-property="{{property}}"
+                                   value="{{#if (getProperty item property)}}{{getProperty item property}}
+                                   {{~else}}{{getProperty ctx property}}{{/if}}" placeholder="&mdash;">
                         {{else}}
-                            {{getProperty item property}}
+                            {{#if (getProperty item property)}}
+                                {{getProperty item property}}
+                            {{else}}
+                                {{getProperty ctx property}}
+                            {{/if}}
                         {{/if}}
                     </div>
                 {{/each}}


### PR DESCRIPTION
- Add `cover` to `ActivatedEffectTemplate` which was missed in initial data models
- Fix issue with deleting value from `qty` or `hp` resulting in data validation error
- Fix `threshold` and `cover` not displaying contents on vehicle sheet