### PR TITLE
[#2867] Add context menus to race, background, classes, & subclasses

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -1,8 +1,9 @@
-import ActorSheet5eCharacter from "./character-sheet.mjs";
-import * as Trait from "../../documents/actor/trait.mjs";
-import Tabs5e from "../tabs.mjs";
-import { simplifyBonus, staticID } from "../../utils.mjs";
 import CharacterData from "../../data/actor/character.mjs";
+import * as Trait from "../../documents/actor/trait.mjs";
+import { simplifyBonus, staticID } from "../../utils.mjs";
+import ContextMenu5e from "../context-menu.mjs";
+import Tabs5e from "../tabs.mjs";
+import ActorSheet5eCharacter from "./character-sheet.mjs";
 
 /**
  * An Actor sheet for player character type actors.
@@ -605,6 +606,12 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
       if ( (event.button === 1) && document.getElementById("tooltip")?.classList.contains("active") ) {
         event.preventDefault();
       }
+    });
+
+    // Apply special context menus for items outside inventory elements
+    const featuresElement = html[0].querySelector(`[data-tab="features"] ${this.options.elements.inventory}`);
+    if ( featuresElement ) new ContextMenu5e(html, ".pills-lg [data-item-id]", [], {
+      onOpen: (...args) => featuresElement._onOpenContextMenu(...args)
     });
 
     if ( this.isEditable ) {


### PR DESCRIPTION
Adds a context menu on ActorSheet5eCharacter2 targeting any element with `data-item-id` that is inside `.pills-lg`, which allows it to target all the concept items that exist outside the normal inventory elements.

In order to properly activate the context menus on these elements it fetches the `InventoryElement` on the features tab and uses its `_onOpenContextMenu`.

Closes #2867 