### PR TITLE
[#2168] Tweak item types to allow certain fields to not be included

### DIFF
--- a/module/data/item/_module.mjs
+++ b/module/data/item/_module.mjs
@@ -25,10 +25,12 @@ export {
   ToolData,
   WeaponData
 };
+export {default as ItemTypeField} from "./fields/item-type-field.mjs";
 export {default as ActionTemplate} from "./templates/action.mjs";
 export {default as ActivatedEffectTemplate} from "./templates/activated-effect.mjs";
 export {default as EquippableItemTemplate} from "./templates/equippable-item.mjs";
 export {default as ItemDescriptionTemplate} from "./templates/item-description.mjs";
+export {default as ItemTypeTemplate} from "./templates/item-type.mjs";
 export {default as MountableTemplate} from "./templates/mountable.mjs";
 export {default as PhysicalItemTemplate} from "./templates/physical-item.mjs";
 

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -21,12 +21,13 @@ import ItemTypeField from "./fields/item-type-field.mjs";
  * @property {boolean} uses.autoDestroy  Should this item be destroyed when it runs out of uses.
  */
 export default class ConsumableData extends SystemDataModel.mixin(
-  ItemDescriptionTemplate, ItemTypeTemplate, PhysicalItemTemplate, EquippableItemTemplate, ActivatedEffectTemplate, ActionTemplate
+  ItemDescriptionTemplate, ItemTypeTemplate, PhysicalItemTemplate, EquippableItemTemplate,
+  ActivatedEffectTemplate, ActionTemplate
 ) {
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({value: "potion"}, {subtype: false, baseItem: false, label: "DND5E.ItemConsumableType"}),
+      type: new ItemTypeField({value: "potion", subtype: false, baseItem: false}, {label: "DND5E.ItemConsumableType"}),
       properties: new MappingField(new foundry.data.fields.BooleanField(), {
         required: false, label: "DND5E.ItemAmmoProperties"
       }),

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -26,7 +26,7 @@ export default class ConsumableData extends SystemDataModel.mixin(
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({ value: "potion" }, { label: "DND5E.ItemConsumableType" }),
+      type: new ItemTypeField({value: "potion"}, {subtype: false, baseItem: false, label: "DND5E.ItemConsumableType"}),
       properties: new MappingField(new foundry.data.fields.BooleanField(), {
         required: false, label: "DND5E.ItemAmmoProperties"
       }),

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -36,7 +36,7 @@ export default class EquipmentData extends SystemDataModel.mixin(
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({value: "light"}, {subtype: false, label: "DND5E.ItemEquipmentType"}),
+      type: new ItemTypeField({value: "light", subtype: false}, {label: "DND5E.ItemEquipmentType"}),
       armor: new foundry.data.fields.SchemaField({
         value: new foundry.data.fields.NumberField({required: true, integer: true, min: 0, label: "DND5E.ArmorClass"}),
         dex: new foundry.data.fields.NumberField({required: true, integer: true, label: "DND5E.ItemEquipmentDexMod"})

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -36,11 +36,11 @@ export default class EquipmentData extends SystemDataModel.mixin(
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({ value: "light" }, { label: "DND5E.ItemEquipmentType" }),
+      type: new ItemTypeField({value: "light"}, {subtype: false, label: "DND5E.ItemEquipmentType"}),
       armor: new foundry.data.fields.SchemaField({
         value: new foundry.data.fields.NumberField({required: true, integer: true, min: 0, label: "DND5E.ArmorClass"}),
         dex: new foundry.data.fields.NumberField({required: true, integer: true, label: "DND5E.ItemEquipmentDexMod"})
-      }, {label: ""}),
+      }),
       speed: new foundry.data.fields.SchemaField({
         value: new foundry.data.fields.NumberField({required: true, min: 0, label: "DND5E.Speed"}),
         conditions: new foundry.data.fields.StringField({required: true, label: "DND5E.SpeedConditions"})

--- a/module/data/item/fields/item-type-field.mjs
+++ b/module/data/item/fields/item-type-field.mjs
@@ -1,25 +1,29 @@
 /**
  * A field for storing Item type data.
+ *
+ * @param {object} [defaults={}]                   Options to configure this field's behavior.
+ * @param {string} [defaults.value]                An initial value for the Item's type.
+ * @param {string} [defaults.subtype]              An initial value for the Item's subtype.
+ * @param {string} [defaults.baseItem]             An initial value for the Item's baseItem.
+ * @param {DataFieldOptions} [schemaOptions]       Options forwarded to the SchemaField.
+ * @param {boolean} [schemaOptions.subtype=true]   Include the subtype field.
+ * @param {boolean} [schemaOptions.baseItem=true]  Include the baseItem field.
  */
 export default class ItemTypeField extends foundry.data.fields.SchemaField {
-  /**
-   * @param {object} [options]                  Options to configure this field's behavior.
-   * @param {string} [options.value=""]         An initial value for the Item's type.
-   * @param {string} [options.subtype=""]       An initial value for the Item's subtype.
-   * @param {string} [options.baseItem=""]      An initial value for the Item's baseItem.
-   * @param {DataFieldOptions} [schemaOptions]  Options forwarded to the SchemaField.
-   */
-  constructor({ value="", subtype="", baseItem="" }={}, schemaOptions={}) {
-    super({
+  constructor(defaults={}, { subtype=true, baseItem=true, ...schemaOptions}={}) {
+    const fields = {
       value: new foundry.data.fields.StringField({
-        required: true, blank: true, initial: value ?? "", label: "DND5E.Type"
+        required: true, blank: true, initial: defaults.value ?? "", label: "DND5E.Type"
       }),
       subtype: new foundry.data.fields.StringField({
-        required: true, blank: true, initial: subtype ?? "", label: "DND5E.Subtype"
+        required: true, blank: true, initial: defaults.subtype ?? "", label: "DND5E.Subtype"
       }),
       baseItem: new foundry.data.fields.StringField({
-        required: true, blank: true, initial: baseItem ?? "", label: "DND5E.BaseItem"
+        required: true, blank: true, initial: defaults.baseItem ?? "", label: "DND5E.BaseItem"
       })
-    }, schemaOptions);
+    };
+    if ( !subtype ) delete fields.subtype;
+    if ( !baseItem ) delete fields.baseItem;
+    super(fields, schemaOptions);
   }
-};
+}

--- a/module/data/item/fields/item-type-field.mjs
+++ b/module/data/item/fields/item-type-field.mjs
@@ -1,29 +1,27 @@
 /**
  * A field for storing Item type data.
  *
- * @param {object} [defaults={}]                   Options to configure this field's behavior.
- * @param {string} [defaults.value]                An initial value for the Item's type.
- * @param {string} [defaults.subtype]              An initial value for the Item's subtype.
- * @param {string} [defaults.baseItem]             An initial value for the Item's baseItem.
- * @param {DataFieldOptions} [schemaOptions]       Options forwarded to the SchemaField.
- * @param {boolean} [schemaOptions.subtype=true]   Include the subtype field.
- * @param {boolean} [schemaOptions.baseItem=true]  Include the baseItem field.
+ * @param {object} [options={}]                   Options to configure this field's behavior.
+ * @param {string} [options.value]                An initial value for the Item's type.
+ * @param {string|boolean} [options.subtype]      An initial value for the Item's subtype, or false to exclude it.
+ * @param {string|boolean} [options.baseItem]     An initial value for the Item's baseItem, or false to exclude it.
+ * @param {DataFieldOptions} [schemaOptions={}]   Options forwarded to the SchemaField.
  */
 export default class ItemTypeField extends foundry.data.fields.SchemaField {
-  constructor(defaults={}, { subtype=true, baseItem=true, ...schemaOptions}={}) {
+  constructor(options={}, schemaOptions={}) {
     const fields = {
       value: new foundry.data.fields.StringField({
-        required: true, blank: true, initial: defaults.value ?? "", label: "DND5E.Type"
+        required: true, blank: true, initial: options.value ?? "", label: "DND5E.Type"
       }),
       subtype: new foundry.data.fields.StringField({
-        required: true, blank: true, initial: defaults.subtype ?? "", label: "DND5E.Subtype"
+        required: true, blank: true, initial: options.subtype ?? "", label: "DND5E.Subtype"
       }),
       baseItem: new foundry.data.fields.StringField({
-        required: true, blank: true, initial: defaults.baseItem ?? "", label: "DND5E.BaseItem"
+        required: true, blank: true, initial: options.baseItem ?? "", label: "DND5E.BaseItem"
       })
     };
-    if ( !subtype ) delete fields.subtype;
-    if ( !baseItem ) delete fields.baseItem;
+    if ( options.subtype === false ) delete fields.subtype;
+    if ( options.baseItem === false ) delete fields.baseItem;
     super(fields, schemaOptions);
   }
 }

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -16,7 +16,7 @@ export default class LootData extends SystemDataModel.mixin(
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({}, {label: "DND5E.ItemLootType"})
+      type: new ItemTypeField({}, {subtype: false, baseItem: false, label: "DND5E.ItemLootType"})
     });
   }
 

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -16,7 +16,7 @@ export default class LootData extends SystemDataModel.mixin(
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({}, {subtype: false, baseItem: false, label: "DND5E.ItemLootType"})
+      type: new ItemTypeField({}, {baseItem: false, label: "DND5E.ItemLootType"})
     });
   }
 

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -16,7 +16,7 @@ export default class LootData extends SystemDataModel.mixin(
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({}, {baseItem: false, label: "DND5E.ItemLootType"})
+      type: new ItemTypeField({baseItem: false}, {label: "DND5E.ItemLootType"})
     });
   }
 

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -24,7 +24,7 @@ export default class ToolData extends SystemDataModel.mixin(
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({}, {subtype: false, label: "DND5E.ItemToolType"}),
+      type: new ItemTypeField({subtype: false}, {label: "DND5E.ItemToolType"}),
       ability: new foundry.data.fields.StringField({
         required: true, blank: true, label: "DND5E.DefaultAbilityCheck"
       }),

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -24,7 +24,7 @@ export default class ToolData extends SystemDataModel.mixin(
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField(),
+      type: new ItemTypeField({}, {subtype: false, label: "DND5E.ItemToolType"}),
       ability: new foundry.data.fields.StringField({
         required: true, blank: true, label: "DND5E.DefaultAbilityCheck"
       }),

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -29,7 +29,7 @@ export default class WeaponData extends SystemDataModel.mixin(
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({ value: "simpleM" }, { label: "DND5E.ItemWeaponType" }),
+      type: new ItemTypeField({value: "simpleM"}, {subtype: false, label: "DND5E.ItemWeaponType"}),
       properties: new MappingField(new foundry.data.fields.BooleanField(), {
         required: true, initialKeys: CONFIG.DND5E.weaponProperties, label: "DND5E.ItemWeaponProperties"
       }),

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -29,7 +29,7 @@ export default class WeaponData extends SystemDataModel.mixin(
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({value: "simpleM"}, {subtype: false, label: "DND5E.ItemWeaponType"}),
+      type: new ItemTypeField({value: "simpleM", subtype: false}, {label: "DND5E.ItemWeaponType"}),
       properties: new MappingField(new foundry.data.fields.BooleanField(), {
         required: true, initialKeys: CONFIG.DND5E.weaponProperties, label: "DND5E.ItemWeaponProperties"
       }),


### PR DESCRIPTION
Modified how the new type fields are created so that we can exclude the fields that aren't used on certain types (e.g. no `baseItem` on consumables or `subtype` on weapons). Also cleaned up a few comment and export issues.