### PR TITLE
Allow stored item data in chat cards to contain active effects

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1910,7 +1910,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       let targets;
       switch ( action ) {
         case "applyEffect":
-          const effect = await fromUuid(button.closest("[data-uuid]")?.dataset.uuid);
+          const li = button.closest("li.effect");
+          let effect = item.effects.get(li.dataset.effectId);
+          if ( !effect ) effect = await fromUuid(li.dataset.uuid);
           let warn = false;
           for ( const token of canvas.tokens.controlled ) {
             if ( await this._applyEffectToToken(effect, token) === false ) warn = true;

--- a/templates/chat/item-card.hbs
+++ b/templates/chat/item-card.hbs
@@ -140,7 +140,7 @@
         </label>
         <ul class="effects collapsible-content unlist">
             {{~#each effects~}}
-            <li class="effect" data-uuid="{{ uuid }}" data-transferred="{{ transfer }}">
+            <li class="effect" data-effect-id="{{ id }}" data-uuid="{{ uuid }}" data-transferred="{{ transfer }}">
                 <img class="gold-icon" alt="{{ name }}" src="{{ img }}">
                 <div class="name-stacked">
                     <span class="title">{{ name }}</span>


### PR DESCRIPTION
I was working on an project using `dnd5e` which required me to store temporary item data in chat cards rather than relying on an actual item that exists on an actual actor.

This worked fine because of our chat card framework supporting the possibility of `storedData = message.getFlag("dnd5e", "itemData")` on the chat message itself, but this broke down if that item contains active effects which should apply to its usage because the `case "applyEffect"` handler required the effect to be retrieved by `uuid` rather than using a local `id` within the `item`.

This change prefers an effect local to the item of the chat card rather than a UUID lookup. 