### PR TITLE
[#2812] Allow favoriting tool categories

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -686,6 +686,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     let type;
     if ( key in CONFIG.DND5E.skills ) type = "skill";
     else if ( key in CONFIG.DND5E.toolIds ) type = "tool";
+    else if ( key in CONFIG.DND5E.toolTypeProficiencies ) type = "tool";
     else if ( preparationMode && (level !== "0") && isSlots ) type = "slots";
     if ( !type ) return super._onDragStart(event);
     const dragData = { dnd5e: { action: "favorite", type } };
@@ -1249,8 +1250,15 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
       let title;
       let reference;
       if ( type === "tool" ) {
-        reference = Trait.getBaseItemUUID(CONFIG.DND5E.toolIds[id]);
-        ({ img, name: title } = Trait.getBaseItem(reference, { indexOnly: true }));
+        const toolItemId = CONFIG.DND5E.toolIds[id];
+        if ( toolItemId ) {
+          reference = Trait.getBaseItemUUID(toolItemId);
+          ({img, name: title} = Trait.getBaseItem(reference, {indexOnly: true}));
+        } else {
+          title = CONFIG.DND5E._toolProficiencies[id];
+          reference = CONFIG.DND5E.toolTypeProficiencies[id].reference;
+          img = CONFIG.DND5E.toolTypeProficiencies[id].icon;
+        }
       }
       else if ( type === "skill" ) ({ icon: img, label: title, reference } = CONFIG.DND5E.skills[id]);
       return { img, title, subtitle, modifier: total, passive, reference };

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -382,27 +382,117 @@ DND5E.ammoIds = {
 /* -------------------------------------------- */
 
 /**
- * The categories into which Tool items can be grouped.
- *
+ * Internal tool categories
  * @enum {string}
+ * @internal
  */
-DND5E.toolTypes = {
+DND5E._toolTypes = {
   art: "DND5E.ToolArtisans",
   game: "DND5E.ToolGamingSet",
   music: "DND5E.ToolMusicalInstrument"
 };
-preLocalize("toolTypes", { sort: true });
+preLocalize("_toolTypes", { sort: true });
+
+/**
+ * The categories into which Tool items can be grouped.
+ * @enum {string}
+ * @deprecated since 3.1, available until 3.3
+ */
+Object.defineProperty(DND5E, 'toolTypes', {
+  get() {
+    foundry.utils.logCompatibilityWarning(
+      "CONFIG.DND5E.toolTypes is deprecated in favor of CONFIG.DND5E.toolItemTypes.",
+      { since: "3.1", until: "3.3" }
+    );
+    return DND5E._toolTypes;
+  },
+  set(obj) {
+    foundry.utils.logCompatibilityWarning(
+      "CONFIG.DND5E.toolTypes is deprecated in favor of CONFIG.DND5E.toolItemTypes.",
+      { since: "3.1", until: "3.3" }
+    );
+    DND5E._toolTypes = obj
+  }
+})
+
+/**
+ * Internal tool category proficiencies
+ * @enum {string}
+ * @internal
+ */
+DND5E._toolProficiencies = {
+  ...DND5E._toolTypes,
+  vehicle: "DND5E.ToolVehicle"
+};
+preLocalize("_toolProficiencies", { sort: true });
 
 /**
  * The categories of tool proficiencies that a character can gain.
- *
  * @enum {string}
+ * @deprecated since 3.1, available until 3.3
  */
-DND5E.toolProficiencies = {
-  ...DND5E.toolTypes,
-  vehicle: "DND5E.ToolVehicle"
+Object.defineProperty(DND5E, 'toolProficiencies', {
+  get() {
+    foundry.utils.logCompatibilityWarning(
+      "CONFIG.DND5E.toolProficiencies has been deprecated in favor of CONFIG.DND5E.toolTypeProficiencies",
+      {since: "3.1", until: "3.3"}
+    )
+    return DND5E._toolProficiencies;
+  },
+  set(obj) {
+    foundry.utils.logCompatibilityWarning(
+      "CONFIG.DND5E.toolTypes has been deprecated in favor of CONFIG.DND5E.toolItemTypes",
+      {since: "3.1", until: "3.3"}
+    );
+    DND5E._toolProficiencies = obj;
+  }
+});
+
+/**
+ * Configuration data for tool types.
+ *
+ * @typedef {object} ToolTypeConfiguration
+ * @property {string} ability      Key for the default ability used by this tool type.
+ * @property {string} [reference]  Reference to a rule page describing this tool type.
+ * @property {string} [icon]       An icon for this tool type
+ *
+ * @todo in DND5e 3.3: get rid of `toolTypes` and `toolProficiencies` and add `label` to `ToolTypeConfiguration`
+ */
+
+/**
+ * The categories into which Tool items can be grouped.
+ * @enum {ToolTypeConfiguration}
+ */
+DND5E.toolItemTypes = {
+  art: {
+    ability: "int",
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.4MfrpERNiQXmvgCI",
+    icon: "icons/tools/hand/hammer-and-nail.webp"
+  },
+  game: {
+    ability: "int",
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.4MfrpERNiQXmvgCI",
+    icon: "icons/sundries/gaming/playing-cards-brown.webp"
+  },
+  music: {
+    ability: "int",
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.4MfrpERNiQXmvgCI",
+    icon: "icons/tools/instruments/harp-lap-brown.webp"
+  }
 };
-preLocalize("toolProficiencies", { sort: true });
+
+/**
+ * The categories of tool proficiencies that a character can gain.
+ * @enum {ToolTypeConfiguration}
+ */
+DND5E.toolTypeProficiencies = {
+  ...DND5E.toolItemTypes,
+  vehicle: {
+    ability: "int",
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.4MfrpERNiQXmvgCI",
+    icon: "icons/svg/cancel.svg"
+  }
+};
 
 /**
  * The basic tool types in 5e. This enables specific tool proficiencies or
@@ -2684,7 +2774,7 @@ DND5E.traits = {
     },
     icon: "systems/dnd5e/icons/svg/trait-tool-proficiencies.svg",
     actorKeyPath: "system.tools",
-    configKey: "toolProficiencies",
+    configKey: "_toolProficiencies",
     subtypes: { keyPath: "toolType", ids: ["toolIds"] },
     children: { vehicle: "vehicleTypes" },
     sortCategories: true,

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -65,7 +65,9 @@ export default class CreatureTemplate extends CommonTemplate {
         bonuses: new foundry.data.fields.SchemaField({
           check: new FormulaField({required: true, label: "DND5E.CheckBonus"})
         }, {label: "DND5E.ToolBonuses"})
-      })),
+      }), {
+        intialValue: this._initialToolValue,
+      }),
       spells: new MappingField(new foundry.data.fields.SchemaField({
         value: new foundry.data.fields.NumberField({
           nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.SpellProgAvailable"
@@ -88,6 +90,20 @@ export default class CreatureTemplate extends CommonTemplate {
    */
   static _initialSkillValue(key, initial) {
     if ( CONFIG.DND5E.skills[key]?.ability ) initial.ability = CONFIG.DND5E.skills[key].ability;
+    return initial;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Populate the proper initial abilities for the tools.
+   * @param {string} key      Key for which the initial data will be created.
+   * @param {object} initial  The initial tool object
+   * @returns {object}        Initial tools object with the ability defined.
+   * @private
+   */
+  static _initialToolValue(key, initial) {
+    if ( CONFIG.DND5E.toolTypeProficiencies[key]?.ability ) initial.ability = CONFIG.DND5E.toolTypeProficiencies[key]?.ability;
     return initial;
   }
 

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -157,7 +157,7 @@ export default class CreatureTemplate extends CommonTemplate {
     if ( !original || foundry.utils.isEmpty(original.value) ) return;
     source.tools ??= {};
     for ( const prof of original.value ) {
-      const validProf = (prof in CONFIG.DND5E.toolProficiencies) || (prof in CONFIG.DND5E.toolIds);
+      const validProf = (prof in CONFIG.DND5E._toolProficiencies) || (prof in CONFIG.DND5E.toolIds);
       if ( !validProf || (prof in source.tools) ) continue;
       source.tools[prof] = {
         value: 1,

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -68,7 +68,7 @@ export default class ToolData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.type.label = CONFIG.DND5E.toolTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.tool);
+    this.type.label = CONFIG.DND5E._toolTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.tool);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Closes #2812

Work in progress:
- [x] Add full tool type proficiency configs so that we can associate tooltip references and icons with tool types.
- [x] Handle drag/drop of tool types.
- [x] Handle using tool type proficiency config to populate favorite data.
- [ ] Add tool type description journal entry pages and use them to populate tooltips for tool types.
- [ ] Find an icon for vehicle tool proficiency??
- [ ] Enable favoriting specific vehicle proficiencies.