### PR TITLE
Allow for exhaustion to be configurable

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -200,7 +200,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     };
 
     // Exhaustion
-    const max = CONFIG.DND5E.conditionTypes.exhaustion.maximum;
+    const max = CONFIG.DND5E.conditionTypes.exhaustion.levels;
     context.exhaustion = {
       pips: Array.fromRange(max, 1).map(n => {
         const label = game.i18n.format("DND5E.ExhaustionLevel", { n });

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -200,14 +200,18 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     };
 
     // Exhaustion
-    context.exhaustion = Array.fromRange(6, 1).map(n => {
-      const label = game.i18n.format("DND5E.ExhaustionLevel", { n });
-      const classes = ["pip"];
-      const filled = attributes.exhaustion >= n;
-      if ( filled ) classes.push("filled");
-      if ( n === 6 ) classes.push("death");
-      return { n, label, filled, tooltip: label, classes: classes.join(" ") };
-    });
+    const max = CONFIG.DND5E.conditionTypes.exhaustion.maximum;
+    context.exhaustion = {
+      pips: Array.fromRange(max, 1).map(n => {
+        const label = game.i18n.format("DND5E.ExhaustionLevel", { n });
+        const classes = ["pip"];
+        const filled = attributes.exhaustion >= n;
+        if ( filled ) classes.push("filled");
+        if ( n === max ) classes.push("death");
+        return { n, label, filled, tooltip: label, classes: classes.join(" ") };
+      }),
+      mid: max / 2
+    };
 
     // Speed
     context.speed = Object.entries(CONFIG.DND5E.movementTypes).reduce((obj, [k, label]) => {

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -201,17 +201,18 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
 
     // Exhaustion
     const max = CONFIG.DND5E.conditionTypes.exhaustion.levels;
-    context.exhaustion = {
-      pips: Array.fromRange(max, 1).map(n => {
-        const label = game.i18n.format("DND5E.ExhaustionLevel", { n });
-        const classes = ["pip"];
-        const filled = attributes.exhaustion >= n;
-        if ( filled ) classes.push("filled");
-        if ( n === max ) classes.push("death");
-        return { n, label, filled, tooltip: label, classes: classes.join(" ") };
-      }),
-      mid: max / 2
-    };
+    context.exhaustion = Array.fromRange(max, 1).reduce((acc, n) => {
+      const label = game.i18n.format("DND5E.ExhaustionLevel", { n });
+      const classes = ["pip"];
+      const filled = attributes.exhaustion >= n;
+      if ( filled ) classes.push("filled");
+      if ( n === max ) classes.push("death");
+      const pip = { n, label, filled, tooltip: label, classes: classes.join(" ") };
+
+      if ( n <= max / 2 ) acc.left.push(pip);
+      else acc.right.push(pip);
+      return acc;
+    }, { left: [], right: [] });
 
     // Speed
     context.speed = Object.entries(CONFIG.DND5E.movementTypes).reduce((obj, [k, label]) => {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2385,7 +2385,8 @@ DND5E.conditionTypes = {
   exhaustion: {
     label: "DND5E.ConExhaustion",
     icon: "systems/dnd5e/icons/svg/statuses/exhaustion.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.cspWveykstnu3Zcv"
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.cspWveykstnu3Zcv",
+    maximum: 6
   },
   frightened: {
     label: "DND5E.ConFrightened",
@@ -2453,14 +2454,16 @@ patchConfig("conditionTypes", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" 
 /* -------------------------------------------- */
 
 /**
- * Various effects of conditions and which conditions apply it.
+ * Various effects of conditions and which conditions apply it. Either keys for the conditions,
+ * or a number for a level of exhaustion.
  * @enum {object}
  */
 DND5E.conditionEffects = {
-  noMovement: new Set(["grappled", "paralyzed", "petrified", "restrained", "stunned", "unconscious"]),
-  halfMovement: new Set(["prone"]),
+  noMovement: new Set([5, "grappled", "paralyzed", "petrified", "restrained", "stunned", "unconscious"]),
+  halfMovement: new Set([2, "prone"]),
   crawl: new Set(["prone", "exceedingCarryingCapacity"]),
-  petrification: new Set(["petrified"])
+  petrification: new Set(["petrified"]),
+  halfHealth: new Set([4])
 };
 
 /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2355,6 +2355,7 @@ DND5E.consumableResources = [
  * @property {string} [icon]       Icon used to represent the condition on the token.
  * @property {string} [reference]  UUID of a journal entry with details on this condition.
  * @property {string} [special]    Set this condition as a special status effect under this name.
+ * @property {number} [levels]     The number of levels of exhaustion an actor can obtain.
  */
 
 /**
@@ -2386,7 +2387,7 @@ DND5E.conditionTypes = {
     label: "DND5E.ConExhaustion",
     icon: "systems/dnd5e/icons/svg/statuses/exhaustion.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.cspWveykstnu3Zcv",
-    maximum: 6
+    levels: 6
   },
   frightened: {
     label: "DND5E.ConFrightened",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2456,7 +2456,7 @@ patchConfig("conditionTypes", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" 
 
 /**
  * Various effects of conditions and which conditions apply it. Either keys for the conditions,
- * or a number for a level of exhaustion.
+ * and with a number appended for a level of exhaustion.
  * @enum {object}
  */
 DND5E.conditionEffects = {

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -105,8 +105,8 @@ export default class AttributesFields {
    */
   static prepareMovement() {
     const statuses = this.parent.statuses;
-    const noMovement = this.parent.hasConditionEffect("noMovement") || (this.attributes.exhaustion >= 5);
-    const halfMovement = this.parent.hasConditionEffect("halfMovement") || (this.attributes.exhaustion >= 2);
+    const noMovement = this.parent.hasConditionEffect("noMovement");
+    const halfMovement = this.parent.hasConditionEffect("halfMovement");
     const reduction = statuses.has("heavilyEncumbered")
       ? CONFIG.DND5E.encumbrance.speedReduction.heavilyEncumbered
       : statuses.has("encumbered") ? CONFIG.DND5E.encumbrance.speedReduction.encumbered : 0;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -285,11 +285,12 @@ export default class ActiveEffect5e extends ActiveEffect {
    * @protected
    */
   _prepareExhaustionLevel() {
+    const config = CONFIG.DND5E.conditionTypes.exhaustion;
     let level = this.getFlag("dnd5e", "exhaustionLevel");
     if ( !Number.isFinite(level) ) level = 1;
-    this.icon = `systems/dnd5e/icons/svg/statuses/exhaustion-${level}.svg`;
+    this.icon = `${config.icon.split(".")[0]}-${level}.svg`;
     this.name = `${game.i18n.localize("DND5E.Exhaustion")} ${level}`;
-    if ( level >= 6 ) this.statuses.add("dead");
+    if ( level >= config.maximum ) this.statuses.add("dead");
   }
 
   /* -------------------------------------------- */
@@ -364,9 +365,10 @@ export default class ActiveEffect5e extends ActiveEffect {
     const actor = app.object.actor;
     const level = foundry.utils.getProperty(actor, "system.attributes.exhaustion");
     if ( Number.isFinite(level) && (level > 0) ) {
+      const [path] = CONFIG.DND5E.conditionTypes.exhaustion.icon.split(".");
       html.find('[data-status-id="exhaustion"]').css({
         objectPosition: "-100px",
-        background: `url('systems/dnd5e/icons/svg/statuses/exhaustion-${level}.svg') no-repeat center / contain`
+        background: `url('${path}-${level}.svg') no-repeat center / contain`
       });
     }
   }
@@ -387,7 +389,8 @@ export default class ActiveEffect5e extends ActiveEffect {
     event.stopPropagation();
     if ( event.button === 0 ) level++;
     else level--;
-    actor.update({ "system.attributes.exhaustion": Math.clamped(level, 0, 6) });
+    const max = CONFIG.DND5E.conditionTypes.exhaustion.maximum;
+    actor.update({ "system.attributes.exhaustion": Math.clamped(level, 0, max) });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -365,7 +365,7 @@ export default class ActiveEffect5e extends ActiveEffect {
     const actor = app.object.actor;
     const level = foundry.utils.getProperty(actor, "system.attributes.exhaustion");
     if ( Number.isFinite(level) && (level > 0) ) {
-      const img = this._getExhaustionImage(level);
+      const img = ActiveEffect5e._getExhaustionImage(level);
       html.find('[data-status-id="exhaustion"]').css({
         objectPosition: "-100px",
         background: `url('${img}') no-repeat center / contain`

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -288,7 +288,7 @@ export default class ActiveEffect5e extends ActiveEffect {
     const config = CONFIG.DND5E.conditionTypes.exhaustion;
     let level = this.getFlag("dnd5e", "exhaustionLevel");
     if ( !Number.isFinite(level) ) level = 1;
-    this.icon = `${config.icon.split(".")[0]}-${level}.svg`;
+    this.icon = this.constructor._getExhaustionImage(level);
     this.name = `${game.i18n.localize("DND5E.Exhaustion")} ${level}`;
     if ( level >= config.maximum ) this.statuses.add("dead");
   }
@@ -365,12 +365,26 @@ export default class ActiveEffect5e extends ActiveEffect {
     const actor = app.object.actor;
     const level = foundry.utils.getProperty(actor, "system.attributes.exhaustion");
     if ( Number.isFinite(level) && (level > 0) ) {
-      const [path] = CONFIG.DND5E.conditionTypes.exhaustion.icon.split(".");
+      const img = this._getExhaustionImage(level);
       html.find('[data-status-id="exhaustion"]').css({
         objectPosition: "-100px",
-        background: `url('${path}-${level}.svg') no-repeat center / contain`
+        background: `url('${img}') no-repeat center / contain`
       });
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the image used to represent exhaustion at this level.
+   * @param {number} level
+   * @returns {string}
+   */
+  static _getExhaustionImage(level) {
+    const split = CONFIG.DND5E.conditionTypes.exhaustion.icon.split(".");
+    const ext = split.pop();
+    const path = split.join(".");
+    return `${path}-${level}.${ext}`;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -212,15 +212,19 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
-   * Is this actor under the effect of this property from some status?
+   *Is this actor under the effect of this property from some status or possibly due to its level of exhaustion?
    * @param {string} key      A key in `DND5E.conditionEffects`.
    * @returns {boolean}       Whether the actor is affected.
    */
   hasConditionEffect(key) {
     const props = CONFIG.DND5E.conditionEffects[key] ?? new Set();
+    const level = this.system.attributes?.exhaustion ?? null;
     const imms = this.system.traits?.ci?.value ?? new Set();
     const statuses = this.statuses;
-    return statuses.difference(imms).intersects(props);
+    return props.some(k => {
+      return (statuses.has(k) && !imms.has(k))
+        || (!imms.has("exhaustion") && (level !== null) && Number.isInteger(k) && (level >= k));
+    });
   }
 
   /* -------------------------------------------- */
@@ -664,7 +668,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
       hp.max = base + levelBonus + overallBonus;
 
-      if ( this.system.attributes.exhaustion >= 4 ) hp.max = Math.floor(hp.max * 0.5);
+      if ( this.hasConditionEffect("halfHealth") ) hp.max = Math.floor(hp.max * 0.5);
     }
 
     hp.value = Math.min(hp.value, hp.max + (hp.tempmax ?? 0));

--- a/templates/actors/character-sheet-2.hbs
+++ b/templates/actors/character-sheet-2.hbs
@@ -148,10 +148,8 @@
                         <div class="top">
 
                             <div class="pips" data-prop="system.attributes.exhaustion">
-                                {{#each exhaustion.pips}}
-                                {{#if (lt @index ../exhaustion.mid)}}
+                                {{#each exhaustion.left}}
                                     {{> pip }}
-                                {{/if}}
                                 {{/each}}
                             </div>
 
@@ -171,10 +169,8 @@
                             </div>
 
                             <div class="pips" data-prop="system.attributes.exhaustion">
-                                {{#each exhaustion.pips}}
-                                {{#if (gte @index ../exhaustion.mid)}}
+                                {{#each exhaustion.right}}
                                     {{> pip }}
-                                {{/if}}
                                 {{/each}}
                             </div>
                         </div>

--- a/templates/actors/character-sheet-2.hbs
+++ b/templates/actors/character-sheet-2.hbs
@@ -148,8 +148,8 @@
                         <div class="top">
 
                             <div class="pips" data-prop="system.attributes.exhaustion">
-                                {{#each exhaustion}}
-                                {{#if (lt @index 3)}}
+                                {{#each exhaustion.pips}}
+                                {{#if (lt @index ../exhaustion.mid)}}
                                     {{> pip }}
                                 {{/if}}
                                 {{/each}}
@@ -171,8 +171,8 @@
                             </div>
 
                             <div class="pips" data-prop="system.attributes.exhaustion">
-                                {{#each exhaustion}}
-                                {{#if (gt @index 2)}}
+                                {{#each exhaustion.pips}}
+                                {{#if (gte @index ../exhaustion.mid)}}
                                     {{> pip }}
                                 {{/if}}
                                 {{/each}}


### PR DESCRIPTION
Allows for exhaustion to be configured in the `CONFIG` object (or entirely disabled) and generalizes some code surrounding it to match.