### PR TITLE
[#2529] Implement damage enricher

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1267,6 +1267,8 @@
 
 "EDITOR.DND5E.Inline.CheckShort": "{check}",
 "EDITOR.DND5E.Inline.CheckLong": "{check} check",
+"EDITOR.DND5E.Inline.DamageShort": "{formula} {type}",
+"EDITOR.DND5E.Inline.DamageLong": "{average} ({formula}) {type}",
 "EDITOR.DND5E.Inline.DC": "DC {dc} {check}",
 "EDITOR.DND5E.Inline.DCPassiveShort": "DC {dc} passive {check}",
 "EDITOR.DND5E.Inline.DCPassiveLong": "passive {check} score of {dc} or higher",


### PR DESCRIPTION
Implements a damage enricher in the format `[[/damage 1d6 bludgeoning]]` or `[[/damage formula=1d6 type=bludgeoning]]` which will present the normal damage rolling dialog, allowing criticals to be rolled and damage types to be passed through.

<img width="957" alt="Screenshot 2023-10-29 at 10 58 32" src="https://github.com/foundryvtt/dnd5e/assets/19979839/d5de2292-22c1-47d9-944d-ab455a227f1c">

Closes #2529