### PR TITLE
[#2668] Derive NPC details from race item if present

### DIFF
--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -1,4 +1,5 @@
 import ActorSheet5e from "./base-sheet.mjs";
+import ActorTypeConfig from "./type-config.mjs";
 
 /**
  * An Actor sheet for NPC type characters.
@@ -116,6 +117,18 @@ export default class ActorSheet5eNPC extends ActorSheet5e {
     super.activateListeners(html);
     if ( !this.isEditable ) return;
     html.find(".rollable[data-action]").click(this._onSheetAction.bind(this));
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  _onConfigMenu(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if ( (event.currentTarget.dataset.action === "type") && (this.actor.system.details.race?.id) ) {
+      new ActorTypeConfig(this.actor.system.details.race, { keyPath: "system.type" }).render(true);
+    }
+    else return super._onConfigMenu(event);
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -207,27 +207,14 @@ export default class CharacterData extends CreatureTemplate {
    * Prepare movement & senses values derived from race item.
    */
   prepareEmbeddedData() {
-    const raceData = this.details.race?.system;
-    if ( !raceData ) {
+    if ( this.details.race instanceof Item ) {
+      AttributesFields.prepareRace.call(this, this.details.race);
+      this.details.type = this.details.race.system.type;
+    } else {
       this.attributes.movement.units ??= Object.keys(CONFIG.DND5E.movementUnits)[0];
       this.attributes.senses.units ??= Object.keys(CONFIG.DND5E.movementUnits)[0];
       this.details.type = new CreatureTypeField({ swarm: false }).initialize({ value: "humanoid" }, this);
-      return;
     }
-
-    for ( const key of Object.keys(CONFIG.DND5E.movementTypes) ) {
-      if ( raceData.movement[key] ) this.attributes.movement[key] ??= raceData.movement[key];
-    }
-    if ( raceData.movement.hover ) this.attributes.movement.hover = true;
-    this.attributes.movement.units ??= raceData.movement.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
-
-    for ( const key of Object.keys(CONFIG.DND5E.senses) ) {
-      if ( raceData.senses[key] ) this.attributes.senses[key] ??= raceData.senses[key];
-    }
-    this.attributes.senses.special = [this.attributes.senses.special, raceData.senses.special].filterJoin(";");
-    this.attributes.senses.units ??= raceData.senses.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
-
-    this.details.type = raceData.type;
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -252,10 +252,9 @@ export default class NPCData extends CreatureTemplate {
    * Prepare movement & senses values derived from race item.
    */
   prepareEmbeddedData() {
-    const race = this.parent.items.find(i => i.type === "race");
-    if ( race ) {
-      AttributesFields.prepareRace.call(this, race, { force: true });
-      this.details.type = race.system.type;
+    if ( this.details.race instanceof Item ) {
+      AttributesFields.prepareRace.call(this, this.details.race, { force: true });
+      this.details.type = this.details.race.system.type;
     }
   }
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -248,6 +248,19 @@ export default class NPCData extends CreatureTemplate {
 
   /* -------------------------------------------- */
 
+  /**
+   * Prepare movement & senses values derived from race item.
+   */
+  prepareEmbeddedData() {
+    const race = this.parent.items.find(i => i.type === "race");
+    if ( race ) {
+      AttributesFields.prepareRace.call(this, race, { force: true });
+      this.details.type = race.system.type;
+    }
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritdoc */
   prepareDerivedData() {
     AttributesFields.prepareExhaustionLevel.call(this);

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -156,4 +156,32 @@ export default class AttributesFields {
       this.attributes.movement[type] = speed;
     }
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Apply movement and sense changes based on a race item. This method should be called during
+   * the `prepareEmbeddedData` step of data preparation.
+   * @param {Item5e} race                    Race item from which to get the stats.
+   * @param {object} [options={}]
+   * @param {boolean} [options.force=false]  Override any values on the actor.
+   * @this {CharacterData|NPCData}
+   */
+  static prepareRace(race, { force=false }={}) {
+    for ( const key of Object.keys(CONFIG.DND5E.movementTypes) ) {
+      if ( !race.system.movement[key] || (!force && (this.attributes.movement[key] !== null)) ) continue;
+      this.attributes.movement[key] = race.system.movement[key];
+    }
+    if ( race.system.movement.hover ) this.attributes.movement.hover = true;
+    if ( force && race.system.movement.units ) this.attributes.movement.units = race.system.movement.units;
+    else this.attributes.movement.units ??= race.system.movement.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
+
+    for ( const key of Object.keys(CONFIG.DND5E.senses) ) {
+      if ( !race.system.senses[key] || (!force && (this.attributes.senses[key] !== null)) ) continue;
+      this.attributes.senses[key] = race.system.senses[key];
+    }
+    this.attributes.senses.special = [this.attributes.senses.special, race.system.senses.special].filterJoin(";");
+    if ( force && race.system.senses.units ) this.attributes.senses.units = race.system.senses.units;
+    else this.attributes.senses.units ??= race.system.senses.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
+  }
 }

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -112,7 +112,7 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
    * @protected
    */
   _onCreate(data, options, userId) {
-    if ( (game.user.id !== userId) || this.parent.actor?.type !== "character" ) return;
+    if ( (game.user.id !== userId) || !["character", "npc"].includes(this.parent.actor?.type) ) return;
     this.parent.actor.update({ "system.details.race": this.parent.id });
   }
 
@@ -127,7 +127,7 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
    * @protected
    */
   async _preDelete(options, user) {
-    if ( (this.parent.actor?.type !== "character") ) return;
+    if ( !["character", "npc"].includes(this.parent.actor?.type) ) return;
     await this.parent.actor.update({ "system.details.race": null });
   }
 }


### PR DESCRIPTION
Introduces a new `AbilitiesFields#prepareRace` method that takes a race item and applies its stats to the actor, either complementing the default values or replacing them depending on whether the `force` option is set.

This then replaces the existing code in `CharacterData` that used to apply race data and is added to `NPCData`.

Closes #2668 