### PR TITLE
[#2404] Ignore honor and sanity for ability score improvements

### DIFF
--- a/module/applications/advancement/ability-score-improvement-config.mjs
+++ b/module/applications/advancement/ability-score-improvement-config.mjs
@@ -17,6 +17,7 @@ export default class AbilityScoreImprovementConfig extends AdvancementConfig {
   /** @inheritdoc */
   getData() {
     const abilities = Object.entries(CONFIG.DND5E.abilities).reduce((obj, [key, data]) => {
+      if ( data.improvement === false ) return obj;
       const fixed = this.advancement.configuration.fixed[key] ?? 0;
       obj[key] = {
         key,

--- a/module/applications/advancement/ability-score-improvement-config.mjs
+++ b/module/applications/advancement/ability-score-improvement-config.mjs
@@ -17,7 +17,7 @@ export default class AbilityScoreImprovementConfig extends AdvancementConfig {
   /** @inheritdoc */
   getData() {
     const abilities = Object.entries(CONFIG.DND5E.abilities).reduce((obj, [key, data]) => {
-      if ( data.improvement === false ) return obj;
+      if ( !this.advancement.canImprove(key) ) return obj;
       const fixed = this.advancement.configuration.fixed[key] ?? 0;
       obj[key] = {
         key,

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -44,7 +44,8 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
   /** @inheritdoc */
   async getData() {
     const points = {
-      assigned: Object.keys(CONFIG.DND5E.abilities).reduce((assigned, key) => {
+      assigned: Object.entries(CONFIG.DND5E.abilities).reduce((assigned, [key, data]) => {
+          if ( data.improvement === false ) return assigned;
           return assigned + (this.advancement.configuration.fixed[key] ?? 0) + (this.assignments[key] ?? 0);
       }, 0),
       total: this.advancement.points.total
@@ -54,6 +55,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
     const formatter = new Intl.NumberFormat(game.i18n.lang, { signDisplay: "always" });
 
     const abilities = Object.entries(CONFIG.DND5E.abilities).reduce((obj, [key, data]) => {
+      if ( data.improvement === false ) return obj;
       const ability = this.advancement.actor.system.abilities[key];
       const fixed = this.advancement.configuration.fixed[key] ?? 0;
       const value = Math.min(ability.value + ((fixed || this.assignments[key]) ?? 0), ability.max);

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -44,8 +44,8 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
   /** @inheritdoc */
   async getData() {
     const points = {
-      assigned: Object.entries(CONFIG.DND5E.abilities).reduce((assigned, [key, data]) => {
-          if ( data.improvement === false ) return assigned;
+      assigned: Object.keys(CONFIG.DND5E.abilities).reduce((assigned, key) => {
+          if ( !this.advancement.canImprove(key) ) return assigned;
           return assigned + (this.advancement.configuration.fixed[key] ?? 0) + (this.assignments[key] ?? 0);
       }, 0),
       total: this.advancement.points.total
@@ -55,7 +55,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
     const formatter = new Intl.NumberFormat(game.i18n.lang, { signDisplay: "always" });
 
     const abilities = Object.entries(CONFIG.DND5E.abilities).reduce((obj, [key, data]) => {
-      if ( data.improvement === false ) return obj;
+      if ( !this.advancement.canImprove(key) ) return obj;
       const ability = this.advancement.actor.system.abilities[key];
       const fixed = this.advancement.configuration.fixed[key] ?? 0;
       const value = Math.min(ability.value + ((fixed || this.assignments[key]) ?? 0), ability.max);

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -68,13 +68,15 @@ DND5E.abilities = {
     label: "DND5E.AbilityHon",
     abbreviation: "DND5E.AbilityHonAbbr",
     type: "mental",
-    defaults: { npc: "cha", vehicle: 0 }
+    defaults: { npc: "cha", vehicle: 0 },
+    improvement: false
   },
   san: {
     label: "DND5E.AbilitySan",
     abbreviation: "DND5E.AbilitySanAbbr",
     type: "mental",
-    defaults: { npc: "wis", vehicle: 0 }
+    defaults: { npc: "wis", vehicle: 0 },
+    improvement: false
   }
 };
 preLocalize("abilities", { keys: ["label", "abbreviation"] });


### PR DESCRIPTION
This adds `improvement` to entries in `CONFIG.DND5E.abilities` which, when explicitly `false`, should entirely ignore the given ability for the purpose of Ability Score Improvement advancements.

Closes #2404