### PR TITLE
[#2969] Add overflow section for abilities

### DIFF
--- a/less/v2/character.less
+++ b/less/v2/character.less
@@ -1051,12 +1051,23 @@
   /* ---------------------------------- */
 
   .ability-scores {
-    position: absolute;
-    top: 0;
-    right: 0;
-    left: calc(var(--dnd5e-sheet-sidebar-width) + 1.25rem);
-    pointer-events: none;
-    container-type: inline-size;
+    &:not(.fixed) {
+      flex: 1 0 100%;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: .75rem 1.375rem;
+      margin-block-end: .25rem;
+    }
+
+    &.fixed {
+      position: absolute;
+      top: 0;
+      right: 0;
+      left: calc(var(--dnd5e-sheet-sidebar-width) + 1.25rem);
+      pointer-events: none;
+      container-type: inline-size;
+    }
 
     .rows {
       padding: 4.75rem 0 4.75rem 1.5rem;

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -248,10 +248,11 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
       ability.sign = Math.sign(ability.mod) < 0 ? "-" : "+";
       ability.mod = Math.abs(ability.mod);
       ability.baseValue = context.source.abilities[k]?.value ?? 0;
-      if ( obj.bottom.length > 5 ) obj.top.push(ability);
+      if ( obj.top.length > 1 ) obj.overflow.push(ability);
+      else if ( obj.bottom.length > 5 ) obj.top.push(ability);
       else obj.bottom.push(ability);
       return obj;
-    }, { top: [], bottom: [] });
+    }, { top: [], bottom: [], overflow: [] });
     context.abilityRows.optional = Object.keys(CONFIG.DND5E.abilities).length - 6;
 
     // Saving Throws

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -200,6 +200,7 @@ export async function preloadHandlebarsTemplates() {
     "systems/dnd5e/templates/apps/parts/trait-list.hbs",
 
     // Actor Sheet Partials
+    "systems/dnd5e/templates/actors/parts/actor-ability-score.hbs",
     "systems/dnd5e/templates/actors/parts/actor-traits.hbs",
     "systems/dnd5e/templates/actors/parts/actor-inventory.hbs",
     "systems/dnd5e/templates/actors/parts/actor-features.hbs",

--- a/templates/actors/character-sheet-2.hbs
+++ b/templates/actors/character-sheet-2.hbs
@@ -4,31 +4,6 @@
             aria-pressed="{{ filled }}"></button>
 {{/inline}}
 
-{{#*inline "ability-score"}}
-    <div class="ability-score {{#if flipped}}flipped{{/if}}" data-ability="{{ key }}">
-        <a class="label {{ @root.rollableClass }} ability-check">{{ abbr }}</a>
-        <div class="mod">
-            {{#if @root.editable}}
-            <a class="config-button" data-action="ability"
-               data-tooltip="{{ localize "DND5E.AbilityConfigure" ability=label }}"
-               aria-label="{{ localize "DND5E.AbilityConfigure" ability=label }}">
-                <i class="fas fa-cog"></i>
-            </a>
-            {{else}}
-            <span class="sign">{{ sign }}</span>{{ mod }}
-            {{/if}}
-        </div>
-        <div class="score">
-            {{#if @root.editable}}
-            <input type="text" name="system.abilities.{{ key }}.value" value="{{ baseValue }}" placeholder="10"
-                   data-dtype="Number" class="uninput">
-            {{else}}
-            {{ value }}
-            {{/if}}
-        </div>
-    </div>
-{{/inline}}
-
 <form class="{{ cssClass }} flexcol" autocomplete="off">
 
     {{!-- Header --}}
@@ -495,16 +470,16 @@
     </section>
 
     {{!-- Ability Scores --}}
-    <section class="ability-scores optional-ability-{{ abilityRows.optional }}">
+    <section class="ability-scores fixed optional-ability-{{ abilityRows.optional }}">
         <div class="rows">
             <div class="top">
                 {{#each abilityRows.top}}
-                    {{> ability-score flipped=true }}
+                    {{> "dnd5e.actor-ability-score" flipped=true }}
                 {{/each}}
             </div>
             <div class="bottom">
                 {{#each abilityRows.bottom}}
-                    {{> ability-score }}
+                    {{> "dnd5e.actor-ability-score" }}
                 {{/each}}
             </div>
         </div>

--- a/templates/actors/parts/actor-ability-score.hbs
+++ b/templates/actors/parts/actor-ability-score.hbs
@@ -1,0 +1,22 @@
+<div class="ability-score {{#if flipped}}flipped{{/if}}" data-ability="{{ key }}">
+    <a class="label {{ @root.rollableClass }} ability-check">{{ abbr }}</a>
+    <div class="mod">
+        {{#if @root.editable}}
+        <a class="config-button" data-action="ability"
+           data-tooltip="{{ localize "DND5E.AbilityConfigure" ability=label }}"
+           aria-label="{{ localize "DND5E.AbilityConfigure" ability=label }}">
+            <i class="fas fa-cog"></i>
+        </a>
+        {{else}}
+        <span class="sign">{{ sign }}</span>{{ mod }}
+        {{/if}}
+    </div>
+    <div class="score">
+        {{#if @root.editable}}
+        <input type="text" name="system.abilities.{{ key }}.value" value="{{ baseValue }}" placeholder="10"
+               data-dtype="Number" class="uninput">
+        {{else}}
+        {{ value }}
+        {{/if}}
+    </div>
+</div>

--- a/templates/actors/tabs/character-details.hbs
+++ b/templates/actors/tabs/character-details.hbs
@@ -121,6 +121,14 @@
         {{!-- Background & Saving Throws --}}
         <div class="top flexrow">
 
+            {{#if abilityRows.overflow.length}}
+            <div class="ability-scores">
+                {{#each abilityRows.overflow}}
+                {{> "dnd5e.actor-ability-score"}}
+                {{/each}}
+            </div>
+            {{/if}}
+
             {{!-- Saving Throws --}}
             <filigree-box class="saves">
                 <h3>


### PR DESCRIPTION
Adds an additional overflow section that appears above the saving throws for additional ability scores.

<img width="544" alt="Screenshot 2024-02-08 at 09 47 23" src="https://github.com/foundryvtt/dnd5e/assets/19979839/15676f5d-9aff-4576-b44a-62f91a5b2780">
<img width="743" alt="Screenshot 2024-02-08 at 09 47 45" src="https://github.com/foundryvtt/dnd5e/assets/19979839/12f6fe1b-fbd5-49bf-b042-84fcadd6d47c">

Closes #2969