### PR TITLE
[#2954] Add 'getData' hooks

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -391,6 +391,8 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     context.favorites = await this._prepareFavorites();
     context.favorites.sort((a, b) => a.sort - b.sort);
 
+    Hooks.call("getDataActorSheet5eCharacter2", this.actor, context );
+
     return context;
   }
 


### PR DESCRIPTION
Add hook to `ActorSheet5eCharacter2.getData`.

Mostly an example to see if it's viable. If so, I can look to see where else it might be appropriate, such as for the legacy sheets.