### PR TITLE
Add bleeding, cursed, silenced, surprised, and transformed to conditions

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -353,7 +353,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     // Effects & Conditions
     const conditionIds = new Set();
     context.conditions = Object.entries(CONFIG.DND5E.conditionTypes).reduce((arr, [k, c]) => {
-      if ( k === "diseased" ) return arr; // Filter out diseased as it's not a real condition.
+      if ( !c.raw ) return arr; // Filter out non-RAW conditions.
       const { label: name, icon, reference } = c;
       const id = staticID(`dnd5e${k}`);
       conditionIds.add(id);

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -353,7 +353,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     // Effects & Conditions
     const conditionIds = new Set();
     context.conditions = Object.entries(CONFIG.DND5E.conditionTypes).reduce((arr, [k, c]) => {
-      if ( !c.raw ) return arr; // Filter out non-RAW conditions.
+      if ( c.pseudo ) return arr; // Filter out pseudo-conditions.
       const { label: name, icon, reference } = c;
       const id = staticID(`dnd5e${k}`);
       conditionIds.add(id);

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2427,7 +2427,8 @@ DND5E.consumableResources = [
 /**
  * @typedef {object} _ConditionConfiguration
  * @property {string} label        Localized label for the condition.
- * @property {boolean} [raw]       Is this a condition by RAW?
+ * @property {boolean} [pseudo]    Is this a pseudo-condition, i.e. one that does not appear in the conditions appendix
+ *                                 but acts as a status effect?
  * @property {number} [levels]     The number of levels of exhaustion an actor can obtain.
  */
 
@@ -2443,65 +2444,60 @@ DND5E.consumableResources = [
 DND5E.conditionTypes = {
   bleeding: {
     label: "EFFECT.DND5E.StatusBleeding",
-    icon: "systems/dnd5e/icons/svg/statuses/bleeding.svg"
+    icon: "systems/dnd5e/icons/svg/statuses/bleeding.svg",
+    pseudo: true
   },
   blinded: {
     label: "DND5E.ConBlinded",
     icon: "systems/dnd5e/icons/svg/statuses/blinded.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.0b8N4FymGGfbZGpJ",
-    special: "BLIND",
-    raw: true
+    special: "BLIND"
   },
   charmed: {
     label: "DND5E.ConCharmed",
     icon: "systems/dnd5e/icons/svg/statuses/charmed.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.zZaEBrKkr66OWJvD",
-    raw: true
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.zZaEBrKkr66OWJvD"
   },
   cursed: {
     label: "EFFECT.DND5E.StatusCursed",
-    icon: "systems/dnd5e/icons/svg/statuses/cursed.svg"
+    icon: "systems/dnd5e/icons/svg/statuses/cursed.svg",
+    pseudo: true
   },
   deafened: {
     label: "DND5E.ConDeafened",
     icon: "systems/dnd5e/icons/svg/statuses/deafened.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.6G8JSjhn701cBITY",
-    raw: true
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.6G8JSjhn701cBITY"
   },
   diseased: {
     label: "DND5E.ConDiseased",
-    icon: "systems/dnd5e/icons/svg/statuses/diseased.svg"
+    icon: "systems/dnd5e/icons/svg/statuses/diseased.svg",
+    pseudo: true
   },
   exhaustion: {
     label: "DND5E.ConExhaustion",
     icon: "systems/dnd5e/icons/svg/statuses/exhaustion.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.cspWveykstnu3Zcv",
-    levels: 6,
-    raw: true
+    levels: 6
   },
   frightened: {
     label: "DND5E.ConFrightened",
     icon: "systems/dnd5e/icons/svg/statuses/frightened.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.oreoyaFKnvZCrgij",
-    raw: true
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.oreoyaFKnvZCrgij"
   },
   grappled: {
     label: "DND5E.ConGrappled",
     icon: "systems/dnd5e/icons/svg/statuses/grappled.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.gYDAhd02ryUmtwZn",
-    raw: true
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.gYDAhd02ryUmtwZn"
   },
   incapacitated: {
     label: "DND5E.ConIncapacitated",
     icon: "systems/dnd5e/icons/svg/statuses/incapacitated.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.TpkZgLfxCmSndmpb",
-    raw: true
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.TpkZgLfxCmSndmpb"
   },
   invisible: {
     label: "DND5E.ConInvisible",
     icon: "systems/dnd5e/icons/svg/statuses/invisible.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.3UU5GCTVeRDbZy9u",
-    raw: true
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.3UU5GCTVeRDbZy9u"
   },
   paralyzed: {
     label: "DND5E.ConParalyzed",
@@ -2518,39 +2514,38 @@ DND5E.conditionTypes = {
   poisoned: {
     label: "DND5E.ConPoisoned",
     icon: "systems/dnd5e/icons/svg/statuses/poisoned.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.lq3TRI6ZlED8ABMx",
-    raw: true
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.lq3TRI6ZlED8ABMx"
   },
   prone: {
     label: "DND5E.ConProne",
     icon: "systems/dnd5e/icons/svg/statuses/prone.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.y0TkcdyoZlOTmAFT",
-    raw: true
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.y0TkcdyoZlOTmAFT"
   },
   restrained: {
     label: "DND5E.ConRestrained",
     icon: "systems/dnd5e/icons/svg/statuses/restrained.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.cSVcyZyNe2iG1fIc",
-    raw: true
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.cSVcyZyNe2iG1fIc"
   },
   silenced: {
     label: "EFFECT.DND5E.StatusSilenced",
-    icon: "systems/dnd5e/icons/svg/statuses/silenced.svg"
+    icon: "systems/dnd5e/icons/svg/statuses/silenced.svg",
+    pseudo: true
   },
   stunned: {
     label: "DND5E.ConStunned",
     icon: "systems/dnd5e/icons/svg/statuses/stunned.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.ZyZMUwA2rboh4ObS",
-    statuses: ["incapacitated"],
-    raw: true
+    statuses: ["incapacitated"]
   },
   surprised: {
     label: "EFFECT.DND5E.StatusSurprised",
-    icon: "systems/dnd5e/icons/svg/statuses/surprised.svg"
+    icon: "systems/dnd5e/icons/svg/statuses/surprised.svg",
+    pseudo: true
   },
   transformed: {
     label: "EFFECT.DND5E.StatusTransformed",
-    icon: "systems/dnd5e/icons/svg/statuses/transformed.svg"
+    icon: "systems/dnd5e/icons/svg/statuses/transformed.svg",
+    pseudo: true
   },
   unconscious: {
     label: "DND5E.ConUnconscious",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2414,19 +2414,26 @@ DND5E.consumableResources = [
 
 /**
  * @typedef {object} _StatusEffectConfig5e
+ * @property {string} icon         Icon used to represent the condition on the token.
  * @property {string} [reference]  UUID of a journal entry with details on this condition.
  * @property {string} [special]    Set this condition as a special status effect under this name.
- * @property {number} [levels]     The number of levels of exhaustion an actor can obtain.
  */
 
 /**
  * Configuration data for system status effects.
- * @typedef {StatusEffectConfig & _StatusEffectConfig5e} StatusEffectConfig5e
+ * @typedef {Omit<StatusEffectConfig, "img"> & _StatusEffectConfig5e} StatusEffectConfig5e
+ */
+
+/**
+ * @typedef {object} _ConditionConfiguration
+ * @property {string} label        Localized label for the condition.
+ * @property {boolean} [raw]       Is this a condition by RAW?
+ * @property {number} [levels]     The number of levels of exhaustion an actor can obtain.
  */
 
 /**
  * Configuration data for system conditions.
- * @typedef {Omit<StatusEffectConfig5e, "name" | "img"> & {label: string, icon: string}} ConditionConfiguration
+ * @typedef {Omit<StatusEffectConfig5e, "name"> & _ConditionConfiguration} ConditionConfiguration
  */
 
 /**
@@ -2434,21 +2441,32 @@ DND5E.consumableResources = [
  * @enum {ConditionConfiguration}
  */
 DND5E.conditionTypes = {
+  bleeding: {
+    label: "EFFECT.DND5E.StatusBleeding",
+    icon: "systems/dnd5e/icons/svg/statuses/bleeding.svg"
+  },
   blinded: {
     label: "DND5E.ConBlinded",
     icon: "systems/dnd5e/icons/svg/statuses/blinded.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.0b8N4FymGGfbZGpJ",
-    special: "BLIND"
+    special: "BLIND",
+    raw: true
   },
   charmed: {
     label: "DND5E.ConCharmed",
     icon: "systems/dnd5e/icons/svg/statuses/charmed.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.zZaEBrKkr66OWJvD"
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.zZaEBrKkr66OWJvD",
+    raw: true
+  },
+  cursed: {
+    label: "EFFECT.DND5E.StatusCursed",
+    icon: "systems/dnd5e/icons/svg/statuses/cursed.svg"
   },
   deafened: {
     label: "DND5E.ConDeafened",
     icon: "systems/dnd5e/icons/svg/statuses/deafened.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.6G8JSjhn701cBITY"
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.6G8JSjhn701cBITY",
+    raw: true
   },
   diseased: {
     label: "DND5E.ConDiseased",
@@ -2458,27 +2476,32 @@ DND5E.conditionTypes = {
     label: "DND5E.ConExhaustion",
     icon: "systems/dnd5e/icons/svg/statuses/exhaustion.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.cspWveykstnu3Zcv",
-    levels: 6
+    levels: 6,
+    raw: true
   },
   frightened: {
     label: "DND5E.ConFrightened",
     icon: "systems/dnd5e/icons/svg/statuses/frightened.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.oreoyaFKnvZCrgij"
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.oreoyaFKnvZCrgij",
+    raw: true
   },
   grappled: {
     label: "DND5E.ConGrappled",
     icon: "systems/dnd5e/icons/svg/statuses/grappled.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.gYDAhd02ryUmtwZn"
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.gYDAhd02ryUmtwZn",
+    raw: true
   },
   incapacitated: {
     label: "DND5E.ConIncapacitated",
     icon: "systems/dnd5e/icons/svg/statuses/incapacitated.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.TpkZgLfxCmSndmpb"
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.TpkZgLfxCmSndmpb",
+    raw: true
   },
   invisible: {
     label: "DND5E.ConInvisible",
     icon: "systems/dnd5e/icons/svg/statuses/invisible.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.3UU5GCTVeRDbZy9u"
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.3UU5GCTVeRDbZy9u",
+    raw: true
   },
   paralyzed: {
     label: "DND5E.ConParalyzed",
@@ -2495,23 +2518,39 @@ DND5E.conditionTypes = {
   poisoned: {
     label: "DND5E.ConPoisoned",
     icon: "systems/dnd5e/icons/svg/statuses/poisoned.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.lq3TRI6ZlED8ABMx"
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.lq3TRI6ZlED8ABMx",
+    raw: true
   },
   prone: {
     label: "DND5E.ConProne",
     icon: "systems/dnd5e/icons/svg/statuses/prone.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.y0TkcdyoZlOTmAFT"
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.y0TkcdyoZlOTmAFT",
+    raw: true
   },
   restrained: {
     label: "DND5E.ConRestrained",
     icon: "systems/dnd5e/icons/svg/statuses/restrained.svg",
-    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.cSVcyZyNe2iG1fIc"
+    reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.cSVcyZyNe2iG1fIc",
+    raw: true
+  },
+  silenced: {
+    label: "EFFECT.DND5E.StatusSilenced",
+    icon: "systems/dnd5e/icons/svg/statuses/silenced.svg"
   },
   stunned: {
     label: "DND5E.ConStunned",
     icon: "systems/dnd5e/icons/svg/statuses/stunned.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.ZyZMUwA2rboh4ObS",
-    statuses: ["incapacitated"]
+    statuses: ["incapacitated"],
+    raw: true
+  },
+  surprised: {
+    label: "EFFECT.DND5E.StatusSurprised",
+    icon: "systems/dnd5e/icons/svg/statuses/surprised.svg"
+  },
+  transformed: {
+    label: "EFFECT.DND5E.StatusTransformed",
+    icon: "systems/dnd5e/icons/svg/statuses/transformed.svg"
   },
   unconscious: {
     label: "DND5E.ConUnconscious",
@@ -2546,10 +2585,6 @@ DND5E.conditionEffects = {
  * @enum {Omit<StatusEffectConfig5e, "img"> & {icon: string}}
  */
 DND5E.statusEffects = {
-  bleeding: {
-    name: "EFFECT.DND5E.StatusBleeding",
-    icon: "systems/dnd5e/icons/svg/statuses/bleeding.svg"
-  },
   burrowing: {
     name: "EFFECT.DND5E.StatusBurrowing",
     icon: "systems/dnd5e/icons/svg/statuses/burrowing.svg",
@@ -2558,10 +2593,6 @@ DND5E.statusEffects = {
   concentrating: {
     name: "EFFECT.DND5E.StatusConcentrating",
     icon: "systems/dnd5e/icons/svg/statuses/concentrating.svg"
-  },
-  cursed: {
-    name: "EFFECT.DND5E.StatusCursed",
-    icon: "systems/dnd5e/icons/svg/statuses/cursed.svg"
   },
   dead: {
     name: "EFFECT.DND5E.StatusDead",
@@ -2594,10 +2625,6 @@ DND5E.statusEffects = {
     name: "EFFECT.DND5E.StatusMarked",
     icon: "systems/dnd5e/icons/svg/statuses/marked.svg"
   },
-  silenced: {
-    name: "EFFECT.DND5E.StatusSilenced",
-    icon: "systems/dnd5e/icons/svg/statuses/silenced.svg"
-  },
   sleeping: {
     name: "EFFECT.DND5E.StatusSleeping",
     icon: "systems/dnd5e/icons/svg/statuses/sleeping.svg",
@@ -2606,14 +2633,6 @@ DND5E.statusEffects = {
   stable: {
     name: "EFFECT.DND5E.StatusStable",
     icon: "systems/dnd5e/icons/svg/statuses/stable.svg"
-  },
-  surprised: {
-    name: "EFFECT.DND5E.StatusSurprised",
-    icon: "systems/dnd5e/icons/svg/statuses/surprised.svg"
-  },
-  transformed: {
-    name: "EFFECT.DND5E.StatusTransformed",
-    icon: "systems/dnd5e/icons/svg/statuses/transformed.svg"
   }
 };
 


### PR DESCRIPTION
We already have *diseased* as a condition even though it technically isn't one so that it shows up nicely under *Condition Immunities* for paladins and monks. So we might as well add some of the other non-RAW conditions, I think. Probably controversial.
- Bleeding: Perhaps useful considering there's blood magic that is only able to target creatures with blood.
- Cursed: I couldn't find a creature that is immune against curses, but it might be possible, not sure.
- Silenced: If you can be immune against blinded and deafened, I imagine you could possibly be immune against being silenced.
- Surprised: Some creatures are immune to being surprised unless incapacitated (e.g. Canoloth). There's also the Helm of Awareness (Artificer Infusion).
- Transformed: Some creatures are immune to any spell or effect that would alter its form (e.g. Clay Golem).