### PR TITLE
[#2135, #2136] Add multiple inline editors to items & display chat description

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -708,6 +708,25 @@ h5 {
   width: 16px;
   height: 16px;
 }
+/* ----------------------------------------- */
+/*  Accordion                                */
+/* ----------------------------------------- */
+.accordion {
+  transition: margin-bottom 500ms ease;
+}
+.accordion.collapsed {
+  margin-bottom: 0.5rem;
+}
+.accordion.collapsed > .accordion-content {
+  height: 0;
+}
+.accordion-heading {
+  cursor: pointer;
+}
+.accordion-content {
+  overflow: hidden;
+  transition: height 500ms ease;
+}
 .dnd5e.sheet.actor {
   /* ----------------------------------------- */
   /*  Shared Styles                            */
@@ -1779,6 +1798,12 @@ h5 {
 .dnd5e.sheet.item [data-tab="description"] .item-description .editor:not(.prosemirror) {
   height: auto;
   padding-inline: 0.25rem;
+}
+.dnd5e.sheet.item [data-tab="description"] .item-description .accordion.collapsed > .editor.accordion-content {
+  height: 0;
+}
+.dnd5e.sheet.item [data-tab="description"] .item-description .editor.accordion-content > .editor-content {
+  overflow: hidden;
 }
 .dnd5e.sheet.item .details input[type="text"],
 .dnd5e.sheet.item .details input[type="number"],

--- a/dnd5e.css
+++ b/dnd5e.css
@@ -1667,6 +1667,9 @@ h5 {
   /*  Sheet Header                             */
   /* ----------------------------------------- */
   /* ----------------------------------------- */
+  /*  Item Description                         */
+  /* ----------------------------------------- */
+  /* ----------------------------------------- */
   /*  Item Details Form                        */
   /* ----------------------------------------- */
   /* ----------------------------------------- */
@@ -1752,6 +1755,30 @@ h5 {
 }
 .dnd5e.sheet.item .sheet-body .item-properties [name="system.price.denomination"] {
   border: none;
+}
+.dnd5e.sheet.item [data-tab="description"] {
+  align-content: stretch;
+}
+.dnd5e.sheet.item [data-tab="description"] .item-description .description-header {
+  display: flex;
+  align-items: first baseline;
+  justify-content: space-between;
+  margin-block-end: 0;
+  padding: 0.25rem;
+  background-color: rgba(0, 0, 0, 0.05);
+}
+.dnd5e.sheet.item [data-tab="description"] .item-description .description-header .description-edit {
+  opacity: 20%;
+}
+.dnd5e.sheet.item [data-tab="description"] .item-description .description-header:hover .description-edit {
+  opacity: 100%;
+}
+.dnd5e.sheet.item [data-tab="description"] .item-description .editor + .description-header {
+  margin-block-start: 0.5rem;
+}
+.dnd5e.sheet.item [data-tab="description"] .item-description .editor:not(.prosemirror) {
+  height: auto;
+  padding-inline: 0.25rem;
 }
 .dnd5e.sheet.item .details input[type="text"],
 .dnd5e.sheet.item .details input[type="number"],

--- a/less/apps.less
+++ b/less/apps.less
@@ -734,3 +734,24 @@ h5 {
     }
   }
 }
+
+/* ----------------------------------------- */
+/*  Accordion                                */
+/* ----------------------------------------- */
+
+.accordion {
+  transition: margin-bottom 500ms ease;
+}
+.accordion.collapsed {
+  margin-bottom: .5rem;
+  > .accordion-content { height: 0; }
+}
+
+.accordion-heading {
+  cursor: pointer;
+}
+
+.accordion-content {
+  overflow: hidden;
+  transition: height 500ms ease;
+}

--- a/less/items.less
+++ b/less/items.less
@@ -133,6 +133,8 @@
         height: auto;
         padding-inline: 0.25rem;
       }
+      .accordion.collapsed > .editor.accordion-content { height: 0; }
+      .editor.accordion-content > .editor-content { overflow: hidden; }
     }
   }
 

--- a/less/items.less
+++ b/less/items.less
@@ -104,6 +104,39 @@
   }
 
   /* ----------------------------------------- */
