### PR TITLE
[#3075] Prevent duplicate targets from same actor and errors on missing actors or attributes

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1497,12 +1497,13 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @protected
    */
   _formatAttackTargets() {
-    const targets = [];
+    const targets = new Map();
     for ( const token of game.user.targets ) {
       const { name, img, system, uuid } = token.actor ?? {};
-      if ( uuid ) targets.push({ name, img, uuid, ac: system.attributes.ac.value });
+      const ac = system?.attributes?.ac ?? {};
+      if ( uuid && Number.isNumeric(ac.value) ) targets.set(uuid, { name, img, uuid, ac: ac.value });
     }
-    return targets;
+    return Array.from(targets.values());
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Currently the `_formatAttackTargets` method errors if the actor is missing (in which case `system` is undefined), if `attributes` is undefined due to a module subtype, or if `ac` is undefined (for both module subtypes as well as group actors).

If one linked actor has multiple tokens, these also ended up being added twice, which made little sense.

Closes #3075.