### PR TITLE
[#885] [#2026] Add 'none' as an option when choosing the ability modifier

### DIFF
--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -144,7 +144,7 @@ export default class ActionTemplate extends foundry.abstract.DataModel {
    * @type {string|null}
    */
   get abilityMod() {
-    if ( this.ability === "flat" ) return null;
+    if ( this.ability === "none" ) return null;
     return this.ability || this._typeAbilityMod || {
       mwak: "str",
       rwak: "dex",

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -144,6 +144,7 @@ export default class ActionTemplate extends foundry.abstract.DataModel {
    * @type {string|null}
    */
   get abilityMod() {
+    if ( this.ability === "flat" ) return null;
     return this.ability || this._typeAbilityMod || {
       mwak: "str",
       rwak: "dex",

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -599,7 +599,7 @@ export default class Item5e extends Item {
     // Take no further action for un-owned items
     if ( !this.isOwned ) return {rollData, parts};
 
-    if( this.system.ability !== "flat" ) {
+    if ( this.system.ability !== "flat" ) {
       // Ability score modifier
       parts.push("@mod");
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2038,7 +2038,8 @@ export default class Item5e extends Item {
     // Get spell data
     const itemData = (spell instanceof Item5e) ? spell.toObject() : spell;
     let {
-      actionType, description, source, activation, duration, target, range, damage, formula, save, level, attackBonus
+      actionType, description, source, activation, duration, target,
+      range, damage, formula, save, level, attackBonus, ability
     } = itemData.system;
 
     // Get scroll data
@@ -2059,7 +2060,8 @@ export default class Item5e extends Item {
 
     // Used a fixed attack modifier and saving throw according to the level of spell scroll.
     if ( ["mwak", "rwak", "msak", "rsak"].includes(actionType) ) {
-      attackBonus = `${scrollData.system.attackBonus} - @mod`;
+      attackBonus = scrollData.system.attackBonus;
+      ability = "flat";
     }
     if ( save.ability ) {
       save.scaling = "flat";
@@ -2071,8 +2073,8 @@ export default class Item5e extends Item {
       name: `${game.i18n.localize("DND5E.SpellScroll")}: ${itemData.name}`,
       img: itemData.img,
       system: {
-        description: {value: desc.trim()}, source, actionType, activation, duration, target, range, damage, formula,
-        save, level, attackBonus
+        description: {value: desc.trim()}, source, actionType, activation, duration, target,
+        range, damage, formula, save, level, attackBonus, ability
       }
     });
     return new this(spellScrollData);

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -600,7 +600,7 @@ export default class Item5e extends Item {
     if ( !this.isOwned ) return {rollData, parts};
 
     // Ability score modifier
-    if ( this.system.ability !== "flat" ) parts.push("@mod");
+    if ( this.system.ability !== "none" ) parts.push("@mod");
 
     // Add proficiency bonus.
     if ( this.system.prof?.hasProficiency ) {
@@ -2061,7 +2061,7 @@ export default class Item5e extends Item {
     // Used a fixed attack modifier and saving throw according to the level of spell scroll.
     if ( ["mwak", "rwak", "msak", "rsak"].includes(actionType) ) {
       attackBonus = scrollData.system.attackBonus;
-      ability = "flat";
+      ability = "none";
     }
     if ( save.ability ) {
       save.scaling = "flat";

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -599,9 +599,8 @@ export default class Item5e extends Item {
     // Take no further action for un-owned items
     if ( !this.isOwned ) return {rollData, parts};
 
-    if ( this.system.ability !== "flat" ) {
-      // Ability score modifier
-      parts.push("@mod");
+    // Ability score modifier
+    if ( this.system.ability !== "flat" ) parts.push("@mod");
 
     // Add proficiency bonus.
     if ( this.system.prof?.hasProficiency ) {
@@ -609,10 +608,9 @@ export default class Item5e extends Item {
       rollData.prof = this.system.prof.term;
     }
 
-      // Actor-level global bonus to attack rolls
-      const actorBonus = this.actor.system.bonuses?.[this.system.actionType] || {};
-      if ( actorBonus.attack ) parts.push(actorBonus.attack);
-    }
+    // Actor-level global bonus to attack rolls
+    const actorBonus = this.actor.system.bonuses?.[this.system.actionType] || {};
+    if ( actorBonus.attack ) parts.push(actorBonus.attack);
 
     // One-time bonus provided by consumed ammunition
     if ( (this.system.consume?.type === "ammo") && this.actor.items ) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -599,8 +599,9 @@ export default class Item5e extends Item {
     // Take no further action for un-owned items
     if ( !this.isOwned ) return {rollData, parts};
 
-    // Ability score modifier
-    parts.push("@mod");
+    if( this.system.ability !== "flat" ) {
+      // Ability score modifier
+      parts.push("@mod");
 
     // Add proficiency bonus.
     if ( this.system.prof?.hasProficiency ) {
@@ -608,9 +609,10 @@ export default class Item5e extends Item {
       rollData.prof = this.system.prof.term;
     }
 
-    // Actor-level global bonus to attack rolls
-    const actorBonus = this.actor.system.bonuses?.[this.system.actionType] || {};
-    if ( actorBonus.attack ) parts.push(actorBonus.attack);
+      // Actor-level global bonus to attack rolls
+      const actorBonus = this.actor.system.bonuses?.[this.system.actionType] || {};
+      if ( actorBonus.attack ) parts.push(actorBonus.attack);
+    }
 
     // One-time bonus provided by consumed ammunition
     if ( (this.system.consume?.type === "ammo") && this.actor.items ) {

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -11,7 +11,15 @@
 <div class="form-group select">
     <label>{{ localize "DND5E.AbilityModifier" }}</label>
     <select name="system.ability">
-        {{selectOptions config.abilities selected=system.ability labelAttr="label" blank=(localize "DND5E.Default")}}
+        {{#select system.ability}}
+        <option value="">{{ localize "DND5E.Default" }}</option>
+        <option value="flat">{{ localize "DND5E.Flat" }}</option>
+        <optgroup label="{{ localize 'DND5E.Ability' }}">
+            {{#each config.abilities as |ability a|}}
+            <option value="{{a}}">{{ability}}</option>
+            {{/each}}
+        </optgroup>
+        {{/select}}
     </select>
 </div>
 

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -13,10 +13,10 @@
     <select name="system.ability">
         {{#select system.ability}}
         <option value="">{{ localize "DND5E.Default" }}</option>
-        <option value="flat">{{ localize "DND5E.Flat" }}</option>
+        <option value="none">{{ localize "DND5E.None" }}</option>
         <optgroup label="{{ localize 'DND5E.Ability' }}">
             {{#each config.abilities as |ability a|}}
-            <option value="{{a}}">{{ability}}</option>
+            <option value="{{a}}">{{ability.label}}</option>
             {{/each}}
         </optgroup>
         {{/select}}


### PR DESCRIPTION
This introduces an additional option when selecting an item's ability modifier; ~~"flat"~~ "none", which will ignore ability modifiers, ~~proficiency bonus, and any bonuses to melee/ranged weapon/spell attacks~~.

![circ_select](https://user-images.githubusercontent.com/50169243/217786851-ee2b74db-2efe-43e7-b2ab-96c69f682b2d.png)

This also adjusts the logic such that an 'equipment' type item is required to have proficient toggled on for proficiency bonus to be added, and removes `@mod` from created spell scrolls, which is not needed any longer (these are set to ~~`flat`~~ `none` if they have an attack).

Example using Circlet of Blasting:

Before (using an actor with a +2 PB and +2 INT):

![circ_before](https://user-images.githubusercontent.com/50169243/217786795-ae6283e4-937b-421a-a707-14feda81ffa8.png)

After (using that same actor, with Proficient toggled off):

![circ_after](https://user-images.githubusercontent.com/50169243/217786825-80e4db37-5330-4727-975e-a7c2cc38394f.png)

Resolves #2026.
Does something to #885.