### PR TITLE
RAW See Invisibility detection mode

### DIFF
--- a/module/canvas/_module.mjs
+++ b/module/canvas/_module.mjs
@@ -1,3 +1,4 @@
 export {default as AbilityTemplate} from "./ability-template.mjs";
+export * from "./detection-mode.mjs";
 export {default as Token5e} from "./token.mjs";
 export {measureDistances} from "./grid.mjs";

--- a/module/canvas/detection-mode.mjs
+++ b/module/canvas/detection-mode.mjs
@@ -1,0 +1,158 @@
+/**
+ * The detection mode for See Invisibility.
+ */
+export class DetectionModeSeeInvisibility extends DetectionMode {
+  constructor() {
+    super({
+      id: "seeInvisibility",
+      label: "DETECTION.SeeInvisibility",
+      type: DetectionMode.DETECTION_TYPES.SIGHT,
+      walls: false
+    });
+  }
+
+  /** @override */
+  static getDetectionFilter() {
+    return this._detectionFilter ??= GlowOverlayFilter.create({
+      glowColor: [0, 0.60, 0.33, 1]
+    });
+  }
+
+  /** @override */
+  _canDetect(visionSource, target) {
+    // Only invisible tokens can be detected.
+    return target instanceof Token && target.document.hasStatusEffect(CONFIG.specialStatusEffects.INVISIBLE);
+  }
+
+  /** @override */
+  _testPoint(visionSource, mode, target, test) {
+    if (!super._testPoint(visionSource, mode, target, test)) {
+      return false;
+    }
+
+    const visionSources = this.#removeOtherVisionSources(visionSource);
+    const detectionsModes = this.#removeNonSightDetectionModes(visionSource);
+    const activeEffects = this.#removeInvisibleStatusEffects(target);
+
+    // Test whether this vision source sees the target without the invisible status effect.
+    const isVisible = canvas.effects.visibility.testVisibility(test.point, { tolerance: 0, object: target });
+
+    this.#restoreOtherVisionSources(visionSources);
+    this.#restoreNonSightDetectionModes(visionSource, detectionsModes);
+    this.#restoreInvisibleStatusEffects(target, activeEffects);
+
+    return isVisible;
+  }
+
+  /**
+   * Temporarily remove other vision sources.
+   * @param {VisionSource} visionSource             The vision source.
+   * @returns {Collection<string, VisionSource>}    The vision sources that need to be restored later.
+   */
+  #removeOtherVisionSources(visionSource) {
+    const visionSources = canvas.effects.visionSources;
+
+    canvas.effects.visionSources = new foundry.utils.Collection();
+    canvas.effects.visionSources.set("", visionSource);
+
+    return visionSources;
+  }
+
+  /**
+   * Restore the vision sources.
+   * @param {Collection<string, VisionSource>} visionSources    The vision sources that need to be restored.
+   */
+  #restoreOtherVisionSources(visionSources) {
+    canvas.effects.visionSources = visionSources;
+  }
+
+  /**
+   * Temporarily remove all detection modes that are not sight-based from the source token.
+   * @param {VisionSource} visionSource      The vision source.
+   * @returns {TokenDetectionMode[]|null}    The detection modes that need to be restored later.
+   */
+  #removeNonSightDetectionModes(visionSource) {
+    const object = visionSource.object;
+    let detectionModes = null;
+
+    if (object instanceof Token) {
+      const document = object.document;
+
+      detectionModes = document.detectionModes;
+      document.detectionModes = detectionModes.filter(
+        m => CONFIG.Canvas.detectionModes[m.id]?.type === DetectionMode.DETECTION_TYPES.SIGHT
+      );
+    }
+
+    return detectionModes;
+  }
+
+  /**
+   * Restore the detection modes.
+   * @param {VisionSource} visionSource                   The vision source.
+   * @param {TokenDetectionMode[]|null} detectionModes    The detection modes that need to be restored.
+   */
+  #restoreNonSightDetectionModes(visionSource, detectionModes) {
+    if (detectionModes) {
+      visionSource.object.document.detectionModes = detectionModes;
+    }
+  }
+
+  /**
+   * Temporarily remove the invisible status effects from the target token.
+   * @param {Token} target                 The target token.
+   * @returns {ActiveEffect[]|string[]}    The effects that need to be restored later.
+   */
+  #removeInvisibleStatusEffects(target) {
+    const document = target.document;
+    const statusId = CONFIG.specialStatusEffects.INVISIBLE;
+    let effects;
+
+    // See TokenDocument.hasStatusEffect
+    if (!document.actor) {
+      const icon = CONFIG.statusEffects.find(e => e.id === statusId)?.icon;
+
+      effects = document.effects;
+      document.effects = effects.filter(e => e !== icon);
+    } else if (foundry.utils.isNewerVersion(game.version, 11)) {
+      effects = document.actor.effects.filter(e => e.statuses.has(statusId));
+
+      for (const effect of effects) {
+        effect.statuses.delete(statusId);
+      }
+    } else {
+      effects = document.actor.effects.filter(e => !e.disabled && e.getFlag("core", "statusId") === statusId);
+
+      for (const effect of effects) {
+        effect.disabled = true;
+      }
+    }
+
+    return effects;
+  }
+
+  /**
+   * Restore the status effects.
+   * @param {Token} target                       The target token.
+   * @param {ActiveEffect[]|string[]} effects    The effects that need to be restored.
+   */
+  #restoreInvisibleStatusEffects(target, effects) {
+    const document = target.document;
+
+    if (!document.actor) {
+      document.effects = effects;
+    } else if (foundry.utils.isNewerVersion(game.version, 11)) {
+      const statusId = CONFIG.specialStatusEffects.INVISIBLE;
+
+      for (const effect of effects) {
+        effect.statuses.add(statusId);
+      }
+    } else {
+      for (const effect of effects) {
+        effect.disabled = false;
+      }
+    }
+  }
+}
+
+CONFIG.Canvas.detectionModes.seeInvisibility = new DetectionModeSeeInvisibility();


### PR DESCRIPTION
Core's See Invisibility detection mode is not RAW (or RAI). See Invisibility does not allow you to see an invisible creature or object that you wouldn't be able to see if the creature or object wasn't invisible. But core's See Invisibility allows that: for example, a token with 0 vision range and no other detection modes other than See Invisibility can see an invisible token in complete darkness provided vision is not obstructed by walls. See Invisibility cannot detect anything on its own. It just suppresses (the first bullet point of) the invisible condition and requires another sense to see the creature or object.

The proposed detection mode test whether this vision source sees the target without the invisible status effect.
1. All vision modes except this vision source are temporarily removed. If there's more than one active vision source and one of them has See Invisibility and the other does not, the vision source with See Invisibility must not make the other vision source see invisible tokens. That's why we need to remove all but this vision source.
2. Non-sight-based detection modes are temporarily removed. Non-sight-based detection modes ignore the invisible condition anyway. If we didn't remove the non-sight-based detection modes, then the invisible target might end up with the wrong detection filter: the See Invisibility detection filter, when in reality the invisible token was detected by Feel Tremor, which of course doesn't need See Invisibility to detect it.
3. The invisible status is removed temporarily, such that `hasStatusEffect(CONFIG.specialStatusEffects.INVISIBLE)` returns false.
4. Visibility is tested.
5. The original state is restored.