### PR TITLE
Add cached roll to direct rollInitiative call

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1591,10 +1591,7 @@ export default class Actor5e extends Actor {
 
   /** @inheritdoc */
   async rollInitiative(options={}, rollOptions={}) {
-    // Set a _cachedInitiativeRoll if not called from rollInitiativeDialog.
-    if ((this._cachedInitiativeRoll ?? undefined) === undefined) {
-      this._cachedInitiativeRoll = this.getInitiativeRoll(rollOptions);
-    }
+    this._cachedInitiativeRoll ??= this.getInitiativeRoll(rollOptions);
     /**
      * A hook event that fires before initiative is rolled for an Actor.
      * @function dnd5e.preRollInitiative

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1592,6 +1592,7 @@ export default class Actor5e extends Actor {
   /** @inheritdoc */
   async rollInitiative(options={}, rollOptions={}) {
     this._cachedInitiativeRoll ??= this.getInitiativeRoll(rollOptions);
+
     /**
      * A hook event that fires before initiative is rolled for an Actor.
      * @function dnd5e.preRollInitiative
@@ -1599,7 +1600,10 @@ export default class Actor5e extends Actor {
      * @param {Actor5e} actor  The Actor that is rolling initiative.
      * @param {D20Roll} roll   The initiative roll.
      */
-    if ( Hooks.call("dnd5e.preRollInitiative", this, this._cachedInitiativeRoll) === false ) return;
+    if ( Hooks.call("dnd5e.preRollInitiative", this, this._cachedInitiativeRoll) === false ) {
+      delete this._cachedInitiativeRoll;
+      return null;
+    }
 
     const combat = await super.rollInitiative(options);
     const combatants = this.isToken ? this.getActiveTokens(false, true).reduce((arr, t) => {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1585,13 +1585,16 @@ export default class Actor5e extends Actor {
     // Temporarily cache the configured roll and use it to roll initiative for the Actor
     this._cachedInitiativeRoll = roll;
     await this.rollInitiative({createCombatants: true});
-    delete this._cachedInitiativeRoll;
   }
 
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  async rollInitiative(options={}) {
+  async rollInitiative(options={}, rollOptions={}) {
+    // Set a _cachedInitiativeRoll if not called from rollInitiativeDialog.
+    if ((this._cachedInitiativeRoll ?? undefined) === undefined) {
+      this._cachedInitiativeRoll = this.getInitiativeRoll(rollOptions);
+    }
     /**
      * A hook event that fires before initiative is rolled for an Actor.
      * @function dnd5e.preRollInitiative
@@ -1616,6 +1619,7 @@ export default class Actor5e extends Actor {
      * @param {Combatant[]} combatants  The associated Combatants in the Combat.
      */
     Hooks.callAll("dnd5e.rollInitiative", this, combatants);
+    delete this._cachedInitiativeRoll;
     return combat;
   }
 


### PR DESCRIPTION
It appears that rollInitiativeDialog creates a _cachedInitiativeRoll before calling rollInitiative which then assumes that a _cachedInitiativeRoll exists for the hook. This would return undefined to the dnd5e.preRollInitiative hook if called directly. (this doesn't cause errors in the initiative roll as foundry code calls getInitiativeRoll and it returns the cached roll if it exists or gets a new roll)
To fix this issue:
- I added a check to see if there is a _cachedInitiativeRoll in rollInitatiative and if not to call getInitiativeRoll to get a new roll and cache it.
- I added a rollOptions to rollInitiative to allow for providing RollOptions to the getInitiativeRoll if the _cachedInitiativeRoll does not exist.
- Moved the delete this._cachedInitiativeRoll from rollInitiativeDialog to rollInitiative as we will now always have a cached roll to delete and eliminates extra checks needed to determine if we need to delete _cachedInitiativeRoll depending on if it is set inside of rollInitiative or not.
Closes #2468