### PR TITLE
Display quantities for NPC items too

### DIFF
--- a/templates/actors/parts/actor-features.hbs
+++ b/templates/actors/parts/actor-features.hbs
@@ -47,6 +47,7 @@
                     {{#if item.system.isOriginalClass}}
                         <i class="original-class fas fa-sun" data-tooltip="DND5E.ClassOriginal"></i>
                     {{/if}}
+                    {{~#if ctx.isStack}} ({{item.system.quantity}}){{/if}}
                 </h4>
             </div>
 


### PR DESCRIPTION
Closes https://github.com/foundryvtt/dnd5e/issues/2243

This small change should be enough to display the quantities of items in NPC sheets too:

![image](https://user-images.githubusercontent.com/20903647/224549607-031ecaa5-52b6-4660-b116-b8fd8a396239.png)

