### PR TITLE
[#2515] Fix warning from referenced active effect label

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -57,7 +57,6 @@ Hooks.once("init", function() {
   CONFIG.Dice.D20Roll = dice.D20Roll;
   CONFIG.MeasuredTemplate.defaults.angle = 53.13; // 5e cone RAW should be 53.13 degrees
   CONFIG.ui.combat = applications.combat.CombatTracker5e;
-  CONFIG.compatibility.excludePatterns.push(/\bActiveEffect5e#label\b/); // Backwards compatibility with v10.
   game.dnd5e.isV10 = game.release.generation < 11;
 
   // Register System Settings

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -294,7 +294,7 @@ export default class ActorSheet5e extends ActorSheet {
   _prepareActiveEffectAttributions(target) {
     return this.actor.effects.reduce((arr, e) => {
       let source = e.sourceName;
-      if ( e.origin === this.actor.uuid ) source = e.label;
+      if ( e.origin === this.actor.uuid ) source = e.name;
       if ( !source || e.disabled || e.isSuppressed ) return arr;
       const value = e.changes.reduce((n, change) => {
         if ( (change.key !== target) || !Number.isNumeric(change.value) ) return n;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -174,4 +174,21 @@ export default class ActiveEffect5e extends ActiveEffect {
     categories.suppressed.hidden = !categories.suppressed.effects.length;
     return categories;
   }
+
+  /* ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~ */
+  /*  Deprecations and Compatibility           */
+  /* ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~ */
+
+  _initialize(options) {
+    super._initialize(options);
+    if ( game.release.generation < 11 ) {
+      Object.defineProperty(this, "name", {
+        get() {
+          return this.label;
+        },
+        configurable: true,
+        enumerable: false
+      });
+    }
+  }
 }

--- a/templates/actors/parts/active-effects.hbs
+++ b/templates/actors/parts/active-effects.hbs
@@ -27,7 +27,7 @@
         <li class="item effect flexrow" data-effect-id="{{effect.id}}">
             <div class="item-name effect-name flexrow">
                 <img class="item-image" src="{{effect.icon}}"/>
-                <h4>{{effect.label}}</h4>
+                <h4>{{effect.name}}</h4>
             </div>
             <div class="effect-source">{{effect.sourceName}}</div>
             <div class="effect-duration">{{effect.duration.label}}</div>


### PR DESCRIPTION
Changes references to `ActiveEffect#label` to use `ActiveEffect#name` and adds a temporary shim to `ActiveEffect5e` on v10 to support that property.