### PR TITLE
[#2747] Move advancement valid item types into config so module subtypes can change it

### DIFF
--- a/module/applications/advancement/advancement-selection.mjs
+++ b/module/applications/advancement/advancement-selection.mjs
@@ -44,9 +44,19 @@ export default class AdvancementSelection extends Dialog {
   /** @inheritDoc */
   getData() {
     const context = { types: {} };
-    for ( const [name, advancement] of Object.entries(CONFIG.DND5E.advancementTypes) ) {
-      if ( !(advancement.prototype instanceof Advancement)
-        || !advancement.metadata.validItemTypes.has(this.item.type) ) continue;
+    for ( let [name, config] of Object.entries(CONFIG.DND5E.advancementTypes) ) {
+      if ( config.prototype instanceof Advancement ) {
+        foundry.utils.logCompatibilityWarning(
+          "Advancement type configuration changed into an object with `documentClass` defining the advancement class.",
+          { since: "DnD5e 3.1", until: "DnD5e 3.3", once: true }
+        );
+        config = {
+          documentClass: config,
+          validItemTypes: config.metadata.validItemTypes
+        };
+      }
+      const advancement = config.documentClass;
+      if ( !config.validItemTypes?.has(this.item.type) ) continue;
       context.types[name] = {
         label: advancement.metadata.title,
         icon: advancement.metadata.icon,

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -718,8 +718,10 @@ export default class ItemSheet5e extends ItemSheet {
       return false;
     }
     advancements = advancements.filter(a => {
+      const validItemTypes = CONFIG.DND5E.advancementTypes[a.constructor.typeName]?.validItemTypes
+        ?? a.metadata.validItemTypes;
       return !this.item.advancement.byId[a.id]
-        && a.constructor.metadata.validItemTypes.has(this.item.type)
+        && validItemTypes.has(this.item.type)
         && a.constructor.availableForItem(this.item);
     });
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2932,17 +2932,48 @@ preLocalize("groupTypes");
 /* -------------------------------------------- */
 
 /**
+ * Configuration information for advancement types.
+ *
+ * @typedef {object} AdvancementTypeConfiguration
+ * @property {typeof Advancement} documentClass  The advancement's document class.
+ * @property {Set<string>} validItemTypes        What item types this advancement can be used with.
+ */
+
+const _ALL_ITEM_TYPES = ["background", "class", "race", "subclass"];
+
+/**
  * Advancement types that can be added to items.
- * @enum {*}
+ * @enum {AdvancementTypeConfiguration}
  */
 DND5E.advancementTypes = {
-  AbilityScoreImprovement: advancement.AbilityScoreImprovementAdvancement,
-  HitPoints: advancement.HitPointsAdvancement,
-  ItemChoice: advancement.ItemChoiceAdvancement,
-  ItemGrant: advancement.ItemGrantAdvancement,
-  ScaleValue: advancement.ScaleValueAdvancement,
-  Size: advancement.SizeAdvancement,
-  Trait: advancement.TraitAdvancement
+  AbilityScoreImprovement: {
+    documentClass: advancement.AbilityScoreImprovementAdvancement,
+    validItemTypes: new Set(["background", "class", "race"])
+  },
+  HitPoints: {
+    documentClass: advancement.HitPointsAdvancement,
+    validItemTypes: new Set(["class"])
+  },
+  ItemChoice: {
+    documentClass: advancement.ItemChoiceAdvancement,
+    validItemTypes: new Set(_ALL_ITEM_TYPES)
+  },
+  ItemGrant: {
+    documentClass: advancement.ItemGrantAdvancement,
+    validItemTypes: new Set(_ALL_ITEM_TYPES)
+  },
+  ScaleValue: {
+    documentClass: advancement.ScaleValueAdvancement,
+    validItemTypes: new Set(_ALL_ITEM_TYPES)
+  },
+  Size: {
+    documentClass: advancement.SizeAdvancement,
+    validItemTypes: new Set(["race"])
+  },
+  Trait: {
+    documentClass: advancement.TraitAdvancement,
+    validItemTypes: new Set(_ALL_ITEM_TYPES)
+  }
 };
 
 /* -------------------------------------------- */

--- a/module/data/fields.mjs
+++ b/module/data/fields.mjs
@@ -1,3 +1,5 @@
+import Advancement from "../documents/advancement/advancement.mjs";
+
 /**
  * Data field that selects the appropriate advancement data model if available, otherwise defaults to generic
  * `ObjectField` to prevent issues with custom advancement types that aren't currently loaded.
@@ -10,7 +12,15 @@ export class AdvancementField extends foundry.data.fields.ObjectField {
    * @returns {typeof BaseAdvancement|null}  The BaseAdvancement class, or null.
    */
   getModelForType(type) {
-    return CONFIG.DND5E.advancementTypes[type] ?? null;
+    let config = CONFIG.DND5E.advancementTypes[type];
+    if ( config.prototype instanceof Advancement ) {
+      foundry.utils.logCompatibilityWarning(
+        "Advancement type configuration changed into an object with `documentClass` defining the advancement class.",
+        { since: "DnD5e 3.1", until: "DnD5e 3.3", once: true }
+      );
+      return config;
+    }
+    return config?.documentClass ?? null;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -95,8 +95,9 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
       { type: "Trait", configuration: { grants: ["languages:standard:common"] } }
     ];
     this.parent.updateSource({"system.advancement": toCreate.map(c => {
-      const AdvancementClass = CONFIG.DND5E.advancementTypes[c.type];
-      return new AdvancementClass(c, { parent: this.parent }).toObject();
+      const config = CONFIG.DND5E.advancementTypes[c.type];
+      const cls = config.documentClass ?? config;
+      return new cls(c, { parent: this.parent }).toObject();
     })});
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1,6 +1,5 @@
 import Proficiency from "./proficiency.mjs";
 import * as Trait from "./trait.mjs";
-import ScaleValueAdvancement from "../advancement/scale-value.mjs";
 import SystemDocumentMixin from "../mixins/document.mjs";
 import { d20Roll } from "../../dice/dice.mjs";
 import { simplifyBonus } from "../../utils.mjs";
@@ -253,7 +252,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   _prepareScaleValues() {
     this.system.scale = this.items.reduce((scale, item) => {
-      if ( ScaleValueAdvancement.metadata.validItemTypes.has(item.type) ) scale[item.identifier] = item.scaleValues;
+      if ( CONFIG.DND5E.advancementTypes.ScaleValue.validItemTypes.has(item.type) ) {
+        scale[item.identifier] = item.scaleValues;
+      }
       return scale;
     }, {});
   }

--- a/module/documents/advancement/ability-score-improvement.mjs
+++ b/module/documents/advancement/ability-score-improvement.mjs
@@ -22,7 +22,6 @@ export default class AbilityScoreImprovementAdvancement extends Advancement {
       icon: "systems/dnd5e/icons/svg/ability-score-improvement.svg",
       title: game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementTitle"),
       hint: game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementHint"),
-      validItemTypes: new Set(["background", "class", "race"]),
       apps: {
         config: AbilityScoreImprovementConfig,
         flow: AbilityScoreImprovementFlow

--- a/module/documents/advancement/advancement.mjs
+++ b/module/documents/advancement/advancement.mjs
@@ -64,7 +64,7 @@ export default class Advancement extends BaseAdvancement {
    *                                   the level selection control in the configuration window is hidden and the
    *                                   advancement should provide its own implementation of `Advancement#levels`
    *                                   and potentially its own level configuration interface.
-   * @property {Set<string>} validItemTypes  Set of types to which this advancement can be added.
+   * @property {Set<string>} validItemTypes  Set of types to which this advancement can be added. (deprecated)
    * @property {object} apps
    * @property {*} apps.config         Subclass of AdvancementConfig that allows for editing of this advancement type.
    * @property {*} apps.flow           Subclass of AdvancementFlow that is displayed while fulfilling this advancement.
@@ -87,6 +87,14 @@ export default class Advancement extends BaseAdvancement {
         flow: AdvancementFlow
       }
     };
+  }
+
+  /**
+   * Configuration information for this advancement type.
+   * @type {AdvancementMetadata}
+   */
+  get metadata() {
+    return this.constructor.metadata;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/advancement/hit-points.mjs
+++ b/module/documents/advancement/hit-points.mjs
@@ -18,7 +18,6 @@ export default class HitPointsAdvancement extends Advancement {
       title: game.i18n.localize("DND5E.AdvancementHitPointsTitle"),
       hint: game.i18n.localize("DND5E.AdvancementHitPointsHint"),
       multiLevel: true,
-      validItemTypes: new Set(["class"]),
       apps: {
         config: HitPointsConfig,
         flow: HitPointsFlow

--- a/module/documents/advancement/scale-value.mjs
+++ b/module/documents/advancement/scale-value.mjs
@@ -19,7 +19,6 @@ export default class ScaleValueAdvancement extends Advancement {
       title: game.i18n.localize("DND5E.AdvancementScaleValueTitle"),
       hint: game.i18n.localize("DND5E.AdvancementScaleValueHint"),
       multiLevel: true,
-      validItemTypes: new Set(["background", "class", "race", "subclass"]),
       apps: {
         config: ScaleValueConfig,
         flow: ScaleValueFlow

--- a/module/documents/advancement/size.mjs
+++ b/module/documents/advancement/size.mjs
@@ -19,7 +19,6 @@ export default class SizeAdvancement extends Advancement {
       icon: "systems/dnd5e/icons/svg/size.svg",
       title: game.i18n.localize("DND5E.AdvancementSizeTitle"),
       hint: game.i18n.localize("DND5E.AdvancementSizeHint"),
-      validItemTypes: new Set(["race"]),
       apps: {
         config: SizeConfig,
         flow: SizeFlow


### PR DESCRIPTION
Changes `advancementTypes` into an object and moved `validItemTypes` from `Advancement#metadata` into the configuration object, so module custom types can define what advancement types they accept.

The deprecations should ensure everything continues working for any custom advancement types.