### PR TITLE
Handle missing size when grabbing config

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1223,6 +1223,8 @@
 "DND5E.SizeSmallAbbr": "Sm",
 "DND5E.SizeTiny": "Tiny",
 "DND5E.SizeTinyAbbr": "Tn",
+"DND5E.SizeUnassigned": "Unassigned",
+"DND5E.SizeUnassignedAbbr": "Un",
 "DND5E.Skill": "Skill",
 "DND5E.Skills": "Skills",
 "DND5E.SkillAcr": "Acrobatics",

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -278,9 +278,10 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     }
 
     // Size
+    const actorSize = CONFIG.DND5E.actorSizes[traits.size] || CONFIG.DND5E.actorSizes.med;
     context.size = {
-      label: CONFIG.DND5E.actorSizes[traits.size].label,
-      abbr: CONFIG.DND5E.actorSizes[traits.size].abbreviation,
+      label: actorSize.label,
+      abbr: actorSize.abbreviation,
       mod: attributes.encumbrance.mod
     };
 

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -278,10 +278,10 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     }
 
     // Size
-    const actorSize = CONFIG.DND5E.actorSizes[traits.size] || CONFIG.DND5E.actorSizes.med;
+    const actorSize = CONFIG.DND5E.actorSizes[traits.size];
     context.size = {
-      label: actorSize.label,
-      abbr: actorSize.abbreviation,
+      label: actorSize?.label || game.i18n.localize("DND5E.SizeUnassigned"),
+      abbr: actorSize?.abbreviation || game.i18n.localize("DND5E.SizeUnassignedAbbr"),
       mod: attributes.encumbrance.mod
     };
 


### PR DESCRIPTION
Fallback for when a custom actor size is added to the config, actors are assigned the custom size, then the custom config is not loaded. In these instances, it will fallback to the medium actor size data. This could alternatively be a placeholder, such as 'Unassigned' as the size isn't actually reassigned when the sheet is opened. Reloading the custom config is likely preferable to having every actor with a custom size actually reverted to medium, but this at least avoids a breaking error when opening the sheet.