### PR TITLE
[#1405] Add TraitAdvancement & TraitConfig

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -1585,6 +1585,9 @@ h5 {
 .dnd5e.advancement.traits {
   --grid-two-column-right-size: 0.6fr;
 }
+.dnd5e.advancement.traits form {
+  grid-gap: 1rem;
+}
 .dnd5e.advancement.traits .selected-trait h4 {
   font-weight: bold;
 }
@@ -1604,6 +1607,18 @@ h5 {
   display: flex;
   gap: 1em;
   align-items: baseline;
+}
+.dnd5e.advancement.traits .selected-trait ul label:not(.selected) {
+  cursor: pointer;
+}
+.dnd5e.advancement.traits .selected-trait ul label:not(.selected):hover {
+  text-shadow: 0 0 8px var(--color-shadow-primary);
+}
+.dnd5e.advancement.traits .selected-trait ul label.selected {
+  font-weight: bold;
+}
+.dnd5e.advancement.traits .selected-trait ul label input[type="radio"] {
+  display: none;
 }
 .dnd5e.advancement.traits .hint textarea {
   flex: 1 0 100%;

--- a/dnd5e.css
+++ b/dnd5e.css
@@ -555,6 +555,12 @@ h5 {
 .trait-selector .trait-list li ol.trait-list {
   margin-left: 1.5em;
 }
+.trait-selector .trait-list .category > label {
+  font-weight: bold;
+}
+.trait-selector .trait-list .wildcard > label {
+  font-style: italic;
+}
 .trait-selector input[type="text"] {
   height: 24px;
   margin: 2px;
@@ -1396,6 +1402,9 @@ h5 {
   /* ----------------------------------------- */
   /*  Scale Value                              */
   /* ----------------------------------------- */
+  /* ----------------------------------------- */
+  /*  Traits                                   */
+  /* ----------------------------------------- */
 }
 .dnd5e.advancement input[type="text"],
 .dnd5e.advancement input[type="number"],
@@ -1572,6 +1581,37 @@ h5 {
 }
 .dnd5e.advancement.scale-value select option[value=""] {
   color: var(--color-text-light-6);
+}
+.dnd5e.advancement.traits {
+  --grid-two-column-right-size: 0.6fr;
+}
+.dnd5e.advancement.traits .selected-trait h4 {
+  font-weight: bold;
+}
+.dnd5e.advancement.traits .selected-trait ul {
+  list-style: none;
+  padding: 0;
+}
+.dnd5e.advancement.traits .selected-trait ul li {
+  display: flex;
+  gap: 0.5em;
+}
+.dnd5e.advancement.traits .selected-trait ul li:not(:first-of-type) {
+  padding-block-start: 0.5em;
+}
+.dnd5e.advancement.traits .selected-trait ul label {
+  flex-grow: 1;
+  display: flex;
+  gap: 1em;
+  align-items: baseline;
+}
+.dnd5e.advancement.traits .hint textarea {
+  flex: 1 0 100%;
+}
+.dnd5e.advancement.traits [data-action="add-choice"] {
+  display: block;
+  padding-block: 0.25em;
+  text-align: center;
 }
 .dnd5e.advancement-migration .items-list {
   margin-block-end: 1em;

--- a/lang/en.json
+++ b/lang/en.json
@@ -248,6 +248,8 @@
 "DND5E.AdvancementTitle": "Advancement",
 "DND5E.AdvancementTraitTitle": "Traits",
 "DND5E.AdvancementTraitHint": "Grant a character certain traits or give them an option to select traits (such as proficiencies, skills, languages).",
+"DND5E.AdvancementTraitActionAddChoice": "Add Choice",
+"DND5E.AdvancementTraitActionRemoveChoice": "Remove Choice",
 "DND5E.AdvancementTraitAllowReplacements": "Allow Replacements",
 "DND5E.AdvancementTraitAllowReplacementsHint": "If a trait is already set on the actor, allow the player to choose from any other trait as a replacement.",
 "DND5E.AdvancementTraitChoiceMode": "Choice Mode",

--- a/less/advancement.less
+++ b/less/advancement.less
@@ -204,6 +204,46 @@
       }
     }
   }
+
+  /* ----------------------------------------- */
+  /*  Traits                                   */
+  /* ----------------------------------------- */
+  &.traits {
+    --grid-two-column-right-size: 0.6fr;
+
+    .selected-trait {
+      h4 {
+        font-weight: bold;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        li {
+          display: flex;
+          gap: 0.5em;
+          &:not(:first-of-type) {
+            padding-block-start: 0.5em;
+          }
+        }
+        label {
+          flex-grow: 1;
+          display: flex;
+          gap: 1em;
+          align-items: baseline;
+        }
+      }
+    }
+
+    .hint textarea {
+      flex: 1 0 100%;
+    }
+
+    [data-action="add-choice"] {
+      display: block;
+      padding-block: 0.25em;
+      text-align: center;
+    }
+  }
 }
 
 .dnd5e.advancement-migration {

--- a/less/advancement.less
+++ b/less/advancement.less
@@ -211,6 +211,10 @@
   &.traits {
     --grid-two-column-right-size: 0.6fr;
 
+    form {
+      grid-gap: 1rem;
+    }
+
     .selected-trait {
       h4 {
         font-weight: bold;
@@ -230,6 +234,20 @@
           display: flex;
           gap: 1em;
           align-items: baseline;
+
+          &:not(.selected) {
+            cursor: pointer;
+            &:hover {
+              text-shadow: 0 0 8px var(--color-shadow-primary);
+            }
+          }
+          &.selected {
+            font-weight: bold;
+          }
+
+          input[type="radio"] {
+            display: none;
+          }
         }
       }
     }

--- a/less/apps.less
+++ b/less/apps.less
@@ -549,6 +549,12 @@ h5 {
     li ol.trait-list {
       margin-left: 1.5em;
     }
+    .category > label {
+      font-weight: bold;
+    }
+    .wildcard > label {
+      font-style: italic;
+    }
   }
 
   input[type="text"] {

--- a/module/applications/advancement/_module.mjs
+++ b/module/applications/advancement/_module.mjs
@@ -15,3 +15,4 @@ export {default as ItemGrantConfig} from "./item-grant-config.mjs";
 export {default as ItemGrantFlow} from "./item-grant-flow.mjs";
 export {default as ScaleValueConfig} from "./scale-value-config.mjs";
 export {default as ScaleValueFlow} from "./scale-value-flow.mjs";
+export {default as TraitConfig} from "./trait-config.mjs";

--- a/module/applications/advancement/trait-config.mjs
+++ b/module/applications/advancement/trait-config.mjs
@@ -1,0 +1,242 @@
+import AdvancementConfig from "./advancement-config.mjs";
+import * as Trait from "../../documents/actor/trait.mjs";
+import { filteredKeys } from "../../utils.mjs";
+
+/**
+ * Configuration application for traits.
+ */
+export default class TraitConfig extends AdvancementConfig {
+  constructor(...args) {
+    super(...args);
+    this.selected = (this.config.choices.length && !this.config.grants.size) ? 0 : -1;
+    this.trait = this.types.first() ?? "skills";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Shortcut to the configuration data on the advancement.
+   * @type {object}
+   */
+  get config() {
+    return this.advancement.configuration;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Index of the selected configuration, `-1` means `grants` array, any other number is equal
+   * to an index in `choices` array.
+   * @type {number}
+   */
+  selected;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Trait type to display in the selector interface.
+   * @type {string}
+   */
+  trait;
+
+  /* -------------------------------------------- */
+
+  /**
+   * List of trait types for the current selected configuration.
+   * @type {Set<string>}
+   */
+  get types() {
+    const pool = this.selected === -1 ? this.config.grants : this.config.choices[this.selected].pool;
+    return this.advancement.representedTraits([pool]);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["dnd5e", "advancement", "traits", "two-column"],
+      template: "systems/dnd5e/templates/advancement/trait-config.hbs",
+      width: 600
+    });
+  }
+
+  /* -------------------------------------------- */
+  /*  Context Preparation                         */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async getData() {
+    const context = super.getData();
+
+    // TODO: Try to make these not async
+    context.grants = {
+      label: Trait.localizedList({ grants: this.config.grants }) || "—",
+      data: this.config.grants,
+      selected: this.selected === -1
+    };
+    context.choices = this.config.choices.map((choice, index) => ({
+      label: Trait.choiceLabel(choice, { only: true }).capitalize() || "—",
+      data: choice,
+      selected: this.selected === index
+    }));
+    const chosen = (this.selected === -1) ? context.grants.data : context.choices[this.selected].data.pool;
+    context.count = context.choices[this.selected]?.data.count;
+    context.selectedIndex = this.selected;
+
+    context.validTraitTypes = Object.entries(CONFIG.DND5E.traits).reduce((obj, [key, config]) => {
+      if ( (this.config.mode === "default") || config.expertise ) obj[key] = config.labels.title;
+      return obj;
+    }, {});
+
+    const traitConfig = CONFIG.DND5E.traits[this.advancement.representedTraits().first()];
+    if ( traitConfig ) {
+      context.default.title = traitConfig.labels.title;
+      context.default.icon = traitConfig.icon;
+    } else {
+      context.default.title = game.i18n.localize("DND5E.TraitGenericPlural.other");
+      context.default.icon = this.advancement.constructor.metadata.icon;
+    }
+    context.default.hint = Trait.localizedList({
+      grants: this.config.grants, choices: this.config.choices, choiceMode: this.config.choiceMode
+    });
+
+    context.choiceOptions = await Trait.choices(this.trait, { chosen, prefixed: true, any: this.selected !== -1 });
+    context.selectedTraitHeader = `${CONFIG.DND5E.traits[this.trait].labels.localization}.other`;
+    context.selectedTrait = this.trait;
+
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Handlers                              */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    this.form.querySelectorAll("[data-action]").forEach(a => a.addEventListener("click", this._onAction.bind(this)));
+
+    // Handle selecting & disabling category children when a category is selected
+    for ( const checkbox of html[0].querySelectorAll(".trait-selector input:checked") ) {
+      const toCheck = checkbox.name.endsWith("*")
+        ? checkbox.closest("ol").querySelectorAll(`input:not([name="${checkbox.name}"])`)
+        : checkbox.closest("li").querySelector("ol")?.querySelectorAll("input");
+      toCheck?.forEach(i => i.checked = i.disabled = true);
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle clicks to the Add and Remove buttons above the list.
+   * @param {Event} event  Triggering click.
+   */
+  async _onAction(event) {
+    event.preventDefault();
+    switch (event.currentTarget.dataset.action) {
+      case "add-choice":
+        this.config.choices.push({ count: 1 });
+        this.selected = this.config.choices.length - 1;
+        break;
+
+      case "remove-choice":
+        const input = event.currentTarget.closest("li").querySelector("[name='selectedIndex']");
+        const selectedIndex = Number(input.value);
+        this.config.choices.splice(selectedIndex, 1);
+        if ( selectedIndex <= this.selected ) this.selected -= 1;
+        break;
+
+      default:
+        return;
+    }
+
+    // Fix to prevent sets in grants & choice pools being saved as `[object Set]`
+    // TOOD: Remove this when https://github.com/foundryvtt/foundryvtt/issues/7706 is resolved
+    this.config.grants = Array.from(this.config.grants);
+    this.config.choices.forEach(c => {
+      if ( !c.pool ) return;
+      c.pool = Array.from(c.pool);
+    });
+
+    await this.advancement.update({configuration: this.config});
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onChangeInput(event) {
+    // Display new set of trait choices
+    if ( event.target.name === "selectedTrait" ) {
+      this.trait = event.target.value;
+      return this.render();
+    }
+
+    // Change selected configuration set
+    else if ( event.target.name === "selectedIndex" ) {
+      this.selected = Number(event.target.value ?? -1);
+      const types = this.types;
+      if ( types.size && !types.has(this.trait) ) this.trait = types.first();
+      return this.render();
+    }
+
+    // If mode is changed from default to one of the others, change selected type if current type is not valid
+    if ( (event.target.name === "configuration.mode")
+      && (event.target.value !== "default")
+      && (this.config.mode === "default") ) {
+      const validTraitTypes = filteredKeys(CONFIG.DND5E.traits, c => c.expertise);
+      if ( !validTraitTypes.includes(this.trait) ) this.trait = validTraitTypes[0];
+    }
+
+    super._onChangeInput(event);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async prepareConfigurationUpdate(configuration) {
+    const choicesCollection = foundry.utils.deepClone(this.config.choices);
+
+    if ( configuration.checked ) {
+      const prefix = `${this.trait}:`;
+      const filteredSelected = filteredKeys(configuration.checked);
+
+      // Update grants
+      if ( this.selected === -1 ) {
+        const filteredPrevious = this.config.grants.filter(k => !k.startsWith(prefix));
+        configuration.grants = [...filteredPrevious, ...filteredSelected];
+      }
+
+      // Update current choice pool
+      else {
+        const current = choicesCollection[this.selected];
+        const filteredPrevious = current.pool.filter(k => !k.startsWith(prefix));
+        current.pool = [...filteredPrevious, ...filteredSelected];
+      }
+      delete configuration.checked;
+    }
+
+    if ( configuration.count ) {
+      choicesCollection[this.selected].count = configuration.count;
+      delete configuration.count;
+    }
+
+    // TODO: Remove when https://github.com/foundryvtt/foundryvtt/issues/7706 is resolved
+    choicesCollection.forEach(c => {
+      if ( !c.pool ) return;
+      c.pool = Array.from(c.pool);
+    });
+    configuration.choices = choicesCollection;
+    configuration.grants ??= Array.from(this.config.grants);
+
+    // If one of the expertise modes is selected, filter out any traits that are not of a valid type
+    if ( (configuration.mode ?? this.config.mode) !== "default" ) {
+      const validTraitTypes = filteredKeys(CONFIG.DND5E.traits, c => c.expertise);
+      configuration.grants = configuration.grants.filter(k => validTraitTypes.some(t => k.startsWith(t)));
+      configuration.choices.forEach(c => c.pool = c.pool.filter(k => validTraitTypes.some(t => k.startsWith(t))));
+    }
+
+    return configuration;
+  }
+}

--- a/module/applications/advancement/trait-config.mjs
+++ b/module/applications/advancement/trait-config.mjs
@@ -57,7 +57,7 @@ export default class TraitConfig extends AdvancementConfig {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["dnd5e", "advancement", "traits", "two-column"],
       template: "systems/dnd5e/templates/advancement/trait-config.hbs",
-      width: 600
+      width: 640
     });
   }
 
@@ -135,7 +135,7 @@ export default class TraitConfig extends AdvancementConfig {
    */
   async _onAction(event) {
     event.preventDefault();
-    switch (event.currentTarget.dataset.action) {
+    switch ( event.currentTarget.dataset.action ) {
       case "add-choice":
         this.config.choices.push({ count: 1 });
         this.selected = this.config.choices.length - 1;
@@ -152,15 +152,7 @@ export default class TraitConfig extends AdvancementConfig {
         return;
     }
 
-    // Fix to prevent sets in grants & choice pools being saved as `[object Set]`
-    // TOOD: Remove this when https://github.com/foundryvtt/foundryvtt/issues/7706 is resolved
-    this.config.grants = Array.from(this.config.grants);
-    this.config.choices.forEach(c => {
-      if ( !c.pool ) return;
-      c.pool = Array.from(c.pool);
-    });
-
-    await this.advancement.update({configuration: this.config});
+    await this.advancement.update({ configuration: await this.prepareConfigurationUpdate() });
   }
 
   /* -------------------------------------------- */
@@ -195,7 +187,7 @@ export default class TraitConfig extends AdvancementConfig {
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  async prepareConfigurationUpdate(configuration) {
+  async prepareConfigurationUpdate(configuration={}) {
     const choicesCollection = foundry.utils.deepClone(this.config.choices);
 
     if ( configuration.checked ) {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1966,7 +1966,8 @@ DND5E.advancementTypes = {
   HitPoints: advancement.HitPointsAdvancement,
   ItemChoice: advancement.ItemChoiceAdvancement,
   ItemGrant: advancement.ItemGrantAdvancement,
-  ScaleValue: advancement.ScaleValueAdvancement
+  ScaleValue: advancement.ScaleValueAdvancement,
+  Trait: advancement.TraitAdvancement
 };
 
 /* -------------------------------------------- */

--- a/module/documents/actor/trait.mjs
+++ b/module/documents/actor/trait.mjs
@@ -515,7 +515,7 @@ export function localizedList({ grants=new Set(), choices=[], choiceMode="inclus
   let sections = Array.from(grants).map(g => keyLabel(g));
   if ( choiceMode === "inclusive" ) {
     sections = sections.concat(choiceSections);
-  } else {
+  } else if ( choiceSections.length ) {
     sections.push(game.i18n.getListFormatter({ style: "long", type: "disjunction" }).format(choiceSections));
   }
 

--- a/module/documents/advancement/_module.mjs
+++ b/module/documents/advancement/_module.mjs
@@ -5,3 +5,4 @@ export {default as HitPointsAdvancement} from "./hit-points.mjs";
 export {default as ItemChoiceAdvancement} from "./item-choice.mjs";
 export {default as ItemGrantAdvancement} from "./item-grant.mjs";
 export {default as ScaleValueAdvancement} from "./scale-value.mjs";
+export {default as TraitAdvancement} from "./trait.mjs";

--- a/module/documents/advancement/trait.mjs
+++ b/module/documents/advancement/trait.mjs
@@ -1,0 +1,90 @@
+import Advancement from "./advancement.mjs";
+import * as Trait from "../actor/trait.mjs";
+import TraitConfig from "../../applications/advancement/trait-config.mjs";
+import {TraitConfigurationData, TraitValueData} from "../../data/advancement/trait.mjs";
+
+/**
+ * Advancement that grants the player with certain traits or presents them with a list of traits from which
+ * to choose.
+ */
+export default class TraitAdvancement extends Advancement {
+
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      dataModels: {
+        configuration: TraitConfigurationData,
+        value: TraitValueData
+      },
+      order: 30,
+      icon: "systems/dnd5e/icons/svg/trait.svg",
+      title: game.i18n.localize("DND5E.AdvancementTraitTitle"),
+      hint: game.i18n.localize("DND5E.AdvancementTraitHint"),
+      apps: {
+        config: TraitConfig
+      }
+    });
+  }
+
+  /* -------------------------------------------- */
+  /*  Preparation Methods                         */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare data for the Advancement.
+   */
+  prepareData() {
+    const traitConfig = CONFIG.DND5E.traits[this.representedTraits().first()];
+    this.title = this.title || traitConfig?.labels.title || this.constructor.metadata.title;
+    this.icon = this.icon || traitConfig?.icon || this.constructor.metadata.icon;
+  }
+
+  /* -------------------------------------------- */
+  /*  Display Methods                             */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  configuredForLevel(level) {
+    return !!this.value.chosen?.size;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  sortingValueForLevel(levels) {
+    const traitOrder = Object.keys(CONFIG.DND5E.traits).findIndex(k => k === this.representedTraits().first());
+    const modeOrder = Object.keys(CONFIG.DND5E.traitModes).findIndex(k => k === this.configuration.mode);
+    const order = traitOrder + (modeOrder * 100);
+    return `${this.constructor.metadata.order.paddedString(4)} ${order.paddedString(4)} ${this.titleForLevel(levels)}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  summaryForLevel(level, { configMode=false }={}) {
+    if ( this.configuration.hint ) return `<p>${this.configuration.hint}</p>`;
+    return `<p>${Trait.localizedList({
+      grants: this.configuration.grants, choices: this.configuration.choices, choiceMode: this.configuration.choiceMode
+    })}</p>`;
+  }
+
+  /* -------------------------------------------- */
+  /*  Helper Methods                              */
+  /* -------------------------------------------- */
+
+  /**
+   * Guess the trait type from the grants & choices on this advancement.
+   * @param {Set<string>[]} [pools]  Trait pools to use when figuring out the type.
+   * @returns {Set<string>}
+   */
+  representedTraits(pools) {
+    const set = new Set();
+    pools ??= [this.configuration.grants, ...this.configuration.choices.map(c => c.pool)];
+    for ( const pool of pools ) {
+      for ( const key of pool ) {
+        const type = key.split(":").shift();
+        set.add(type);
+      }
+    }
+    return set;
+  }
+}

--- a/module/documents/advancement/trait.mjs
+++ b/module/documents/advancement/trait.mjs
@@ -9,6 +9,7 @@ import {TraitConfigurationData, TraitValueData} from "../../data/advancement/tra
  */
 export default class TraitAdvancement extends Advancement {
 
+  /** @inheritdoc */
   static get metadata() {
     return foundry.utils.mergeObject(super.metadata, {
       dataModels: {
@@ -81,7 +82,7 @@ export default class TraitAdvancement extends Advancement {
     pools ??= [this.configuration.grants, ...this.configuration.choices.map(c => c.pool)];
     for ( const pool of pools ) {
       for ( const key of pool ) {
-        const type = key.split(":").shift();
+        const [type] = key.split(":");
         set.add(type);
       }
     }

--- a/templates/advancement/trait-config.hbs
+++ b/templates/advancement/trait-config.hbs
@@ -16,7 +16,7 @@
       <label>{{localize "DND5E.AdvancementTraitAllowReplacements"}}</label>
       <div class="form-fields">
         <input name="configuration.allowReplacements" id="allowReplacements"
-          type="checkbox" {{checked configuration.allowReplacements}}>
+               type="checkbox" {{checked configuration.allowReplacements}}>
       </div>
       <p class="hint">{{localize "DND5E.AdvancementTraitAllowReplacementsHint"}}</p>
     </div>
@@ -31,8 +31,13 @@
       <p class="hint">{{localize "DND5E.AdvancementTraitGrantsHint"}}</p>
       <ul>
         <li>
-          <label>
-            <input type="radio" name="selectedIndex" value="-1" {{checked (eq selectedIndex -1)}}>
+          <label {{~#if grants.selected}} class="selected"{{/if}}>
+            <input type="radio" name="selectedIndex" value="-1" {{checked grants.selected}}>
+            {{#if grants.selected}}
+              <i class="fa-solid fa-arrow-right-long"></i>
+            {{else}}
+              <i class="fa-solid fa-gear"></i>
+            {{/if}}
             <span>{{grants.label}}</span>
           </label>
         </li>
@@ -63,13 +68,17 @@
       <ul>
         {{#each choices}}
           <li>
-            <label>
-              <input type="radio" name="selectedIndex" value="{{@index}}"
-                {{checked (eq @root.selectedIndex @index)}}>
+            <label {{~#if this.selected}} class="selected"{{/if}}>
+              <input type="radio" name="selectedIndex" value="{{@index}}" {{checked this.selected}}>
+              {{#if this.selected}}
+                <i class="fa-solid fa-arrow-right-long"></i>
+              {{else}}
+                <i class="fa-solid fa-gear"></i>
+              {{/if}}
               <span>{{this.label}}</span>
             </label>
             <a data-action="remove-choice" data-tooltip="DND5E.AdvancementTraitActionRemoveChoice">
-              <i class="fas fa-minus"></i>
+              <i class="fa-solid fa-trash"></i>
             </a>
           </li>
         {{/each}}
@@ -77,6 +86,11 @@
       <a data-action="add-choice">
         <i class="fas fa-plus"></i> {{localize "DND5E.AdvancementTraitActionAddChoice"}}
       </a>
+    </fieldset>
+  </div>
+
+  {{#if choiceOptions}}
+    <div class="right-column trait-selector">
       {{#if (ne selectedIndex -1)}}
         <div class="form-group">
           <label>{{localize "DND5E.AdvancementTraitCount"}}</label>
@@ -85,11 +99,7 @@
           </div>
         </div>
       {{/if}}
-    </fieldset>
-  </div>
 
-  {{#if choiceOptions}}
-    <div class="right-column trait-selector">
       <div class="form-group">
         <label>{{localize "DND5E.AdvancementTraitType"}}</label>
         <div class="form-fields">

--- a/templates/advancement/trait-config.hbs
+++ b/templates/advancement/trait-config.hbs
@@ -1,0 +1,105 @@
+<form autocomplete="off">
+  <div class="left-column">
+    {{> "dnd5e.advancement-controls"}}
+
+    <div class="form-group">
+      <label>{{localize "DND5E.AdvancementTraitMode"}}</label>
+      <div class="form-fields">
+        <select name="configuration.mode">
+          {{selectOptions CONFIG.traitModes selected=configuration.mode labelAttr="label"}}
+        </select>
+      </div>
+      <p class="hint">{{localize (lookup (lookup CONFIG.traitModes configuration.mode) "hint")}}</p>
+    </div>
+
+    <div class="form-group">
+      <label>{{localize "DND5E.AdvancementTraitAllowReplacements"}}</label>
+      <div class="form-fields">
+        <input name="configuration.allowReplacements" id="allowReplacements"
+          type="checkbox" {{checked configuration.allowReplacements}}>
+      </div>
+      <p class="hint">{{localize "DND5E.AdvancementTraitAllowReplacementsHint"}}</p>
+    </div>
+
+    <div class="form-group hint">
+      <label>Hint</label>
+      <textarea name="configuration.hint" placeholder="{{default.hint}}">{{configuration.hint}}</textarea>
+    </div>
+
+    <fieldset class="selected-trait">
+      <legend>{{localize "DND5E.AdvancementTraitGrants"}}</legend>
+      <p class="hint">{{localize "DND5E.AdvancementTraitGrantsHint"}}</p>
+      <ul>
+        <li>
+          <label>
+            <input type="radio" name="selectedIndex" value="-1" {{checked (eq selectedIndex -1)}}>
+            <span>{{grants.label}}</span>
+          </label>
+        </li>
+      </ul>
+    </fieldset>
+
+    <fieldset class="selected-trait">
+      <legend>{{localize "DND5E.AdvancementTraitChoices"}}</legend>
+      <p class="hint">{{localize "DND5E.AdvancementTraitChoicesHint"}}</p>
+      <div class="form-group">
+        <label>{{localize "DND5E.AdvancementTraitChoiceMode"}}</label>
+        <div class="form-fields">
+          <select name="configuration.choiceMode">
+            {{#select configuration.choiceMode}}
+              <option value="inclusive">{{localize "DND5E.AdvancementTraitChoiceModeInclusive"}}</option>
+              <option value="exclusive">{{localize "DND5E.AdvancementTraitChoiceModeExclusive"}}</option>
+            {{/select}}
+          </select>
+        </div>
+      </div>
+      <p class="hint">
+        {{#if (eq configuration.choiceMode "inclusive")}}
+          {{localize "DND5E.AdvancementTraitChoiceModeInclusiveHint"}}
+        {{else}}
+          {{localize "DND5E.AdvancementTraitChoiceModeExclusiveHint"}}
+        {{/if}}
+      </p>
+      <ul>
+        {{#each choices}}
+          <li>
+            <label>
+              <input type="radio" name="selectedIndex" value="{{@index}}"
+                {{checked (eq @root.selectedIndex @index)}}>
+              <span>{{this.label}}</span>
+            </label>
+            <a data-action="remove-choice" data-tooltip="DND5E.AdvancementTraitActionRemoveChoice">
+              <i class="fas fa-minus"></i>
+            </a>
+          </li>
+        {{/each}}
+      </ul>
+      <a data-action="add-choice">
+        <i class="fas fa-plus"></i> {{localize "DND5E.AdvancementTraitActionAddChoice"}}
+      </a>
+      {{#if (ne selectedIndex -1)}}
+        <div class="form-group">
+          <label>{{localize "DND5E.AdvancementTraitCount"}}</label>
+          <div class="form-fields">
+            <input name="configuration.count" type="number" step="1" value="{{count}}">
+          </div>
+        </div>
+      {{/if}}
+    </fieldset>
+  </div>
+
+  {{#if choiceOptions}}
+    <div class="right-column trait-selector">
+      <div class="form-group">
+        <label>{{localize "DND5E.AdvancementTraitType"}}</label>
+        <div class="form-fields">
+          <select name="selectedTrait">
+            {{selectOptions validTraitTypes selected=selectedTrait localize=true}}
+          </select>
+        </div>
+      </div>
+
+      {{> "dnd5e.trait-list" choices=choiceOptions prefix="configuration.checked"}}
+    </div>
+  {{/if}}
+</form>

--- a/templates/apps/parts/trait-list.hbs
+++ b/templates/apps/parts/trait-list.hbs
@@ -1,8 +1,9 @@
 <ol class="trait-list">
   {{#each choices as |choice key|}}
-    <li>
+    <li class="{{#if choice.category}}category{{/if}} {{#if choice.wildcard}}wildcard{{/if}}">
       <label class="checkbox">
-        <input type="checkbox" name="{{#if ../prefix}}{{../prefix}}.{{/if}}{{key}}" {{checked choice.chosen}}>
+        <input type="checkbox" name="{{#if ../prefix}}{{../prefix}}.{{/if}}{{key}}"
+               {{checked choice.chosen}} {{disabled choice.disabled}}>
         {{choice.label}}
       </label>
       {{#if choice.children}}


### PR DESCRIPTION
Adds the `TraitAdvancement` type and the configuration application.

<img width="607" alt="Screenshot 2023-10-25 at 12 26 57" src="https://github.com/foundryvtt/dnd5e/assets/19979839/f041b17d-25f9-46e5-9516-e1e915a6bac3">
