### PR TITLE
[#997] Add lookup enricher for including non-roll data

### DIFF
--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -341,10 +341,9 @@ export class ActorDataModel extends SystemDataModel {
    * @param {object} [options]
    * @param {boolean} [options.deterministic] Whether to force deterministic values for data properties that could be
    *                                          either a die term or a flat term.
-   * @param {boolean} [options.extended]      Include extra values like "name" that aren't useful in formulas.
    * @returns {object}
    */
-  getRollData({ deterministic=false, extended=false }={}) {
+  getRollData({ deterministic=false }={}) {
     const data = { ...this };
     data.prof = new Proficiency(this.attributes?.prof ?? 0, 1);
     if ( deterministic ) data.prof = data.prof.flat;
@@ -498,12 +497,11 @@ export class ItemDataModel extends SystemDataModel {
    * @param {object} [options]
    * @param {boolean} [options.deterministic] Whether to force deterministic values for data properties that could be
    *                                          either a die term or a flat term.
-   * @param {boolean} [options.extended]      Include extra values like "name" that aren't useful in formulas.
    * @returns {object}
    */
-  getRollData({ deterministic=false, extended }={}) {
+  getRollData({ deterministic=false }={}) {
     if ( !this.parent.actor ) return null;
-    const actorRollData = this.parent.actor.getRollData({ deterministic, extended });
+    const actorRollData = this.parent.actor.getRollData({ deterministic });
     const data = { ...actorRollData, item: { ...this } };
     return data;
   }

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -341,9 +341,10 @@ export class ActorDataModel extends SystemDataModel {
    * @param {object} [options]
    * @param {boolean} [options.deterministic] Whether to force deterministic values for data properties that could be
    *                                          either a die term or a flat term.
+   * @param {boolean} [options.extended]      Include extra values like "name" that aren't useful in formulas.
    * @returns {object}
    */
-  getRollData({ deterministic=false }={}) {
+  getRollData({ deterministic=false, extended=false }={}) {
     const data = { ...this };
     data.prof = new Proficiency(this.attributes?.prof ?? 0, 1);
     if ( deterministic ) data.prof = data.prof.flat;
@@ -497,11 +498,12 @@ export class ItemDataModel extends SystemDataModel {
    * @param {object} [options]
    * @param {boolean} [options.deterministic] Whether to force deterministic values for data properties that could be
    *                                          either a die term or a flat term.
+   * @param {boolean} [options.extended]      Include extra values like "name" that aren't useful in formulas.
    * @returns {object}
    */
-  getRollData({ deterministic=false }={}) {
+  getRollData({ deterministic=false, extended }={}) {
     if ( !this.parent.actor ) return null;
-    const actorRollData = this.parent.actor.getRollData({ deterministic });
+    const actorRollData = this.parent.actor.getRollData({ deterministic, extended });
     const data = { ...actorRollData, item: { ...this } };
     return data;
   }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -181,14 +181,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @param {object} [options]
    * @param {boolean} [options.deterministic] Whether to force deterministic values for data properties that could be
    *                                          either a die term or a flat term.
-   * @param {boolean} [options.extended]      Include extra values like "name" that aren't useful in formulas.
    */
-  getRollData({ deterministic=false, extended=false }={}) {
+  getRollData({ deterministic=false }={}) {
     let data;
-    if ( this.system.getRollData ) data = this.system.getRollData({ deterministic, extended });
+    if ( this.system.getRollData ) data = this.system.getRollData({ deterministic });
     else data = {...super.getRollData()};
     data.flags = {...this.flags};
-    if ( extended ) data.name = this.name;
+    data.name = this.name;
     return data;
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -180,13 +180,15 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @inheritdoc
    * @param {object} [options]
    * @param {boolean} [options.deterministic] Whether to force deterministic values for data properties that could be
-   *                                            either a die term or a flat term.
+   *                                          either a die term or a flat term.
+   * @param {boolean} [options.extended]      Include extra values like "name" that aren't useful in formulas.
    */
-  getRollData({ deterministic=false }={}) {
+  getRollData({ deterministic=false, extended=false }={}) {
     let data;
-    if ( this.system.getRollData ) data = this.system.getRollData({ deterministic });
+    if ( this.system.getRollData ) data = this.system.getRollData({ deterministic, extended });
     else data = {...super.getRollData()};
     data.flags = {...this.flags};
+    if ( extended ) data.name = this.name;
     return data;
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1837,18 +1837,17 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @param {object} [options]
    * @param {boolean} [options.deterministic] Whether to force deterministic values for data properties that could be
    *                                          either a die term or a flat term.
-   * @param {boolean} [options.extended]      Include extra values like "name" that aren't useful in formulas.
    */
-  getRollData({ deterministic=false, extended=false }={}) {
+  getRollData({ deterministic=false }={}) {
     let data;
-    if ( this.system.getRollData ) data = this.system.getRollData({ deterministic, extended });
+    if ( this.system.getRollData ) data = this.system.getRollData({ deterministic });
     else {
       if ( !this.actor ) return null;
-      data = { ...this.actor.getRollData({ deterministic, extended }), item: { ...this.system } };
+      data = { ...this.actor.getRollData({ deterministic }), item: { ...this.system } };
     }
     if ( data?.item ) {
       data.item.flags = { ...this.flags };
-      if ( extended ) data.item.name = this.name;
+      data.item.name = this.name;
     }
     return data;
   }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1837,15 +1837,19 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @param {object} [options]
    * @param {boolean} [options.deterministic] Whether to force deterministic values for data properties that could be
    *                                          either a die term or a flat term.
+   * @param {boolean} [options.extended]      Include extra values like "name" that aren't useful in formulas.
    */
-  getRollData({ deterministic=false }={}) {
+  getRollData({ deterministic=false, extended=false }={}) {
     let data;
-    if ( this.system.getRollData ) data = this.system.getRollData({ deterministic });
+    if ( this.system.getRollData ) data = this.system.getRollData({ deterministic, extended });
     else {
       if ( !this.actor ) return null;
-      data = { ...this.actor.getRollData({ deterministic }), item: { ...this.system } };
+      data = { ...this.actor.getRollData({ deterministic, extended }), item: { ...this.system } };
     }
-    if ( data?.item ) data.item.flags = { ...this.flags };
+    if ( data?.item ) {
+      data.item.flags = { ...this.flags };
+      if ( extended ) data.item.name = this.name;
+    }
     return data;
   }
 

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -10,7 +10,11 @@ const slugify = value => value?.slugify().replaceAll("-", "");
  */
 export function registerCustomEnrichers() {
   CONFIG.TextEditor.enrichers.push({
-    pattern: /\[\[\/(?<type>award|check|damage|lookup|save|skill|tool) (?<config>[^\]]+)]](?:{(?<label>[^}]+)})?/gi,
+    pattern: /\[\[\/(?<type>award|check|damage|save|skill|tool) (?<config>[^\]]+)]](?:{(?<label>[^}]+)})?/gi,
+    enricher: enrichString
+  },
+  {
+    pattern: /\[\[(?<type>lookup) (?<config>[^\]]+)]](?:{(?<label>[^}]+)})?/gi,
     enricher: enrichString
   },
   {
@@ -653,6 +657,13 @@ function wrapEmbeddedText(enriched, config, label, options) {
  * @param {string} [fallback]          Optional fallback if the value couldn't be found.
  * @param {EnrichmentOptions} options  Options provided to customize text enrichment.
  * @returns {HTMLElement|null}         An HTML element if the lookup could be built, otherwise null.
+ *
+ * @example Include a creature's name in its description:
+ * ```[[lookup @name]]``
+ * becomes
+ * ```html
+ * <span class="lookup-value">Adult Black Dragon</span>
+ * ```
  */
 function enrichLookup(config, fallback, options) {
   let keyPath = config.path;
@@ -696,7 +707,7 @@ function enrichLookup(config, fallback, options) {
  * @returns {HTMLElement|null}         An HTML link to the Journal Entry Page for the given reference.
  *
  * @example Create a content link to the relevant reference:
- * ```@Reference[condition=unconscious]{Label}```
+ * ```&Reference[condition=unconscious]{Label}```
  * becomes
  * ```html
  * <span class="reference-link">

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -680,7 +680,7 @@ function enrichLookup(config, fallback, options) {
     return null;
   }
 
-  const data = options.relativeTo?.getRollData({ extended: true });
+  const data = options.relativeTo?.getRollData();
   let value = foundry.utils.getProperty(data, keyPath.substring(1)) ?? fallback;
   if ( value && style ) {
     if ( style === "capitalize" ) value = value.capitalize();

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -10,7 +10,7 @@ const slugify = value => value?.slugify().replaceAll("-", "");
  */
 export function registerCustomEnrichers() {
   CONFIG.TextEditor.enrichers.push({
-    pattern: /\[\[\/(?<type>award|check|damage|save|skill|tool) (?<config>[^\]]+)]](?:{(?<label>[^}]+)})?/gi,
+    pattern: /\[\[\/(?<type>award|check|damage|lookup|save|skill|tool) (?<config>[^\]]+)]](?:{(?<label>[^}]+)})?/gi,
     enricher: enrichString
   },
   {
@@ -47,6 +47,7 @@ async function enrichString(match, options) {
     case "check":
     case "skill":
     case "tool": return enrichCheck(config, label, options);
+    case "lookup": return enrichLookup(config, label, options);
     case "save": return enrichSave(config, label, options);
     case "embed": return enrichEmbed(config, label, options);
     case "reference": return enrichReference(config, label, options);
@@ -643,6 +644,47 @@ function wrapEmbeddedText(enriched, config, label, options) {
 }
 
 /* -------------------------------------------- */
+/*  Lookup Enricher                             */
+/* -------------------------------------------- */
+
+/**
+ * Enrich a property lookup.
+ * @param {object} config              Configuration data.
+ * @param {string} [fallback]          Optional fallback if the value couldn't be found.
+ * @param {EnrichmentOptions} options  Options provided to customize text enrichment.
+ * @returns {HTMLElement|null}         An HTML element if the lookup could be built, otherwise null.
+ */
+function enrichLookup(config, fallback, options) {
+  let keyPath = config.path;
+  let style = config.style;
+  for ( const value of config.values ) {
+    if ( value === "capitalize" ) style ??= "capitalize";
+    else if ( value === "lowercase" ) style ??= "lowercase";
+    else if ( value === "uppercase" ) style ??= "uppercase";
+    else if ( value.startsWith("@") ) keyPath ??= value;
+  }
+
+  if ( !keyPath ) {
+    console.warn(`Lookup path must be defined to enrich ${config._input}.`);
+    return null;
+  }
+
+  const data = options.relativeTo?.getRollData({ extended: true });
+  let value = foundry.utils.getProperty(data, keyPath.substring(1)) ?? fallback;
+  if ( value && style ) {
+    if ( style === "capitalize" ) value = value.capitalize();
+    else if ( style === "lowercase" ) value = value.toLowerCase();
+    else if ( style === "uppercase" ) value = value.toUpperCase();
+  }
+
+  const span = document.createElement("span");
+  span.classList.add("lookup-value");
+  if ( !value ) span.classList.add("not-found");
+  span.innerText = value ?? keyPath;
+  return span;
+}
+
+/* -------------------------------------------- */
 /*  Reference Enricher                          */
 /* -------------------------------------------- */
 
@@ -711,6 +753,8 @@ async function enrichReference(config, label, options) {
   return span;
 }
 
+/* -------------------------------------------- */
+/*  Helpers                                     */
 /* -------------------------------------------- */
 
 /**


### PR DESCRIPTION
Adds a new enricher that allows for looking up values within roll data and displaying them as is:

<img width="979" alt="Screenshot 2024-02-28 at 17 06 01" src="https://github.com/foundryvtt/dnd5e/assets/19979839/49f89032-9ac4-4b1e-ade6-9f8c26921d3f">

This includes an extra `extended` option for `getRollData` that includes the creature's name. This could be extended in the future to include additional data, like perhaps the localized creature type or anything else that would be useful in this context but not in standard roll formulas.