### PR TITLE
Add 'concentration' to scroll properties, fix createScrollFromSpell

### DIFF
--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -102,6 +102,7 @@ export default class ConsumableData extends SystemDataModel.mixin(
     if ( this.type.value === "ammo" ) Object.entries(CONFIG.DND5E.itemProperties).forEach(([k, v]) => {
       if ( v.isPhysical ) valid.add(k);
     });
+    else if ( (this.type.value === "scroll") ) valid.add("concentration");
     return valid;
   }
 }

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -102,7 +102,8 @@ export default class ConsumableData extends SystemDataModel.mixin(
     if ( this.type.value === "ammo" ) Object.entries(CONFIG.DND5E.itemProperties).forEach(([k, v]) => {
       if ( v.isPhysical ) valid.add(k);
     });
-    else if ( this.type.value === "scroll" ) valid.add("concentration");
+    else if ( this.type.value === "scroll" ) CONFIG.DND5E.validProperties.spell
+      .filter(p => p !== "material").forEach(p => valid.add(p));
     return valid;
   }
 }

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -102,7 +102,7 @@ export default class ConsumableData extends SystemDataModel.mixin(
     if ( this.type.value === "ammo" ) Object.entries(CONFIG.DND5E.itemProperties).forEach(([k, v]) => {
       if ( v.isPhysical ) valid.add(k);
     });
-    else if ( (this.type.value === "scroll") ) valid.add("concentration");
+    else if ( this.type.value === "scroll" ) valid.add("concentration");
     return valid;
   }
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2233,6 +2233,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const spellScrollData = foundry.utils.mergeObject(scrollData, {
       name: `${game.i18n.localize("DND5E.SpellScroll")}: ${itemData.name}`,
       img: itemData.img,
+      effects: itemData.effects ?? [],
       system: {
         description: {value: desc.trim()}, source, actionType, activation, duration, target,
         range, damage, formula, save, level, attackBonus, ability, properties

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2188,7 +2188,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     // Get scroll data
     let scrollUuid;
     const id = CONFIG.DND5E.spellScrollIds[level];
-    if (foundry.data.validators.isValidId(id)) {
+    if ( foundry.data.validators.isValidId(id) ) {
       scrollUuid = game.packs.get(CONFIG.DND5E.sourcePacks.ITEMS).index.get(id).uuid;
     } else {
       scrollUuid = id;
@@ -2206,13 +2206,18 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const isConc = properties.includes("concentration");
 
     // Create a composite description from the scroll description and the spell details
-    const desc = `
-      ${scrollIntro}
-      <hr><h3>${itemData.name} (${game.i18n.format("DND5E.LevelNumber", {level})})</h3>
-      ${(isConc ? `<p><em>${game.i18n.localize("DND5E.ScrollRequiresConcentration")}</em></p>` : "")}
-      <hr>${description.value}<hr>
-      <h3>${game.i18n.localize("DND5E.ScrollDetails")}</h3><hr>${scrollDetails}
-    `;
+    const desc = [
+      scrollIntro,
+      "<hr>",
+      `<h3>${itemData.name} (${game.i18n.format("DND5E.LevelNumber", {level})})</h3>`,
+      isConc ? `<p><em>${game.i18n.localize("DND5E.ScrollRequiresConcentration")}</em></p>` : null,
+      "<hr>",
+      description.value,
+      "<hr>",
+      `<h3>${game.i18n.localize("DND5E.ScrollDetails")}</h3>`,
+      "<hr>",
+      scrollDetails
+    ].filterJoin("");
 
     // Used a fixed attack modifier and saving throw according to the level of spell scroll.
     if ( ["mwak", "rwak", "msak", "rsak"].includes(actionType) ) {


### PR DESCRIPTION
Adds `concentration` as a valid item property if the consumable subtype is `scroll`, and fixes a few issues with `Item5e#createScrollFromSpell`.