### PR TITLE
[#893] Add summoning to item activation workflow

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1384,7 +1384,9 @@
   "Action": {
     "Add": "Add Profile",
     "Configure": "Configure Summons",
-    "Remove": "Remove Profile"
+    "Place": "Place Summons",
+    "Remove": "Remove Profile",
+    "Summon": "Summon"
   },
   "ArmorClass": {
     "Label": "Bonus Armor Class",
@@ -1420,8 +1422,13 @@
     }
   },
   "Profile": {
-    "Label": "Summons Profiles",
+    "Label": "Summons Profile",
+    "LabelPl": "Summons Profiles",
     "Empty": "Click above to add a profile or drop an creature to summon here."
+  },
+  "Prompt": {
+    "Label": "Summon Prompt",
+    "Hint": "Disable the summoning prompt when item is used. Players will still be able to summon from the chat card."
   }
 },
 "DND5E.Supply": "Supply",

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -2,7 +2,7 @@ import { ItemDataModel } from "../../abstract.mjs";
 import { FormulaField } from "../../fields.mjs";
 
 const {
-  ArrayField, BooleanField, DocumentIdField, IntegerSortField, NumberField, SchemaField, StringField
+  ArrayField, BooleanField, DocumentIdField, NumberField, SchemaField, StringField
 } = foundry.data.fields;
 
 /**
@@ -41,6 +41,7 @@ const {
  * @property {boolean} summons.match.proficiency  Match proficiency on summoned actor to the summoner.
  * @property {boolean} summons.match.saves        Match the save DC on summoned actor's abilities to the summoner.
  * @property {SummonsProfile[]} summons.profiles  Information on creatures that can be summoned.
+ * @property {boolean} summons.prompt             Should the player be prompted to place the summons?
  * @mixin
  */
 export default class ActionTemplate extends ItemDataModel {
@@ -86,7 +87,10 @@ export default class ActionTemplate extends ItemDataModel {
           count: new NumberField({integer: true, min: 1}),
           name: new StringField(),
           uuid: new StringField()
-        }))
+        })),
+        prompt: new BooleanField({
+          initial: true, label: "DND5E.Summoning.Prompt.Label", hint: "DND5E.Summoning.Prompt.Hint"
+        })
       })
     };
   }
