### PR TITLE
Display currencies in NPC sheets too

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -2084,7 +2084,7 @@ h5 {
 /*  Basic Structure                          */
 /* ----------------------------------------- */
 .dnd5e.sheet.actor.npc {
-  min-width: 600px;
+  min-width: 610px;
   min-height: 680px;
 }
 .dnd5e.sheet.actor.npc .header-exp {

--- a/less/npc.less
+++ b/less/npc.less
@@ -4,7 +4,7 @@
 /*  Basic Structure                          */
 /* ----------------------------------------- */
 .dnd5e.sheet.actor.npc {
-  min-width: 600px;
+  min-width: 610px;
   min-height: 680px;
 
   .header-exp {

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -9,7 +9,7 @@ export default class ActorSheet5eNPC extends ActorSheet5e {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["dnd5e", "sheet", "actor", "npc"],
-      width: 600
+      width: 610
     });
   }
 
@@ -106,6 +106,38 @@ export default class ActorSheet5eNPC extends ActorSheet5e {
     else label.push(game.i18n.localize(CONFIG.DND5E.armorClasses[ac.calc].label));
     if ( this.actor.shield ) label.push(this.actor.shield.name);
     return label.filterJoin(", ");
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  activateListeners(html) {
+    super.activateListeners(html);
+    if ( !this.isEditable ) return;
+    html.find(".rollable[data-action]").click(this._onSheetAction.bind(this));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle mouse click events for character sheet actions.
+   * @param {MouseEvent} event  The originating click event.
+   * @returns {Promise}         Dialog or roll result.
+   * @private
+   */
+  _onSheetAction(event) {
+    event.preventDefault();
+    const button = event.currentTarget;
+    switch ( button.dataset.action ) {
+      case "convertCurrency":
+        return Dialog.confirm({
+          title: `${game.i18n.localize("DND5E.CurrencyConvert")}`,
+          content: `<p>${game.i18n.localize("DND5E.CurrencyConvertHint")}</p>`,
+          yes: () => this.actor.convertCurrency()
+        });
+    }
   }
 
   /* -------------------------------------------- */

--- a/templates/actors/parts/actor-features.hbs
+++ b/templates/actors/parts/actor-features.hbs
@@ -1,5 +1,19 @@
 {{#unless isVehicle}}
 <div class="inventory-filters flexrow">
+    <ol class="currency flexrow">
+        <h3>
+            {{localize "DND5E.Currency"}}
+            <a class="action-button currency-convert {{rollableClass}}" data-action="convertCurrency"
+               data-tooltip="DND5E.CurrencyConvert">
+                <i class="fas fa-coins"></i>
+            </a>
+        </h3>
+        {{#each system.currency as |v k|}}
+        <label class="denomination {{k}}">{{ lookup ../labels.currencies k }}</label>
+        <input type="text" name="system.currency.{{k}}" value="{{v}}" data-dtype="Number">
+        {{/each}}
+    </ol>
+
     <ul class="filter-list flexrow" data-filter="features">
         <li class="filter-item" data-filter="action">{{localize "DND5E.Action"}}</li>
         <li class="filter-item" data-filter="bonus">{{localize "DND5E.BonusAction"}}</li>

--- a/templates/actors/parts/actor-features.hbs
+++ b/templates/actors/parts/actor-features.hbs
@@ -1,5 +1,6 @@
 {{#unless isVehicle}}
 <div class="inventory-filters flexrow">
+    {{#if isNPC}}
     <ol class="currency flexrow">
         <h3>
             {{localize "DND5E.Currency"}}
@@ -13,6 +14,7 @@
         <input type="text" name="system.currency.{{k}}" value="{{v}}" data-dtype="Number">
         {{/each}}
     </ol>
+    {{/if}}
 
     <ul class="filter-list flexrow" data-filter="features">
         <li class="filter-item" data-filter="action">{{localize "DND5E.Action"}}</li>


### PR DESCRIPTION
Closes https://github.com/foundryvtt/dnd5e/issues/2247

Display the currencies of the NPCs in the sheet instead of having to manually check the model.

![image](https://user-images.githubusercontent.com/20903647/224560936-5ee4d3f3-5be8-4bab-a29f-7d48f0e60fd2.png)

The minimum width of the sheet had to be increased a bit to avoid tinkering with the currencies styles.