### PR TITLE
[#3116] Add ability to embed actor & item descriptions

### DIFF
--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -418,7 +418,10 @@ async function embedDocument(config, label, options) {
   options = { ...options, _embedDepth: options._embedDepth + 1, relativeTo: config.doc };
   config.inline ??= config.values.includes("inline");
 
-  const keyPath = (config.doc instanceof Actor) ? "system.details.biography.value" : "system.description.value";
+  const keyPath = (config.doc instanceof Actor) ? "system.details.biography.value"
+    : game.user.isGM || (config.doc.system.identified !== false)
+      ? "system.description.value"
+      : "system.unidentified.description";
   const description = foundry.utils.getProperty(config.doc, keyPath);
   if ( description === undefined ) return null;
 
@@ -605,9 +608,9 @@ async function embedRollTable(config, label, options) {
 
 /**
  * Wrap embeds in containing elements.
- * @param {string} enriched  Enriched text content to include.
+ * @param {string} enriched            Enriched text content to include.
  * @param {object} config              Configuration data.
- * @param {string} label               Optional label to use as the table caption.
+ * @param {string} label               Optional label to replace the default caption.
  * @param {EnrichmentOptions} options  Options provided to customize text enrichment.
  * @returns {Promise<HTMLElement>}
  */


### PR DESCRIPTION
<img width="706" alt="Actor:Item Embeds" src="https://github.com/foundryvtt/dnd5e/assets/19979839/24fd8b07-75da-4c04-af08-d1089d5d8da6">

Did a bit of re-ordering of enrichers to keep things grouped together for easier code perusal.

Closes #3116 
