### PR TITLE
[#2827] Fix localization strings for bypasses, make tooltip clearer

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -569,7 +569,7 @@
 "DND5E.DamagePhysicalBypass": "Physical Bypasses",
 "DND5E.DamagePhysicalBypassHint": "These weapon properties will bypass damage resistance for physical damage.",
 "DND5E.DamagePhysicalBypasses": "{damageTypes} from attacks that are not {bypassTypes}",
-"DND5E.DamagePhysicalBypassesShort": "Not {type}",
+"DND5E.DamagePhysicalBypassesShort": "Bypassed by {type} Sources",
 "DND5E.DamagePoison": "Poison",
 "DND5E.DamagePsychic": "Psychic",
 "DND5E.DamageRadiant": "Radiant",

--- a/lang/en.json
+++ b/lang/en.json
@@ -569,6 +569,7 @@
 "DND5E.DamagePhysicalBypass": "Physical Bypasses",
 "DND5E.DamagePhysicalBypassHint": "These weapon properties will bypass damage resistance for physical damage.",
 "DND5E.DamagePhysicalBypasses": "{damageTypes} from attacks that are not {bypassTypes}",
+"DND5E.DamagePhysicalBypassesShort": "Not {type}",
 "DND5E.DamagePoison": "Poison",
 "DND5E.DamagePsychic": "Psychic",
 "DND5E.DamageRadiant": "Radiant",

--- a/templates/actors/tabs/character-details.hbs
+++ b/templates/actors/tabs/character-details.hbs
@@ -59,8 +59,10 @@
             {{#each values}}
             <li class="pill {{ ../color }}">
                 {{#each icons}}
-                <i class="{{ this }}" data-tooltip="{{ lookup @root.config.physicalWeaponProperties this }}"
-                   aria-label="{{ lookup @root.config.physicalWeaponProperties this }}"></i>
+                {{#with (lookup (lookup @root.config.itemProperties this) "label") as |label|}}
+                <i class="{{ ../this }}" data-tooltip="{{ localize 'DND5E.DamagePhysicalBypassesShort' type=label }}"
+                   aria-label="{{ localize 'DND5E.DamagePhysicalBypassesShort' type=label }}"></i>
+                {{/with}}
                 {{/each}}
                 <span class="label">{{ label }}</span>
             </li>


### PR DESCRIPTION
<img width="278" alt="Screenshot 2024-02-02 at 10 50 56" src="https://github.com/foundryvtt/dnd5e/assets/19979839/30160dfe-0d22-4562-be22-8418385974ef">

Closes #2827 