### PR TITLE
Pack Folders - Heroes location correction

### DIFF
--- a/system.json
+++ b/system.json
@@ -152,7 +152,7 @@
         "tables",
         "heroes"
       ],
-      "folders":[
+      "folders": [
         {
           "name": "Character Features",
           "sorting": "m",
@@ -162,8 +162,7 @@
             "subclasses",
             "classfeatures",
             "backgrounds",
-            "races",
-            "heroes"
+            "races"
           ]
         },
         {


### PR DESCRIPTION
Remove second instance of "heroes" from the pack folder structure. Put in a missing space for Zhell.

Closes #2406 