### PR TITLE
[#2457] Fix non-GMs being unable to drop items onto advancement flows

### DIFF
--- a/module/applications/advancement/advancement-flow.mjs
+++ b/module/applications/advancement/advancement-flow.mjs
@@ -104,4 +104,11 @@ export default class AdvancementFlow extends FormApplication {
     await this.advancement.apply(this.level, formData);
   }
 
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  _canDragDrop(selector) {
+    return true;
+  }
+
 }


### PR DESCRIPTION
The `AdvancementFlow` inherits drag and drop permissions from `FormApplication` which apparently only allows GMs by default.

Closes #2457.