### PR TITLE
[#2979] Clamp damage/healing amount so it doesn't exceed HP bounds

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1129,7 +1129,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       "system.attributes.hp.temp": hp.temp - deltaTemp,
       "system.attributes.hp.value": hp.value - deltaHP
     };
-    amount = deltaTemp + deltaHP;
 
     /**
      * A hook event that fires before damage is applied to an actor.

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -674,6 +674,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     hp.effectiveMax = hp.max + (hp.tempmax ?? 0);
     hp.value = Math.min(hp.value, hp.effectiveMax);
+    hp.damage = hp.effectiveMax - hp.value;
     hp.pct = Math.clamped(hp.effectiveMax ? (hp.value / hp.effectiveMax) * 100 : 0, 0, 100);
   }
 
@@ -1123,11 +1124,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     amount = amount > 0 ? Math.floor(amount) : Math.ceil(amount);
 
     const deltaTemp = amount > 0 ? Math.min(hp.temp, amount) : 0;
-    const deltaHP = amount - deltaTemp;
+    const deltaHP = Math.clamped(amount - deltaTemp, -hp.damage, hp.value);
     const updates = {
       "system.attributes.hp.temp": hp.temp - deltaTemp,
       "system.attributes.hp.value": hp.value - deltaHP
     };
+    amount = deltaTemp + deltaHP;
 
     /**
      * A hook event that fires before damage is applied to an actor.


### PR DESCRIPTION
Previously the scrolling damage numbers and token flashes would be calculated based on the damage amount, without regards to how much HP the actor currently has. This results in showing floating numbers even when nothing about the actor's HP has been modified.

This change clamps the change to HP based on their current HP (for damage) or the negative of their current damage (for healing). To assist with this `hp.damage` has been added during hit points preparation for easy reference.

One limitation of this is that the damage numbers reflect only the damage applied, not the total damage taken, which might underrepresent massive hits. An alternative solution is to do the same clamping, but only check if `deltaTemp + deltaHP` is zero and don't pass `dhp` to the update function if nothing was change (or just skip the update all together).