### PR TITLE
[#2668, #3149] Allow advancement and races, classes, and backgrounds on NPCs

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -614,6 +614,9 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
       // Configure Special Flags
       html.find(".config-button").click(this._onConfigMenu.bind(this));
 
+      // Changing Level
+      html.find(".level-selector").change(this._onLevelChange.bind(this));
+
       // Owned Item management
       html.find(".slot-max-override").click(this._onSpellSlotOverride.bind(this));
       html.find(".attunement-max-override").click(this._onAttunementOverride.bind(this));
@@ -674,7 +677,35 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
   }
 
   /* -------------------------------------------- */
-  /*  Event Listeners and Handlers                */
+
+  /**
+   * Respond to a new level being selected from the level selector.
+   * @param {Event} event                           The originating change.
+   * @returns {Promise<AdvancementManager|Item5e>}  Manager if advancements needed, otherwise updated class item.
+   * @private
+   */
+  async _onLevelChange(event) {
+    event.preventDefault();
+    const delta = Number(event.target.value);
+    const classId = event.target.closest("[data-item-id]")?.dataset.itemId;
+    if ( !delta || !classId ) return;
+    const classItem = this.actor.items.get(classId);
+    if ( !game.settings.get("dnd5e", "disableAdvancements") ) {
+      const manager = AdvancementManager.forLevelChange(this.actor, classId, delta);
+      if ( manager.steps.length ) {
+        if ( delta > 0 ) return manager.render(true);
+        try {
+          const shouldRemoveAdvancements = await AdvancementConfirmationDialog.forLevelDown(classItem);
+          if ( shouldRemoveAdvancements ) return manager.render(true);
+        }
+        catch(err) {
+          return;
+        }
+      }
+    }
+    return classItem.update({"system.levels": classItem.system.levels + delta});
+  }
+
   /* -------------------------------------------- */
 
   /**

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -220,7 +220,6 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
   activateListeners(html) {
     super.activateListeners(html);
     if ( !this.isEditable ) return;
-    html.find(".level-selector").change(this._onLevelChange.bind(this));
     html.find(".short-rest").click(this._onShortRest.bind(this));
     html.find(".long-rest").click(this._onLongRest.bind(this));
     html.find(".rollable[data-action]").click(this._onSheetAction.bind(this));
@@ -262,36 +261,6 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
       case "rollInitiative":
         return this.actor.rollInitiativeDialog({event});
     }
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Respond to a new level being selected from the level selector.
-   * @param {Event} event                           The originating change.
-   * @returns {Promise<AdvancementManager|Item5e>}  Manager if advancements needed, otherwise updated class item.
-   * @private
-   */
-  async _onLevelChange(event) {
-    event.preventDefault();
-    const delta = Number(event.target.value);
-    const classId = event.target.closest("[data-item-id]")?.dataset.itemId;
-    if ( !delta || !classId ) return;
-    const classItem = this.actor.items.get(classId);
-    if ( !game.settings.get("dnd5e", "disableAdvancements") ) {
-      const manager = AdvancementManager.forLevelChange(this.actor, classId, delta);
-      if ( manager.steps.length ) {
-        if ( delta > 0 ) return manager.render(true);
-        try {
-          const shouldRemoveAdvancements = await AdvancementConfirmationDialog.forLevelDown(classItem);
-          if ( shouldRemoveAdvancements ) return manager.render(true);
-        }
-        catch(err) {
-          return;
-        }
-      }
-    }
-    return classItem.update({"system.levels": classItem.system.levels + delta});
   }
 
   /* -------------------------------------------- */

--- a/module/applications/advancement/advancement-manager.mjs
+++ b/module/applications/advancement/advancement-manager.mjs
@@ -201,7 +201,7 @@ export default class AdvancementManager extends Application {
     }
 
     // All other items, just create some flows up to current character level (or class level for subclasses)
-    let targetLevel = manager.clone.system.details.level;
+    let targetLevel = manager.clone.system.details.level ?? 0;
     if ( clonedItem.type === "subclass" ) targetLevel = clonedItem.class?.system.levels ?? 0;
     Array.fromRange(targetLevel + 1)
       .flatMap(l => this.flowsForLevel(clonedItem, l))
@@ -293,7 +293,7 @@ export default class AdvancementManager extends Application {
     }
 
     // All other items, just create some flows down from current character level
-    Array.fromRange(manager.clone.system.details.level + 1)
+    Array.fromRange((manager.clone.system.details.level ?? 0) + 1)
       .flatMap(l => this.flowsForLevel(clonedItem, l))
       .reverse()
       .forEach(flow => manager.steps.push({ type: "reverse", flow, automatic: true }));
