### PR TITLE
Don't add init bonus if it is at all falsy

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1523,7 +1523,7 @@ export default class Actor5e extends Actor {
         parts.push("@prof");
         data.prof = init.prof.term;
       }
-      if ( init.bonus !== 0 ) {
+      if ( init.bonus ) {
         parts.push("@bonus");
         data.bonus = init.bonus;
       }


### PR DESCRIPTION
Closes #2277.

Before and after, with an empty string init bonus:

![image](https://github.com/foundryvtt/dnd5e/assets/50169243/97fdbd17-f622-4a3b-aae2-30f771111bb1)
