### PR TITLE
Improve compatibility of localized token resources.

### DIFF
--- a/module/applications/token-config.mjs
+++ b/module/applications/token-config.mjs
@@ -92,6 +92,8 @@ export default class TokenConfig5e extends TokenConfig {
     if ( !this._minimized ) this.setPosition();
   }
 
+  /* -------------------------------------------- */
+
   /**
    * Adds charge based items as attributes for the current token.
    * @param {object} attributes The attribute groups to add the item entries to.
@@ -104,7 +106,7 @@ export default class TokenConfig5e extends TokenConfig {
       if ( per && max ) arr.push([i.getRelativeUUID(actor), i.name]);
       return arr;
     }, []) ?? [];
-    if ( items.length > 0 ) {
+    if ( items.length ) {
       items.sort(([, a], [, b]) => a.localeCompare(b, game.i18n.lang));
       attributes[game.i18n.localize("DND5E.ConsumeCharges")] = items.map(i => i[0]);
     }
@@ -127,7 +129,7 @@ export default class TokenConfig5e extends TokenConfig {
         // Localize attribute paths.
         options.forEach(option => {
           const label = getHumanReadableAttributeLabel(option.value, { actor });
-          if (label) option.innerText = label;
+          if ( label ) option.innerText = label;
         });
 
         // Sort options by localized label.

--- a/module/applications/token-config.mjs
+++ b/module/applications/token-config.mjs
@@ -39,6 +39,7 @@ export default class TokenConfig5e extends TokenConfig {
     const context = await super.getData(options);
     const doc = this.preview ?? this.document;
     context.scale = Math.abs(doc._source.texture.scaleX);
+    this._addItemAttributes(context.barAttributes);
     return context;
   }
 
@@ -91,64 +92,48 @@ export default class TokenConfig5e extends TokenConfig {
     if ( !this._minimized ) this.setPosition();
   }
 
+  /**
+   * Adds charge based items as attributes for the current token.
+   * @param {object} attributes The attribute groups to add the item entries to.
+   * @protected
+   */
+  _addItemAttributes(attributes) {
+    const actor = this.object?.actor;
+    const items = actor?.items.reduce((arr, i) => {
+      const { per, max } = i.system.uses ?? {};
+      if ( per && max ) arr.push([i.getRelativeUUID(actor), i.name]);
+      return arr;
+    }, []) ?? [];
+    if ( items.length > 0 ) {
+      items.sort(([, a], [, b]) => a.localeCompare(b, game.i18n.lang));
+      attributes[game.i18n.localize("DND5E.ConsumeCharges")] = items.map(i => i[0]);
+    }
+  }
+
   /* -------------------------------------------- */
 
   /**
-   * Handle rendering human-readable labels and adding item uses.
+   * Replace the attribute paths in token resources with human readable labels and sort them alphabetically.
    * @param {HTMLElement} html  The rendered markup.
    * @protected
    */
   _prepareResourceLabels(html) {
     const actor = this.object?.actor;
-    const makeOptgroup = (label, parent) => {
-      const optgroup = document.createElement("optgroup");
-      optgroup.label = game.i18n.localize(label);
-      parent.appendChild(optgroup);
-      return optgroup;
-    };
 
-    const items = actor?.items.reduce((obj, i) => {
-      const { per, max } = i.system.uses ?? {};
-      if ( per && max ) obj[i.getRelativeUUID(actor)] = i.name;
-      return obj;
-    }, {}) ?? {};
-
-    // Add human-readable labels, categorize, and sort entries, and add item uses.
-    for ( const select of html.querySelectorAll('[name="bar1.attribute"], [name="bar2.attribute"]') ) {
-      const groups = {
-        abilities: makeOptgroup("DND5E.AbilityScorePl", select),
-        movement: makeOptgroup("DND5E.MovementSpeeds", select),
-        senses: makeOptgroup("DND5E.Senses", select),
-        skills: makeOptgroup("DND5E.SkillPassives", select),
-        slots: makeOptgroup("JOURNALENTRYPAGE.DND5E.Class.SpellSlots", select)
-      };
-
-      select.querySelectorAll("option").forEach(option => {
-        const label = getHumanReadableAttributeLabel(option.value, { actor });
-        if ( label ) option.innerText = label;
-        if ( option.value.startsWith("abilities.") ) groups.abilities.appendChild(option);
-        else if ( option.value.startsWith("attributes.movement.") ) groups.movement.appendChild(option);
-        else if ( option.value.startsWith("attributes.senses.") ) groups.senses.appendChild(option);
-        else if ( option.value.startsWith("skills.") ) groups.skills.appendChild(option);
-        else if ( option.value.startsWith("spells.") ) groups.slots.appendChild(option);
-      });
-
+    for ( const select of html.querySelectorAll("select.bar-attribute") ) {
       select.querySelectorAll("optgroup").forEach(group => {
         const options = Array.from(group.querySelectorAll("option"));
+
+        // Localize attribute paths.
+        options.forEach(option => {
+          const label = getHumanReadableAttributeLabel(option.value, { actor });
+          if (label) option.innerText = label;
+        });
+
+        // Sort options by localized label.
         options.sort((a, b) => a.innerText.localeCompare(b.innerText, game.i18n.lang));
         group.append(...options);
       });
-
-      if ( !foundry.utils.isEmpty(items) ) {
-        const group = makeOptgroup("DND5E.ConsumeCharges", select);
-        for ( const [k, v] of Object.entries(items).sort(([, a], [, b]) => a.localeCompare(b, game.i18n.lang)) ) {
-          const option = document.createElement("option");
-          if ( k === foundry.utils.getProperty(this.object, select.name) ) option.selected = true;
-          option.value = k;
-          option.innerText = v;
-          group.appendChild(option);
-        }
-      }
     }
   }
 

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -89,6 +89,38 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     return CONFIG.DND5E.consumableResources;
   }
 
