### PR TITLE
Tweaks and fixes to the scroll creation process

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -908,6 +908,8 @@
 "DND5E.NewDayHint": "Recover limited use abilities which recharge \"per day\"?",
 "DND5E.SaveBonus": "Saving Throw Bonus",
 "DND5E.SaveGlobalBonusHint": "This bonus applies to all saving throws made by this actor.",
+"DND5E.ScrollDetails": "Scroll Details",
+"DND5E.ScrollRequiresConcentration": "Requires Concentration",
 "DND5E.Senses": "Senses",
 "DND5E.SensesConfig": "Configure Senses",
 "DND5E.SensesConfigHint": "Configure any special sensory perception abilities that this actor possesses.",

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2039,7 +2039,7 @@ export default class Item5e extends Item {
     const itemData = (spell instanceof Item5e) ? spell.toObject() : spell;
     let {
       actionType, description, source, activation, duration, target,
-      range, damage, formula, save, level, attackBonus, ability
+      range, damage, formula, save, level, attackBonus, ability, components
     } = itemData.system;
 
     // Get scroll data
@@ -2056,7 +2056,11 @@ export default class Item5e extends Item {
     const scrollDetails = scrollDescription.slice(scrollIntroEnd + pdel.length);
 
     // Create a composite description from the scroll description and the spell details
-    const desc = `${scrollIntro}<hr/><h3>${itemData.name} (Level ${level})</h3><hr/>${description.value}<hr/><h3>Scroll Details</h3><hr/>${scrollDetails}`;
+    const desc = scrollIntro
+    + `<hr/><h3>${itemData.name} (${game.i18n.format("DND5E.LevelNumber", {level})})</h3>`
+    + (components.concentration ? `<em>${game.i18n.localize("DND5E.ScrollRequiresConcentration")}</em>` : "")
+    + `<hr/>${description.value}<hr/>`
+    + `<h3>${game.i18n.localize("DND5E.ScrollDetails")}</h3><hr/>${scrollDetails}`;
 
     // Used a fixed attack modifier and saving throw according to the level of spell scroll.
     if ( ["mwak", "rwak", "msak", "rsak"].includes(actionType) ) {
@@ -2075,8 +2079,19 @@ export default class Item5e extends Item {
       system: {
         description: {value: desc.trim()}, source, actionType, activation, duration, target,
         range, damage, formula, save, level, attackBonus, ability
-      }
+      },
+      flags: {dnd5e: {concentration: components.concentration}}
     });
+
+    /**
+     * A hook event that fires after the item data for a scroll is created but before the item is returned.
+     * @function dnd5e.createScrollFromSpell
+     * @memberof hookEvents
+     * @param {Item5e|object} spell       The spell or item data triggering this function.
+     * @param {object} itemData           The item data of the spell triggering this function.
+     * @param {object} spellScrollData    The final item data used to make the scroll.
+     */
+    Hooks.callAll("dnd5e.createScrollFromSpell", spell, itemData, spellScrollData);
     return new this(spellScrollData);
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2031,7 +2031,7 @@ export default class Item5e extends Item {
   /**
    * Create a consumable spell scroll Item from a spell Item.
    * @param {Item5e|object} spell     The spell or item data to be made into a scroll
-   * @param {object} options          Additional options that modify the created scroll
+   * @param {object} [options]        Additional options that modify the created scroll
    * @returns {Item5e}                The created scroll consumable item
    */
   static async createScrollFromSpell(spell, options={}) {
@@ -2058,10 +2058,10 @@ export default class Item5e extends Item {
 
     // Create a composite description from the scroll description and the spell details
     const desc = scrollIntro
-    + `<hr/><h3>${itemData.name} (${game.i18n.format("DND5E.LevelNumber", {level})})</h3>`
+    + `<hr><h3>${itemData.name} (${game.i18n.format("DND5E.LevelNumber", {level})})</h3>`
     + (components.concentration ? `<p><em>${game.i18n.localize("DND5E.ScrollRequiresConcentration")}</em></p>` : "")
-    + `<hr/>${description.value}<hr/>`
-    + `<h3>${game.i18n.localize("DND5E.ScrollDetails")}</h3><hr/>${scrollDetails}`;
+    + `<hr>${description.value}<hr>`
+    + `<h3>${game.i18n.localize("DND5E.ScrollDetails")}</h3><hr>${scrollDetails}`;
 
     // Used a fixed attack modifier and saving throw according to the level of spell scroll.
     if ( ["mwak", "rwak", "msak", "rsak"].includes(actionType) ) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2030,8 +2030,8 @@ export default class Item5e extends Item {
 
   /**
    * Create a consumable spell scroll Item from a spell Item.
-   * @param {Item5e} spell      The spell to be made into a scroll
-   * @returns {Item5e}          The created scroll consumable item
+   * @param {Item5e|object} spell     The spell or item data to be made into a scroll
+   * @returns {Item5e}                The created scroll consumable item
    */
   static async createScrollFromSpell(spell) {
 
@@ -2086,11 +2086,10 @@ export default class Item5e extends Item {
      * A hook event that fires after the item data for a scroll is created but before the item is returned.
      * @function dnd5e.createScrollFromSpell
      * @memberof hookEvents
-     * @param {Item5e|object} spell       The spell or item data triggering this function.
-     * @param {object} itemData           The item data of the spell triggering this function.
+     * @param {Item5e|object} spell       The spell or item data to be made into a scroll.
      * @param {object} spellScrollData    The final item data used to make the scroll.
      */
-    Hooks.callAll("dnd5e.createScrollFromSpell", spell, itemData, spellScrollData);
+    Hooks.callAll("dnd5e.createScrollFromSpell", spell, spellScrollData);
     return new this(spellScrollData);
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2031,9 +2031,10 @@ export default class Item5e extends Item {
   /**
    * Create a consumable spell scroll Item from a spell Item.
    * @param {Item5e|object} spell     The spell or item data to be made into a scroll
+   * @param {object} options          Additional options that modify the created scroll
    * @returns {Item5e}                The created scroll consumable item
    */
-  static async createScrollFromSpell(spell) {
+  static async createScrollFromSpell(spell, options={}) {
 
     // Get spell data
     const itemData = (spell instanceof Item5e) ? spell.toObject() : spell;
@@ -2081,6 +2082,7 @@ export default class Item5e extends Item {
         range, damage, formula, save, level, attackBonus, ability
       }
     });
+    foundry.utils.mergeObject(spellScrollData, options);
 
     /**
      * A hook event that fires after the item data for a scroll is created but before the item is returned.

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2058,7 +2058,7 @@ export default class Item5e extends Item {
     // Create a composite description from the scroll description and the spell details
     const desc = scrollIntro
     + `<hr/><h3>${itemData.name} (${game.i18n.format("DND5E.LevelNumber", {level})})</h3>`
-    + (components.concentration ? `<em>${game.i18n.localize("DND5E.ScrollRequiresConcentration")}</em>` : "")
+    + (components.concentration ? `<p><em>${game.i18n.localize("DND5E.ScrollRequiresConcentration")}</em></p>` : "")
     + `<hr/>${description.value}<hr/>`
     + `<h3>${game.i18n.localize("DND5E.ScrollDetails")}</h3><hr/>${scrollDetails}`;
 
@@ -2079,8 +2079,7 @@ export default class Item5e extends Item {
       system: {
         description: {value: desc.trim()}, source, actionType, activation, duration, target,
         range, damage, formula, save, level, attackBonus, ability
-      },
-      flags: {dnd5e: {concentration: components.concentration}}
+      }
     });
 
     /**


### PR DESCRIPTION
Added missing localization in the scroll description.

Added a hook (`dnd5e.createScrollFromSpell`) for those who want to tweak the scroll creation process further (the process cannot be cancelled).

Add concentration tag as a piece of descriptive text under the spell name (closes #1241), only for concentration spells.

![image](https://user-images.githubusercontent.com/50169243/218254677-5791c715-a378-4977-b61b-e97e47c13e06.png)
