### PR TITLE
[#2864] Add theme option to sheet config & system settings

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -10,7 +10,7 @@
 
 // Import Configuration
 import DND5E from "./module/config.mjs";
-import registerSystemSettings from "./module/settings.mjs";
+import { registerSystemSettings, registerDeferredSettings } from "./module/settings.mjs";
 
 // Import Submodules
 import * as applications from "./module/applications/_module.mjs";
@@ -324,6 +324,9 @@ Hooks.once("setup", function() {
   game.dnd5e.moduleArt.registerModuleArt();
   Tooltips5e.activateListeners();
   game.dnd5e.tooltips.observe();
+
+  // Register settings after modules have had a chance to initialize
+  registerDeferredSettings();
 
   // Apply table of contents compendium style if specified in flags
   game.packs

--- a/lang/en.json
+++ b/lang/en.json
@@ -1686,5 +1686,10 @@
   "Hint": "Disabling the token ring animations can improve performance."
 },
 
+"SHEETS.DND5E.Theme.Automatic": "Automatic",
+"SHEETS.DND5E.Theme.Dark": "Dark Mode",
+"SHEETS.DND5E.Theme.Label": "Theme",
+"SHEETS.DND5E.Theme.Light": "Light Mode",
+
 "SOURCE.BOOK.SRD": "System Reference Document 5.1"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1685,11 +1685,21 @@
   "Name": "Disable Dynamic Token Rings",
   "Hint": "Disabling the token ring animations can improve performance."
 },
+"SETTINGS.DND5E": {
+  "THEME": {
+    "Name": "Theme",
+    "Hint": "Theme that will apply to the UI and all sheets by default. Automatic will be determined by your browser or operating system settings. Can be overridden on a sheet-by-sheet basis."
+  }
+},
 
-"SHEETS.DND5E.Theme.Automatic": "Automatic",
-"SHEETS.DND5E.Theme.Dark": "Dark Mode",
-"SHEETS.DND5E.Theme.Label": "Theme",
-"SHEETS.DND5E.Theme.Light": "Light Mode",
+"SHEETS.DND5E": {
+  "THEME": {
+    "Label": "Theme",
+    "Automatic": "Automatic",
+    "Dark": "Dark Mode",
+    "Light": "Light Mode"
+  }
+},
 
 "SOURCE.BOOK.SRD": "System Reference Document 5.1"
 }

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -11,6 +11,7 @@ export {default as ContextMenu5e} from "./context-menu.mjs";
 export {default as CurrencyManager} from "./currency-manager.mjs";
 export {default as DialogMixin} from "./dialog-mixin.mjs";
 export {default as PropertyAttribution} from "./property-attribution.mjs";
+export {default as SheetConfig} from "./sheet-config.mjs";
 export {default as SourceConfig} from "./source-config.mjs";
 export {default as Tabs5e} from "./tabs.mjs";
 export {default as TokenConfig5e} from "./token-config.mjs";

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -2,6 +2,7 @@ import CharacterData from "../../data/actor/character.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
 import { simplifyBonus, staticID } from "../../utils.mjs";
 import ContextMenu5e from "../context-menu.mjs";
+import SheetConfig5e from "../sheet-config.mjs";
 import Tabs5e from "../tabs.mjs";
 import ActorSheet5eCharacter from "./character-sheet.mjs";
 
@@ -159,6 +160,9 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
       if ( this._tabs?.[0]?.active !== t.initial ) t.initial = this._tabs?.[0]?.active ?? t.initial;
       return new Tabs5e(t);
     });
+
+    // Set theme
+    html[0].dataset.theme = this.actor.getFlag("dnd5e", "theme");
 
     return html;
   }
