### PR TITLE
[#2180] Fix CommonTemplate#migrateData not being called

### DIFF
--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -39,6 +39,7 @@ export default class CommonTemplate extends SystemDataModel.mixin(CurrencyTempla
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     CommonTemplate.#migrateACData(source);
     CommonTemplate.#migrateMovementData(source);
   }

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -93,6 +93,7 @@ export default class CreatureTemplate extends CommonTemplate {
 
   /** @inheritdoc */
   static migrateData(source) {
+    super.migrateData(source);
     CreatureTemplate.#migrateSensesData(source);
   }
 


### PR DESCRIPTION
Fixes a bug preventing `migrateACData` and `migrateMovementData` from being called.

Resolves #2180