### PR TITLE
Fix armor class, allow for shield subtypes

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -231,7 +231,8 @@ export default class ItemSheet5e extends ItemSheet {
    */
   async _getItemBaseTypes() {
     const type = this.item.type === "equipment" ? "armor" : this.item.type;
-    const baseIds = CONFIG.DND5E[`${type}Ids`];
+    const {armorIds, shieldIds} = CONFIG.DND5E;
+    const baseIds = this.item.type === "equipment" ? {...armorIds, ...shieldIds} : CONFIG.DND5E[`${type}Ids`];
     if ( baseIds === undefined ) return {};
 
     const baseType = this.item.system.type.value;

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -231,8 +231,10 @@ export default class ItemSheet5e extends ItemSheet {
    */
   async _getItemBaseTypes() {
     const type = this.item.type === "equipment" ? "armor" : this.item.type;
-    const {armorIds, shieldIds} = CONFIG.DND5E;
-    const baseIds = this.item.type === "equipment" ? {...armorIds, ...shieldIds} : CONFIG.DND5E[`${type}Ids`];
+    const baseIds = this.item.type === "equipment" ? {
+      ...CONFIG.DND5E.armorIds,
+      ...CONFIG.DND5E.shieldIds
+    } : CONFIG.DND5E[`${type}Ids`];
     if ( baseIds === undefined ) return {};
 
     const baseType = this.item.system.type.value;

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -230,7 +230,6 @@ export default class ItemSheet5e extends ItemSheet {
    * @protected
    */
   async _getItemBaseTypes() {
-    const type = this.item.type === "equipment" ? "armor" : this.item.type;
     const baseIds = this.item.type === "equipment" ? {
       ...CONFIG.DND5E.armorIds,
       ...CONFIG.DND5E.shieldIds

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -233,7 +233,7 @@ export default class ItemSheet5e extends ItemSheet {
     const baseIds = this.item.type === "equipment" ? {
       ...CONFIG.DND5E.armorIds,
       ...CONFIG.DND5E.shieldIds
-    } : CONFIG.DND5E[`${type}Ids`];
+    } : CONFIG.DND5E[`${this.item.type}Ids`];
     if ( baseIds === undefined ) return {};
 
     const baseType = this.item.system.type.value;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -469,7 +469,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     // Identify Equipped Items
     const armorTypes = new Set(Object.keys(CONFIG.DND5E.armorTypes));
     const {armors, shields} = this.itemTypes.equipment.reduce((obj, equip) => {
-      if ( !equip.system.equipped || !armorTypes.has(equip.type.value) ) return obj;
+      if ( !equip.system.equipped || !armorTypes.has(equip.system.type.value) ) return obj;
       if ( equip.system.type.value === "shield" ) obj.shields.push(equip);
       else obj.armors.push(equip);
       return obj;


### PR DESCRIPTION
The 2.5 branch broke AC due to a missing word.

This also adds the ability to add shield 'subtypes', in line with how other armor proficiency categories work. To clarify, the issue is that adding anything to `CONFIG.DND5E.shieldIds` does not allow a user to set an item to be of this newly added shield type.