### PR TITLE
Move data-type attribute for Empty Spellbook

### DIFF
--- a/templates/actors/parts/actor-spellbook.hbs
+++ b/templates/actors/parts/actor-spellbook.hbs
@@ -121,9 +121,9 @@
     {{#if filters.spellbook.size}}
     <li class="item flexrow"><p class="notes">{{localize "DND5E.FilterNoSpells"}}</p></li>
     {{else}}
-    <li class="item flexrow inventory-header spellbook-header spellbook-empty">
+    <li class="item flexrow inventory-header spellbook-header spellbook-empty" data-type="spell" data-level="{{lvl}}">
         <div class="item-controls flexrow">
-            <a class="item-control item-create" data-tooltip="DND5E.SpellCreate" data-type="spell" data-level="{{lvl}}">
+            <a class="item-control item-create" data-tooltip="DND5E.SpellCreate">
                 <i class="fas fa-plus"></i> {{localize "DND5E.SpellAdd"}}
             </a>
         </div>


### PR DESCRIPTION
Changes in PR #2156 moved data-type and data-level attributes to the spellbook-header li tag from the item-create a tag for spellbook's with sections. However for the spellbook-empty li the attributes were still on the a tag. 
This was causing the _onItemCreate in base-sheet.mjs to get an empty dataset and undefined type.
This was fixed by moving those attributes to the li tag for the empty spell book as well.
Closes #2476