### PR TITLE
[#2944] Modify inventory/effect styles to not use element name

### DIFF
--- a/less/v1/apps.less
+++ b/less/v1/apps.less
@@ -542,7 +542,7 @@ h5 {
 /*  Active Effects                           */
 /* ----------------------------------------- */
 
-dnd5e-effects {
+.effects-element {
   display: flex;
   flex-direction: column;
   overflow-y: hidden;

--- a/less/v1/inventory.less
+++ b/less/v1/inventory.less
@@ -1,4 +1,4 @@
-.dnd5e dnd5e-inventory {
+.dnd5e .inventory-element {
   display: flex;
   flex-direction: column;
   overflow-y: hidden;

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -795,7 +795,7 @@
 /*  Active Effects Pane               */
 /* ---------------------------------- */
 
-.dnd5e2 dnd5e-effects {
+.dnd5e2 .effects-element {
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -1,4 +1,4 @@
-.dnd5e2 dnd5e-inventory {
+.dnd5e2 .inventory-element {
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -567,7 +567,7 @@
 /*  Locked                            */
 /* ---------------------------------- */
 
-.dnd5e2 .locked dnd5e-inventory {
+.dnd5e2 .locked .inventory-element {
   .item :is(.item-quantity, .item-uses) input:is(:focus-visible, :hover) { box-shadow: none; }
 }
 
@@ -575,7 +575,7 @@
 /*  Edit Mode                         */
 /* ---------------------------------- */
 
-.dnd5e2 .editable dnd5e-inventory {
+.dnd5e2 .editable .inventory-element {
   .middle .attunement { padding-right: 0; }
   .items-section .pips { display: none; }
 }

--- a/templates/actors/parts/actor-features.hbs
+++ b/templates/actors/parts/actor-features.hbs
@@ -1,4 +1,4 @@
-<{{elements.inventory}}>
+<{{elements.inventory}} class="inventory-element">
   {{#unless isVehicle}}
   <div class="inventory-filters inventory-header flexrow">
     <ul class="filter-list flexrow" data-filter="features">

--- a/templates/actors/parts/actor-spellbook.hbs
+++ b/templates/actors/parts/actor-spellbook.hbs
@@ -1,4 +1,4 @@
-<{{elements.inventory}}>
+<{{elements.inventory}} class="inventory-element">
   <div class="inventory-filters spellbook-filters flexrow">
     <div class="form-group spellcasting-ability">
         {{#unless isNPC}}

--- a/templates/actors/tabs/character-features.hbs
+++ b/templates/actors/tabs/character-features.hbs
@@ -61,7 +61,7 @@
 </section>
 
 {{!-- Features --}}
-<{{elements.inventory}} v2>
+<{{elements.inventory}} class="inventory-element" v2>
 
     {{!-- Searching, Filtering, & Sorting --}}
     <item-list-controls for="features" label="{{ localize "DND5E.FeatureSearch" }}" sort="toggle" group

--- a/templates/actors/tabs/character-spells.hbs
+++ b/templates/actors/tabs/character-spells.hbs
@@ -33,7 +33,7 @@
 </section>
 
 {{!-- Spells --}}
-<{{ elements.inventory }} v2>
+<{{ elements.inventory }} class="inventory-element" v2>
 
     {{!-- Searching & Filtering --}}
     <item-list-controls for="spellbook" label="{{ localize "DND5E.SpellsSearch" }}" sort="toggle" collection="items"

--- a/templates/shared/active-effects.hbs
+++ b/templates/shared/active-effects.hbs
@@ -1,5 +1,5 @@
 {{#dnd5e-concealSection concealDetails}}
-<{{elements.effects}}>
+<{{elements.effects}} class="effects-element">
   <ol class="items-list effects-list">
     {{#each effects as |section sid|}}
     {{#unless section.hidden}}

--- a/templates/shared/active-effects2.hbs
+++ b/templates/shared/active-effects2.hbs
@@ -1,4 +1,4 @@
-<{{ elements.effects }} v2>
+<{{ elements.effects }} class="effects-element" v2>
 
     {{!-- Searching --}}
     <item-list-controls for="effects" label="{{ localize "DND5E.EffectsSearch" }}" sort="a"

--- a/templates/shared/inventory.hbs
+++ b/templates/shared/inventory.hbs
@@ -1,4 +1,4 @@
-<{{elements.inventory}}>
+<{{elements.inventory}} class="inventory-element">
     <div class="inventory-header flexrow">
         {{#unless isNPC}}
         <ol class="currency flexrow">

--- a/templates/shared/inventory2.hbs
+++ b/templates/shared/inventory2.hbs
@@ -1,4 +1,4 @@
-<{{ elements.inventory }} v2>
+<{{ elements.inventory }} class="inventory-element" v2>
 
     {{!-- Encumbrance & Containers --}}
     <div class="top">


### PR DESCRIPTION
Adds `inventory-element` and `effects-element` classes to any place we use `dnd-inventory` and `dnd-effects` custom elements to allow those sections to be styled even when the custom element is swapped for something else. 

Closes #2944 