### PR TITLE
Fix the v2.5 `type` migration

### DIFF
--- a/module/data/item/templates/item-type.mjs
+++ b/module/data/item/templates/item-type.mjs
@@ -28,9 +28,8 @@ export default class ItemTypeTemplate extends SystemDataModel {
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateType(source) {
-    if ( foundry.utils.getType(source.type) === "Object" ) return;
     const oldType = source.consumableType ?? source.armor?.type ?? source.toolType ?? source.weaponType;
-    if ( (oldType !== null) && (oldType !== undefined) ) foundry.utils.setProperty(source, "type.value", oldType);
+    if ( oldType ) foundry.utils.setProperty(source, "type.value", oldType);
     if ( "baseItem" in source ) foundry.utils.setProperty(source, "type.baseItem", source.baseItem);
   }
 }


### PR DESCRIPTION
Since the embedded `type` field always exists, the source data migration was never performed.