@@ -339,7 +339,7 @@ export default class AdvancementManager extends Application {
     // Level increased
     for ( let offset = 1; offset <= levelDelta; offset++ ) {
       const classLevel = classItem.system.levels + offset;
-      const characterLevel = this.actor.system.details.level + offset;
+      const characterLevel = (this.actor.system.details.level ?? 0) + offset;
       const stepData = { type: "forward", class: {item: classItem, level: classLevel} };
       pushSteps(this.constructor.flowsForLevel(classItem, classLevel), stepData);
       pushSteps(this.constructor.flowsForLevel(classItem.subclass, classLevel), stepData);
@@ -349,7 +349,7 @@ export default class AdvancementManager extends Application {
     // Level decreased
     for ( let offset = 0; offset > levelDelta; offset-- ) {
       const classLevel = classItem.system.levels + offset;
-      const characterLevel = this.actor.system.details.level + offset;
+      const characterLevel = (this.actor.system.details.level ?? 0) + offset;
       const stepData = { type: "reverse", class: {item: classItem, level: classLevel}, automatic: true };
       pushSteps(getItemFlows(characterLevel).reverse(), stepData);
       pushSteps(this.constructor.flowsForLevel(classItem.subclass, classLevel).reverse(), stepData);
@@ -390,7 +390,7 @@ export default class AdvancementManager extends Application {
    * @returns {number}       Working level.
    */
   static currentLevel(item, actor) {
-    return item.system.levels ?? item.class?.system.levels ?? actor.system.details.level;
+    return item.system.levels ?? item.class?.system.levels ?? actor.system.details.level ?? 0;
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -48,6 +48,13 @@ import TraitsFields from "./templates/traits.mjs";
 export default class NPCData extends CreatureTemplate {
 
   /** @inheritdoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    supportsAdvancement: true
+  }, {inplace: false}));
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
   static _systemType = "npc";
 
   /* -------------------------------------------- */
@@ -81,7 +88,7 @@ export default class NPCData extends CreatureTemplate {
           failure: new foundry.data.fields.NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveFailures"
           })
-        }, {label: "DND5E.DeathSave"}),
+        }, {label: "DND5E.DeathSave"})
       }, {label: "DND5E.Attributes"}),
       details: new foundry.data.fields.SchemaField({
         ...DetailsFields.common,
@@ -209,23 +216,31 @@ export default class NPCData extends CreatureTemplate {
 
   /** @inheritdoc */
   prepareBaseData() {
-    const cr = this.details.cr;
+    this.details.level = 0;
 
-    // Attuned items
-    this.attributes.attunement.value = this.parent.items.filter(i => {
-      return i.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED;
-    }).length;
+    for ( const item of this.parent.items ) {
+      // Class levels & hit dice
+      if ( item.type === "class" ) {
+        const classLevels = parseInt(item.system.levels) ?? 1;
+        this.details.level += classLevels;
+      }
+
+      // Attuned items
+      else if ( item.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED ) {
+        this.attributes.attunement.value += 1;
+      }
+    }
 
     // Kill Experience
     this.details.xp ??= {};
-    this.details.xp.value = this.parent.getCRExp(cr);
+    this.details.xp.value = this.parent.getCRExp(this.details.cr);
 
     // Proficiency
-    this.attributes.prof = Proficiency.calculateMod(Math.max(cr, 1));
+    this.attributes.prof = Proficiency.calculateMod(Math.max(this.details.cr, this.details.level, 1));
 
     // Spellcaster Level
     if ( this.attributes.spellcasting && !Number.isNumeric(this.details.spellLevel) ) {
-      this.details.spellLevel = Math.max(cr, 1);
+      this.details.spellLevel = Math.max(this.details.cr, 1);
     }
 
     AttributesFields.prepareBaseArmorClass.call(this);

--- a/module/documents/advancement/hit-points.mjs
+++ b/module/documents/advancement/hit-points.mjs
@@ -145,7 +145,7 @@ export default class HitPointsAdvancement extends Advancement {
   #getApplicableValue(value) {
     const abilityId = CONFIG.DND5E.defaultAbilities.hitPoints || "con";
     value = Math.max(value + (this.actor.system.abilities[abilityId]?.mod ?? 0), 1);
-    value += simplifyBonus(this.actor.system.attributes.hp.bonuses.level, this.actor.getRollData());
+    value += simplifyBonus(this.actor.system.attributes.hp.bonuses?.level, this.actor.getRollData());
     return value;
   }
 


### PR DESCRIPTION
Removes the restriction that prevents races, classes, and backgrounds from being added to NPCs and fixed a few issues preventing advancement on that actor type.

NPCs with classes will now get `system.details.level` calculated, and their proficiency bonus will be calculated based off either their level or their CR, whichever is higher.

Class, race, and background items are just listed in the passive features section, not given any special prominence.

### Future Work
- [ ] Decide how to handle creature type, speed, and senses from race items
- [ ] Modify `HitPointsAdvancement` to actually change NPC hit points
- [ ] Properly derive NPC spellcasting from classes