### PR TITLE
[#2698] Move getRollData to system models

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -1,3 +1,4 @@
+import Proficiency from "../../documents/actor/proficiency.mjs";
 import { FormulaField, LocalDocumentField } from "../fields.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
 import AttributesFields from "./templates/attributes.mjs";
@@ -158,6 +159,21 @@ export default class CharacterData extends CreatureTemplate {
     this.attributes.senses.units ??= raceData.senses.units;
 
     this.details.type = raceData.type;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  getRollData({ deterministic=false }={}) {
+    const data = {...this};
+    data.prof = new Proficiency(this.attributes.prof, 1);
+    if ( deterministic ) data.prof = data.prof.flat;
+    data.classes = {};
+    for ( const [identifier, cls] of Object.entries(this.parent.classes) ) {
+      data.classes[identifier] = {...cls.system};
+      if ( cls.subclass ) data.classes[identifier].subclass = cls.subclass.system;
+    }
+    return data;
   }
 }
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -162,6 +162,8 @@ export default class CharacterData extends CreatureTemplate {
   }
 
   /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   getRollData({ deterministic=false }={}) {

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -1,3 +1,4 @@
+import Proficiency from "../../documents/actor/proficiency.mjs";
 import { FormulaField } from "../fields.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
 import SourceField from "../shared/source-field.mjs";
@@ -189,5 +190,15 @@ export default class NPCData extends CreatureTemplate {
       source.type.value = "custom";
       source.type.custom = original;
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  getRollData({ deterministic=false }={}) {
+    const data = {...this};
+    data.prof = new Proficiency(this.attributes.prof, 1);
+    if ( deterministic ) data.prof = data.prof.flat;
+    return data;
   }
 }

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -193,6 +193,8 @@ export default class NPCData extends CreatureTemplate {
   }
 
   /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   getRollData({ deterministic=false }={}) {

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -111,4 +111,17 @@ export default class CommonTemplate extends SystemDataModel.mixin(CurrencyTempla
     const s = original.split(" ");
     if ( s.length > 0 ) source.attributes.movement.walk = Number.isNumeric(s[0]) ? parseInt(s[0]) : 0;
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare a data object which defines the data schema used by dice roll commands against this Actor.
+   * @param {object} [options]
+   * @param {boolean} [options.deterministic] Whether to force deterministic values for data properties that could be
+   *                                            either a die term or a flat term.
+   * @returns {object}
+   */
+  getRollData({ deterministic=false }={}) {
+    return {...this};
+  }
 }

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -113,6 +113,8 @@ export default class CommonTemplate extends SystemDataModel.mixin(CurrencyTempla
   }
 
   /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
 
   /**
    * Prepare a data object which defines the data schema used by dice roll commands against this Actor.

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -144,6 +144,8 @@ export default class VehicleData extends CommonTemplate {
   }
 
   /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   getRollData({ deterministic=false }={}) {

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -1,3 +1,4 @@
+import Proficiency from "../../documents/actor/proficiency.mjs";
 import { FormulaField } from "../fields.mjs";
 import SourceField from "../shared/source-field.mjs";
 import AttributesFields from "./templates/attributes.mjs";
@@ -140,6 +141,16 @@ export default class VehicleData extends CommonTemplate {
     if ( source.details?.source && (foundry.utils.getType(source.details.source) !== "Object") ) {
       source.details.source = { custom: source.details.source };
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  getRollData({ deterministic=false }={}) {
+    const data = {...this};
+    data.prof = new Proficiency(this.attributes.prof, 1);
+    if ( deterministic ) data.prof = data.prof.flat;
+    return data;
   }
 }
 


### PR DESCRIPTION
This moves the getRollData to a system method (if it has one).
Also adds `flags` to getRollData, which is a common ask.
Also moves `attributes.spellmod` to data prep where it probably should always have been. \:-)

Closes #2698