### PR TITLE
[#893] Add data model & configuration data for summoning

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1369,42 +1369,42 @@
     "Configure": "Configure Summons",
     "Remove": "Remove Profile"
   },
-  "ActorChanges": {
-    "Label": "Actor Changes",
-    "Hint": "Changes that will be made to the actor being summoned. Any @ references used in the following formulas will be based on the summoner’s stats."
-  },
   "ArmorClass": {
     "Label": "Bonus Armor Class",
-    "Hint": "Bonus to the Armor Class set on the summoned actor added to what is specified in their statblock."
+    "Hint": "Bonus to the Armor Class set on the summoned creature added to what is specified in their statblock."
   },
   "Configuration": "Summoning Configuration",
+  "CreatureChanges": {
+    "Label": "Creature Changes",
+    "Hint": "Changes that will be made to the creature being summoned. Any @ references used in the following formulas will be based on the summoner's stats."
+  },
   "DisplayName": "Display Name",
-  "DropHint": "Drop actor here",
+  "DropHint": "Drop creature here",
   "HitPoints": {
     "Label": "Bonus Hit Points",
-    "Hint": "Additional hit points added to the actor on top of what is specified in their statblock."
+    "Hint": "Additional hit points added to the creature on top of what is specified in their statblock."
   },
   "ItemChanges": {
     "Label": "Item Changes",
-    "Hint": "Changes made to items on the summoned actor."
+    "Hint": "Changes made to items on the summoned creature."
   },
   "Match": {
     "Attacks": {
       "Label": "Match Attacks",
-      "Hint": "Modify to hit values on the summoned actor’s attacks to match that of the summoner."
+      "Hint": "Modify to hit values on the summoned creature's attacks to match that of the summoner."
     },
     "Proficiency": {
       "Label": "Match Proficiency",
-      "Hint": "Modify the summoned actor’s proficiency to match that of the summoner."
+      "Hint": "Modify the summoned creature's proficiency to match that of the summoner."
     },
     "Saves": {
       "Label": "Match Saves",
-      "Hint": "Modify to saving throw DCs on the summoned actor’s abilities to match that of the summoner."
+      "Hint": "Modify to saving throw DCs on the summoned creature's abilities to match that of the summoner."
     }
   },
   "Profile": {
     "Label": "Summons Profiles",
-    "Empty": "Click above to add a profile or drop an actor to summon here."
+    "Empty": "Click above to add a profile or drop an creature to summon here."
   }
 },
 "DND5E.Supply": "Supply",

--- a/lang/en.json
+++ b/lang/en.json
@@ -135,6 +135,7 @@
 "DND5E.ActionRSAK": "Ranged Spell Attack",
 "DND5E.ActionRWAK": "Ranged Weapon Attack",
 "DND5E.ActionSave": "Saving Throw",
+"DND5E.ActionSumm": "Summon",
 "DND5E.ActionUtil": "Utility",
 "DND5E.ActionWarningNoItem": "The requested item {item} no longer exists on Actor {name}",
 "DND5E.ActionWarningNoToken": "You must have one or more controlled Tokens in order to use this option.",
@@ -1361,6 +1362,51 @@
 "DND5E.SubclassMismatchWarn": "{name} subclass has no matching class with identifier '{class}'.",
 "DND5E.SubclassName": "Subclass Name",
 "DND5E.Subtype": "Subtype",
