### PR TITLE
[#2456] Fix methods returning notification ids rather than null

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -289,7 +289,7 @@ Hooks.once("ready", function() {
 
   // Perform the migration
   if ( cv && isNewerVersion(game.system.flags.compatibleMigrationVersion, cv) ) {
-    ui.notifications.error(game.i18n.localize("MIGRATION.5eVersionTooOldWarning"), {permanent: true});
+    ui.notifications.error("MIGRATION.5eVersionTooOldWarning", {localize: true, permanent: true});
   }
   migrations.migrateWorld();
 });

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1354,7 +1354,8 @@ export default class ActorSheet5e extends ActorSheet {
     // Check to make sure the newly created class doesn't take player over level cap
     if ( type === "class" && (this.actor.system.details.level + 1 > CONFIG.DND5E.maxLevel) ) {
       const err = game.i18n.format("DND5E.MaxCharacterLevelExceededWarn", {max: CONFIG.DND5E.maxLevel});
-      return ui.notifications.error(err);
+      ui.notifications.error(err);
+      return null;
     }
 
     const itemData = {

--- a/module/applications/actor/hit-points-config.mjs
+++ b/module/applications/actor/hit-points-config.mjs
@@ -99,7 +99,7 @@ export default class ActorHitPointsConfig extends BaseConfigSheet {
       this.clone.updateSource({"system.attributes.hp.max": roll.total});
       this.render();
     } catch(error) {
-      ui.notifications.error(game.i18n.localize("DND5E.HPFormulaError"));
+      ui.notifications.error("DND5E.HPFormulaError", {localize: true});
       throw error;
     }
   }

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -187,9 +187,10 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
     if ( data.type !== "Item" ) return false;
     const item = await Item.implementation.fromDropData(data);
 
-    if ( (item.type !== "feat") || (item.system.type.value !== "feat") ) return ui.notifications.error(
-      game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementFeatWarning")
-    );
+    if ( (item.type !== "feat") || (item.system.type.value !== "feat") ) {
+      ui.notifications.error("DND5E.AdvancementAbilityScoreImprovementFeatWarning", {localize: true});
+      return null;
+    }
 
     this.feat = item;
     this.render();

--- a/module/applications/advancement/advancement-config.mjs
+++ b/module/applications/advancement/advancement-config.mjs
@@ -194,19 +194,22 @@ export default class AdvancementConfig extends FormApplication {
     try {
       this._validateDroppedItem(event, item);
     } catch(err) {
-      return ui.notifications.error(err.message);
+      ui.notifications.error(err.message);
+      return null;
     }
 
     const existingItems = foundry.utils.getProperty(this.advancement.configuration, this.options.dropKeyPath);
 
     // Abort if this uuid is the parent item
     if ( item.uuid === this.item.uuid ) {
-      return ui.notifications.error(game.i18n.localize("DND5E.AdvancementItemGrantRecursiveWarning"));
+      ui.notifications.error("DND5E.AdvancementItemGrantRecursiveWarning", {localize: true});
+      return null;
     }
 
     // Abort if this uuid exists already
     if ( existingItems.includes(item.uuid) ) {
-      return ui.notifications.warn(game.i18n.localize("DND5E.AdvancementItemGrantDuplicateWarning"));
+      ui.notifications.warn("DND5E.AdvancementItemGrantDuplicateWarning", {localize: true});
+      return null;
     }
 
     await this.advancement.update({[`configuration.${this.options.dropKeyPath}`]: [...existingItems, item.uuid]});

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -128,7 +128,8 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     try {
       this.advancement._validateItemType(item);
     } catch(err) {
-      return ui.notifications.error(err.message);
+      ui.notifications.error(err.message);
+      return null;
     }
 
     // If the item is already been marked as selected, no need to go further
@@ -138,7 +139,8 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     for ( const [level, data] of Object.entries(this.advancement.value.added ?? {}) ) {
       if ( level >= this.level ) continue;
       if ( Object.values(data).includes(item.uuid) ) {
-        return ui.notifications.error(game.i18n.localize("DND5E.AdvancementItemChoicePreviouslyChosenWarning"));
+        ui.notifications.error("DND5E.AdvancementItemChoicePreviouslyChosenWarning", {localize: true});
+        return null;
       }
     }
 
@@ -146,9 +148,12 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     const spellLevel = this.advancement.configuration.restriction.level;
     if ( (this.advancement.configuration.type === "spell") && spellLevel === "available" ) {
       const maxSlot = this._maxSpellSlotLevel();
-      if ( item.system.level > maxSlot ) return ui.notifications.error(game.i18n.format(
-        "DND5E.AdvancementItemChoiceSpellLevelAvailableWarning", { level: CONFIG.DND5E.spellLevels[maxSlot] }
-      ));
+      if ( item.system.level > maxSlot ) {
+        ui.notifications.error(game.i18n.format("DND5E.AdvancementItemChoiceSpellLevelAvailableWarning", {
+          level: CONFIG.DND5E.spellLevels[maxSlot]
+        }));
+        return null;
+      }
     }
 
     // Mark the item as selected

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -391,9 +391,10 @@ export default class ItemSheet5e extends ItemSheet {
       if ( !maxRoll.isDeterministic ) {
         uses.max = this.item._source.system.uses.max;
         this.form.querySelector("input[name='system.uses.max']").value = uses.max;
-        return ui.notifications.error(game.i18n.format("DND5E.FormulaCannotContainDiceError", {
+        ui.notifications.error(game.i18n.format("DND5E.FormulaCannotContainDiceError", {
           name: game.i18n.localize("DND5E.LimitedUses")
         }));
+        return null;
       }
     }
 
@@ -404,9 +405,10 @@ export default class ItemSheet5e extends ItemSheet {
       if ( !durationRoll.isDeterministic ) {
         duration.value = this.item._source.system.duration.value;
         this.form.querySelector("input[name='system.duration.value']").value = duration.value;
-        return ui.notifications.error(game.i18n.format("DND5E.FormulaCannotContainDiceError", {
+        ui.notifications.error(game.i18n.format("DND5E.FormulaCannotContainDiceError", {
           name: game.i18n.localize("DND5E.Duration")
         }));
+        return null;
       }
     }
 
@@ -414,7 +416,8 @@ export default class ItemSheet5e extends ItemSheet {
     if ( formData.system?.identifier && !dnd5e.utils.validators.isValidIdentifier(formData.system.identifier) ) {
       formData.system.identifier = this.item._source.system.identifier;
       this.form.querySelector("input[name='system.identifier']").value = formData.system.identifier;
-      return ui.notifications.error(game.i18n.localize("DND5E.IdentifierError"));
+      ui.notifications.error("DND5E.IdentifierError", {localize: true});
+      return null;
     }
 
     // Return the flattened submission data

--- a/module/applications/trait-selector.mjs
+++ b/module/applications/trait-selector.mjs
@@ -99,10 +99,12 @@ export default class TraitSelector extends DocumentSheet {
 
     // Validate the number chosen
     if ( o.minimum && (chosen.length < o.minimum) ) {
-      return ui.notifications.error(`You must choose at least ${o.minimum} options`);
+      ui.notifications.error(`You must choose at least ${o.minimum} options`);
+      return null;
     }
     if ( o.maximum && (chosen.length > o.maximum) ) {
-      return ui.notifications.error(`You may choose no more than ${o.maximum} options`);
+      ui.notifications.error(`You may choose no more than ${o.maximum} options`);
+      return null;
     }
 
     return updateData;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1376,7 +1376,7 @@ export default class Actor5e extends Actor {
 
     // Display a warning if we are not at zero HP or if we already have reached 3
     if ( (this.system.attributes.hp.value > 0) || (death.failure >= 3) || (death.success >= 3) ) {
-      ui.notifications.warn(game.i18n.localize("DND5E.DeathSaveUnnecessary"));
+      ui.notifications.warn("DND5E.DeathSaveUnnecessary", {localize: true});
       return null;
     }
 
@@ -2316,7 +2316,8 @@ export default class Actor5e extends Actor {
     // Ensure the player is allowed to polymorph
     const allowed = game.settings.get("dnd5e", "allowPolymorphing");
     if ( !allowed && !game.user.isGM ) {
-      return ui.notifications.warn(game.i18n.localize("DND5E.PolymorphWarn"));
+      ui.notifications.warn("DND5E.PolymorphWarn", {localize: true});
+      return null;
     }
 
     // Get the original Actor data and the new source data
@@ -2528,7 +2529,10 @@ export default class Actor5e extends Actor {
    */
   async revertOriginalForm({renderSheet=true}={}) {
     if ( !this.isPolymorphed ) return;
-    if ( !this.isOwner ) return ui.notifications.warn(game.i18n.localize("DND5E.PolymorphRevertWarn"));
+    if ( !this.isOwner ) {
+      ui.notifications.warn("DND5E.PolymorphRevertWarn", {localize: true});
+      return null;
+    }
 
     /**
      * A hook event that fires just before the actor is reverted to original form.

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1671,8 +1671,10 @@ export default class Item5e extends Item {
     const storedData = message.getFlag("dnd5e", "itemData");
     const item = storedData ? new this(storedData, {parent: actor}) : actor.items.get(card.dataset.itemId);
     if ( !item ) {
-      const err = game.i18n.format("DND5E.ActionWarningNoItem", {item: card.dataset.itemId, name: actor.name});
-      return ui.notifications.error(err);
+      ui.notifications.error(game.i18n.format("DND5E.ActionWarningNoItem", {
+        item: card.dataset.itemId, name: actor.name
+      }));
+      return null;
     }
     const spellLevel = parseInt(card.dataset.spellLevel) || null;
 
@@ -1776,7 +1778,7 @@ export default class Item5e extends Item {
   static _getChatCardTargets(card) {
     let targets = canvas.tokens.controlled.filter(t => !!t.actor);
     if ( !targets.length && game.user.character ) targets = targets.concat(game.user.character.getActiveTokens());
-    if ( !targets.length ) ui.notifications.warn(game.i18n.localize("DND5E.ActionWarningNoToken"));
+    if ( !targets.length ) ui.notifications.warn("DND5E.ActionWarningNoToken", {localize: true});
     return targets;
   }
 
@@ -1954,7 +1956,7 @@ export default class Item5e extends Item {
 
     // Check to make sure the updated class level isn't below zero
     if ( changed.system.levels <= 0 ) {
-      ui.notifications.warn(game.i18n.localize("DND5E.MaxClassLevelMinimumWarn"));
+      ui.notifications.warn("DND5E.MaxClassLevelMinimumWarn", {localize: true});
       changed.system.levels = 1;
     }
 

--- a/module/documents/macro.mjs
+++ b/module/documents/macro.mjs
@@ -9,7 +9,10 @@ export async function create5eMacro(dropData, slot) {
   switch ( dropData.type ) {
     case "Item":
       const itemData = await Item.implementation.fromDropData(dropData);
-      if ( !itemData ) return ui.notifications.warn(game.i18n.localize("MACRO.5eUnownedWarn"));
+      if ( !itemData ) {
+        ui.notifications.warn("MACRO.5eUnownedWarn", {localize: true});
+        return null;
+      }
       foundry.utils.mergeObject(macroData, {
         name: itemData.name,
         img: itemData.img,
@@ -19,7 +22,10 @@ export async function create5eMacro(dropData, slot) {
       break;
     case "ActiveEffect":
       const effectData = await ActiveEffect.implementation.fromDropData(dropData);
-      if ( !effectData ) return ui.notifications.warn(game.i18n.localize("MACRO.5eUnownedWarn"));
+      if ( !effectData ) {
+        ui.notifications.warn("MACRO.5eUnownedWarn", {localize: true});
+        return null;
+      }
       foundry.utils.mergeObject(macroData, {
         name: effectData.label,
         img: effectData.icon,
@@ -51,7 +57,10 @@ function getMacroTarget(name, documentType) {
   const speaker = ChatMessage.getSpeaker();
   if ( speaker.token ) actor = game.actors.tokens[speaker.token];
   actor ??= game.actors.get(speaker.actor);
-  if ( !actor ) return ui.notifications.warn(game.i18n.localize("MACRO.5eNoActorSelected"));
+  if ( !actor ) {
+    ui.notifications.warn("MACRO.5eNoActorSelected", {localize: true});
+    return null;
+  }
 
   const collection = (documentType === "Item") ? actor.items : actor.effects;
   const nameKeyPath = (documentType === "Item") ? "name" : "label";
@@ -60,7 +69,8 @@ function getMacroTarget(name, documentType) {
   const documents = collection.filter(i => foundry.utils.getProperty(i, nameKeyPath) === name);
   const type = game.i18n.localize(`DOCUMENT.${documentType}`);
   if ( documents.length === 0 ) {
-    return ui.notifications.warn(game.i18n.format("MACRO.5eMissingTargetWarn", { actor: actor.name, type, name }));
+    ui.notifications.warn(game.i18n.format("MACRO.5eMissingTargetWarn", { actor: actor.name, type, name }));
+    return null;
   }
   if ( documents.length > 1 ) {
     ui.notifications.warn(game.i18n.format("MACRO.5eMultipleTargetsWarn", { actor: actor.name, type, name }));


### PR DESCRIPTION
Closes #2456.

These seemed to come up a lot more often than just in the macro methods.

Also `ui.notifications.<x>(game.i18n.localize(...))` was unnecessary in a lot of cases. It makes it easier to parse switching to the built-in `localize: true` option.