### PR TITLE
[#2229] Add support for getField requests to MappingField

### DIFF
--- a/module/data/fields.mjs
+++ b/module/data/fields.mjs
@@ -245,4 +245,14 @@ export class MappingField extends foundry.data.fields.ObjectField {
       return obj;
     }, {});
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  _getField(path) {
+    if ( path.length === 0 ) return this;
+    else if ( path.length === 1 ) return this.model;
+    path.shift();
+    return this.model._getField(path);
+  }
 }


### PR DESCRIPTION
```javascript
actor.system.schema.getField("abilities");          // Returns abilities MappingField
actor.system.schema.getField("abilities.*");        // Returns ability's SchemaField ("*" can be any value)
actor.system.schema.getField("abilities.*.value");  // Returns value's NumberField
```

Resolves #2229