### PR TITLE
[#2744] Add min-width to .ability-scores .ability

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -940,7 +940,6 @@ h5 {
   white-space: nowrap;
 }
 .dnd5e.sheet.actor .ability-scores {
-  display: grid;
   flex: 0 0 100px;
   align-content: flex-start;
   list-style: none;
@@ -957,6 +956,7 @@ h5 {
   text-align: center;
   border-bottom: 2px groove #eeede0;
   position: relative;
+  min-width: 100%;
 }
 .dnd5e.sheet.actor .ability-scores .ability:last-child {
   border-bottom: none;

--- a/dnd5e.css
+++ b/dnd5e.css
@@ -940,6 +940,7 @@ h5 {
   white-space: nowrap;
 }
 .dnd5e.sheet.actor .ability-scores {
+  display: grid;
   flex: 0 0 100px;
   align-content: flex-start;
   list-style: none;

--- a/less/actors.less
+++ b/less/actors.less
@@ -206,6 +206,7 @@
       text-align: center;
       border-bottom: @borderGroove;
       position: relative;
+      min-width: 100%;
 
       &:last-child {
         border-bottom: none;


### PR DESCRIPTION
[#2744] Prevent short ability score names from being improperly displayed by adding `display: grid` property to `.dnd5e.sheet.actor .ability-scores`

thanks to Zhell for this cleaner solution, my original idea was:
```css
.dnd5e.sheet.actor h4.box-title {
  min-width: 36px
}
```
