### PR TITLE
[#2849] Display damage modification on sheet, add configuration app

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -563,6 +563,11 @@
 "DND5E.DamageFire": "Fire",
 "DND5E.DamageForce": "Force",
 "DND5E.DamageLightning": "Lightning",
+"DND5E.DamageModification": {
+  "Label": "Damage Modification",
+  "Hint": "Formulas for amount that will be added to typed damage applied to this actor. Negative values will reduce the damage taken.",
+  "BypassHint": "These weapon properties will bypass damage modification for physical damage."
+},
 "DND5E.DamageNecrotic": "Necrotic",
 "DND5E.DamagePiercing": "Piercing",
 "DND5E.DamagePhysical": "Non-Magical Physical",

--- a/lang/en.json
+++ b/lang/en.json
@@ -565,7 +565,7 @@
 "DND5E.DamageLightning": "Lightning",
 "DND5E.DamageModification": {
   "Label": "Damage Modification",
-  "Hint": "Formulas for amount that will be added to typed damage applied to this actor. Negative values will reduce the damage taken.",
+  "Hint": "Formulas for amounts that will be added to typed damage applied to this actor. Negative values will reduce the damage taken.",
   "BypassHint": "These weapon properties will bypass damage modification for physical damage."
 },
 "DND5E.DamageNecrotic": "Necrotic",

--- a/less/v1/apps.less
+++ b/less/v1/apps.less
@@ -567,7 +567,7 @@ dnd5e-effects {
 /* ----------------------------------------- */
 
 .trait-selector {
-  max-height: 700px;
+  max-height: 80vh;
 
   form {
     overflow: hidden;
@@ -599,6 +599,18 @@ dnd5e-effects {
   input[type="text"] {
     height: 24px;
     margin: 2px;
+  }
+}
+
+.damage-modification {
+  .modifications label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    input {
+      flex: 0 0 150px;
+    }
   }
 }
 

--- a/less/v1/apps.less
+++ b/less/v1/apps.less
@@ -583,7 +583,9 @@ dnd5e-effects {
   .trait-list {
     list-style: none;
     margin: 0;
+    margin-block-end: 6px;
     padding: 0;
+    padding-block-end: 6px;
 
     li ol.trait-list {
       margin-left: 1.5em;

--- a/module/applications/actor/_module.mjs
+++ b/module/applications/actor/_module.mjs
@@ -8,6 +8,7 @@ export {default as GroupActorSheet} from "./group-sheet.mjs";
 export {default as BaseConfigSheet} from "./base-config.mjs";
 export {default as ActorAbilityConfig} from "./ability-config.mjs";
 export {default as ActorArmorConfig} from "./armor-config.mjs";
+export {default as DamageModificationConfig} from "./damage-modification-config.mjs";
 export {default as ActorHitDiceConfig} from "./hit-dice-config.mjs";
 export {default as ActorHitPointsConfig} from "./hit-points-config.mjs";
 export {default as ActorSpellSlotsConfig} from "./spell-slots-config.mjs";

--- a/module/applications/actor/armor-config.mjs
+++ b/module/applications/actor/armor-config.mjs
@@ -22,8 +22,7 @@ export default class ActorArmorConfig extends BaseConfigSheet {
       classes: ["dnd5e", "actor-armor-config"],
       template: "systems/dnd5e/templates/apps/actor-armor.hbs",
       width: 320,
-      height: "auto",
-      sheetConfig: false
+      height: "auto"
     });
   }
 

--- a/module/applications/actor/base-config.mjs
+++ b/module/applications/actor/base-config.mjs
@@ -4,6 +4,16 @@
  * @abstract
  */
 export default class BaseConfigSheet extends DocumentSheet {
+
+  /** @inheritDoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      sheetConfig: false
+    });
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritdoc */
   activateListeners(html) {
     super.activateListeners(html);
@@ -26,5 +36,21 @@ export default class BaseConfigSheet extends DocumentSheet {
    */
   _getActorOverrides() {
     return Object.keys(foundry.utils.flattenObject(this.object.overrides || {}));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Helper method to add choices that have been overridden.
+   * @param {string} prefix       The initial form prefix under which the choices are grouped.
+   * @param {string} path         Path in actor data.
+   * @param {string[]} overrides  The list of fields that are currently modified by Active Effects. *Will be mutated.*
+   * @internal
+   */
+  _addOverriddenChoices(prefix, path, overrides) {
+    const source = new Set(foundry.utils.getProperty(this.document._source, path) ?? []);
+    const current = foundry.utils.getProperty(this.document, path) ?? new Set();
+    const delta = current.symmetricDifference(source);
+    for ( const choice of delta ) overrides.push(`${prefix}.${choice}`);
   }
 }

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -11,6 +11,7 @@ import ActorMovementConfig from "./movement-config.mjs";
 import ActorSensesConfig from "./senses-config.mjs";
 import ActorSheetFlags from "./sheet-flags.mjs";
 import ActorTypeConfig from "./type-config.mjs";
+import DamageModificationConfig from "./damage-modification-config.mjs";
 import SourceConfig from "../source-config.mjs";
 
 import AdvancementManager from "../advancement/advancement-manager.mjs";
@@ -1175,6 +1176,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
     event.preventDefault();
     const trait = event.currentTarget.dataset.trait;
     if ( trait === "tool" ) return new ToolSelector(this.actor, trait).render(true);
+    else if ( trait === "dm" ) return new DamageModificationConfig(this.actor).render(true);
     return new TraitSelector(this.actor, trait).render(true);
   }
 

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -1,7 +1,7 @@
 import CharacterData from "../../data/actor/character.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
 import { setTheme } from "../../settings.mjs";
-import { simplifyBonus, staticID } from "../../utils.mjs";
+import { formatNumber, simplifyBonus, staticID } from "../../utils.mjs";
 import ContextMenu5e from "../context-menu.mjs";
 import SheetConfig5e from "../sheet-config.mjs";
 import Tabs5e from "../tabs.mjs";
@@ -455,6 +455,25 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
       traits.di.push(...traits.ci);
       delete traits.ci;
     }
+
+    // Prepare damage modifications
+    const dm = this.actor.system.traits?.dm;
+    if ( dm ) {
+      const rollData = this.actor.getRollData({ deterministic: true });
+      const values = Object.entries(dm.amount).map(([k, v]) => {
+        const total = simplifyBonus(v, rollData);
+        if ( !total ) return null;
+        const value = {
+          label: `${CONFIG.DND5E.damageTypes[k]?.label ?? key} ${formatNumber(total, { signDisplay: "always" })}`,
+          color: total < 0 ? "maroon" : "green"
+        };
+        const icons = value.icons = [];
+        if ( dm.bypasses.size && CONFIG.DND5E.damageTypes[k]?.isPhysical ) icons.push(...dm.bypasses);
+        return value;
+      }).filter(f => f);
+      if ( values.length ) traits.dm = values;
+    }
+
     return traits;
   }
 

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -465,7 +465,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
         if ( !total ) return null;
         const value = {
           label: `${CONFIG.DND5E.damageTypes[k]?.label ?? key} ${formatNumber(total, { signDisplay: "always" })}`,
-          color: total < 0 ? "maroon" : "green"
+          color: total > 0 ? "maroon" : "green"
         };
         const icons = value.icons = [];
         if ( dm.bypasses.size && CONFIG.DND5E.damageTypes[k]?.isPhysical ) icons.push(...dm.bypasses);

--- a/module/applications/actor/damage-modification-config.mjs
+++ b/module/applications/actor/damage-modification-config.mjs
@@ -1,0 +1,70 @@
+import { filteredKeys } from "../../utils.mjs";
+import BaseConfig from "./base-config.mjs";
+
+/**
+ * Configuration app for damage modification.
+ */
+export default class DamageModificationConfig extends BaseConfig {
+
+  /** @inheritDoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["dnd5e", "damage-modification", "trait-selector", "subconfig"],
+      template: "systems/dnd5e/templates/apps/damage-modification-config.hbs",
+      width: 320,
+      height: "auto"
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  get title() {
+    return game.i18n.localize("DND5E.DamageModification.Label");
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async getData(options={}) {
+    const context = await super.getData(options);
+    const data = foundry.utils.getProperty(this.document, "system.traits.dm");
+    context.bypasses = Object.entries(CONFIG.DND5E.itemProperties).reduce((obj, [k, v]) => {
+      if ( v.isPhysical ) obj[k] = { ...v, chosen: data.bypasses.has(k) };
+      return obj;
+    }, {});
+    context.modifications = Object.entries(CONFIG.DND5E.damageTypes).reduce((obj, [k, v]) => {
+      obj[k] = {
+        ...v,
+        value: data.amount[k]
+      };
+      return obj;
+    }, {});
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _getActorOverrides() {
+    const overrides = super._getActorOverrides();
+    this._addOverriddenChoices("system.traits.dm.bypasses", "system.traits.dm.bypasses", overrides);
+    return overrides;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _getSubmitData(updateData) {
+    const data = foundry.utils.expandObject(super._getSubmitData(updateData));
+    const formData = {};
+    for ( const [type, formula] of Object.entries(foundry.utils.getProperty(data, "system.traits.dm.amount")) ) {
+      if ( formula ) formData[`system.traits.dm.amount.${type}`] = formula;
+      else formData[`system.traits.dm.amount.-=${type}`] = "";
+    }
+    formData["system.traits.dm.bypasses"] = filteredKeys(
+      foundry.utils.getProperty(data, "system.traits.dm.bypasses") ?? {}
+    );
+    return formData;
+  }
+}

--- a/module/applications/actor/hit-points-config.mjs
+++ b/module/applications/actor/hit-points-config.mjs
@@ -22,8 +22,7 @@ export default class ActorHitPointsConfig extends BaseConfigSheet {
       classes: ["dnd5e", "actor-hit-points-config"],
       template: "systems/dnd5e/templates/apps/hit-points-config.hbs",
       width: 320,
-      height: "auto",
-      sheetConfig: false
+      height: "auto"
     });
   }
 

--- a/module/applications/actor/movement-config.mjs
+++ b/module/applications/actor/movement-config.mjs
@@ -12,7 +12,6 @@ export default class ActorMovementConfig extends BaseConfigSheet {
       template: "systems/dnd5e/templates/apps/movement-config.hbs",
       width: 300,
       height: "auto",
-      sheetConfig: false,
       keyPath: "system.attributes.movement"
     });
   }

--- a/module/applications/actor/trait-selector.mjs
+++ b/module/applications/actor/trait-selector.mjs
@@ -38,7 +38,6 @@ export default class TraitSelector extends BaseConfigSheet {
       template: "systems/dnd5e/templates/apps/trait-selector.hbs",
       width: 320,
       height: "auto",
-      sheetConfig: false,
       allowCustom: true
     });
   }
@@ -95,28 +94,13 @@ export default class TraitSelector extends BaseConfigSheet {
   _getActorOverrides() {
     const overrides = super._getActorOverrides();
     const path = Trait.actorKeyPath(this.trait);
-    this.#addOverriddenChoices("choices", Trait.changeKeyPath(this.trait), overrides);
-    this.#addOverriddenChoices("bypasses", `${path}.bypasses`, overrides);
+    this._addOverriddenChoices("choices", Trait.changeKeyPath(this.trait), overrides);
+    this._addOverriddenChoices("bypasses", `${path}.bypasses`, overrides);
     const pathCustom = `${path}.custom`;
     const sourceCustom = foundry.utils.getProperty(this.document._source, pathCustom);
     const currentCustom = foundry.utils.getProperty(this.document, pathCustom);
     if ( sourceCustom !== currentCustom ) overrides.push(pathCustom);
     return overrides;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Add choices that have been overridden.
-   * @param {string} prefix       The initial form prefix under which the choices are grouped.
-   * @param {string} path         Path in actor data.
-   * @param {string[]} overrides  The list of fields that are currently modified by Active Effects. *Will be mutated.*
-   */
-  #addOverriddenChoices(prefix, path, overrides) {
-    const source = new Set(foundry.utils.getProperty(this.document._source, path) ?? []);
-    const current = foundry.utils.getProperty(this.document, path) ?? new Set();
-    const delta = current.symmetricDifference(source);
-    for ( const choice of delta ) overrides.push(`${prefix}.${choice}`);
   }
 
   /* -------------------------------------------- */

--- a/templates/actors/tabs/character-details.hbs
+++ b/templates/actors/tabs/character-details.hbs
@@ -56,7 +56,7 @@
         </h3>
         <ul class="pills">
             {{#each values}}
-            <li class="pill {{ ../color }}">
+            <li class="pill {{ ../color }} {{ color }}">
                 {{#each icons}}
                 {{#with (lookup (lookup @root.config.itemProperties this) "label") as |label|}}
                 <i class="{{ ../this }}" data-tooltip="{{ localize 'DND5E.DamagePhysicalBypassesShort' type=label }}"
@@ -250,6 +250,9 @@
 
         {{!-- Vulnerabilities --}}
         {{> "traits" values=traits.dv key="dv" color="maroon" icon="fas fa-heart-crack" label="DND5E.Vulnerabilities" }}
+
+        {{!-- Damage Modification --}}
+        {{> "traits" values=traits.dm key="dm" icon="fas fa-heart-circle-plus" label="DND5E.DamageModification.Label" }}
 
         {{!-- Armor --}}
         {{> "traits" values=traits.armor key="armor" svg="checked-shield" label="DND5E.Armor" }}

--- a/templates/apps/damage-modification-config.hbs
+++ b/templates/apps/damage-modification-config.hbs
@@ -1,0 +1,22 @@
+<form autocomplete="off">
+    <h3>{{ localize "DND5E.DamageTypes" }}</h3>
+    <p class="note">{{ localize "DND5E.DamageModification.Hint" }}</p>
+    <ol class="trait-list modifications">
+        {{#each modifications}}
+        <li>
+            <label>
+                {{ label }}
+                <input type="text" name="system.traits.dm.amount.{{ @key }}" value="{{ value }}"
+            </label>
+        </li>
+        {{/each}}
+    </ol>
+
+    <h3>{{ localize "DND5E.DamagePhysicalBypass" }}</h3>
+    <p class="note">{{ localize "DND5E.DamageModification.BypassHint" }}</p>
+    {{> "dnd5e.trait-list" choices=bypasses prefix="system.traits.dm.bypasses" }}
+
+    <button type="submit" name="submit" value="1">
+        <i class="fa-regular fa-save"></i> {{ localize "DND5E.TraitSave" }}
+    </button>
+</form>


### PR DESCRIPTION
Displays damage modifications on the sheet beneath vulnerabilities:

<img width="283" alt="Damage Modification Display" src="https://github.com/foundryvtt/dnd5e/assets/19979839/8670b9c5-b1f2-4e22-b42f-0e889070e471">

And provides a new configuration application for setting them:

<img width="332" alt="Damage Modification Config" src="https://github.com/foundryvtt/dnd5e/assets/19979839/f94d5739-9d88-4b07-a96c-86d328e2a666">

Closes #2849