### PR TITLE
[#2472] Change ammo logic for attack and damage rolls

### DIFF
--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -178,8 +178,8 @@ export default class ActionTemplate extends SystemDataModel {
   get criticalThreshold() {
     if ( !this.hasAttack ) return null;
     let ammoThreshold = Infinity;
-    if ( this.consume?.type === "ammo" ) {
-      ammoThreshold = this.parent?.actor?.items.get(this.consume.target).system.critical.threshold ?? Infinity;
+    if ( this.hasAmmo ) {
+      ammoThreshold = this.parent?.actor?.items.get(this.consume.target)?.system.critical.threshold ?? Infinity;
     }
     const threshold = Math.min(this.critical.threshold ?? Infinity, this._typeCriticalThreshold, ammoThreshold);
     return threshold < Infinity ? threshold : 20;

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -220,6 +220,8 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
     return !!this.activation.type;
   }
 
+  /* -------------------------------------------- */
+
   /**
    * Does the Item have an area of effect target?
    * @type {boolean}
@@ -248,6 +250,8 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
     return this.isActive && (this.uses.per in CONFIG.DND5E.limitedUsePeriods) && (this.uses.max > 0);
   }
 
+  /* -------------------------------------------- */
+
   /**
    * Does this Item draw from a resource?
    * @type {boolean}
@@ -255,6 +259,17 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   get hasResource() {
     const consume = this.consume;
     return this.isActive && !!consume.target && !!consume.type && (!this.hasAttack || (consume.type !== "ammo"));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does this Item draw from ammunition?
+   * @type {boolean}
+   */
+  get hasAmmo() {
+    const consume = this.consume;
+    return this.isActive && !!consume.target && !!consume.type && this.hasAttack && (consume.type === "ammo");
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -660,17 +660,15 @@ export default class Item5e extends Item {
     if ( actorBonus.attack ) parts.push(actorBonus.attack);
 
     // One-time bonus provided by consumed ammunition
-    if ( (this.system.consume?.type === "ammo") && this.actor.items ) {
-      const ammoItem = this.actor.items.get(this.system.consume.target);
-      if ( ammoItem ) {
-        const ammoItemQuantity = ammoItem.system.quantity;
-        const ammoCanBeConsumed = ammoItemQuantity && (ammoItemQuantity - (this.system.consume.amount ?? 0) >= 0);
-        const ammoItemAttackBonus = ammoItem.system.attackBonus;
-        const ammoIsTypeConsumable = (ammoItem.type === "consumable") && (ammoItem.system.consumableType === "ammo");
-        if ( ammoCanBeConsumed && ammoItemAttackBonus && ammoIsTypeConsumable ) {
-          parts.push("@ammo");
-          rollData.ammo = ammoItemAttackBonus;
-        }
+    const ammo = this.hasAmmo ? this.actor.items.get(this.system.consume.target) : null;
+    if ( ammo ) {
+      const ammoItemQuantity = ammo.system.quantity;
+      const ammoCanBeConsumed = ammoItemQuantity && (ammoItemQuantity - (this.system.consume.amount ?? 0) >= 0);
+      const ammoItemAttackBonus = ammo.system.attackBonus;
+      const ammoIsTypeConsumable = (ammo.type === "consumable") && (ammo.system.consumableType === "ammo");
+      if ( ammoCanBeConsumed && ammoItemAttackBonus && ammoIsTypeConsumable ) {
+        parts.push("@ammo");
+        rollData.ammo = ammoItemAttackBonus;
       }
     }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -125,6 +125,8 @@ export default class Item5e extends Item {
     return this.system.hasLimitedUses ?? false;
   }
 
+  /* -------------------------------------------- */
+
   /**
    * Does this Item draw from a resource?
    * @type {boolean}
@@ -132,6 +134,17 @@ export default class Item5e extends Item {
    */
   get hasResource() {
     return this.system.hasResource ?? false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does this Item draw from ammunition?
+   * @type {boolean}
+   * @see {@link ActivatedEffectTemplate#hasAmmo}
+   */
+  get hasAmmo() {
+    return this.system.hasAmmo ?? false;
   }
 
   /* -------------------------------------------- */
@@ -1279,19 +1292,14 @@ export default class Item5e extends Item {
     if ( options.spellLevel ) rollData.item.level = options.spellLevel;
 
     // Handle ammunition consumption
-    delete this._ammo;
-    let ammo = null;
     let ammoUpdate = [];
     const consume = this.system.consume;
-    if ( consume?.type === "ammo" ) {
-      ammo = this.actor.items.get(consume.target);
-      if ( ammo?.system ) {
-        const q = ammo.system.quantity;
-        const consumeAmount = consume.amount ?? 0;
-        if ( q && (q - consumeAmount >= 0) ) {
-          this._ammo = ammo;
-          title += ` [${ammo.name}]`;
-        }
+    const ammo = this.hasAmmo ? this.actor.items.get(consume.target) : null;
+    if ( ammo ) {
+      const q = ammo.system.quantity;
+      const consumeAmount = consume.amount ?? 0;
+      if ( q && (q - consumeAmount >= 0) ) {
+        title += ` [${ammo.name}]`;
       }
 
       // Get pending ammunition update
@@ -1426,11 +1434,11 @@ export default class Item5e extends Item {
     }
 
     // Only add the ammunition damage if the ammunition is a consumable with type 'ammo'
-    if ( this._ammo && (this._ammo.type === "consumable") && (this._ammo.system.consumableType === "ammo") ) {
+    const ammo = this.hasAmmo ? this.actor.items.get(this.system.consume.target) : null;
+    if ( ammo ) {
       parts.push("@ammo");
-      rollData.ammo = this._ammo.system.damage.parts.map(p => p[0]).join("+");
-      rollConfig.flavor += ` [${this._ammo.name}]`;
-      delete this._ammo;
+      rollData.ammo = ammo.system.damage.parts.map(p => p[0]).join("+");
+      rollConfig.flavor += ` [${ammo.name}]`;
     }
 
     // Factor in extra critical damage dice from the Barbarian's "Brutal Critical"


### PR DESCRIPTION
Instead of a damage roll requiring a preceding attack roll to gain the benefit of 'ammo damage', the damage roll simply checks if the item has ammo and can attack. The attack roll simply serves to consume ammo, nothing more.

There are some additional benefits to this.
- If one user made the attack roll, another user can still gain the benefit of the ammo on the damage roll, in that weird edge case of two owners of one actor, where before the addition of `_ammo` to the item was local only.
- Users can make all their attack rolls first, and then roll all the damage rolls for easier calculation.
- Users can "redo" a damage roll that was meant to be a critical hit, without having to make another attack roll first.