### PR TITLE
Add Coin support in _simplifyDiceTerms

### DIFF
--- a/module/dice/simplify-roll-formula.mjs
+++ b/module/dice/simplify-roll-formula.mjs
@@ -107,7 +107,7 @@ function _simplifyDiceTerms(terms) {
   // Split the unannotated terms into different die sizes and signs
   const diceQuantities = unannotated.reduce((obj, curr, i) => {
     if ( curr instanceof OperatorTerm ) return obj;
-    let face = curr.constructor?.name === "Coin" ? "c":curr.faces;
+    const face = curr.constructor?.name === "Coin" ? "c" : curr.faces;
     const key = `${unannotated[i - 1].operator}${face}`;
     obj[key] = (obj[key] ?? 0) + curr.number;
     return obj;

--- a/module/dice/simplify-roll-formula.mjs
+++ b/module/dice/simplify-roll-formula.mjs
@@ -107,7 +107,8 @@ function _simplifyDiceTerms(terms) {
   // Split the unannotated terms into different die sizes and signs
   const diceQuantities = unannotated.reduce((obj, curr, i) => {
     if ( curr instanceof OperatorTerm ) return obj;
-    const key = `${unannotated[i - 1].operator}${curr.faces}`;
+    let face = curr.constructor?.name === "Coin" ? "c":curr.faces;
+    const key = `${unannotated[i - 1].operator}${face}`;
     obj[key] = (obj[key] ?? 0) + curr.number;
     return obj;
   }, {});
@@ -115,7 +116,9 @@ function _simplifyDiceTerms(terms) {
   // Add new die and operator terms to simplified for each die size and sign
   const simplified = Object.entries(diceQuantities).flatMap(([key, number]) => ([
     new OperatorTerm({ operator: key.charAt(0) }),
-    new Die({ number, faces: parseInt(key.slice(1)) })
+    key.slice(1) === "c"
+      ? new Coin({ number: number })
+      : new Die({ number, faces: parseInt(key.slice(1)) })
   ]));
   return [...simplified, ...annotated];
 }


### PR DESCRIPTION
Closes #2281
There was an issue in _simplifyDiceTerms where a Coin was reduced to its operator and number of faces, then assumed to be a die when passed back out. This ended up turning a coin into a die 2 and combining it with any other die 2s in the Dice Terms.
This was fixed by using a c for the faces value if the DiceTerm is Coin and returning a DiceTerm of Coin, instead of Die, if the face value is c.
(Any DiceTerm other than Coin should default to using the number of faces and return as a Die DiceTerm)