### PR TITLE
[#1019] Add resting buttons to group actor for GMs

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -834,6 +834,10 @@
 "DND5E.HPFormulaRollMessage": "Roll Hit Point Formula",
 "DND5E.HitDie": "Hit Die",
 "DND5E.HitDice": "Hit Dice",
+"DND5E.HitDiceAutoSpend": {
+  "Label": "Auto Spend HD",
+  "Hint": "Automatically spend hit dice until they run out or health is full."
+},
 "DND5E.HitDiceConfig": "Adjust Hit Dice",
 "DND5E.HitDiceConfigHint": "Adjust remaining hit dice levels for each class.",
 "DND5E.HitDiceMax": "Maximum Hit Dice",
@@ -1013,6 +1017,7 @@
 "DND5E.LongRestEpic": "Long Rest (1 hour)",
 "DND5E.LongRestOvernight": "Long Rest (New Day)",
 "DND5E.LongRestHint": "Take a long rest? On a long rest you will recover hit points, half your maximum hit dice, class resources, limited use item charges, and spell slots.",
+"DND5E.LongRestHintGroup": "Take a long rest? On a long rest group members will recover hit points, half of their maximum hit dice, class resources, limited use item charges, and spell slots.",
 "DND5E.LongRestRecovery": "Recovers after Long Rest",
 "DND5E.LongRestResult": "{name} takes a long rest and recovers {health} Hit Points and {dice} Hit Dice.",
 "DND5E.LongRestResultHitDice": "{name} takes a long rest and recovers {dice} Hit Dice.",
@@ -1204,7 +1209,8 @@
 "DND5E.ShortRestGritty": "Short Rest (8 hours)",
 "DND5E.ShortRestEpic": "Short Rest (5 minutes)",
 "DND5E.ShortRestOvernight": "Short Rest (New Day)",
-"DND5E.ShortRestHint": "Take a short rest? On a short rest you may spend remaining Hit Dice and recover primary or secondary resources.",
+"DND5E.ShortRestHint": "Take a short rest? On a short rest you may spend remaining Hit Dice and recover item uses.",
+"DND5E.ShortRestHintGroup": "Take a short rest? On a short rest group members can spend Hit Dice and will recover item uses.",
 "DND5E.ShortRestNoHD": "No Hit Dice remaining",
 "DND5E.ShortRestRecovery": "Recovers after Short Rest",
 "DND5E.ShortRestResult": "{name} takes a short rest spending {dice} Hit Dice to recover {health} Hit Points.",

--- a/less/v1/group.less
+++ b/less/v1/group.less
@@ -2,6 +2,25 @@
   min-width: 620px;
   min-height: 620px;
 
+  .member-controls {
+    max-width: calc(100% - 2px);
+    gap: 8px;
+    justify-content: flex-end;
+    margin-block: 4px;
+    padding: 0;
+    list-style: none;
+    font-size: var(--font-size-12);
+
+    li {
+      flex: 0 1 max-content;
+
+      button {
+        padding-inline: 8px;
+        line-height: 1.5em;
+      }
+    }
+  }
+
   .attribute.health span.value {
     line-height: 64px;
     flex: 0 0 64px;

--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -53,6 +53,7 @@ export default class GroupActorSheet extends ActorSheetMixin(ActorSheet) {
     context.system = this.actor.system;
     context.items = Array.from(this.actor.items);
     context.config = CONFIG.DND5E;
+    context.isGM = game.user.isGM;
 
     // Membership
     const {sections, stats} = this.#prepareMembers();
@@ -276,6 +277,8 @@ export default class GroupActorSheet extends ActorSheetMixin(ActorSheet) {
       inputs.focus(ev => ev.currentTarget.select());
       inputs.addBack().find('[type="text"][data-dtype="Number"]').change(this._onChangeInputDelta.bind(this));
       html.find(".action-button").click(this._onClickActionButton.bind(this));
+    } else {
+      html.find(".rest-button").click(this._onClickActionButton.bind(this));
     }
   }
 
@@ -298,12 +301,18 @@ export default class GroupActorSheet extends ActorSheetMixin(ActorSheet) {
         const removeMemberId = button.closest("li.group-member").dataset.actorId;
         this.object.system.removeMember(removeMemberId);
         break;
-      case "rollQuantities":
-        this.object.system.rollQuantities();
+      case "longRest":
+        this.object.longRest();
         break;
       case "movementConfig":
         const movementConfig = new ActorMovementConfig(this.object);
         movementConfig.render(true);
+        break;
+      case "rollQuantities":
+        this.object.system.rollQuantities();
+        break;
+      case "shortRest":
+        this.object.shortRest();
         break;
     }
   }

--- a/module/applications/actor/long-rest.mjs
+++ b/module/applications/actor/long-rest.mjs
@@ -25,11 +25,12 @@ export default class LongRestDialog extends Dialog {
 
   /** @inheritDoc */
   getData() {
-    const data = super.getData();
+    const context = super.getData();
     const variant = game.settings.get("dnd5e", "restVariant");
-    data.promptNewDay = variant !== "gritty";     // It's always a new day when resting 1 week
-    data.newDay = variant === "normal";           // It's probably a new day when resting normally (8 hours)
-    return data;
+    context.isGroup = this.actor.type === "group";
+    context.promptNewDay = variant !== "gritty";     // It's always a new day when resting 1 week
+    context.newDay = variant === "normal";           // It's probably a new day when resting normally (8 hours)
+    return context;
   }
 
   /* -------------------------------------------- */
@@ -50,11 +51,8 @@ export default class LongRestDialog extends Dialog {
             icon: '<i class="fas fa-bed"></i>',
             label: game.i18n.localize("DND5E.Rest"),
             callback: html => {
-              let newDay = true;
-              if (game.settings.get("dnd5e", "restVariant") !== "gritty") {
-                newDay = html.find('input[name="newDay"]')[0].checked;
-              }
-              resolve(newDay);
+              const formData = new FormDataExtended(html.find("form")[0]);
+              resolve(formData.object);
             }
           },
           cancel: {

--- a/module/applications/actor/short-rest.mjs
+++ b/module/applications/actor/short-rest.mjs
@@ -36,26 +36,29 @@ export default class ShortRestDialog extends Dialog {
 
   /** @inheritDoc */
   getData() {
-    const data = super.getData();
+    const context = super.getData();
+    context.isGroup = this.actor.type === "group";
 
-    // Determine Hit Dice
-    data.availableHD = this.actor.items.reduce((hd, item) => {
-      if ( item.type === "class" ) {
-        const {levels, hitDice, hitDiceUsed} = item.system;
-        const denom = hitDice ?? "d6";
-        const available = parseInt(levels ?? 1) - parseInt(hitDiceUsed ?? 0);
-        hd[denom] = denom in hd ? hd[denom] + available : available;
-      }
-      return hd;
-    }, {});
-    data.canRoll = this.actor.system.attributes.hd > 0;
-    data.denomination = this._denom;
+    if ( foundry.utils.hasProperty(this.actor, "system.attributes.hd") ) {
+      // Determine Hit Dice
+      context.availableHD = this.actor.items.reduce((hd, item) => {
+        if ( item.type === "class" ) {
+          const {levels, hitDice, hitDiceUsed} = item.system;
+          const denom = hitDice ?? "d6";
+          const available = parseInt(levels ?? 1) - parseInt(hitDiceUsed ?? 0);
+          hd[denom] = denom in hd ? hd[denom] + available : available;
+        }
+        return hd;
+      }, {});
+      context.canRoll = this.actor.system.attributes.hd > 0;
+      context.denomination = this._denom;
+    }
 
     // Determine rest type
     const variant = game.settings.get("dnd5e", "restVariant");
-    data.promptNewDay = variant !== "epic";     // It's never a new day when only resting 1 minute
-    data.newDay = false;                        // It may be a new day, but not by default
-    return data;
+    context.promptNewDay = variant !== "epic";     // It's never a new day when only resting 1 minute
+    context.newDay = false;                        // It may be a new day, but not by default
+    return context;
   }
 
   /* -------------------------------------------- */
@@ -101,11 +104,8 @@ export default class ShortRestDialog extends Dialog {
             icon: '<i class="fas fa-bed"></i>',
             label: game.i18n.localize("DND5E.Rest"),
             callback: html => {
-              let newDay = false;
-              if ( game.settings.get("dnd5e", "restVariant") !== "epic" ) {
-                newDay = html.find('input[name="newDay"]')[0].checked;
-              }
-              resolve(newDay);
+              const formData = new FormDataExtended(html.find("form")[0]);
+              resolve(formData.object);
             }
           },
           cancel: {

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -229,6 +229,54 @@ export default class GroupActor extends ActorDataModel.mixin(CurrencyTemplate) {
   }
 
   /* -------------------------------------------- */
+  /*  Resting                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Initiate a long rest for all members of the group.
+   * @param {RestConfiguration} config  Configuration data for the rest.
+   */
+  async longRest(config) {
+    this._rest(config, "long");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Initiate a short rest for all members of the group.
+   * @param {RestConfiguration} config  Configuration data for the rest.
+   */
+  async shortRest(config) {
+    this._rest(config, "short");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Initiate a rest for all members of this group.
+   * @param {RestConfiguration} config  Configuration data for the rest.
+   * @param {short|long} type           Type of rest to perform.
+   */
+  async _rest(config, type) {
+    const results = new Map();
+    for ( const member of this.members ) {
+      results.set(
+        member.actor,
+        await member.actor[type === "short" ? "shortRest" : "longRest"]({ ...config, dialog: false }) ?? null
+      );
+    }
+
+    /**
+     * A hook event that fires when the rest process is completed for a group.
+     * @function dnd5e.groupRestCompleted
+     * @memberof hookEvents
+     * @param {Actor5e} group                         The group that just completed resting.
+     * @param {Map<Actor5e, RestResult|null>} result  Details on the rests completed.
+     */
+    Hooks.callAll("dnd5e.groupRestCompleted", this.parent, results);
+  }
+
+  /* -------------------------------------------- */
   /*  Socket Event Handlers                       */
   /* -------------------------------------------- */
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -209,6 +209,7 @@ export async function preloadHandlebarsTemplates() {
     "systems/dnd5e/templates/actors/tabs/character-features.hbs",
     "systems/dnd5e/templates/actors/tabs/character-spells.hbs",
     "systems/dnd5e/templates/actors/tabs/character-biography.hbs",
+    "systems/dnd5e/templates/actors/tabs/group-members.hbs",
 
     // Item Sheet Partials
     "systems/dnd5e/templates/items/parts/item-action.hbs",

--- a/templates/actors/group-sheet.hbs
+++ b/templates/actors/group-sheet.hbs
@@ -65,76 +65,7 @@
 
     <section class="sheet-body">
         <div class="tab members" data-group="primary" data-tab="members">
-            {{#each sections as |section id|}}
-            <section class="directory" data-section="{{id}}">
-                <header class="directory-header flexrow">
-                    <h3 class="name">{{localize section.label}}</h3>
-                    {{#if section.displayHPColumn}}
-                    <span class="hp">{{localize "DND5E.HitPoints"}}</span>
-                    {{/if}}
-                    {{#if section.displayQuantityColumn}}
-                    <span class="quantity">
-                        {{localize "DND5E.Quantity"}}
-                        {{#if @root.editable}}
-                        <a class="action-button" data-action="rollQuantities" data-tooltip="DND5E.QuantityRoll"
-                           aria-label="{{localize 'DND5E.QuantityRoll'}}">
-                            <i class="fa-solid fa-dice"></i>
-                        </a>
-                        {{/if}}
-                    </span>
-                    {{/if}}
-                    {{#if section.displayChallengeColumn}}
-                    <span class="challenge">{{localize "DND5E.Group.Challenge"}}</span>
-                    {{/if}}
-                    <span class="controls">{{localize "DND5E.GroupControls"}}</span>
-                </header>
-                <ol class="members-list directory-list">
-                    {{#each section.members as |member|}}
-                    <li class="group-member directory-item flexrow" data-actor-id="{{member.id}}">
-                        <input type="hidden" name="system.members.{{index}}.actor" value="{{member.id}}">
-                        <div class="name flexrow">
-                            <img class="thumbnail" src="{{member.img}}">
-                            <h4 class="document-name"><a class="member-link">{{member.name}}</a></h4>
-                        </div>
-                        {{#if section.displayHPColumn}}
-                        <div class="hp flexrow">
-                            <div class="bar-container">
-                                <div class="bar" style="width:{{member.hp.pct}}%; background:{{member.hp.color}}; border-color:{{member.hp.border}}"></div>
-                            </div>
-                            {{#if displayHPValues}}
-                            <span class="current">{{member.hp.current}}</span>
-                            <span class="sep">/</span>
-                            <span class="max">{{member.hp.max}}</span>
-                            {{/if}}
-                        </div>
-                        {{/if}}
-                        {{#if section.displayQuantityColumn}}
-                        <div class="quantity flexrow">
-                            <input type="number" name="system.members.{{index}}.quantity.value" min="0" step="1"
-                                   value="{{member.quantity.value}}">
-                            <input type="text" name="system.members.{{index}}.quantity.formula"
-                                   value="{{member.quantity.formula}}" placeholder="{{localize 'DND5E.Formula'}}">
-                        </div>
-                        {{else}}
-                        <input type="hidden" name="system.members.{{index}}.quantity.value"
-                               value="{{member.quantity.value}}">
-                        <input type="hidden" name="system.members.{{index}}.quantity.formula"
-                               value="{{member.quantity.formula}}">
-                        {{/if}}
-                        {{#if section.displayChallengeColumn}}
-                        <div class="challenge">
-                            <abbr>{{localize "DND5E.AbbreviationCR"}}</abbr> {{member.cr}}{{#if member.xp}} —
-                            {{member.xp}} <abbr>{{localize "DND5E.ExperiencePointsAbbr"}}</abbr>{{/if}}
-                        </div>
-                        {{/if}}
-                        <div class="controls">
-                            <a class="action-button" data-action="removeMember"><i class="fa-solid fa-close"></i></a>
-                        </div>
-                    </li>
-                    {{/each}}
-                </ol>
-            </section>
-            {{/each}}
+            {{> "dnd5e.group-members"}}
         </div>
 
         <div class="tab inventory flexcol" data-group="primary" data-tab="inventory">

--- a/templates/actors/tabs/group-members.hbs
+++ b/templates/actors/tabs/group-members.hbs
@@ -1,0 +1,85 @@
+{{#if isGM}}
+<menu class="member-controls flexrow">
+    <li>
+        <button type="button" class="action-button rest-button" data-action="shortRest">
+            <i class="fa-solid fa-utensils" inert></i> {{localize "DND5E.ShortRest"}}
+        </button>
+    </li>
+    <li>
+        <button type="button" class="action-button rest-button" data-action="longRest">
+            <i class="fa-solid fa-campground" inert></i> {{localize "DND5E.LongRest"}}
+        </button>
+    </li>
+</menu>
+{{/if}}
+
+{{#each sections as |section id|}}
+<section class="directory" data-section="{{id}}">
+    <header class="directory-header flexrow">
+        <h3 class="name">{{localize section.label}}</h3>
+        {{#if section.displayHPColumn}}
+        <span class="hp">{{localize "DND5E.HitPoints"}}</span>
+        {{/if}}
+        {{#if section.displayQuantityColumn}}
+        <span class="quantity">
+            {{localize "DND5E.Quantity"}}
+            {{#if @root.editable}}
+            <a class="action-button" data-action="rollQuantities" data-tooltip="DND5E.QuantityRoll"
+               aria-label="{{localize 'DND5E.QuantityRoll'}}">
+                <i class="fa-solid fa-dice"></i>
+            </a>
+            {{/if}}
+        </span>
+        {{/if}}
+        {{#if section.displayChallengeColumn}}
+        <span class="challenge">{{localize "DND5E.Group.Challenge"}}</span>
+        {{/if}}
+        <span class="controls">{{localize "DND5E.GroupControls"}}</span>
+    </header>
+    <ol class="members-list directory-list">
+        {{#each section.members as |member|}}
+        <li class="group-member directory-item flexrow" data-actor-id="{{member.id}}">
+            <input type="hidden" name="system.members.{{index}}.actor" value="{{member.id}}">
+            <div class="name flexrow">
+                <img class="thumbnail" src="{{member.img}}">
+                <h4 class="document-name"><a class="member-link">{{member.name}}</a></h4>
+            </div>
+            {{#if section.displayHPColumn}}
+            <div class="hp flexrow">
+                <div class="bar-container">
+                    <div class="bar" style="width:{{member.hp.pct}}%; background:{{member.hp.color}}; border-color:{{member.hp.border}}"></div>
+                </div>
+                {{#if displayHPValues}}
+                <span class="current">{{member.hp.current}}</span>
+                <span class="sep">/</span>
+                <span class="max">{{member.hp.max}}</span>
+                {{/if}}
+            </div>
+            {{/if}}
+            {{#if section.displayQuantityColumn}}
+            <div class="quantity flexrow">
+                <input type="number" name="system.members.{{index}}.quantity.value" min="0" step="1"
+                       value="{{member.quantity.value}}">
+                <input type="text" name="system.members.{{index}}.quantity.formula"
+                       value="{{member.quantity.formula}}" placeholder="{{localize 'DND5E.Formula'}}">
+            </div>
+            {{else}}
+            <input type="hidden" name="system.members.{{index}}.quantity.value"
+                   value="{{member.quantity.value}}">
+            <input type="hidden" name="system.members.{{index}}.quantity.formula"
+                   value="{{member.quantity.formula}}">
+            {{/if}}
+            {{#if section.displayChallengeColumn}}
+            <div class="challenge">
+                <abbr>{{localize "DND5E.AbbreviationCR"}}</abbr> {{member.cr}}{{#if member.xp}} —
+                {{member.xp}} <abbr>{{localize "DND5E.ExperiencePointsAbbr"}}</abbr>{{/if}}
+            </div>
+            {{/if}}
+            <div class="controls">
+                <a class="action-button" data-action="removeMember"><i class="fa-solid fa-close"></i></a>
+            </div>
+        </li>
+        {{/each}}
+    </ol>
+</section>
+{{/each}}

--- a/templates/apps/long-rest.hbs
+++ b/templates/apps/long-rest.hbs
@@ -1,5 +1,8 @@
 <form id="long-rest" class="dialog-content" onsubmit="event.preventDefault();">
-   <p>{{ localize "DND5E.LongRestHint" }}</p>
+    <p>
+        {{#if isGroup}}{{ localize "DND5E.LongRestHintGroup" }}
+        {{else}}{{ localize "DND5E.LongRestHint" }}{{/if}}
+    </p>
 
     {{#if promptNewDay}}
     <div class="form-group">

--- a/templates/apps/short-rest.hbs
+++ b/templates/apps/short-rest.hbs
@@ -1,5 +1,10 @@
 <form id="short-rest-hd" class="dialog-content" onsubmit="event.preventDefault();">
-    <p>{{ localize "DND5E.ShortRestHint" }}</p>
+    <p>
+        {{#if isGroup}}{{ localize "DND5E.ShortRestHintGroup" }}
+        {{else}}{{ localize "DND5E.ShortRestHint" }}{{/if}}
+    </p>
+
+    {{#if availableHD}}
     <div class="form-group">
         <label>{{ localize "DND5E.ShortRestSelect" }}</label>
         <div class="form-fields">
@@ -18,11 +23,18 @@
         <p class="notes">{{ localize "DND5E.ShortRestNoHD" }}</p>
         {{/unless}}
     </div>
+    {{else}}
+    <div class="form-group">
+        <label>{{ localize "DND5E.HitDiceAutoSpend.Label" }}</label>
+        <input type="checkbox" name="autoHD">
+        <p class="hint">{{localize "DND5E.HitDiceAutoSpend.Hint" }}</p>
+    </div>
+    {{/if}}
 
     {{#if promptNewDay}}
     <div class="form-group">
         <label>{{ localize "DND5E.NewDay" }}</label>
-        <input type="checkbox" name="newDay" {{checked newDay}}/>
+        <input type="checkbox" name="newDay" {{checked newDay}}>
         <p class="hint">{{ localize "DND5E.NewDayHint" }}</p>
     </div>
     {{/if}}


### PR DESCRIPTION
Adds resting buttons for GMs on the group sheet.

<img width="627" alt="Group Rests" src="https://github.com/foundryvtt/dnd5e/assets/19979839/390b3402-2c79-4425-bad1-70c1b3603d84">

These will bring up slightly modified versions of the existing rest dialogs:

<img width="835" alt="Screenshot 2024-02-12 at 11 19 41" src="https://github.com/foundryvtt/dnd5e/assets/19979839/dfc5e1ea-2612-43b0-86e2-ca55a5c15ea0">

And then initiate a rest for all members of the group.

### Future Development
- Add interface for only resting individual members
- Combine resting chat messages into one big group message
- Automatically advance game time by rest amount