### PR TITLE
[#1668] Allow for `.item-properties` to scroll

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -1706,9 +1706,11 @@ h5 {
 }
 .dnd5e.sheet.item .sheet-body .item-properties {
   flex: 0 0 120px;
-  margin: 5px 5px 5px 0;
-  padding-right: 5px;
+  margin: 0 5px 0 0;
+  padding: 5px 5px 0 0;
   border-right: 2px groove #eeede0;
+  overflow: hidden auto;
+  height: 100%;
 }
 .dnd5e.sheet.item .sheet-body .item-properties .form-group {
   margin: 0;

--- a/less/items.less
+++ b/less/items.less
@@ -60,9 +60,11 @@
 
     .item-properties {
       flex: 0 0 120px;
-      margin: 5px 5px 5px 0;
-      padding-right: 5px;
+      margin: 0 5px 0 0;
+      padding: 5px 5px 0 0;
       border-right: @borderGroove;
+      overflow: hidden auto;
+      height: 100%;
 
       .form-group {
         margin: 0;

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -27,7 +27,7 @@ export default class ItemSheet5e extends ItemSheet {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       width: 560,
-      height: 400,
+      height: 500,
       classes: ["dnd5e", "sheet", "item"],
       resizable: true,
       scrollY: [".tab.details"],


### PR DESCRIPTION
Also increases the base height of item sheets to 500px, up from 400px, to accommodate a common amount of item properties in that section.

Closes #1668