### PR TITLE
Make icon use currency abbreviation

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1404,27 +1404,32 @@ DND5E.currencies = {
   pp: {
     label: "DND5E.CurrencyPP",
     abbreviation: "DND5E.CurrencyAbbrPP",
-    conversion: 0.1
+    conversion: 0.1,
+    icon: "pp"
   },
   gp: {
     label: "DND5E.CurrencyGP",
     abbreviation: "DND5E.CurrencyAbbrGP",
-    conversion: 1
+    conversion: 1,
+    icon: "gp"
   },
   ep: {
     label: "DND5E.CurrencyEP",
     abbreviation: "DND5E.CurrencyAbbrEP",
-    conversion: 2
+    conversion: 2,
+    icon: "ep"
   },
   sp: {
     label: "DND5E.CurrencySP",
     abbreviation: "DND5E.CurrencyAbbrSP",
-    conversion: 10
+    conversion: 10,
+    icon: "sp"
   },
   cp: {
     label: "DND5E.CurrencyCP",
     abbreviation: "DND5E.CurrencyAbbrCP",
-    conversion: 100
+    conversion: 100,
+    icon: "cp"
   }
 };
 preLocalize("currencies", { keys: ["label", "abbreviation"] });

--- a/templates/shared/inventory2.hbs
+++ b/templates/shared/inventory2.hbs
@@ -67,7 +67,7 @@
         </button>
         {{#each system.currency}}
         <label aria-label="{{ lookup (lookup @root.config.currencies @key) "label" }}">
-            <i class="currency {{ lookup (lookup @root.config.currencies @key) "abbreviation" }}"
+            <i class="currency {{ lookup (lookup @root.config.currencies @key) "icon" }}"
                data-tooltip="{{ lookup (lookup @root.config.currencies @key) "label" }}"></i>
             <input type="text" class="uninput" name="system.currency.{{ @key }}" value="{{ this }}"
                    data-dtype="Number" inputmode="numeric" pattern="[0-9+=\-]*">

--- a/templates/shared/inventory2.hbs
+++ b/templates/shared/inventory2.hbs
@@ -67,7 +67,7 @@
         </button>
         {{#each system.currency}}
         <label aria-label="{{ lookup (lookup @root.config.currencies @key) "label" }}">
-            <i class="currency {{ @key }}"
+            <i class="currency {{ lookup (lookup @root.config.currencies @key) "abbreviation" }}"
                data-tooltip="{{ lookup (lookup @root.config.currencies @key) "label" }}"></i>
             <input type="text" class="uninput" name="system.currency.{{ @key }}" value="{{ this }}"
                    data-dtype="Number" inputmode="numeric" pattern="[0-9+=\-]*">


### PR DESCRIPTION
Currently, the currency icons depend on the object key in `CONFIG.DND5E.currenices`. This is not ideal because it means these icons will be mismatched if a module patches the currencies object.

This pull requests updates the inventory template that that it will use icons based on the currency abbreviations, which can be patched by https://github.com/cstby/foundryvtt-world-currency-5e.