### PR TITLE
[#2504] Implement editor for source data

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -691,13 +691,6 @@ h5 {
   overflow-y: auto;
 }
 /* ----------------------------------------- */
-/*  Source Config Sheet Specifically         */
-/* ----------------------------------------- */
-.dnd5e.source-config .source-uuid {
-  display: flex;
-  justify-content: space-between;
-}
-/* ----------------------------------------- */
 /*  Polymorph Features                       */
 /* ----------------------------------------- */
 .polymorph {

--- a/dnd5e.css
+++ b/dnd5e.css
@@ -691,6 +691,13 @@ h5 {
   overflow-y: auto;
 }
 /* ----------------------------------------- */
+/*  Source Config Sheet Specifically         */
+/* ----------------------------------------- */
+.dnd5e.source-config .source-uuid {
+  display: flex;
+  justify-content: space-between;
+}
+/* ----------------------------------------- */
 /*  Polymorph Features                       */
 /* ----------------------------------------- */
 .polymorph {
@@ -1849,6 +1856,27 @@ h5 {
   padding: 0 0.25em;
   text-align: right;
 }
+.dnd5e.sheet.item .sheet-header .summary li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.25em;
+}
+.dnd5e.sheet.item .sheet-header .summary li span {
+  padding-inline: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 400;
+}
+.dnd5e.sheet.item .sheet-header .summary li .config-button {
+  display: none;
+  font-size: var(--font-size-14);
+  font-weight: normal;
+  padding-inline-end: 0.25em;
+}
+.dnd5e.sheet.item .sheet-header .summary li:hover .config-button {
+  display: block;
+}
 .dnd5e.sheet.item .sheet-navigation {
   margin-bottom: 5px;
 }
@@ -2520,25 +2548,31 @@ a.roll-link i {
 .dnd5e.sheet.actor.npc .summary {
   font-size: 18px;
 }
-.dnd5e.sheet.actor.npc .summary .creature-type {
+.dnd5e.sheet.actor.npc .summary li {
   display: flex;
   justify-content: space-between;
-  width: 1em;
-  padding: 0 3px;
+  gap: 0.25em;
 }
-.dnd5e.sheet.actor.npc .summary .creature-type span {
+.dnd5e.sheet.actor.npc .summary li span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.dnd5e.sheet.actor.npc .summary .creature-type .config-button {
+.dnd5e.sheet.actor.npc .summary li .config-button {
   display: none;
   font-size: 12px;
   font-weight: normal;
   line-height: 2em;
 }
-.dnd5e.sheet.actor.npc .summary .creature-type:hover .config-button {
+.dnd5e.sheet.actor.npc .summary li:hover .config-button {
   display: block;
+}
+.dnd5e.sheet.actor.npc .summary .creature-type {
+  width: 1em;
+  padding: 0 3px;
+}
+.dnd5e.sheet.actor.npc .summary .source {
+  width: 1em;
 }
 .dnd5e.sheet.actor.vehicle {
   min-width: 720px;

--- a/lang/en.json
+++ b/lang/en.json
@@ -1049,6 +1049,15 @@
 "DND5E.SkillPassiveHint": "Passive {skill}",
 "DND5E.Skip": "Skip",
 "DND5E.Source": "Source",
+"DND5E.SourceBook": "Book",
+"DND5E.SourceConfig": "Configure Source",
+"DND5E.SourceCustom": "Custom Label",
+"DND5E.SourceDisplay": "{book} {page}",
+"DND5E.SourceLicense": "License",
+"DND5E.SourcePage": "Page/Section",
+"DND5E.SourcePageDisplay": "pg. {page}",
+"DND5E.SourceUUID": "Original Source",
+"DND5E.SourceUUIDDrop": "Drop Item Here",
 "DND5E.Special": "Special",
 "DND5E.SpecialTraits": "Special Traits",
 "DND5E.Speed": "Speed",
@@ -1389,5 +1398,8 @@
 "SETTINGS.5eGridAlignedSquareTemplatesN": "Grid-Aligned Square Templates",
 "SETTINGS.5eSanityL": "Enable the use of the optional Sanity ability score. Requires the world to be reloaded.",
 "SETTINGS.5eSanityN": "Sanity Ability Score",
-"SETTINGS.5eUndoChanges": "Undo Changes"
+"SETTINGS.5eUndoChanges": "Undo Changes",
+
+"SOURCE.BOOK.SRD": "System Reference Document 5.1",
+"SOURCE.LICENSE.CC-BY-40": "Creative Commons Attribution 4.0 International License"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1399,6 +1399,5 @@
 "SETTINGS.5eSanityN": "Sanity Ability Score",
 "SETTINGS.5eUndoChanges": "Undo Changes",
 
-"SOURCE.BOOK.SRD": "System Reference Document 5.1",
-"SOURCE.LICENSE.CC-BY-40": "Creative Commons Attribution 4.0 International License"
+"SOURCE.BOOK.SRD": "System Reference Document 5.1"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1057,7 +1057,6 @@
 "DND5E.SourcePage": "Page/Section",
 "DND5E.SourcePageDisplay": "pg. {page}",
 "DND5E.SourceUUID": "Original Source",
-"DND5E.SourceUUIDDrop": "Drop Item Here",
 "DND5E.Special": "Special",
 "DND5E.SpecialTraits": "Special Traits",
 "DND5E.Speed": "Speed",

--- a/less/apps.less
+++ b/less/apps.less
@@ -708,6 +708,17 @@ h5 {
 }
 
 /* ----------------------------------------- */
+/*  Source Config Sheet Specifically         */
+/* ----------------------------------------- */
+
+.dnd5e.source-config {
+  .source-uuid {
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
+/* ----------------------------------------- */
 /*  Polymorph Features                       */
 /* ----------------------------------------- */
 

--- a/less/apps.less
+++ b/less/apps.less
@@ -708,17 +708,6 @@ h5 {
 }
 
 /* ----------------------------------------- */
-/*  Source Config Sheet Specifically         */
-/* ----------------------------------------- */
-
-.dnd5e.source-config {
-  .source-uuid {
-    display: flex;
-    justify-content: space-between;
-  }
-}
-
-/* ----------------------------------------- */
 /*  Polymorph Features                       */
 /* ----------------------------------------- */
 

--- a/less/items.less
+++ b/less/items.less
@@ -40,6 +40,29 @@
         padding: 0 0.25em;
         text-align: right;
       }
+      li {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.25em;
+      
+        span {
+          padding-inline: 4px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          font-weight: 400;
+        }
+      
+        .config-button {
+          display: none;
+          font-size: var(--font-size-14);
+          font-weight: normal;
+          padding-inline-end: 0.25em;
+        }
+        &:hover .config-button {
+          display: block;
+        }
+      }
     }
   }
 

--- a/less/npc.less
+++ b/less/npc.less
@@ -34,11 +34,10 @@
   .summary {
     font-size: 18px;
 
-    .creature-type {
+    li {
       display: flex;
       justify-content: space-between;
-      width: 1em;
-      padding: 0 3px;
+      gap: 0.25em;
 
       span {
         overflow: hidden;
@@ -55,6 +54,14 @@
       &:hover .config-button {
         display: block;
       }
+    }
+
+    .creature-type {
+      width: 1em;
+      padding: 0 3px;
+    }
+    .source {
+      width: 1em;
     }
   }
 }

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -5,3 +5,4 @@ export * as item from "./item/_module.mjs";
 export * as journal from "./journal/_module.mjs";
 
 export {default as PropertyAttribution} from "./property-attribution.mjs";
+export {default as SourceConfig} from "./source-config.mjs";

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -11,6 +11,7 @@ import ActorMovementConfig from "./movement-config.mjs";
 import ActorSensesConfig from "./senses-config.mjs";
 import ActorSheetFlags from "./sheet-flags.mjs";
 import ActorTypeConfig from "./type-config.mjs";
+import SourceConfig from "../source-config.mjs";
 
 import AdvancementConfirmationDialog from "../advancement/advancement-confirmation-dialog.mjs";
 import AdvancementManager from "../advancement/advancement-manager.mjs";
@@ -807,24 +808,24 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
       case "senses":
         app = new ActorSensesConfig(this.actor);
         break;
+      case "source":
+        app = new SourceConfig(this.actor);
+        break;
       case "type":
         app = new ActorTypeConfig(this.actor);
         break;
-      case "ability": {
+      case "ability":
         const ability = event.currentTarget.closest("[data-ability]").dataset.ability;
         app = new ActorAbilityConfig(this.actor, null, ability);
         break;
-      }
-      case "skill": {
+      case "skill":
         const skill = event.currentTarget.closest("[data-key]").dataset.key;
         app = new ProficiencyConfig(this.actor, {property: "skills", key: skill});
         break;
-      }
-      case "tool": {
+      case "tool":
         const tool = event.currentTarget.closest("[data-key]").dataset.key;
         app = new ProficiencyConfig(this.actor, {property: "tools", key: tool});
         break;
-      }
     }
     app?.render(true);
   }
@@ -1120,8 +1121,6 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
     parent.removeChild(span);
     parent.appendChild(input);
   }
-
-
 
   /* -------------------------------------------- */
 

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -4,6 +4,7 @@ import ActorTypeConfig from "../actor/type-config.mjs";
 import AdvancementManager from "../advancement/advancement-manager.mjs";
 import AdvancementMigrationDialog from "../advancement/advancement-migration-dialog.mjs";
 import Accordion from "../accordion.mjs";
+import SourceConfig from "../source-config.mjs";
 import ActiveEffect5e from "../../documents/active-effect.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
 
@@ -557,6 +558,9 @@ export default class ItemSheet5e extends ItemSheet {
         break;
       case "senses":
         app = new ActorSensesConfig(this.item, { keyPath: "system.senses" });
+        break;
+      case "source":
+        app = new SourceConfig(this.item, { keyPath: "system.source" });
         break;
       case "type":
         app = new ActorTypeConfig(this.item, { keyPath: "system.type" });

--- a/module/applications/source-config.mjs
+++ b/module/applications/source-config.mjs
@@ -10,9 +10,6 @@ export default class SourceConfig extends DocumentSheet {
       template: "systems/dnd5e/templates/apps/source-config.hbs",
       width: 400,
       height: "auto",
-      dragDrop: [{dropSelector: "form"}],
-      submitOnChange: true,
-      closeOnSubmit: false,
       sheetConfig: false,
       keyPath: "system.details.source"
     });
@@ -35,6 +32,7 @@ export default class SourceConfig extends DocumentSheet {
     context.appId = this.id;
     context.CONFIG = CONFIG.DND5E;
     context.source = foundry.utils.getProperty(this.document, this.options.keyPath);
+    context.sourceUuid = foundry.utils.getProperty(this.document, "flags.core.sourceId");
     return context;
   }
 
@@ -42,39 +40,9 @@ export default class SourceConfig extends DocumentSheet {
   /*  Event Handlers                              */
   /* -------------------------------------------- */
 
-  /** @inheritdoc */
-  activateListeners(html) {
-    super.activateListeners(html);
-    html.find('[data-action="delete"]').click(() => {
-      this.form.querySelector('[name="source.uuid"]').value = "";
-      this.submit();
-    });
-  }
-
-  /* -------------------------------------------- */
-
   /** @override */
   async _updateObject(event, formData) {
     const source = foundry.utils.expandObject(formData).source;
     return this.document.update({[this.options.keyPath]: source});
-  }
-
-  /* -------------------------------------------- */
-  /*  Drag & Drop                                 */
-  /* -------------------------------------------- */
-
-  /** @inheritdoc */
-  async _onDrop(event) {
-    const data = TextEditor.getDragEventData(event);
-    const input = this.form.querySelector('[name="source.uuid"]');
-
-    if ( data.uuid ) input.value = data.uuid;
-    else {
-      const item = await Item.implementation.fromDropData(data);
-      if ( !item.uuid ) return;
-      input.value = item.uuid;
-    }
-
-    return this.submit();
   }
 }

--- a/module/applications/source-config.mjs
+++ b/module/applications/source-config.mjs
@@ -1,0 +1,80 @@
+/**
+ * Application for configuring the source data on actors and items.
+ */
+export default class SourceConfig extends DocumentSheet {
+
+  /** @inheritdoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["dnd5e", "source-config", "dialog"],
+      template: "systems/dnd5e/templates/apps/source-config.hbs",
+      width: 400,
+      height: "auto",
+      dragDrop: [{dropSelector: "form"}],
+      submitOnChange: true,
+      closeOnSubmit: false,
+      sheetConfig: false,
+      keyPath: "system.details.source"
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  get title() {
+    return `${game.i18n.localize("DND5E.SourceConfig")}: ${this.document.name}`;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  getData(options) {
+    const context = super.getData(options);
+    context.appId = this.id;
+    context.CONFIG = CONFIG.DND5E;
+    context.source = foundry.utils.getProperty(this.document, this.options.keyPath);
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Handlers                              */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  activateListeners(html) {
+    super.activateListeners(html);
+    html.find('[data-action="delete"]').click(() => {
+      this.form.querySelector('[name="source.uuid"]').value = "";
+      this.submit();
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _updateObject(event, formData) {
+    const source = foundry.utils.expandObject(formData).source;
+    return this.document.update({[this.options.keyPath]: source});
+  }
+
+  /* -------------------------------------------- */
+  /*  Drag & Drop                                 */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onDrop(event) {
+    const data = TextEditor.getDragEventData(event);
+    const input = this.form.querySelector('[name="source.uuid"]');
+
+    if ( data.uuid ) input.value = data.uuid;
+    else {
+      const item = await Item.implementation.fromDropData(data);
+      if ( !item.uuid ) return;
+      input.value = item.uuid;
+    }
+
+    return this.submit();
+  }
+}

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2055,6 +2055,32 @@ DND5E.advancementTypes = {
 };
 
 /* -------------------------------------------- */
+/*  Sources                                     */
+/* -------------------------------------------- */
+
+/**
+ * List of books available as sources.
+ * @enum {string}
+ */
+DND5E.sourceBooks = {
+  "SRD 5.1": "SOURCE.BOOK.SRD"
+};
+preLocalize("sourceBooks", { sort: true });
+
+/* -------------------------------------------- */
+
+/**
+ * List of licenses available with sources.
+ * @enum {string}
+ */
+DND5E.sourceLicenses = {
+  "CC-BY-4.0": "SOURCE.LICENSE.CC-BY-40"
+};
+preLocalize("sourceLicenses", { sort: true });
+
+/* -------------------------------------------- */
+/*  Enrichment                                  */
+/* -------------------------------------------- */
 
 let _enrichmentLookup;
 Object.defineProperty(DND5E, "enrichmentLookup", {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2068,17 +2068,6 @@ DND5E.sourceBooks = {
 preLocalize("sourceBooks", { sort: true });
 
 /* -------------------------------------------- */
-
-/**
- * List of licenses available with sources.
- * @enum {string}
- */
-DND5E.sourceLicenses = {
-  "CC-BY-4.0": "SOURCE.LICENSE.CC-BY-40"
-};
-preLocalize("sourceLicenses", { sort: true });
-
-/* -------------------------------------------- */
 /*  Enrichment                                  */
 /* -------------------------------------------- */
 

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -6,7 +6,6 @@ const { SchemaField, StringField } = foundry.data.fields;
  * @property {string} book     Book/publication where the item originated.
  * @property {string} page     Page or section where the item can be found.
  * @property {string} custom   Fully custom source label.
- * @property {string} uuid     Upstream source of this data if it originated in another compendium.
  * @property {string} license  Type of license that covers this item.
  */
 export default class SourceField extends SchemaField {
@@ -15,7 +14,6 @@ export default class SourceField extends SchemaField {
       book: new StringField({label: "DND5E.SourceBook"}),
       page: new StringField({label: "DND5E.SourcePage"}),
       custom: new StringField({label: "DND5E.SourceCustom"}),
-      uuid: new StringField({label: "DND5E.SourceUUID"}), // TODO: Convert to UUIDField with v12
       license: new StringField({label: "DND5E.SourceLicense"}),
       ...fields
     }, { label: "DND5E.Source", ...options });

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -9,14 +9,14 @@ const { SchemaField, StringField } = foundry.data.fields;
  * @property {string} uuid     Upstream source of this data if it originated in another compendium.
  * @property {string} license  Type of license that covers this item.
  */
-export default class SourceTemplate extends SchemaField {
+export default class SourceField extends SchemaField {
   constructor(fields={}, options={}) {
     super({
-      book: new StringField(),
-      page: new StringField(),
-      custom: new StringField(),
-      uuid: new StringField(), // TODO: Convert to UUIDField with v12
-      license: new StringField(),
+      book: new StringField({label: "DND5E.SourceBook"}),
+      page: new StringField({label: "DND5E.SourcePage"}),
+      custom: new StringField({label: "DND5E.SourceCustom"}),
+      uuid: new StringField({label: "DND5E.SourceUUID"}), // TODO: Convert to UUIDField with v12
+      license: new StringField({label: "DND5E.SourceLicense"}),
       ...fields
     }, { label: "DND5E.Source", ...options });
   }
@@ -30,8 +30,9 @@ export default class SourceTemplate extends SchemaField {
     Object.defineProperty(obj, "label", {
       get() {
         if ( this.custom ) return this.custom;
-        // TODO: Improve this logic
-        return this.book ? this.page ? `${this.book} ${this.page}` : this.book : "";
+        const page = Number.isNumeric(this.page)
+          ? game.i18n.format("DND5E.SourcePageDisplay", { page: this.page }) : this.page;
+        return game.i18n.format("DND5E.SourceDisplay", { book: this.book ?? "", page: page ?? "" }).trim();
       },
       enumerable: false
     });

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -139,6 +139,7 @@ export async function preloadHandlebarsTemplates() {
     "systems/dnd5e/templates/items/parts/item-description.hbs",
     "systems/dnd5e/templates/items/parts/item-mountable.hbs",
     "systems/dnd5e/templates/items/parts/item-spellcasting.hbs",
+    "systems/dnd5e/templates/items/parts/item-source.hbs",
     "systems/dnd5e/templates/items/parts/item-summary.hbs",
 
     // Journal Partials

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -41,8 +41,17 @@
                     </a>
                 </li>
                 <li class="source">
-                    <input type="text" name="system.details.source.custom" value="{{system.details.source.custom}}"
-                           placeholder="{{ localize 'DND5E.Source' }}"/>
+                    {{#if (eq system.details.source.custom system.details.source.label)}}
+                        <input type="text" name="system.details.source.custom" value="{{system.details.source.custom}}"
+                                     placeholder="{{ localize 'DND5E.Source' }}">
+                    {{else}}
+                        <span data-tooltip="{{system.details.source.label}}">{{system.details.source.label}}</span>
+                    {{/if}}
+                    {{#if editable}}
+                        <a class="config-button" data-action="source" data-tooltip="DND5E.SourceConfig">
+                            <i class="fas fa-cog"></i>
+                        </a>
+                    {{/if}}
                 </li>
             </ul>
 

--- a/templates/apps/source-config.hbs
+++ b/templates/apps/source-config.hbs
@@ -1,40 +1,37 @@
 <form autocomplete="off">
-	<div class="form-group">
-		<label>{{localize "DND5E.SourceBook"}}</label>
-		<input type="text" name="source.book" value="{{source.book}}" list="{{appId}}-books">
-		<datalist id="{{appId}}-books">
-			{{#each CONFIG.sourceBooks as |label key|}}
-				<option value="{{key}}">{{label}}</option>
-			{{/each}}
-		</datalist>
-	</div>
-	<div class="form-group">
-		<label>{{localize "DND5E.SourcePage"}}</label>
-		<input type="text" name="source.page" value="{{source.page}}">
-	</div>
-	<div class="form-group">
-		<label>{{localize "DND5E.SourceCustom"}}</label>
-		<input type="text" name="source.custom" value="{{source.custom}}">
-	</div>
-	<div class="form-group">
-		<label>{{localize "DND5E.SourceLicense"}}</label>
-		<input type="text" name="source.license" value="{{source.license}}" list="{{appId}}-licenses">
-		<datalist id="{{appId}}-licenses">
-			{{#each CONFIG.sourceLicenses as |label key|}}
-				<option value="{{key}}">{{label}}</option>
-			{{/each}}
-		</datalist>
-	</div>
-	<div class="form-group">
-		<label>{{localize "DND5E.SourceUUID"}}</label>
-		<div class="source-uuid">
-			{{#if source.uuid}}
-				{{{dnd5e-linkForUuid source.uuid}}}
-				<a class="item-control" data-action="delete"><i class="fas fa-trash"></i></a>
-			{{else}}
-				{{localize "DND5E.SourceUUIDDrop"}}
-			{{/if}}
-		</div>
-		<input type="hidden" name="source.uuid" value="{{source.uuid}}">
-	</div>
+  <div class="form-group">
+    <label>{{localize "DND5E.SourceBook"}}</label>
+    <input type="text" name="source.book" value="{{source.book}}" list="{{appId}}-books">
+    <datalist id="{{appId}}-books">
+      {{#each CONFIG.sourceBooks as |label key|}}
+        <option value="{{key}}">{{label}}</option>
+      {{/each}}
+    </datalist>
+  </div>
+  <div class="form-group">
+    <label>{{localize "DND5E.SourcePage"}}</label>
+    <input type="text" name="source.page" value="{{source.page}}">
+  </div>
+  <div class="form-group">
+    <label>{{localize "DND5E.SourceCustom"}}</label>
+    <input type="text" name="source.custom" value="{{source.custom}}">
+  </div>
+  <div class="form-group">
+    <label>{{localize "DND5E.SourceLicense"}}</label>
+    <input type="text" name="source.license" value="{{source.license}}" list="{{appId}}-licenses">
+    <datalist id="{{appId}}-licenses">
+      {{#each CONFIG.sourceLicenses as |label key|}}
+        <option value="{{key}}">{{label}}</option>
+      {{/each}}
+    </datalist>
+  </div>
+  {{#if sourceUuid}}
+    <div class="form-group">
+      <label>{{localize "DND5E.SourceUUID"}}</label>
+      <div class="source-uuid">
+        {{{dnd5e-linkForUuid sourceUuid}}}
+      </div>
+    </div>
+  {{/if}}
+  <button type="submit"><i class="far fa-save"></i> {{ localize "Submit"}}</button>
 </form>

--- a/templates/apps/source-config.hbs
+++ b/templates/apps/source-config.hbs
@@ -1,0 +1,40 @@
+<form autocomplete="off">
+	<div class="form-group">
+		<label>{{localize "DND5E.SourceBook"}}</label>
+		<input type="text" name="source.book" value="{{source.book}}" list="{{appId}}-books">
+		<datalist id="{{appId}}-books">
+			{{#each CONFIG.sourceBooks as |label key|}}
+				<option value="{{key}}">{{label}}</option>
+			{{/each}}
+		</datalist>
+	</div>
+	<div class="form-group">
+		<label>{{localize "DND5E.SourcePage"}}</label>
+		<input type="text" name="source.page" value="{{source.page}}">
+	</div>
+	<div class="form-group">
+		<label>{{localize "DND5E.SourceCustom"}}</label>
+		<input type="text" name="source.custom" value="{{source.custom}}">
+	</div>
+	<div class="form-group">
+		<label>{{localize "DND5E.SourceLicense"}}</label>
+		<input type="text" name="source.license" value="{{source.license}}" list="{{appId}}-licenses">
+		<datalist id="{{appId}}-licenses">
+			{{#each CONFIG.sourceLicenses as |label key|}}
+				<option value="{{key}}">{{label}}</option>
+			{{/each}}
+		</datalist>
+	</div>
+	<div class="form-group">
+		<label>{{localize "DND5E.SourceUUID"}}</label>
+		<div class="source-uuid">
+			{{#if source.uuid}}
+				{{{dnd5e-linkForUuid source.uuid}}}
+				<a class="item-control" data-action="delete"><i class="fas fa-trash"></i></a>
+			{{else}}
+				{{localize "DND5E.SourceUUIDDrop"}}
+			{{/if}}
+		</div>
+		<input type="hidden" name="source.uuid" value="{{source.uuid}}">
+	</div>
+</form>

--- a/templates/apps/source-config.hbs
+++ b/templates/apps/source-config.hbs
@@ -18,12 +18,7 @@
   </div>
   <div class="form-group">
     <label>{{localize "DND5E.SourceLicense"}}</label>
-    <input type="text" name="source.license" value="{{source.license}}" list="{{appId}}-licenses">
-    <datalist id="{{appId}}-licenses">
-      {{#each CONFIG.sourceLicenses as |label key|}}
-        <option value="{{key}}">{{label}}</option>
-      {{/each}}
-    </datalist>
+    <input type="text" name="source.license" value="{{source.license}}">
   </div>
   {{#if sourceUuid}}
     <div class="form-group">

--- a/templates/items/background.hbs
+++ b/templates/items/background.hbs
@@ -16,8 +16,7 @@
 
       <ul class="summary flexrow">
         <li>
-          <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                 placeholder="{{ localize 'DND5E.Source' }}">
+          {{> "dnd5e.item-source"}}
         </li>
       </ul>
     </div>

--- a/templates/items/backpack.hbs
+++ b/templates/items/backpack.hbs
@@ -21,8 +21,7 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                            placeholder="{{ localize 'DND5E.Source' }}">
+                    {{> "dnd5e.item-source"}}
                 </li>
             </ul>
         </div>

--- a/templates/items/class.hbs
+++ b/templates/items/class.hbs
@@ -16,8 +16,7 @@
 
             <ul class="summary flexrow">
                 <li>
-                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                           placeholder="{{ localize 'DND5E.Source' }}">
+                    {{> "dnd5e.item-source"}}
                 </li>
             </ul>
         </div>

--- a/templates/items/consumable.hbs
+++ b/templates/items/consumable.hbs
@@ -24,8 +24,7 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                           placeholder="{{ localize 'DND5E.Source' }}">
+                    {{> "dnd5e.item-source"}}
                 </li>
             </ul>
         </div>

--- a/templates/items/equipment.hbs
+++ b/templates/items/equipment.hbs
@@ -24,8 +24,7 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                           placeholder="{{ localize 'DND5E.Source' }}">
+                    {{> "dnd5e.item-source"}}
                 </li>
             </ul>
         </div>

--- a/templates/items/feat.hbs
+++ b/templates/items/feat.hbs
@@ -22,8 +22,7 @@
                     <input type="text" name="system.requirements" value="{{system.requirements}}" placeholder="{{ localize 'DND5E.Requirements' }}"/>
                 </li>
                 <li>
-                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                           placeholder="{{ localize 'DND5E.Source' }}">
+                    {{> "dnd5e.item-source"}}
                 </li>
             </ul>
         </div>

--- a/templates/items/loot.hbs
+++ b/templates/items/loot.hbs
@@ -21,8 +21,7 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                           placeholder="{{ localize 'DND5E.Source' }}">
+                    {{> "dnd5e.item-source"}}
                 </li>
             </ul>
         </div>

--- a/templates/items/parts/item-source.hbs
+++ b/templates/items/parts/item-source.hbs
@@ -1,0 +1,11 @@
+{{#if (eq system.source.custom system.source.label)}}
+	<input type="text" name="system.source.custom" value="{{system.source.custom}}"
+				 placeholder="{{ localize 'DND5E.Source' }}">
+{{else}}
+	<span>{{system.source.label}}</span>
+{{/if}}
+{{#if editable}}
+	<a class="config-button" data-action="source" data-tooltip="DND5E.SourceConfig">
+		<i class="fas fa-cog"></i>
+	</a>
+{{/if}}

--- a/templates/items/parts/item-source.hbs
+++ b/templates/items/parts/item-source.hbs
@@ -1,11 +1,11 @@
 {{#if (eq system.source.custom system.source.label)}}
-	<input type="text" name="system.source.custom" value="{{system.source.custom}}"
-				 placeholder="{{ localize 'DND5E.Source' }}">
+  <input type="text" name="system.source.custom" value="{{system.source.custom}}"
+         placeholder="{{ localize 'DND5E.Source' }}">
 {{else}}
-	<span>{{system.source.label}}</span>
+  <span>{{system.source.label}}</span>
 {{/if}}
 {{#if editable}}
-	<a class="config-button" data-action="source" data-tooltip="DND5E.SourceConfig">
-		<i class="fas fa-cog"></i>
-	</a>
+  <a class="config-button" data-action="source" data-tooltip="DND5E.SourceConfig">
+    <i class="fas fa-cog"></i>
+  </a>
 {{/if}}

--- a/templates/items/race.hbs
+++ b/templates/items/race.hbs
@@ -15,8 +15,7 @@
 
       <ul class="summary flexrow">
         <li>
-          <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                 placeholder="{{localize 'DND5E.Source'}}">
+          {{> "dnd5e.item-source"}}
         </li>
       </ul>
     </div>

--- a/templates/items/spell.hbs
+++ b/templates/items/spell.hbs
@@ -22,8 +22,7 @@
                     {{labels.school}}
                 </li>
                 <li>
-                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                           placeholder="{{ localize 'DND5E.Source' }}">
+                    {{> "dnd5e.item-source"}}
                 </li>
             </ul>
         </div>

--- a/templates/items/subclass.hbs
+++ b/templates/items/subclass.hbs
@@ -16,8 +16,7 @@
 
       <ul class="summary flexrow">
         <li>
-          <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                 placeholder="{{ localize 'DND5E.Source' }}">
+          {{> "dnd5e.item-source"}}
         </li>
       </ul>
     </div>

--- a/templates/items/tool.hbs
+++ b/templates/items/tool.hbs
@@ -28,8 +28,7 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                           placeholder="{{ localize 'DND5E.Source' }}">
+                    {{> "dnd5e.item-source"}}
                 </li>
             </ul>
         </div>

--- a/templates/items/weapon.hbs
+++ b/templates/items/weapon.hbs
@@ -24,8 +24,7 @@
                     </select>
                 </li>
                 <li>
-                    <input type="text" name="system.source.custom" value="{{system.source.custom}}"
-                           placeholder="{{ localize 'DND5E.Source' }}">
+                    {{> "dnd5e.item-source"}}
                 </li>
             </ul>
         </div>

--- a/templates/journal/page-class-edit.hbs
+++ b/templates/journal/page-class-edit.hbs
@@ -7,7 +7,7 @@
       <ol class="items-list">
         {{#if document.system.item}}
           <li class="item flexrow" data-item-uuid="{{document.system.item}}" data-item-type="class">
-            <div class="item.name">{{{dnd5e-linkForUuid document.system.item}}}</div>
+            <div class="item-name">{{{dnd5e-linkForUuid document.system.item}}}</div>
             <div class="item-controls flexrow">
               <a class="item-control item-delete" data-tooltip="DND5E.ItemDelete">
                 <i class="fas fa-trash"></i>

--- a/templates/journal/page-class-edit.hbs
+++ b/templates/journal/page-class-edit.hbs
@@ -7,7 +7,7 @@
       <ol class="items-list">
         {{#if document.system.item}}
           <li class="item flexrow" data-item-uuid="{{document.system.item}}" data-item-type="class">
-            <div clas="item.name">{{{dnd5e-linkForUuid document.system.item}}}</div>
+            <div class="item.name">{{{dnd5e-linkForUuid document.system.item}}}</div>
             <div class="item-controls flexrow">
               <a class="item-control item-delete" data-tooltip="DND5E.ItemDelete">
                 <i class="fas fa-trash"></i>
@@ -84,7 +84,7 @@
       <ol class="items-list">
         {{#each subclasses}}
           <li class="item flexrow" data-item-uuid="{{this.document.uuid}}" data-item-type="subclass">
-            <div clas="item-name">{{{dnd5e-linkForUuid this.document.uuid}}}</div>
+            <div class="item-name">{{{dnd5e-linkForUuid this.document.uuid}}}</div>
             <div class="item-controls flexrow">
               <a class="item-control item-delete" data-tooltip="DND5E.ItemDelete">
                 <i class="fas fa-trash"></i>


### PR DESCRIPTION
Add a source editor for configuring the new source data on items and NPCs:

<img width="408" alt="Source Editor" src="https://github.com/foundryvtt/dnd5e/assets/19979839/c04ff112-102a-477a-9166-05b0a5059538">

The editor uses a data list to display recommendations for Book and License, but it doesn't require they match something in config:

<img width="408" alt="Source List" src="https://github.com/foundryvtt/dnd5e/assets/19979839/4b5eadd1-a5e2-4c96-a756-13765d0e04ba">

I've only added on book and license at the moment for the SRD, but it might be worth it to add other options even if we aren't going to use them for built-in system content to aid players creating stuff themselves.
