### PR TITLE
Attunement tracker on character sheet

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -1126,6 +1126,15 @@ h5 {
   flex: 0 0 20px;
   justify-content: flex-end;
 }
+.dnd5e.sheet.actor .inventory-filters .attunement {
+  color: #7a7971;
+  font-size: 12px;
+}
+.dnd5e.sheet.actor .inventory-filters .attunement [name="system.attributes.attunement.max"] {
+  display: inline;
+  max-width: 23px;
+  text-align: center;
+}
 .dnd5e.sheet.actor .inventory-filters .currency {
   flex: 0 0 100%;
   list-style: none;

--- a/lang/en.json
+++ b/lang/en.json
@@ -252,6 +252,7 @@
 "DND5E.AttunementNone": "Attunement Not Required",
 "DND5E.AttunementRequired": "Attunement Required",
 "DND5E.AttunementAttuned": "Attuned",
+"DND5E.AttunementOverride": "Override attunement",
 "DND5E.Attuned": "Attuned",
 "DND5E.Armor": "Armor",
 "DND5E.ArmorClass": "Armor Class",

--- a/less/actors.less
+++ b/less/actors.less
@@ -485,6 +485,17 @@
     flex: 0 0 20px;
     justify-content: flex-end;
 
+    .attunement {
+      color: #7a7971;
+      font-size: 12px;
+
+      [name="system.attributes.attunement.max"] {
+        display: inline;
+        max-width: 23px;
+        text-align: center;
+      }
+    }
+
     .currency {
       flex: 0 0 100%;
       list-style: none;

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1143,7 +1143,7 @@ export default class ActorSheet5e extends ActorSheet {
     input.value = override;
     input.placeholder = span.dataset.slots;
     input.dataset.dtype = "Number";
-    input.addEventListener("focus", (event) => event.currentTarget.select());
+    input.addEventListener("focus", event => event.currentTarget.select());
 
     // Replace the HTML
     const parent = span.parentElement;
@@ -1166,7 +1166,7 @@ export default class ActorSheet5e extends ActorSheet {
     input.value = this.actor.system.attributes.attunement.max;
     input.placeholder = 3;
     input.dataset.dtype = "Number";
-    input.addEventListener("focus", (event) => event.currentTarget.select());
+    input.addEventListener("focus", event => event.currentTarget.select());
 
     // Replace the HTML
     const parent = span.parentElement;

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1143,6 +1143,7 @@ export default class ActorSheet5e extends ActorSheet {
     input.value = override;
     input.placeholder = span.dataset.slots;
     input.dataset.dtype = "Number";
+    input.addEventListener("focus", (event) => event.currentTarget.select());
 
     // Replace the HTML
     const parent = span.parentElement;
@@ -1165,6 +1166,7 @@ export default class ActorSheet5e extends ActorSheet {
     input.value = this.actor.system.attributes.attunement.max;
     input.placeholder = 3;
     input.dataset.dtype = "Number";
+    input.addEventListener("focus", (event) => event.currentTarget.select());
 
     // Replace the HTML
     const parent = span.parentElement;

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -694,9 +694,7 @@ export default class ActorSheet5e extends ActorSheet {
       tool: /system\.tools\.([^.]+)\.value/
     };
 
-    const overrides = Object.keys(foundry.utils.flattenObject(this.actor.overrides));
-
-    for ( const override of overrides ) {
+    for ( const override of Object.keys(foundry.utils.flattenObject(this.actor.overrides)) ) {
       html.find(`input[name="${override}"],select[name="${override}"]`).each((i, el) => {
         el.disabled = true;
         el.dataset.tooltip = "DND5E.ActiveEffectOverrideWarning";
@@ -714,10 +712,6 @@ export default class ActorSheet5e extends ActorSheet {
       const [, spell] = override.match(/system\.spells\.(spell\d)\.override/) || [];
       if ( spell ) {
         html.find(`.spell-max[data-level="${spell}"]`).attr("data-tooltip", "DND5E.ActiveEffectOverrideWarning");
-      }
-
-      if( overrides.includes("system.attributes.attunement.max") ) {
-        html[0].querySelector(".attunement-max")?.setAttribute("data-tooltip", "DND5E.ActiveEffectOverrideWarning");
       }
     }
   }

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -14,6 +14,20 @@
         {{/each}}
     </ol>
     {{/unless}}
+    {{#if isCharacter}}
+    <div class="attunement">
+      <label>{{localize "DND5E.Attunement"}}</label>
+      <span class="attunement-value">{{system.attributes.attunement.value}}</span>
+      <span class="sep"> / </span>
+      <span class="attunement-max">{{system.attributes.attunement.max}}
+        {{#unless (or overrides.attunement (not editable))}}
+        <a class="attunement-max-override" data-tooltip="{{localize 'DND5E.AttunementOverride'}}">
+          <i class="fa-solid fa-edit"></i>
+        </a>
+        {{/unless}}
+      </span>
+    </div>
+    {{/if}}
 
     {{#if inventoryFilters}}
     <ul class="filter-list flexrow" data-filter="inventory">

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -22,7 +22,7 @@
       <span class="attunement-max" {{#if overrides.attunement}}data-tooltip="DND5E.ActiveEffectOverrideWarning"{{/if}}>
         {{system.attributes.attunement.max}}
         {{#unless (or overrides.attunement (not editable))}}
-        <a class="attunement-max-override" data-tooltip="{{localize 'DND5E.AttunementOverride'}}">
+        <a class="attunement-max-override" data-tooltip="DND5E.AttunementOverride">
           <i class="fa-solid fa-edit"></i>
         </a>
         {{/unless}}

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -19,7 +19,8 @@
       <label>{{localize "DND5E.Attunement"}}</label>
       <span class="attunement-value">{{system.attributes.attunement.value}}</span>
       <span class="sep"> / </span>
-      <span class="attunement-max">{{system.attributes.attunement.max}}
+      <span class="attunement-max" {{#if overrides.attunement}}data-tooltip="DND5E.ActiveEffectOverrideWarning"{{/if}}>
+        {{system.attributes.attunement.max}}
         {{#unless (or overrides.attunement (not editable))}}
         <a class="attunement-max-override" data-tooltip="{{localize 'DND5E.AttunementOverride'}}">
           <i class="fa-solid fa-edit"></i>


### PR DESCRIPTION
This adds a smol attunement tracker on the character sheet under Inventory.

It is displayed in the same fashion as spell slot overrides, and should work with active effects overriding it (removing the edit icon).

[att.webm](https://github.com/foundryvtt/dnd5e/assets/50169243/3d8127f1-210d-4401-8bce-e57adb329324)

Closes #1309.