### PR TITLE
[#2224] Only automatically set item sheet height on tab change

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -16,15 +16,6 @@ export default class ItemSheet5e extends ItemSheet {
   constructor(...args) {
     super(...args);
 
-    // Expand the default size of the class sheet
-    if ( this.object.type === "class" ) {
-      this.options.width = this.position.width = 600;
-      this.options.height = this.position.height = 680;
-    }
-    else if ( this.object.type === "subclass" ) {
-      this.options.height = this.position.height = 540;
-    }
-
     this._accordions = this._createAccordions();
   }
 
@@ -34,7 +25,6 @@ export default class ItemSheet5e extends ItemSheet {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       width: 560,
-      height: 500,
       classes: ["dnd5e", "sheet", "item"],
       resizable: true,
       scrollY: [
@@ -401,11 +391,8 @@ export default class ItemSheet5e extends ItemSheet {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  setPosition(position={}) {
-    if ( !(this._minimized || position.height) ) {
-      position.height = (this._tabs[0].active === "details") ? "auto" : Math.max(this.height, this.options.height);
-    }
-    return super.setPosition(position);
+  _onChangeTab(event, tabs, active) {
+    this.setPosition({ height: "auto" });
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Previously we forced the height of the item sheet to certain values whenever the app was moved (due to overriding `setPosition`). The approach in this PR only automatically changes the height when the tab changes, rather than any time the app moves.

We can also just rely on the standard auto height sizing to adjust the size of the sheet for the content (like for a class or subclass sheet). This results in fewer non-standard cases and is more consistent UX IMO.

Closes #2224

[changing tabs on the item sheet](https://github.com/foundryvtt/dnd5e/assets/1226888/fe0e96b1-e346-44f6-8559-de1835d9e345)
