### PR TITLE
Adapt high contrast mode to dark mode

### DIFF
--- a/less/dnd5e.less
+++ b/less/dnd5e.less
@@ -28,3 +28,8 @@
 @import "v2/dark/apps.less";
 @import "v2/dark/character.less";
 @import "v2/dark/inventory.less";
+
+/* High Contrast */
+@import "v2/high-contrast/apps.less";
+@import "v2/high-contrast/character.less";
+@import "v2/high-contrast/inventory.less";

--- a/less/elements.less
+++ b/less/elements.less
@@ -149,10 +149,6 @@ item-list-controls search {
       .filter {
         color: var(--dnd5e-color-gold);
         border-right: 1px solid var(--color-border-light-1);
-
-        @media (prefers-contrast: more) {
-          color: var(--dnd5e-color-dark);
-        }
       }
 
       .filter-list { display: flex; }
@@ -186,8 +182,4 @@ item-list-controls search {
   }
 
   .filter-control[data-action="sort"] { padding-left: .625rem; }
-
-  @media (prefers-contrast: more) {
-    border-color: var(--dnd5e-color-dark);
-  }
 }

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -63,10 +63,6 @@
     box-shadow: 0 0 6px var(--dnd5e-shadow-45);
     border: var(--dnd5e-border-gold);
 
-    @media (prefers-contrast: more) {
-      border-color: var(--dnd5e-color-dark);
-    }
-
     .header {
       background: linear-gradient(to right, var(--dnd5e-color-hd-1), var(--dnd5e-color-hd-2));
       color: white;
@@ -183,10 +179,6 @@
     max-width: 280px;
     position: relative;
 
-    @media (prefers-contrast: more) {
-      border-color: var(--dnd5e-color-dark);
-    }
-
     &.empty {
       border: 2px dashed var(--dnd5e-color-black);
       color: var(--dnd5e-color-black);
@@ -194,10 +186,6 @@
       display: grid;
       place-content: center;
       opacity: .25;
-
-      @media (prefers-contrast: more) {
-        opacity: .5;
-      }
     }
 
     .gold-icon {
@@ -388,13 +376,6 @@
         margin-inline-start: auto;
         font-size: var(--font-size-14);
         opacity: .8;
-      }
-
-      @media (prefers-contrast: more) {
-        .value, .max {
-          text-shadow: 0 0 2px var(--dnd5e-color-dark);
-          filter: drop-shadow(0 0 2px var(--dnd5e-color-dark));
-        }
       }
     }
   }
@@ -825,12 +806,6 @@
       color: var(--color-text-light-6);
       --icon-fill: var(--color-text-light-6);
       --icon-stroke: var(--dnd5e-color-card);
-
-      @media (prefers-contrast: more) {
-        --border-style: var(--dnd5e-border-dark);
-        span { color: var(--color-text-dark-5); }
-        &.active span { color: var(--color-text-dark-1); }
-      }
 
       &.active {
         color: var(--color-text-dark-primary);

--- a/less/v2/character.less
+++ b/less/v2/character.less
@@ -86,10 +86,6 @@
     grid-template-columns: 1fr var(--dnd5e-sheet-header-right-width);
     align-items: center;
 
-    @media (prefers-contrast: more) {
-      background: var(--dnd5e-color-maroon);
-    }
-
     input {
       background: rgb(0 0 0 / 45%);
       border: 1px solid transparent;
@@ -518,11 +514,6 @@
                 line-height: 30px;
                 text-shadow: 0 0 4px var(--dnd5e-highlight-45);
 
-                @media (prefers-contrast: more) {
-                  text-shadow: 0 0 2px var(--dnd5e-color-dark);
-                  filter: drop-shadow(0 0 2px var(--dnd5e-color-dark));
-                }
-
                 .config-button {
                   color: inherit;
                   font-size: inherit;
@@ -624,10 +615,6 @@
               border-left: 1px dashed var(--dnd5e-color-gold);
 
               > input { color: var(--dnd5e-color-blue); }
-
-              @media (prefers-contrast: more) {
-                > input::placeholder { color: var(--color-text-light-6); }
-              }
             }
           }
         }
@@ -705,10 +692,6 @@
           border-bottom-color: currentcolor;
           color: var(--dnd5e-color-gold);
           margin-bottom: .5rem;
