### PR TITLE
Add preHook on the "createScrollFromSpell" function

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2149,7 +2149,7 @@ export default class Item5e extends Item {
      * A hook event that fires before the item data for a scroll is created.
      * @function dnd5e.preCreateScrollFromSpell
      * @memberof hookEvents
-     * @param {object} itemData    The final item data used to make the scroll
+     * @param {object} itemData    The initial item data of the spell to convert to a scroll
      * @param {object} [options]   Additional options that modify the created scroll
      * @returns {boolean}          Explicitly return false to prevent the scroll to be created.
      */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2144,6 +2144,17 @@ export default class Item5e extends Item {
 
     // Get spell data
     const itemData = (spell instanceof Item5e) ? spell.toObject() : spell;
+
+    /**
+     * A hook event that fires before the item data for a scroll is created.
+     * @function dnd5e.preCreateScrollFromSpell
+     * @memberof hookEvents
+     * @param {object} itemData    The final item data used to make the scroll
+     * @param {object} [options]   Additional options that modify the created scroll
+     * @returns {boolean}          Explicitly return false to prevent the scroll to be created.
+     */
+    if ( Hooks.call("dnd5e.preCreateScrollFromSpell", itemData, options) === false ) return;
+
     let {
       actionType, description, source, activation, duration, target,
       range, damage, formula, save, level, attackBonus, ability, components


### PR DESCRIPTION
There are at least for me a lot of cases where I want to keep the creation of spell scrolls under control.

For example, only mages can create them, or to prevent players from messing up when a spell is dragged on the sheet.

A simple preHook in the method is more than enough for any existing use case.

