### PR TITLE
[#2885] Hide active effect names when from unidentified item

### DIFF
--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -104,6 +104,7 @@ export default class EffectsElement extends HTMLElement {
 
     // Iterate over active effects, classifying them into categories
     for ( const e of effects ) {
+      if ( (e.parent.system?.identified === false) && !game.user.isGM ) continue;
       if ( e.isSuppressed ) categories.suppressed.effects.push(e);
       else if ( e.disabled ) categories.inactive.effects.push(e);
       else if ( e.isTemporary ) categories.temporary.effects.push(e);

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -284,6 +284,9 @@ export default class ActiveEffect5e extends ActiveEffect {
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    if ( (this.parent.system?.identified === false) && !game.user.isGM ) this.name = game.i18n.format(
+      "DND5E.Unidentified.DefaultName", { name: game.i18n.localize("DOCUMENT.ActiveEffect") }
+    );
     if ( this.id === this.constructor.ID.EXHAUSTION ) this._prepareExhaustionLevel();
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -284,9 +284,6 @@ export default class ActiveEffect5e extends ActiveEffect {
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    if ( (this.parent.system?.identified === false) && !game.user.isGM ) this.name = game.i18n.format(
-      "DND5E.Unidentified.DefaultName", { name: game.i18n.localize("DOCUMENT.ActiveEffect") }
-    );
     if ( this.id === this.constructor.ID.EXHAUSTION ) this._prepareExhaustionLevel();
   }
 


### PR DESCRIPTION
Just changes the names of active effects that belong to items that are unidentified.

<img width="532" alt="Screenshot 2024-02-09 at 16 33 38" src="https://github.com/foundryvtt/dnd5e/assets/19979839/85132442-b221-4c43-9796-7384cafb7a5b">

The details of the active effect can still be determined by opening its sheet, but modifying that behavior is a much larger change.