### PR TITLE
[#2561] Display ASI values in config mode

### DIFF
--- a/module/documents/advancement/ability-score-improvement.mjs
+++ b/module/documents/advancement/ability-score-improvement.mjs
@@ -99,22 +99,34 @@ export default class AbilityScoreImprovementAdvancement extends Advancement {
 
   /** @inheritdoc */
   summaryForLevel(level, { configMode=false }={}) {
-    if ( (this.value.type === "feat") && this.value.feat ) {
+    const formatter = new Intl.NumberFormat(game.i18n.lang, { signDisplay: "always" });
+    if ( configMode ) {
+      const entries = Object.entries(this.configuration.fixed).map(([key, value]) => {
+        if ( !value ) return null;
+        const name = CONFIG.DND5E.abilities[key]?.label ?? key;
+        return `<span class="tag">${name} <strong>${formatter.format(value)}</strong></span>`;
+      });
+      if ( this.configuration.points ) entries.push(`<span class="tag">${
+        game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementPoints")}: <strong>${
+        this.configuration.points}</strong></span>`
+      );
+      return entries.filterJoin("\n");
+    }
 
+    else if ( (this.value.type === "feat") && this.value.feat ) {
       const id = Object.keys(this.value.feat)[0];
       const feat = this.actor.items.get(id);
       if ( feat ) return feat.toAnchor({classes: ["content-link"]}).outerHTML;
+    }
 
-    } else if ( (this.value.type === "asi") && this.value.assignments ) {
-
-      const formatter = new Intl.NumberFormat(game.i18n.lang, { signDisplay: "always" });
+    else if ( (this.value.type === "asi") && this.value.assignments ) {
       return Object.entries(this.value.assignments).reduce((html, [key, value]) => {
         const name = CONFIG.DND5E.abilities[key]?.label ?? key;
         html += `<span class="tag">${name} <strong>${formatter.format(value)}</strong></span>\n`;
         return html;
       }, "");
-
     }
+
     return "";
   }
 


### PR DESCRIPTION
Displays what ASIs will be granted when in config mode so more information is available at a glance:

<img width="197" alt="Config Preview" src="https://github.com/foundryvtt/dnd5e/assets/19979839/50c775bb-2406-4482-af01-48667b1efb28">
