### PR TITLE
[#3029] Add 'concentration' object in actor system data

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -283,6 +283,7 @@
 "DND5E.AdvancementTraitModeUpgradeHint": "Gain proficiency in a trait unless you already have it, otherwise gain expertise.",
 "DND5E.AdvancementTraitType": "Trait Type",
 "DND5E.Advantage": "Advantage",
+"DND5E.AdvantageMode": "Advantage Mode",
 "DND5E.Age": "Age",
 "DND5E.Alignment": "Alignment",
 "DND5E.AlignmentCE": "Chaotic Evil",
@@ -328,6 +329,9 @@
 "DND5E.AttackPl": "Attacks",
 "DND5E.AttackRoll": "Attack Roll",
 "DND5E.Attributes": "Attributes",
+"DND5E.AttrConcentration": {
+  "Limit": "Limit"
+},
 "DND5E.Automatic": "Automatic",
 "DND5E.AutomaticValue": "Automatic ({value})",
 "DND5E.Award": {
@@ -1023,6 +1027,8 @@
 "DND5E.MaxCharacterLevelExceededWarn": "Character cannot be advanced past level {max}.",
 "DND5E.MaxClassLevelExceededWarn": "Class cannot be advanced past level {max}.",
 "DND5E.MaxClassLevelMinimumWarn": "Class must have at least one level.",
+"DND5E.Maximum": "Maximum",
+"DND5E.Minimum": "Minimum",
 "DND5E.Modifier": "Modifier",
 "DND5E.ModuleArtConfigH": "Configure which module-provided art should be used.",
 "DND5E.ModuleArtConfigL": "Configure Art",

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -2,6 +2,7 @@ import { FormulaField } from "../../fields.mjs";
 import MovementField from "../../shared/movement-field.mjs";
 import SensesField from "../../shared/senses-field.mjs";
 import ActiveEffect5e from "../../../documents/active-effect.mjs";
+import RollConfigField from "../../shared/roll-config-field.mjs";
 
 /**
  * Shared contents of the attributes schema between various actor types.
@@ -12,8 +13,8 @@ export default class AttributesFields {
    *
    * @type {object}
    * @property {object} init
-   * @property {number} init.value       Calculated initiative modifier.
-   * @property {number} init.bonus       Fixed bonus provided to initiative rolls.
+   * @property {string} init.ability     The ability used for initiative rolls.
+   * @property {string} init.bonus       The bonus provided to initiative rolls.
    * @property {object} movement
    * @property {number} movement.burrow  Actor burrowing speed.
    * @property {number} movement.climb   Actor climbing speed.
@@ -40,15 +41,24 @@ export default class AttributesFields {
    *
    * @type {object}
    * @property {object} attunement
-   * @property {number} attunement.max      Maximum number of attuned items.
+   * @property {number} attunement.max          Maximum number of attuned items.
    * @property {object} senses
-   * @property {number} senses.darkvision   Creature's darkvision range.
-   * @property {number} senses.blindsight   Creature's blindsight range.
-   * @property {number} senses.tremorsense  Creature's tremorsense range.
-   * @property {number} senses.truesight    Creature's truesight range.
-   * @property {string} senses.units        Distance units used to measure senses.
-   * @property {string} senses.special      Description of any special senses or restrictions.
-   * @property {string} spellcasting        Primary spellcasting ability.
+   * @property {number} senses.darkvision       Creature's darkvision range.
+   * @property {number} senses.blindsight       Creature's blindsight range.
+   * @property {number} senses.tremorsense      Creature's tremorsense range.
+   * @property {number} senses.truesight        Creature's truesight range.
+   * @property {string} senses.units            Distance units used to measure senses.
+   * @property {string} senses.special          Description of any special senses or restrictions.
+   * @property {string} spellcasting            Primary spellcasting ability.
+   * @property {number} exhaustion              Creature's exhaustion level.
+   * @property {object} concentration
+   * @property {string} concentration.ability   The ability used for concentration saving throws.
+   * @property {string} concentration.bonus     The bonus provided to concentration saving throws.
+   * @property {number} concentration.limit     The amount of items this actor can concentrate on.
+   * @property {number} concentration.mode      The default advantage mode for this actor's concentration saving throws.
+   * @property {object} concentration.roll
+   * @property {number} concentration.roll.min  The minimum the d20 can roll.
+   * @property {number} concentration.roll.max  The maximum the d20 can roll.
    */
   static get creature() {
     return {
@@ -63,7 +73,10 @@ export default class AttributesFields {
       }),
       exhaustion: new foundry.data.fields.NumberField({
         required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.Exhaustion"
-      })
+      }),
+      concentration: new RollConfigField({
+        limit: new foundry.data.fields.NumberField({integer: true, min: 0, initial: 1, label: "DND5E.AttrConcentration.Limit"})
+      }, {label: "DND5E.Concentration"})
     };
   }
 

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -1,0 +1,23 @@
+import {FormulaField} from "../fields.mjs";
+
+const { StringField, NumberField, SchemaField } = foundry.data.fields;
+
+/**
+ * Field for storing data for a specific type of roll.
+ */
+export default class RollConfigField extends foundry.data.fields.SchemaField {
+  constructor(fields={}, options={}) {
+    const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
+    fields = {
+      ability: new StringField({required: true, label: "DND5E.AbilityModifier"}),
+      bonus: new FormulaField({required: true, label: "DND5E.Bonus"}),
+      mode: new NumberField({choices: [-1, 0, 1], initial: 0, label: "DND5E.AdvantageMode"}),
+      roll: new SchemaField({
+        min: new NumberField({...opts, label: "DND5E.Minimum"}),
+        max: new NumberField({...opts, label: "DND5E.Maximum"})
+      }),
+      ...fields
+    };
+    super(fields, options);
+  }
+}


### PR DESCRIPTION
This introduces a `RollConfig` field which shares some common data that all similar fields can have (eg initiative, skills, abilities).

The `concentration` property is for `creatures` only.

(Also fixes the documentation for the `init` property.)

```js
  /*
   * @property {object} concentration
   * @property {string} concentration.ability   The ability used for concentration saving throws.
   * @property {string} concentration.bonus     The bonus provided to concentration saving throws.
   * @property {number} concentration.limit     The amount of items this actor can concentrate on.
   * @property {number} concentration.mode      The default advantage mode for this actor's concentration saving throws.
   * @property {object} concentration.roll
   * @property {number} concentration.roll.min  The minimum the d20 can roll.
   * @property {number} concentration.roll.max  The maximum the d20 can roll.
   */
```