### PR TITLE
Calego's AE guide

### DIFF
--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -232,7 +232,7 @@ E.g. An Item or Spell which sets the Actor's AC to `12 + Int` for the duration.
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.attributes.ac.calc`     | Override     | `custom`     |
-| `system.attributes.ac.formula`     | Custom     | `12 + @abilities.int.mod`     |
+| `system.attributes.ac.formula`     | Override     | `12 + @abilities.int.mod`     |
 
 ---
 

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -1,0 +1,410 @@
+# FoundryVTT dnd5e Active Effects Examples
+###### tags: `active-effects`
+
+![Up to date as of 2.1.x](https://img.shields.io/badge/dnd5e-v2.1.x-informational)
+
+See [Kandashi's Active Effects Guide](https://docs.google.com/document/d/1DuZaIFVq0YulDOvpahrfhZ6dK7LuclIRlGOtT0BIYEo) for a trove of useful information
+
+This document only covers Active Effects available to the Core dnd5e System.
+
+### Legend
+
+`[number]`
+
+These square brakets mean "replace this with your value of the type within the brackets".
+
+So this example: `+[number]` would mean you input `+3`.
+
+`[formula]`
+When `formula` is mentioned in this document it means this value can be populated with any dice formula. For example, Bless adds several effects with the Effect Value of `1d4`.
+
+
+As part of this, an Actor's Rolldata is available as ["@attributes."](https://github.com/foundryvtt/dnd5e/wiki/Roll-Formulas) Useful examples:
+
+| @attribute                 | Description                   |
+| -------------------------- | ----------------------------- |
+| `@abilities.dex.mod`       | Actor's Dexterity Modifier    |
+| `@prof`                    | Actor's Proficiency Bonus     |
+| `@details.level`           | Actor's overall Level         |
+| `@classes.barbarian.levels` | Actor's Barbarian Class Level |
+
+> [!NOTE]
+> Note that when using formulas in an Active Effect Value, the actor sheet display that corresponds to the changed value will not display the evaluated formula, but it will be applied when rolled.
+> E.g. When adding `@abilities.cha.mod` to `system.bonuses.abilities.save` to simulate a Paladin's Aura of Protection, the actor sheet will not display that bonus applied to saving throws. The bonus will be present when the saving throw is rolled.
+
+To find out more about these, this post from Unsoluble in the [FoundryVTT Discord server](https://discord.gg/foundryvtt)'s #core-how-to channel can help:
+
+> To explore the data model in order to refer to inline properties like character levels, attributes, and other values, here are a few approaches:
+>
+> • Select a token, then open up the dev tools (F12 on Win; ⌥⌘I on Mac), and paste this into the Console:
+`console.log(canvas.tokens.controlled[0].actor.getRollData());`
+>
+> • Or: Install the "Autocomplete Inline Properties" module, to be able to just start typing in a supported field and have the available properties pop up (not all systems supported yet).
+>
+> • Or: Install this module (by pasting this manifest URL into the bottom of the Install Module window), enable it in your world, find and import its macro from the bundled Compendium, and run it on the selected token. `https://raw.githubusercontent.com/relick/FoundryVTT-Actor-Attribute-Lists/master/module.json`
+>
+> • Or: Right-click an actor in the sidebar and choose Export Data, which will get you a JSON file you can browse through. 
+
+
+## Commonly Desired Effect Examples
+
+### Abilities
+
+```
+system.abilities.[abbreviation].value
+                                bonuses.check
+                                        save
+```
+
+> [!NOTE]
+> <details>
+> <summary>Ability Abbreviations</summary>
+> 
+> | Ability      | Abbreviation |
+> | ------------ | ------------ |
+> | Strength     | `str`        |
+> | Dexterity    | `dex`        |
+> | Constitution | `con`        |
+> | Wisdom       | `wis`        |
+> | Intelligence | `int`        |
+> | Charisma     | `cha`        |
+> 
+> Source: `CONFIG.DND5E.abilities`
+>   
+> </details>
+
+
+#### Overriding an Ability Value
+E.g. an Item or potion that sets an ability score to a set value while in use
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.abilities.[abbreviation].value`     | Override     | `[number]`     |
+
+#### Bonus to a Specific Ability Save
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.abilities.[abbreviation].bonuses.save`     | Add     | `+[number/formula]`     |
+
+
+#### Bonus to a Specific Ability Check
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.abilities.[abbreviation].bonuses.check`     | Add     | `+[number/formula]`     |
+
+
+#### Bonus to All Ability Checks
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.bonuses.abilities.skill`     | Add     | `+[number/formula]`     |
+
+
+#### Bonus to All Ability Saves
+
+E.g. Paladin Aura of Protection
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.bonuses.abilities.save`     | Add     | `+[number/formula]`     |
+
+---
+
+### Skills
+```
+system.skills.[abbreviation].bonuses.check
+                                     passive
+```
+
+> [!NOTE]
+> <details>
+> <summary>Skill Abbreviations</summary>
+> 
+> | Skill           | Abbreviation |
+> | --------------- | ------------ |
+> | Acrobatics      | `acr`        |
+> | Animal Handling | `ani`        |
+> | Arcana          | `arc`        |
+> | Athletics       | `ath`        |
+> | Deception       | `dec`        |
+> | History         | `his`        |
+> | Insight         | `ins`        |
+> | Investigation   | `inv`        |
+> | Intimidation    | `itm`        |
+> | Medicine        | `med`        |
+> | Nature          | `nat`        |
+> | Persuasion      | `per`        |
+> | Perception      | `prc`        |
+> | Performance     | `prf`        |
+> | Religion        | `rel`        |
+> | Sleight of Hand | `slt`        |
+> | Stealth         | `ste`        |
+> | Survival        | `sur`        |
+> 
+> Source: `CONFIG.DND5E.skills`
+> </details>
+
+
+#### Bonus to a Specific Skill Check
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.skills.[abbreviation].bonuses.check`     | Add     | `+[number/formula]`     |
+
+#### Bonus to a Specific Skill Passive
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.skills.[abbreviation].bonuses.passive`     | Add     | `+[number/formula]`     |
+
+#### Bonus to All Skill Checks
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.bonuses.abilities.skill`     | Add     | `+[number/formula]`     |
+
+#### Bonus to Initiative
+
+Initiative is not quite a skill but behaves similarly.
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.attributes.init.bonus`     | Add     | `+[number/formula]`     |
+
+---
+
+### Movement
+
+```
+system.attributes.movement.[movementType]
+```
+
+> [!NOTE]
+> <details>
+> <summary>Movement Types</summary>
+> 
+> | Movement Type | Value    |
+> | ------------- | -------- |
+> | Burrow        | `burrow` |
+> | Climb         | `climb`  |
+> | Fly           | `fly`    |
+> | Swim          | `swim`   |
+> | Walk          | `walk`   |
+> 
+> Source: `CONFIG.DND5E.movementTypes`
+> </details>
+
+
+#### Multiply Speed by modifier
+E.g. An Item or Spell which doubles/halves/etc. an Actor's speed.
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.attributes.movement.[movementType]`     | Multiply     | `[number]`     |
+
+
+#### Add a different Speed
+E.g. An Item or Spell which grants an Actor a flying or swimming speed.
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.attributes.movement.[movementType]`     | Override     | `[number]`     |
+
+---
+
+### Armor Class
+
+```
+system.attributes.ac.bonus
+                     formula
+                     calc
+                     cover
+                     flat
+```
+
+#### Add a Bonus to AC
+
+E.g. An Item or Spell which adds to the Actor's current AC to something for the duration.
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.attributes.ac.bonus`     | Add     | `+[number]`     |
+
+
+
+#### Override the AC Calculation to a custom formula
+
+E.g. An Item or Spell which sets the Actor's AC to something like `12 + Int` for the duration.
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.attributes.ac.calc`     | Override     | `custom`     |
+| `system.attributes.ac.formula`     | Custom     | `10 + @abilities.str.mod`     |
+
+---
+
+### Attack Roll Bonuses
+
+```
+system.bonuses.msak.attack
+               mwak
+               rsak
+               rwak
+```
+
+> [!NOTE]
+> <details>
+> <summary>Attack Roll Types</summary>
+> 
+> | Movement Type        | Value  |
+> | -------------------- | ------ |
+> | Melee Spell attack   | `msak` |
+> | Melee Weapon attack  | `mwak` |
+> | Ranged Spell attack  | `rsak` |
+> | Ranged Weapon attack | `rwak` |
+> 
+> Source: `CONFIG.DND5E.itemActionTypes`
+> </details>
+
+#### Bonus to All Melee Attack Rolls (both spell and weapon)
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.bonuses.mwak.attack`     | Add     | `+[number/formula]`     |
+| `system.bonuses.msak.attack`     | Add     | `+[number/formula]`     |
+
+
+#### Bonus to All Ranged Attack Rolls (both spell and weapon)
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.bonuses.rwak.attack`     | Add     | `+[number/formula]`     |
+| `system.bonuses.rsak.attack`     | Add     | `+[number/formula]`     |
+
+---
+
+### Damage Roll Bonuses
+
+```
+system.bonuses.msak.damage
+               mwak
+               rsak
+               rwak
+```
+
+> [!NOTE]
+> <details>
+> <summary>Attack Roll Types</summary>
+> 
+> | Movement Type        | Value  |
+> | -------------------- | ------ |
+> | Melee Spell attack   | `msak` |
+> | Melee Weapon attack  | `mwak` |
+> | Ranged Spell attack  | `rsak` |
+> | Ranged Weapon attack | `rwak` |
+> 
+> Source: `CONFIG.DND5E.itemActionTypes`
+> </details>
+
+#### Bonus to All Melee Attack Damage Rolls (both spell and weapon)
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.bonuses.mwak.damage`     | Add     | `+[number/formula]`     |
+| `system.bonuses.msak.damage`     | Add     | `+[number/formula]`     |
+
+
+#### Bonus to All Ranged Attack Damage Rolls (both spell and weapon)
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.bonuses.rwak.damage`     | Add     | `+[number/formula]`     |
+| `system.bonuses.rsak.damage`     | Add     | `+[number/formula]`     |
+
+---
+
+### Immunities/Resistances/Vulnerabilities
+
+```
+system.traits.ci.value
+              di
+              dr
+              dv
+```
+
+> [!WARNING]
+> These only serve as a marker on the actor sheet, the core system has no automations around immunities, resistances, or vulnerabilities.
+
+#### Add a Condition Immunity
+> [!NOTE]
+> <details>
+> <summary>Condition Types</summary>
+> 
+> | Condition     | Value           |
+> | ------------- | --------------- |
+> | Blinded       | `blinded`       |
+> | Charmed       | `charmed`       |
+> | Deafened      | `deafened`      |
+> | Diseased      | `diseased`      |
+> | Exhaustion    | `exhaustion`    |
+> | Frightened    | `frightened`    |
+> | Grappled      | `grappled`      |
+> | Incapacitated | `incapacitated` |
+> | Invisible     | `invisible`     |
+> | Paralyzed     | `paralyzed`     |
+> | Petrified     | `petrified`     |
+> | Poisoned      | `poisoned`      |
+> | Prone         | `prone`         |
+> | Restrained    | `restrained`    |
+> | Stunned       | `stunned`       |
+> | Unconscious   | `unconscious`   |
+> 
+> Source: `CONFIG.DND5E.conditionTypes`
+> </details>
+
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.traits.ci.value`     | Add     | `[conditionType]`     |
+
+#### Add a Damage Type Immunity
+> [!NOTE]
+> <details>
+> <summary>Damage Types</summary>
+> 
+> | Damage Type | Value         |
+> | ----------- | ------------- |
+> | Acid        | `acid`        |
+> | Bludgeoning | `bludgeoning` |
+> | Cold        | `cold`        |
+> | Fire        | `fire`        |
+> | Force       | `force`       |
+> | Lightning   | `lightning`   |
+> | Necrotic    | `necrotic`    |
+> | Piercing    | `piercing`    |
+> | Poison      | `poison`      |
+> | Psychic     | `psychic`     |
+> | Radiant     | `radiant`     |
+> | Slashing    | `slashing`    |
+> | Thunder     | `thunder`     |
+>   
+> Source: `CONFIG.DND5E.damageTypes`
+> </details>
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.traits.di.value`     | Add     | `[damageType]`     |
+
+#### Add a Damage Type Resistance
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.traits.dr.value`     | Add     | `[damageType]`     |
+
+#### Add a Damage Type Vulnerability
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.traits.dv.value`     | Add     | `[damageType]`     |

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -107,6 +107,12 @@ E.g. Paladin Aura of Protection
 | -------- | -------- | -------- |
 | `system.bonuses.abilities.save`     | Add     | `+[number/formula]`     |
 
+#### Bonus to Initiative
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.attributes.init.bonus`     | Add     | `+[number/formula]`     |
+
 ---
 
 ### Skills
