### PR TITLE
[#2636] Modify spell component migration to avoid losing properties

### DIFF
--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -63,13 +63,12 @@ export default class SpellData extends SystemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
-  /*  Migrations                                  */
+  /*  Data Migrations                             */
   /* -------------------------------------------- */
 
   /** @inheritdoc */
   static _migrateData(source) {
     super._migrateData(source);
-    SpellData.#migrateComponentData(source);
     SpellData.#migrateScaling(source);
   }
 
@@ -79,9 +78,9 @@ export default class SpellData extends SystemDataModel.mixin(
    * Migrate the component object to be 'properties' instead.
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
-  static #migrateComponentData(source) {
-    if ( !source.components || ("properties" in source)) return;
-    source.properties = filteredKeys(source.components);
+  static _migrateComponentData(source) {
+    const components = filteredKeys(source.system?.components ?? {});
+    if ( components.length ) foundry.utils.setProperty(source, "flags.dnd5e.migratedProperties", components);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,5 +1,6 @@
 import ClassData from "../data/item/class.mjs";
 import ContainerData from "../data/item/container.mjs";
+import SpellData from "../data/item/spell.mjs";
 import {d20Roll, damageRoll} from "../dice/dice.mjs";
 import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
 import Advancement from "./advancement/advancement.mjs";
@@ -2245,7 +2246,8 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   static migrateData(source) {
     source = super.migrateData(source);
     if ( source.type === "class" ) ClassData._migrateTraitAdvancement(source);
-    if ( source.type === "backpack" ) ContainerData._migrateWeightlessData(source);
+    else if ( source.type === "backpack" ) ContainerData._migrateWeightlessData(source);
+    else if ( source.type === "spell" ) SpellData._migrateComponentData(source);
     return source;
   }
 }


### PR DESCRIPTION
Swap spell components over to using the new properties migration system added to avoid potential data loss.