### PR TITLE
[#2947] Add metadata.supportsAdvancement, fix issue with deleteDialog failing

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -949,21 +949,20 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
     const stacked = this._onDropStackConsumables(itemData);
     if ( stacked ) return false;
 
-    // Ensure that this item isn't violating the singleton rule
-    // TODO: When v10 support is dropped, this will only need to be handled for items with advancement
-    const dataModel = CONFIG.Item[dnd5e.isV10 ? "systemDataModels" : "dataModels"][itemData.type];
-    const singleton = dataModel?.metadata.singleton ?? false;
-    if ( singleton && this.actor.itemTypes[itemData.type].length ) {
-      ui.notifications.error(game.i18n.format("DND5E.ActorWarningSingleton", {
-        itemType: game.i18n.localize(CONFIG.Item.typeLabels[itemData.type]),
-        actorType: game.i18n.localize(CONFIG.Actor.typeLabels[this.actor.type])
-      }));
-      return false;
-    }
-
     // Bypass normal creation flow for any items with advancement
     if ( this.actor.system.metadata?.supportsAdvancement && itemData.system.advancement?.length
         && !game.settings.get("dnd5e", "disableAdvancements") ) {
+      // Ensure that this item isn't violating the singleton rule
+      const dataModel = CONFIG.Item.dataModels[itemData.type];
+      const singleton = dataModel?.metadata.singleton ?? false;
+      if ( singleton && this.actor.itemTypes[itemData.type].length ) {
+        ui.notifications.error(game.i18n.format("DND5E.ActorWarningSingleton", {
+          itemType: game.i18n.localize(CONFIG.Item.typeLabels[itemData.type]),
+          actorType: game.i18n.localize(CONFIG.Actor.typeLabels[this.actor.type])
+        }));
+        return false;
+      }
+
       const manager = AdvancementManager.forNewItem(this.actor, itemData);
       if ( manager.steps.length ) {
         manager.render(true);

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -962,7 +962,8 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
     }
 
     // Bypass normal creation flow for any items with advancement
-    if ( itemData.system.advancement?.length && !game.settings.get("dnd5e", "disableAdvancements") ) {
+    if ( this.actor.system.metadata?.supportsAdvancement && itemData.system.advancement?.length
+        && !game.settings.get("dnd5e", "disableAdvancements") ) {
       const manager = AdvancementManager.forNewItem(this.actor, itemData);
       if ( manager.steps.length ) {
         manager.render(true);

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -733,7 +733,7 @@ export default class ItemSheet5e extends ItemSheet {
     }
 
     if ( !advancements.length ) return false;
-    if ( this.item.isEmbedded && !game.settings.get("dnd5e", "disableAdvancements") ) {
+    if ( this.item.actor?.system.metadata?.supportsAdvancement && !game.settings.get("dnd5e", "disableAdvancements") ) {
       const manager = AdvancementManager.forNewAdvancement(this.item.actor, this.item.id, advancements);
       if ( manager.steps.length ) return manager.render(true);
     }
@@ -761,7 +761,8 @@ export default class ItemSheet5e extends ItemSheet {
       case "add": return game.dnd5e.applications.advancement.AdvancementSelection.createDialog(this.item);
       case "edit": return new advancement.constructor.metadata.apps.config(advancement).render(true);
       case "delete":
-        if ( this.item.isEmbedded && !game.settings.get("dnd5e", "disableAdvancements") ) {
+        if ( this.item.actor?.system.metadata?.supportsAdvancement
+            && !game.settings.get("dnd5e", "disableAdvancements") ) {
           manager = AdvancementManager.forDeletedAdvancement(this.item.actor, this.item.id, id);
           if ( manager.steps.length ) return manager.render(true);
         }

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -76,9 +76,9 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
    * Metadata that describes this DataModel.
    * @type {SystemDataModelMetadata}
    */
-  static metadata = Object.freeze({
+  static metadata = {
     systemFlagsModel: null
-  });
+  };
 
   get metadata() {
     return this.constructor.metadata;
@@ -312,9 +312,9 @@ export class ActorDataModel extends SystemDataModel {
    */
 
   /** @type {ActorDataModelMetadata} */
-  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+  static metadata = foundry.utils.mergeObject(super.metadata, {
     supportsAdvancement: false
-  }, {inplace: false}));
+  }, {inplace: false});
 
   /* -------------------------------------------- */
   /*  Properties                                  */
@@ -364,9 +364,9 @@ export class ItemDataModel extends SystemDataModel {
    */
 
   /** @type {ItemDataModelMetadata} */
-  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+  static metadata = foundry.utils.mergeObject(super.metadata, {
     singleton: false
-  }, {inplace: false}));
+  }, {inplace: false});
 
   /**
    * The handlebars template for rendering item tooltips.

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -69,7 +69,6 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
 
   /**
    * @typedef {object} SystemDataModelMetadata
-   * @property {boolean} [singleton]                  Should only a single item of this type be allowed on an actor?
    * @property {typeof DataModel} [systemFlagsModel]  Model that represents flags data within the dnd5e namespace.
    */
 
@@ -77,7 +76,9 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
    * Metadata that describes this DataModel.
    * @type {SystemDataModelMetadata}
    */
-  static metadata = {};
+  static metadata = Object.freeze({
+    systemFlagsModel: null
+  });
 
   get metadata() {
     return this.constructor.metadata;
@@ -305,6 +306,16 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
  */
 export class ActorDataModel extends SystemDataModel {
 
+  /**
+   * @typedef {SystemDataModelMetadata} ActorDataModelMetadata
+   * @property {boolean} supportsAdvancement  Can advancement be performed for this actor type?
+   */
+
+  /** @type {ActorDataModelMetadata} */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    supportsAdvancement: false
+  }, {inplace: false}));
+
   /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
@@ -346,6 +357,16 @@ export class ActorDataModel extends SystemDataModel {
  * Variant of the SystemDataModel with support for rich item tooltips.
  */
 export class ItemDataModel extends SystemDataModel {
+
+  /**
+   * @typedef {SystemDataModelMetadata} ItemDataModelMetadata
+   * @property {boolean} singleton  Should only a single item of this type be allowed on an actor?
+   */
+
+  /** @type {ItemDataModelMetadata} */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    singleton: false
+  }, {inplace: false}));
 
   /**
    * The handlebars template for rendering item tooltips.

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -58,6 +58,13 @@ const { SchemaField, NumberField, StringField, BooleanField, ArrayField, Integer
 export default class CharacterData extends CreatureTemplate {
 
   /** @inheritdoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    supportsAdvancement: true
+  }, {inplace: false}));
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
   static _systemType = "character";
 
   /* -------------------------------------------- */

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -80,9 +80,9 @@ export default class GroupActor extends ActorDataModel.mixin(CurrencyTemplate) {
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  static metadata = Object.freeze({
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     systemFlagsModel: GroupSystemFlags
-  });
+  }, {inplace: false}));
 
   /* -------------------------------------------- */
   /*  Properties                                  */

--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -19,9 +19,9 @@ export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionT
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  static metadata = Object.freeze({
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     singleton: true
-  });
+  }, {inplace: false}));
 
   /* -------------------------------------------- */
   /*  Socket Event Handlers                       */

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -29,9 +29,9 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  static metadata = Object.freeze({
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     singleton: true
-  });
+  }, {inplace: false}));
 
   /* -------------------------------------------- */
   /*  Properties                                  */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2356,7 +2356,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /** @inheritdoc */
   async deleteDialog(options={}) {
     // If item has advancement, handle it separately
-    if ( this.isEmbedded && (this.actor.type !== "group") && !game.settings.get("dnd5e", "disableAdvancements") ) {
+    if ( this.actor?.system.metadata?.supportsAdvancement && !game.settings.get("dnd5e", "disableAdvancements") ) {
       const manager = AdvancementManager.forDeletedItem(this.actor, this.id);
       if ( manager.steps.length ) {
         try {


### PR DESCRIPTION
Move singleton property from `SystemDataModel#metadata` to `ItemDataModel#metadata` and reworked data model metadata as frozen object with proper default values.

Added `supportsAdvancement` metadata option to `ActorDataModel#metadata` to indicate actor types that can have advancement applied. Using the new metadata property in `deleteDialog` should ensure no errors for module-provided actor types.