### PR TITLE
Use the CONFIG to determine (or override) whether a spell preparation mode prepares or simply knows its spells

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -392,14 +392,14 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
     const useLabels = {"-20": "-", "-10": "-", 0: "&infin;"};
 
     // Format a spellbook entry for a certain indexed level
-    const registerSection = (sl, i, label, {prepMode="prepared", value, max, override}={}) => {
+    const registerSection = (sl, i, label, {prepMode="prepared", value, max, override, config}={}) => {
       const aeOverride = foundry.utils.hasProperty(this.actor.overrides, `system.spells.spell${i}.override`);
       spellbook[i] = {
         order: i,
         label: label,
         usesSlots: i > 0,
         canCreate: owner,
-        canPrepare: (context.actor.type === "character") && (i >= 1),
+        canPrepare: ((context.actor.type === "character") && (i >= 1)) || config?.prepares,
         spells: [],
         uses: useLabels[i] || value || 0,
         slots: useLabels[i] || max || 0,
@@ -432,14 +432,14 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
 
       if ( !spellbook["0"] && v.cantrips ) registerSection("spell0", 0, CONFIG.DND5E.spellLevels[0]);
       const l = levels[k];
-      const config = CONFIG.DND5E.spellPreparationModes[k];
       const level = game.i18n.localize(`DND5E.SpellLevel${l.level}`);
-      const label = `${config.label} — ${level}`;
+      const label = `${v.label} — ${level}`;
       registerSection(k, sections[k], label, {
         prepMode: k,
         value: l.value,
         max: l.max,
-        override: l.override
+        override: l.override,
+        config: v
       });
     }
 
@@ -459,7 +459,8 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
             prepMode: mode,
             value: l.value,
             max: l.max,
-            override: l.override
+            override: l.override,
+            config: config
           });
         }
       }

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -578,7 +578,8 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
 
       // Prepared
       const mode = system.preparation?.mode;
-      if ( (mode === "always") || (mode === "prepared") ) {
+      const config = CONFIG.DND5E.spellPreparationModes[mode] ?? {};
+      if ( config.prepares ) {
         const isAlways = mode === "always";
         const prepared = isAlways || system.preparation.prepared;
         ctx.preparation = {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1942,6 +1942,7 @@ DND5E.pactCastingProgression = {
  * @property {boolean} [upcast]       Whether this preparation mode allows for upcasting.
  * @property {boolean} [cantrips]     Whether this mode allows for cantrips in a spellbook.
  * @property {number} [order]         The sort order of this mode in a spellbook.
+ * @property {boolean} [prepares]     Whether this preparation mode prepares spells.
  */
 
 /**
@@ -1951,7 +1952,8 @@ DND5E.pactCastingProgression = {
 DND5E.spellPreparationModes = {
   prepared: {
     label: "DND5E.SpellPrepPrepared",
-    upcast: true
+    upcast: true,
+    prepares: true
   },
   pact: {
     label: "DND5E.PactMagic",
@@ -1961,7 +1963,8 @@ DND5E.spellPreparationModes = {
   },
   always: {
     label: "DND5E.SpellPrepAlways",
-    upcast: true
+    upcast: true,
+    prepares: true
   },
   atwill: {
     label: "DND5E.SpellPrepAtWill",


### PR DESCRIPTION
- Closes #3375 

This is a simple quality of life change for any spell preparation mode, allowing them to toggle whether a spell is prepared or not on the actor sheet.

Only remaining issue beyond this is that there is no way to set a spell as 'always prepared' as this is always implied to be a type of regular 'leveled' spell but that is a much larger undertaking than this PR would deal with.