### PR TITLE
[#342] Apply senses/movement to actor when race is added

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1403,15 +1403,12 @@ export default class ActorSheet5e extends ActorSheet {
     if ( !game.settings.get("dnd5e", "disableAdvancements") ) {
       const manager = AdvancementManager.forDeletedItem(this.actor, item.id);
       if ( manager.steps.length ) {
-        if ( ["class", "subclass"].includes(item.type) ) {
-          try {
-            const shouldRemoveAdvancements = await AdvancementConfirmationDialog.forDelete(item);
-            if ( shouldRemoveAdvancements ) return manager.render(true);
-          } catch(err) {
-            return;
-          }
-        } else {
-          return manager.render(true);
+        try {
+          const shouldRemoveAdvancements = await AdvancementConfirmationDialog.forDelete(item);
+          if ( shouldRemoveAdvancements ) return manager.render(true);
+          else return item.delete({ shouldRemoveAdvancements });
+        } catch(err) {
+          return;
         }
       }
     }

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1406,7 +1406,7 @@ export default class ActorSheet5e extends ActorSheet {
         try {
           const shouldRemoveAdvancements = await AdvancementConfirmationDialog.forDelete(item);
           if ( shouldRemoveAdvancements ) return manager.render(true);
-          else return item.delete({ shouldRemoveAdvancements });
+          return item.delete({ shouldRemoveAdvancements });
         } catch(err) {
           return;
         }

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -97,7 +97,7 @@ export default class CharacterData extends CreatureTemplate {
           required: true, fallback: true, label: "DND5E.Background"
         }),
         originalClass: new foundry.data.fields.StringField({required: true, label: "DND5E.ClassOriginal"}),
-        type: new CreatureTypeField({ swarm: false }),
+        type: new CreatureTypeField({ swarm: false }, { initial: { value: "humanoid" } }),
         xp: new foundry.data.fields.SchemaField({
           value: new foundry.data.fields.NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.ExperiencePointsCurrent"

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -106,12 +106,13 @@ export default class RaceData extends SystemDataModel.mixin(ItemDescriptionTempl
       }
     }
     if ( this.senses.special ) {
-      updates[system.attributes.senses.special] = attributes.senses.special
-        ? `${attributes.senses.special}:${this.senses.special}` : this.senses.special;
+      updates[system.attributes.senses.special] = [attributes.senses.special, this.senses.special].filterJoin(";");
     }
     updates["system.attributes.senses.units"] = this.senses.units;
 
-    // TODO: Set creature type once defined on actor
+    if ( this.type.value ) updates["system.details.type.value"] = this.type.value;
+    if ( this.type.subtype ) updates["system.details.type.subtype"] = this.type.subtype;
+    if ( this.type.custom ) updates["system.details.type.custom"] = this.type.custom;
 
     this.parent.actor.update(updates);
   }
@@ -148,7 +149,10 @@ export default class RaceData extends SystemDataModel.mixin(ItemDescriptionTempl
       updates[system.attributes.senses.special] = attributes.senses.special.replace(this.senses.special, "");
     }
 
-    // TODO: Unset creature type once defined on actor
+    const type = this.parent.actor.system.details.type;
+    if ( this.type.value === type.value ) updates["system.details.type.value"] = "humanoid";
+    if ( this.type.subtype === type.subtype ) updates["system.details.type.subtype"] = "";
+    if ( this.type.custom === type.custom ) updates["system.details.type.custom"] = "";
 
     await this.parent.actor.update(updates);
   }


### PR DESCRIPTION
- Movement types and senses are applied automatically, assuming the current value on the actor isn't already higher
- ~~Creature type isn't applied yet because we don't have it displayed on the actor, I'll handle that in another PR~~
- When deleting the race, movement and senses are unapplied if the value is equal to that on the race (so we don't get rid of values if the player has changed them)
- We now prompt when removing backgrounds & races with advancement just like with classes & subclasses
- If the player unchecks "Remove advancement changes" when deleting a race, it will not unapply any of the direct changes