### PR TITLE
Add reference to the tool being used in tool checks

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1716,6 +1716,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       ability: this.system.ability,
       bonus: this.system.bonus,
       prof: this.system.prof,
+      item: this,
       ...options
     });
   }


### PR DESCRIPTION
In a [module](https://github.com/krbz999/babonus/issues/222), I read several properties of the item being used for attack rolls, damage rolls, and tool checks. When the tool checks were moved over to the actor, I lost the ability to read any additional properties in the tool's flags for my purposes. This adds a simple reference to the tool, if any specific one was used, so I can do that again.