### PR TITLE
[#2495] Allow prepareData methods to be called on module actors

### DIFF
--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -56,11 +56,8 @@ export default class GroupActor extends SystemDataModel.mixin(CurrencyTemplate) 
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 
-  /**
-   * Prepare base data for group actors.
-   * @internal
-   */
-  _prepareBaseData() {
+  /** @inheritdoc */
+  prepareBaseData() {
     this.members.clear();
     for ( const id of this._source.members ) {
       const a = game.actors.get(id);
@@ -72,14 +69,6 @@ export default class GroupActor extends SystemDataModel.mixin(CurrencyTemplate) 
       }
       else console.warn(`Actor "${id}" in group "${this._id}" does not exist within the World.`);
     }
-  }
-
-  /**
-   * Prepare derived data for group actors.
-   * @internal
-   */
-  _prepareDerivedData() {
-    // No preparation needed at this time
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -132,8 +132,7 @@ export default class Actor5e extends Actor {
 
   /** @inheritDoc */
   prepareDerivedData() {
-    if ( !game.template.Actor.types.includes(this.type) ) return;
-    if ( this.type === "group" ) return;
+    if ( !game.template.Actor.types.includes(this.type) || (this.type === "group") ) return;
 
     const flags = this.flags.dnd5e || {};
     this.labels = {};

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -91,8 +91,7 @@ export default class Actor5e extends Actor {
 
   /** @inheritDoc */
   prepareData() {
-    // Do not attempt to prepare non-system types.
-    if ( !game.template.Actor.types.includes(this.type) ) return;
+    if ( !game.template.Actor.types.includes(this.type) ) return super.prepareData();
     this._classes = undefined;
     this._preparationWarnings = [];
     super.prepareData();
@@ -103,13 +102,9 @@ export default class Actor5e extends Actor {
 
   /** @inheritDoc */
   prepareBaseData() {
-
-    // Delegate preparation to type-subclass
-    if ( this.type === "group" ) {  // Eventually other types will also support this
-      return this.system._prepareBaseData();
-    }
-
-    this._prepareBaseArmorClass();
+    if ( !game.template.Actor.types.includes(this.type) ) return;
+    if ( this.type !== "group" ) this._prepareBaseArmorClass();
+    else if ( game.release.generation < 11 ) this.system.prepareBaseData();
 
     // Type-specific preparation
     switch ( this.type ) {
@@ -137,11 +132,8 @@ export default class Actor5e extends Actor {
 
   /** @inheritDoc */
   prepareDerivedData() {
-
-    // Delegate preparation to type-subclass
-    if ( this.type === "group" ) {  // Eventually other types will also support this
-      return this.system._prepareDerivedData();
-    }
+    if ( !game.template.Actor.types.includes(this.type) ) return;
+    if ( this.type === "group" ) return;
 
     const flags = this.flags.dnd5e || {};
     this.labels = {};


### PR DESCRIPTION
- `SystemDataModel` now inherits from `TypeDataModel`
- Renamed `_prepareBaseData` on `GroupData` to match naming in core
- Adjusted data preparation to ensure `TypeDataModel` preparation methods are still called