### PR TITLE
[#2934] Fix issue with active effect de-duplication

### DIFF
--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -23,7 +23,7 @@ export const migrateWorld = async function() {
         }
         await actor.update(updateData, {enforceTypes: false, diff: valid && !flags.persistSourceMigration});
       }
-      if ( actor.effects && actor.items && foundry.utils.isNewerVersion("3.0.0", actor._stats.systemVersion) ) {
+      if ( actor.effects && actor.items && foundry.utils.isNewerVersion("3.0.3", actor._stats.systemVersion) ) {
         const deleteIds = _duplicatedEffects(actor);
         if ( deleteIds.size ) await actor.deleteEmbeddedDocuments("ActiveEffect", Array.from(deleteIds));
       }
@@ -164,13 +164,16 @@ export const migrateCompendium = async function(pack) {
     try {
       const flags = { persistSourceMigration: false };
       const source = doc.toObject();
-      switch (documentName) {
+      switch ( documentName ) {
         case "Actor":
           updateData = migrateActorData(source, migrationData, flags);
           if ( (documentName === "Actor") && source.effects && source.items
-            && foundry.utils.isNewerVersion("3.0.0", source._stats.systemVersion) ) {
+            && foundry.utils.isNewerVersion("3.0.3", source._stats.systemVersion) ) {
             const deleteIds = _duplicatedEffects(source);
-            if ( deleteIds.size ) await doc.deleteEmbeddedDocuments("ActiveEffect", Array.from(deleteIds));
+            if ( deleteIds.size ) {
+              if ( flags.persistSourceMigration ) source.effects = source.effects.filter(e => !deleteIds.has(e._id));
+              else await doc.deleteEmbeddedDocuments("ActiveEffect", Array.from(deleteIds));
+            }
           }
           break;
         case "Item":
@@ -560,7 +563,7 @@ function _duplicatedEffects(parent) {
       if ( !effect.transfer ) continue;
       const match = parent.effects.find(t => {
         const diff = foundry.utils.diffObject(t, effect);
-        return t.origin.endsWith(`Item.${item._id}`) && !("changes" in diff) && !deleteIds.has(t._id);
+        return t.origin?.endsWith(`Item.${item._id}`) && !("changes" in diff) && !deleteIds.has(t._id);
       });
       if ( match ) deleteIds.add(match._id);
     }


### PR DESCRIPTION
First fix was a bug that was thrown if the `origin` on an effect was `null`. The existing check assumed all origins were strings, which would throw an error on `null` origins and prevent checks against subsequent effects from occuring.

The second fix was due to the way the effect de-duplicate worked with the `persistSourceMigration`. The de-duplication operated by calling `deleteEmbeddedDocuments` on the document being migrated to remove the effects, but when `persistSourceMigration` was set it would perform an update on the actor data without diffing resulting in the effects being added back. To fix this we swap to removing the effects from the source data if that flag is set. This fix is only necessary for compendium migrations because world migrations perform the update before the de-duplication.