### PR TITLE
[#2442] Adjust look of trait selectors to always show submit buttons

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -547,6 +547,19 @@ h5 {
 /* ----------------------------------------- */
 /* Trait Selector
 /* ----------------------------------------- */
+.trait-selector {
+  max-height: 700px;
+}
+.trait-selector form {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.trait-selector form > .trait-list {
+  overflow: auto;
+  border-bottom: 2px groove;
+  margin-bottom: 0.5em;
+}
 .trait-selector .trait-list {
   list-style: none;
   margin: 0;

--- a/dnd5e.css
+++ b/dnd5e.css
@@ -557,8 +557,7 @@ h5 {
 }
 .trait-selector form > .trait-list {
   overflow: auto;
-  border-bottom: 2px groove;
-  margin-bottom: 0.5em;
+  border-bottom: 2px groove #eeede0;
 }
 .trait-selector .trait-list {
   list-style: none;

--- a/less/apps.less
+++ b/less/apps.less
@@ -541,6 +541,20 @@ h5 {
 /* ----------------------------------------- */
 
 .trait-selector {
+  max-height: 700px;
+
+  form {
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    >.trait-list {
+      overflow: auto;
+      border-bottom: 2px groove;
+      margin-bottom: 0.5em;
+    }
+  }
+
   .trait-list {
     list-style: none;
     margin: 0;

--- a/less/apps.less
+++ b/less/apps.less
@@ -548,10 +548,9 @@ h5 {
     display: flex;
     flex-direction: column;
 
-    >.trait-list {
+    > .trait-list {
       overflow: auto;
-      border-bottom: 2px groove;
-      margin-bottom: 0.5em;
+      border-bottom: @borderGroove;
     }
   }
 

--- a/templates/apps/trait-selector.hbs
+++ b/templates/apps/trait-selector.hbs
@@ -4,7 +4,9 @@
     {{#if customPath}}
         <div class="form-group stacked">
             <label>{{localize "DND5E.TraitSelectorSpecial"}}</label>
-            <input type="text" name="{{customPath}}" value="{{custom}}">
+            <div class="form-fields">
+                <input type="text" name="{{customPath}}" value="{{custom}}">
+            </div>
         </div>
     {{/if}}
 


### PR DESCRIPTION
Just a smol change for ease of use

Closes #2442

https://github.com/foundryvtt/dnd5e/assets/50169243/611c6f39-7d7d-45cb-afeb-b9b2bd277a5c

