### PR TITLE
[#2132, #2181, #2205] Fix few nagging bugs

### DIFF
--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -9,6 +9,15 @@ import Item5e from "../../documents/item.mjs";
  */
 export default class GroupActorSheet extends ActorSheet {
 
+  /**
+   * IDs for items on the sheet that have been expanded.
+   * @type {Set<string>}
+   * @protected
+   */
+  _expanded = new Set();
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
@@ -50,6 +59,11 @@ export default class GroupActorSheet extends ActorSheet {
     // Inventory
     context.itemContext = {};
     context.inventory = this.#prepareInventory(context);
+    context.expandedData = {};
+    for ( const id of this._expanded ) {
+      const item = this.actor.items.get(id);
+      if ( item ) context.expandedData[id] = await item.getChatData({secrets: this.actor.isOwner});
+    }
     context.inventoryFilters = false;
     context.rollableClass = this.isEditable ? "rollable" : "";
 
@@ -181,6 +195,7 @@ export default class GroupActorSheet extends ActorSheet {
       const {quantity} = item.system;
       ctx.isStack = Number.isNumeric(quantity) && (quantity > 1);
       ctx.canToggle = false;
+      ctx.isExpanded = this._expanded.has(item.id);
       if ( (item.type in sections) && (item.type !== "loot") ) sections[item.type].items.push(item);
       else sections.loot.items.push(item);
     }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2414,7 +2414,7 @@ export default class Actor5e extends Actor {
     }, {renderSheet});
 
     // Create new Actor with transformed data
-    const newActor = await this.constructor.create(d, {renderSheet: true});
+    const newActor = await this.constructor.create(d, {renderSheet});
 
     // Update placed Token instances
     if ( !transformTokens ) return;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2343,7 +2343,7 @@ export default class Item5e extends Item {
       name: `${game.i18n.localize("DND5E.SpellScroll")}: ${itemData.name}`,
       img: itemData.img,
       system: {
-        "description.value": desc.trim(), source, actionType, activation, duration, target, range, damage, formula,
+        description: {value: desc.trim()}, source, actionType, activation, duration, target, range, damage, formula,
         save, level, attackBonus
       }
     });


### PR DESCRIPTION
A few bugs that are annoying but easy to fix that should probably be solved sooner rather than waiting for `2.2.0`.

- Fix issue with items in group inventory repeatedly expanding
- Fix issue with spell scrolls not getting spell description
- Fix issue with `transformInto` ignoring `renderSheet` option for linked actors

Resolves #2132 
Resolves #2181 
Resolves #2205