### PR TITLE
Add rendering and system data for spell points

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -673,6 +673,8 @@
 "DND5E.FlagsReliableTalentHint": "Rogues Reliable Talent Feature.",
 "DND5E.FlagsRemarkableAthlete": "Remarkable Athlete",
 "DND5E.FlagsRemarkableAthleteHint": "Half-Proficiency (rounded-up) to physical Ability Checks and Initiative.",
+"DND5E.FlagsSpellPoints": "Spell Points",
+"DND5E.FlagsSpellPointsHint": "Use spell points instead of leveled spell slots.",
 "DND5E.FlagsWeaponCritThreshold": "Weapon Critical Hit Threshold",
 "DND5E.FlagsWeaponCritThresholdHint": "An expanded critical hit threshold for weapon attacks.",
 "DND5E.FlagsSpellCritThreshold": "Spell Critical Hit Threshold",

--- a/less/actors.less
+++ b/less/actors.less
@@ -610,8 +610,8 @@
     }
   }
 
-  /* Encumbrance Bar */
-  .encumbrance {
+  /* Encumbrance and Spell points Bars */
+  .encumbrance, .spell-points {
     flex: 0 0 12px;
     background: @colorTan;
     margin: 1px 15px 0 1px;
@@ -619,7 +619,7 @@
     border-radius: 3px;
     position: relative;
 
-    .encumbrance-bar {
+    .bar {
       position: absolute;
       top: 1px;
       left: 1px;
@@ -627,9 +627,13 @@
       height: 8px;
       border: 1px solid #cde4ff;
       border-radius: 2px;
+
+      &.spell {
+        background: rgb(64 96 255);
+      }
     }
 
-    .encumbrance-label {
+    .label {
       height: 10px;
       padding: 0 5px;
       position: absolute;

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -34,6 +34,16 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
       return arr.concat([res]);
     }, []);
 
+    // Spell points.
+    if ( this.actor.flags.dnd5e?.spellPoints ) {
+      const pts = this.actor.system.spells.points;
+      context.spellPoints = {
+        value: pts.value,
+        max: pts.max,
+        pct: Math.clamped(parseInt(pts.value / pts.max * 100), 0, 100)
+      };
+    }
+
     const classes = this.actor.itemTypes.class;
     return foundry.utils.mergeObject(context, {
       disableExperience: game.settings.get("dnd5e", "disableExperienceTracking"),

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -35,8 +35,8 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
     }, []);
 
     // Spell points.
-    if ( this.actor.flags.dnd5e?.spellPoints ) {
-      const pts = this.actor.system.spells.points;
+    const pts = this.actor.system.spells.points;
+    if ( pts.max > 0 ) {
       context.spellPoints = {
         value: pts.value,
         max: pts.max,

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1225,6 +1225,56 @@ DND5E.SPELL_SLOT_TABLE = [
 /* -------------------------------------------- */
 
 /**
+ * Define the standard amount of spell points by character level for a full spell-caster,
+ * and the maximum level of a spell they are able to cast.
+ * @typedef {object} SpellPointProgressionConfig
+ * @property {number} points      The amount of spell points.
+ * @property {number} max         The maximum spell level.
+ */
+DND5E.spellPointsProgression = {
+  1: {points: 4, max: 1},
+  2: {points: 6, max: 1},
+  3: {points: 14, max: 2},
+  4: {points: 17, max: 2},
+  5: {points: 27, max: 3},
+  6: {points: 32, max: 3},
+  7: {points: 38, max: 4},
+  8: {points: 44, max: 4},
+  9: {points: 57, max: 5},
+  10: {points: 64, max: 5},
+  11: {points: 73, max: 6},
+  12: {points: 73, max: 6},
+  13: {points: 83, max: 7},
+  14: {points: 83, max: 7},
+  15: {points: 94, max: 8},
+  16: {points: 94, max: 8},
+  17: {points: 107, max: 9},
+  18: {points: 114, max: 9},
+  19: {points: 123, max: 9},
+  20: {points: 133, max: 9}
+};
+
+/* -------------------------------------------- */
+
+/**
+ * Define the spell point cost of a spell by spell level.
+ * @enum {number}
+ */
+DND5E.spellPointCost = {
+  1: 2,
+  2: 3,
+  3: 5,
+  4: 6,
+  5: 7,
+  6: 9,
+  7: 10,
+  8: 11,
+  9: 13
+};
+
+/* -------------------------------------------- */
+
+/**
  * Configuration data for pact casting progression.
  *
  * @typedef {object} PactProgressionConfig
@@ -2005,6 +2055,12 @@ DND5E.characterFlags = {
     name: "DND5E.FlagsRemarkableAthlete",
     hint: "DND5E.FlagsRemarkableAthleteHint",
     abilities: ["str", "dex", "con"],
+    section: "DND5E.Feats",
+    type: Boolean
+  },
+  spellPoints: {
+    name: "DND5E.FlagsSpellPoints",
+    hint: "DND5E.FlagsSpellPointsHint",
     section: "DND5E.Feats",
     type: Boolean
   },

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -100,7 +100,7 @@ export default class CreatureTemplate extends CommonTemplate {
    */
   static get _spellLevels() {
     const levels = Object.keys(CONFIG.DND5E.spellLevels).filter(a => a !== "0").map(l => `spell${l}`);
-    return [...levels, "pact"];
+    return [...levels, "pact", "points"];
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -788,10 +788,15 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   static prepareLeveledSlots(spells, actor, progression) {
     const levels = Math.clamped(progression.slot, 0, CONFIG.DND5E.maxLevel);
+    const usePoints = actor.flags.dnd5e?.spellPoints === true;
+    const points = CONFIG.DND5E.spellPointsProgression[levels] ?? {};
     const slots = CONFIG.DND5E.SPELL_SLOT_TABLE[Math.min(levels, CONFIG.DND5E.SPELL_SLOT_TABLE.length) - 1] ?? [];
+    const slot = spells.points ??= { value: 0 };
+    slot.max = Number.isNumeric(slot.override) ? Math.max(parseInt(slot.override), 0) : points.points ?? 0;
     for ( const level of Array.fromRange(Object.keys(CONFIG.DND5E.spellLevels).length - 1, 1) ) {
       const slot = spells[`spell${level}`] ??= { value: 0 };
-      slot.max = Number.isNumeric(slot.override) ? Math.max(parseInt(slot.override), 0) : slots[level - 1] ?? 0;
+      const fallback = usePoints ? 0 : (slots[level - 1] ?? 0);
+      slot.max = Number.isNumeric(slot.override) ? Math.max(parseInt(slot.override), 0) : fallback;
     }
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -792,7 +792,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const points = CONFIG.DND5E.spellPointsProgression[levels] ?? {};
     const slots = CONFIG.DND5E.SPELL_SLOT_TABLE[Math.min(levels, CONFIG.DND5E.SPELL_SLOT_TABLE.length) - 1] ?? [];
     const slot = spells.points ??= { value: 0 };
-    slot.max = Number.isNumeric(slot.override) ? Math.max(parseInt(slot.override), 0) : points.points ?? 0;
+    const fallback = usePoints ? (points.points ?? 0) : 0;
+    slot.max = Number.isNumeric(slot.override) ? Math.max(parseInt(slot.override), 0) : fallback;
     for ( const level of Array.fromRange(Object.keys(CONFIG.DND5E.spellLevels).length - 1, 1) ) {
       const slot = spells[`spell${level}`] ??= { value: 0 };
       const fallback = usePoints ? 0 : (slots[level - 1] ?? 0);

--- a/templates/actors/parts/actor-inventory.hbs
+++ b/templates/actors/parts/actor-inventory.hbs
@@ -168,8 +168,8 @@
 {{#unless isNPC}}
 {{#with encumbrance}}
 <div class="encumbrance {{#if encumbered}}encumbered{{/if}}">
-    <span class="encumbrance-bar" style="width:{{pct}}%"></span>
-    <span class="encumbrance-label">{{value}} / {{max}}</span>
+    <span class="bar" style="width:{{pct}}%"></span>
+    <span class="label">{{value}} / {{max}}</span>
     <i class="encumbrance-breakpoint encumbrance-33 arrow-up"></i>
     <i class="encumbrance-breakpoint encumbrance-33 arrow-down"></i>
     <i class="encumbrance-breakpoint encumbrance-66 arrow-up"></i>

--- a/templates/actors/parts/actor-spellbook.hbs
+++ b/templates/actors/parts/actor-spellbook.hbs
@@ -133,3 +133,12 @@
     {{/if}}
 {{/each}}
 </ol>
+
+{{#unless isNPC}}
+{{#with spellPoints}}
+<div class="spell-points">
+    <span class="spell bar" style="width:{{pct}}%"></span>
+    <span class="label">{{value}} / {{max}}</span>
+</div>
+{{/with}}
+{{/unless}}


### PR DESCRIPTION
This adds a character flag (in special traits) for switching an actor to spell points.
This nullifies spell slots (other than pact slots) unless their max are overridden to be non-zero.
A bar is shown at the bottom of the spellbook tab (similar to encumbrance) that shows all spell points remaining.
Two objects are added to the system config for spell point progression, max spell level, and cost per spell level.

Usage of spells to consume points properly will be follow-up work.