### PR TITLE
[#3185] Enable NPC HP advancement

### DIFF
--- a/module/documents/advancement/hit-points.mjs
+++ b/module/documents/advancement/hit-points.mjs
@@ -155,9 +155,11 @@ export default class HitPointsAdvancement extends Advancement {
   apply(level, data) {
     let value = this.constructor.valueForLevel(data, this.hitDieValue, level);
     if ( value === undefined ) return;
-    this.actor.updateSource({
-      "system.attributes.hp.value": this.actor.system.attributes.hp.value + this.#getApplicableValue(value)
-    });
+    const delta = this.#getApplicableValue(value);
+    const updates = { "system.attributes.hp.value": this.actor.system.attributes.hp.value + delta };
+    const max = this.actor.system.toObject().attributes.hp.max;
+    if ( max !== null ) updates["system.attributes.hp.max"] = max + delta;
+    this.actor.updateSource(updates);
     this.updateSource({ value: data });
   }
 
@@ -174,9 +176,11 @@ export default class HitPointsAdvancement extends Advancement {
   reverse(level) {
     let value = this.valueForLevel(level);
     if ( value === undefined ) return;
-    this.actor.updateSource({
-      "system.attributes.hp.value": this.actor.system.attributes.hp.value - this.#getApplicableValue(value)
-    });
+    const delta = this.#getApplicableValue(value);
+    const updates = { "system.attributes.hp.value": this.actor.system.attributes.hp.value - delta };
+    const max = this.actor.system.toObject().attributes.hp.max;
+    if ( max !== null ) updates["system.attributes.hp.max"] = max - delta;
+    this.actor.updateSource(updates);
     const source = { [level]: this.value[level] };
     this.updateSource({ [`value.-=${level}`]: null });
     return source;


### PR DESCRIPTION
If the `attributes.hp.max` source value is not `null` then it will be automatically adjusted by HP advancement. This allows HP advancement to be used for NPCs as well as actors with manually overridden hit point maximums.