### PR TITLE
[#2949] Rename some conditions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1564,9 +1564,11 @@
 "EFFECT.DND5E": {
   "StatusBurrowing": "Burrowing",
   "StatusConcentrating": "Concentrating",
+  "StatusCursed": "Cursed",
   "StatusDodging": "Dodging",
   "StatusEncumbered": "Encumbered",
   "StatusExceedingCarryingCapacity": "Exceeding Carrying Capacity",
+  "StatusFlying": "Flying",
   "StatusHeavilyEncumbered": "Heavily Encumbered",
   "StatusHidden": "Hidden",
   "StatusMarked": "Marked",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2482,7 +2482,10 @@ DND5E.statusEffects = {
     name: "EFFECT.DND5E.StatusConcentrating",
     icon: "systems/dnd5e/icons/svg/statuses/concentrating.svg"
   },
-  curse: {},
+  cursed: {
+    name: "EFFECT.DND5E.StatusCursed",
+    icon: "icons/svg/sun.svg"
+  },
   dead: {
     icon: "systems/dnd5e/icons/svg/statuses/dead.svg"
   },
@@ -2490,7 +2493,10 @@ DND5E.statusEffects = {
     name: "EFFECT.DND5E.StatusDodging",
     icon: "systems/dnd5e/icons/svg/statuses/dodging.svg"
   },
-  fly: {},
+  flying: {
+    name: "EFFECT.DND5E.StatusFlying",
+    icon: "icons/svg/wing.svg"
+  },
   hidden: {
     name: "EFFECT.DND5E.StatusHidden",
     icon: "icons/svg/cowled.svg"
@@ -2502,8 +2508,9 @@ DND5E.statusEffects = {
   silence: {
     icon: "systems/dnd5e/icons/svg/statuses/silenced.svg"
   },
-  sleep: {
-    name: "EFFECT.DND5E.StatusSleeping"
+  sleeping: {
+    name: "EFFECT.DND5E.StatusSleeping",
+    icon: "icons/svg/sleep.svg"
   },
   surprised: {
     name: "EFFECT.DND5E.StatusSurprised",


### PR DESCRIPTION
Closes #2949.

The string for 'Sleeping' was already there, so this must have been half a mistake. They were named this way in my initial PR.