### PR TITLE
[#2636] Move valid properties into system data models

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -136,12 +136,9 @@ export default class ItemSheet5e extends ItemSheet {
     context.abilityConsumptionTargets = this._getItemConsumptionTargets();
 
     if ( ("properties" in item.system) && (item.type in CONFIG.DND5E.validProperties) ) {
-      const isAmmo = item.system.type?.value === "ammo";
-      const valids = CONFIG.DND5E.validProperties[item.type];
+      const valids = item.system.validProperties;
       context.properties = Object.entries(CONFIG.DND5E.itemProperties).reduce((obj, [k, v]) => {
-        if ( valids.has(k) || (isAmmo && v.isPhysical) || (item.system.isArmor && (k === "stealthDisadvantage")) ) {
-          obj[k] = { label: v.label, selected: item.system.properties.has(k) };
-        }
+        if ( valids.has(k) ) obj[k] = { label: v.label, selected: item.system.properties.has(k) };
         return obj;
       }, {});
       if ( item.type !== "spell" ) context.properties = sortObjectEntries(context.properties, "label");

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -93,4 +93,15 @@ export default class ConsumableData extends SystemDataModel.mixin(
     const isProficient = this.parent?.actor?.getFlag("dnd5e", "tavernBrawlerFeat");
     return isProficient ? 1 : 0;
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  get validProperties() {
+    const valid = super.validProperties;
+    if ( this.type.value === "ammo" ) Object.entries(CONFIG.DND5E.itemProperties).forEach(([k, v]) => {
+      if ( v.isPhysical ) valid.add(k);
+    });
+    return valid;
+  }
 }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -199,4 +199,13 @@ export default class EquipmentData extends SystemDataModel.mixin(
     );
     return this.properties.has("stealthDisadvantage");
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  get validProperties() {
+    const valid = super.validProperties;
+    if ( this.isArmor ) valid.add("stealthDisadvantage");
+    return valid;
+  }
 }

--- a/module/data/item/templates/item-description.mjs
+++ b/module/data/item/templates/item-description.mjs
@@ -27,7 +27,7 @@ export default class ItemDescriptionTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
-  /*  Migrations                                  */
+  /*  Data Migrations                             */
   /* -------------------------------------------- */
 
   /** @inheritdoc */
@@ -46,5 +46,17 @@ export default class ItemDescriptionTemplate extends SystemDataModel {
     if ( ("source" in source) && (foundry.utils.getType(source.source) !== "Object") ) {
       source.source = { custom: source.source };
     }
+  }
+
+  /* -------------------------------------------- */
+  /*  Getters                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * What properties can be used for this item?
+   * @returns {Set<string>}
+   */
+  get validProperties() {
+    return new Set(CONFIG.DND5E.validProperties[this.parent.type] ?? []);
   }
 }


### PR DESCRIPTION
Allows individual item types to define their own custom properties behavior rather than ballooning the method on the item sheet for each exception.