### PR TITLE
[#3099] Fix chat messages collapsing when clicking on details element

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2007,7 +2007,14 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   static _onChatCardToggleContent(event) {
     // If the user is clicking on a link in the collapsible region, don't collapse
-    if ( event.target.closest(":is(.item-name, .collapsible) :is(a, button)") ) return;
+    const closest = event.target.closest(":is(.item-name, .collapsible) :is(a, button, summary)");
+    if ( closest ) {
+      if ( closest.tagName === "SUMMARY" ) requestAnimationFrame(() => {
+        const details = event.currentTarget.querySelector(".collapsible-content");
+        details.style.height = `${details.scrollHeight}px`;
+      });
+      return;
+    }
 
     event.preventDefault();
     const header = event.currentTarget;


### PR DESCRIPTION
Would love another set of eyes on this one. It fixes all the issues with using `<details>` elements in chat card descriptions, except when you collapse the details section the chat card doesn't reclaim the height properly:

<img width="282" alt="Screenshot 2024-02-22 at 11 18 07" src="https://github.com/foundryvtt/dnd5e/assets/19979839/95025eb4-3dc3-4808-9c2c-1ca67e50d5ba">