### PR TITLE
[#2100] Turn `attributes.hd` into an object, save reference to smallest and largest

### DIFF
--- a/module/applications/actor/short-rest.mjs
+++ b/module/applications/actor/short-rest.mjs
@@ -48,7 +48,7 @@ export default class ShortRestDialog extends Dialog {
       }
       return hd;
     }, {});
-    data.canRoll = this.actor.system.attributes.hd > 0;
+    data.canRoll = this.actor.system.attributes.hd.amount > 0;
     data.denomination = this._denom;
 
     // Determine rest type

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -281,6 +281,14 @@ export default class Actor5e extends Actor {
     this.system.attributes.hd.smallest = hd.size ? Math.min(...hd) : null;
     this.system.attributes.hd.largest = hd.size ? Math.max(...hd) : null;
 
+    this.system.attributes.hd.toString = function() {
+      foundry.utils.logCompatibilityWarning(
+        "You are accessing 'attributes.hd' which has been moved to 'attributes.hd.amount'.",
+        {since: "DnD5e 2.4.0", until: "DnD5e 2.5"}
+      );
+      return this.amount;
+    }
+
     // Character proficiency bonus
     this.system.attributes.prof = Proficiency.calculateMod(this.system.details.level);
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -266,8 +266,9 @@ export default class Actor5e extends Actor {
       if ( item.type === "class" ) {
         const classLevels = parseInt(item.system.levels) || 1;
         this.system.details.level += classLevels;
-        this.system.attributes.hd.amount += classLevels - (parseInt(item.system.hitDiceUsed) || 0);
-        hd.add(Number(item.system.hitDice.replace("d", "")));
+        const available = classLevels - (parseInt(item.system.hitDiceUsed) || 0);
+        this.system.attributes.hd.amount += available;
+        if ( available > 0 ) hd.add(Number(item.system.hitDice.replace("d", "")));
       }
 
       // Attuned items
@@ -277,8 +278,8 @@ export default class Actor5e extends Actor {
     }
 
     // Smallest, largest hit dice.
-    this.system.attributes.hd.smallest = hd.size ? `d${Math.min(...hd)}` : null;
-    this.system.attributes.hd.largest = hd.size ? `d${Math.max(...hd)}` : null;
+    this.system.attributes.hd.smallest = hd.size ? Math.min(...hd) : null;
+    this.system.attributes.hd.largest = hd.size ? Math.max(...hd) : null;
 
     // Character proficiency bonus
     this.system.attributes.prof = Proficiency.calculateMod(this.system.details.level);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -282,12 +282,8 @@ export default class Actor5e extends Actor {
     this.system.attributes.hd.largest = hd.size ? Math.max(...hd) : null;
 
     this.system.attributes.hd.toString = function() {
-      foundry.utils.logCompatibilityWarning(
-        "You are accessing 'attributes.hd' which has been moved to 'attributes.hd.amount'.",
-        {since: "DnD5e 2.4.0", until: "DnD5e 2.5"}
-      );
       return this.amount;
-    }
+    };
 
     // Character proficiency bonus
     this.system.attributes.prof = Proficiency.calculateMod(this.system.details.level);

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -81,7 +81,7 @@
                     </a>
                     <div class="attribute-value multiple">
                         <label class="hit-dice">
-                            <span data-tooltip="DND5E.HitDiceRemaining">{{system.attributes.hd}}</span>
+                            <span data-tooltip="DND5E.HitDiceRemaining">{{system.attributes.hd.amount}}</span>
                             <span class="sep"> / </span>
                             <span data-tooltip="DND5E.HitDiceMax">{{system.details.level}}</span>
                         </label>


### PR DESCRIPTION
Instead of `attributes.hd` being an integer (number of remaining hit dice), it's now an object with `amount` (the remaining quantity), `smallest`, and `largest`.

