### PR TITLE
[#342, #2538] Display race on sheet, add singleton logic to race & background items

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -140,6 +140,7 @@
 "DND5E.ActionWarningNoItem": "The requested item {item} no longer exists on Actor {name}",
 "DND5E.ActionWarningNoToken": "You must have one or more controlled Tokens in order to use this option.",
 "DND5E.ActorWarningInvalidItem": "{itemType} items cannot be added to a {actorType}.",
+"DND5E.ActorWarningSingleton": "Only a single {itemType} can be added to a {actorType}.",
 "DND5E.ActiveEffectOverrideWarning": "This value is being modified by an Active Effect and cannot be edited. Disable the effect to edit it.",
 "DND5E.Add": "Add",
 "DND5E.AddEmbeddedItemPromptHint": "Do you want to add these items to your character sheet?",

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -169,7 +169,6 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
     context.spellbook = spellbook;
     context.preparedSpells = nPrepared;
     context.features = Object.values(features);
-    context.labels.background = backgrounds[0]?.name;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -56,7 +56,7 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
     }
 
     // Partition items by category
-    let {items, spells, feats, backgrounds, classes, subclasses} = context.items.reduce((obj, item) => {
+    let {items, spells, feats, races, backgrounds, classes, subclasses} = context.items.reduce((obj, item) => {
       const {quantity, uses, recharge} = item.system;
 
       // Item details
@@ -90,12 +90,13 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
       // Classify items into types
       if ( item.type === "spell" ) obj.spells.push(item);
       else if ( item.type === "feat" ) obj.feats.push(item);
+      else if ( item.type === "race" ) obj.races.push(item);
       else if ( item.type === "background" ) obj.backgrounds.push(item);
       else if ( item.type === "class" ) obj.classes.push(item);
       else if ( item.type === "subclass" ) obj.subclasses.push(item);
       else if ( Object.keys(inventory).includes(item.type) ) obj.items.push(item);
       return obj;
-    }, { items: [], spells: [], feats: [], backgrounds: [], classes: [], subclasses: [] });
+    }, { items: [], spells: [], feats: [], races: [], backgrounds: [], classes: [], subclasses: [] });
 
     // Apply active item filters
     items = this._filterItems(items, this._filters.inventory);
