### PR TITLE
[#2094] Move actor base data preparation into data models

### DIFF
--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -1,3 +1,4 @@
+import Proficiency from "../../documents/actor/proficiency.mjs";
 import { FormulaField } from "../fields.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
 import SourceField from "../shared/source-field.mjs";
@@ -192,10 +193,36 @@ export default class NPCData extends CreatureTemplate {
   }
 
   /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
 
-  /**
-   * Prepare remaining NPC data.
-   */
+  /** @inheritdoc */
+  prepareBaseData() {
+    const cr = this.details.cr;
+
+    // Attuned items
+    this.attributes.attunement.value = this.parent.items.filter(i => {
+      return i.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED;
+    }).length;
+
+    // Kill Experience
+    this.details.xp ??= {};
+    this.details.xp.value = this.parent.getCRExp(cr);
+
+    // Proficiency
+    this.attributes.prof = Proficiency.calculateMod(Math.max(cr, 1));
+
+    // Spellcaster Level
+    if ( this.attributes.spellcasting && !Number.isNumeric(this.details.spellLevel) ) {
+      this.details.spellLevel = Math.max(cr, 1);
+    }
+
+    AttributesFields.prepareBaseArmorClass.call(this);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
   prepareDerivedData() {
     AttributesFields.prepareExhaustionLevel.call(this);
     AttributesFields.prepareMovement.call(this);

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -88,6 +88,19 @@ export default class AttributesFields {
   /* -------------------------------------------- */
 
   /**
+   * Initialize derived AC fields for Active Effects to target.
+   * @this {CharacterData|NPCData|VehicleData}
+   */
+  static prepareBaseArmorClass() {
+    const ac = this.attributes.ac;
+    ac.armor = 10;
+    ac.shield = ac.cover = 0;
+    ac.bonus = "";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Adjust exhaustion level based on Active Effects.
    * @this {CharacterData|NPCData}
    */

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -141,6 +141,16 @@ export default class VehicleData extends CommonTemplate {
       source.details.source = { custom: source.details.source };
     }
   }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareBaseData() {
+    this.attributes.prof = 0;
+    AttributesFields.prepareBaseArmorClass.call(this);
+  }
 }
 
 /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -102,24 +102,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     this.items.forEach(item => item.prepareFinalAttributes());
   }
 
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  prepareBaseData() {
-    if ( !game.template.Actor.types.includes(this.type) ) return;
-    if ( this.type !== "group" ) this._prepareBaseArmorClass();
-
-    // Type-specific preparation
-    switch ( this.type ) {
-      case "character":
-        return this._prepareCharacterData();
-      case "npc":
-        return this._prepareNPCData();
-      case "vehicle":
-        return this._prepareVehicleData();
-    }
-  }
-
   /* --------------------------------------------- */
 
   /** @inheritDoc */
@@ -233,20 +215,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
-   * Initialize derived AC fields for Active Effects to target.
-   * Mutates the system.attributes.ac object.
-   * @protected
-   */
-  _prepareBaseArmorClass() {
-    const ac = this.system.attributes.ac;
-    ac.armor = 10;
-    ac.shield = ac.cover = 0;
-    ac.bonus = "";
-  }
-
-  /* -------------------------------------------- */
-
-  /**
    * Derive any values that have been scaled by the Advancement system.
    * Mutates the value of the `system.scale` object.
    * @protected
@@ -256,86 +224,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       if ( ScaleValueAdvancement.metadata.validItemTypes.has(item.type) ) scale[item.identifier] = item.scaleValues;
       return scale;
     }, {});
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Perform any Character specific preparation.
-   * Mutates several aspects of the system data object.
-   * @protected
-   */
-  _prepareCharacterData() {
-    this.system.details.level = 0;
-    this.system.attributes.hd = 0;
-    this.system.attributes.attunement.value = 0;
-
-    for ( const item of this.items ) {
-      // Class levels & hit dice
-      if ( item.type === "class" ) {
-        const classLevels = parseInt(item.system.levels) || 1;
-        this.system.details.level += classLevels;
-        this.system.attributes.hd += classLevels - (parseInt(item.system.hitDiceUsed) || 0);
-      }
-
-      // Attuned items
-      else if ( item.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED ) {
-        this.system.attributes.attunement.value += 1;
-      }
-    }
-
-    // Character proficiency bonus
-    this.system.attributes.prof = Proficiency.calculateMod(this.system.details.level);
-
-    // Experience required for next level
-    const { xp, level } = this.system.details;
-    xp.max = this.getLevelExp(level || 1);
-    xp.min = level ? this.getLevelExp(level - 1) : 0;
-    if ( level >= CONFIG.DND5E.CHARACTER_EXP_LEVELS.length ) xp.pct = 100;
-    else {
-      const required = xp.max - xp.min;
-      const pct = Math.round((xp.value - xp.min) * 100 / required);
-      xp.pct = Math.clamped(pct, 0, 100);
-    }
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Perform any NPC specific preparation.
-   * Mutates several aspects of the system data object.
-   * @protected
-   */
-  _prepareNPCData() {
-    const cr = this.system.details.cr;
-
-    // Attuned items
-    this.system.attributes.attunement.value = this.items.filter(i => {
-      return i.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED;
-    }).length;
-
-    // Kill Experience
-    this.system.details.xp ??= {};
-    this.system.details.xp.value = this.getCRExp(cr);
-
-    // Proficiency
-    this.system.attributes.prof = Proficiency.calculateMod(Math.max(cr, 1));
-
-    // Spellcaster Level
-    if ( this.system.attributes.spellcasting && !Number.isNumeric(this.system.details.spellLevel) ) {
-      this.system.details.spellLevel = Math.max(cr, 1);
-    }
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Perform any Vehicle specific preparation.
-   * Mutates several aspects of the system data object.
-   * @protected
-   */
-  _prepareVehicleData() {
-    this.system.attributes.prof = 0;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Moves the base data preparation methods in `Actor5e` into their respective data models.