### PR TITLE
[#2819] Remove subject fallback to prevent 404s

### DIFF
--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -125,9 +125,7 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     for ( const [src, dest] of Object.entries(CONFIG.Token.ringClass.subjectPaths) ) {
       if ( path.startsWith(src) ) return path.replace(src, dest);
     }
-    const parts = path.split(".");
-    const extension = parts.pop();
-    return `${parts.join(".")}-subject.${extension}`;
+    return path;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Remove the fallback that appends `-subject` to the inferred subject path because it is causing a lot of 404 errors for users. Technically a breaking change if anyone was using it, but not a big one.