@@ -160,14 +166,6 @@ system.skills.[abbreviation].bonuses.check
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.bonuses.abilities.skill`     | Add     | `+[number/formula]`     |
-
-#### Bonus to Initiative
-
-Initiative is not quite a skill but behaves similarly.
-
-| Attribute Key | Change Mode | Effect Value |
-| -------- | -------- | -------- |
-| `system.attributes.init.bonus`     | Add     | `+[number/formula]`     |
 
 ---
 
@@ -440,3 +438,40 @@ E.g. An Item or Spell which increases the number of die in a Dice Scale Value (e
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.scale.rogue.sneak-attack.number`     | Add     | `+[number]`     |
+
+---
+
+### Hit Points
+
+```
+system.attributes.hp.value
+                     max
+                     temp
+                     tempmax
+                     bonuses.level
+                             overall
+```
+
+> [!warning]
+> **Never** alter the `value`, `max`, or `temp` attributes with an active effect, as this **will** cause issues.
+
+#### Temporary Bonus to the Maximum HP
+E.g. An Item or Spell which temporarily increases a character's Max HP (e.g. Aid).
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.attributes.hp.tempmax`     | Add     | `+[number]`     |
+
+#### Bonus to the Maximum HP
+E.g. An Item or Feature which increases a character's Max HP.
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.attributes.hp.bonuses.overall`     | Add     | `+[number/formula]`     |
+
+#### Bonus HP for each Character Level
+E.g. An effect that provides a bonus to the HP a character gains for each Level they acquire (e.g. Tough).
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.attributes.hp.bonuses.level`     | Add     | `+[number/formula]`     |

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -26,7 +26,7 @@ As part of this, an [Actor's Rolldata](https://github.com/foundryvtt/dnd5e/wiki/
 
 | Change Mode | Description |
 |------------ | ------------|
-| Add         | Adds the provided value to a number. This can be used to both add and subtract from a particular value by specifying `+1` or `-1` as the value to add. |
+| Add         | Adds the provided value to the specified attribute. For numerical attributes, this can be used to both add and subtract from a particular value by specifying `+1` or `-1` as the value to add. |
 | Multiply    | Multiplies the defined attribute by the numeric value in the Effect Value field.|
 | Override    | Replaces the defined attribute with the value provided in the Effect Value field.|
 | Downgrade   | Reduces the defined attribute only in cases where the current value of that attribute would be greater than value specified in the Effect Value field.|

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -399,3 +399,35 @@ system.traits.ci.value
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.traits.dv.value`     | Add     | `[damageType]`     |
+
+---
+
+### Scale Value
+
+```
+system.scale.[classId].[scaleId]
+                                 .value
+                                 .number
+                                 .die
+                                 .faces
+```
+
+> <details>
+> <summary>Dice Scale Values</summary>
+> 
+> The Dice Scale Values have a few unique keys, here is an example of the result for these keys based on a scale value that is 3d8
+>
+> | Key | Value    |
+> | ------------- | -------- |
+> |`system.scale.[classId].[scaleId]`| 3d8|
+> | `system.scale.[classId].[scaleId].number` | 3 |
+> | `system.scale.[classId].[scaleId].die` | d8  |
+> | `system.scale.[classId].[scaleId].faces` | 8    |
+> </details>
+
+#### Increase the value of a Scale Values
+E.g. An Item or Spell which allows additional use(s) of a Class Feature.
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.scale.[classId].[scaleId].value`     | Add     | `+[number]`     |

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -1,20 +1,17 @@
 # FoundryVTT dnd5e Active Effects Examples
 
-![Up to date as of 2.1.x](https://img.shields.io/badge/dnd5e-v2.1.x-informational)
-
-See [Kandashi's Active Effects Guide](https://docs.google.com/document/d/1DuZaIFVq0YulDOvpahrfhZ6dK7LuclIRlGOtT0BIYEo) for a trove of useful information
+![Up to date as of 2.3.x](https://img.shields.io/badge/dnd5e-v2.3.x-informational)
 
 This document only covers Active Effects available to the Core dnd5e System.
 
 ## Legend
 
-`[number]` - These square brakets mean "replace this with your value of the type within the brackets".
+`[number]` - These square brackets mean "replace this with your value of the type within the brackets".
 So this example: `+[number]` would mean you input `+3`.
 
 `[formula]` - When `formula` is mentioned in this document it means this value can be populated with any dice formula. For example, Bless adds several effects with the Effect Value of `1d4`.
 
-
-As part of this, an Actor's Rolldata is available as ["@attributes."](https://github.com/foundryvtt/dnd5e/wiki/Roll-Formulas) Useful examples:
+As part of this, an [Actor's Rolldata](https://github.com/foundryvtt/dnd5e/wiki/Roll-Formulas) is available as "@attributes." Useful examples:
 
 | @attribute                 | Description                   |
 | -------------------------- | ----------------------------- |
@@ -23,23 +20,21 @@ As part of this, an Actor's Rolldata is available as ["@attributes."](https://gi
 | `@details.level`           | Actor's overall Level         |
 | `@classes.barbarian.levels` | Actor's Barbarian Class Level |
 
-  
-> Note that when using formulas in an Active Effect Value, the actor sheet display that corresponds to the changed value will not display the evaluated formula, but it will be applied when rolled.
+> [!Note]
+> When using formulas in an Active Effect Value, the actor sheet display that corresponds to the changed value will not display the evaluated formula, but it will be applied when rolled.
 > E.g. When adding `+@abilities.cha.mod` to `system.bonuses.abilities.save` to simulate a Paladin's Aura of Protection, the actor sheet will not display that bonus applied to saving throws. The bonus will be present when the saving throw is rolled.
 
-To find out more about these, this post from Unsoluble in the [FoundryVTT Discord server](https://discord.gg/foundryvtt)'s #core-how-to channel can help:
+| Change Mode | Description |
+|------------ | ------------|
+| Add         | Adds the provided value to a number. This can be used to both add and subtract from a particular value by specifying `+1` or `-1` as the value to add. |
+| Multiply    | Multiplies the defined attribute by the numeric value in the Effect Value field.|
+| Override    | Replaces the defined attribute with the value provided in the Effect Value field.|
+| Downgrade   | Reduces the defined attribute only in cases where the current value of that attribute would be greater than value specified in the Effect Value field.|
+| Upgrade     | Increases the defined attribute only in cases where the current value of that attribute would be less than value specified in the Effect Value field. |
+| Custom      | The Custom change mode applies logic defined by a game system or add-on module. The dnd5e system does not utilize the Custom Change Mode|
 
-> To explore the data model in order to refer to inline properties like character levels, attributes, and other values, here are a few approaches:
->
-> • Select a token, then open up the dev tools (F12 on Win; ⌥⌘I on Mac), and paste this into the Console:
-`console.log(canvas.tokens.controlled[0].actor.getRollData());`
->
-> • Or: Install the "Autocomplete Inline Properties" module, to be able to just start typing in a supported field and have the available properties pop up (not all systems supported yet).
->
-> • Or: Install this module (by pasting this manifest URL into the bottom of the Install Module window), enable it in your world, find and import its macro from the bundled Compendium, and run it on the selected token. `https://raw.githubusercontent.com/relick/FoundryVTT-Actor-Attribute-Lists/master/module.json`
->
-> • Or: Right-click an actor in the sidebar and choose Export Data, which will get you a JSON file you can browse through. 
-
+> [!important]
+> When using the `ADD` change mode, it is always recommended to include the `+` in the Effect Value, this will ensure that if you have multiple effects targeting the same Attribute, they will not be concatenated (e.g. two effects that `ADD | +1` will result in a bonus of `+1+1`, whereas two effects that `ADD | 1` will result in a bonus of `+11`.
 
 ## Commonly Desired Effect Examples
 
@@ -75,6 +70,13 @@ E.g. an Item or potion that sets an ability score to a set value while in use
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.abilities.[abbreviation].value`     | Override     | `[number]`     |
+
+#### Upgrading an Ability Value
+E.g. an Item or potion that sets an ability score to a set value, if the value does not already exceed that value, such as the Gauntlets of Ogre Power
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.abilities.[abbreviation].value`     | Upgrade     | `[number]`     |
 
 #### Bonus to a Specific Ability Save
 
@@ -229,12 +231,12 @@ E.g. An Item or Spell which adds to the Actor's current AC to something for the 
 
 #### Override the AC Calculation to a custom formula
 
-E.g. An Item or Spell which sets the Actor's AC to something like `12 + Int` for the duration.
+E.g. An Item or Spell which sets the Actor's AC to `12 + Int` for the duration.
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.attributes.ac.calc`     | Override     | `custom`     |
-| `system.attributes.ac.formula`     | Custom     | `10 + @abilities.str.mod`     |
+| `system.attributes.ac.formula`     | Custom     | `12 + @abilities.int.mod`     |
 
 ---
 
@@ -430,11 +432,11 @@ E.g. An Item or Spell which allows additional use(s) of a Class Feature (e.g. ad
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
-| `system.scale.[classIdentifier].[scaleIdentifier].value`     | Add     | `+[number]`     |
+| `system.scale.barbarian.rages.value`     | Add     | `+[number]`     |
 
 #### Increase the number of die of a Dice Scale Value
 E.g. An Item or Spell which increases the number of die in a Dice Scale Value (e.g. adds a die to a Rogue's Sneak Attack).
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
-| `system.scale.[classIdentifier].[scaleIdentifier].number`     | Add     | `+[number]`     |
+| `system.scale.rogue.sneak-attack.number`     | Add     | `+[number]`     |

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -1,5 +1,4 @@
 # FoundryVTT dnd5e Active Effects Examples
-###### tags: `active-effects`
 
 ![Up to date as of 2.1.x](https://img.shields.io/badge/dnd5e-v2.1.x-informational)
 
@@ -7,16 +6,12 @@ See [Kandashi's Active Effects Guide](https://docs.google.com/document/d/1DuZaIF
 
 This document only covers Active Effects available to the Core dnd5e System.
 
-### Legend
+## Legend
 
-`[number]`
-
-These square brakets mean "replace this with your value of the type within the brackets".
-
+`[number]` - These square brakets mean "replace this with your value of the type within the brackets".
 So this example: `+[number]` would mean you input `+3`.
 
-`[formula]`
-When `formula` is mentioned in this document it means this value can be populated with any dice formula. For example, Bless adds several effects with the Effect Value of `1d4`.
+`[formula]` - When `formula` is mentioned in this document it means this value can be populated with any dice formula. For example, Bless adds several effects with the Effect Value of `1d4`.
 
 
 As part of this, an Actor's Rolldata is available as ["@attributes."](https://github.com/foundryvtt/dnd5e/wiki/Roll-Formulas) Useful examples:
@@ -28,9 +23,9 @@ As part of this, an Actor's Rolldata is available as ["@attributes."](https://gi
 | `@details.level`           | Actor's overall Level         |
 | `@classes.barbarian.levels` | Actor's Barbarian Class Level |
 
-> [!NOTE]
+  
 > Note that when using formulas in an Active Effect Value, the actor sheet display that corresponds to the changed value will not display the evaluated formula, but it will be applied when rolled.
-> E.g. When adding `@abilities.cha.mod` to `system.bonuses.abilities.save` to simulate a Paladin's Aura of Protection, the actor sheet will not display that bonus applied to saving throws. The bonus will be present when the saving throw is rolled.
+> E.g. When adding `+@abilities.cha.mod` to `system.bonuses.abilities.save` to simulate a Paladin's Aura of Protection, the actor sheet will not display that bonus applied to saving throws. The bonus will be present when the saving throw is rolled.
 
 To find out more about these, this post from Unsoluble in the [FoundryVTT Discord server](https://discord.gg/foundryvtt)'s #core-how-to channel can help:
 
@@ -56,7 +51,7 @@ system.abilities.[abbreviation].value
                                         save
 ```
 
-> [!NOTE]
+
 > <details>
 > <summary>Ability Abbreviations</summary>
 > 
@@ -118,7 +113,6 @@ system.skills.[abbreviation].bonuses.check
                                      passive
 ```
 
-> [!NOTE]
 > <details>
 > <summary>Skill Abbreviations</summary>
 > 
@@ -181,7 +175,6 @@ Initiative is not quite a skill but behaves similarly.
 system.attributes.movement.[movementType]
 ```
 
-> [!NOTE]
 > <details>
 > <summary>Movement Types</summary>
 > 
@@ -254,7 +247,6 @@ system.bonuses.msak.attack
                rwak
 ```
 
-> [!NOTE]
 > <details>
 > <summary>Attack Roll Types</summary>
 > 
@@ -294,7 +286,6 @@ system.bonuses.msak.damage
                rwak
 ```
 
-> [!NOTE]
 > <details>
 > <summary>Attack Roll Types</summary>
 > 
@@ -338,7 +329,7 @@ system.traits.ci.value
 > These only serve as a marker on the actor sheet, the core system has no automations around immunities, resistances, or vulnerabilities.
 
 #### Add a Condition Immunity
-> [!NOTE]
+
 > <details>
 > <summary>Condition Types</summary>
 > 
@@ -370,7 +361,7 @@ system.traits.ci.value
 | `system.traits.ci.value`     | Add     | `[conditionType]`     |
 
 #### Add a Damage Type Immunity
-> [!NOTE]
+
 > <details>
 > <summary>Damage Types</summary>
 > 

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -64,21 +64,21 @@ system.abilities.[abbreviation].value
 > </details>
 
 
-#### Overriding an Ability Value
+#### Overriding an Ability Score
 E.g. an Item or potion that sets an ability score to a set value while in use
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.abilities.[abbreviation].value`     | Override     | `[number]`     |
 
-#### Upgrading an Ability Value
+#### Upgrading an Ability Score
 E.g. an Item or potion that sets an ability score to a set value, if the value does not already exceed that value, such as the Gauntlets of Ogre Power
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.abilities.[abbreviation].value`     | Upgrade     | `[number]`     |
 
-#### Bonus to a Specific Ability Save
+#### Bonus to a Specific Saving Throw
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
@@ -99,7 +99,7 @@ E.g. an Item or potion that sets an ability score to a set value, if the value d
 | `system.bonuses.abilities.skill`     | Add     | `+[number/formula]`     |
 
 
-#### Bonus to All Ability Saves
+#### Bonus to All Saving Throws
 
 E.g. Paladin Aura of Protection
 
@@ -221,7 +221,7 @@ system.attributes.ac.bonus
 
 #### Add a Bonus to AC
 
-E.g. An Item or Spell which adds to the Actor's current AC to something for the duration.
+E.g. An Item or Spell which adds something to the Actor's current AC for the duration.
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -221,7 +221,7 @@ E.g. An Item or Spell which adds something to the Actor's current AC for the dur
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
-| `system.attributes.ac.bonus`     | Add     | `+[number]`     |
+| `system.attributes.ac.bonus`     | Add     | `+[number/formula]`     |
 
 
 

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -1,10 +1,8 @@
-# FoundryVTT dnd5e Active Effects Examples
-
 ![Up to date as of 2.3.x](https://img.shields.io/badge/dnd5e-v2.3.x-informational)
 
 This document only covers Active Effects available to the Core dnd5e System.
 
-## Legend
+# Legend
 
 `[number]` - These square brackets mean "replace this with your value of the type within the brackets".
 So this example: `+[number]` would mean you input `+3`.
@@ -36,9 +34,9 @@ As part of this, an [Actor's Rolldata](https://github.com/foundryvtt/dnd5e/wiki/
 > [!important]
 > When using the `ADD` change mode, it is always recommended to include the `+` in the Effect Value, this will ensure that if you have multiple effects targeting the same Attribute, they will not be concatenated (e.g. two effects that `ADD | +1` will result in a bonus of `+1+1`, whereas two effects that `ADD | 1` will result in a bonus of `+11`.
 
-## Commonly Desired Effect Examples
+# Commonly Desired Effect Examples
 
-### Abilities
+## Abilities
 
 ```
 system.abilities.[abbreviation].value
@@ -64,42 +62,42 @@ system.abilities.[abbreviation].value
 > </details>
 
 
-#### Overriding an Ability Score
+### Overriding an Ability Score
 E.g. an Item or potion that sets an ability score to a set value while in use
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.abilities.[abbreviation].value`     | Override     | `[number]`     |
 
-#### Upgrading an Ability Score
+### Upgrading an Ability Score
 E.g. an Item or potion that sets an ability score to a set value, if the value does not already exceed that value, such as the Gauntlets of Ogre Power
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.abilities.[abbreviation].value`     | Upgrade     | `[number]`     |
 
-#### Bonus to a Specific Saving Throw
+### Bonus to a Specific Saving Throw
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.abilities.[abbreviation].bonuses.save`     | Add     | `+[number/formula]`     |
 
 
-#### Bonus to a Specific Ability Check
+### Bonus to a Specific Ability Check
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.abilities.[abbreviation].bonuses.check`     | Add     | `+[number/formula]`     |
 
 
-#### Bonus to All Ability Checks
+### Bonus to All Ability Checks
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.bonuses.abilities.skill`     | Add     | `+[number/formula]`     |
 
 
-#### Bonus to All Saving Throws
+### Bonus to All Saving Throws
 
 E.g. Paladin Aura of Protection
 
@@ -107,7 +105,7 @@ E.g. Paladin Aura of Protection
 | -------- | -------- | -------- |
 | `system.bonuses.abilities.save`     | Add     | `+[number/formula]`     |
 
-#### Bonus to Initiative
+### Bonus to Initiative
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
@@ -115,7 +113,7 @@ E.g. Paladin Aura of Protection
 
 ---
 
-### Skills
+## Skills
 ```
 system.skills.[abbreviation].bonuses.check
                                      passive
@@ -149,19 +147,19 @@ system.skills.[abbreviation].bonuses.check
 > </details>
 
 
-#### Bonus to a Specific Skill Check
+### Bonus to a Specific Skill Check
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.skills.[abbreviation].bonuses.check`     | Add     | `+[number/formula]`     |
 
-#### Bonus to a Specific Skill Passive
+### Bonus to a Specific Skill Passive
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.skills.[abbreviation].bonuses.passive`     | Add     | `+[number/formula]`     |
 
-#### Bonus to All Skill Checks
+### Bonus to All Skill Checks
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
@@ -169,7 +167,7 @@ system.skills.[abbreviation].bonuses.check
 
 ---
 
-### Movement
+## Movement
 
 ```
 system.attributes.movement.[movementType]
@@ -190,7 +188,7 @@ system.attributes.movement.[movementType]
 > </details>
 
 
-#### Multiply Speed by modifier
+### Multiply Speed by modifier
 E.g. An Item or Spell which doubles/halves/etc. an Actor's speed.
 
 | Attribute Key | Change Mode | Effect Value |
@@ -198,7 +196,7 @@ E.g. An Item or Spell which doubles/halves/etc. an Actor's speed.
 | `system.attributes.movement.[movementType]`     | Multiply     | `[number]`     |
 
 
-#### Add a different Speed
+### Add a different Speed
 E.g. An Item or Spell which grants an Actor a flying or swimming speed.
 
 | Attribute Key | Change Mode | Effect Value |
@@ -207,7 +205,7 @@ E.g. An Item or Spell which grants an Actor a flying or swimming speed.
 
 ---
 
-### Armor Class
+## Armor Class
 
 ```
 system.attributes.ac.bonus
@@ -217,7 +215,7 @@ system.attributes.ac.bonus
                      flat
 ```
 
-#### Add a Bonus to AC
+### Add a Bonus to AC
 
 E.g. An Item or Spell which adds something to the Actor's current AC for the duration.
 
@@ -227,7 +225,7 @@ E.g. An Item or Spell which adds something to the Actor's current AC for the dur
 
 
 
-#### Override the AC Calculation to a custom formula
+### Override the AC Calculation to a custom formula
 
 E.g. An Item or Spell which sets the Actor's AC to `12 + Int` for the duration.
 
@@ -238,7 +236,7 @@ E.g. An Item or Spell which sets the Actor's AC to `12 + Int` for the duration.
 
 ---
 
-### Attack Roll Bonuses
+## Attack Roll Bonuses
 
 ```
 system.bonuses.msak.attack
@@ -260,7 +258,7 @@ system.bonuses.msak.attack
 > Source: `CONFIG.DND5E.itemActionTypes`
 > </details>
 
-#### Bonus to All Melee Attack Rolls (both spell and weapon)
+### Bonus to All Melee Attack Rolls (both spell and weapon)
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
@@ -268,7 +266,7 @@ system.bonuses.msak.attack
 | `system.bonuses.msak.attack`     | Add     | `+[number/formula]`     |
 
 
-#### Bonus to All Ranged Attack Rolls (both spell and weapon)
+### Bonus to All Ranged Attack Rolls (both spell and weapon)
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
@@ -277,7 +275,7 @@ system.bonuses.msak.attack
 
 ---
 
-### Damage Roll Bonuses
+## Damage Roll Bonuses
 
 ```
 system.bonuses.msak.damage
@@ -299,7 +297,7 @@ system.bonuses.msak.damage
 > Source: `CONFIG.DND5E.itemActionTypes`
 > </details>
 
-#### Bonus to All Melee Attack Damage Rolls (both spell and weapon)
+### Bonus to All Melee Attack Damage Rolls (both spell and weapon)
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
@@ -307,7 +305,7 @@ system.bonuses.msak.damage
 | `system.bonuses.msak.damage`     | Add     | `+[number/formula]`     |
 
 
-#### Bonus to All Ranged Attack Damage Rolls (both spell and weapon)
+### Bonus to All Ranged Attack Damage Rolls (both spell and weapon)
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
@@ -316,7 +314,7 @@ system.bonuses.msak.damage
 
 ---
 
-### Immunities/Resistances/Vulnerabilities
+## Immunities/Resistances/Vulnerabilities
 
 ```
 system.traits.ci.value
@@ -328,7 +326,7 @@ system.traits.ci.value
 > [!WARNING]
 > These only serve as a marker on the actor sheet, the core system has no automations around immunities, resistances, or vulnerabilities.
 
-#### Add a Condition Immunity
+### Add a Condition Immunity
 
 > <details>
 > <summary>Condition Types</summary>
@@ -360,7 +358,7 @@ system.traits.ci.value
 | -------- | -------- | -------- |
 | `system.traits.ci.value`     | Add     | `[conditionType]`     |
 
-#### Add a Damage Type Immunity
+### Add a Damage Type Immunity
 
 > <details>
 > <summary>Damage Types</summary>
@@ -388,13 +386,13 @@ system.traits.ci.value
 | -------- | -------- | -------- |
 | `system.traits.di.value`     | Add     | `[damageType]`     |
 
-#### Add a Damage Type Resistance
+### Add a Damage Type Resistance
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.traits.dr.value`     | Add     | `[damageType]`     |
 
-#### Add a Damage Type Vulnerability
+### Add a Damage Type Vulnerability
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
@@ -402,7 +400,7 @@ system.traits.ci.value
 
 ---
 
-### Scale Value
+## Scale Value
 
 ```
 system.scale.[classIdentifier].[scaleIdentifier]
@@ -425,14 +423,14 @@ system.scale.[classIdentifier].[scaleIdentifier]
 > | `system.scale.[classIdentifier].[scaleIdentifier].faces` | 8    |
 > </details>
 
-#### Increase the value of a Scale Value
+### Increase the value of a Scale Value
 E.g. An Item or Spell which allows additional use(s) of a Class Feature (e.g. adds an additional use of a Barbarian's Rage).
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.scale.barbarian.rages.value`     | Add     | `+[number]`     |
 
-#### Increase the number of die of a Dice Scale Value
+### Increase the number of die of a Dice Scale Value
 E.g. An Item or Spell which increases the number of die in a Dice Scale Value (e.g. adds a die to a Rogue's Sneak Attack).
 
 | Attribute Key | Change Mode | Effect Value |
@@ -441,7 +439,7 @@ E.g. An Item or Spell which increases the number of die in a Dice Scale Value (e
 
 ---
 
-### Hit Points
+## Hit Points
 
 ```
 system.attributes.hp.value
@@ -455,21 +453,21 @@ system.attributes.hp.value
 > [!warning]
 > **Never** alter the `value`, `max`, or `temp` attributes with an active effect, as this **will** cause issues.
 
-#### Temporary Bonus to the Maximum HP
+### Temporary Bonus to the Maximum HP
 E.g. An Item or Spell which temporarily increases a character's Max HP (e.g. Aid).
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.attributes.hp.tempmax`     | Add     | `+[number]`     |
 
-#### Bonus to the Maximum HP
+### Bonus to the Maximum HP
 E.g. An Item or Feature which increases a character's Max HP.
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
 | `system.attributes.hp.bonuses.overall`     | Add     | `+[number/formula]`     |
 
-#### Bonus HP for each Character Level
+### Bonus HP for each Character Level
 E.g. An effect that provides a bonus to the HP a character gains for each Level they acquire (e.g. Tough).
 
 | Attribute Key | Change Mode | Effect Value |

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -405,11 +405,11 @@ system.traits.ci.value
 ### Scale Value
 
 ```
-system.scale.[classId].[scaleId]
-                                 .value
-                                 .number
-                                 .die
-                                 .faces
+system.scale.[classIdentifier].[scaleIdentifier]
+                                                .value
+                                                .number
+                                                .die
+                                                .faces
 ```
 
 > <details>
@@ -419,15 +419,22 @@ system.scale.[classId].[scaleId]
 >
 > | Key | Value    |
 > | ------------- | -------- |
-> |`system.scale.[classId].[scaleId]`| 3d8|
-> | `system.scale.[classId].[scaleId].number` | 3 |
-> | `system.scale.[classId].[scaleId].die` | d8  |
-> | `system.scale.[classId].[scaleId].faces` | 8    |
+> |`system.scale.[classIdentifier].[scaleIdentifier]`| 3d8|
+> | `system.scale.[classIdentifier].[scaleIdentifier].number` | 3 |
+> | `system.scale.[classIdentifier].[scaleIdentifier].die` | d8  |
+> | `system.scale.[classIdentifier].[scaleIdentifier].faces` | 8    |
 > </details>
 
-#### Increase the value of a Scale Values
-E.g. An Item or Spell which allows additional use(s) of a Class Feature.
+#### Increase the value of a Scale Value
+E.g. An Item or Spell which allows additional use(s) of a Class Feature (e.g. adds an additional use of a Barbarian's Rage).
 
 | Attribute Key | Change Mode | Effect Value |
 | -------- | -------- | -------- |
-| `system.scale.[classId].[scaleId].value`     | Add     | `+[number]`     |
+| `system.scale.[classIdentifier].[scaleIdentifier].value`     | Add     | `+[number]`     |
+
+#### Increase the number of die of a Dice Scale Value
+E.g. An Item or Spell which increases the number of die in a Dice Scale Value (e.g. adds a die to a Rogue's Sneak Attack).
+
+| Attribute Key | Change Mode | Effect Value |
+| -------- | -------- | -------- |
+| `system.scale.[classIdentifier].[scaleIdentifier].number`     | Add     | `+[number]`     |

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,5 +1,6 @@
 # Welcome to the DnD5e FoundryVTT Wiki
 
+- [Active Effects Guide](Active-Effect-Guide.md)
 - [Advancement Overview](Advancement.md)
   - [Advancement User Guide](Advancement-User-Guide.md)
   - [Custom Class Example](Custom-Class-Advancement.md)  

--- a/wiki/Roll-Formulas.md
+++ b/wiki/Roll-Formulas.md
@@ -1,4 +1,13 @@
-![Up to date as of 2.1.2](https://img.shields.io/static/v1?label=dnd5e&message=2.1.2&color=informational)
+![Up to date as of 2.3](https://img.shields.io/static/v1?label=dnd5e&message=2.3&color=informational)
+> <details><summary>To explore the data model within Foundry to find the properties detailed below, here are a few approaches:</summary>
+>
+> • Select a token, then open up the dev tools (F12 on Win; ⌥⌘I on Mac), and paste this into the Console (or save it as a Script macro in your hotbar):
+`console.log(canvas.tokens.controlled[0].actor.getRollData());`
+>
+> • Or: Install the "Autocomplete Inline Properties" module, to be able to just start typing in a supported field and have the available properties pop up (not all systems supported yet).
+>
+> • Or: Right-click an actor in the sidebar and choose Export Data, which will get you a JSON file you can browse through. (This won’t contain any values that are derived at roll-time.)
+></details>
 
 ## Actor Properties
 


### PR DESCRIPTION
Adds a guide for Active Effect to the wiki

Closes #2481 

tried to include some of the additional md styles outlined here https://github.com/orgs/community/discussions/16925 like this:  
> [!WARNING]  
but it doesnt seem to work in the wiki for some reason https://github.com/orgs/community/discussions/16925#discussioncomment-6883415 hopefully soon, seems potentially useful

I did double check some info from the original guide and made updates/removed changed info, but a second pass would be helpful

Preview on my wiki here: https://github.com/MaxPat931/dnd5e/wiki/Active-Effect-Guide