### PR TITLE
Expose ItemUseConfiguration in AbilityUseDialog

### DIFF
--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -1,13 +1,14 @@
 /**
  * A specialized Dialog subclass for ability usage.
  *
- * @param {Item5e} item                   Item that is being used.
- * @param {ItemUseConfiguration} config   The ability use configuration's values.
- * @param {object} [dialogData={}]        An object of dialog data which configures how the modal window is rendered.
- * @param {object} [options={}]           Dialog rendering options.
+ * @param {Item5e} item                                Item that is being used.
+ * @param {object} [dialogData={}]                     An object of dialog data which configures
+ *                                                     how the modal window is rendered.
+ * @param {object} [options={}]                        Dialog rendering options.
+ * @param {ItemUseConfiguration} [options.usageConfig] The ability use configuration's values.
  */
 export default class AbilityUseDialog extends Dialog {
-  constructor(item, config={}, dialogData={}, options={}) {
+  constructor(item, dialogData={}, options={}) {
     super(dialogData, options);
     this.options.classes = ["dnd5e", "dialog"];
 
@@ -21,7 +22,7 @@ export default class AbilityUseDialog extends Dialog {
      * Store a reference to the ItemUseConfiguration being used
      * @type {ItemUseConfiguration}
      */
-    this.configuration = config;
+    this.configuration = options.usageConfig ?? {};
   }
 
   /* -------------------------------------------- */
@@ -62,7 +63,7 @@ export default class AbilityUseDialog extends Dialog {
     const isSpell = item.type === "spell";
     const label = game.i18n.localize(`DND5E.AbilityUse${isSpell ? "Cast" : "Use"}`);
     return new Promise(resolve => {
-      const dlg = new this(item, config, {
+      const dlg = new this(item, {
         title: `${item.name}: ${game.i18n.localize("DND5E.AbilityUseConfig")}`,
         content: html,
         buttons: {
@@ -77,6 +78,8 @@ export default class AbilityUseDialog extends Dialog {
         },
         default: "use",
         close: () => resolve(null)
+      }, {
+        usageConfig: config
       });
       dlg.render(true);
     });

--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -1,12 +1,13 @@
 /**
  * A specialized Dialog subclass for ability usage.
  *
- * @param {Item5e} item             Item that is being used.
- * @param {object} [dialogData={}]  An object of dialog data which configures how the modal window is rendered.
- * @param {object} [options={}]     Dialog rendering options.
+ * @param {Item5e} item                   Item that is being used.
+ * @param {ItemUseConfiguration} config   The ability use configuration's values.
+ * @param {object} [dialogData={}]        An object of dialog data which configures how the modal window is rendered.
+ * @param {object} [options={}]           Dialog rendering options.
  */
 export default class AbilityUseDialog extends Dialog {
-  constructor(item, dialogData={}, options={}) {
+  constructor(item, config={}, dialogData={}, options={}) {
     super(dialogData, options);
     this.options.classes = ["dnd5e", "dialog"];
 
@@ -15,6 +16,12 @@ export default class AbilityUseDialog extends Dialog {
      * @type {Item5e}
      */
     this.item = item;
+
+    /**
+     * Store a reference to the ItemUseConfiguration being used
+     * @type {ItemUseConfiguration}
+     */
+    this.configuration = config;
   }
 
   /* -------------------------------------------- */
@@ -55,7 +62,7 @@ export default class AbilityUseDialog extends Dialog {
     const isSpell = item.type === "spell";
     const label = game.i18n.localize(`DND5E.AbilityUse${isSpell ? "Cast" : "Use"}`);
     return new Promise(resolve => {
-      const dlg = new this(item, {
+      const dlg = new this(item, config, {
         title: `${item.name}: ${game.i18n.localize("DND5E.AbilityUseConfig")}`,
         content: html,
         buttons: {


### PR DESCRIPTION
Modules can use `dnd5e.preUseItem` to add their own properties to the configuration, but this is not be available in the `AbilityUseDialog`.

Currently we can only use a render hook, and *assume* that the key must be `true` if the item is able to do the related thing (and otherwise do nothing), but it would be good to be able to make use of the pre-use hook as well in case a user wants to programmatically skip the prompt; i.e., set it to `null` or `false`.

With this, a module can read the key in `abilityUseDialog.configuration` and set the default value accordingly (or not at all if `null`).