+"DND5E.Summoning": {
+  "Label": "Summoning",
+  "Action": {
+    "Add": "Add Profile",
+    "Configure": "Configure Summons",
+    "Remove": "Remove Profile"
+  },
+  "ActorChanges": {
+    "Label": "Actor Changes",
+    "Hint": "Changes that will be made to the actor being summoned. Any @ references used in the following formulas will be based on the summoner’s stats."
+  },
+  "ArmorClass": {
+    "Label": "Bonus Armor Class",
+    "Hint": "Bonus to the Armor Class set on the summoned actor added to what is specified in their statblock."
+  },
+  "Configuration": "Summoning Configuration",
+  "DisplayName": "Display Name",
+  "DropHint": "Drop actor here",
+  "HitPoints": {
+    "Label": "Bonus Hit Points",
+    "Hint": "Additional hit points added to the actor on top of what is specified in their statblock."
+  },
+  "ItemChanges": {
+    "Label": "Item Changes",
+    "Hint": "Changes made to items on the summoned actor."
+  },
+  "Match": {
+    "Attacks": {
+      "Label": "Match Attacks",
+      "Hint": "Modify to hit values on the summoned actor’s attacks to match that of the summoner."
+    },
+    "Proficiency": {
+      "Label": "Match Proficiency",
+      "Hint": "Modify the summoned actor’s proficiency to match that of the summoner."
+    },
+    "Saves": {
+      "Label": "Match Saves",
+      "Hint": "Modify to saving throw DCs on the summoned actor’s abilities to match that of the summoner."
+    }
+  },
+  "Profile": {
+    "Label": "Summons Profiles",
+    "Empty": "Click above to add a profile or drop an actor to summon here."
+  }
+},
 "DND5E.Supply": "Supply",
 "DND5E.Suppressed": "Suppressed",
 "DND5E.Target": "Target",

--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -480,23 +480,10 @@
     border-radius: 4px;
     box-shadow: 0 0 4px var(--dnd5e-shadow-45);
 
-    &:has(.drag-bar) { padding-inline-end: 18px; }
-
     .details {
       gap: 4px;
       input { height: unset; }
       input::placeholder { opacity: .5; }
-    }
-    .drag-bar {
-      position: absolute;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      inset-block: 0;
-      inset-inline-end: 0;
-      inline-size: 16px;
-      cursor: grab;
-      color: var(--dnd5e-color-faint);
     }
     [data-action="delete-profile"] {
       --size: 26px;

--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -340,6 +340,13 @@
     }
   }
 
+  .summoning.form-group {
+    .config-button {
+      opacity: 1;
+      font-size: var(--font-size-12);
+    }
+  }
+
   /* ----------------------------------------- */
   /*  Item Actions                             */
   /* ----------------------------------------- */
@@ -436,5 +443,76 @@
   .tag {
     font-size: var(--font-size-11);
     padding: 0.1em 0.5em;
+  }
+}
+
+/* ----------------------------------------- */
+/*  Summoning Configuration                  */
+/* ----------------------------------------- */
+
+.dnd5e.summoning-config {
+  .unbutton {
+    width: unset;
+    border: none;
+    background: none;
+    line-height: unset;
+
+    &:hover, &:focus { box-shadow: none; }
+    &:hover { text-shadow: 0 0 8px var(--color-shadow-primary); }
+    &:focus-visible { outline: 2px solid black; }
+  }
+
+  .form-header {
+    justify-content: space-between;
+    button { flex: unset; }
+  }
+
+  ul.profiles {
+    padding: 0;
+    list-style: none;
+    gap: 12px;
+  }
+  li.profile {
+    position: relative;
+    padding: 8px;
+    background: var(--dnd5e-color-card);
+    border: 2px solid var(--dnd5e-color-gold);
+    border-radius: 4px;
+    box-shadow: 0 0 4px var(--dnd5e-shadow-45);
+
+    &:has(.drag-bar) { padding-inline-end: 18px; }
+
+    .details {
+      gap: 4px;
+      input { height: unset; }
+      input::placeholder { opacity: .5; }
+    }
+    .drag-bar {
+      position: absolute;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      inset-block: 0;
+      inset-inline-end: 0;
+      inline-size: 16px;
+      cursor: grab;
+      color: var(--dnd5e-color-faint);
+    }
+    [data-action="delete-profile"] {
+      --size: 26px;
+      flex: 0 0 var(--size);
+      block-size: var(--size);
+      inline-size: var(--size);
+    }
+    .content-link, .drop-area {
+      flex: 0 0 175px;
+      display: flex;
+      align-items: center;
+    }
+    .drop-area {
+      border: 1px dashed black;
+      border-radius: 4px;
+      padding-inline: 4px;
+    }
   }
 }

--- a/module/applications/item/_module.mjs
+++ b/module/applications/item/_module.mjs
@@ -4,3 +4,4 @@ export {default as ItemDirectory5e} from "./item-directory.mjs";
 export {default as ItemSheet5e} from "./item-sheet.mjs";
 
 export {default as AbilityUseDialog} from "./ability-use-dialog.mjs";
