### PR TITLE
[#2868] Fix issue with active tab not being saved when sheet is re-opened

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -148,6 +148,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     html[0].insertAdjacentElement("afterbegin", nav);
     this._tabs = this.options.tabs.map(t => {
       t.callback = this._onChangeTab.bind(this);
+      if (this._tabs?.[0]?.active !== t.initial) t.initial = this._tabs?.[0]?.active ?? t.initial;
       return new Tabs5e(t);
     });
 
@@ -174,7 +175,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     const context = await super.getData(options);
     context.editable = this.isEditable && (this._mode === this.constructor.MODES.EDIT);
     context.cssClass = context.editable ? "editable" : this.isEditable ? "interactable" : "locked";
-    const activeTab = this.element.length ? this._tabs?.[0]?.active ?? "details" : "details";
+    const activeTab = this._tabs?.[0]?.active ?? "details";
     context.cssClass += ` tab-${activeTab}`;
     const sidebarCollapsed = game.user.getFlag("dnd5e", `sheetPrefs.character.tabs.${activeTab}.collapseSidebar`);
     if ( sidebarCollapsed ) {


### PR DESCRIPTION
There was an issue in character-sheet-2.mjs _renderOuter() when mapping a callback we return a new Tabs5e using the this.options.tabs which used the initial as the active, which overwrote the previous active. New code changes the initial to the previous active tab if the initial does not match the active tab, before passing it to the constructor. 

Additionally changed a check condition in setting GetData() activeTab where the DOM element length was checked and otherwise "details" was set as the activeTab even when we had an existing active tab. This element check was removed.

Closes #2868