### PR TITLE
[#2918] Add modifiers Set to dice scale values

### DIFF
--- a/module/data/advancement/scale-value.mjs
+++ b/module/data/advancement/scale-value.mjs
@@ -226,9 +226,11 @@ export class ScaleValueTypeCR extends ScaleValueTypeNumber {
 export class ScaleValueTypeDice extends ScaleValueType {
   /** @inheritdoc */
   static defineSchema() {
+    const fields = foundry.data.fields;
     return {
-      number: new foundry.data.fields.NumberField({nullable: true, integer: true, positive: true}),
-      faces: new foundry.data.fields.NumberField({required: true, integer: true, positive: true})
+      number: new fields.NumberField({nullable: true, integer: true, positive: true}),
+      faces: new fields.NumberField({required: true, integer: true, positive: true}),
+      modifiers: new fields.SetField(new fields.StringField({required: true}))
     };
   }
 
@@ -275,7 +277,7 @@ export class ScaleValueTypeDice extends ScaleValueType {
    */
   get die() {
     if ( !this.faces ) return "";
-    return `d${this.faces}`;
+    return `d${this.faces}${Array.from(this.modifiers).filterJoin("")}`;
   }
 
   /* -------------------------------------------- */

--- a/module/data/advancement/scale-value.mjs
+++ b/module/data/advancement/scale-value.mjs
@@ -272,12 +272,36 @@ export class ScaleValueTypeDice extends ScaleValueType {
   /* -------------------------------------------- */
 
   /**
-   * The die value to be rolled with the leading "d" (e.g. "d4").
+   * The entire die, with leading "d" and any modifiers, e.g., "d4" or "d4r1".
    * @type {string}
    */
   get die() {
     if ( !this.faces ) return "";
-    return `d${this.faces}${Array.from(this.modifiers).filterJoin("")}`;
+    return `d${this.faces}${this.mods}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The die modifiers.
+   * @type {string}
+   */
+  get mods() {
+    if ( !this.modifiers ) return "";
+    return this.modifiers.reduce((acc, mod) => {
+      return acc + (dnd5e.utils.isValidDieModifier(mod) ? mod : "");
+    }, "");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The die value to be rolled with the leading "d" (e.g. "d4").
+   * @type {string}
+   */
+  get denom() {
+    if ( !this.faces ) return "";
+    return `d${this.faces}`;
   }
 
   /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -40,6 +40,23 @@ export function formatText(value) {
 /* -------------------------------------------- */
 
 /**
+ * Return whether a string is a valid reroll, explosion, min, or max dice modifier.
+ * @param {string} mod      The modifier to test.
+ * @returns {boolean}
+ */
+export function isValidDieModifier(mod) {
+  const regex = {
+    reroll: /rr?([0-9]+)?([<>=]+)?([0-9]+)?/i,
+    explode: /xo?([0-9]+)?([<>=]+)?([0-9]+)?/i,
+    minimum: /(?:min)([0-9]+)/i,
+    maximum: /(?:max)([0-9]+)/i
+  };
+  return Object.values(regex).some(rgx => rgx.test(mod));
+}
+
+/* -------------------------------------------- */
+
+/**
  * Handle a delta input for a number value from a form.
  * @param {HTMLInputElement} input  Input that contains the modified value.
  * @param {Document} target         Target document to be updated.


### PR DESCRIPTION
Closes #2918.

This adds a new property, `modifiers`, to dice scale values, intended for properties like `min2` or `r<3`.

Using this ensures that scale values won't get pummeled into strings by appending such onto the scale value itself, or onto `.faces` or `.number`.

Adds the `dnd5e.utils.isValidDiceModifier` method, and the `denom` and `mods` getters to dice scale values.

![image](https://github.com/foundryvtt/dnd5e/assets/50169243/dbff50c6-1062-43e9-807a-2210ef1a2c35)
