### PR TITLE
[#2504] Convert source on items & actors into object

### DIFF
--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -136,8 +136,9 @@ export default class NPCData extends CreatureTemplate {
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateSource(source) {
-    if ( !source.details?.source || foundry.utils.getType(source.details.source) === "Object" ) return;
-    source.details.source = { custom: source.details.source };
+    if ( source.details?.source && (foundry.utils.getType(source.details.source) !== "Object") ) {
+      source.details.source = { custom: source.details.source };
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -1,4 +1,5 @@
 import { FormulaField } from "../fields.mjs";
+import SourceField from "../shared/source-field.mjs";
 import AttributesFields from "./templates/attributes.mjs";
 import CreatureTemplate from "./templates/creature.mjs";
 import DetailsFields from "./templates/details.mjs";
@@ -27,7 +28,7 @@ import TraitsFields from "./templates/traits.mjs";
  * @property {string} details.environment        Common environments in which this NPC is found.
  * @property {number} details.cr                 NPC's challenge rating.
  * @property {number} details.spellLevel         Spellcasting level of this NPC.
- * @property {string} details.source             What book or adventure is this NPC from?
+ * @property {SourceField} details.source        Adventure or sourcebook where this NPC originated.
  * @property {object} resources
  * @property {object} resources.legact           NPC's legendary actions.
  * @property {number} resources.legact.value     Currently available legendary actions.
@@ -85,7 +86,7 @@ export default class NPCData extends CreatureTemplate {
         spellLevel: new foundry.data.fields.NumberField({
           required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.SpellcasterLevel"
         }),
-        source: new foundry.data.fields.StringField({required: true, label: "DND5E.Source"})
+        source: new SourceField()
       }, {label: "DND5E.Details"}),
       resources: new foundry.data.fields.SchemaField({
         legact: new foundry.data.fields.SchemaField({
@@ -123,8 +124,20 @@ export default class NPCData extends CreatureTemplate {
   /** @inheritdoc */
   static _migrateData(source) {
     super._migrateData(source);
+    NPCData.#migrateSource(source);
     NPCData.#migrateTypeData(source);
     AttributesFields._migrateInitiative(source.attributes);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Convert source string into custom object.
+   * @param {object} source  The candidate source data from which the model will be constructed.
+   */
+  static #migrateSource(source) {
+    if ( !source.details?.source || foundry.utils.getType(source.details.source) === "Object" ) return;
+    source.details.source = { custom: source.details.source };
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -137,8 +137,9 @@ export default class VehicleData extends CommonTemplate {
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateSource(source) {
-    if ( !source.details?.source || foundry.utils.getType(source.details.source) === "Object" ) return;
-    source.details.source = { custom: source.details.source };
+    if ( source.details?.source && (foundry.utils.getType(source.details.source) !== "Object") ) {
+      source.details.source = { custom: source.details.source };
+    }
   }
 }
 

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -1,4 +1,5 @@
 import { FormulaField } from "../fields.mjs";
+import SourceField from "../shared/source-field.mjs";
 import AttributesFields from "./templates/attributes.mjs";
 import CommonTemplate from "./templates/common.mjs";
 import DetailsFields from "./templates/details.mjs";
@@ -37,6 +38,8 @@ import TraitsFields from "./templates/traits.mjs";
  * @property {object} cargo                            Details on this vehicle's crew and cargo capacities.
  * @property {PassengerData[]} cargo.crew              Creatures responsible for operating the vehicle.
  * @property {PassengerData[]} cargo.passengers        Creatures just takin' a ride.
+ * @property {object} details
+ * @property {SourceField} details.source              Adventure or sourcebook where this vehicle originated.
  */
 export default class VehicleData extends CommonTemplate {
 
@@ -99,7 +102,7 @@ export default class VehicleData extends CommonTemplate {
       }, {label: "DND5E.Attributes"}),
       details: new foundry.data.fields.SchemaField({
         ...DetailsFields.common,
-        source: new foundry.data.fields.StringField({required: true, label: "DND5E.Source"})
+        source: new SourceField()
       }, {label: "DND5E.Details"}),
       traits: new foundry.data.fields.SchemaField({
         ...TraitsFields.common,
@@ -124,6 +127,18 @@ export default class VehicleData extends CommonTemplate {
   static _migrateData(source) {
     super._migrateData(source);
     AttributesFields._migrateInitiative(source.attributes);
+    VehicleData.#migrateSource(source);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Convert source string into custom object.
+   * @param {object} source  The candidate source data from which the model will be constructed.
+   */
+  static #migrateSource(source) {
+    if ( !source.details?.source || foundry.utils.getType(source.details.source) === "Object" ) return;
+    source.details.source = { custom: source.details.source };
   }
 }
 

--- a/module/data/item/templates/item-description.mjs
+++ b/module/data/item/templates/item-description.mjs
@@ -1,4 +1,5 @@
 import SystemDataModel from "../../abstract.mjs";
+import SourceField from "../../shared/source-field.mjs";
 
 /**
  * Data model template with item description & source.
@@ -7,7 +8,7 @@ import SystemDataModel from "../../abstract.mjs";
  * @property {string} description.value         Full item description.
  * @property {string} description.chat          Description displayed in chat card.
  * @property {string} description.unidentified  Description displayed if item is unidentified.
- * @property {string} source                    Adventure or sourcebook where this item originated.
+ * @property {SourceField} source               Adventure or sourcebook where this item originated.
  * @mixin
  */
 export default class ItemDescriptionTemplate extends SystemDataModel {
@@ -21,7 +22,7 @@ export default class ItemDescriptionTemplate extends SystemDataModel {
           required: true, nullable: true, label: "DND5E.DescriptionUnidentified"
         })
       }),
-      source: new foundry.data.fields.StringField({required: true, label: "DND5E.Source"})
+      source: new SourceField()
     };
   }
 
@@ -38,10 +39,11 @@ export default class ItemDescriptionTemplate extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
-   * Convert null source to the blank string.
+   * Convert source string into custom object.
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateSource(source) {
-    if ( source.source === null ) source.source = "";
+    if ( foundry.utils.getType(source.source) === "Object" ) return;
+    source.source = { custom: source.source };
   }
 }

--- a/module/data/item/templates/item-description.mjs
+++ b/module/data/item/templates/item-description.mjs
@@ -43,7 +43,8 @@ export default class ItemDescriptionTemplate extends SystemDataModel {
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateSource(source) {
-    if ( foundry.utils.getType(source.source) === "Object" ) return;
-    source.source = { custom: source.source };
+    if ( foundry.utils.getType(source.source) !== "Object" ) {
+      source.source = { custom: source.source };
+    }
   }
 }

--- a/module/data/shared/_module.mjs
+++ b/module/data/shared/_module.mjs
@@ -1,1 +1,2 @@
 export {default as CurrencyTemplate} from "./currency.mjs";
+export {default as SourceField} from "./source-field.mjs";

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -1,0 +1,47 @@
+const { SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * Data fields that stores information on the adventure or sourcebook where this document originated.
+ *
+ * @property {string} book     Book/publication where the item originated.
+ * @property {string} page     Page or section where the item can be found.
+ * @property {string} custom   Fully custom source label.
+ * @property {string} uuid     Upstream source of this data if it originated in another compendium.
+ * @property {string} license  Type of license that covers this item.
+ */
+export default class SourceTemplate extends SchemaField {
+  constructor(fields={}, options={}) {
+    super({
+      book: new StringField(),
+      page: new StringField(),
+      custom: new StringField(),
+      uuid: new StringField(), // TODO: Convert to UUIDField with v12
+      license: new StringField(),
+      ...fields
+    }, { label: "DND5E.Source", ...options });
+  }
+
+  /* -------------------------------------------- */
+
+  initialize(value, model, options={}) {
+    const obj = super.initialize(value, model, options);
+
+    Object.defineProperty(obj, "label", {
+      get() {
+        // TODO: Implement logic for generating source
+        return this.custom ?? "";
+      },
+      enumerable: false
+    });
+    Object.defineProperty(obj, "toString", {
+      value: () => {
+        foundry.utils.logCompatibilityWarning("Source has been converted to an object, the label can now be accessed "
+         + "using the `source#label` property.", { since: "DnD5e 2.4", until: "DnD5e 2.6" });
+        return obj.label;
+      },
+      enumerable: false
+    });
+
+    return obj;
+  }
+}

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -28,8 +28,9 @@ export default class SourceTemplate extends SchemaField {
 
     Object.defineProperty(obj, "label", {
       get() {
-        // TODO: Implement logic for generating source
-        return this.custom ?? "";
+        if ( this.custom ) return this.custom;
+        // TODO: Improve this logic
+        return this.book ? this.page ? `${this.book} ${this.page}` : this.book : "";
       },
       enumerable: false
     });

--- a/template.json
+++ b/template.json
@@ -510,7 +510,7 @@
           "chat": "",
           "unidentified": ""
         },
-        "source": ""
+        "source": {}
       },
       "physicalItem": {
         "quantity": 1,

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -41,7 +41,7 @@
                     </a>
                 </li>
                 <li class="source">
-                    <input type="text" name="system.details.source" value="{{system.details.source}}"
+                    <input type="text" name="system.details.source.custom" value="{{system.details.source.custom}}"
                            placeholder="{{ localize 'DND5E.Source' }}"/>
                 </li>
             </ul>

--- a/templates/actors/vehicle-sheet.hbs
+++ b/templates/actors/vehicle-sheet.hbs
@@ -22,7 +22,7 @@
                            placeholder="{{localize 'DND5E.Dimensions'}}">
                 </li>
                 <li class="source">
-                    <input type="text" name="system.details.source" value="{{system.details.source}}"
+                    <input type="text" name="system.details.source.custom" value="{{system.details.source.custom}}"
                            placeholder="{{localize 'DND5E.Source'}}">
                 </li>
             </ul>

--- a/templates/items/background.hbs
+++ b/templates/items/background.hbs
@@ -16,7 +16,8 @@
 
       <ul class="summary flexrow">
         <li>
-          <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+          <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+                 placeholder="{{ localize 'DND5E.Source' }}">
         </li>
       </ul>
     </div>

--- a/templates/items/backpack.hbs
+++ b/templates/items/backpack.hbs
@@ -21,7 +21,8 @@
 					</select>
 				</li>
 				<li>
-					<input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+					<input type="text" name="system.source.custom" value="{{system.source.custom}}"
+						     placeholder="{{ localize 'DND5E.Source' }}">
 				</li>
 			</ul>
 		</div>

--- a/templates/items/class.hbs
+++ b/templates/items/class.hbs
@@ -16,7 +16,8 @@
 
             <ul class="summary flexrow">
                 <li>
-                    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+                           placeholder="{{ localize 'DND5E.Source' }}">
                 </li>
             </ul>
         </div>

--- a/templates/items/consumable.hbs
+++ b/templates/items/consumable.hbs
@@ -24,7 +24,8 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}">
+                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+                           placeholder="{{ localize 'DND5E.Source' }}">
                 </li>
             </ul>
         </div>

--- a/templates/items/equipment.hbs
+++ b/templates/items/equipment.hbs
@@ -24,7 +24,8 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+                           placeholder="{{ localize 'DND5E.Source' }}">
                 </li>
             </ul>
         </div>

--- a/templates/items/feat.hbs
+++ b/templates/items/feat.hbs
@@ -22,7 +22,8 @@
                     <input type="text" name="system.requirements" value="{{system.requirements}}" placeholder="{{ localize 'DND5E.Requirements' }}"/>
                 </li>
                 <li>
-                    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+                           placeholder="{{ localize 'DND5E.Source' }}">
                 </li>
             </ul>
         </div>

--- a/templates/items/loot.hbs
+++ b/templates/items/loot.hbs
@@ -21,7 +21,8 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+                           placeholder="{{ localize 'DND5E.Source' }}">
                 </li>
             </ul>
         </div>

--- a/templates/items/spell.hbs
+++ b/templates/items/spell.hbs
@@ -22,7 +22,8 @@
                     {{labels.school}}
                 </li>
                 <li>
-                    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+                           placeholder="{{ localize 'DND5E.Source' }}">
                 </li>
             </ul>
         </div>

--- a/templates/items/subclass.hbs
+++ b/templates/items/subclass.hbs
@@ -16,7 +16,8 @@
 
       <ul class="summary flexrow">
         <li>
-          <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+          <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+                 placeholder="{{ localize 'DND5E.Source' }}">
         </li>
       </ul>
     </div>

--- a/templates/items/tool.hbs
+++ b/templates/items/tool.hbs
@@ -28,7 +28,8 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+                           placeholder="{{ localize 'DND5E.Source' }}">
                 </li>
             </ul>
         </div>

--- a/templates/items/weapon.hbs
+++ b/templates/items/weapon.hbs
@@ -24,7 +24,8 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND5E.Source' }}"/>
+                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+                           placeholder="{{ localize 'DND5E.Source' }}">
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
First part of #2504 that migrates the data structure to an object. This updates the existing templates to display and reference `source.custom` so a future PR can add a source configuration app.

```javascript
{
  book: "",
  page: "",
  custom: "",
  uuid: "",
  license: ""
}
```