### PR TITLE
[#2879] Ensure grandchild documents with identical IDs are displayed properly

### DIFF
--- a/module/applications/components/item-list-controls.mjs
+++ b/module/applications/components/item-list-controls.mjs
@@ -254,11 +254,12 @@ export default class ItemListControlsElement extends HTMLElement {
     const elementMap = {};
     if ( !this.keepEmpty ) this.list.querySelectorAll(".items-section").forEach(el => el.hidden = true);
     this.list.querySelectorAll(".item-list .item").forEach(el => {
-      elementMap[el.dataset.entryId] = el;
+      const uniqueID = el.dataset.parentId ? `${el.dataset.parentId}.${el.dataset.entryId}` : el.dataset.entryId;
+      elementMap[uniqueID] = el;
       el.hidden = true;
     });
     for ( const entry of entries ) {
-      const el = elementMap[entry.id];
+      const el = elementMap[`${entry.parent.id}.${entry.id}`] ?? elementMap[entry.id];
       if ( el ) el.hidden = false;
     }
     this.list.querySelectorAll(".items-section:has(.item-list .item:not([hidden]))").forEach(el => el.hidden = false);


### PR DESCRIPTION
The filtering method on ItemListControlsElement creates a mapping between entry IDs and the elements they represent in the list. The problem is that grandchild elements might share identical IDs, but this setup only allows them to be associated with a single element, causing one of the grandchild documents to not appear at all in the list.

The fix was to rely on the `data-parent-id` property already in the list to handle dragging effects to ensure each document has a totally unique identifier in the element map.