### PR TITLE
[#2473] Add ammo description, save, and template (if applicable) to item messages

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1810,7 +1810,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       case "placeTemplate":
       case "placeAmmoTemplate":
         try {
-          const templateItem = action === "placeTemplate" ? item : ammo;
+          const templateItem = (action === "placeTemplate") ? item : ammo;
           await dnd5e.canvas.AbilityTemplate.fromItem(templateItem, {"flags.dnd5e.spellLevel": spellLevel})?.drawPreview();
         } catch(err) {
           Hooks.onError("Item5e._onChatCardAction", err, {

--- a/templates/chat/item-card.hbs
+++ b/templates/chat/item-card.hbs
@@ -1,5 +1,7 @@
 <div class="dnd5e chat-card item-card" data-actor-id="{{actor._id}}" data-item-id="{{item._id}}"
-     {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}} {{#if isSpell}}data-spell-level="{{item.system.level}}"{{/if}}>
+     {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}
+     {{#if isSpell}}data-spell-level="{{item.system.level}}"{{/if}}
+     {{#if hasAmmo}}data-ammo-id="{{ammo.item._id}}"{{/if}}>
     <header class="card-header flexrow">
         <img src="{{item.img}}" title="{{item.name}}" width="36" height="36"/>
         <h3 class="item-name">{{item.name}}</h3>
@@ -13,6 +15,16 @@
         {{/if}}
         {{#if data.materials.value}}
         <p><strong>{{ localize "DND5E.RequiredMaterials" }}.</strong> {{data.materials.value}}</p>
+        {{/if}}
+
+        {{#if hasAmmo}}
+        <fieldset><legend>{{ammo.item.name}}</legend>
+            {{#if ammo.data.description.chat}}
+                {{{ammo.data.description.chat}}}
+            {{else}}
+                {{{ammo.data.description.value}}}
+            {{/if}}
+        </fieldset>
         {{/if}}
     </div>
 
@@ -50,6 +62,20 @@
 
         {{#if hasAbilityCheck}}
         <button data-action="abilityCheck" data-ability="{{data.ability}}">{{labels.abilityCheck}}</button>
+        {{/if}}
+
+        {{#if hasAmmo}}
+
+          {{#if ammo.hasSave}}
+          <button data-action="save" data-ability="{{ammo.data.save.ability}}">
+              {{ localize "DND5E.SavingThrow" }} {{ammo.labels.save}} [{{ammo.item.name}}]
+          </button>
+          {{/if}}
+
+          {{#if ammo.hasAreaTarget}}
+          <button data-action="placeAmmoTemplate">{{ localize "DND5E.PlaceTemplate" }} [{{ammo.item.name}}]</button>
+          {{/if}}
+
         {{/if}}
     </div>
 

--- a/templates/chat/item-card.hbs
+++ b/templates/chat/item-card.hbs
@@ -68,12 +68,12 @@
 
           {{#if ammo.hasSave}}
           <button data-action="save" data-ability="{{ammo.data.save.ability}}">
-              {{ localize "DND5E.SavingThrow" }} {{ammo.labels.save}} [{{ammo.item.name}}]
+              {{ localize "DND5E.SavingThrow" }} {{ammo.labels.save}} [{{ localize "DND5E.ConsumableAmmo" }}]
           </button>
           {{/if}}
 
           {{#if ammo.hasAreaTarget}}
-          <button data-action="placeAmmoTemplate">{{ localize "DND5E.PlaceTemplate" }} [{{ammo.item.name}}]</button>
+          <button data-action="placeAmmoTemplate">{{ localize "DND5E.PlaceTemplate" }} [{{ localize "DND5E.ConsumableAmmo" }}]</button>
           {{/if}}
 
         {{/if}}


### PR DESCRIPTION
![image](https://github.com/foundryvtt/dnd5e/assets/50169243/9451dbfd-5367-43a1-baba-a8fd34d2ae47)

This checks the ammo of an item being used for whether it has either a saving throw or a measured template. If it has either, some buttons are appended as well as the ammo's description.