@@ -856,6 +860,17 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     const item = this.actor.items.get(itemId);
     if ( event.target.closest(".favorites") && name && item ) return item.update({ [name]: event.target.value });
     return super._onChangeInput(event);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onConfigureSheet(event) {
+    event.preventDefault();
+    new SheetConfig5e(this.document, {
+      top: this.position.top + 40,
+      left: this.position.left + ((this.position.width - DocumentSheet.defaultOptions.width) / 2)
+    }).render(true);
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -1,5 +1,6 @@
 import CharacterData from "../../data/actor/character.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
+import { setTheme } from "../../settings.mjs";
 import { simplifyBonus, staticID } from "../../utils.mjs";
 import ContextMenu5e from "../context-menu.mjs";
 import SheetConfig5e from "../sheet-config.mjs";
@@ -162,7 +163,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     });
 
     // Set theme
-    html[0].dataset.theme = this.actor.getFlag("dnd5e", "theme");
+    setTheme(html[0], this.actor.getFlag("dnd5e", "theme"));
 
     return html;
   }

--- a/module/applications/sheet-config.mjs
+++ b/module/applications/sheet-config.mjs
@@ -1,0 +1,35 @@
+/**
+ * Sheet config with extra options.
+ */
+export default class SheetConfig5e extends DocumentSheetConfig {
+
+  /** @inheritdoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      template: "systems/dnd5e/templates/shared/sheet-config.hbs"
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  getData(options) {
+    const context = super.getData(options);
+    context.CONFIG = CONFIG.DND5E;
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  async _updateObject(event, formData) {
+    super._updateObject(event, formData);
+    delete formData.sheetClass;
+    delete formData.defaultClass;
+    this.object.update(formData);
+
+    if ( "flags.dnd5e.theme" in formData ) {
+      const sheet = this.object.sheet.element?.[0];
+      if ( sheet ) sheet.dataset.theme = formData["flags.dnd5e.theme"];
+    }
+  }
+}

--- a/module/applications/sheet-config.mjs
+++ b/module/applications/sheet-config.mjs
@@ -1,3 +1,5 @@
+import { setTheme } from "../settings.mjs";
+
 /**
  * Sheet config with extra options.
  */
@@ -29,7 +31,7 @@ export default class SheetConfig5e extends DocumentSheetConfig {
 
     if ( "flags.dnd5e.theme" in formData ) {
       const sheet = this.object.sheet.element?.[0];
-      if ( sheet ) sheet.dataset.theme = formData["flags.dnd5e.theme"];
+      if ( sheet ) setTheme(sheet, formData["flags.dnd5e.theme"]);
     }
   }
 }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3196,8 +3196,8 @@ preLocalize("sourceBooks", { sort: true });
  * @enum {string}
  */
 DND5E.themes = {
-  light: "SHEETS.DND5E.Theme.Light",
-  dark: "SHEETS.DND5E.Theme.Dark"
+  light: "SHEETS.DND5E.THEME.Light",
+  dark: "SHEETS.DND5E.THEME.Dark"
 };
 preLocalize("themes");
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3188,6 +3188,20 @@ DND5E.sourceBooks = {
 preLocalize("sourceBooks", { sort: true });
 
 /* -------------------------------------------- */
+/*  Themes                                      */
+/* -------------------------------------------- */
+
+/**
+ * Themes that can be set for the system or on sheets.
+ * @enum {string}
+ */
+DND5E.themes = {
+  light: "SHEETS.DND5E.Theme.Light",
+  dark: "SHEETS.DND5E.Theme.Dark"
+};
+preLocalize("themes");
+
+/* -------------------------------------------- */
 /*  Enrichment                                  */
 /* -------------------------------------------- */
 

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -3,7 +3,7 @@ import { ModuleArtConfig } from "./module-art.mjs";
 /**
  * Register all of the system's settings.
  */
-export default function registerSystemSettings() {
+export function registerSystemSettings() {
   // Internal System Migration Version
   game.settings.register("dnd5e", "systemMigrationVersion", {
     name: "System Migration Version",
@@ -314,4 +314,27 @@ class PrimaryPartyData extends foundry.abstract.DataModel {
   static defineSchema() {
     return { actor: new foundry.data.fields.ForeignDocumentField(foundry.documents.BaseActor) };
   }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Register additional settings after modules have had a chance to initialize to give them a chance to modify choices.
+ */
+export function registerDeferredSettings() {
+  game.settings.register("dnd5e", "theme", {
+    name: "SETTINGS.DND5E.THEME.Name",
+    hint: "SETTINGS.DND5E.THEME.Hint",
+    scope: "client",
+    config: true,
+    default: "",
+    type: String,
+    choices: {
+      "": "SHEETS.DND5E.THEME.Automatic",
+      ...CONFIG.DND5E.themes
+    },
+    onChange: s => document.body.dataset.theme = s
+  });
+
+  document.body.dataset.theme = game.settings.get("dnd5e", "theme");
 }

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -333,8 +333,21 @@ export function registerDeferredSettings() {
       "": "SHEETS.DND5E.THEME.Automatic",
       ...CONFIG.DND5E.themes
     },
-    onChange: s => document.body.dataset.theme = s
+    onChange: s => setTheme(document.body, s)
   });
 
-  document.body.dataset.theme = game.settings.get("dnd5e", "theme");
+  setTheme(document.body, game.settings.get("dnd5e", "theme"));
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Set the theme on an element, removing the previous theme class in the process.
+ * @param {HTMLElement} element  Body or sheet element on which to set the theme data.
+ * @param {string} [theme=""]    Theme key to set.
+ */
+export function setTheme(element, theme="") {
+  element.dataset.theme = theme;
+  element.className = element.className.replace(/\bdnd5e-theme-\w+/g, "");
+  if ( theme ) element.classList.add(`dnd5e-theme-${theme.slugify()}`);
 }

--- a/templates/shared/sheet-config.hbs
+++ b/templates/shared/sheet-config.hbs
@@ -1,0 +1,31 @@
+<form autocomplete="off">
+    <div class="form-group">
+        <label>{{localize "SHEETS.ThisSheet"}}</label>
+        <select name="sheetClass">
+            {{selectOptions sheetClasses selected=sheetClass blank=blankLabel}}
+        </select>
+        <p class="notes">{{localize "SHEETS.DocumentSheetHint"}}</p>
+    </div>
+
+    <div class="form-group">
+        <label>{{localize "Default"}} <strong>{{type}}</strong> {{localize "Sheet"}}</label>
+        <select name="defaultClass" {{#unless isGM}}disabled{{/unless}}>
+            {{selectOptions defaultClasses selected=defaultClass}}
+        </select>
+        <p class="notes">{{localize "SHEETS.TypeSheetHint"}}</p>
+    </div>
+
+    <div class="form-group">
+        <label>{{localize "SHEETS.DND5E.Theme.Label"}}</label>
+        <select name="flags.dnd5e.theme">
+            {{#select object.flags.dnd5e.theme}}
+            <option value="">{{localize "SHEETS.DND5E.Theme.Automatic"}}</option>
+            {{selectOptions CONFIG.themes}}
+            {{/select}}
+        </select>
+    </div>
+
+    <button type="submit">
+        <i class="fas fa-save"></i> {{localize "SHEETS.Save"}}
+    </button>
+</form>

--- a/templates/shared/sheet-config.hbs
+++ b/templates/shared/sheet-config.hbs
@@ -16,10 +16,10 @@
     </div>
 
     <div class="form-group">
-        <label>{{localize "SHEETS.DND5E.Theme.Label"}}</label>
+        <label>{{localize "SHEETS.DND5E.THEME.Label"}}</label>
         <select name="flags.dnd5e.theme">
             {{#select object.flags.dnd5e.theme}}
-            <option value="">{{localize "SHEETS.DND5E.Theme.Automatic"}}</option>
+            <option value="">{{localize "SHEETS.DND5E.THEME.Automatic"}}</option>
             {{selectOptions CONFIG.themes}}
             {{/select}}
         </select>


### PR DESCRIPTION
Replaces the standard sheet configuration dialog with one that includes a theme dropdown:

<img width="414" alt="Screenshot 2024-02-12 at 10 03 54" src="https://github.com/foundryvtt/dnd5e/assets/19979839/4857e315-9bb4-462f-a348-40076247326e">

It also adds the same theme dropdown into the system settings.

Doesn't implement any themes itself, but will add `data-theme="<name>"` to the sheet if selected on the sheet, or the body if set in the global settings.