### PR TITLE
Add more detail to formula simplification failure warning message

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -540,7 +540,8 @@ export default class Item5e extends Item {
         formula = simplifyRollFormula(roll.formula, { preserveFlavor: true });
       }
       catch(err) {
-        console.warn(`Unable to simplify formula for ${this.name}: ${err}`);
+        const parentInfo = this.parent ? ` on ${this.parent.name} (${this.parent.id})` : '';
+        console.warn(`Unable to simplify formula for ${this.name} (${this.id})${parentInfo}`, err);
       }
       const damageType = damagePart[1];
       return { formula, damageType, label: `${formula} ${damageLabels[damageType] ?? ""}` };


### PR DESCRIPTION
This adds the item ID and the parent name and ID to the warning message output in the console when the formula simplification fails for an item, and also provides the full error object rather than just the message. The motivation behind this is to make it much easier to identify the source of this warning.