### PR TITLE
[#2408] Gray text and no box shadow on `readonly` advancement inputs

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -1394,6 +1394,12 @@ h5 {
 .dnd5e.advancement select {
   height: var(--form-field-height);
 }
+.dnd5e.advancement input[type="text"][readonly],
+.dnd5e.advancement input[type="number"][readonly],
+.dnd5e.advancement select[readonly] {
+  color: var(--color-text-dark-6);
+  box-shadow: none;
+}
 .dnd5e.advancement .form-group .form-fields button {
   flex: 0;
 }

--- a/less/advancement.less
+++ b/less/advancement.less
@@ -1,6 +1,10 @@
 .dnd5e.advancement {
   input[type="text"], input[type="number"], select {
     height: var(--form-field-height);
+    &[readonly] {
+      color: var(--color-text-dark-6);
+      box-shadow: none;
+    }
   }
   .form-group .form-fields button {
     flex: 0;


### PR DESCRIPTION
Just a small quality-of-life visual change.

Closes #2408