### PR TITLE
[#2920, #3147] Add magical bonus to ammo, fix attack bonus data

### DIFF
--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -9,7 +9,7 @@ import ItemTypeTemplate from "./templates/item-type.mjs";
 import PhysicalItemTemplate from "./templates/physical-item.mjs";
 import ItemTypeField from "./fields/item-type-field.mjs";
 
-const { BooleanField, SetField, StringField } = foundry.data.fields;
+const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields;
 
 /**
  * Data definition for Consumable items.
@@ -21,6 +21,7 @@ const { BooleanField, SetField, StringField } = foundry.data.fields;
  * @mixes ActivatedEffectTemplate
  * @mixes ActionTemplate
  *
+ * @property {number} magicalBonus       Magical bonus added to attack & damage rolls by ammunition.
  * @property {Set<string>} properties    Ammunition properties.
  * @property {object} uses
  * @property {boolean} uses.autoDestroy  Should this item be destroyed when it runs out of uses.
@@ -33,6 +34,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
       type: new ItemTypeField({value: "potion", baseItem: false}, {label: "DND5E.ItemConsumableType"}),
+      magicalBonus: new NumberField({min: 0, integer: true, label: "DND5E.MagicalBonus"}),
       properties: new SetField(new StringField(), { label: "DND5E.ItemAmmoProperties" }),
       uses: new ActivatedEffectTemplate.ItemUsesField({
         autoDestroy: new BooleanField({required: true, label: "DND5E.ItemDestroyEmpty"})

--- a/templates/items/consumable.hbs
+++ b/templates/items/consumable.hbs
@@ -115,6 +115,15 @@
                 {{/each}}
             </div>
 
+            {{#if (and properties.mgc.selected (eq system.type.value "ammo"))}}
+            <div class="form-group">
+                <label>{{ localize "DND5E.MagicalBonus" }}</label>
+                <div class="form-fields">
+                    {{ numberInput system.magicalBonus name="system.magicalBonus" min="0" step="1" placeholder="0" }}
+                </div>
+            </div>
+            {{/if}}
+
             <h3 class="form-header">{{ localize "DND5E.ItemConsumableUsage" }}</h3>
 
             {{!-- Item Activation Template --}}


### PR DESCRIPTION
Calls `Roll.replaceFormulaData` on the ammo attack bonus before it is added to the weapon's to hit formula to avoid errors with string terms not resolving.

Adds `magicalBonus` to ammunition that acts like that on weapons. This adds to the attack bonus for the weapon when it is being used with the ammunition. The damage bonus is appended to the first damage formula on the weapon, and the damage properties gain any physical properties provided by the ammunition so silvered or magical ammo properly carries through to the weapon damage.

This also changes how additional ammo damage is added to make use of the new system for multiple rolls on damage. Ammunition damage is now constructed as separate rolls with their own type data rather than being appended to the base weapon damage formula.

Closes #2920 
Closes #3147