### PR TITLE
[#2420] Add proficiency bonus to features', consumables, and improvised weapons' attack rolls, and implement 'Tavern Brawler' feat in Special Traits

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -620,6 +620,8 @@
 "DND5E.FlagsJOATHint": "Half-Proficiency to Ability Checks in which you are not already Proficient.",
 "DND5E.FlagsObservant": "Observant Feat",
 "DND5E.FlagsObservantHint": "Provides a +5 to passive Perception and Investigation.",
+"DND5E.FlagsTavernBrawler": "Tavern Brawler Feat",
+"DND5E.FlagsTavernBrawlerHint": "Proficient with improvised weapons.",
 "DND5E.FlagsReliableTalent": "Reliable Talent",
 "DND5E.FlagsReliableTalentHint": "Rogues Reliable Talent Feature.",
 "DND5E.FlagsRemarkableAthlete": "Remarkable Athlete.",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -198,7 +198,6 @@ preLocalize("weaponProficiencies");
  * @enum {(boolean|string)}
  */
 DND5E.weaponProficienciesMap = {
-  natural: true,
   simpleM: "sim",
   simpleR: "sim",
   martialM: "mar",
@@ -1822,6 +1821,12 @@ DND5E.characterFlags = {
     name: "DND5E.FlagsObservant",
     hint: "DND5E.FlagsObservantHint",
     skills: ["prc", "inv"],
+    section: "DND5E.Feats",
+    type: Boolean
+  },
+  tavernBrawlerFeat: {
+    name: "DND5E.FlagsTavernBrawler",
+    hint: "DND5E.FlagsTavernBrawlerHint",
     section: "DND5E.Feats",
     type: Boolean
   },

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -58,4 +58,15 @@ export default class ConsumableData extends SystemDataModel.mixin(
     if ( this.consumableType !== "scroll" ) return null;
     return this.parent?.actor?.system.attributes.spellcasting || "int";
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The proficiency multiplier for this item.
+   * @returns {number}
+   */
+  get proficiencyMultiplier() {
+    const isProficient = this.parent?.actor?.getFlag("dnd5e", "tavernBrawlerFeat");
+    return isProficient ? 1 : 0;
+  }
 }

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -91,4 +91,14 @@ export default class FeatData extends SystemDataModel.mixin(
   get hasLimitedUses() {
     return !!this.recharge.value || super.hasLimitedUses;
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The proficiency multiplier for this item.
+   * @returns {number}
+   */
+  get proficiencyMultiplier() {
+    return 1;
+  }
 }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -144,7 +144,9 @@ export default class WeaponData extends SystemDataModel.mixin(
     const config = CONFIG.DND5E.weaponProficienciesMap;
     const itemProf = config[this.weaponType];
     const actorProfs = actor.system.traits?.weaponProf?.value ?? new Set();
-    const isProficient = (itemProf === true) || actorProfs.has(itemProf) || actorProfs.has(this.baseItem);
+    const natural = this.weaponType === "natural";
+    const improvised = (this.weaponType === "improv") && !!actor.getFlag("dnd5e", "tavernBrawlerFeat");
+    const isProficient = natural || improvised || actorProfs.has(itemProf) || actorProfs.has(this.baseItem);
     return Number(isProficient);
   }
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -475,7 +475,7 @@ export default class Item5e extends Item {
    * @protected
    */
   _prepareProficiency() {
-    if ( !["spell", "weapon", "equipment", "tool", "feat"].includes(this.type) ) return;
+    if ( !["spell", "weapon", "equipment", "tool", "feat", "consumable"].includes(this.type) ) return;
     if ( !this.actor?.system.attributes?.prof ) {
       this.system.prof = new Proficiency(0, 0);
       return;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -475,7 +475,7 @@ export default class Item5e extends Item {
    * @protected
    */
   _prepareProficiency() {
-    if ( !["spell", "weapon", "equipment", "tool"].includes(this.type) ) return;
+    if ( !["spell", "weapon", "equipment", "tool", "feat"].includes(this.type) ) return;
     if ( !this.actor?.system.attributes?.prof ) {
       this.system.prof = new Proficiency(0, 0);
       return;


### PR DESCRIPTION
This re-implements the PB for attack rolls with feature-type items, which are treated as always proficient.

Additionally, the 'Tavern Brawler' feat is added in Special Traits. When checked, the actor is considered proficient with attack rolls of consumable items and weapons that are set as 'Improvised' (unless the item is set to 'not proficient').

Lastly, the 'Natural' weapon type is removed from the CONFIG weapon proficiency mapping and placed inside the same proficiency getter in the weapon data, where it will always be treated as proficient (again unless set as 'not proficient').

Closes #2420
Closes #2439 