+export {default as SummoningConfig} from "./summoning-config.mjs";

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -1,3 +1,5 @@
+import * as Trait from "../../documents/actor/trait.mjs";
+import { filteredKeys, sortObjectEntries } from "../../utils.mjs";
 import ActorMovementConfig from "../actor/movement-config.mjs";
 import ActorSensesConfig from "../actor/senses-config.mjs";
 import ActorTypeConfig from "../actor/type-config.mjs";
@@ -6,8 +8,7 @@ import AdvancementMigrationDialog from "../advancement/advancement-migration-dia
 import Accordion from "../accordion.mjs";
 import EffectsElement from "../components/effects.mjs";
 import SourceConfig from "../source-config.mjs";
-import * as Trait from "../../documents/actor/trait.mjs";
-import { filteredKeys, sortObjectEntries } from "../../utils.mjs";
+import SummoningConfig from "./summoning-config.mjs";
 
 /**
  * Override and extend the core ItemSheet implementation to handle specific item types.
@@ -573,6 +574,9 @@ export default class ItemSheet5e extends ItemSheet {
         break;
       case "source":
         app = new SourceConfig(this.item, { keyPath: "system.source" });
+        break;
+      case "summoning":
+        app = new SummoningConfig(this.item);
         break;
       case "type":
         app = new ActorTypeConfig(this.item, { keyPath: "system.type" });

--- a/module/applications/item/summoning-config.mjs
+++ b/module/applications/item/summoning-config.mjs
@@ -7,7 +7,7 @@ export default class SummoningConfig extends DocumentSheet {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["dnd5e", "summoning-config"],
-      dragDrop: [{ dragSelector: ".drag-bar", dropSelector: "form" }],
+      dragDrop: [{ dropSelector: "form" }],
       template: "systems/dnd5e/templates/apps/summoning-config.hbs",
       width: 500,
       height: "auto",
@@ -48,7 +48,9 @@ export default class SummoningConfig extends DocumentSheet {
       const profile = { id: p._id, ...p };
       if ( p.uuid ) profile.document = fromUuidSync(p.uuid);
       return profile;
-    }).sort((lhs, rhs) => lhs.sort - rhs.sort);
+    }).sort((lhs, rhs) =>
+      (lhs.name || lhs.document?.name || "").localeCompare(rhs.name || rhs.document?.name || "", game.i18n.lang)
+    );
     context.summons = this.document.system.summons;
     return context;
   }
@@ -76,13 +78,11 @@ export default class SummoningConfig extends DocumentSheet {
   _getSubmitData(...args) {
     const data = foundry.utils.expandObject(super._getSubmitData(...args));
     data.profiles = Object.values(data.profiles ?? {});
-    const highestSort = this.profiles.reduce((sort, i) => i.sort > sort ? i.sort : sort, 0);
 
     switch ( data.action ) {
       case "add-profile":
         data.profiles.push({
           _id: foundry.utils.randomID(),
-          sort: highestSort + CONST.SORT_INTEGER_DENSITY,
           ...(data.addDetails ?? {})
         });
         break;
@@ -113,25 +113,9 @@ export default class SummoningConfig extends DocumentSheet {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _onDragStart(event) {
-    const entry = event.target.closest("[data-profile-id]");
-    if ( !entry ) return;
-    event.dataTransfer.setData("text/plain", JSON.stringify({
-      type: "summoning-profile", item: this.document.uuid, profileId: entry.dataset.profileId
-    }));
-    const box = entry.getBoundingClientRect();
-    event.dataTransfer.setDragImage(entry, box.width - 6, box.height / 2);
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
   async _onDrop(event) {
     // Try to extract the data
     const data = TextEditor.getDragEventData(event);
-
-    // Handle re-ordering of list
-    if ( data.item === this.document.uuid ) return this._onSortEntry(event, data);
 
     // Handle dropping linked items
     if ( data?.type !== "Actor" ) return;
@@ -146,41 +130,5 @@ export default class SummoningConfig extends DocumentSheet {
 
     // Otherwise create a new profile
     else this.submit({ updateData: { action: "add-profile", addDetails: { uuid: actor.uuid } } });
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Sort a profile on drop.
-   * @param {DragEvent} event  Triggering drop event.
-   * @param {object} data      Drag event data.
-   */
-  _onSortEntry(event, data) {
-    const dropArea = event.target.closest("[data-profile-id]");
-    const dragProfile = this.profiles.find(p => p._id === data?.profileId);
-    const dropProfile = this.profiles.find(p => p._id === dropArea?.dataset.profileId);
-
-    // Do nothing if dropped on itself
-    if ( dragProfile === dropProfile ) return;
-
-    const siblings = this.profiles.filter(e => e !== dragProfile).sort((lhs, rhs) => lhs.sort - rhs.sort);
-    let sortBefore;
-    let target = dropProfile;
-
-    // If dropped outside any profile, sort to top or bottom of list
-    if ( !target ) {
-      const box = this.form.getBoundingClientRect();
-      sortBefore = (event.clientY - box.y) < (box.height * .25);
-      target = sortBefore ? siblings[0] : siblings[siblings.length - 1];
-    }
-
-    if ( !target ) return;
-
-    const sortUpdates = SortingHelpers.performIntegerSort(dragProfile, { target, siblings, sortBefore });
-    const updateData = sortUpdates.reduce((obj, { target, update }) => {
-      obj[`profiles.${target._id}.sort`] = update.sort;
-      return obj;
-    }, {});
-    this.submit({ updateData });
   }
 }