+  /*  Item Description                         */
+  /* ----------------------------------------- */
+
+  [data-tab="description"] {
+    align-content: stretch;
+
+    .item-description {
+      .description-header {
+        display: flex;
+        align-items: first baseline;
+        justify-content: space-between;
+        margin-block-end: 0;
+        padding: 0.25rem;
+        background-color: rgb(0 0 0 / 0.05);
+
+        .description-edit {
+          opacity: 20%;
+        }
+        &:hover .description-edit {
+          opacity: 100%;
+        }
+      }
+      .editor + .description-header {
+        margin-block-start: 0.5rem;
+      }
+      .editor:not(.prosemirror) {
+        height: auto;
+        padding-inline: 0.25rem;
+      }
+    }
+  }
+
+  /* ----------------------------------------- */
   /*  Item Details Form                        */
   /* ----------------------------------------- */
 

--- a/module/applications/accordion.mjs
+++ b/module/applications/accordion.mjs
@@ -1,0 +1,205 @@
+/**
+ * @typedef {object} AccordionConfiguration
+ * @property {string} headingSelector    The CSS selector that identifies accordion headers in the given markup.
+ * @property {string} contentSelector    The CSS selector that identifies accordion content in the given markup. This
+ *                                       can match content within the heading element, or sibling to the heading
+ *                                       element, with priority given to the former.
+ * @property {boolean} [collapseOthers]  Automatically collapses the other headings in this group when one heading is
+ *                                       clicked.
+ */
+
+/**
+ * A class responsible for augmenting markup with an accordion effect.
+ * @param {AccordionConfiguration} config  Configuration options.
+ */
+export default class Accordion {
+  constructor(config) {
+    config.contentSelector = `${config.contentSelector}:not(.accordion-content)`;
+    this.#config = config;
+  }
+
+  /**
+   * Configuration options.
+   * @type {AccordionConfiguration}
+   */
+  #config;
+
+  /**
+   * A mapping of heading elements to content elements.
+   * @type {Map<HTMLElement, HTMLElement>}
+   */
+  #sections = new Map();
+
+  /**
+   * A mapping of heading elements to any ongoing transition effect functions.
+   * @type {Map<HTMLElement, Function>}
+   */
+  #ongoing = new Map();
+
+  /**
+   * Record the state of collapsed sections.
+   * @type {boolean[]}
+   */
+  #collapsed;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Augment the given markup with an accordion effect.
+   * @param {HTMLElement} root  The root HTML node.
+   */
+  async bind(root) {
+    const firstBind = this.#sections.size < 1;
+    if ( firstBind ) this.#collapsed = [];
+    this.#sections = new Map();
+    this.#ongoing = new Map();
+    const { headingSelector, contentSelector } = this.#config;
+    for ( const heading of root.querySelectorAll(headingSelector) ) {
+      const content = heading.querySelector(contentSelector) ?? heading.parentElement.querySelector(contentSelector);
+      if ( !content ) continue;
+      const wrapper = document.createElement("div");
+      wrapper.classList.add("accordion");
+      heading.before(wrapper);
+      wrapper.append(heading, content);
+      this.#sections.set(heading, content);
+      if ( firstBind ) this.#collapsed.push(this.#collapsed.length > 0);
+      heading.classList.add("accordion-heading");
+      content.classList.add("accordion-content");
+      heading.addEventListener("click", this._onClickHeading.bind(this));
+    }
+    await new Promise(resolve => { setTimeout(resolve, 0); }); // Allow re-paint.
+    this._restoreCollapsedState();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle clicking an accordion heading.
+   * @param {PointerEvent} event  The triggering event.
+   * @protected
+   */
+  _onClickHeading(event) {
+    if ( event.target.closest("a") ) return;
+    const heading = event.currentTarget;
+    const content = this.#sections.get(heading);
+    if ( !content ) return;
+    event.preventDefault();
+    const collapsed = heading.parentElement.classList.contains("collapsed");
+    if ( collapsed ) this._onExpandSection(heading, content);
+    else this._onCollapseSection(heading, content);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle expanding a section.
+   * @param {HTMLElement} heading             The section heading.
+   * @param {HTMLElement} content             The section content.
+   * @param {object} [options]
+   * @param {boolean} [options.animate=true]  Whether to animate the expand effect.
+   * @protected
+   */
+  async _onExpandSection(heading, content, { animate=true }={}) {
+    this.#cancelOngoing(heading);
+
+    if ( this.#config.collapseOthers ) {
+      for ( const [otherHeading, otherContent] of this.#sections.entries() ) {
+        if ( (heading !== otherHeading) && !otherHeading.parentElement.classList.contains("collapsed") ) {
+          this._onCollapseSection(otherHeading, otherContent, { animate });
+        }
+      }
+    }
+
+    heading.parentElement.classList.remove("collapsed");
+    if ( animate ) content.style.height = "0";
+    else {
+      content.style.height = `${content._fullHeight}px`;
+      return;
+    }
+    await new Promise(resolve => { setTimeout(resolve, 0); }); // Allow re-paint.
+    const onEnd = this._onEnd.bind(this, heading, content);
+    this.#ongoing.set(heading, onEnd);
+    content.addEventListener("transitionend", onEnd, { once: true });
+    content.style.height = `${content._fullHeight}px`;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle collapsing a section.
+   * @param {HTMLElement} heading             The section heading.
+   * @param {HTMLElement} content             The section content.
+   * @param {object} [options]
+   * @param {boolean} [options.animate=true]  Whether to animate the collapse effect.
+   * @protected
+   */
+  async _onCollapseSection(heading, content, { animate=true }={}) {
+    this.#cancelOngoing(heading);
+    const { height } = content.getBoundingClientRect();
+    heading.parentElement.classList.add("collapsed");
+    content._fullHeight = height;
+    if ( animate ) content.style.height = `${height}px`;
+    else {
+      content.style.height = "0";
+      return;
+    }
+    await new Promise(resolve => { setTimeout(resolve, 0); }); // Allow re-paint.
+    const onEnd = this._onEnd.bind(this, heading, content);
+    this.#ongoing.set(heading, onEnd);
+    content.addEventListener("transitionend", onEnd, { once: true });
+    content.style.height = "0";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * A function to invoke when the height transition has ended.
+   * @param {HTMLElement} heading  The section heading.
+   * @param {HTMLElement} content  The section content.
+   * @protected
+   */
+  _onEnd(heading, content) {
+    content.style.height = "";
+    this.#ongoing.delete(heading);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Cancel an ongoing effect.
+   * @param {HTMLElement} heading  The section heading.
+   */
+  #cancelOngoing(heading) {
+    const ongoing = this.#ongoing.get(heading);
+    const content = this.#sections.get(heading);
+    if ( ongoing && content ) content.removeEventListener("transitionend", ongoing);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Save the accordion state.
+   * @protected
+   */
+  _saveCollapsedState() {
+    this.#collapsed = [];
+    for ( const heading of this.#sections.keys() ) {
+      this.#collapsed.push(heading.parentElement.classList.contains("collapsed"));
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Restore the accordion state.
+   * @protected
+   */
+  _restoreCollapsedState() {
+    const entries = Array.from(this.#sections.entries());
+    for ( let i = 0; i < entries.length; i++ ) {
+      const collapsed = this.#collapsed[i];
+      const [heading, content] = entries[i];
+      if ( collapsed ) this._onCollapseSection(heading, content, { animate: false });
+    }
+  }
+}

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -1,5 +1,6 @@
 import AdvancementManager from "../advancement/advancement-manager.mjs";
 import AdvancementMigrationDialog from "../advancement/advancement-migration-dialog.mjs";
+import Accordion from "../accordion.mjs";
 import TraitSelector from "../trait-selector.mjs";
 import ActiveEffect5e from "../../documents/active-effect.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
@@ -19,6 +20,8 @@ export default class ItemSheet5e extends ItemSheet {
     else if ( this.object.type === "subclass" ) {
       this.options.height = this.position.height = 540;
     }
+
+    this._accordions = this._createAccordions();
   }
 
   /* -------------------------------------------- */
@@ -40,7 +43,10 @@ export default class ItemSheet5e extends ItemSheet {
       dragDrop: [
         {dragSelector: "[data-effect-id]", dropSelector: ".effects-list"},
         {dragSelector: ".advancement-item", dropSelector: ".advancement"}
-      ]
+      ],
+      accordions: [{
+        headingSelector: ".description-header", contentSelector: ".editor"
+      }]
     });
   }
 
@@ -69,6 +75,14 @@ export default class ItemSheet5e extends ItemSheet {
 
   /* -------------------------------------------- */
   /*  Context Preparation                         */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _render(force, options) {
+    if ( !this.editingDescriptionTarget ) this._accordions.forEach(accordion => accordion._saveCollapsedState());
+    return super._render(force, options);
+  }
+
   /* -------------------------------------------- */
 
   /** @override */
@@ -448,6 +462,7 @@ export default class ItemSheet5e extends ItemSheet {
   /** @inheritDoc */
   activateListeners(html) {
     super.activateListeners(html);
+    if ( !this.editingDescriptionTarget ) this._accordions.forEach(accordion => accordion.bind(html[0]));
     if ( this.isEditable ) {
       html.find(".damage-control").click(this._onDamageControl.bind(this));
       html.find(".trait-selector").click(this._onConfigureTraits.bind(this));
@@ -740,5 +755,16 @@ export default class ItemSheet5e extends ItemSheet {
   async _onSubmit(...args) {
     if ( this._tabs[0].active === "details" ) this.position.height = "auto";
     await super._onSubmit(...args);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Instantiate accordion widgets.
+   * @returns {Accordion[]}
+   * @protected
+   */
+  _createAccordions() {
+    return this.options.accordions.map(config => new Accordion(config));
   }
 }

--- a/templates/chat/item-card.hbs
+++ b/templates/chat/item-card.hbs
@@ -6,7 +6,11 @@
     </header>
 
     <div class="card-content">
-        {{{data.description.value}}}
+        {{#if data.description.chat}}
+            {{{data.description.chat}}}
+        {{else}}
+            {{{data.description.value}}}
+        {{/if}}
         {{#if data.materials.value}}
         <p><strong>{{ localize "DND5E.RequiredMaterials" }}.</strong> {{data.materials.value}}</p>
         {{/if}}

--- a/templates/items/parts/item-description.hbs
+++ b/templates/items/parts/item-description.hbs
@@ -68,7 +68,7 @@
                     </a>
                 </h3>
             {{/if}}
-            {{editor enriched.description target="system.description.value" editable=false}}
+            {{editor enriched.description target="system.description.value" editable=false engine="prosemirror"}}
         {{/if}}
 
         {{#if (or editable system.description.unidentified)}}
@@ -80,7 +80,7 @@
                     </a>
                 {{/if}}
             </h3>
-            {{editor enriched.unidentified target="system.description.unidentified" editable=false}}
+            {{editor enriched.unidentified target="system.description.unidentified" editable=false engine="prosemirror"}}
         {{/if}}
 
         {{#if (or editable system.description.chat)}}
@@ -92,7 +92,7 @@
                     </a>
                 {{/if}}
             </h3>
-            {{editor enriched.chat target="system.description.chat" editable=false}}
+            {{editor enriched.chat target="system.description.chat" editable=false engine="prosemirror"}}
         {{/if}}
     </div>
 {{/if}}

--- a/templates/items/parts/item-description.hbs
+++ b/templates/items/parts/item-description.hbs
@@ -1,5 +1,9 @@
 <div class="tab flexrow active" data-group="primary" data-tab="description">
 
+{{#if editingDescriptionTarget}}
+    {{editor enriched.editing target=editingDescriptionTarget button=false editable=editable
+             engine="prosemirror" collaborate=true}}
+{{else}}
     <div class="item-properties">
         {{#if isPhysical}}
         <div class="form-group">
@@ -54,6 +58,42 @@
         {{/if}}
     </div>
 
-    {{editor descriptionHTML target="system.description.value" button=true editable=editable engine="prosemirror"
-             collaborate=false}}
+    <div class="item-description">
+        {{#if (or editable system.description.value)}}
+            {{#if editable}}
+                <h3 class="description-header">
+                    {{localize "DND5E.Description"}}
+                    <a class="description-edit" data-target="system.description.value">
+                        <i class="fa-solid fa-edit"></i>
+                    </a>
+                </h3>
+            {{/if}}
+            {{editor enriched.description target="system.description.value" editable=false}}
+        {{/if}}
+
+        {{#if (or editable system.description.unidentified)}}
+            <h3 class="description-header">
+                {{localize "DND5E.DescriptionUnidentified"}}
+                {{#if editable}}
+                    <a class="description-edit" data-target="system.description.unidentified">
+                        <i class="fa-solid fa-edit"></i>
+                    </a>
+                {{/if}}
+            </h3>
+            {{editor enriched.unidentified target="system.description.unidentified" editable=false}}
+        {{/if}}
+
+        {{#if (or editable system.description.chat)}}
+            <h3 class="description-header">
+                {{localize "DND5E.DescriptionChat"}}
+                {{#if editable}}
+                    <a class="description-edit" data-target="system.description.chat">
+                        <i class="fa-solid fa-edit"></i>
+                    </a>
+                {{/if}}
+            </h3>
+            {{editor enriched.chat target="system.description.chat" editable=false}}
+        {{/if}}
+    </div>
+{{/if}}
 </div>


### PR DESCRIPTION
Adds multiple inline editors into items to allow editing normal description, unidentified description, and chat text. When the edit button is clicked the editor replaces the whole tab giving plenty of space to write.

https://github.com/foundryvtt/dnd5e/assets/19979839/09eb8de2-5b2b-409c-830c-5b9d3e559e50

This also will display the chat text in created chat messages rather than the default description if it is provided.
 
Closes #2135
Closes #2136