@@ -267,6 +271,16 @@ export default class ActionTemplate extends ItemDataModel {
    */
   get hasSave() {
     return this.actionType && !!(this.save.ability && this.save.scaling);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does this Item implement summoning as part of its usage?
+   * @type {boolean}
+   */
+  get hasSummoning() {
+    return (this.actionType === "summ") && !!this.summons.profiles.length;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -17,6 +17,7 @@ import { FormulaField } from "../../fields.mjs";
  * @property {number} target.width          Width of line when line type is selected.
  * @property {string} target.units          Units used for value and width as defined in `DND5E.distanceUnits`.
  * @property {string} target.type           Targeting mode as defined in `DND5E.targetTypes`.
+ * @property {boolean} target.prompt        Should the player be prompted to place the template?
  * @property {object} range                 Effect's range.
  * @property {number} range.value           Regular targeting distance for item's effect.
  * @property {number} range.long            Maximum targeting distance for features that have a separate long range.

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -971,11 +971,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     }
     if ( item.type === "spell" ) foundry.utils.mergeObject(options.flags, {"dnd5e.use.spellLevel": item.system.level});
 
-    // Store selected summons type in flag
-    if ( config.createSummons && config.summonsProfile ) {
-      foundry.utils.setProperty(options.flags, "dnd5e.use.summonsProfile", config.summonsProfile);
-    }
-
     /**
      * A hook event that fires before an item's resource consumption has been calculated.
      * @function dnd5e.preItemUsageConsumption
@@ -2036,15 +2031,15 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @param {Item5e} item            The item from which to summon.
    */
   static async _onChatCardSummon(message, item) {
-    let summonsProfile = message.getFlag("dnd5e", "use.summonsProfile");
+    let summonsProfile;
 
     // No profile specified and only one profile on item, use that one
-    if ( !summonsProfile && (item.system.summons.profiles.length === 1) ) {
+    if ( item.system.summons.profiles.length === 1 ) {
       summonsProfile = item.system.summons.profiles[0]._id;
     }
 
     // Otherwise show the item use dialog to get the profile
-    else if ( !summonsProfile ) {
+    else {
       const config = await AbilityUseDialog.create(item, {
         consumeResource: null,
         consumeSpellSlot: null,

--- a/templates/apps/ability-use.hbs
+++ b/templates/apps/ability-use.hbs
@@ -32,7 +32,8 @@
 
     <div class="form-group">
         <label class="checkbox">
-            <input type="checkbox" name="consumeSpellSlot" {{checked consumeSpellSlot}}>{{localize "DND5E.SpellCastConsume"}}
+            <input type="checkbox" name="consumeSpellSlot" {{ checked consumeSpellSlot }}>
+            {{localize "DND5E.SpellCastConsume"}}
         </label>
     </div>
     {{/if}}
@@ -40,7 +41,8 @@
     {{#if (ne consumeUsage null)}}
     <div class="form-group">
         <label class="checkbox">
-            <input type="checkbox" name="consumeUsage" {{checked consumeUsage}}>{{localize "DND5E.AbilityUseConsume"}}
+            <input type="checkbox" name="consumeUsage" {{ checked consumeUsage }}>
+            {{localize "DND5E.AbilityUseConsume"}}
         </label>
     </div>
     {{/if}}
@@ -48,7 +50,8 @@
     {{#if (ne consumeResource null)}}
     <div class="form-group">
         <label class="checkbox">
-            <input type="checkbox" name="consumeResource" {{checked consumeResource}}>{{localize "DND5E.ConsumeResource"}}
+            <input type="checkbox" name="consumeResource" {{ checked consumeResource }}>
+            {{localize "DND5E.ConsumeResource"}}
         </label>
     </div>
     {{/if}}
@@ -56,8 +59,27 @@
     {{#if (ne createMeasuredTemplate null)}}
     <div class="form-group">
         <label class="checkbox">
-            <input type="checkbox" name="createMeasuredTemplate" {{checked createMeasuredTemplate}}>{{localize "DND5E.PlaceTemplate"}}
+            <input type="checkbox" name="createMeasuredTemplate" {{ checked createMeasuredTemplate }}>
+            {{ localize "DND5E.PlaceTemplate" }}
         </label>
+    </div>
+    {{/if}}
+
+    {{#if (ne createSummons null)}}
+    <div class="form-group">
+        <label class="checkbox">
+            <input type="checkbox" name="createSummons" {{ checked createSummons }}>
+            {{ localize "DND5E.Summoning.Action.Place" }}
+        </label>
+        {{#if summoningOptions}}
+        <div class="form-fields">
+            <select name="summonsProfile" aria-label="{{ localize 'DND5E.Summoning.Profile.Label' }}">
+                {{ selectOptions summoningOptions selected=summonsProfile }}
+            </select>
+        </div>
+        {{else}}
+        <input type="hidden" name="summonsProfile" value="{{ summonsProfile }}">
+        {{/if}}
     </div>
     {{/if}}
 </form>

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -1,6 +1,6 @@
 <form autocomplete="off">
     <h3 class="form-header flexrow">
-        {{ localize "DND5E.Summoning.Profile.Label" }}
+        {{ localize "DND5E.Summoning.Profile.LabelPl" }}
         <button type="button" class="unbutton" data-action="add-profile">
             <i class="fa-solid fa-plus" aria-hidden="true"></i>
             {{ localize 'DND5E.Summoning.Action.Add' }}

--- a/templates/chat/item-card.hbs
+++ b/templates/chat/item-card.hbs
@@ -87,6 +87,14 @@
         </button>
         {{/if}}
 
+        {{!-- Summoning --}}
+        {{#if item.system.hasSummoning}}
+        <button type="button" data-action="summon">
+            <i class="fa-solid fa-spaghetti-monster-flying"></i>
+            {{ localize "DND5E.Summoning.Action.Summon" }}
+        </button>
+        {{/if}}
+
         {{!-- Tool Check --}}
         {{#if isTool}}
         <button type="button" data-action="toolCheck" data-ability="{{ item.system.ability }}">

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -123,8 +123,12 @@
     <div class="form-fields">
         <a class="config-button" data-action="summoning">
             <i class="fa-solid fa-gear" aria-hidden="true"></i>
-            {{ localize 'DND5E.Summoning.Action.Configure' }}
+            {{ localize "DND5E.Summoning.Action.Configure" }}
         </a>
+        <label class="checkbox" data-tooltip="DND5E.Summoning.Prompt.Hint">
+            <input type="checkbox" name="system.summons.prompt" {{ checked system.summons.prompt }}>
+            {{ localize "DND5E.Summoning.Prompt.Label" }}
+        </label>
     </div>
 </div>
 {{/if}}


### PR DESCRIPTION
Adds summoning configuration to the item usage configuration and the ability use dialog. Players will see a checkbox to indicate whether summoning should occur and if the item has more than one summoning profile, a dropdown for selecting which profile to use:

<img width="413" alt="Summoning Ability Use Dialog" src="https://github.com/foundryvtt/dnd5e/assets/19979839/241b9c31-2bd5-43d8-a90b-d102d9687909">

This also introduces a `prompt` boolean similar to the one used for measured templates and limited uses to control whether it is done by default or not. If the `"Place Summons"` checkbox is checked, then the selected summoning profile ID is stored in flags in the chat message.

A new `"Summon"` button has been added to the chat message to perform the summoning if not done automatically through the ability use process:

<img width="298" alt="Summoning Chat Card" src="https://github.com/foundryvtt/dnd5e/assets/19979839/dabc3623-68ff-4d9d-be79-4e17c422fc3a">

If the button is clicked it will try to summon whatever profile is specified in the flags, or if none is specified it will throw up the ability use dialog again to ask which should be used.