### PR TITLE
[#3147] Add magical bonus to weapons & armor

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1035,6 +1035,7 @@
 "DND5E.LongRestResultHitDice": "{name} takes a long rest and recovers {dice} Hit Dice.",
 "DND5E.LongRestResultHitPoints": "{name} takes a long rest and recovers {health} Hit Points.",
 "DND5E.LongRestResultShort": "{name} takes a long rest.",
+"DND5E.MagicalBonus": "Magical Bonus",
 "DND5E.Materials": "Materials",
 "DND5E.Max": "Max",
 "DND5E.MaxCharacterLevelExceededWarn": "Character cannot be advanced past level {max}.",

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -143,6 +143,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.armor.value = (this._source.armor.value ?? 0) + (this.magicAvailable ? (this.armor.magicalBonus ?? 0) : 0);
     this.type.label = CONFIG.DND5E.equipmentTypes[this.type.value]
       ?? game.i18n.localize(CONFIG.Item.typeLabels.equipment);
   }
@@ -184,16 +185,6 @@ export default class EquipmentData extends ItemDataModel.mixin(
       (this.isArmor || this.isMountable) ? (this.parent.labels?.armor ?? null) : null,
       this.properties.has("stealthDisadvantage") ? game.i18n.localize("DND5E.Item.Property.StealthDisadvantage") : null
     ];
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Effective armor class, taking any magical bonus into account.
-   * @type {number}
-   */
-  get effectiveAC() {
-    return this.armor.value + (this.magicAvailable ? (this.armor.magicalBonus ?? 0) : 0);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -9,6 +9,8 @@ import PhysicalItemTemplate from "./templates/physical-item.mjs";
 import MountableTemplate from "./templates/mountable.mjs";
 import ItemTypeField from "./fields/item-type-field.mjs";
 
+const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+
 /**
  * Data definition for Equipment items.
  * @mixes ItemDescriptionTemplate
@@ -20,15 +22,16 @@ import ItemTypeField from "./fields/item-type-field.mjs";
  * @mixes ActionTemplate
  * @mixes MountableTemplate
  *
- * @property {object} armor             Armor details and equipment type information.
- * @property {number} armor.value       Base armor class or shield bonus.
- * @property {number} armor.dex         Maximum dex bonus added to armor class.
- * @property {object} speed             Speed granted by a piece of vehicle equipment.
- * @property {number} speed.value       Speed granted by this piece of equipment measured in feet or meters
- *                                      depending on system setting.
- * @property {string} speed.conditions  Conditions that may affect item's speed.
- * @property {number} strength          Minimum strength required to use a piece of armor.
- * @property {number} proficient        Does the owner have proficiency in this piece of equipment?
+ * @property {object} armor               Armor details and equipment type information.
+ * @property {number} armor.value         Base armor class or shield bonus.
+ * @property {number} armor.dex           Maximum dex bonus added to armor class.
+ * @property {number} armor.magicalBonus  Bonus added to AC from the armor's magical nature.
+ * @property {object} speed               Speed granted by a piece of vehicle equipment.
+ * @property {number} speed.value         Speed granted by this piece of equipment measured in feet or meters
+ *                                        depending on system setting.
+ * @property {string} speed.conditions    Conditions that may affect item's speed.
+ * @property {number} strength            Minimum strength required to use a piece of armor.
+ * @property {number} proficient          Does the owner have proficiency in this piece of equipment?
  */
 export default class EquipmentData extends ItemDataModel.mixin(
   ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate, PhysicalItemTemplate, EquippableItemTemplate,
@@ -38,21 +41,22 @@ export default class EquipmentData extends ItemDataModel.mixin(
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
       type: new ItemTypeField({value: "light", subtype: false}, {label: "DND5E.ItemEquipmentType"}),
-      armor: new foundry.data.fields.SchemaField({
-        value: new foundry.data.fields.NumberField({required: true, integer: true, min: 0, label: "DND5E.ArmorClass"}),
-        dex: new foundry.data.fields.NumberField({required: true, integer: true, label: "DND5E.ItemEquipmentDexMod"})
+      armor: new SchemaField({
+        value: new NumberField({required: true, integer: true, min: 0, label: "DND5E.ArmorClass"}),
+        magicalBonus: new NumberField({min: 0, integer: true, label: "DND5E.MagicalBonus"}),
+        dex: new NumberField({required: true, integer: true, label: "DND5E.ItemEquipmentDexMod"})
       }),
-      properties: new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {
+      properties: new SetField(new StringField(), {
         label: "DND5E.ItemEquipmentProperties"
       }),
-      speed: new foundry.data.fields.SchemaField({
-        value: new foundry.data.fields.NumberField({required: true, min: 0, label: "DND5E.Speed"}),
-        conditions: new foundry.data.fields.StringField({required: true, label: "DND5E.SpeedConditions"})
+      speed: new SchemaField({
+        value: new NumberField({required: true, min: 0, label: "DND5E.Speed"}),
+        conditions: new StringField({required: true, label: "DND5E.SpeedConditions"})
       }, {label: "DND5E.Speed"}),
-      strength: new foundry.data.fields.NumberField({
+      strength: new NumberField({
         required: true, integer: true, min: 0, label: "DND5E.ItemRequiredStr"
       }),
-      proficient: new foundry.data.fields.NumberField({
+      proficient: new NumberField({
         required: true, min: 0, max: 1, integer: true, initial: null, label: "DND5E.ProficiencyLevel"
       })
     });
@@ -154,7 +158,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
-  /*  Getters                                     */
+  /*  Properties                                  */
   /* -------------------------------------------- */
 
   /**
@@ -180,6 +184,16 @@ export default class EquipmentData extends ItemDataModel.mixin(
       (this.isArmor || this.isMountable) ? (this.parent.labels?.armor ?? null) : null,
       this.properties.has("stealthDisadvantage") ? game.i18n.localize("DND5E.Item.Property.StealthDisadvantage") : null
     ];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Effective armor class, taking any magical bonus into account.
+   * @type {number}
+   */
+  get effectiveAC() {
+    return this.armor.value + (this.magicAvailable ? (this.armor.magicalBonus ?? 0) : 0);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -52,7 +52,7 @@ export default class EquippableItemTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
-  /*  Getters                                     */
+  /*  Properties                                  */
   /* -------------------------------------------- */
 
   /**
@@ -66,6 +66,16 @@ export default class EquippableItemTemplate extends SystemDataModel {
       game.i18n.localize(this.equipped ? "DND5E.Equipped" : "DND5E.Unequipped"),
       ("proficient" in this) ? CONFIG.DND5E.proficiencyLevels[this.prof?.multiplier || 0] : null
     ];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Are the magical properties of this item, such as magical bonuses to armor & damage, available?
+   * @type {boolean}
+   */
+  get magicAvailable() {
+    return this.attunement !== CONFIG.DND5E.attunementTypes.REQUIRED;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -23,7 +23,7 @@ const { NumberField, SetField, StringField } = foundry.data.fields;
  * @mixes ActionTemplate
  * @mixes MountableTemplate
  *
- * @property {number} magicalBonus     Bonus added to attack & damage rolls, so long as the weapon is attuned.
+ * @property {number} magicalBonus     Magical bonus added to attack & damage rolls.
  * @property {Set<string>} properties  Weapon's properties.
  * @property {number} proficient       Does the weapon's owner have proficiency?
  */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -23,6 +23,7 @@ const { NumberField, SetField, StringField } = foundry.data.fields;
  * @mixes ActionTemplate
  * @mixes MountableTemplate
  *
+ * @property {number} magicalBonus     Bonus added to attack & damage rolls, so long as the weapon is attuned.
  * @property {Set<string>} properties  Weapon's properties.
  * @property {number} proficient       Does the weapon's owner have proficiency?
  */
@@ -34,6 +35,7 @@ export default class WeaponData extends ItemDataModel.mixin(
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
       type: new ItemTypeField({value: "simpleM", subtype: false}, {label: "DND5E.ItemWeaponType"}),
+      magicalBonus: new NumberField({min: 0, integer: true, label: "DND5E.MagicalBonus"}),
       properties: new SetField(new StringField(), {label: "DND5E.ItemWeaponProperties"}),
       proficient: new NumberField({
         required: true, min: 0, max: 1, integer: true, initial: null, label: "DND5E.ProficiencyLevel"

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -447,7 +447,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
           });
           const armorData = armors[0].system.armor;
           const isHeavy = armors[0].system.type.value === "heavy";
-          ac.armor = armors[0].system.effectiveAC ?? ac.armor;
+          ac.armor = armorData.value ?? ac.armor;
           ac.dex = isHeavy ? 0 : Math.min(armorData.dex ?? Infinity, this.system.abilities.dex?.mod ?? 0);
           ac.equippedArmor = armors[0];
         }
@@ -472,7 +472,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       if ( shields.length > 1 ) this._preparationWarnings.push({
         message: game.i18n.localize("DND5E.WarnMultipleShields"), type: "warning"
       });
-      ac.shield = shields[0].system.effectiveAC ?? 0;
+      ac.shield = shields[0].system.armor.value ?? 0;
       ac.equippedShield = shields[0];
     }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -447,7 +447,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
           });
           const armorData = armors[0].system.armor;
           const isHeavy = armors[0].system.type.value === "heavy";
-          ac.armor = armorData.value ?? ac.armor;
+          ac.armor = armors[0].system.effectiveAC ?? ac.armor;
           ac.dex = isHeavy ? 0 : Math.min(armorData.dex ?? Infinity, this.system.abilities.dex?.mod ?? 0);
           ac.equippedArmor = armors[0];
         }
@@ -472,7 +472,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       if ( shields.length > 1 ) this._preparationWarnings.push({
         message: game.i18n.localize("DND5E.WarnMultipleShields"), type: "warning"
       });
-      ac.shield = shields[0].system.armor.value ?? 0;
+      ac.shield = shields[0].system.effectiveAC ?? 0;
       ac.equippedShield = shields[0];
     }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -445,7 +445,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @protected
    */
   _prepareEquipment() {
-    this.labels.armor = this.system.armor.value ? `${this.system.effectiveAC} ${game.i18n.localize("DND5E.AC")}` : "";
+    this.labels.armor = this.system.armor.value ? `${this.system.armor.value} ${game.i18n.localize("DND5E.AC")}` : "";
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -445,7 +445,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @protected
    */
   _prepareEquipment() {
-    this.labels.armor = this.system.armor.value ? `${this.system.armor.value} ${game.i18n.localize("DND5E.AC")}` : "";
+    this.labels.armor = this.system.armor.value ? `${this.system.effectiveAC} ${game.i18n.localize("DND5E.AC")}` : "";
   }
 
   /* -------------------------------------------- */
@@ -682,10 +682,12 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     if ( !this.hasDamage || !this.isOwned ) return [];
     const rollData = this.getRollData();
     const damageLabels = { ...CONFIG.DND5E.damageTypes, ...CONFIG.DND5E.healingTypes };
-    const derivedDamage = this.system.damage?.parts?.map(damagePart => {
+    const derivedDamage = this.system.damage?.parts?.map((damagePart, index) => {
       let formula;
       try {
-        const roll = new Roll(damagePart[0], rollData);
+        formula = damagePart[0];
+        if ( (index === 0) && this.system.magicAvailable ) formula = `${formula} + ${this.system.magicalBonus ?? 0}`;
+        const roll = new Roll(formula, rollData);
         formula = simplifyRollFormula(roll.formula, { preserveFlavor: true });
       }
       catch(err) {
@@ -728,47 +730,45 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
   /**
    * Update a label to the Item detailing its total to hit bonus from the following sources:
-   * - item document's innate attack bonus
    * - item's actor's proficiency bonus if applicable
    * - item's actor's global bonuses to the given item type
+   * - item document's innate & magical attack bonuses
    * - item's ammunition if applicable
    * @returns {{rollData: object, parts: string[]}|null}  Data used in the item's Attack roll.
    */
   getAttackToHit() {
     if ( !this.hasAttack ) return null;
+    const flat = this.system.attack.flat;
     const rollData = this.getRollData();
     const parts = [];
+    let ammo;
 
-    // Include the item's innate attack bonus as the initial value and label
-    const ab = this.system.attack?.bonus ?? "";
-    if ( ab ) {
-      parts.push(ab);
-      this.labels.toHit = !/^[+-]/.test(ab) ? `+ ${ab}` : ab;
-      if ( this.system.attack?.flat ) return {rollData, parts};
+    if ( this.isOwned && !flat ) {
+      // Ability score modifier
+      if ( this.system.ability !== "none" ) parts.push("@mod");
+
+      // Add proficiency bonus.
+      if ( this.system.prof?.hasProficiency ) {
+        parts.push("@prof");
+        rollData.prof = this.system.prof.term;
+      }
+
+      // Actor-level global bonus to attack rolls
+      const actorBonus = this.actor.system.bonuses?.[this.system.actionType] || {};
+      if ( actorBonus.attack ) parts.push(actorBonus.attack);
+
+      ammo = this.hasAmmo ? this.actor.items.get(this.system.consume.target) : null;
     }
 
-    // Take no further action for un-owned items
-    if ( !this.isOwned ) return {rollData, parts};
-
-    // Ability score modifier
-    if ( this.system.ability !== "none" ) parts.push("@mod");
-
-    // Add proficiency bonus.
-    if ( this.system.prof?.hasProficiency ) {
-      parts.push("@prof");
-      rollData.prof = this.system.prof.term;
-    }
-
-    // Actor-level global bonus to attack rolls
-    const actorBonus = this.actor.system.bonuses?.[this.system.actionType] || {};
-    if ( actorBonus.attack ) parts.push(actorBonus.attack);
+    // Include the item's innate & magical attack bonuses
+    if ( this.system.attack.bonus ) parts.push(this.system.attack.bonus);
+    if ( this.system.magicalBonus && this.system.magicAvailable && !flat ) parts.push(this.system.magicalBonus);
 
     // One-time bonus provided by consumed ammunition
-    const ammo = this.hasAmmo ? this.actor.items.get(this.system.consume.target) : null;
-    if ( ammo ) {
+    if ( ammo && !flat ) {
       const ammoItemQuantity = ammo.system.quantity;
       const ammoCanBeConsumed = ammoItemQuantity && (ammoItemQuantity - (this.system.consume.amount ?? 0) >= 0);
-      const ammoItemAttackBonus = ammo.system.attack.bonus;
+      const ammoItemAttackBonus = ammo.system.attackBonus;
       const ammoIsTypeConsumable = (ammo.type === "consumable") && (ammo.system.type.value === "ammo");
       if ( ammoCanBeConsumed && ammoItemAttackBonus && ammoIsTypeConsumable ) {
         parts.push("@ammo");
@@ -781,7 +781,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const formula = simplifyRollFormula(roll.formula) || "0";
     this.labels.modifier = simplifyRollFormula(roll.formula, { deterministic: true }) || "0";
     this.labels.toHit = !/^[+-]/.test(formula) ? `+ ${formula}` : formula;
-    return {rollData, parts};
+    return { rollData, parts };
   }
 
   /* -------------------------------------------- */
@@ -1563,6 +1563,11 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     if ( versatile && dmg.versatile ) {
       rollConfigs[0].parts[0] = dmg.versatile;
       messageData["flags.dnd5e.roll"].versatile = true;
+    }
+
+    // Add magical damage if available
+    if ( this.system.magicalBonus && this.system.magicAvailable ) {
+      rollConfigs[0].parts.push(this.system.magicalBonus);
     }
 
     // Scale damage from up-casting spells

--- a/templates/items/equipment.hbs
+++ b/templates/items/equipment.hbs
@@ -126,7 +126,7 @@
             <div class="form-group">
                 <label>{{ localize "DND5E.ArmorClass" }}</label>
                 <div class="form-fields">
-                    {{numberInput system.armor.value name="system.armor.value"}}
+                    {{ numberInput source.armor.value name="system.armor.value" step="1" }}
                 </div>
             </div>
 
@@ -134,7 +134,8 @@
             <div class="form-group">
                 <label>{{ localize "DND5E.MagicalBonus" }}</label>
                 <div class="form-fields">
-                    {{ numberInput system.armor.magicalBonus name="system.armor.magicalBonus" placeholder=0 }}
+                    {{ numberInput system.armor.magicalBonus name="system.armor.magicalBonus"
+                       min="0" step="1" placeholder="0" }}
                 </div>
             </div>
             {{/if}}

--- a/templates/items/equipment.hbs
+++ b/templates/items/equipment.hbs
@@ -129,6 +129,15 @@
                     {{numberInput system.armor.value name="system.armor.value"}}
                 </div>
             </div>
+
+            {{#if properties.mgc.selected}}
+            <div class="form-group">
+                <label>{{ localize "DND5E.MagicalBonus" }}</label>
+                <div class="form-fields">
+                    {{ numberInput system.armor.magicalBonus name="system.armor.magicalBonus" placeholder=0 }}
+                </div>
+            </div>
+            {{/if}}
             {{/if}}
 
             {{#if hasDexModifier}}

--- a/templates/items/weapon.hbs
+++ b/templates/items/weapon.hbs
@@ -128,6 +128,15 @@
             {{> "dnd5e.item-mountable"}}
             {{/if}}
 
+            {{#if properties.mgc.selected}}
+            <div class="form-group">
+                <label>{{ localize "DND5E.MagicalBonus" }}</label>
+                <div class="form-fields">
+                    {{ numberInput system.magicalBonus name="system.magicalBonus" placeholder=0 }}
+                </div>
+            </div>
+            {{/if}}
+
             <h3 class="form-header">{{ localize "DND5E.ItemWeaponUsage" }}</h3>
 
             {{!-- Item Activation Template --}}

--- a/templates/items/weapon.hbs
+++ b/templates/items/weapon.hbs
@@ -132,7 +132,7 @@
             <div class="form-group">
                 <label>{{ localize "DND5E.MagicalBonus" }}</label>
                 <div class="form-fields">
-                    {{ numberInput system.magicalBonus name="system.magicalBonus" placeholder=0 }}
+                    {{ numberInput system.magicalBonus name="system.magicalBonus" min="0" step="1" placeholder="0" }}
                 </div>
             </div>
             {{/if}}


### PR DESCRIPTION
Introduces `system.magicalBonus` to weapons and `system.armor.magicalBonus` to equipment to represent bonuses to attack, damage, and AC from the magical part of these items.

Also introduces `system.magicAvailable` to physical items that indicates whether the magical effects of these items is available. Currently this is only based on current attunement, but could be expanded later to other things that might make magic unavailable.

### Followup Work
- [ ] Modify SRD weapons & armor to use these new properties
- [ ] Add magical bonus to ammunition