### PR TITLE
[#2479, #2232] Prevent resource objects from being mutated

### DIFF
--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -24,11 +24,10 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
 
     // Resources
     context.resources = ["primary", "secondary", "tertiary"].reduce((arr, r) => {
-      const res = context.actor.system.resources[r] || {};
-      res.name = r;
-      res.placeholder = game.i18n.localize(`DND5E.Resource${r.titleCase()}`);
-      if (res && res.value === 0) delete res.value;
-      if (res && res.max === 0) delete res.max;
+      const res = foundry.utils.mergeObject(context.actor.system.resources[r], {
+        name: r,
+        placeholder: game.i18n.localize(`DND5E.Resource${r.titleCase()}`)
+      }, {inplace: false});
       return arr.concat([res]);
     }, []);
 

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -24,10 +24,12 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
 
     // Resources
     context.resources = ["primary", "secondary", "tertiary"].reduce((arr, r) => {
-      const res = foundry.utils.mergeObject(context.actor.system.resources[r], {
+      const res = foundry.utils.mergeObject(context.actor.system.resources[r] || {}, {
         name: r,
         placeholder: game.i18n.localize(`DND5E.Resource${r.titleCase()}`)
       }, {inplace: false});
+      if ( res.value === 0 ) delete res.value;
+      if ( res.max === 0 ) delete res.max;
       return arr.concat([res]);
     }, []);
 


### PR DESCRIPTION
In the character sheet, not only was `value` (and sometimes `max`) getting deleted, all resource objects were getting mutated with `name` and `placeholder`.

While unsure if actually related, I am also unable to reproduce #2165 with this fix (with a character sheet open or not), but I am if I swap to a different branch without this fix.

![image](https://github.com/foundryvtt/dnd5e/assets/50169243/8aefcc45-bdfc-47a4-9515-b16d6ca9d62c)
