### PR TITLE
[#2607] Fix collpased accordion sections not opening after editing description

### DIFF
--- a/module/applications/accordion.mjs
+++ b/module/applications/accordion.mjs
@@ -48,7 +48,7 @@ export default class Accordion {
    * Augment the given markup with an accordion effect.
    * @param {HTMLElement} root  The root HTML node.
    */
-  async bind(root) {
+  bind(root) {
     const firstBind = this.#sections.size < 1;
     if ( firstBind ) this.#collapsed = [];
     this.#sections = new Map();
@@ -102,7 +102,7 @@ export default class Accordion {
    * @param {boolean} [options.animate=true]  Whether to animate the expand effect.
    * @protected
    */
-  async _onExpandSection(heading, content, { animate=true }={}) {
+  _onExpandSection(heading, content, { animate=true }={}) {
     this.#cancelOngoing(heading);
 
     if ( this.#config.collapseOthers ) {
@@ -137,7 +137,7 @@ export default class Accordion {
    * @param {boolean} [options.animate=true]  Whether to animate the collapse effect.
    * @protected
    */
-  async _onCollapseSection(heading, content, { animate=true }={}) {
+  _onCollapseSection(heading, content, { animate=true }={}) {
     this.#cancelOngoing(heading);
     const { height } = content.getBoundingClientRect();
     heading.parentElement.classList.add("collapsed");

--- a/module/applications/accordion.mjs
+++ b/module/applications/accordion.mjs
@@ -63,6 +63,7 @@ export default class Accordion {
       heading.before(wrapper);
       wrapper.append(heading, content);
       this.#sections.set(heading, content);
+      content._fullHeight = content.getBoundingClientRect().height;
       if ( firstBind ) this.#collapsed.push(this.#collapsed.length > 0);
       else if ( this.#collapsed[collapsedIndex] ) wrapper.classList.add("collapsed");
       heading.classList.add("accordion-heading");
@@ -140,7 +141,7 @@ export default class Accordion {
     this.#cancelOngoing(heading);
     const { height } = content.getBoundingClientRect();
     heading.parentElement.classList.add("collapsed");
-    content._fullHeight = height;
+    content._fullHeight = height || content._fullHeight;
     if ( animate ) content.style.height = `${height}px`;
     else {
       content.style.height = "0";

--- a/module/applications/accordion.mjs
+++ b/module/applications/accordion.mjs
@@ -71,8 +71,7 @@ export default class Accordion {
       heading.addEventListener("click", this._onClickHeading.bind(this));
       collapsedIndex++;
     }
-    await new Promise(resolve => { setTimeout(resolve, 0); }); // Allow re-paint.
-    this._restoreCollapsedState();
+    requestAnimationFrame(() => this._restoreCollapsedState());
   }
 
   /* -------------------------------------------- */
@@ -120,11 +119,12 @@ export default class Accordion {
       content.style.height = `${content._fullHeight}px`;
       return;
     }
-    await new Promise(resolve => { setTimeout(resolve, 0); }); // Allow re-paint.
-    const onEnd = this._onEnd.bind(this, heading, content);
-    this.#ongoing.set(heading, onEnd);
-    content.addEventListener("transitionend", onEnd, { once: true });
-    content.style.height = `${content._fullHeight}px`;
+    requestAnimationFrame(() => {
+      const onEnd = this._onEnd.bind(this, heading, content);
+      this.#ongoing.set(heading, onEnd);
+      content.addEventListener("transitionend", onEnd, { once: true });
+      content.style.height = `${content._fullHeight}px`;
+    });
   }
 
   /* -------------------------------------------- */
@@ -147,11 +147,12 @@ export default class Accordion {
       content.style.height = "0";
       return;
     }
-    await new Promise(resolve => { setTimeout(resolve, 0); }); // Allow re-paint.
-    const onEnd = this._onEnd.bind(this, heading, content);
-    this.#ongoing.set(heading, onEnd);
-    content.addEventListener("transitionend", onEnd, { once: true });
-    content.style.height = "0";
+    requestAnimationFrame(() => {
+      const onEnd = this._onEnd.bind(this, heading, content);
+      this.#ongoing.set(heading, onEnd);
+      content.addEventListener("transitionend", onEnd, { once: true });
+      content.style.height = "0";
+    });
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
~~This fix at least ensures that the contents of the accordion are always visible, but it doesn't animate for the first expanding after changing another property. I would welcome thoughts as to a better fix.~~

Found a better fix that properly stores the height.

> [!Note]
> I switched from using `setTimeout` to `requestAnimationFrame` for the accordion timing here because it felt more appropriate, but that isn't part of the actual bug fix.