-
-          @media (prefers-contrast: more) {
-            color: var(--dnd5e-color-dark);
-          }
         }
 
         > ul {
@@ -747,10 +730,6 @@
             opacity: .25;
             justify-content: center;
             margin-top: .75rem;
-
-            @media (prefers-contrast: more) {
-              opacity: .5;
-            }
           }
 
           figure {
@@ -885,10 +864,6 @@
           padding: .375rem;
           border-bottom: var(--dnd5e-border-dotted);
 
-          @media (prefers-contrast: more) {
-            border-bottom: var(--dnd5e-border-dark);
-          }
-
           &:last-child { border: none; }
 
           .config-button {
@@ -912,10 +887,6 @@
         color: var(--color-text-dark-5);
         width: 30px;
         padding-top: 2px;
-
-        @media (prefers-contrast: more) {
-          color: var(--color-text-dark-primary);
-        }
       }
 
       select.ability {
@@ -945,10 +916,6 @@
         font-size: var(--font-size-11);
         color: var(--color-text-dark-5);
         text-align: center;
-
-        @media (prefers-contrast: more) {
-          color: var(--color-text-dark-primary);
-        }
       }
     }
 
@@ -964,11 +931,6 @@
           --border-style: var(--dnd5e-border-dotted);
           border-bottom: none;
           border-top: var(--border-style);
-
-          @media (prefers-contrast: more) {
-            --border-style: var(--dnd5e-border-dark);
-            &:nth-child(odd) { border-inline-end: var(--border-style); }
-          }
 
           &:nth-child(1), &:nth-child(2) { border-top: none; }
           &:last-child { border-top: var(--border-style); }
@@ -1018,10 +980,6 @@
         cursor: pointer;
         transition: opacity 250ms ease;
         &:hover { opacity: .5; }
-
-        @media (prefers-contrast: more) {
-          &:hover { opacity: 1; }
-        }
       }
 
       &.texture {
@@ -1044,10 +1002,6 @@
           border-radius: 5px;
           mix-blend-mode: unset;
           filter: unset;
-
-          @media (prefers-contrast: more) {
-            --gradient-end: color-mix(in oklab, var(--dnd5e-background-card), transparent 40%);
-          }
         }
 
         > * { position: relative; }
@@ -1146,10 +1100,6 @@
         inset: 0;
         background: transparent url("ui/ability-score-tab.svg") no-repeat top center / contain;
         z-index: -1;