@@ -141,6 +142,9 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
 
     // Organize Features
     const features = {
+      race: {
+        label: CONFIG.Item.typeLabels.race, items: races,
+        hasActions: false, dataset: {type: "race"} },
       background: {
         label: CONFIG.Item.typeLabels.background, items: backgrounds,
         hasActions: false, dataset: {type: "background"} },

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -16,7 +16,7 @@ export default class ActorSheet5eNPC extends ActorSheet5e {
   /* -------------------------------------------- */
 
   /** @override */
-  static unsupportedItemTypes = new Set(["background", "class", "subclass"]);
+  static unsupportedItemTypes = new Set(["background", "class", "race", "subclass"]);
 
   /* -------------------------------------------- */
   /*  Context Preparation                         */

--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -15,7 +15,7 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
   /* -------------------------------------------- */
 
   /** @override */
-  static unsupportedItemTypes = new Set(["background", "class", "subclass"]);
+  static unsupportedItemTypes = new Set(["background", "class", "race", "subclass"]);
 
   /* -------------------------------------------- */
 

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -65,6 +65,23 @@ export default class SystemDataModel extends foundry.abstract.DataModel {
 
   /* -------------------------------------------- */
 
+  /**
+   * @typedef {object} SystemDataModelMetadata
+   * @property {boolean} [singleton] - Should only a single item of this type be allowed on an actor?
+   */
+
+  /**
+   * Metadata that describes this DataModel.
+   * @type {SystemDataModelMetadata}
+   */
+  static metadata = {};
+
+  get metadata() {
+    return this.constructor.metadata;
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritdoc */
   static defineSchema() {
     const schema = {};
@@ -143,6 +160,31 @@ export default class SystemDataModel extends foundry.abstract.DataModel {
     return super.validate(options);
   }
 
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /**
+   * Pre-creation logic for this system data.
+   * @param {object} data     The initial data object provided to the document creation request.
+   * @param {object} options  Additional options which modify the creation request.
+   * @param {User} user       The User requesting the document creation.
+   * @protected
+   */
+  async _preCreate(data, options, user) {
+    const actor = this.parent.actor;
+    if ( (actor?.type !== "character") || !this.metadata?.singleton ) return;
+    if ( actor.itemTypes[data.type]?.length ) {
+      ui.notifications.error(game.i18n.format("DND5E.ActorWarningSingleton", {
+        itemType: game.i18n.localize(CONFIG.Item.typeLabels[data.type]),
+        actorType: game.i18n.localize(CONFIG.Actor.typeLabels[actor.type])
+      }));
+      return false;
+    }
+  }
+
+  /* -------------------------------------------- */
+  /*  Mixin                                       */
   /* -------------------------------------------- */
 
   /** @inheritdoc */

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -166,9 +166,11 @@ export default class SystemDataModel extends foundry.abstract.DataModel {
 
   /**
    * Pre-creation logic for this system data.
-   * @param {object} data     The initial data object provided to the document creation request.
-   * @param {object} options  Additional options which modify the creation request.
-   * @param {User} user       The User requesting the document creation.
+   * @param {object} data               The initial data object provided to the document creation request.
+   * @param {object} options            Additional options which modify the creation request.
+   * @param {User} user                 The User requesting the document creation.
+   * @returns {Promise<boolean|void>}   A return value of false indicates the creation operation should be cancelled.
+   * @see {Document#_preCreate}
    * @protected
    */
   async _preCreate(data, options, user) {

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -1,4 +1,4 @@
-import { FormulaField } from "../fields.mjs";
+import { FormulaField, LocalDocumentField } from "../fields.mjs";
 import AttributesFields from "./templates/attributes.mjs";
 import CreatureTemplate from "./templates/creature.mjs";
 import DetailsFields from "./templates/details.mjs";
@@ -26,7 +26,7 @@ import TraitsFields from "./templates/traits.mjs";
  * @property {number} attributes.exhaustion               Number of levels of exhaustion.
  * @property {number} attributes.inspiration              Does this character have inspiration?
  * @property {object} details
- * @property {string} details.background                  Name of character's background.
+ * @property {Item5e|string} details.background           Character's background item or name.
  * @property {string} details.originalClass               ID of first class taken by character.
  * @property {XPData} details.xp                          Experience points gained.
  * @property {number} details.xp.value                    Total experience points earned.
@@ -91,7 +91,9 @@ export default class CharacterData extends CreatureTemplate {
       details: new foundry.data.fields.SchemaField({
         ...DetailsFields.common,
         ...DetailsFields.creature,
-        background: new foundry.data.fields.StringField({required: true, label: "DND5E.Background"}),
+        background: new LocalDocumentField(foundry.documents.BaseItem, {
+          required: true, fallback: true, label: "DND5E.Background"
+        }),
         originalClass: new foundry.data.fields.StringField({required: true, label: "DND5E.ClassOriginal"}),
         xp: new foundry.data.fields.SchemaField({
           value: new foundry.data.fields.NumberField({

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -127,19 +127,6 @@ export default class CharacterData extends CreatureTemplate {
     super._migrateData(source);
     AttributesFields._migrateInitiative(source.attributes);
   }
-
-  /* -------------------------------------------- */
-
-  prepareDerivedData() {
-    // Populate the background field with background if background item exists but is not set
-    if ( !(this.details.background instanceof dnd5e.documents.Item5e) ) {
-      const background = this.parent.itemTypes.background?.[0];
-      if ( background ) Object.defineProperty(this.details, "background", {
-        get() { return background; },
-        enumerable: false
-      });
-    }
-  }
 }
 
 /* -------------------------------------------- */

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -127,6 +127,19 @@ export default class CharacterData extends CreatureTemplate {
     super._migrateData(source);
     AttributesFields._migrateInitiative(source.attributes);
   }
+
+  /* -------------------------------------------- */
+
+  prepareDerivedData() {
+    // Populate the background field with background if background item exists but is not set
+    if ( !(this.details.background instanceof dnd5e.documents.Item5e) ) {
+      const background = this.parent.itemTypes.background?.[0];
+      if ( background ) Object.defineProperty(this.details, "background", {
+        get() { return background; },
+        enumerable: false
+      });
+    }
+  }
 }
 
 /* -------------------------------------------- */

--- a/module/data/actor/templates/details.mjs
+++ b/module/data/actor/templates/details.mjs
@@ -1,3 +1,5 @@
+import { LocalDocumentField } from "../../fields.mjs";
+
 /**
  * Shared contents of the details schema between various actor types.
  */
@@ -25,13 +27,15 @@ export default class DetailsField {
    * Fields shared between characters and NPCs.
    *
    * @type {object}
-   * @property {string} alignment  Creature's alignment.
-   * @property {string} race       Creature's race.
+   * @property {string} alignment    Creature's alignment.
+   * @property {Item5e|string} race  Creature's race item or name.
    */
   static get creature() {
     return {
       alignment: new foundry.data.fields.StringField({required: true, label: "DND5E.Alignment"}),
-      race: new foundry.data.fields.StringField({required: true, label: "DND5E.Race"})
+      race: new LocalDocumentField(foundry.documents.BaseItem, {
+        required: true, fallback: true, label: "DND5E.Race"
+      })
     };
   }
 }

--- a/module/data/fields.mjs
+++ b/module/data/fields.mjs
@@ -151,6 +151,86 @@ export class IdentifierField extends foundry.data.fields.StringField {
 /* -------------------------------------------- */
 
 /**
+ * @typedef {StringFieldOptions} LocalDocumentFieldOptions
+ * @property {boolean} [fallback=false]  Display the string value if no matching item is found.
+ */
+
+/**
+ * A mirror of ForeignDocumentField that references a Document embedded within this Document.
+ *
+ * @param {typeof Document} model              The local DataModel class definition which this field should link to.
+ * @param {LocalDocumentFieldOptions} options  Options which configure the behavior of the field.
+ */
+export class LocalDocumentField extends foundry.data.fields.DocumentIdField {
+  constructor(model, options={}) {
+    if ( !foundry.utils.isSubclass(model, foundry.abstract.DataModel) ) {
+      throw new Error("A ForeignDocumentField must specify a DataModel subclass as its type");
+    }
+
+    super(options);
+    this.model = model;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * A reference to the model class which is stored in this field.
+   * @type {typeof Document}
+   */
+  model;
+
+  /* -------------------------------------------- */
+
+  static get _defaults() {
+    return foundry.utils.mergeObject(super._defaults, {
+      nullable: true,
+      readonly: false,
+      idOnly: false,
+      fallback: false
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  _cast(value) {
+    if ( typeof value === "string" ) return value;
+    if ( (value instanceof this.model) ) return value._id;
+    throw new Error(`The value provided to a LocalDocumentField must be a ${this.model.name} instance.`);
+  }
+
+  /* -------------------------------------------- */
+
+  _validateType(value) {
+    if ( !this.options.fallback ) super._validateType(value);
+  }
+
+  /* -------------------------------------------- */
+
+  initialize(value, model, options={}) {
+    if ( this.idOnly ) return value;
+    const collection = model.parent?.[this.model.metadata.collection];
+    return () => {
+      const document = collection?.get(value);
+      if ( !document ) return this.options.fallback ? value : null;
+      if ( this.options.fallback ) Object.defineProperty(document, "toString", {
+        value: () => document.name,
+        configurable: true,
+        enumerable: false
+      });
+      return document;
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  toObject(value) {
+    return value?._id ?? value;
+  }
+}
+
+/* -------------------------------------------- */
+
+/**
  * @callback MappingFieldInitialValueBuilder
  * @param {string} key       The key within the object where this new value is being generated.
  * @param {*} initial        The generic initial data provided by the contained model.

--- a/module/data/fields.mjs
+++ b/module/data/fields.mjs
@@ -181,6 +181,7 @@ export class LocalDocumentField extends foundry.data.fields.DocumentIdField {
 
   /* -------------------------------------------- */
 
+  /** @inheritdoc */
   static get _defaults() {
     return foundry.utils.mergeObject(super._defaults, {
       nullable: true,
@@ -192,6 +193,7 @@ export class LocalDocumentField extends foundry.data.fields.DocumentIdField {
 
   /* -------------------------------------------- */
 
+  /** @override */
   _cast(value) {
     if ( typeof value === "string" ) return value;
     if ( (value instanceof this.model) ) return value._id;
@@ -200,14 +202,16 @@ export class LocalDocumentField extends foundry.data.fields.DocumentIdField {
 
   /* -------------------------------------------- */
 
+  /** @inheritdoc */
   _validateType(value) {
     if ( !this.options.fallback ) super._validateType(value);
   }
 
   /* -------------------------------------------- */
 
+  /** @override */
   initialize(value, model, options={}) {
-    if ( this.idOnly ) return value;
+    if ( this.idOnly ) return this.options.fallback || foundry.data.validators.isValidId(value) ? value : null;
     const collection = model.parent?.[this.model.metadata.collection];
     return () => {
       const document = collection?.get(value);
@@ -223,6 +227,7 @@ export class LocalDocumentField extends foundry.data.fields.DocumentIdField {
 
   /* -------------------------------------------- */
 
+  /** @inheritdoc */
   toObject(value) {
     return value?._id ?? value;
   }

--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -27,6 +27,14 @@ export default class BackgroundData extends SystemDataModel.mixin(ItemDescriptio
   /*  Socket Event Handlers                       */
   /* -------------------------------------------- */
 
+  /**
+   * Set the background reference in actor data.
+   * @param {object} data     The initial data object provided to the document creation request
+   * @param {object} options  Additional options which modify the creation request
+   * @param {string} userId   The id of the User requesting the document update
+   * @see {Document#_onCreate}
+   * @protected
+   */
   _onCreate(data, options, userId) {
     if ( (game.user.id !== userId) || this.parent.actor?.type !== "character" ) return;
     this.parent.actor.update({"system.details.background": this.parent.id});
@@ -34,6 +42,14 @@ export default class BackgroundData extends SystemDataModel.mixin(ItemDescriptio
 
   /* -------------------------------------------- */
 
+  /**
+   * Remove the background reference in actor data.
+   * @param {object} options            Additional options which modify the deletion request
+   * @param {documents.BaseUser} user   The User requesting the document deletion
+   * @returns {Promise<boolean|void>}   A return value of false indicates the deletion operation should be cancelled.
+   * @see {Document#_preDelete}
+   * @protected
+   */
   async _preDelete(options, user) {
     if ( this.parent.actor?.type !== "character" ) return;
     await this.parent.actor.update({"system.details.background": null});

--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -29,7 +29,7 @@ export default class BackgroundData extends SystemDataModel.mixin(ItemDescriptio
 
   _onCreate(data, options, userId) {
     if ( (game.user.id !== userId) || this.parent.actor?.type !== "character" ) return;
-    this.parent.actor.update({"system.details.background": this.parent});
+    this.parent.actor.update({"system.details.background": this.parent.id});
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -15,4 +15,27 @@ export default class BackgroundData extends SystemDataModel.mixin(ItemDescriptio
       advancement: new foundry.data.fields.ArrayField(new AdvancementField(), {label: "DND5E.AdvancementTitle"})
     });
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static metadata = Object.freeze({
+    singleton: true
+  });
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  _onCreate(data, options, userId) {
+    if ( (game.user.id !== userId) || this.parent.actor?.type !== "character" ) return;
+    this.parent.actor.update({"system.details.background": this.parent});
+  }
+
+  /* -------------------------------------------- */
+
+  async _preDelete(options, user) {
+    if ( this.parent.actor?.type !== "character" ) return;
+    await this.parent.actor.update({"system.details.background": null});
+  }
 }

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -27,6 +27,13 @@ export default class RaceData extends SystemDataModel.mixin(ItemDescriptionTempl
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static metadata = Object.freeze({
+    singleton: true
+  });
+
+  /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
 
@@ -66,5 +73,21 @@ export default class RaceData extends SystemDataModel.mixin(ItemDescriptionTempl
    */
   get typeLabel() {
     return Actor5e.formatCreatureType(this.type);
+  }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  _onCreate(data, options, userId) {
+    if ( (game.user.id !== userId) || this.parent.actor?.type !== "character" ) return;
+    this.parent.actor.update({"system.details.race": this.parent});
+  }
+
+  /* -------------------------------------------- */
+
+  async _preDelete(options, user) {
+    if ( this.parent.actor?.type !== "character" ) return;
+    await this.parent.actor.update({"system.details.race": null});
   }
 }

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -81,7 +81,7 @@ export default class RaceData extends SystemDataModel.mixin(ItemDescriptionTempl
 
   _onCreate(data, options, userId) {
     if ( (game.user.id !== userId) || this.parent.actor?.type !== "character" ) return;
-    this.parent.actor.update({"system.details.race": this.parent});
+    this.parent.actor.update({"system.details.race": this.parent.id});
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -22,7 +22,7 @@ export default class RaceData extends SystemDataModel.mixin(ItemDescriptionTempl
       advancement: new foundry.data.fields.ArrayField(new AdvancementField(), {label: "DND5E.AdvancementTitle"}),
       movement: new MovementField(),
       senses: new SensesField(),
-      type: new CreatureTypeField({ swarm: false })
+      type: new CreatureTypeField({ swarm: false }, { initial: { value: "humanoid" } })
     });
   }
 
@@ -79,6 +79,14 @@ export default class RaceData extends SystemDataModel.mixin(ItemDescriptionTempl
   /*  Socket Event Handlers                       */
   /* -------------------------------------------- */
 
+  /**
+   * Set the race reference in actor data.
+   * @param {object} data     The initial data object provided to the document creation request
+   * @param {object} options  Additional options which modify the creation request
+   * @param {string} userId   The id of the User requesting the document update
+   * @see {Document#_onCreate}
+   * @protected
+   */
   _onCreate(data, options, userId) {
     if ( (game.user.id !== userId) || this.parent.actor?.type !== "character" ) return;
     this.parent.actor.update({"system.details.race": this.parent.id});
@@ -86,6 +94,14 @@ export default class RaceData extends SystemDataModel.mixin(ItemDescriptionTempl
 
   /* -------------------------------------------- */
 
+  /**
+   * Remove the race reference in actor data.
+   * @param {object} options            Additional options which modify the deletion request
+   * @param {documents.BaseUser} user   The User requesting the document deletion
+   * @returns {Promise<boolean|void>}   A return value of false indicates the deletion operation should be cancelled.
+   * @see {Document#_preDelete}
+   * @protected
+   */
   async _preDelete(options, user) {
     if ( this.parent.actor?.type !== "character" ) return;
     await this.parent.actor.update({"system.details.race": null});

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1,6 +1,7 @@
 import Proficiency from "./proficiency.mjs";
 import * as Trait from "./trait.mjs";
 import ScaleValueAdvancement from "../advancement/scale-value.mjs";
+import { DocumentMixin } from "../mixin.mjs";
 import { d20Roll } from "../../dice/dice.mjs";
 import { simplifyBonus } from "../../utils.mjs";
 import ShortRestDialog from "../../applications/actor/short-rest.mjs";
@@ -9,7 +10,7 @@ import LongRestDialog from "../../applications/actor/long-rest.mjs";
 /**
  * Extend the base Actor class to implement additional system-specific logic.
  */
-export default class Actor5e extends Actor {
+export default class Actor5e extends DocumentMixin(Actor) {
 
   /**
    * The data source for Actor5e.classes allowing it to be lazily computed.
@@ -838,7 +839,9 @@ export default class Actor5e extends Actor {
 
   /** @inheritdoc */
   async _preCreate(data, options, user) {
-    await super._preCreate(data, options, user);
+    let allowed = await super._preCreate(data, options, user);
+    if ( allowed === false ) return allowed;
+
     const sourceId = this.getFlag("core", "sourceId");
     if ( sourceId?.startsWith("Compendium.") ) return;
 
@@ -859,7 +862,8 @@ export default class Actor5e extends Actor {
 
   /** @inheritdoc */
   async _preUpdate(changed, options, user) {
-    await super._preUpdate(changed, options, user);
+    let allowed = await super._preUpdate(changed, options, user);
+    if ( allowed === false ) return allowed;
 
     // Apply changes in Actor size to Token width/height
     if ( "size" in (this.system.traits || {}) ) {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1,7 +1,7 @@
 import Proficiency from "./proficiency.mjs";
 import * as Trait from "./trait.mjs";
 import ScaleValueAdvancement from "../advancement/scale-value.mjs";
-import { DocumentMixin } from "../mixin.mjs";
+import { SystemDocumentMixin } from "../mixin.mjs";
 import { d20Roll } from "../../dice/dice.mjs";
 import { simplifyBonus } from "../../utils.mjs";
 import ShortRestDialog from "../../applications/actor/short-rest.mjs";
@@ -10,7 +10,7 @@ import LongRestDialog from "../../applications/actor/long-rest.mjs";
 /**
  * Extend the base Actor class to implement additional system-specific logic.
  */
-export default class Actor5e extends DocumentMixin(Actor) {
+export default class Actor5e extends SystemDocumentMixin(Actor) {
 
   /**
    * The data source for Actor5e.classes allowing it to be lazily computed.
@@ -839,8 +839,7 @@ export default class Actor5e extends DocumentMixin(Actor) {
 
   /** @inheritdoc */
   async _preCreate(data, options, user) {
-    let allowed = await super._preCreate(data, options, user);
-    if ( allowed === false ) return allowed;
+    if ( (await super._preCreate(data, options, user)) === false ) return false;
 
     const sourceId = this.getFlag("core", "sourceId");
     if ( sourceId?.startsWith("Compendium.") ) return;
@@ -862,8 +861,7 @@ export default class Actor5e extends DocumentMixin(Actor) {
 
   /** @inheritdoc */
   async _preUpdate(changed, options, user) {
-    let allowed = await super._preUpdate(changed, options, user);
-    if ( allowed === false ) return allowed;
+    if ( (await super._preUpdate(changed, options, user)) === false ) return false;
 
     // Apply changes in Actor size to Token width/height
     if ( "size" in (this.system.traits || {}) ) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -3,12 +3,12 @@ import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
 import Advancement from "./advancement/advancement.mjs";
 import AbilityUseDialog from "../applications/item/ability-use-dialog.mjs";
 import Proficiency from "./actor/proficiency.mjs";
-import { DocumentMixin } from "./mixin.mjs";
+import { SystemDocumentMixin } from "./mixin.mjs";
 
 /**
  * Override and extend the basic Item implementation.
  */
-export default class Item5e extends DocumentMixin(Item) {
+export default class Item5e extends SystemDocumentMixin(Item) {
 
   /**
    * Caches an item linked to this one, such as a subclass associated with a class.
@@ -1982,8 +1982,7 @@ export default class Item5e extends DocumentMixin(Item) {
 
   /** @inheritdoc */
   async _preCreate(data, options, user) {
-    let allowed = await super._preCreate(data, options, user);
-    if ( allowed === false ) return allowed;
+    if ( (await super._preCreate(data, options, user)) === false ) return false;
 
     // Create class identifier based on name
     if ( ["class", "subclass"].includes(this.type) && !this.system.identifier ) {
@@ -2028,8 +2027,7 @@ export default class Item5e extends DocumentMixin(Item) {
 
   /** @inheritdoc */
   async _preUpdate(changed, options, user) {
-    let allowed = await super._preUpdate(changed, options, user);
-    if ( allowed === false ) return allowed;
+    if ( (await super._preUpdate(changed, options, user)) === false ) return false;
     if ( (this.type !== "class") || !("levels" in (changed.system || {})) ) return;
 
     // Check to make sure the updated class level isn't below zero

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -3,11 +3,12 @@ import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
 import Advancement from "./advancement/advancement.mjs";
 import AbilityUseDialog from "../applications/item/ability-use-dialog.mjs";
 import Proficiency from "./actor/proficiency.mjs";
+import { DocumentMixin } from "./mixin.mjs";
 
 /**
  * Override and extend the basic Item implementation.
  */
-export default class Item5e extends Item {
+export default class Item5e extends DocumentMixin(Item) {
 
   /**
    * Caches an item linked to this one, such as a subclass associated with a class.
@@ -1981,7 +1982,8 @@ export default class Item5e extends Item {
 
   /** @inheritdoc */
   async _preCreate(data, options, user) {
-    await super._preCreate(data, options, user);
+    let allowed = await super._preCreate(data, options, user);
+    if ( allowed === false ) return allowed;
 
     // Create class identifier based on name
     if ( ["class", "subclass"].includes(this.type) && !this.system.identifier ) {
@@ -2026,7 +2028,8 @@ export default class Item5e extends Item {
 
   /** @inheritdoc */
   async _preUpdate(changed, options, user) {
-    await super._preUpdate(changed, options, user);
+    let allowed = await super._preUpdate(changed, options, user);
+    if ( allowed === false ) return allowed;
     if ( (this.type !== "class") || !("levels" in (changed.system || {})) ) return;
 
     // Check to make sure the updated class level isn't below zero

--- a/module/documents/mixin.mjs
+++ b/module/documents/mixin.mjs
@@ -3,12 +3,22 @@
  * @type {function(Class)}
  * @mixin
  */
-export const DocumentMixin = Base => class extends Base {
+export const SystemDocumentMixin = Base => class extends Base {
 
   /* -------------------------------------------- */
   /*  Socket Event Handlers                       */
   /* -------------------------------------------- */
 
+  /**
+   * Perform preliminary operations before a Document of this type is created.
+   * Pre-creation operations only occur for the client which requested the operation.
+   * @param {object} data               The initial data object provided to the document creation request.
+   * @param {object} options            Additional options which modify the creation request.
+   * @param {User} user                 The User requesting the document creation.
+   * @returns {Promise<boolean|void>}   A return value of false indicates the creation operation should be cancelled.
+   * @see {Document#_preCreate}
+   * @protected
+   */
   async _preCreate(data, options, user) {
     let allowed = await super._preCreate(data, options, user);
     if ( allowed !== false ) allowed = await this.system._preCreate?.(data, options, user);
@@ -17,6 +27,16 @@ export const DocumentMixin = Base => class extends Base {
 
   /* -------------------------------------------- */
 
+  /**
+   * Perform preliminary operations before a Document of this type is updated.
+   * Pre-update operations only occur for the client which requested the operation.
+   * @param {object} changed            The differential data that is changed relative to the documents prior values
+   * @param {object} options            Additional options which modify the update request
+   * @param {documents.BaseUser} user   The User requesting the document update
+   * @returns {Promise<boolean|void>}   A return value of false indicates the update operation should be cancelled.
+   * @see {Document#_preUpdate}
+   * @protected
+   */
   async _preUpdate(changed, options, user) {
     let allowed = await super._preUpdate(changed, options, user);
     if ( allowed !== false ) allowed = await this.system._preUpdate?.(changed, options, user);
@@ -25,6 +45,15 @@ export const DocumentMixin = Base => class extends Base {
 
   /* -------------------------------------------- */
 
+  /**
+   * Perform preliminary operations before a Document of this type is deleted.
+   * Pre-delete operations only occur for the client which requested the operation.
+   * @param {object} options            Additional options which modify the deletion request
+   * @param {documents.BaseUser} user   The User requesting the document deletion
+   * @returns {Promise<boolean|void>}   A return value of false indicates the deletion operation should be cancelled.
+   * @see {Document#_preDelete}
+   * @protected
+   */
   async _preDelete(options, user) {
     let allowed = await super._preDelete(options, user);
     if ( allowed !== false ) allowed = await this.system._preDelete?.(options, user);
@@ -33,6 +62,15 @@ export const DocumentMixin = Base => class extends Base {
 
   /* -------------------------------------------- */
 
+  /**
+   * Perform follow-up operations after a Document of this type is created.
+   * Post-creation operations occur for all clients after the creation is broadcast.
+   * @param {object} data               The initial data object provided to the document creation request
+   * @param {object} options            Additional options which modify the creation request
+   * @param {string} userId             The id of the User requesting the document update
+   * @see {Document#_onCreate}
+   * @protected
+   */
   _onCreate(data, options, userId) {
     super._onCreate(data, options, userId);
     this.system._onCreate?.(data, options, userId);
@@ -40,6 +78,15 @@ export const DocumentMixin = Base => class extends Base {
 
   /* -------------------------------------------- */
 
+  /**
+   * Perform follow-up operations after a Document of this type is updated.
+   * Post-update operations occur for all clients after the update is broadcast.
+   * @param {object} changed            The differential data that was changed relative to the documents prior values
+   * @param {object} options            Additional options which modify the update request
+   * @param {string} userId             The id of the User requesting the document update
+   * @see {Document#_onUpdate}
+   * @protected
+   */
   _onUpdate(changed, options, userId) {
     super._onUpdate(changed, options, userId);
     this.system._onUpdate?.(changed, options, userId);
@@ -47,6 +94,14 @@ export const DocumentMixin = Base => class extends Base {
 
   /* -------------------------------------------- */
 
+  /**
+   * Perform follow-up operations after a Document of this type is deleted.
+   * Post-deletion operations occur for all clients after the deletion is broadcast.
+   * @param {object} options            Additional options which modify the deletion request
+   * @param {string} userId             The id of the User requesting the document update
+   * @see {Document#_onDelete}
+   * @protected
+   */
   _onDelete(options, userId) {
     super._onDelete(options, userId);
     this.system._onDelete?.(options, userId);

--- a/module/documents/mixin.mjs
+++ b/module/documents/mixin.mjs
@@ -1,0 +1,54 @@
+/**
+ * Mixin used to share some logic between Actor & Item documents.
+ * @type {function(Class)}
+ * @mixin
+ */
+export const DocumentMixin = Base => class extends Base {
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  async _preCreate(data, options, user) {
+    let allowed = await super._preCreate(data, options, user);
+    if ( allowed !== false ) allowed = await this.system._preCreate?.(data, options, user);
+    return allowed;
+  }
+
+  /* -------------------------------------------- */
+
+  async _preUpdate(changed, options, user) {
+    let allowed = await super._preUpdate(changed, options, user);
+    if ( allowed !== false ) allowed = await this.system._preUpdate?.(changed, options, user);
+    return allowed;
+  }
+
+  /* -------------------------------------------- */
+
+  async _preDelete(options, user) {
+    let allowed = await super._preDelete(options, user);
+    if ( allowed !== false ) allowed = await this.system._preDelete?.(options, user);
+    return allowed;
+  }
+
+  /* -------------------------------------------- */
+
+  _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
+    this.system._onCreate?.(data, options, userId);
+  }
+
+  /* -------------------------------------------- */
+
+  _onUpdate(changed, options, userId) {
+    super._onUpdate(changed, options, userId);
+    this.system._onUpdate?.(changed, options, userId);
+  }
+
+  /* -------------------------------------------- */
+
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    this.system._onDelete?.(options, userId);
+  }
+};

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -267,7 +267,9 @@ export const migrateActorData = function(actor, migrationData) {
     const itemData = i instanceof CONFIG.Item.documentClass ? i.toObject() : i;
     let itemUpdate = migrateItemData(itemData, migrationData);
 
-    if ( itemData.type === "background" ) updateData["system.details.background"] = itemData._id;
+    if ( (itemData.type === "background") && (actor.system?.details?.background !== itemData._id) ) {
+      updateData["system.details.background"] = itemData._id;
+    }
 
     // Prepared, Equipped, and Proficient for NPC actors
     if ( actor.type === "npc" ) {

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -267,6 +267,8 @@ export const migrateActorData = function(actor, migrationData) {
     const itemData = i instanceof CONFIG.Item.documentClass ? i.toObject() : i;
     let itemUpdate = migrateItemData(itemData, migrationData);
 
+    if ( itemData.type === "background" ) updateData["system.details.background"] = itemData._id;
+
     // Prepared, Equipped, and Proficient for NPC actors
     if ( actor.type === "npc" ) {
       if (foundry.utils.getProperty(itemData.system, "preparation.prepared") === false) itemUpdate["system.preparation.prepared"] = true;

--- a/system.json
+++ b/system.json
@@ -207,7 +207,7 @@
   "gridUnits": "ft",
   "primaryTokenAttribute": "attributes.hp",
   "flags": {
-    "needsMigrationVersion": "2.3.0",
+    "needsMigrationVersion": "2.4.0",
     "compatibleMigrationVersion": "0.8"
   }
 }

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -32,11 +32,16 @@
             {{!-- Character Summary --}}
             <ul class="summary flexrow">
                 <li class="race">
-                    <input type="text" name="system.details.race" value="{{system.details.race}}" placeholder="{{ localize 'DND5E.Race' }}"/>
+                    {{#if system.details.race.name}}
+                        <span data-tooltip="DND5E.Race">{{system.details.race.name}}</span>
+                    {{else}}
+                        <input type="text" name="system.details.race" value="{{system.details.race}}"
+                               placeholder="{{ localize 'DND5E.Race' }}">
+                    {{/if}}
                 </li>
                 <li class="background">
-                    {{#if labels.background}}
-                        <span data-tooltip="DND5E.Background">{{labels.background}}</span>
+                    {{#if system.details.background.name}}
+                        <span data-tooltip="DND5E.Background">{{system.details.background.name}}</span>
                     {{else}}
                         <input type="text" name="system.details.background" value="{{system.details.background}}" placeholder="{{ localize 'DND5E.Background' }}"/>
                     {{/if}}


### PR DESCRIPTION
Displays race item above background on features tab of character sheet.

Adds a `LocalDocumentField` to reference a single item on an actor, and replace `background` & `race` properties with this new field. This field has a `fallback` option so that if the item isn't found, then string is displayed (allowing existing hand-typed Race and Background values to continue displaying properly).

Used a mixin for `Item5e` and `Actor5e` that forwards socket event handler requests to their data models, allowing each type to add custom socket event handler behavior. This behavior is used in `RaceData` and `BackgroundData` to set `system.details.race` and `system.details.background` to reference any newly added items, and unset it when they are deleted. This is also used for any item marked with the `singleton` metadata property to only allow one to be created at a time.

I've also tweaked all of our current socket event handlers to ensure they return `false` if the parent handler returns `false` so we can properly prevent items from being created.