### PR TITLE
[#2992] Use different icons for unprepared & always prepared states

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -548,6 +548,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
           applicable: true,
           disabled: !item.isOwner || isAlways,
           cls: prepared ? "active" : "",
+          icon: `<i class="fa-${prepared ? "solid" : "regular"} fa-${isAlways ? "certificate" : "sun"}"></i>`,
           title: isAlways
             ? CONFIG.DND5E.spellPreparationModes.always
             : prepared

--- a/templates/actors/tabs/character-spells.hbs
+++ b/templates/actors/tabs/character-spells.hbs
@@ -198,7 +198,7 @@
                         {{#if applicable}}
                         <a class="item-control item-action {{ cls }}" data-action="prepare" data-tooltip="{{ title }}"
                            aria-label="{{ title }}" aria-disabled="{{ this.disabled }}">
-                            <i class="fas fa-sun"></i>
+                            {{{ icon }}}
                         </a>
                         {{/if}}
                         {{/with}}


### PR DESCRIPTION
Showing "Always Prepared", "Prepared", and "Unprepared" spells:

<img width="314" alt="Screenshot 2024-02-09 at 10 24 16" src="https://github.com/foundryvtt/dnd5e/assets/19979839/dbb0c5e1-479f-4247-a8bf-7de8c1f594fe">

Here is an alternative icon:

<img width="312" alt="Screenshot 2024-02-09 at 10 20 52" src="https://github.com/foundryvtt/dnd5e/assets/19979839/b9ea2a96-bc85-4a3e-8478-0070f1752c03">