### PR TITLE
[#2798] Support adjustable encumbrance arrows

### DIFF
--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -34,6 +34,8 @@
     width: 230px;
 
     .meter {
+      --encumbrance-low: 33%;
+      --encumbrance-high: 66%;
       border-radius: 3px 3px 0 0;
       height: 25px;
       border: none;
@@ -51,8 +53,6 @@
       }
 
       .breakpoint {
-        --encumbrance-low: 33%;
-        --encumbrance-high: 66%;
         display: block;
         position: absolute;
         block-size: 0;

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -51,13 +51,15 @@
       }
 
       .breakpoint {
+        --encumbrance-low: 33%;
+        --encumbrance-high: 66%;
         display: block;
         position: absolute;
         block-size: 0;
         inline-size: 0;
         border-inline: 3px solid transparent;
-        &.encumbrance-33 { inset-inline-start: 33% }
-        &.encumbrance-66 { inset-inline-start: 66% }
+        &.encumbrance-low { inset-inline-start: var(--encumbrance-low); }
+        &.encumbrance-high { inset-inline-start: var(--encumbrance-high); }
         &.arrow-up {
           inset-block-end: 0;
           border-block-end: 3px solid var(--dnd5e-color-gold);

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -198,6 +198,19 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
       path: showTokenPortrait ? this.actor.isToken ? "" : "prototypeToken.texture.src" : "img"
     };
 
+    // Encumbrance
+    const encumberedThreshold = game.settings.get("dnd5e", "metricWeightUnits") 
+      ? CONFIG.DND5E.encumbrance.threshold.encumbered.metric 
+      : CONFIG.DND5E.encumbrance.threshold.encumbered.imperial;
+    const heavilyEncumberedThreshold = game.settings.get("dnd5e", "metricWeightUnits") 
+      ? CONFIG.DND5E.encumbrance.threshold.heavilyEncumbered.metric
+      : CONFIG.DND5E.encumbrance.threshold.heavilyEncumbered.imperial;
+    const maximumThreshold = game.settings.get("dnd5e", "metricWeightUnits")
+      ? CONFIG.DND5E.encumbrance.threshold.maximum.metric
+      : CONFIG.DND5E.encumbrance.threshold.maximum.imperial;
+    context.encumbrance.low = (encumberedThreshold / maximumThreshold) * 100;
+    context.encumbrance.high = (heavilyEncumberedThreshold / maximumThreshold) * 100;
+
     // Exhaustion
     context.exhaustion = Array.fromRange(6, 1).map(n => {
       const label = game.i18n.format("DND5E.ExhaustionLevel", { n });

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -198,19 +198,6 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
       path: showTokenPortrait ? this.actor.isToken ? "" : "prototypeToken.texture.src" : "img"
     };
 
-    // Encumbrance
-    const encumberedThreshold = game.settings.get("dnd5e", "metricWeightUnits") 
-      ? CONFIG.DND5E.encumbrance.threshold.encumbered.metric 
-      : CONFIG.DND5E.encumbrance.threshold.encumbered.imperial;
-    const heavilyEncumberedThreshold = game.settings.get("dnd5e", "metricWeightUnits") 
-      ? CONFIG.DND5E.encumbrance.threshold.heavilyEncumbered.metric
-      : CONFIG.DND5E.encumbrance.threshold.heavilyEncumbered.imperial;
-    const maximumThreshold = game.settings.get("dnd5e", "metricWeightUnits")
-      ? CONFIG.DND5E.encumbrance.threshold.maximum.metric
-      : CONFIG.DND5E.encumbrance.threshold.maximum.imperial;
-    context.encumbrance.low = (encumberedThreshold / maximumThreshold) * 100;
-    context.encumbrance.high = (heavilyEncumberedThreshold / maximumThreshold) * 100;
-
     // Exhaustion
     context.exhaustion = Array.fromRange(6, 1).map(n => {
       const label = game.i18n.format("DND5E.ExhaustionLevel", { n });

--- a/templates/shared/inventory2.hbs
+++ b/templates/shared/inventory2.hbs
@@ -14,10 +14,10 @@
                     <span class="separator">&sol;</span>
                     <span class="max">{{ max }}</span>
                 </div>
-                <i class="breakpoint encumbrance-33 arrow-up" role="presentation"></i>
-                <i class="breakpoint encumbrance-33 arrow-down" role="presentation"></i>
-                <i class="breakpoint encumbrance-66 arrow-up" role="presentation"></i>
-                <i class="breakpoint encumbrance-66 arrow-down" role="presentation"></i>
+                <i class="breakpoint encumbrance-low arrow-up" role="presentation" style="--encumbrance-low: {{ low }}%"></i>
+                <i class="breakpoint encumbrance-low  arrow-down" role="presentation" style="--encumbrance-low: {{ low }}%"></i>
+                <i class="breakpoint encumbrance-high arrow-up" role="presentation" style="--encumbrance-high: {{ high }}%"></i>
+                <i class="breakpoint encumbrance-high arrow-down" role="presentation" style="--encumbrance-high: {{ high }}%"></i>
             </div>
             {{/with}}
             <div class="info">

--- a/templates/shared/inventory2.hbs
+++ b/templates/shared/inventory2.hbs
@@ -7,17 +7,17 @@
         <div class="encumbrance card">
             {{#with encumbrance}}
             <div class="meter progress" role="meter" aria-valuemin="0" aria-valuenow="{{ pct }}"
-                 aria-valuetext="{{ value }}" aria-valuemax="{{ max }}" style="--bar-percentage: {{ pct }}%">
+                 aria-valuetext="{{ value }}" aria-valuemax="{{ max }}" style="--bar-percentage: {{ pct }}%; --encumbrance-low: {{ stops.encumbered }}%; --encumbrance-high: {{ stops.heavilyEncumbered }}%;">
                 <div class="label">
                     <i class="fas fa-weight-hanging"></i>
                     <span class="value">{{ value }}</span>
                     <span class="separator">&sol;</span>
                     <span class="max">{{ max }}</span>
                 </div>
-                <i class="breakpoint encumbrance-low arrow-up" role="presentation" style="--encumbrance-low: {{ low }}%"></i>
-                <i class="breakpoint encumbrance-low  arrow-down" role="presentation" style="--encumbrance-low: {{ low }}%"></i>
-                <i class="breakpoint encumbrance-high arrow-up" role="presentation" style="--encumbrance-high: {{ high }}%"></i>
-                <i class="breakpoint encumbrance-high arrow-down" role="presentation" style="--encumbrance-high: {{ high }}%"></i>
+                <i class="breakpoint encumbrance-low arrow-up" role="presentation"></i>
+                <i class="breakpoint encumbrance-low  arrow-down" role="presentation"></i>
+                <i class="breakpoint encumbrance-high arrow-up" role="presentation"></i>
+                <i class="breakpoint encumbrance-high arrow-down" role="presentation"></i>
             </div>
             {{/with}}
             <div class="info">


### PR DESCRIPTION
Allows for the encumbrance arrows on the encumbrance card to adjust based on thresholds:
![image](https://github.com/foundryvtt/dnd5e/assets/105953297/87ba5c5c-4617-4922-9f9a-30d5267a5b3a)
