### PR TITLE
[#2513] Add link for GMs to request roll from inline roll

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -2349,17 +2349,30 @@ h5 {
 /* ----------------------------------------- */
 /*  Inline Roll Actions                      */
 /* ----------------------------------------- */
-a.roll-link {
+.roll-link a {
   background: #DDD;
   padding: 1px 4px;
   border: 1px solid var(--color-border-dark-tertiary);
-  border-radius: 2px;
   white-space: nowrap;
   word-break: break-all;
 }
-a.roll-link i {
+.roll-link a:first-child {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+.roll-link a:last-child {
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+}
+.roll-link a i {
   color: var(--color-text-dark-inactive);
   margin-inline-end: 0.25em;
+}
+.roll-link a[data-action="request"] {
+  padding-inline-end: 1px;
+}
+.roll-link a + a {
+  margin-inline-start: 2px;
 }
 /* ----------------------------------------- */
 /*  Basic Structure                          */

--- a/lang/en.json
+++ b/lang/en.json
@@ -1319,6 +1319,8 @@
 "EDITOR.DND5E.Inline.DCPassiveShort": "DC {dc} passive {check}",
 "EDITOR.DND5E.Inline.DCPassiveLong": "passive {check} score of {dc} or higher",
 "EDITOR.DND5E.Inline.NoActorWarning": "No selected or assigned actor could be found to execute this roll.",
+"EDITOR.DND5E.Inline.RequestRoll": "Request Roll",
+"EDITOR.DND5E.Inline.RollRequest": "Roll Request",
 "EDITOR.DND5E.Inline.SaveShort": "{save}",
 "EDITOR.DND5E.Inline.SaveLong": "{save} saving throw",
 "EDITOR.DND5E.Inline.SpecificCheck": "{ability} ({type})",

--- a/less/chat.less
+++ b/less/chat.less
@@ -106,16 +106,33 @@
 /*  Inline Roll Actions                      */
 /* ----------------------------------------- */
 
-a.roll-link {
-  background: #DDD;
-  padding: 1px 4px;
-  border: 1px solid var(--color-border-dark-tertiary);
-  border-radius: 2px;
-  white-space: nowrap;
-  word-break: break-all;
+.roll-link {
+  a {
+    background: #DDD;
+    padding: 1px 4px;
+    border: 1px solid var(--color-border-dark-tertiary);
+    white-space: nowrap;
+    word-break: break-all;
   
-  i {
-    color: var(--color-text-dark-inactive);
-    margin-inline-end: 0.25em;
+    &:first-child {
+      border-top-left-radius: 3px;
+      border-bottom-left-radius: 3px;
+    }
+    &:last-child {
+      border-top-right-radius: 3px;
+      border-bottom-right-radius: 3px;
+    }
+
+    i {
+      color: var(--color-text-dark-inactive);
+      margin-inline-end: 0.25em;
+    }
+
+    &[data-action="request"] {
+      padding-inline-end: 1px;
+    }
+  }
+  a + a {
+    margin-inline-start: 2px;
   }
 }

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -157,28 +157,10 @@ async function enrichCheck(config, label, options) {
 
   if ( invalid ) return config.input;
 
-  // Insert the icon and label into the link
-  if ( !label ) {
-    const ability = abilityConfig?.label;
-    const skill = skillConfig?.label;
-    const tool = toolIndex?.name;
-    if ( ability && (skill || tool) ) {
-      label = game.i18n.format("EDITOR.DND5E.Inline.SpecificCheck", { ability, type: skill ?? tool });
-    } else {
-      label = ability;
-    }
-    const longSuffix = config.format === "long" ? "Long" : "Short";
-    if ( config.passive ) {
-      label = game.i18n.format(`EDITOR.DND5E.Inline.DCPassive${longSuffix}`, { dc: config.dc, check: label });
-    } else {
-      if ( config.dc ) label = game.i18n.format("EDITOR.DND5E.Inline.DC", { dc: config.dc, check: label });
-      label = game.i18n.format(`EDITOR.DND5E.Inline.Check${longSuffix}`, { check: label });
-    }
-  }
-
-  if ( config.passive ) return createPassiveTag(label, config);
   const type = config.skill ? "skill" : config.tool ? "tool" : "check";
-  return createRollLink(label, { type, ...config });
+  config = { type, ...config };
+  if ( !label ) label = createRollLabel(config);
+  return config.passive ? createPassiveTag(label, config) : createRollLink(label, config);
 }
 
 /* -------------------------------------------- */
@@ -297,15 +279,9 @@ async function enrichSave(config, label, options) {
 
   if ( config.dc && !Number.isNumeric(config.dc) ) config.dc = simplifyBonus(config.dc, options.rollData ?? {});
 
-  if ( !label ) {
-    label = abilityConfig.label;
-    if ( config.dc ) label = game.i18n.format("EDITOR.DND5E.Inline.DC", { dc: config.dc, check: label });
-    label = game.i18n.format(`EDITOR.DND5E.Inline.Save${config.format === "long" ? "Long" : "Short"}`, {
-      save: label
-    });
-  }
-
-  return createRollLink(label, { type: "save", ...config });
+  config = { type: "save", ...config };
+  if ( !label ) label = createRollLabel(config);
+  return createRollLink(label, config);
 }
 
 /* -------------------------------------------- */
@@ -341,17 +317,77 @@ function createPassiveTag(label, dataset) {
 /* -------------------------------------------- */
 
 /**
+ * Create a label for a roll message.
+ * @param {object} config  Enrichment configuration data.
+ * @returns {string}
+ */
+function createRollLabel(config) {
+  const ability = CONFIG.DND5E.abilities[config.ability]?.label;
+  const skill = CONFIG.DND5E.skills[config.skill]?.label;
+  const toolUUID = CONFIG.DND5E.enrichmentLookup.tools[config.tool];
+  const tool = toolUUID ? Trait.getBaseItem(toolUUID, { indexOnly: true })?.name : null;
+  const longSuffix = config.format === "long" ? "Long" : "Short";
+
+  let label;
+  switch ( config.type ) {
+    case "check":
+    case "skill":
+    case "tool":
+      if ( ability && (skill || tool) ) {
+        label = game.i18n.format("EDITOR.DND5E.Inline.SpecificCheck", { ability, type: skill ?? tool });
+      } else {
+        label = ability;
+      }
+      if ( config.passive ) {
+        label = game.i18n.format(`EDITOR.DND5E.Inline.DCPassive${longSuffix}`, { dc: config.dc, check: label });
+      } else {
+        if ( config.dc ) label = game.i18n.format("EDITOR.DND5E.Inline.DC", { dc: config.dc, check: label });
+        label = game.i18n.format(`EDITOR.DND5E.Inline.Check${longSuffix}`, { check: label });
+      }
+      break;
+    case "save":
+      label = ability;
+      if ( config.dc ) label = game.i18n.format("EDITOR.DND5E.Inline.DC", { dc: config.dc, check: label });
+      label = game.i18n.format(`EDITOR.DND5E.Inline.Save${longSuffix}`, {
+        save: label
+      });
+      break;
+    default:
+      return "";
+  }
+
+  return label;
+}
+
+/* -------------------------------------------- */
+
+/**
  * Create a rollable link.
  * @param {string} label    Label to display.
  * @param {object} dataset  Data that will be added to the link for the rolling method.
  * @returns {HTMLElement}
  */
 function createRollLink(label, dataset) {
+  const span = document.createElement("span");
+  span.classList.add("roll-link");
+  _addDataset(span, dataset);
+
+  // Add main link
   const link = document.createElement("a");
-  link.classList.add("roll-link");
-  _addDataset(link, dataset);
+  link.dataset.action = "roll";
   link.innerHTML = `<i class="fa-solid fa-dice-d20"></i> ${label}`;
-  return link;
+  span.insertAdjacentElement("afterbegin", link);
+
+  // Add chat request link for GMs
+  if ( game.user.isGM && (dataset.type !== "damage") ) {
+    const gmLink = document.createElement("a");
+    gmLink.dataset.action = "request";
+    gmLink.dataset.tooltip = "EDITOR.DND5E.Inline.RequestRoll";
+    gmLink.innerHTML = '<i class="fa-solid fa-comment-dots"></i>';
+    span.insertAdjacentElement("beforeend", gmLink);
+  }
+
+  return span;
 }
 
 /* -------------------------------------------- */
@@ -363,8 +399,8 @@ function createRollLink(label, dataset) {
  * @param {Event} event  The click event triggering the action.
  * @returns {Promise|void}
  */
-function rollAction(event) {
-  const target = event.target.closest(".roll-link");
+async function rollAction(event) {
+  const target = event.target.closest(".roll-link") ?? event.target.closest('[data-action="rollRequest"]');
   if ( !target ) return;
   event.stopPropagation();
 
@@ -372,31 +408,53 @@ function rollAction(event) {
   const options = { event };
   if ( dc ) options.targetValue = dc;
 
-  // Fetch the actor that should perform the roll
-  let actor;
-  const speaker = ChatMessage.implementation.getSpeaker();
-  if ( speaker.token ) actor = game.actors.tokens[speaker.token];
-  actor ??= game.actors.get(speaker.actor);
-  if ( !actor && (type !== "damage") ) {
-    ui.notifications.warn(game.i18n.localize("EDITOR.DND5E.Inline.NoActorWarning"));
-    return;
+  const action = event.target.closest("a")?.dataset.action ?? "roll";
+
+  // Direct roll
+  if ( (action === "roll") || !game.user.isGM ) {
+    // Fetch the actor that should perform the roll
+    let actor;
+    const speaker = ChatMessage.implementation.getSpeaker();
+    if ( speaker.token ) actor = game.actors.tokens[speaker.token];
+    actor ??= game.actors.get(speaker.actor);
+    if ( !actor && (type !== "damage") ) {
+      ui.notifications.warn(game.i18n.localize("EDITOR.DND5E.Inline.NoActorWarning"));
+      return;
+    }
+
+    switch ( type ) {
+      case "check":
+        return actor.rollAbilityTest(ability, options);
+      case "damage":
+        return rollDamage(event, speaker);
+      case "save":
+        return actor.rollAbilitySave(ability, options);
+      case "skill":
+        if ( ability ) options.ability = ability;
+        return actor.rollSkill(skill, options);
+      case "tool":
+        options.ability = ability;
+        return actor.rollToolCheck(tool, options);
+      default:
+        return console.warn(`DnD5e | Unknown roll type ${type} provided.`);
+    }
   }
 
-  switch ( type ) {
-    case "check":
-      return actor.rollAbilityTest(ability, options);
-    case "damage":
-      return rollDamage(event, speaker);
-    case "save":
-      return actor.rollAbilitySave(ability, options);
-    case "skill":
-      if ( ability ) options.ability = ability;
-      return actor.rollSkill(skill, options);
-    case "tool":
-      options.ability = ability;
-      return actor.rollToolCheck(tool, options);
-    default:
-      return console.warn(`DnD5e | Unknown roll type ${type} provided.`);
+  // Roll request
+  else {
+    const MessageClass = getDocumentClass("ChatMessage");
+    const chatData = {
+      user: game.user.id,
+      type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+      content: await renderTemplate("systems/dnd5e/templates/chat/request-card.hbs", {
+        buttonLabel: createRollLabel({ ...target.dataset, format: "short" }),
+        dataset: { ...target.dataset, action: "rollRequest" }
+      }),
+      flavor: game.i18n.localize("EDITOR.DND5E.Inline.RollRequest"),
+      speaker: MessageClass.getSpeaker({user: game.user})
+    };
+    MessageClass.applyRollMode(chatData, game.settings.get("core", "rollMode"));
+    return MessageClass.create(chatData);
   }
 }
 

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -348,9 +348,7 @@ function createRollLabel(config) {
     case "save":
       label = ability;
       if ( config.dc ) label = game.i18n.format("EDITOR.DND5E.Inline.DC", { dc: config.dc, check: label });
-      label = game.i18n.format(`EDITOR.DND5E.Inline.Save${longSuffix}`, {
-        save: label
-      });
+      label = game.i18n.format(`EDITOR.DND5E.Inline.Save${longSuffix}`, { save: label });
       break;
     default:
       return "";
@@ -383,6 +381,7 @@ function createRollLink(label, dataset) {
     const gmLink = document.createElement("a");
     gmLink.dataset.action = "request";
     gmLink.dataset.tooltip = "EDITOR.DND5E.Inline.RequestRoll";
+    gmLink.setAttribute("aria-label", game.i18n.localize(gmLink.dataset.tooltip));
     gmLink.innerHTML = '<i class="fa-solid fa-comment-dots"></i>';
     span.insertAdjacentElement("beforeend", gmLink);
   }
@@ -400,7 +399,7 @@ function createRollLink(label, dataset) {
  * @returns {Promise|void}
  */
 async function rollAction(event) {
-  const target = event.target.closest(".roll-link") ?? event.target.closest('[data-action="rollRequest"]');
+  const target = event.target.closest('.roll-link, [data-action="rollRequest"]');
   if ( !target ) return;
   event.stopPropagation();
 
@@ -453,7 +452,6 @@ async function rollAction(event) {
       flavor: game.i18n.localize("EDITOR.DND5E.Inline.RollRequest"),
       speaker: MessageClass.getSpeaker({user: game.user})
     };
-    MessageClass.applyRollMode(chatData, game.settings.get("core", "rollMode"));
     return MessageClass.create(chatData);
   }
 }

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -163,6 +163,23 @@ export async function preloadHandlebarsTemplates() {
 /* -------------------------------------------- */
 
 /**
+ * A helper that converts the provided object into a series of `data-` entries.
+ * @param {object} context  Current evaluation context.
+ * @param {object} options  Handlebars options.
+ * @returns {string}
+ */
+function dataset(context, options) {
+  const entries = [];
+  for ( let [key, value] of Object.entries(context ?? {}) ) {
+    key = key.replace(/[A-Z]+(?![a-z])|[A-Z]/g, (a, b) => (b ? "-" : "") + a.toLowerCase());
+    entries.push(`data-${key}="${value}"`);
+  }
+  return new Handlebars.SafeString(entries.join(" "));
+}
+
+/* -------------------------------------------- */
+
+/**
  * A helper to create a set of <option> elements in a <select> block grouped together
  * in <optgroup> based on the provided categories.
  *
@@ -241,6 +258,7 @@ function itemContext(context, options) {
 export function registerHandlebarsHelpers() {
   Handlebars.registerHelper({
     getProperty: foundry.utils.getProperty,
+    "dnd5e-dataset": dataset,
     "dnd5e-groupedSelectOptions": groupedSelectOptions,
     "dnd5e-linkForUuid": linkForUuid,
     "dnd5e-itemContext": itemContext

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -164,13 +164,13 @@ export async function preloadHandlebarsTemplates() {
 
 /**
  * A helper that converts the provided object into a series of `data-` entries.
- * @param {object} context  Current evaluation context.
+ * @param {object} object   Object to convert into dataset entries.
  * @param {object} options  Handlebars options.
  * @returns {string}
  */
-function dataset(context, options) {
+function dataset(object, options) {
   const entries = [];
-  for ( let [key, value] of Object.entries(context ?? {}) ) {
+  for ( let [key, value] of Object.entries(object ?? {}) ) {
     key = key.replace(/[A-Z]+(?![a-z])|[A-Z]/g, (a, b) => (b ? "-" : "") + a.toLowerCase());
     entries.push(`data-${key}="${value}"`);
   }

--- a/templates/chat/request-card.hbs
+++ b/templates/chat/request-card.hbs
@@ -1,0 +1,7 @@
+<div class="dnd5e chat-card request-card">
+  <div class="card-buttons">
+    <button {{dnd5e-dataset dataset}}>
+      {{buttonLabel}}
+    </button>
+  </div>
+</div>


### PR DESCRIPTION
Adds a button that is displayed for GMs next to enriched checks & saves to request a roll from players:

<img width="637" alt="Enriched Roll Request" src="https://github.com/foundryvtt/dnd5e/assets/19979839/03375dc5-d486-48df-bfed-06bc414cb99d">

This creates a chat card that can then be clicked by players:

<img width="295" alt="Enriched Roll Request Card" src="https://github.com/foundryvtt/dnd5e/assets/19979839/00e7f5f4-e200-4a34-83ac-4d461e30c89a">

### Future Directions
- Option to hide the DC of the check from players
- Ability for GM to whisper the request to certain players
- Nicer chat card design