### PR TITLE
[#2796] Align encumbrance arrows on centre

### DIFF
--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -11,7 +11,7 @@
     // Becomes more red the closer it is to 100% encumbrance.
     --bar-color-2: color-mix(in oklab, var(--dnd5e-color-blue), var(--dnd5e-color-maroon) var(--bar-percentage));
     --bar-color-1: color-mix(in oklab, var(--bar-color-2), black 33%);
-    --bar-color-3: color-mix(in oklab, var(--bar-color-2), black 40%);
+    --bar-color-3: color-mix(in oklab, var(--bar-color-2), black 20%);
     background: linear-gradient(to right, var(--bar-color-1), var(--bar-color-2));
     border-right: var(--border-width) solid var(--bar-color-3);
     border-radius: 3px 3px 0 0;

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -66,6 +66,7 @@
           inset-block-start: 0;
           border-top: 3px solid var(--dnd5e-color-gold);
         }
+        transform: translateX(-50%);
         z-index: 1;
       }
     }


### PR DESCRIPTION
Align encumbrance arrows on their centres. Position of arrow in image is just to show an easy reference point.
![image](https://github.com/foundryvtt/dnd5e/assets/105953297/8478a735-fd76-477f-9ef8-cd64440b04a7)

Partially closes #2796 depending on the handling of the bar's border width.
