### PR TITLE
[#2571]

### DIFF
--- a/module/canvas/ability-template.mjs
+++ b/module/canvas/ability-template.mjs
@@ -30,15 +30,16 @@ export default class AbilityTemplate extends MeasuredTemplate {
   /**
    * A factory method to create an AbilityTemplate instance using provided data from an Item5e instance
    * @param {Item5e} item               The Item object for which to construct the template
+   * @param {object} [options={}]       Options to modify the created template.
    * @returns {AbilityTemplate|null}    The template object, or null if the item does not produce a template
    */
-  static fromItem(item) {
+  static fromItem(item, options={}) {
     const target = item.system.target ?? {};
     const templateShape = dnd5e.config.areaTargetTypes[target.type]?.template;
     if ( !templateShape ) return null;
 
     // Prepare template data
-    const templateData = {
+    const templateData = foundry.utils.mergeObject({
       t: templateShape,
       user: game.user.id,
       distance: target.value,
@@ -46,9 +47,8 @@ export default class AbilityTemplate extends MeasuredTemplate {
       x: 0,
       y: 0,
       fillColor: game.user.color,
-      flags: { dnd5e: { origin: item.uuid } }
-    };
-    if ( item.type === "spell" ) foundry.utils.mergeObject(templateData.flags, {"dnd5e.spellLevel": item.system.level});
+      flags: { dnd5e: { origin: item.uuid, spellLevel: item.system.level } }
+    }, options);
 
     // Additional type-specific data
     switch ( templateShape ) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1787,7 +1787,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
         await item.rollToolCheck({event}); break;
       case "placeTemplate":
         try {
-          await dnd5e.canvas.AbilityTemplate.fromItem(item)?.drawPreview();
+          await dnd5e.canvas.AbilityTemplate.fromItem(item, {"flags.dnd5e.spellLevel": spellLevel})?.drawPreview();
         } catch(err) {
           Hooks.onError("Item5e._onChatCardAction", err, {
             msg: game.i18n.localize("DND5E.PlaceTemplateError"),


### PR DESCRIPTION
Considered cloning the created item and scaling up its level, however this would cause damage rolls to not be upscaled, so an options object modifying the template seemed the best solution currently.