### PR TITLE
Update creatureTypes to be object

### DIFF
--- a/module/applications/actor/type-config.mjs
+++ b/module/applications/actor/type-config.mjs
@@ -63,7 +63,7 @@ export default class ActorTypeConfig extends DocumentSheet {
     const types = {};
     for ( let [k, v] of Object.entries(CONFIG.DND5E.creatureTypes) ) {
       types[k] = {
-        label: game.i18n.localize(v),
+        label: game.i18n.localize(v.label),
         chosen: attr.value === k
       };
     }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -478,24 +478,59 @@ DND5E.tokenHPColors = {
 /**
  * Default types of creatures.
  * *Note: Not pre-localized to allow for easy fetching of pluralized forms.*
- * @enum {string}
+ * @enum {{ label: string, [detectAlignment]: boolean }}
  */
 DND5E.creatureTypes = {
-  aberration: "DND5E.CreatureAberration",
-  beast: "DND5E.CreatureBeast",
-  celestial: "DND5E.CreatureCelestial",
-  construct: "DND5E.CreatureConstruct",
-  dragon: "DND5E.CreatureDragon",
-  elemental: "DND5E.CreatureElemental",
-  fey: "DND5E.CreatureFey",
-  fiend: "DND5E.CreatureFiend",
-  giant: "DND5E.CreatureGiant",
-  humanoid: "DND5E.CreatureHumanoid",
-  monstrosity: "DND5E.CreatureMonstrosity",
-  ooze: "DND5E.CreatureOoze",
-  plant: "DND5E.CreaturePlant",
-  undead: "DND5E.CreatureUndead"
+  aberration: {
+    label: "DND5E.CreatureAberration",
+    detectAlignment: true
+  },
+  beast: {
+    label: "DND5E.CreatureBeast"
+  },
+  celestial: {
+    label: "DND5E.CreatureCelestial",
+    detectAlignment: true
+  },
+  construct: {
+    label: "DND5E.CreatureConstruct"
+  },
+  dragon: {
+    label: "DND5E.CreatureDragon"
+  },
+  elemental: {
+    label: "DND5E.CreatureElemental",
+    detectAlignment: true
+  },
+  fey: {
+    label: "DND5E.CreatureFey",
+    detectAlignment: true
+  },
+  fiend: {
+    label: "DND5E.CreatureFiend",
+    detectAlignment: true
+  },
+  giant: {
+    label: "DND5E.CreatureGiant"
+  },
+  humanoid: {
+    label: "DND5E.CreatureHumanoid"
+  },
+  monstrosity: {
+    label: "DND5E.CreatureMonstrosity"
+  },
+  ooze: {
+    label: "DND5E.CreatureOoze"
+  },
+  plant: {
+    label: "DND5E.CreaturePlant"
+  },
+  undead: {
+    label: "DND5E.CreatureUndead",
+    detectAlignment: true
+  }
 };
+patchConfig("creatureTypes", "label", { since: "DnD5e 2.5", until: "DnD5e 2.7" });
 
 /* -------------------------------------------- */
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -163,8 +163,8 @@ export default class NPCData extends CreatureTemplate {
       const typeLc = match.groups.type.trim().toLowerCase();
       const typeMatch = Object.entries(CONFIG.DND5E.creatureTypes).find(([k, v]) => {
         return (typeLc === k)
-          || (typeLc === game.i18n.localize(v).toLowerCase())
-          || (typeLc === game.i18n.localize(`${v}Pl`).toLowerCase());
+          || (typeLc === game.i18n.localize(v.label).toLowerCase())
+          || (typeLc === game.i18n.localize(`${v.label}Pl`).toLowerCase());
       });
       if ( typeMatch ) source.type.value = typeMatch[0];
       else {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2673,7 +2673,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       localizedType = typeData.custom;
     } else {
       let code = CONFIG.DND5E.creatureTypes[typeData.value];
-      localizedType = game.i18n.localize(typeData.swarm ? `${code}Pl` : code);
+      localizedType = game.i18n.localize(typeData.swarm ? `${code.label}Pl` : code.label);
     }
     let type = localizedType;
     if ( typeData.swarm ) {


### PR DESCRIPTION
Changes `CONFIG.DND5E.creatureTypes` to be nested objects, each with `label` and optionally `detectAlignment`.

I opted not to do something like `alignment: "good"`, since the official rules seem to be shying away from such things.

[Related](https://github.com/foundryvtt/dnd5e/pull/2269#discussion_r1269791096)