### PR TITLE
Convert several attribute fields to use `RollConfigField`

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -2,6 +2,7 @@ import Proficiency from "../../documents/actor/proficiency.mjs";
 import { simplifyBonus } from "../../utils.mjs";
 import { FormulaField, LocalDocumentField } from "../fields.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
+import RollConfigField from "../shared/roll-config-field.mjs";
 import AttributesFields from "./templates/attributes.mjs";
 import CreatureTemplate from "./templates/creature.mjs";
 import DetailsFields from "./templates/details.mjs";
@@ -96,7 +97,7 @@ export default class CharacterData extends CreatureTemplate {
             overall: new FormulaField({deterministic: true, label: "DND5E.HitPointsBonusOverall"})
           })
         }, {label: "DND5E.HitPoints"}),
-        death: new SchemaField({
+        death: new RollConfigField({
           success: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveSuccesses"
           }),

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -1,6 +1,7 @@
 import Proficiency from "../../documents/actor/proficiency.mjs";
 import { FormulaField } from "../fields.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
+import RollConfigField from "../shared/roll-config-field.mjs";
 import SourceField from "../shared/source-field.mjs";
 import AttributesFields from "./templates/attributes.mjs";
 import CreatureTemplate from "./templates/creature.mjs";
@@ -81,7 +82,7 @@ export default class NPCData extends CreatureTemplate {
           tempmax: new foundry.data.fields.NumberField({integer: true, initial: 0, label: "DND5E.HitPointsTempMax"}),
           formula: new FormulaField({required: true, label: "DND5E.HPFormula"})
         }, {label: "DND5E.HitPoints"}),
-        death: new foundry.data.fields.SchemaField({
+        death: new RollConfigField({
           success: new foundry.data.fields.NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveSuccesses"
           }),

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -26,9 +26,9 @@ export default class AttributesFields {
    */
   static get common() {
     return {
-      init: new foundry.data.fields.SchemaField({
-        ability: new foundry.data.fields.StringField({label: "DND5E.AbilityModifier"}),
-        bonus: new FormulaField({label: "DND5E.InitiativeBonus"})
+      init: new RollConfigField({
+        ability: "dex",
+        bonus: new FormulaField({required: true, label: "DND5E.InitiativeBonus"})
       }, { label: "DND5E.Initiative" }),
       movement: new MovementField()
     };
@@ -76,6 +76,9 @@ export default class AttributesFields {
       }),
       concentration: new RollConfigField({
         ability: "con",
+        bonuses: new foundry.data.fields.SchemaField({
+          save: new FormulaField({required: true, label: "DND5E.SaveBonus"})
+        }),
         limit: new foundry.data.fields.NumberField({integer: true, min: 0, initial: 1, label: "DND5E.AttrConcentration.Limit"})
       }, {label: "DND5E.Concentration"})
     };

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -55,10 +55,10 @@ export default class AttributesFields {
    * @property {string} concentration.ability   The ability used for concentration saving throws.
    * @property {string} concentration.bonus     The bonus provided to concentration saving throws.
    * @property {number} concentration.limit     The amount of items this actor can concentrate on.
-   * @property {number} concentration.mode      The default advantage mode for this actor's concentration saving throws.
    * @property {object} concentration.roll
    * @property {number} concentration.roll.min  The minimum the d20 can roll.
    * @property {number} concentration.roll.max  The maximum the d20 can roll.
+   * @property {number} concentration.roll.mode The default advantage mode for this actor's concentration saving throws.
    */
   static get creature() {
     return {

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -1,4 +1,5 @@
 import { FormulaField, MappingField } from "../../fields.mjs";
+import RollConfigField from "../../shared/roll-config-field.mjs";
 import CommonTemplate from "./common.mjs";
 
 /**
@@ -44,11 +45,11 @@ export default class CreatureTemplate extends CommonTemplate {
           dc: new FormulaField({required: true, deterministic: true, label: "DND5E.BonusSpellDC"})
         }, {label: "DND5E.BonusSpell"})
       }, {label: "DND5E.Bonuses"}),
-      skills: new MappingField(new foundry.data.fields.SchemaField({
+      skills: new MappingField(new RollConfigField({
         value: new foundry.data.fields.NumberField({
           required: true, nullable: false, min: 0, max: 2, step: 0.5, initial: 0, label: "DND5E.ProficiencyLevel"
         }),
-        ability: new foundry.data.fields.StringField({required: true, initial: "dex", label: "DND5E.Ability"}),
+        ability: "dex",
         bonuses: new foundry.data.fields.SchemaField({
           check: new FormulaField({required: true, label: "DND5E.SkillBonusCheck"}),
           passive: new FormulaField({required: true, label: "DND5E.SkillBonusPassive"})
@@ -57,11 +58,11 @@ export default class CreatureTemplate extends CommonTemplate {
         initialKeys: CONFIG.DND5E.skills, initialValue: this._initialSkillValue,
         initialKeysOnly: true, label: "DND5E.Skills"
       }),
-      tools: new MappingField(new foundry.data.fields.SchemaField({
+      tools: new MappingField(new RollConfigField({
         value: new foundry.data.fields.NumberField({
           required: true, nullable: false, min: 0, max: 2, step: 0.5, initial: 1, label: "DND5E.ProficiencyLevel"
         }),
-        ability: new foundry.data.fields.StringField({required: true, initial: "int", label: "DND5E.Ability"}),
+        ability: "int",
         bonuses: new foundry.data.fields.SchemaField({
           check: new FormulaField({required: true, label: "DND5E.CheckBonus"})
         }, {label: "DND5E.ToolBonuses"})

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -8,10 +8,10 @@ export default class RollConfigField extends foundry.data.fields.SchemaField {
     const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
     fields = {
       ability: new StringField({required: true, initial: ability, label: "DND5E.AbilityModifier"}),
-      mode: new NumberField({choices: [-1, 0, 1], initial: 0, label: "DND5E.AdvantageMode"}),
       roll: new SchemaField({
         min: new NumberField({...opts, label: "DND5E.Minimum"}),
         max: new NumberField({...opts, label: "DND5E.Maximum"}),
+        mode: new NumberField({choices: [-1, 0, 1], initial: 0, label: "DND5E.AdvantageMode"}),
         ...roll
       }),
       ...fields

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -1,5 +1,3 @@
-import {FormulaField} from "../fields.mjs";
-
 const { StringField, NumberField, SchemaField } = foundry.data.fields;
 
 /**
@@ -10,7 +8,6 @@ export default class RollConfigField extends foundry.data.fields.SchemaField {
     const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
     fields = {
       ability: new StringField({required: true, initial: ability, label: "DND5E.AbilityModifier"}),
-      bonus: new FormulaField({required: true, label: "DND5E.Bonus"}),
       mode: new NumberField({choices: [-1, 0, 1], initial: 0, label: "DND5E.AdvantageMode"}),
       roll: new SchemaField({
         min: new NumberField({...opts, label: "DND5E.Minimum"}),

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1673,8 +1673,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       ability: ability,
       isConcentration: true,
       targetValue: 10,
-      advantage: options.advantage || (conc.mode === modes.ADVANTAGE),
-      disadvantage: options.disadvantage || (conc.mode === modes.DISADVANTAGE)
+      advantage: options.advantage || (conc.roll.mode === modes.ADVANTAGE),
+      disadvantage: options.disadvantage || (conc.roll.mode === modes.DISADVANTAGE)
     }, options);
     options.parts = parts.concat(options.parts ?? []);
 


### PR DESCRIPTION
Removed `bonus` field from `RollConfigField`. This would have conflicted with those properties, like `skills`, that have `bonus` as derived data. Instead individual properties define `bonuses` with 'check' and/or 'save'.

Seems the only property that has `bonus` as an actual field is `attributes.init`, but it doesn't - in my opinion - seem worth it to migrate this to `attributes.init.bonuses.check`.