### PR TITLE
Popout! compatibilty (Fixes #3044)

### DIFF
--- a/module/applications/components/_module.mjs
+++ b/module/applications/components/_module.mjs
@@ -5,6 +5,7 @@ import InventoryElement from "./inventory.mjs";
 import ItemListControlsElement from "./item-list-controls.mjs";
 import ProficiencyCycleElement from "./proficiency-cycle.mjs";
 import SlideToggleElement from "./slide-toggle.mjs";
+import AdoptedStyleSheetMixin from "./adopted-stylesheet-mixin.mjs";
 
 window.customElements.define("dnd5e-effects", EffectsElement);
 window.customElements.define("dnd5e-icon", IconElement);
@@ -15,6 +16,6 @@ window.customElements.define("proficiency-cycle", ProficiencyCycleElement);
 window.customElements.define("slide-toggle", SlideToggleElement);
 
 export {
-  EffectsElement, IconElement, InventoryElement, ItemListControlsElement, FiligreeBoxElement, ProficiencyCycleElement,
-  SlideToggleElement
+  AdoptedStyleSheetMixin, EffectsElement, IconElement, InventoryElement, ItemListControlsElement, FiligreeBoxElement,
+  ProficiencyCycleElement, SlideToggleElement
 };

--- a/module/applications/components/adopted-stylesheet-mixin.mjs
+++ b/module/applications/components/adopted-stylesheet-mixin.mjs
@@ -1,0 +1,58 @@
+/**
+ * Adds functionality to a custom HTML element for caching its stylesheet and adopting it into its Shadow DOM, rather
+ * than having each stylesheet duplicated per element.
+ * @param {typeof HTMLElement} Base  The base class being mixed.
+ * @returns {typeof AdoptedStyleSheetElement}
+ */
+export default function AdoptedStyleSheetMixin(Base) {
+  return class AdoptedStyleSheetElement extends Base {
+    /**
+     * A map of cached stylesheets per Document root.
+     * @type {WeakMap<WeakKey<Document>, CSSStyleSheet>}
+     * @protected
+     */
+    static _stylesheets;
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    adoptedCallback() {
+      this._adoptStyleSheet(this._getStyleSheet());
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Retrieves the cached stylesheet, or generates a new one.
+     * @protected
+     */
+    _getStyleSheet() {
+      this.constructor._stylesheets ??= new WeakMap();
+      let sheet = this.constructor._stylesheets.get(this.ownerDocument);
+      if ( !sheet ) {
+        sheet = new this.ownerDocument.defaultView.CSSStyleSheet();
+        this._buildCSS(sheet);
+        this.constructor._stylesheets.set(this.ownerDocument, sheet);
+      }
+      return sheet;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Adopt the stylesheet into the Shadow DOM.
+     * @param {CSSStyleSheet} sheet  The sheet to adopt.
+     * @abstract
+     */
+    _adoptStyleSheet(sheet) {}
+
+    /* -------------------------------------------- */
+
+    /**
+     * Build the element's custom CSS.
+     * @param {CSSStyleSheet} sheet  The stylesheet instance to append the CSS to.
+     * @abstract
+     */
+    _buildCSS(sheet) {}
+  }
+}

--- a/module/applications/components/adopted-stylesheet-mixin.mjs
+++ b/module/applications/components/adopted-stylesheet-mixin.mjs
@@ -11,7 +11,13 @@ export default function AdoptedStyleSheetMixin(Base) {
      * @type {WeakMap<WeakKey<Document>, CSSStyleSheet>}
      * @protected
      */
-    static _stylesheets;
+    static _stylesheets = new WeakMap();
+
+    /**
+     * The CSS content for this element.
+     * @type {string}
+     */
+    static CSS = "";
 
     /* -------------------------------------------- */
 
@@ -27,11 +33,10 @@ export default function AdoptedStyleSheetMixin(Base) {
      * @protected
      */
     _getStyleSheet() {
-      this.constructor._stylesheets ??= new WeakMap();
       let sheet = this.constructor._stylesheets.get(this.ownerDocument);
       if ( !sheet ) {
         sheet = new this.ownerDocument.defaultView.CSSStyleSheet();
-        this._buildCSS(sheet);
+        sheet.replaceSync(this.constructor.CSS);
         this.constructor._stylesheets.set(this.ownerDocument, sheet);
       }
       return sheet;
@@ -45,14 +50,5 @@ export default function AdoptedStyleSheetMixin(Base) {
      * @abstract
      */
     _adoptStyleSheet(sheet) {}
-
-    /* -------------------------------------------- */
-
-    /**
-     * Build the element's custom CSS.
-     * @param {CSSStyleSheet} sheet  The stylesheet instance to append the CSS to.
-     * @abstract
-     */
-    _buildCSS(sheet) {}
   }
 }

--- a/module/applications/components/filigree-box.mjs
+++ b/module/applications/components/filigree-box.mjs
@@ -23,6 +23,56 @@ export default class FiligreeBoxElement extends AdoptedStyleSheetMixin(HTMLEleme
     this.#shadowRoot.appendChild(slot);
   }
 
+  /** @inheritDoc */
+  static CSS = `
+    :host {
+      position: relative;
+      isolation: isolate;
+      min-height: 56px;
+      filter: var(--filigree-drop-shadow, drop-shadow(0 0 12px var(--dnd5e-shadow-15)));
+    }
+    .backdrop {
+      --chamfer: 12px;
+      position: absolute;
+      inset: 0;
+      background: var(--filigree-background-color, var(--dnd5e-color-card));
+      z-index: -2;
+      clip-path: polygon(
+        var(--chamfer) 0,
+        calc(100% - var(--chamfer)) 0,
+        100% var(--chamfer),
+        100% calc(100% - var(--chamfer)),
+        calc(100% - var(--chamfer)) 100%,
+        var(--chamfer) 100%,
+        0 calc(100% - var(--chamfer)),
+        0 var(--chamfer)
+      );
+    }
+    .filigree {
+      position: absolute;
+      fill: var(--filigree-border-color, var(--dnd5e-color-gold));
+      z-index: -1;
+
+      &.top, &.bottom { height: 30px; }
+      &.top { top: 0; }
+      &.bottom { bottom: 0; scale: 1 -1; }
+
+      &.left, &.right { width: 25px; }
+      &.left { left: 0; }
+      &.right { right: 0; scale: -1 1; }
+
+      &.bottom.right { scale: -1 -1; }
+    }
+    .filigree.block {
+      inline-size: calc(100% - 50px);
+      inset-inline: 25px;
+    }
+    .filigree.inline {
+      block-size: calc(100% - 60px);
+      inset-block: 30px;
+    }
+  `;
+
   /**
    * Path definitions for the various box corners and edges.
    * @type {object}
@@ -44,60 +94,6 @@ export default class FiligreeBoxElement extends AdoptedStyleSheetMixin(HTMLEleme
   /** @inheritDoc */
   _adoptStyleSheet(sheet) {
     this.#shadowRoot.adoptedStyleSheets = [sheet];
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  _buildCSS(sheet) {
-    sheet.replaceSync(`
-      :host {
-        position: relative;
-        isolation: isolate;
-        min-height: 56px;
-        filter: var(--filigree-drop-shadow, drop-shadow(0 0 12px var(--dnd5e-shadow-15)));
-      }
-      .backdrop {
-        --chamfer: 12px;
-        position: absolute;
-        inset: 0;
-        background: var(--filigree-background-color, var(--dnd5e-color-card));
-        z-index: -2;
-        clip-path: polygon(
-          var(--chamfer) 0,
-          calc(100% - var(--chamfer)) 0,
-          100% var(--chamfer),
-          100% calc(100% - var(--chamfer)),
-          calc(100% - var(--chamfer)) 100%,
-          var(--chamfer) 100%,
-          0 calc(100% - var(--chamfer)),
-          0 var(--chamfer)
-        );
-      }
-      .filigree {
-        position: absolute;
-        fill: var(--filigree-border-color, var(--dnd5e-color-gold));
-        z-index: -1;
-  
-        &.top, &.bottom { height: 30px; }
-        &.top { top: 0; }
-        &.bottom { bottom: 0; scale: 1 -1; }
-  
-        &.left, &.right { width: 25px; }
-        &.left { left: 0; }
-        &.right { right: 0; scale: -1 1; }
-  
-        &.bottom.right { scale: -1 -1; }
-      }
-      .filigree.block {
-        inline-size: calc(100% - 50px);
-        inset-inline: 25px;
-      }
-      .filigree.inline {
-        block-size: calc(100% - 60px);
-        inset-block: 30px;
-      }
-    `);
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/icon.mjs
+++ b/module/applications/components/icon.mjs
@@ -11,6 +11,18 @@ export default class IconElement extends AdoptedStyleSheetMixin(HTMLElement) {
     this.#shadowRoot = this.attachShadow({ mode: "closed" });
   }
 
+  /** @inheritDoc */
+  static CSS = `
+    :host {
+      display: contents;
+    }
+    svg {
+      fill: var(--icon-fill, #000);
+      width: var(--icon-width, var(--icon-size, 1em));
+      height: var(--icon-height, var(--icon-size, 1em));
+    }
+  `;
+
   /**
    * Cached SVG files by SRC.
    * @type {Map<string, SVGElement|Promise<SVGElement>>}
@@ -48,22 +60,6 @@ export default class IconElement extends AdoptedStyleSheetMixin(HTMLElement) {
   /** @inheritDoc */
   _adoptStyleSheet(sheet) {
     this.#shadowRoot.adoptedStyleSheets = [sheet];
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  _buildCSS(sheet) {
-    sheet.replaceSync(`
-      :host {
-        display: contents;
-      }
-      svg {
-        fill: var(--icon-fill, #000);
-        width: var(--icon-width, var(--icon-size, 1em));
-        height: var(--icon-height, var(--icon-size, 1em));
-      }
-    `);
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/proficiency-cycle.mjs
+++ b/module/applications/components/proficiency-cycle.mjs
@@ -15,6 +15,66 @@ export default class ProficiencyCycleElement extends AdoptedStyleSheetMixin(HTML
     this._adoptStyleSheet(this._getStyleSheet());
     this.#value = Number(this.getAttribute("value") ?? 0);
   }
+
+  /** @inheritDoc */
+  static CSS = `
+    :host { display: inline-block; }
+    div { --_fill: var(--proficiency-cycle-enabled-color, var(--dnd5e-color-blue)); }
+    div:has(:disabled, :focus-visible) { --_fill: var(--proficiency-cycle-disabled-color, var(--dnd5e-color-gold)); }
+    div:not(:has(:disabled)) { cursor: pointer; }
+
+    div {
+      position: relative;
+      overflow: clip;
+      width: 100%;
+      aspect-ratio: 1;
+
+      &::before {
+        content: "";
+        position: absolute;
+        display: block;
+        inset: 3px;
+        border: 1px solid var(--_fill);
+        border-radius: 100%;
+      }
+
+      &:has([value="1"])::before { background: var(--_fill); }
+
+      &:has([value="0.5"], [value="2"])::after {
+        content: "";
+        position: absolute;
+        background: var(--_fill);  
+      }
+
+      &:has([value="0.5"])::after {
+        inset: 4px;
+        width: 4px;
+        aspect-ratio: 1 / 2;
+        border-radius: 100% 0 0 100%;
+      }
+
+      &:has([value="2"]) {
+        &::before {
+          inset: 1px;
+          border-width: 2px;
+        }
+
+        &::after {
+          inset: 5px;
+          border-radius: 100%;
+        }
+      }
+    }
+
+    input {
+      position: absolute;
+      inset-block-start: -100px;
+      width: 1px;
+      height: 1px;
+      opacity: 0;
+    }
+  `;
+
   /**
    * Controller for removing listeners automatically.
    * @type {AbortController}
@@ -131,69 +191,6 @@ export default class ProficiencyCycleElement extends AdoptedStyleSheetMixin(HTML
   /** @inheritDoc */
   _adoptStyleSheet(sheet) {
     this.#shadowRoot.adoptedStyleSheets = [sheet];
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  _buildCSS(sheet) {
-    sheet.replaceSync(`
-      :host { display: inline-block; }
-      div { --_fill: var(--proficiency-cycle-enabled-color, var(--dnd5e-color-blue)); }
-      div:has(:disabled, :focus-visible) { --_fill: var(--proficiency-cycle-disabled-color, var(--dnd5e-color-gold)); }
-      div:not(:has(:disabled)) { cursor: pointer; }
-  
-      div {
-        position: relative;
-        overflow: clip;
-        width: 100%;
-        aspect-ratio: 1;
-  
-        &::before {
-          content: "";
-          position: absolute;
-          display: block;
-          inset: 3px;
-          border: 1px solid var(--_fill);
-          border-radius: 100%;
-        }
-  
-        &:has([value="1"])::before { background: var(--_fill); }
-  
-        &:has([value="0.5"], [value="2"])::after {
-          content: "";
-          position: absolute;
-          background: var(--_fill);  
-        }
-  
-        &:has([value="0.5"])::after {
-          inset: 4px;
-          width: 4px;
-          aspect-ratio: 1 / 2;
-          border-radius: 100% 0 0 100%;
-        }
-  
-        &:has([value="2"]) {
-          &::before {
-            inset: 1px;
-            border-width: 2px;
-          }
-  
-          &::after {
-            inset: 5px;
-            border-radius: 100%;
-          }
-        }
-      }
-  
-      input {
-        position: absolute;
-        inset-block-start: -100px;
-        width: 1px;
-        height: 1px;
-        opacity: 0;
-      }
-    `);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
For details of the actual buggy behavior see: https://github.com/League-of-Foundry-Developers/fvtt-module-popout/issues/109

TL;DR - Moving a custom (or otherwise) HTML element to a new window involves adopting it into the new windows document. However any use of constructed CSS (i.e. new CSSStyleSheet) will be silently stripped or fail outright unless we are careful to construct new copies of the CSSStyleSheet object via the new window's constructor.


For custom elements that use constructed CSS, we have to implement the adoptedCallback method and manually reconstruct and reattach a new CSS object to the shadow DOM. This is because when a custom element is moved to a new document, any constructed CSS objects that it has adopted already are silently stripped.

We also need to update how we construct our CSS objects. Specifically we need to ensure we are accessing the current owner document of our custom element, and not bind the root document from which ever window we defined our custom element in.

We also can no longer use a static variable to store our CSS obj, since in Chrome based browsers the static element is shared across windows (though not the case in firefox). So we need to keep a map from document to CSS obj singleton and do the lookup manually.