### PR TITLE
Fix deprecation warning on tool item sheets.

### DIFF
--- a/templates/items/tool.hbs
+++ b/templates/items/tool.hbs
@@ -84,7 +84,7 @@
             <div class="form-group">
                 <label>{{ localize "DND5E.DefaultAbilityCheck" }}</label>
                 <select name="system.ability">
-                    {{selectOptions config.abilities selected=system.ability blank=(localize "DND5E.Default")}}
+                    {{selectOptions config.abilities selected=system.ability labelAttr="label" blank=(localize "DND5E.Default")}}
                 </select>
             </div>
 


### PR DESCRIPTION
Set label attribute to be the label attribute.

Closes #2298.