+  /** @inheritdoc */
+  static getTrackedAttributeChoices(attributes) {
+    const groups = super.getTrackedAttributeChoices(attributes);
+    const abilities = [];
+    const movement = [];
+    const senses = [];
+    const skills = [];
+    const slots = [];
+
+    // Regroup existing attributes based on their path.
+    for ( const group of Object.values(groups) ) {
+      for ( let i = 0; i < group.length; i++ ) {
+        const attribute = group[i];
+        if ( attribute.startsWith("abilities.") ) abilities.push(attribute);
+        else if ( attribute.startsWith("attributes.movement.") ) movement.push(attribute);
+        else if ( attribute.startsWith("attributes.senses.") ) senses.push(attribute);
+        else if ( attribute.startsWith("skills.") ) skills.push(attribute);
+        else if ( attribute.startsWith("spells.") ) slots.push(attribute);
+        else continue;
+        group.splice(i--, 1);
+      }
+    }
+
+    // Add new groups to choices.
+    if ( abilities.length ) groups[game.i18n.localize("DND5E.AbilityScorePl")] = abilities;
+    if ( movement.length ) groups[game.i18n.localize("DND5E.MovementSpeeds")] = movement;
+    if ( senses.length ) groups[game.i18n.localize("DND5E.Senses")] = senses;
+    if ( skills.length ) groups[game.i18n.localize("DND5E.SkillPassives")] = skills;
+    if ( slots.length ) groups[game.i18n.localize("JOURNALENTRYPAGE.DND5E.Class.SpellSlots")] = slots;
+    return groups;
+  }
+
   /* -------------------------------------------- */
 
   /** @inheritdoc */

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -89,6 +89,8 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     return CONFIG.DND5E.consumableResources;
   }
 
+  /* -------------------------------------------- */
+
   /** @inheritdoc */
   static getTrackedAttributeChoices(attributes) {
     const groups = super.getTrackedAttributeChoices(attributes);

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -483,6 +483,11 @@ export function getHumanReadableAttributeLabel(attr, { actor }={}) {
     return game.i18n.localize("DND5E.ExperiencePointsValue");
   }
 
+  if ( attr.startsWith(".") && actor ) {
+    const item = fromUuidSync(attr, { relative: actor });
+    return item?.name ?? attr;
+  }
+
   // Check if the attribute is already in cache.
   let label = _attributeLabelCache.get(attr);
   if ( label ) return label;


### PR DESCRIPTION
The goal of this PR is to simplify the usage of the new item resources without fully replicating the system's behavior. Working around the current implementation of `TokenConfig._prepareResourceLabels` is very difficult because it runs after the entire rendering pipeline. This is resolved by moving the logic to the earliest possible place. More specifically:
- Moved the attribute grouping to `TokenDocument.getTrackedAttributeChoices` to allow modules to use the localized groups.
- Moved the item attributes to `TokenConfig.getData` to allow dealing with them in the regular rendering pipeline.
- Moved the item name resolution to `getHumanReadableAttributeLabel` to allow resolving relative item names globally.
- Changed the selector in `TokenConfig._prepareResourceLabels` to `select.bar-attribute` to cover additional inputs.
- Slightly optimized the sorting process to avoid an unnecessary loop.