--- a/module/applications/item/summoning-config.mjs
+++ b/module/applications/item/summoning-config.mjs
@@ -131,7 +131,7 @@ export default class SummoningConfig extends DocumentSheet {
     const data = TextEditor.getDragEventData(event);
 
     // Handle re-ordering of list
-    if ( data?.item && (data.item === this.document.uuid) ) return this._onSortEntry(event, data);
+    if ( data.item === this.document.uuid ) return this._onSortEntry(event, data);
 
     // Handle dropping linked items
     if ( data?.type !== "Actor" ) return;

--- a/module/applications/item/summoning-config.mjs
+++ b/module/applications/item/summoning-config.mjs
@@ -1,0 +1,186 @@
+/**
+ * Application for configuring summoning information for an item.
+ */
+export default class SummoningConfig extends DocumentSheet {
+
+  /** @inheritDoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["dnd5e", "summoning-config"],
+      dragDrop: [{ dragSelector: ".drag-bar", dropSelector: "form" }],
+      template: "systems/dnd5e/templates/apps/summoning-config.hbs",
+      width: 500,
+      height: "auto",
+      sheetConfig: false,
+      closeOnSubmit: false,
+      submitOnChange: true,
+      submitOnClose: true
+    });
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Shortcut to the summoning profiles.
+   * @type {object[]}
+   */
+  get profiles() {
+    return this.document.system.summons.profiles;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  get title() {
+    return `${game.i18n.localize("DND5E.Summoning.Configuration")}: ${this.document.name}`;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async getData(options={}) {
+    const context = await super.getData(options);
+    context.profiles = this.profiles.map(p => {
+      const profile = { id: p._id, ...p };
+      if ( p.uuid ) profile.document = fromUuidSync(p.uuid);
+      return profile;
+    }).sort((lhs, rhs) => lhs.sort - rhs.sort);
+    context.summons = this.document.system.summons;
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Handling                              */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  activateListeners(jQuery) {
+    super.activateListeners(jQuery);
+    const html = jQuery[0];
+
+    for ( const element of html.querySelectorAll("[data-action]") ) {
+      element.addEventListener("click", event => this.submit({ updateData: {
+        action: event.target.dataset.action,
+        profileId: event.target.closest("[data-profile-id]")?.dataset.profileId
+      } }));
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _getSubmitData(...args) {
+    const data = foundry.utils.expandObject(super._getSubmitData(...args));
+    data.profiles = Object.values(data.profiles ?? {});
+    const highestSort = this.profiles.reduce((sort, i) => i.sort > sort ? i.sort : sort, 0);
+
+    switch ( data.action ) {
+      case "add-profile":
+        data.profiles.push({
+          _id: foundry.utils.randomID(),
+          sort: highestSort + CONST.SORT_INTEGER_DENSITY,
+          ...(data.addDetails ?? {})
+        });
+        break;
+      case "delete-profile":
+        data.profiles = data.profiles.filter(e => e._id !== data.profileId);
+        break;
+    }
+
+    return data;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _updateObject(event, formData) {
+    this.document.update({"system.summons": formData});
+  }
+
+  /* -------------------------------------------- */
+  /*  Drag & Drop                                 */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _canDragDrop() {
+    return this.isEditable;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onDragStart(event) {
+    const entry = event.target.closest("[data-profile-id]");
+    if ( !entry ) return;
+    event.dataTransfer.setData("text/plain", JSON.stringify({
+      type: "summoning-profile", item: this.document.uuid, profileId: entry.dataset.profileId
+    }));
+    const box = entry.getBoundingClientRect();
+    event.dataTransfer.setDragImage(entry, box.width - 6, box.height / 2);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onDrop(event) {
+    // Try to extract the data
+    const data = TextEditor.getDragEventData(event);
+
+    // Handle re-ordering of list
+    if ( data?.item && (data.item === this.document.uuid) ) return this._onSortEntry(event, data);
+
+    // Handle dropping linked items
+    if ( data?.type !== "Actor" ) return;
+    const actor = await Actor.implementation.fromDropData(data);
+
+    // Determine where this was dropped
+    const existingProfile = event.target.closest("[data-profile-id]");
+    const { profileId } = existingProfile?.dataset ?? {};
+
+    // If dropped onto existing profile, add or replace link
+    if ( profileId ) this.submit({ updateData: { [`profiles.${profileId}.uuid`]: actor.uuid } });
+
+    // Otherwise create a new profile
+    else this.submit({ updateData: { action: "add-profile", addDetails: { uuid: actor.uuid } } });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Sort a profile on drop.
+   * @param {DragEvent} event  Triggering drop event.
+   * @param {object} data      Drag event data.
+   */
+  _onSortEntry(event, data) {
+    const dropArea = event.target.closest("[data-profile-id]");
+    const dragProfile = this.profiles.find(p => p._id === data?.profileId);
+    const dropProfile = this.profiles.find(p => p._id === dropArea?.dataset.profileId);
+
+    // Do nothing if dropped on itself
+    if ( dragProfile === dropProfile ) return;
+
+    const siblings = this.profiles.filter(e => e !== dragProfile).sort((lhs, rhs) => lhs.sort - rhs.sort);
+    let sortBefore;
+    let target = dropProfile;
+
+    // If dropped outside any profile, sort to top or bottom of list
+    if ( !target ) {
+      const box = this.form.getBoundingClientRect();
+      sortBefore = (event.clientY - box.y) < (box.height * .25);
+      target = sortBefore ? siblings[0] : siblings[siblings.length - 1];
+    }
+
+    if ( !target ) return;
+
+    const sortUpdates = SortingHelpers.performIntegerSort(dragProfile, { target, siblings, sortBefore });
+    const updateData = sortUpdates.reduce((obj, { target, update }) => {
+      obj[`profiles.${target._id}.sort`] = update.sort;
+      return obj;
+    }, {});
+    this.submit({ updateData });
+  }
+}

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -788,6 +788,7 @@ DND5E.itemActionTypes = {
   msak: "DND5E.ActionMSAK",
   rsak: "DND5E.ActionRSAK",
   save: "DND5E.ActionSave",
+  summ: "DND5E.ActionSumm",
   heal: "DND5E.ActionHeal",
   abil: "DND5E.ActionAbil",
   util: "DND5E.ActionUtil",

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -9,8 +9,9 @@ const {
  * Information for a single summoned creature.
  *
  * @typedef {object} SummonsProfile
+ * @property {string} _id    Unique ID for this profile.
  * @property {number} count  Number of creatures to summon.
- * @property {string} label  Display name for this profile if it differs from actor's name.
+ * @property {string} name   Display name for this profile if it differs from actor's name.
  * @property {string} uuid   UUID of the actor to summon.
  */
 
@@ -84,7 +85,6 @@ export default class ActionTemplate extends ItemDataModel {
           _id: new DocumentIdField({initial: () => foundry.utils.randomID()}),
           count: new NumberField({integer: true, min: 1}),
           name: new StringField(),
-          sort: new IntegerSortField(),
           uuid: new StringField()
         }))
       })

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -1,6 +1,19 @@
 import { ItemDataModel } from "../../abstract.mjs";
 import { FormulaField } from "../../fields.mjs";
 
+const {
+  ArrayField, BooleanField, DocumentIdField, IntegerSortField, NumberField, SchemaField, StringField
+} = foundry.data.fields;
+
+/**
+ * Information for a single summoned creature.
+ *
+ * @typedef {object} SummonsProfile
+ * @property {number} count  Number of creatures to summon.
+ * @property {string} label  Display name for this profile if it differs from actor's name.
+ * @property {string} uuid   UUID of the actor to summon.
+ */
+
 /**
  * Data model template for item actions.
  *
@@ -19,42 +32,62 @@ import { FormulaField } from "../../fields.mjs";
  * @property {string} save.ability        Ability required for the save.
  * @property {number} save.dc             Custom saving throw value.
  * @property {string} save.scaling        Method for automatically determining saving throw DC.
+ * @property {object} summons
+ * @property {string} summons.ac                  Formula used to calculate the AC on summoned actors.
+ * @property {string} summons.hp                  Formula indicating bonus hit points to add to each summoned actor.
+ * @property {object} summons.match
+ * @property {boolean} summons.match.attacks      Match the to hit values on summoned actor's attack to the summoner.
+ * @property {boolean} summons.match.proficiency  Match proficiency on summoned actor to the summoner.
+ * @property {boolean} summons.match.saves        Match the save DC on summoned actor's abilities to the summoner.
+ * @property {SummonsProfile[]} summons.profiles  Information on creatures that can be summoned.
  * @mixin
  */
 export default class ActionTemplate extends ItemDataModel {
   /** @inheritdoc */
   static defineSchema() {
     return {
-      ability: new foundry.data.fields.StringField({
-        required: true, nullable: true, initial: null, label: "DND5E.AbilityModifier"
-      }),
-      actionType: new foundry.data.fields.StringField({
-        required: true, nullable: true, initial: null, label: "DND5E.ItemActionType"
-      }),
+      ability: new StringField({required: true, nullable: true, initial: null, label: "DND5E.AbilityModifier"}),
+      actionType: new StringField({required: true, nullable: true, initial: null, label: "DND5E.ItemActionType"}),
       attackBonus: new FormulaField({required: true, label: "DND5E.ItemAttackBonus"}),
-      chatFlavor: new foundry.data.fields.StringField({required: true, label: "DND5E.ChatFlavor"}),
-      critical: new foundry.data.fields.SchemaField({
-        threshold: new foundry.data.fields.NumberField({
+      chatFlavor: new StringField({required: true, label: "DND5E.ChatFlavor"}),
+      critical: new SchemaField({
+        threshold: new NumberField({
           required: true, integer: true, initial: null, positive: true, label: "DND5E.ItemCritThreshold"
         }),
         damage: new FormulaField({required: true, label: "DND5E.ItemCritExtraDamage"})
       }),
-      damage: new foundry.data.fields.SchemaField({
-        parts: new foundry.data.fields.ArrayField(new foundry.data.fields.ArrayField(
-          new foundry.data.fields.StringField({nullable: true})
-        ), {required: true}),
+      damage: new SchemaField({
+        parts: new ArrayField(new ArrayField(new StringField({nullable: true})), {required: true}),
         versatile: new FormulaField({required: true, label: "DND5E.VersatileDamage"})
       }, {label: "DND5E.Damage"}),
       formula: new FormulaField({required: true, label: "DND5E.OtherFormula"}),
-      save: new foundry.data.fields.SchemaField({
-        ability: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.Ability"}),
-        dc: new foundry.data.fields.NumberField({
-          required: true, min: 0, integer: true, label: "DND5E.AbbreviationDC"
+      save: new SchemaField({
+        ability: new StringField({required: true, blank: true, label: "DND5E.Ability"}),
+        dc: new NumberField({required: true, min: 0, integer: true, label: "DND5E.AbbreviationDC"}),
+        scaling: new StringField({required: true, blank: false, initial: "spell", label: "DND5E.ScalingFormula"})
+      }, {label: "DND5E.SavingThrow"}),
+      summons: new SchemaField({
+        ac: new FormulaField({label: "DND5E.Summoning.ArmorClass.Label", hint: "DND5E.Summoning.ArmorClass.hint"}),
+        hp: new FormulaField({label: "DND5E.Summoning.HitPoints.Label", hint: "DND5E.Summoning.HitPoints.hint"}),
+        match: new SchemaField({
+          attacks: new BooleanField({
+            label: "DND5E.Summoning.Match.Attacks.Label", hint: "DND5E.Summoning.Match.Attacks.Hint"
+          }),
+          proficiency: new BooleanField({
+            label: "DND5E.Summoning.Match.Proficiency.Label", hint: "DND5E.Summoning.Match.Proficiency.Hint"
+          }),
+          saves: new BooleanField({
+            label: "DND5E.Summoning.Match.Saves.Label", hint: "DND5E.Summoning.Match.Saves.Hint"
+          })
         }),
-        scaling: new foundry.data.fields.StringField({
-          required: true, blank: false, initial: "spell", label: "DND5E.ScalingFormula"
-        })
-      }, {label: "DND5E.SavingThrow"})
+        profiles: new ArrayField(new SchemaField({
+          _id: new DocumentIdField({initial: () => foundry.utils.randomID()}),
+          count: new NumberField({integer: true, min: 1}),
+          name: new StringField(),
+          sort: new IntegerSortField(),
+          uuid: new StringField()
+        }))
+      })
     };
   }
 

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -26,9 +26,7 @@
                     <i class="fa-solid fa-trash fa-fw" inert></i>
                 </button>
             </div>
-            <div class="drag-bar"><i class="fa-solid fa-grip-lines-vertical" inert></i></div>
             <input type="hidden" name="profiles.{{ id }}._id" value="{{ id }}">
-            <input type="hidden" name="profiles.{{ id }}.sort" value="{{ sort }}" data-dtype="Number">
             <input type="hidden" name="profiles.{{ id }}.uuid" value="{{ uuid }}">
         </li>
         {{else}}

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -1,0 +1,69 @@
+<form autocomplete="off">
+    <h3 class="form-header flexrow">
+        {{ localize "DND5E.Summoning.Profile.Label" }}
+        <button type="button" class="unbutton" data-action="add-profile">
+            <i class="fa-solid fa-plus" aria-hidden="true"></i>
+            {{ localize 'DND5E.Summoning.Action.Add' }}
+        </a>
+    </h3>
+    <ul class="profiles flexcol">
+        {{#each profiles}}
+        <li class="profile" data-profile-id="{{ id }}">
+            <div class="details flexrow">
+                {{#if document}}
+                {{{ dnd5e-linkForUuid uuid }}}
+                {{else}}
+                <div class="drop-area">
+                    {{localize "DND5E.Summoning.DropHint"}}
+                </div>
+                {{/if}}
+                <input type="text" name="profiles.{{ id }}.name" value="{{ name }}" aria-label="{{ localize 'Name' }}"
+                       placeholder="{{#if document}}{{ document.name }}{{else}}
+                       {{~ localize 'DND5E.Summoning.DisplayName' }}{{/if}}">
+                <button type="button" class="unbutton" data-action="delete-profile"
+                        data-tooltip="DND5E.Summoning.Action.Remove"
+                        aria-label="{{ localize 'DND5E.Summoning.Action.Remove' }}">
+                    <i class="fa-solid fa-trash fa-fw" inert></i>
+                </button>
+            </div>
+            <div class="drag-bar"><i class="fa-solid fa-grip-lines-vertical" inert"></i></div>
+            <input type="hidden" name="profiles.{{ id }}._id" value="{{ id }}">
+            <input type="hidden" name="profiles.{{ id }}.sort" value="{{ sort }}" data-dtype="Number">
+            <input type="hidden" name="profiles.{{ id }}.uuid" value="{{ uuid }}">
+        </li>
+        {{else}}
+        <li class="empty">{{ localize "DND5E.Summoning.Profile.Empty" }}</li>
+        {{/each}}
+    </ul>
+
+    <h3 class="form-header">{{ localize "DND5E.Summoning.ActorChanges.Label" }}</h3>
+    <p class="hint">{{ localize "DND5E.Summoning.ActorChanges.Hint" }}</p>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Summoning.Match.Proficiency.Label" }}</label>
+        <input type="checkbox" name="match.proficiency" {{ checked summons.match.proficiency }}>
+        <p class="hint">{{ localize "DND5E.Summoning.Match.Proficiency.Hint" }}</p>
+    </div>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Summoning.ArmorClass.Label" }}</label>
+        <input type="text" name="ac" value="{{ summons.ac }}">
+        <p class="hint">{{ localize "DND5E.Summoning.ArmorClass.Hint" }}</p>
+    </div>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Summoning.HitPoints.Label" }}</label>
+        <input type="text" name="hp" value="{{ summons.hp }}">
+        <p class="hint">{{ localize "DND5E.Summoning.HitPoints.Hint" }}</p>
+    </div>
+
+    <h3 class="form-header">{{ localize "DND5E.Summoning.ItemChanges.Label" }}</h3>
+    <p class="hint">{{ localize "DND5E.Summoning.ItemChanges.Hint" }}</p>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Summoning.Match.Attacks.Label" }}</label>
+        <input type="checkbox" name="match.attacks" {{ checked summons.match.attacks }}>
+        <p class="hint">{{ localize "DND5E.Summoning.Match.Attacks.Hint" }}</p>
+    </div>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Summoning.Match.Saves.Label" }}</label>
+        <input type="checkbox" name="match.saves" {{ checked summons.match.saves }}>
+        <p class="hint">{{ localize "DND5E.Summoning.Match.Saves.Hint" }}</p>
+    </div>
+</form>

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -26,7 +26,7 @@
                     <i class="fa-solid fa-trash fa-fw" inert></i>
                 </button>
             </div>
-            <div class="drag-bar"><i class="fa-solid fa-grip-lines-vertical" inert"></i></div>
+            <div class="drag-bar"><i class="fa-solid fa-grip-lines-vertical" inert></i></div>
             <input type="hidden" name="profiles.{{ id }}._id" value="{{ id }}">
             <input type="hidden" name="profiles.{{ id }}.sort" value="{{ sort }}" data-dtype="Number">
             <input type="hidden" name="profiles.{{ id }}.uuid" value="{{ uuid }}">
@@ -36,8 +36,8 @@
         {{/each}}
     </ul>
 
-    <h3 class="form-header">{{ localize "DND5E.Summoning.ActorChanges.Label" }}</h3>
-    <p class="hint">{{ localize "DND5E.Summoning.ActorChanges.Hint" }}</p>
+    <h3 class="form-header">{{ localize "DND5E.Summoning.CreatureChanges.Label" }}</h3>
+    <p class="hint">{{ localize "DND5E.Summoning.CreatureChanges.Hint" }}</p>
     <div class="form-group">
         <label>{{ localize "DND5E.Summoning.Match.Proficiency.Label" }}</label>
         <input type="checkbox" name="match.proficiency" {{ checked summons.match.proficiency }}>

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -116,6 +116,19 @@
     </div>
 </div>
 
+{{!-- Summoning --}}
+{{#if (eq system.actionType "summ")}}
+<div class="form-group summoning">
+    <label>{{ localize "DND5E.Summoning.Label" }}</label>
+    <div class="form-fields">
+        <a class="config-button" data-action="summoning">
+            <i class="fa-solid fa-gear" aria-hidden="true"></i>
+            {{ localize 'DND5E.Summoning.Action.Configure' }}
+        </a>
+    </div>
+</div>
+{{/if}}
+
 {{!-- Chat Message Flavor --}}
 <div class="form-group stacked">
     <label>{{ localize "DND5E.ChatFlavor" }}</label>


### PR DESCRIPTION
Adds a new item action mode, "Summon", which displays a configuration application for configuring summoning from that item:

<img width="573" alt="Summoning Action" src="https://github.com/foundryvtt/dnd5e/assets/19979839/51949d95-cb82-48d3-ba17-22846a192d3c">

The application allows for configuring several potential summoning profiles, which at the moment are limited to summoning a single actor via UUID but could be expanded in the future to support referencing certain creature types & CRs for something like Conjure Animals.

The configuration window also displays changes made to the summoned actor and any items on that actor during the process of summoning, allowing changes to armor class & hit points to match summoner's stats or spell level, and matching proficiency, attacks' to hit, and saving throw DCs.

![Summoning Configuration v1](https://github.com/foundryvtt/dnd5e/assets/19979839/f39f4a47-adbf-4420-9d60-baf372495c2c)

The is the initial part of the process of merging the functionality from [Arbron’s Summoning](https://github.com/arbron/fvtt-summoner) into the system. Follow up PRs will handle actually creating the tokens when the item is used.