-
-        @media (prefers-contrast: more) {
-          background: transparent url("ui/ability-score-tab-hc.svg") no-repeat top center / contain;
-        }
       }
 
       &.flipped {
@@ -1173,10 +1123,6 @@
         text-transform: uppercase;
         font-size: var(--font-size-11);
         color: var(--dnd5e-color-gold);
-
-        @media (prefers-contrast: more) {
-          color: var(--dnd5e-color-dark);
-        }
       }
 
       .mod {
@@ -1196,10 +1142,6 @@
         background: black;
         border-radius: 3px;
         margin-top: -2px;
-
-        @media (prefers-contrast: more) {
-          color: var(--color-text-light-1);
-        }
 
         > input {
           padding: 4px;
@@ -1329,10 +1271,6 @@
         > span {
           text-shadow: 0 0 12px var(--dnd5e-shadow-15);
           color: var(--dnd5e-color-gold);
-
-          @media (prefers-contrast: more) {
-            color: var(--dnd5e-color-dark);
-          }
         }
 
         > select {

--- a/less/v2/dark/apps.less
+++ b/less/v2/dark/apps.less
@@ -12,6 +12,8 @@
     --dnd5e-background-card: var(--dnd5e-color-blue-gray-2);
     --dnd5e-background-parchment: var(--dnd5e-color-blue-gray-2);
     --dnd5e-border-gold: 1px solid var(--dnd5e-color-blue-gray-1);
+    --filigree-background-color: var(--dnd5e-color-blue-gray-2);
+    --filigree-border-color: var(--dnd5e-color-blue-gray-3);
 
     select option { background: var(--dnd5e-color-blue-gray-2); }
     .meter { --meter-background: var(--dnd5e-color-dark-gray); }
@@ -22,11 +24,7 @@
       .header { background: linear-gradient(to right, #491d25, #311b1f); }
     }
 
-    filigree-box {
-      --filigree-background-color: var(--dnd5e-color-blue-gray-2);
-      --filigree-border-color: var(--dnd5e-color-blue-gray-3);
-      > h3 > span { color: var(--dnd5e-color-gold); }
-    }
+    filigree-box > h3 > span { color: var(--dnd5e-color-gold); }
 
     h3.icon {
       color: var(--color-text-light-6);

--- a/less/v2/high-contrast/apps.less
+++ b/less/v2/high-contrast/apps.less
@@ -69,9 +69,15 @@
   &.sheet {
     --color-text-dark-primary: #fff;
     --color-text-dark-secondary: var(--color-text-light-3);
+    --dnd5e-background-card: #000000;
+    --dnd5e-background-parchment: #000000;
+    --dnd5e-border-dark: 1px solid #999;
     --dnd5e-color-blue-white: #fff;
     --dnd5e-color-card: #fff;
+    --filigree-background-color: #000000;
     --filigree-border-color: #999;
+    --proficiency-cycle-enabled-color: unset;
+    --proficiency-cycle-disabled-color: unset;
   }
 
   .card { border: var(--dnd5e-border-dark); }

--- a/less/v2/high-contrast/apps.less
+++ b/less/v2/high-contrast/apps.less
@@ -1,0 +1,76 @@
+.dnd5e-flag-high-contrast .dnd5e2,
+.ddn5e2.dnd5e-flag-high-contrast {
+  --color-text-dark-primary: #000000;
+  --dnd5e-color-gold: #e3ce9e;
+  --dnd5e-color-scrollbar: var(--dnd5e-color-maroon);
+
+  .card { border-color: var(--dnd5e-color-dark); }
+
+  .pill-lg {
+    border-color: var(--dnd5e-color-dark);
+    &.empty { opacity: .5; }
+  }
+
+  .meter .label :is(.value, .max) {
+    text-shadow: 0 0 2px var(--dnd5e-color-dark);
+    filter: drop-shadow(0 0 2px var(--dnd5e-color-dark));
+  }
+}
+
+/* ---------------------------------- */
+/*  Custom Elements                   */
+/* ---------------------------------- */
+
+.dnd5e-flag-high-contrast item-list-controls search {
+  border: var(--dnd5e-border-dark);
+  .filter-list{
+    & > li:hover button { font-weight: bold; }
+  }
+}
+
+.dnd5e-flag-high-contrast .effects-element {
+  .conditions-list .condition {
+    --border-style: var(--dnd5e-border-dark);
+    span { color: var(--color-text-dark-5); }
+    &.active span { color: var(--color-text-dark-1); }
+  }
+}
+
+/* ---------------------------------- */
+/*  Light Mode                        */
+/* ---------------------------------- */
+
+.dnd5e-flag-high-contrast.dnd5e-theme-light .dnd5e2,
+.ddn5e2.dnd5e-flag-high-contrast.dnd5e-theme-light {
+  --filigree-background-color: #ffffff;
+  --filigree-border-color: var(--dnd5e-color-dark);
+  --dnd5e-background-card: #ffffff;
+  --dnd5e-background-parchment: #ffffff;
+  --dnd5e-border-dark: 1px solid #000;
+  --proficiency-cycle-enabled-color: color-mix(in oklab, var(--dnd5e-color-blue), black 20%);
+  --proficiency-cycle-disabled-color: var(--dnd5e-color-dark);
+}
+
+.dnd5e-flag-high-contrast.dnd5e-theme-light item-list-controls search {
+  .filter-list .filter-item.active::after { color: var(--color-text-dark-3); }
+  .dropdown:focus-within .filter { color: var(--dnd5e-color-dark); }
+}
+
+/* ---------------------------------- */
+/*  Dark Mode                         */
+/* ---------------------------------- */
+
+.dnd5e-flag-high-contrast.dnd5e-theme-dark .dnd5e2,
+.ddn5e2.dnd5e-flag-high-contrast.dnd5e-theme-dark {
+  --color-text-dark-primary: #fff;
+  --color-text-dark-secondary: var(--color-text-light-3);
+  --dnd5e-color-blue-white: #fff;
+  --dnd5e-color-card: #fff;
+  --filigree-border-color: #999;
+
+  .card { border: var(--dnd5e-border-dark); }
+}
+
+.dnd5e-flag-high-contrast.dnd5e-theme-light item-list-controls search {
+  .filter-list .filter-item.active::after { color: var(--color-text-light-3); }
+}

--- a/less/v2/high-contrast/apps.less
+++ b/less/v2/high-contrast/apps.less
@@ -1,8 +1,10 @@
 .dnd5e-flag-high-contrast .dnd5e2,
-.ddn5e2.dnd5e-flag-high-contrast {
-  --color-text-dark-primary: #000000;
-  --dnd5e-color-gold: #e3ce9e;
-  --dnd5e-color-scrollbar: var(--dnd5e-color-maroon);
+.dnd5e2.dnd5e-flag-high-contrast {
+  &.sheet {
+    --color-text-dark-primary: #000000;
+    --dnd5e-color-gold: #e3ce9e;
+    --dnd5e-color-scrollbar: var(--dnd5e-color-maroon);
+  }
 
   .card { border-color: var(--dnd5e-color-dark); }
 
@@ -41,14 +43,16 @@
 /* ---------------------------------- */
 
 .dnd5e-flag-high-contrast.dnd5e-theme-light .dnd5e2,
-.ddn5e2.dnd5e-flag-high-contrast.dnd5e-theme-light {
-  --filigree-background-color: #ffffff;
-  --filigree-border-color: var(--dnd5e-color-dark);
-  --dnd5e-background-card: #ffffff;
-  --dnd5e-background-parchment: #ffffff;
-  --dnd5e-border-dark: 1px solid #000;
-  --proficiency-cycle-enabled-color: color-mix(in oklab, var(--dnd5e-color-blue), black 20%);
-  --proficiency-cycle-disabled-color: var(--dnd5e-color-dark);
+.dnd5e2.dnd5e-flag-high-contrast.dnd5e-theme-light {
+  &.sheet {
+    --filigree-background-color: #ffffff;
+    --filigree-border-color: var(--dnd5e-color-dark);
+    --dnd5e-background-card: #ffffff;
+    --dnd5e-background-parchment: #ffffff;
+    --dnd5e-border-dark: 1px solid #000;
+    --proficiency-cycle-enabled-color: color-mix(in oklab, var(--dnd5e-color-blue), black 20%);
+    --proficiency-cycle-disabled-color: var(--dnd5e-color-dark);
+  }
 }
 
 .dnd5e-flag-high-contrast.dnd5e-theme-light item-list-controls search {
@@ -61,16 +65,18 @@
 /* ---------------------------------- */
 
 .dnd5e-flag-high-contrast.dnd5e-theme-dark .dnd5e2,
-.ddn5e2.dnd5e-flag-high-contrast.dnd5e-theme-dark {
-  --color-text-dark-primary: #fff;
-  --color-text-dark-secondary: var(--color-text-light-3);
-  --dnd5e-color-blue-white: #fff;
-  --dnd5e-color-card: #fff;
-  --filigree-border-color: #999;
+.dnd5e2.dnd5e-flag-high-contrast.dnd5e-theme-dark {
+  &.sheet {
+    --color-text-dark-primary: #fff;
+    --color-text-dark-secondary: var(--color-text-light-3);
+    --dnd5e-color-blue-white: #fff;
+    --dnd5e-color-card: #fff;
+    --filigree-border-color: #999;
+  }
 
   .card { border: var(--dnd5e-border-dark); }
 }
 
-.dnd5e-flag-high-contrast.dnd5e-theme-light item-list-controls search {
-  .filter-list .filter-item.active::after { color: var(--color-text-light-3); }
+.dnd5e-flag-high-contrast.dnd5e-theme-dark item-list-controls search {
+  .filter-control:not(.active) { color: var(--color-text-light-6); }
 }

--- a/less/v2/high-contrast/character.less
+++ b/less/v2/high-contrast/character.less
@@ -51,11 +51,11 @@
 
 .dnd5e-flag-high-contrast.dnd5e-theme-dark .dnd5e2.sheet.actor.character,
 .dnd5e2.sheet.actor.character.dnd5e-flag-high-contrast.dnd5e-theme-dark {
+  .sheet-header { background: none; }
   .sidebar .favorites > h3 { color: var(--dnd5e-color-light); }
+  .tab.features .classes .class .level > span { color: var(--dnd5e-color-light); }
   .ability-scores .ability-score {
     &::before { filter: invert(100%); }
-  }
-  .ability-scores .ability-score {
     .label { color: var(--color-text-light-1); }
   }
 }

--- a/less/v2/high-contrast/character.less
+++ b/less/v2/high-contrast/character.less
@@ -1,0 +1,61 @@
+.dnd5e-flag-high-contrast .dnd5e2.sheet.actor.character,
+.dnd5e2.sheet.actor.character.dnd5e-flag-high-contrast {
+  .sidebar {
+    .card {
+      .stats .lozenges .lozenge .value {
+        text-shadow: 0 0 2px var(--dnd5e-color-dark);
+        filter: drop-shadow(0 0 2px var(--dnd5e-color-dark));
+      }
+      .meter.sectioned > .tmp > input::placeholder { color: var(--color-text-light-6); }
+    }
+    .favorites > ul .drop { opacity: .5; }
+  }
+
+  .skills, .tools {
+    > ul > li { border-bottom: var(--dnd5e-border-dark); }
+    .ability, .passive { color: var(--color-text-dark-primary); }
+  }
+  .saves {
+    > ul > li {
+      --border-style: var(--dnd5e-border-dark);
+      &:nth-child(odd) { border-inline-end: var(--border-style); }
+    }
+  }
+
+  .pill-lg {
+    &.empty:hover { opacity: 1; }
+    &.texture::before { --gradient-end: color-mix(in oklab, var(--dnd5e-background-card), transparent 40%); }
+  }
+
+  .ability-scores .ability-score {
+    &::before { background: transparent url("ui/ability-score-tab-hc.svg") no-repeat top center / contain; }
+    .label { color: var(--dnd5e-color-dark); }
+    .score { color: var(--color-text-light-1); }
+  }
+}
+
+/* ---------------------------------- */
+/*  Light Mode                        */
+/* ---------------------------------- */
+
+.dnd5e-flag-high-contrast.dnd5e-theme-light .dnd5e2.sheet.actor.character,
+.dnd5e2.sheet.actor.character.dnd5e-flag-high-contrast.dnd5e-theme-light {
+  .sheet-header { background: var(--dnd5e-color-maroon); }
+  .sidebar .favorites > h3 { color: var(--dnd5e-color-dark); }
+  .tab.features .classes .class .level > span { color: var(--dnd5e-color-dark); }
+}
+
+/* ---------------------------------- */
+/*  Dark Mode                         */
+/* ---------------------------------- */
+
+.dnd5e-flag-high-contrast.dnd5e-theme-dark .dnd5e2.sheet.actor.character,
+.dnd5e2.sheet.actor.character.dnd5e-flag-high-contrast.dnd5e-theme-dark {
+  .sidebar .favorites > h3 { color: var(--dnd5e-color-light); }
+  .ability-scores .ability-score {
+    &::before { filter: invert(100%); }
+  }
+  .ability-scores .ability-score {
+    .label { color: var(--color-text-light-1); }
+  }
+}

--- a/less/v2/high-contrast/inventory.less
+++ b/less/v2/high-contrast/inventory.less
@@ -4,6 +4,9 @@
     .encumbrance .meter { border-block-end: var(--dnd5e-border-dark); }
     .middle .attunement { border: var(--dnd5e-border-dark); }
   }
+  section.currency, .currency-style {
+    input, button { border: var(--dnd5e-border-dark); }
+  }
 }
 
 /* ---------------------------------- */
@@ -45,12 +48,4 @@
       color: var(--color-text-light-6);
     }
   }
-}
-
-/* ---------------------------------- */
-/*  Currency                          */
-/* ---------------------------------- */
-
-.dnd5e2 section.currency, .dnd5e2 .currency-style {
-  input, button { border: var(--dnd5e-border-dark); }
 }

--- a/less/v2/high-contrast/inventory.less
+++ b/less/v2/high-contrast/inventory.less
@@ -1,5 +1,5 @@
 .dnd5e-flag-high-contrast .dnd5e2,
-.ddn5e2.dnd5e-flag-high-contrast {
+.dnd5e2.dnd5e-flag-high-contrast {
   .inventory-element {
     .encumbrance .meter { border-block-end: var(--dnd5e-border-dark); }
     .middle .attunement { border: var(--dnd5e-border-dark); }
@@ -11,7 +11,7 @@
 /* ---------------------------------- */
 
 .dnd5e-flag-high-contrast.dnd5e-theme-light .dnd5e2,
-.ddn5e2.dnd5e-flag-high-contrast.dnd5e-theme-light {
+.dnd5e2.dnd5e-flag-high-contrast.dnd5e-theme-light {
   .inventory-element {
     .encumbrance .meter { border-color: var(--dnd5e-color-dark); }
     .middle .attunement {
@@ -31,7 +31,7 @@
 /* ---------------------------------- */
 
 .dnd5e-flag-high-contrast.dnd5e-theme-dark .dnd5e2,
-.ddn5e2.dnd5e-flag-high-contrast.dnd5e-theme-dark {
+.dnd5e2.dnd5e-flag-high-contrast.dnd5e-theme-dark {
   .inventory-element {
     .middle .attunement {
       .fa-sun, .separator { color: var(--dnd5e-color-light); }
@@ -41,6 +41,9 @@
     :is(.items-header, .item) .item-name .tags { opacity: 1; }
     .item-school { --icon-fill: var(--dnd5e-color-blue-white); }
     .item-roll .ability { color: var(--color-text-light-4); }
+    .item .item-controls .item-control:not(.active) {
+      color: var(--color-text-light-6);
+    }
   }
 }
 

--- a/less/v2/high-contrast/inventory.less
+++ b/less/v2/high-contrast/inventory.less
@@ -1,0 +1,53 @@
+.dnd5e-flag-high-contrast .dnd5e2,
+.ddn5e2.dnd5e-flag-high-contrast {
+  .inventory-element {
+    .encumbrance .meter { border-block-end: var(--dnd5e-border-dark); }
+    .middle .attunement { border: var(--dnd5e-border-dark); }
+  }
+}
+
+/* ---------------------------------- */
+/*  Light Mode                        */
+/* ---------------------------------- */
+
+.dnd5e-flag-high-contrast.dnd5e-theme-light .dnd5e2,
+.ddn5e2.dnd5e-flag-high-contrast.dnd5e-theme-light {
+  .inventory-element {
+    .encumbrance .meter { border-color: var(--dnd5e-color-dark); }
+    .middle .attunement {
+      border-color: var(--dnd5e-color-dark);
+      .fa-sun, .separator { color: var(--dnd5e-color-dark); }
+    }
+  }
+  .items-section {
+    :is(.items-header, .item) .item-name .tags { opacity: .5; }
+    .item-school { --icon-fill: var(--dnd5e-color-black); }
+    .item-roll .ability { color: var(--color-text-dark-4); }
+  }
+}
+
+/* ---------------------------------- */
+/*  Dark Mode                         */
+/* ---------------------------------- */
+
+.dnd5e-flag-high-contrast.dnd5e-theme-dark .dnd5e2,
+.ddn5e2.dnd5e-flag-high-contrast.dnd5e-theme-dark {
+  .inventory-element {
+    .middle .attunement {
+      .fa-sun, .separator { color: var(--dnd5e-color-light); }
+    }
+  }
+  .items-section {
+    :is(.items-header, .item) .item-name .tags { opacity: 1; }
+    .item-school { --icon-fill: var(--dnd5e-color-blue-white); }
+    .item-roll .ability { color: var(--color-text-light-4); }
+  }
+}
+
+/* ---------------------------------- */
+/*  Currency                          */
+/* ---------------------------------- */
+
+.dnd5e2 section.currency, .dnd5e2 .currency-style {
+  input, button { border: var(--dnd5e-border-dark); }
+}

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -41,10 +41,6 @@
       border: none;
       border-bottom: var(--dnd5e-border-gold);
 
-      @media (prefers-contrast: more) {
-        border-color: var(--dnd5e-color-dark);
-      }
-
       .label {
         display: flex;
         align-items: center;
@@ -155,11 +151,6 @@
       .config-button { color: var(--color-text-light-6); }
       .max { color: var(--color-text-dark-5); }
 
-      @media (prefers-contrast: more) {
-        border-color: var(--dnd5e-color-dark);
-        .fa-sun, .separator { color: var(--dnd5e-color-dark); }
-      }
-
       input.max {
         width: 22px;
         text-align: left;
@@ -257,10 +248,6 @@
           align-items: center;
           gap: .25rem;
           --icon-fill: var(--dnd5e-color-black);
-
-          @media (prefers-contrast: more) {
-            opacity: .5;
-          }
         }
       }
 
@@ -354,10 +341,6 @@
         --icon-fill: var(--dnd5e-color-gold);
         display: none;
         &.item-detail { font-size: var(--font-size-18); }
-
-        @media (prefers-contrast: more) {
-          --icon-fill: var(--dnd5e-color-black);
-        }
       }
 
       .item-roll {
@@ -375,10 +358,6 @@
           text-transform: uppercase;
           font-size: var(--font-size-10);
           color: var(--dnd5e-color-gold);
-
-          @media (prefers-contrast: more) {
-            color: var(--color-text-dark-4);
-          }
         }
       }
 
@@ -534,11 +513,6 @@
     border: var(--dnd5e-border-gold);
     background: var(--dnd5e-background-parchment);
     box-shadow: 0 0 6px var(--dnd5e-shadow-15);
-
-    @media (prefers-contrast: more) {
-      border: var(--dnd5e-border-dark);
-      background: var(--dnd5e-color-card);
-    }
 
     &:hover, &:focus {
       box-shadow: 0 0 6px var(--dnd5e-color-gold);

--- a/less/variables.less
+++ b/less/variables.less
@@ -88,18 +88,6 @@
   --dnd5e-capacity-background-color: oklch(62% 0.05 246);
   --dnd5e-capacity-border-color: oklch(91% 0.044 252.5);
   --dnd5e-capacity-text-color: oklch(95% 0 0);
-
-  @media (prefers-contrast: more) {
-    --dnd5e-color-card: #ffffff;
-    --dnd5e-color-gold: #e3ce9e;
-    --dnd5e-color-scrollbar: var(--dnd5e-color-maroon);
-    --filigree-border-color: var(--dnd5e-color-dark);
-    --proficiency-cycle-enabled-color: color-mix(in oklab, var(--dnd5e-color-blue), black 20%);
-    --proficiency-cycle-disabled-color: var(--dnd5e-color-dark);
-    .window-app .window-content {
-      --color-text-dark-primary: #000000;
-    }
-  }
 }
 
 /* ----------------------------------------- */

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -368,7 +368,7 @@ export function setTheme(element, theme="", flags=new Set()) {
   else delete element.dataset.theme;
 
   // Additional Flags
-  if ( matchMedia("(prefers-contrast: more)").matches ) flags.add("high-contrast");
+  if ( (element === document.body) && matchMedia("(prefers-contrast: more)").matches ) flags.add("high-contrast");
   for ( const flag of flags ) element.classList.add(`dnd5e-flag-${flag.slugify()}`);
   element.dataset.themeFlags = Array.from(flags).join(" ");
 }

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -340,6 +340,9 @@ export function registerDeferredSettings() {
   matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
     setTheme(document.body, game.settings.get("dnd5e", "theme"));
   });
+  matchMedia("(prefers-contrast: more)").addEventListener("change", () => {
+    setTheme(document.body, game.settings.get("dnd5e", "theme"));
+  });
 }
 
 /* -------------------------------------------- */
@@ -348,16 +351,24 @@ export function registerDeferredSettings() {
  * Set the theme on an element, removing the previous theme class in the process.
  * @param {HTMLElement} element  Body or sheet element on which to set the theme data.
  * @param {string} [theme=""]    Theme key to set.
+ * @param {string[]} [flags=[]]  Additional theming flags to set.
  */
-export function setTheme(element, theme="") {
+export function setTheme(element, theme="", flags=new Set()) {
+  element.className = element.className.replace(/\bdnd5e-(theme|flag)-[\w-]+\b/g, "");
+
+  // Primary Theme
   if ( !theme && (element === document.body) ) {
     if ( matchMedia("(prefers-color-scheme: dark)").matches ) theme = "dark";
     if ( matchMedia("(prefers-color-scheme: light)").matches ) theme = "light";
   }
-  element.className = element.className.replace(/\bdnd5e-theme-\w+/g, "");
   if ( theme ) {
     element.classList.add(`dnd5e-theme-${theme.slugify()}`);
     element.dataset.theme = theme;
   }
   else delete element.dataset.theme;
+
+  // Additional Flags
+  if ( matchMedia("(prefers-contrast: more)").matches ) flags.add("high-contrast");
+  for ( const flag of flags ) element.classList.add(`dnd5e-flag-${flag.slugify()}`);
+  element.dataset.themeFlags = Array.from(flags).join(" ");
 }


### PR DESCRIPTION
This uses `matchMedia` to set a high contrast flag. This is handled as a flag list in preparation for additional theme flags.

Moves all the high contrast changes into separate folder to match dark mode separation.