### PR TITLE
Movement speed calculation fixes

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2461,7 +2461,7 @@ patchConfig("conditionTypes", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" 
  */
 DND5E.conditionEffects = {
   noMovement: new Set(["exhaustion-5", "grappled", "paralyzed", "petrified", "restrained", "stunned", "unconscious"]),
-  halfMovement: new Set(["exhaustion-2", "prone"]),
+  halfMovement: new Set(["exhaustion-2"]),
   crawl: new Set(["prone", "exceedingCarryingCapacity"]),
   petrification: new Set(["petrified"]),
   halfHealth: new Set(["exhaustion-4"])

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1627,7 +1627,7 @@ preLocalize("distanceUnits");
  * @property {Record<string, number>} threshold.encumbered
  * @property {Record<string, number>} threshold.heavilyEncumbered
  * @property {Record<string, number>} threshold.maximum
- * @property {Record<string, number>} speedReduction     Speed reduction caused by encumbered status effects.
+ * @property {Record<string, {ft: number, m: number}>} speedReduction  Speed reduction caused by encumbered status.
  * @property {Record<string, number>} vehicleWeightMultiplier  Multiplier used to determine vehicle carrying capacity.
  */
 
@@ -1669,8 +1669,18 @@ DND5E.encumbrance = {
     }
   },
   speedReduction: {
-    encumbered: 10,
-    heavilyEncumbered: 20
+    encumbered: {
+      ft: 10,
+      m: 3
+    },
+    heavilyEncumbered: {
+      ft: 20,
+      m: 6
+    },
+    exceedingCarryingCapacity: {
+      ft: 5,
+      m: 1.5
+    }
   },
   vehicleWeightMultiplier: {
     imperial: 2000, // 2000 lbs in an imperial ton

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -162,6 +162,8 @@ export default class CharacterData extends CreatureTemplate {
   prepareEmbeddedData() {
     const raceData = this.details.race?.system;
     if ( !raceData ) {
+      this.attributes.movement.units ??= Object.keys(CONFIG.DND5E.movementUnits)[0];
+      this.attributes.senses.units ??= Object.keys(CONFIG.DND5E.movementUnits)[0];
       this.details.type = new CreatureTypeField({ swarm: false }).initialize({ value: "humanoid" }, this);
       return;
     }
@@ -170,13 +172,13 @@ export default class CharacterData extends CreatureTemplate {
       if ( raceData.movement[key] ) this.attributes.movement[key] ??= raceData.movement[key];
     }
     if ( raceData.movement.hover ) this.attributes.movement.hover = true;
-    this.attributes.movement.units ??= raceData.movement.units;
+    this.attributes.movement.units ??= raceData.movement.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
 
     for ( const key of Object.keys(CONFIG.DND5E.senses) ) {
       if ( raceData.senses[key] ) this.attributes.senses[key] ??= raceData.senses[key];
     }
     this.attributes.senses.special = [this.attributes.senses.special, raceData.senses.special].filterJoin(";");
-    this.attributes.senses.units ??= raceData.senses.units;
+    this.attributes.senses.units ??= raceData.senses.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
 
     this.details.type = raceData.type;
   }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -115,7 +115,7 @@ export default class AttributesFields {
       if ( reduction ) this.attributes.movement[k] = Math.max(0, this.attributes.movement[k] - reduction);
       if ( (crawl && (k !== "walk")) || noMovement ) this.attributes.movement[k] = 0;
       else if ( statuses.has("exceedingCarryingCapacity") ) this.attributes.movement[k] = 5;
-      else if ( halfMovement ) this.attributes.movement[k] = Math.floor(this.attributes.movement[k] * 0.5);
+      else if ( halfMovement ) this.attributes.movement[k] *= 0.5;
     });
   }
 }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -111,18 +111,21 @@ export default class AttributesFields {
     const heavilyEncumbered = statuses.has("heavilyEncumbered");
     const exceedingCarryingCapacity = statuses.has("exceedingCarryingCapacity");
     const crawl = this.parent.hasConditionEffect("crawl");
+    const units = this.attributes.movement.units
+        ?? this.details?.race?.system?.movement.units
+        ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
     for ( const type in CONFIG.DND5E.movementTypes ) {
       let speed = this.attributes.movement[type];
       if ( noMovement || (crawl && (type !== "walk")) ) speed = 0;
       else {
         if ( halfMovement ) speed *= 0.5;
         if ( heavilyEncumbered ) {
-          speed = Math.max(0, speed - CONFIG.DND5E.encumbrance.speedReduction.heavilyEncumbered);
+          speed = Math.max(0, speed - (CONFIG.DND5E.encumbrance.speedReduction.heavilyEncumbered[units] ?? 0));
         } else if ( encumbered ) {
-          speed = Math.max(0, speed - CONFIG.DND5E.encumbrance.speedReduction.encumbered);
+          speed = Math.max(0, speed - (CONFIG.DND5E.encumbrance.speedReduction.encumbered[units] ?? 0));
         }
         if ( exceedingCarryingCapacity ) {
-          speed = Math.min(speed, 5);
+          speed = Math.min(speed, CONFIG.DND5E.encumbrance.speedReduction.exceedingCarryingCapacity[units] ?? 0);
         }
       }
       this.attributes.movement[type] = speed;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -111,9 +111,7 @@ export default class AttributesFields {
     const heavilyEncumbered = statuses.has("heavilyEncumbered");
     const exceedingCarryingCapacity = statuses.has("exceedingCarryingCapacity");
     const crawl = this.parent.hasConditionEffect("crawl");
-    const units = this.attributes.movement.units
-        ?? this.details?.race?.system?.movement.units
-        ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
+    const units = this.attributes.movement.units;
     for ( const type in CONFIG.DND5E.movementTypes ) {
       let speed = this.attributes.movement[type];
       if ( noMovement || (crawl && (type !== "walk")) ) speed = 0;


### PR DESCRIPTION
- Fixed: *Prone* condition halved the movement speed incorrectly.
- Changed: Apply flat speed reductions of encumbrance after speed halving of *Exhaustion 2*.
- Fixed: Halved movement speed was rounded (floored).
- Added: Support for metric units in movement speed calculations. 