### PR TITLE
[#2567, #2569] Add status indicator to accordions, fix jump on sheet re-render

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -732,11 +732,19 @@ h5 {
 .accordion {
   transition: margin-bottom 500ms ease;
 }
-.accordion.collapsed {
-  margin-bottom: 0.5rem;
-}
 .accordion.collapsed > .accordion-content {
   height: 0;
+}
+.accordion-indicator {
+  display: none;
+  transition: transform 500ms ease;
+}
+.accordion .accordion-indicator {
+  display: inherit;
+  transform: rotate(0deg);
+}
+.accordion.collapsed .accordion-indicator {
+  transform: rotate(-90deg);
 }
 .accordion-heading {
   cursor: pointer;
@@ -1912,12 +1920,13 @@ h5 {
 .dnd5e.sheet.item [data-tab="description"] .item-description .description-header {
   display: flex;
   align-items: first baseline;
-  justify-content: space-between;
+  gap: 0.5em;
   margin-block-end: 0;
   padding: 0.25rem;
   background-color: rgba(0, 0, 0, 0.05);
 }
 .dnd5e.sheet.item [data-tab="description"] .item-description .description-header .description-edit {
+  margin-inline-start: auto;
   opacity: 20%;
 }
 .dnd5e.sheet.item [data-tab="description"] .item-description .description-header:hover .description-edit {
@@ -1930,11 +1939,22 @@ h5 {
   height: auto;
   padding-inline: 0.25rem;
 }
+.dnd5e.sheet.item [data-tab="description"] .item-description .accordion {
+  margin-block-end: 0.5rem;
+}
+.dnd5e.sheet.item [data-tab="description"] .item-description .accordion p:last-child {
+  margin-block-end: 0;
+}
 .dnd5e.sheet.item [data-tab="description"] .item-description .accordion.collapsed > .editor.accordion-content {
   height: 0;
 }
 .dnd5e.sheet.item [data-tab="description"] .item-description .editor.accordion-content > .editor-content {
   overflow: hidden;
+}
+.dnd5e.sheet.item [data-tab="description"] .item-description .accordion-indicator {
+  align-self: center;
+  opacity: 0.5;
+  font-size: 0.75em;
 }
 .dnd5e.sheet.item .details input[type="text"],
 .dnd5e.sheet.item .details input[type="number"],

--- a/less/apps.less
+++ b/less/apps.less
@@ -762,8 +762,19 @@ h5 {
   transition: margin-bottom 500ms ease;
 }
 .accordion.collapsed {
-  margin-bottom: .5rem;
   > .accordion-content { height: 0; }
+}
+
+.accordion-indicator {
+  display: none;
+  transition: transform 500ms ease;
+}
+.accordion .accordion-indicator {
+  display: inherit;
+  transform: rotate(0deg);
+}
+.accordion.collapsed .accordion-indicator {
+  transform: rotate(-90deg);
 }
 
 .accordion-heading {

--- a/less/items.less
+++ b/less/items.less
@@ -130,12 +130,13 @@
       .description-header {
         display: flex;
         align-items: first baseline;
-        justify-content: space-between;
+        gap: 0.5em;
         margin-block-end: 0;
         padding: 0.25rem;
         background-color: rgb(0 0 0 / 0.05);
 
         .description-edit {
+          margin-inline-start: auto;
           opacity: 20%;
         }
         &:hover .description-edit {
@@ -149,8 +150,15 @@
         height: auto;
         padding-inline: 0.25rem;
       }
+      .accordion { margin-block-end: 0.5rem; }
+      .accordion p:last-child { margin-block-end: 0; }
       .accordion.collapsed > .editor.accordion-content { height: 0; }
       .editor.accordion-content > .editor-content { overflow: hidden; }
+      .accordion-indicator {
+        align-self: center;
+        opacity: 0.5;
+        font-size: 0.75em;
+      }
     }
   }
 

--- a/module/applications/accordion.mjs
+++ b/module/applications/accordion.mjs
@@ -54,11 +54,13 @@ export default class Accordion {
     this.#sections = new Map();
     this.#ongoing = new Map();
     const { headingSelector, contentSelector } = this.#config;
+    let idx = 0;
     for ( const heading of root.querySelectorAll(headingSelector) ) {
       const content = heading.querySelector(contentSelector) ?? heading.parentElement.querySelector(contentSelector);
       if ( !content ) continue;
       const wrapper = document.createElement("div");
       wrapper.classList.add("accordion");
+      if ( this.#collapsed[idx] ) wrapper.classList.add("collapsed");
       heading.before(wrapper);
       wrapper.append(heading, content);
       this.#sections.set(heading, content);
@@ -66,6 +68,7 @@ export default class Accordion {
       heading.classList.add("accordion-heading");
       content.classList.add("accordion-content");
       heading.addEventListener("click", this._onClickHeading.bind(this));
+      idx++;
     }
     await new Promise(resolve => { setTimeout(resolve, 0); }); // Allow re-paint.
     this._restoreCollapsedState();

--- a/module/applications/accordion.mjs
+++ b/module/applications/accordion.mjs
@@ -54,7 +54,7 @@ export default class Accordion {
     this.#sections = new Map();
     this.#ongoing = new Map();
     const { headingSelector, contentSelector } = this.#config;
-    let collpasedIndex = 0;
+    let collapsedIndex = 0;
     for ( const heading of root.querySelectorAll(headingSelector) ) {
       const content = heading.querySelector(contentSelector) ?? heading.parentElement.querySelector(contentSelector);
       if ( !content ) continue;
@@ -64,11 +64,11 @@ export default class Accordion {
       wrapper.append(heading, content);
       this.#sections.set(heading, content);
       if ( firstBind ) this.#collapsed.push(this.#collapsed.length > 0);
-      else if ( this.#collapsed[collpasedIndex] ) wrapper.classList.add("collapsed");
+      else if ( this.#collapsed[collapsedIndex] ) wrapper.classList.add("collapsed");
       heading.classList.add("accordion-heading");
       content.classList.add("accordion-content");
       heading.addEventListener("click", this._onClickHeading.bind(this));
-      collpasedIndex++;
+      collapsedIndex++;
     }
     await new Promise(resolve => { setTimeout(resolve, 0); }); // Allow re-paint.
     this._restoreCollapsedState();

--- a/module/applications/accordion.mjs
+++ b/module/applications/accordion.mjs
@@ -54,21 +54,21 @@ export default class Accordion {
     this.#sections = new Map();
     this.#ongoing = new Map();
     const { headingSelector, contentSelector } = this.#config;
-    let idx = 0;
+    let collpasedIndex = 0;
     for ( const heading of root.querySelectorAll(headingSelector) ) {
       const content = heading.querySelector(contentSelector) ?? heading.parentElement.querySelector(contentSelector);
       if ( !content ) continue;
       const wrapper = document.createElement("div");
       wrapper.classList.add("accordion");
-      if ( this.#collapsed[idx] ) wrapper.classList.add("collapsed");
       heading.before(wrapper);
       wrapper.append(heading, content);
       this.#sections.set(heading, content);
       if ( firstBind ) this.#collapsed.push(this.#collapsed.length > 0);
+      else if ( this.#collapsed[collpasedIndex] ) wrapper.classList.add("collapsed");
       heading.classList.add("accordion-heading");
       content.classList.add("accordion-content");
       heading.addEventListener("click", this._onClickHeading.bind(this));
-      idx++;
+      collpasedIndex++;
     }
     await new Promise(resolve => { setTimeout(resolve, 0); }); // Allow re-paint.
     this._restoreCollapsedState();

--- a/templates/items/parts/item-description.hbs
+++ b/templates/items/parts/item-description.hbs
@@ -63,6 +63,7 @@
             {{#if editable}}
                 <h3 class="description-header">
                     {{localize "DND5E.Description"}}
+                    <i class="accordion-indicator fa-solid fa-chevron-down"></i>
                     <a class="description-edit" data-target="system.description.value">
                         <i class="fa-solid fa-edit"></i>
                     </a>
@@ -74,6 +75,7 @@
         {{#if (or editable system.description.unidentified)}}
             <h3 class="description-header">
                 {{localize "DND5E.DescriptionUnidentified"}}
+                <i class="accordion-indicator fa-solid fa-chevron-down"></i>
                 {{#if editable}}
                     <a class="description-edit" data-target="system.description.unidentified">
                         <i class="fa-solid fa-edit"></i>
@@ -86,6 +88,7 @@
         {{#if (or editable system.description.chat)}}
             <h3 class="description-header">
                 {{localize "DND5E.DescriptionChat"}}
+                <i class="accordion-indicator fa-solid fa-chevron-down"></i>
                 {{#if editable}}
                     <a class="description-edit" data-target="system.description.chat">
                         <i class="fa-solid fa-edit"></i>

--- a/templates/items/parts/item-description.hbs
+++ b/templates/items/parts/item-description.hbs
@@ -62,8 +62,8 @@
         {{#if (or editable system.description.value)}}
             {{#if editable}}
                 <h3 class="description-header">
-                    {{localize "DND5E.Description"}}
                     <i class="accordion-indicator fa-solid fa-chevron-down"></i>
+                    {{localize "DND5E.Description"}}
                     <a class="description-edit" data-target="system.description.value">
                         <i class="fa-solid fa-edit"></i>
                     </a>
@@ -74,8 +74,8 @@
 
         {{#if (or editable system.description.unidentified)}}
             <h3 class="description-header">
-                {{localize "DND5E.DescriptionUnidentified"}}
                 <i class="accordion-indicator fa-solid fa-chevron-down"></i>
+                {{localize "DND5E.DescriptionUnidentified"}}
                 {{#if editable}}
                     <a class="description-edit" data-target="system.description.unidentified">
                         <i class="fa-solid fa-edit"></i>
@@ -87,8 +87,8 @@
 
         {{#if (or editable system.description.chat)}}
             <h3 class="description-header">
-                {{localize "DND5E.DescriptionChat"}}
                 <i class="accordion-indicator fa-solid fa-chevron-down"></i>
+                {{localize "DND5E.DescriptionChat"}}
                 {{#if editable}}
                     <a class="description-edit" data-target="system.description.chat">
                         <i class="fa-solid fa-edit"></i>


### PR DESCRIPTION
- Adds an indicator that helps indicate whether the accordion is open or closed (#2569)
- Fixes a jump that occurs when sheet is re-rendered (#2567)
- Fixes spacing for empty accordions that are expanded

https://github.com/foundryvtt/dnd5e/assets/19979839/55c19eda-7fd7-4d11-9177-9d787e048361