### PR TITLE
Amend warning on AbilityUseDialog for pact slots

### DIFF
--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -245,15 +245,16 @@ export default class AbilityUseDialog extends Dialog {
   static _getAbilityUseWarnings(data) {
     const warnings = [];
     const item = data.item;
-    const { quantity, level, consume, consumableType } = item.system;
+    const { quantity, level, consume, consumableType, preparation } = item.system;
     const scale = item.usageScaling;
+    const levels = (preparation.mode === "pact") ? [level, item.actor.system.spells.pact.level] : [level];
 
     if ( (scale === "slot") && data.slotOptions.every(o => !o.hasSlots) ) {
       // Warn that the actor has no spell slots of any level with which to use this item.
       warnings.push(game.i18n.format("DND5E.SpellCastNoSlotsLeft", {
         name: item.name
       }));
-    } else if ( (scale === "slot") && !data.slotOptions.some(o => (o.level === level) && o.hasSlots) ) {
+    } else if ( (scale === "slot") && !data.slotOptions.some(o => levels.includes(o.level) && o.hasSlots) ) {
       // Warn that the actor has no spell slots of this particular level with which to use this item.
       warnings.push(game.i18n.format("DND5E.SpellCastNoSlots", {
         level: CONFIG.DND5E.spellLevels[level],

--- a/templates/apps/ability-use.hbs
+++ b/templates/apps/ability-use.hbs
@@ -2,7 +2,7 @@
     <p>{{title}}</p>
     <p class="notes">{{note}}</p>
     {{#each warnings}}
-    <p class="notification error">{{this}}</p>
+    <p class="notification warning">{{this}}</p>
     {{/each}}
 
     {{#if (eq scaling "resource")}}


### PR DESCRIPTION
When a spell is set to "pact," a warning is always shown despite there being pact slots available if the actor has no regular slots of the spell's level.
This changes it so warnings are not shown for spells set to "pact" if there are slots of the spell's level _or_ there are pact slots available.