### PR TITLE
[#2094, #3185] Move ability & hp prep, fix advancement HP on NPCs

### DIFF
--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -250,8 +250,19 @@ export default class NPCData extends CreatureTemplate {
 
   /** @inheritdoc */
   prepareDerivedData() {
+    const rollData = this.getRollData({ deterministic: true });
+    const { originalSaves } = this.parent.getOriginalStats();
+
+    this.prepareAbilities({ rollData, originalSaves });
     AttributesFields.prepareExhaustionLevel.call(this);
     AttributesFields.prepareMovement.call(this);
     TraitsFields.prepareResistImmune.call(this);
+
+    // Hit Points
+    const hpOptions = {
+      advancement: Object.values(this.parent.classes).map(c => c.advancement.byType.HitPoints?.[0]).filter(a => a),
+      mod: this.abilities[CONFIG.DND5E.defaultAbilities.hitPoints ?? "con"]?.mod ?? 0
+    };
+    AttributesFields.prepareHitPoints.call(this, this.attributes.hp, hpOptions);
   }
 }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -127,6 +127,28 @@ export default class AttributesFields {
   /* -------------------------------------------- */
 
   /**
+   * Calculate maximum hit points, taking an provided advancement into consideration.
+   * @param {object} hp                 HP object to calculate.
+   * @param {object} [options={}]
+   * @param {HitPointsAdvancement[]} [options.advancement=[]]  Advancement items from which to get hit points per-level.
+   * @param {number} [options.bonus=0]  Additional bonus to add atop the calculated value.
+   * @param {number} [options.mod=0]    Modifier for the ability to add to hit points from advancement.
+   * @this {ActorDataModel}
+   */
+  static prepareHitPoints(hp, { advancement=[], mod=0, bonus=0 }={}) {
+    const base = advancement.reduce((total, advancement) => total + advancement.getAdjustedTotal(mod), 0);
+    hp.max = (hp.max ?? 0) + base + bonus;
+    if ( this.parent.hasConditionEffect("halfHealth") ) hp.max = Math.floor(hp.max * 0.5);
+
+    hp.effectiveMax = hp.max + (hp.tempmax ?? 0);
+    hp.value = Math.min(hp.value, hp.effectiveMax);
+    hp.damage = hp.effectiveMax - hp.value;
+    hp.pct = Math.clamped(hp.effectiveMax ? (hp.value / hp.effectiveMax) * 100 : 0, 0, 100);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Modify movement speeds taking exhaustion and any other conditions into account.
    * @this {CharacterData|NPCData}
    */

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -1,3 +1,5 @@
+import Proficiency from "../../../documents/actor/proficiency.mjs";
+import { simplifyBonus } from "../../../utils.mjs";
 import { ActorDataModel } from "../../abstract.mjs";
 import { FormulaField, MappingField } from "../../fields.mjs";
 import CurrencyTemplate from "../../shared/currency.mjs";
@@ -65,7 +67,7 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
   }
 
   /* -------------------------------------------- */
-  /*  Migrations                                  */
+  /*  Data Migration                              */
   /* -------------------------------------------- */
 
   /** @inheritdoc */
@@ -110,5 +112,45 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
     source.attributes.movement ??= {};
     const s = original.split(" ");
     if ( s.length > 0 ) source.attributes.movement.walk = Number.isNumeric(s[0]) ? parseInt(s[0]) : 0;
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare modifiers and other values for abilities.
+   * @param {object} [options={}]
+   * @param {object} [options.rollData={}]    Roll data used to calculate bonuses.
+   * @param {object} [options.originalSaves]  Original ability data for transformed actors.
+   */
+  prepareAbilities({ rollData={}, originalSaves }={}) {
+    const flags = this.parent.flags.dnd5e ?? {};
+    const prof = this.attributes?.prof ?? 0;
+    const checkBonus = simplifyBonus(this.bonuses?.abilities?.check, rollData);
+    const saveBonus = simplifyBonus(this.bonuses?.abilities?.save, rollData);
+    const dcBonus = simplifyBonus(this.bonuses?.spell?.dc, rollData);
+    for ( const [id, abl] of Object.entries(this.abilities) ) {
+      if ( flags.diamondSoul ) abl.proficient = 1;  // Diamond Soul is proficient in all saves
+      abl.mod = Math.floor((abl.value - 10) / 2);
+
+      const isRA = this.parent._isRemarkableAthlete(id);
+      abl.checkProf = new Proficiency(prof, (isRA || flags.jackOfAllTrades) ? 0.5 : 0, !isRA);
+      const saveBonusAbl = simplifyBonus(abl.bonuses?.save, rollData);
+      abl.saveBonus = saveBonusAbl + saveBonus;
+
+      abl.saveProf = new Proficiency(prof, abl.proficient);
+      const checkBonusAbl = simplifyBonus(abl.bonuses?.check, rollData);
+      abl.checkBonus = checkBonusAbl + checkBonus;
+
+      abl.save = abl.mod + abl.saveBonus;
+      if ( Number.isNumeric(abl.saveProf.term) ) abl.save += abl.saveProf.flat;
+      abl.dc = 8 + abl.mod + prof + dcBonus;
+
+      if ( !Number.isFinite(abl.max) ) abl.max = CONFIG.DND5E.maxAbilityScore;
+
+      // If we merged saves when transforming, take the highest bonus here.
+      if ( originalSaves && abl.proficient ) abl.save = Math.max(abl.save, originalSaves[id].save);
+    }
   }
 }

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -146,10 +146,21 @@ export default class VehicleData extends CommonTemplate {
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   prepareBaseData() {
     this.attributes.prof = 0;
     AttributesFields.prepareBaseArmorClass.call(this);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareDerivedData() {
+    const rollData = this.getRollData({ deterministic: true });
+    const { originalSaves } = this.parent.getOriginalStats();
+
+    this.prepareAbilities({ rollData, originalSaves });
+    AttributesFields.prepareHitPoints.call(this, this.attributes.hp);
   }
 }
 

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -66,8 +66,12 @@
                         <input name="system.attributes.hp.value" type="text" value="{{hp.value}}" placeholder="10"
                             data-tooltip="DND5E.HitPointsCurrent" data-dtype="Number">
                         <span class="sep"> / </span>
-                        <input name="system.attributes.hp.max" type="text" value="{{hp.max}}" placeholder="10"
-                            data-tooltip="DND5E.HitPointsMax" data-dtype="Number">
+                        {{#if system.details.level}}
+                        <span data-tooltip="DND5E.HitPointsMax">{{ hp.max }}</span>
+                        {{else}}
+                        <input name="system.attributes.hp.max" type="text" value="{{ hp.max }}" placeholder="10"
+                               data-tooltip="DND5E.HitPointsMax" data-dtype="Number">
+                        {{/if}}
                     </div>
                     <footer class="attribute-footer flexrow">
                         <input name="system.attributes.hp.temp" type="text" class="temphp"

--- a/templates/apps/hit-points-config.hbs
+++ b/templates/apps/hit-points-config.hbs
@@ -18,7 +18,7 @@
     {{else}}
 
     <div class="hp-field form-group">
-        <input type="number" class="number-lg" name="hp.max" value="{{hp.max}}" data-tooltip="DND5E.HitPointsMax">
+        <input type="number" class="number-lg" name="hp.max" value="{{ source.max }}" data-tooltip="DND5E.HitPointsMax">
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
Moves most of the logic from `Actor5e._prepareHitPoints` into a new `AttributesFields.prepareHitPoints` method with changes to allow different types to customize how their hit points are prepared.

In order to make that change it also required the moving of `Actor5e._prepareAbilities` to `CommonTemplate.prepareAbilities` so that ability modifiers could still be calculated before the hit points.

`NPCData` now fetches `HitPointsAdvancement`s from its classes and adds those to the hit points it calculates.

Closes #3185 