### PR TITLE
Add `magical` field to `PhysicalItemTemplate`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -780,6 +780,7 @@
 "DND5E.LongRestResultHitDice": "{name} takes a long rest and recovers {dice} Hit Dice.",
 "DND5E.LongRestResultHitPoints": "{name} takes a long rest and recovers {health} Hit Points.",
 "DND5E.LongRestResultShort": "{name} takes a long rest.",
+"DND5E.Magical": "Magical",
 "DND5E.Max": "Max",
 "DND5E.MaxCharacterLevelExceededWarn": "Character cannot be advanced past level {max}.",
 "DND5E.MaxClassLevelExceededWarn": "Class cannot be advanced past level {max}.",

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -7,6 +7,7 @@
  * @property {number} price.value         Item's cost in the specified denomination.
  * @property {string} price.denomination  Currency denomination used to determine price.
  * @property {string} rarity              Item rarity as defined in `DND5E.itemRarity`.
+ * @property {boolean} magical            Is this item magical?
  * @property {boolean} identified         Has this item been identified?
  * @mixin
  */
@@ -29,6 +30,7 @@ export default class PhysicalItemTemplate extends foundry.abstract.DataModel {
         })
       }, {label: "DND5E.Price"}),
       rarity: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.Rarity"}),
+      magical: new foundry.data.fields.BooleanField({required: true, initial: d => !!d.system?.rarity, label: "DND5E.Magical"}),
       identified: new foundry.data.fields.BooleanField({required: true, initial: true, label: "DND5E.Identified"})
     };
   }


### PR DESCRIPTION
By RAW only magic items have a rarity. So technically magic items are those items that have a rarity and mundane items are those that do not. But that is unreliable, because some people use rarity for mundane items or rule that common magic items are nonmagical.