### PR TITLE
Add deprecation note to spell comps and tags

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2099,6 +2099,7 @@ preLocalize("spellScalingModes", { sort: true });
 
 /**
  * Types of components that can be required when casting a spell.
+ * @deprecated since DnD5e 3.0, available until DnD5e 3.3
  * @enum {SpellComponentConfiguration}
  */
 DND5E.spellComponents = {
@@ -2134,6 +2135,7 @@ preLocalize("spellComponents", { keys: ["label", "abbr"] });
 
 /**
  * Supplementary rules keywords that inform a spell's use.
+ * @deprecated since DnD5e 3.0, available until DnD5e 3.3
  * @enum {SpellTagConfiguration}
  */
 DND5E.spellTags = {


### PR DESCRIPTION
These were deprecated on the 2.5 branch, then un-deprecated during v3.0.0 development, then properly deprecated again in a minor update.

This adds the notes of deprecation to them, which were missing. I opted for v3.3 due to the above circumstances.