### PR TITLE
[#3058] Fix bad spacing with alternate font sizes

### DIFF
--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -176,8 +176,8 @@
     box-shadow: 0 0 12px var(--dnd5e-shadow-15);
     display: flex;
     align-items: center;
-    gap: .5rem;
-    padding: .5rem;
+    gap: 8px;
+    padding: 8px;
     height: 50px;
     max-width: 280px;
     position: relative;
@@ -439,7 +439,7 @@
     font-weight: bold;
     font-size: var(--font-size-13);
     text-transform: uppercase;
-    padding: .1875rem;
+    padding: 3px;
     border: 1px solid var(--color-border-light-2);
     box-shadow: 0 0 8px var(--dnd5e-shadow-15);
     display: flex;
@@ -543,8 +543,8 @@
   /* Pips */
   .pips {
     display: flex;
-    gap: .3125rem;
-    padding: .625rem .75rem;
+    gap: 5px;
+    padding: 10px 12px;
 
     .pip {
       background: var(--dnd5e-color-light-gray);
@@ -891,7 +891,7 @@
   background: transparent;
   color: var(--dnd5e-color-black);
   overflow: hidden;
-  font-size: var(--font-size-16);
+  font-size: 16px;
   cursor: nwse-resize;
   opacity: .4;
 

--- a/less/v2/character.less
+++ b/less/v2/character.less
@@ -278,7 +278,7 @@
       display: flex;
       justify-content: end;
       align-items: center;
-      padding-right: .75rem;
+      padding-right: 12px;
       background: var(--dnd5e-color-black);
       color: var(--dnd5e-color-gold);
       --icon-fill: var(--dnd5e-color-gold);
@@ -298,7 +298,7 @@
       &::after {
         content: "";
         position: absolute;
-        inset: .25rem .25rem .25rem 0;
+        inset: 4px 4px 4px 0;
         border-radius: 0 5px 5px 0;
         border: 1px solid var(--dnd5e-color-gold);
         border-left: none;
@@ -323,10 +323,10 @@
     .main-content {
       display: grid;
       grid-template-columns: var(--dnd5e-sheet-sidebar-width) 1fr;
-      gap: .75rem;
+      gap: 12px;
       position: absolute;
       inset: 0;
-      padding: .5rem;
+      padding: 8px;
       overflow: hidden auto;
       scrollbar-width: thin;
       scrollbar-color: var(--dnd5e-color-scrollbar) transparent;
@@ -347,7 +347,7 @@
     .sidebar {
       display: flex;
       flex-direction: column;
-      gap: 1rem;
+      gap: 16px;
       transition: margin-left 450ms ease;
 
       /* Character Card */
@@ -387,7 +387,7 @@
 
           > i {
             color: var(--dnd5e-color-gold);
-            font-size: var(--font-size-12);
+            font-size: 12px;
             margin: 0;
           }
         }
@@ -639,7 +639,7 @@
           display: flex;
           flex-direction: column;
           align-items: center;
-          padding: 0 .5rem;
+          padding: 0 8px;
           position: absolute;
           width: 100%;
           top: calc(100% - var(--tray-height));
@@ -649,7 +649,7 @@
           &.open { top: calc(100% - var(--lip)); }
 
           .death-saves {
-            --padding: .375rem;
+            --padding: 6px;
             background: black;
             border-radius: 0 0 5px 5px;
             box-shadow: 0 0 6px var(--color-shadow-dark);
@@ -1103,12 +1103,12 @@
     position: absolute;
     top: 0;
     right: 0;
-    left: calc(var(--dnd5e-sheet-sidebar-width) + 1.25rem);
+    left: calc(var(--dnd5e-sheet-sidebar-width) + 18px);
     pointer-events: none;
     container-type: inline-size;
 
     .rows {
-      padding: 4.75rem 0 4.75rem 1.5rem;
+      padding: 76px 0 76px 24px;
       display: flex;
       flex-wrap: wrap;
       width: 546px;
@@ -1116,7 +1116,7 @@
 
       > div {
         display: flex;
-        gap: 1.375rem;
+        gap: 22px;
       }
     }
 
@@ -1124,8 +1124,7 @@
       width: unset;
       margin: 0;
       justify-content: center;
-      padding-left: .75rem;
-      padding-right: .75rem;
+      padding-inline: 12px;
     }
 
     .top {
@@ -1143,7 +1142,7 @@
       justify-content: space-between;
       align-items: center;
       font-family: var(--dnd5e-font-roboto);
-      padding-top: .75rem;
+      padding-top: 12px;
       filter: drop-shadow(0 0 6px var(--dnd5e-shadow-45));
       pointer-events: all;
 
@@ -1160,10 +1159,10 @@
       }
 
       &.flipped {
-        padding: 0 0 .5rem 0;
+        padding: 0 0 8px 0;
         height: 72px;
         justify-content: start;
-        gap: .125rem;
+        gap: 2px;
 
         &::before { transform: scaleY(-1); }
         .mod { padding: 0; }
@@ -1190,26 +1189,26 @@
         font-weight: bold;
         color: var(--dnd5e-color-black);
         font-size: var(--font-size-16);
-        padding: .1875rem 0;
+        padding: 3px 0;
       }
 
       .score {
         width: 50px;
         height: 23px;
-        padding: .25rem;
+        padding: 4px;
         text-align: center;
         font-size: var(--font-size-13);
         color: var(--dnd5e-color-gold);
         background: black;
         border-radius: 3px;
-        margin-top: -.125rem;
+        margin-top: -2px;
 
         @media (prefers-contrast: more) {
           color: var(--color-text-light-1);
         }
 
         > input {
-          padding: .25rem;
+          padding: 4px;
           color: var(--dnd5e-color-gold);
           width: 50px;
           height: 23px;
@@ -1227,8 +1226,8 @@
     @container (min-width: 700px) {
       .rows {
         justify-content: center;
-        gap: 1.375rem;
-        padding-top: 9.25rem;
+        gap: 22px;
+        padding-top: 148px;
         width: unset;
         margin: 0;
 
@@ -1240,16 +1239,16 @@
         }
 
         .ability-score.flipped {
-          padding: .75rem 0 0;
+          padding: 12px 0 0;
           height: 64px;
           justify-content: space-between;
           gap: unset;
 
           &::before { transform: unset; }
-          .mod { padding: .1875rem 0; }
+          .mod { padding: 3px 0; }
 
           .score {
-            margin: -.125rem 0 0;
+            margin: -2px 0 0;
             order: unset;
           }
         }
@@ -1558,7 +1557,7 @@
     }
 
     .sheet-header > .left:is(.optional-ability-1, .optional-ability-2) {
-      padding-right: 1.5rem;
+      padding-right: 24px;
       .document-name { font-size: var(--font-size-46); }
     }
 


### PR DESCRIPTION
Swapped a bunch of relative units used for spacing and positioning with absolute ones to fix the worst of the layout issues at alternate font sizes. Font size can go down as low as 1 and everything still lays out fine, but it still has some issues going much higher than 7.

### Font Size 3

<img width="400" alt="Character Sheet - Font Size 3 (before)" src="https://github.com/foundryvtt/dnd5e/assets/19979839/eb80c0d4-e22d-4953-ad60-a80d3b8a7e7e">
<img width="400" alt="Character Sheet - Font Size 3 (after)" src="https://github.com/foundryvtt/dnd5e/assets/19979839/48618c13-079b-4253-a4c1-31817e14686c">


### Font Size 7

<img width="400" alt="Character Sheet - Font Size 7 (before)" src="https://github.com/foundryvtt/dnd5e/assets/19979839/911725a3-3639-4b32-b0b9-b0cfce666728">
<img width="400" alt="Character Sheet - Font Size 7 (after)" src="https://github.com/foundryvtt/dnd5e/assets/19979839/bc35eba1-6536-48df-ac4b-7ac5252e8c6f">
