### PR TITLE
Move trackable attributes to setup

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -86,12 +86,12 @@ Hooks.once("init", function() {
   // Configure tooltips
   game.dnd5e.tooltips = new Tooltips5e();
 
+  // Set up status effects
+  _configureStatusEffects();
+
   // Remove honor & sanity from configuration if they aren't enabled
   if ( !game.settings.get("dnd5e", "honorScore") ) delete DND5E.abilities.hon;
   if ( !game.settings.get("dnd5e", "sanityScore") ) delete DND5E.abilities.san;
-
-  // Patch Core Functions
-  Combatant.prototype.getInitiativeRoll = documents.combat.getInitiativeRoll;
 
   // Register Roll Extensions
   CONFIG.Dice.rolls.push(dice.D20Roll);
@@ -320,9 +320,6 @@ Hooks.once("setup", function() {
   // Configure trackable & consumable attributes.
   _configureTrackableAttributes();
   _configureConsumableAttributes();
-
-  // Set up status effects
-  _configureStatusEffects();
 
   CONFIG.DND5E.trackableAttributes = expandAttributeList(CONFIG.DND5E.trackableAttributes);
   game.dnd5e.moduleArt.registerModuleArt();

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -86,16 +86,12 @@ Hooks.once("init", function() {
   // Configure tooltips
   game.dnd5e.tooltips = new Tooltips5e();
 
-  // Set up status effects
-  _configureStatusEffects();
-
   // Remove honor & sanity from configuration if they aren't enabled
   if ( !game.settings.get("dnd5e", "honorScore") ) delete DND5E.abilities.hon;
   if ( !game.settings.get("dnd5e", "sanityScore") ) delete DND5E.abilities.san;
 
-  // Configure trackable & consumable attributes.
-  _configureTrackableAttributes();
-  _configureConsumableAttributes();
+  // Patch Core Functions
+  Combatant.prototype.getInitiativeRoll = documents.combat.getInitiativeRoll;
 
   // Register Roll Extensions
   CONFIG.Dice.rolls.push(dice.D20Roll);
@@ -321,6 +317,13 @@ function _configureStatusEffects() {
  * Prepare attribute lists.
  */
 Hooks.once("setup", function() {
+  // Configure trackable & consumable attributes.
+  _configureTrackableAttributes();
+  _configureConsumableAttributes();
+
+  // Set up status effects
+  _configureStatusEffects();
+
   CONFIG.DND5E.trackableAttributes = expandAttributeList(CONFIG.DND5E.trackableAttributes);
   game.dnd5e.moduleArt.registerModuleArt();
   Tooltips5e.activateListeners();


### PR DESCRIPTION
Closes #3153.

Moved `_configureTrackableAttributes` as well as `_configureConsumableAttributes` and `_configureStatusEffects` for good measure to the `setup` hook to allow modules to update `CONFIG.DND5E` on `init` before these are generated. Saves having to update these objects as they'd most likely need to be rebuilt or looped through to remove attributes that no longer exist in the config.