### PR TITLE
[#342] Add creature type data to PCs

### DIFF
--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -37,6 +37,9 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
     return foundry.utils.mergeObject(context, {
       disableExperience: game.settings.get("dnd5e", "disableExperienceTracking"),
       classLabels: classes.map(c => c.name).join(", "),
+      labels: {
+        type: context.system.details.type.label
+      },
       multiclassLabels: classes.map(c => [c.subclass?.name ?? "", c.name, c.system.levels].filterJoin(" ")).join(", "),
       weightUnit: game.i18n.localize(`DND5E.Abbreviation${
         game.settings.get("dnd5e", "metricWeightUnits") ? "Kg" : "Lbs"}`),

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -33,7 +33,7 @@ export default class ActorSheet5eNPC extends ActorSheet5e {
     return foundry.utils.mergeObject(context, {
       labels: {
         cr: cr >= 1 ? String(cr) : crLabels[cr] ?? 1,
-        type: this.actor.constructor.formatCreatureType(context.system.details.type),
+        type: context.system.details.type.label,
         armorType: this.getArmorLabel()
       }
     });

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -1,4 +1,5 @@
 import { FormulaField, LocalDocumentField } from "../fields.mjs";
+import CreatureTypeField from "../shared/creature-type-field.mjs";
 import AttributesFields from "./templates/attributes.mjs";
 import CreatureTemplate from "./templates/creature.mjs";
 import DetailsFields from "./templates/details.mjs";
@@ -28,6 +29,7 @@ import TraitsFields from "./templates/traits.mjs";
  * @property {object} details
  * @property {Item5e|string} details.background           Character's background item or name.
  * @property {string} details.originalClass               ID of first class taken by character.
+ * @property {CreatureTypeField} details.type             Creature type of this actor.
  * @property {XPData} details.xp                          Experience points gained.
  * @property {number} details.xp.value                    Total experience points earned.
  * @property {string} details.appearance                  Description of character's appearance.
@@ -95,6 +97,7 @@ export default class CharacterData extends CreatureTemplate {
           required: true, fallback: true, label: "DND5E.Background"
         }),
         originalClass: new foundry.data.fields.StringField({required: true, label: "DND5E.ClassOriginal"}),
+        type: new CreatureTypeField({ swarm: false }),
         xp: new foundry.data.fields.SchemaField({
           value: new foundry.data.fields.NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.ExperiencePointsCurrent"

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -1,10 +1,10 @@
 import { FormulaField } from "../fields.mjs";
+import CreatureTypeField from "../shared/creature-type-field.mjs";
 import SourceField from "../shared/source-field.mjs";
 import AttributesFields from "./templates/attributes.mjs";
 import CreatureTemplate from "./templates/creature.mjs";
 import DetailsFields from "./templates/details.mjs";
 import TraitsFields from "./templates/traits.mjs";
-import CreatureTypeField from "../shared/creature-type-field.mjs";
 
 /**
  * System data definition for NPCs.

--- a/module/data/shared/creature-type-field.mjs
+++ b/module/data/shared/creature-type-field.mjs
@@ -13,4 +13,19 @@ export default class CreatureTypeField extends foundry.data.fields.SchemaField {
     Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);
     super(fields, { label: "DND5E.CreatureType", ...options });
   }
+
+  /* -------------------------------------------- */
+
+  initialize(value, model, options={}) {
+    const obj = super.initialize(value, model, options);
+
+    Object.defineProperty(obj, "label", {
+      get() {
+        return dnd5e.documents.Actor5e.formatCreatureType(this);
+      },
+      enumerable: false
+    });
+
+    return obj;
+  }
 }

--- a/module/data/shared/creature-type-field.mjs
+++ b/module/data/shared/creature-type-field.mjs
@@ -16,6 +16,7 @@ export default class CreatureTypeField extends foundry.data.fields.SchemaField {
 
   /* -------------------------------------------- */
 
+  /** @inheritdoc */
   initialize(value, model, options={}) {
     const obj = super.initialize(value, model, options);
 

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -23,6 +23,7 @@ export default class SourceTemplate extends SchemaField {
 
   /* -------------------------------------------- */
 
+  /** @inheritdoc */
   initialize(value, model, options={}) {
     const obj = super.initialize(value, model, options);
 

--- a/templates/actors/parts/actor-traits.hbs
+++ b/templates/actors/parts/actor-traits.hbs
@@ -13,7 +13,7 @@
     {{#if isCharacter}}
     <div class="form-group">
         <label>{{localize "DND5E.CreatureType"}}</label>
-        <a class="config-button" data-action="type" data-tooltip="DND5E.SensesConfig">
+        <a class="config-button" data-action="type" data-tooltip="DND5E.CreatureTypeConfig">
             <i class="fas fa-cog"></i>
         </a>
         <ul class="traits-list">

--- a/templates/actors/parts/actor-traits.hbs
+++ b/templates/actors/parts/actor-traits.hbs
@@ -10,6 +10,20 @@
         </select>
     </div>
 
+    {{#if isCharacter}}
+    <div class="form-group">
+        <label>{{localize "DND5E.CreatureType"}}</label>
+        <a class="config-button" data-action="type" data-tooltip="DND5E.SensesConfig">
+            <i class="fas fa-cog"></i>
+        </a>
+        <ul class="traits-list">
+            {{#if labels.type}}
+                <li class="tag">{{labels.type}}</li>
+            {{/if}}
+        </ul>
+    </div>
+    {{/if}}
+
     {{#unless isVehicle}}
     <div class="form-group">
         <label>{{localize "DND5E.Senses"}}</label>


### PR DESCRIPTION
Adds creature type to the PC traits section:

<img width="397" alt="Creature Type" src="https://github.com/foundryvtt/dnd5e/assets/19979839/1ab0191b-9490-44d6-8831-5547a353ea0a">