### PR TITLE
Set feature items on NPCs as 'Monster Feature' by default

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1901,6 +1901,9 @@ export default class Item5e extends Item {
       case "weapon":
         updates = this._onCreateOwnedWeapon(data, isNPC);
         break;
+      case "feat":
+        updates = this._onCreateOwnedFeature(data, isNPC);
+        break;
     }
     if ( updates ) return this.updateSource(updates);
   }
@@ -2057,6 +2060,21 @@ export default class Item5e extends Item {
     else {
       const actorProfs = this.parent.system.traits?.weaponProf?.value || new Set();
       updates["system.proficient"] = actorProfs.has(weaponProf) || actorProfs.has(this.system.baseItem);
+    }
+    return updates;
+  }
+
+  /**
+   * Pre-creation logic for the automatic configuration of owned feature type Items.
+   * @param {object} data       Data for the newly created item.
+   * @param {boolean} isNPC     Is this actor an NPC?
+   * @returns {object}          Updates to apply to the item data.
+   * @private
+   */
+  _onCreateOwnedFeature(data, isNPC) {
+    const updates = {};
+    if ( isNPC && !foundry.utils.getProperty(data, "system.type.value") ) {
+      updates["system.type.value"] = "monster"; // Set features on NPCs to be 'monster features'.
     }
     return updates;
   }


### PR DESCRIPTION
This adds a `preCreate` method for feature type items on npc sheets such that the items dropped or created are set to "Monster Feature" unless a feature type already exists on the item data.

Closes #2067.