### PR TITLE
Consult source of hp max for characters

### DIFF
--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -60,7 +60,7 @@
                         <input name="system.attributes.hp.value" type="text" value="{{hp.value}}" placeholder="10"
                             data-tooltip="DND5E.HitPointsCurrent" data-dtype="Number">
                         <span class="sep"> / </span>
-                        <span data-tooltip="{{#if hp.max}}DND5E.HitPointsOverride{{else}}DND5E.HitPointsMax{{/if}}">
+                        <span data-tooltip="{{#if source.attributes.hp.max}}DND5E.HitPointsOverride{{else}}DND5E.HitPointsMax{{/if}}">
                             {{hp.max}}
                         </span>
                     </div>


### PR DESCRIPTION
A fix for [this bug](https://github.com/foundryvtt/dnd5e/issues/2175) which was caused by a change [this PR](https://github.com/foundryvtt/dnd5e/pull/2019)

Closes #2175