### PR TITLE
[#893] Improve permissions checks & allow compendium summoning

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1491,9 +1491,9 @@
     "Hint": "Disable the summoning prompt when item is used. Players will still be able to summon from the chat card."
   },
   "Warning": {
-    "CreateActor": "You must have 'Create New Actors' permission in order to summon directly a compendium.",
+    "CreateActor": "You must have 'Create New Actors' permission in order to summon directly from a compendium.",
     "NoActor": "Actor cannot be found with UUID '{uuid}' to summon.",
-    "NoOwnership": "You do not have ownership of '{actor}' which you must have to summon it.",
+    "NoOwnership": "You must have ownership of '{actor}' in order to summon it.",
     "NoProfile": "Cannot find summoning profile {profileId} on '{item}'.",
     "Wildcard": "You must have 'Use File Browser' permissions to summon creatures with wildcard artwork."
   }
@@ -1845,6 +1845,10 @@
   "Hint": "Disabling the token ring animations can improve performance."
 },
 "SETTINGS.DND5E": {
+  "ALLOWSUMMONING": {
+    "Name": "Allow Summoning",
+    "Hint": "Allow players to use summoning abilities to summon actors. Players must also have the Create Token core permission for this to work."
+  },
   "THEME": {
     "Name": "Theme",
     "Hint": "Theme that will apply to the UI and all sheets by default. Automatic will be determined by your browser or operating system settings. Can be overridden on a sheet-by-sheet basis."

--- a/lang/en.json
+++ b/lang/en.json
@@ -1481,9 +1481,6 @@
       "Hint": "Modify to saving throw DCs on the summoned creature's abilities to match that of the summoner."
     }
   },
-  "Placement": {
-    "GenericError": "Failed to place summoned actor"
-  },
   "Profile": {
     "Label": "Summons Profile",
     "LabelPl": "Summons Profiles",
@@ -1492,6 +1489,13 @@
   "Prompt": {
     "Label": "Summon Prompt",
     "Hint": "Disable the summoning prompt when item is used. Players will still be able to summon from the chat card."
+  },
+  "Warning": {
+    "CreateActor": "You must have 'Create New Actors' permission in order to summon directly a compendium.",
+    "NoActor": "Actor cannot be found with UUID '{uuid}' to summon.",
+    "NoOwnership": "You do not have ownership of '{actor}' which you must have to summon it.",
+    "NoProfile": "Cannot find summoning profile {profileId} on '{item}'.",
+    "Wildcard": "You must have 'Use File Browser' permissions to summon creatures with wildcard artwork."
   }
 },
 "DND5E.Supply": "Supply",

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -94,7 +94,7 @@ export class SummonsData extends foundry.abstract.DataModel {
    * @type {boolean}
    */
   static get canSummon() {
-    return game.user.can("TOKEN_CREATE");
+    return game.user.can("TOKEN_CREATE") && (game.user.isGM || game.settings.get("dnd5e", "allowSummoning"));
   }
 
   get canSummon() {

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -246,7 +246,7 @@ export default class ActionTemplate extends ItemDataModel {
    * @type {boolean}
    */
   get hasSummoning() {
-    return (this.actionType === "summ") && !!this.summons.profiles.length;
+    return (this.actionType === "summ") && !!this.summons?.profiles.length;
   }
 
   /* -------------------------------------------- */

--- a/module/data/token/token-system-flags.mjs
+++ b/module/data/token/token-system-flags.mjs
@@ -22,6 +22,7 @@ const {
  * @property {boolean} isPolymorphed        Is the actor represented by this token transformed?
  * @property {string} originalActor         Original actor before transformation.
  * @property {object} previousActorData     Actor data from before transformation for unlinked tokens.
+ * @property {object} summon                Data for summoned tokens.
  * @property {TokenRingFlagData} tokenRing
  */
 export default class TokenSystemFlags extends foundry.abstract.DataModel {
@@ -33,6 +34,7 @@ export default class TokenSystemFlags extends foundry.abstract.DataModel {
         required: false, initial: undefined, idOnly: true
       }),
       previousActorData: new ObjectField({required: false, initial: undefined}),
+      summon: new ObjectField({required: false, initial: undefined}),
       tokenRing: new SchemaField({
         enabled: new BooleanField({label: "DND5E.TokenRings.Enabled"}),
         colors: new SchemaField({

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -1,3 +1,4 @@
+import { SummonsData } from "../data/item/fields/summons-field.mjs";
 import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
 import DamageRoll from "../dice/damage-roll.mjs";
 
@@ -99,6 +100,8 @@ export default class ChatMessage5e extends ChatMessage {
       // If the user is the message author or the actor owner, proceed
       let actor = game.actors.get(this.speaker.actor);
       if ( game.user.isGM || actor?.isOwner || (this.user.id === game.user.id) ) {
+        const summonsButton = chatCard[0].querySelector('button[data-action="summon"]');
+        if ( summonsButton && !SummonsData.canSummon ) summonsButton.style.display = "none";
         const template = chatCard[0].querySelector('button[data-action="placeTemplate"]');
         if ( template && !game.user.can("TEMPLATE_CREATE") ) template.style.display = "none";
         return;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1056,11 +1056,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       try {
         summoned = await item.system.summons.summon(config.summonsProfile);
       } catch(err) {
-        Hooks.onError("Item5e#use", err, {
-          msg: game.i18n.localize("DND5E.Summoning.Placement.GenericError"),
-          log: "error",
-          notify: "error"
-        });
+        Hooks.onError("Item5e#use", err, { log: "error", notify: "error" });
       }
     }
 
@@ -1116,7 +1112,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     if ( game.user.can("TEMPLATE_CREATE") && this.hasAreaTarget && canvas.scene ) {
       config.createMeasuredTemplate = target.prompt;
     }
-    if ( this.system.hasSummoning ) {
+    if ( this.system.hasSummoning && this.system.summons.canSummon && canvas.scene ) {
       config.createSummons = summons.prompt;
       config.summonsProfile = this.system.summons.profiles[0]._id;
     }
@@ -2148,11 +2144,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     try {
       await item.system.summons.summon(summonsProfile);
     } catch(err) {
-      Hooks.onError("Item5e#_onChatCardSummon", err, {
-        msg: game.i18n.localize("DND5E.Summoning.Placement.GenericError"),
-        log: "error",
-        notify: "error"
-      });
+      Hooks.onError("Item5e#_onChatCardSummon", err, { log: "error", notify: "error" });
     }
   }
 

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -222,6 +222,16 @@ export function registerSystemSettings() {
     }
   });
 
+  // Allow Summoning
+  game.settings.register("dnd5e", "allowSummoning", {
+    name: "SETTINGS.DND5E.ALLOWSUMMONING.Name",
+    hint: "SETTINGS.DND5E.ALLOWSUMMONING.Hint",
+    scope: "world",
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
   // Metric Unit Weights
   game.settings.register("dnd5e", "metricWeightUnits", {
     name: "SETTINGS.5eMetricN",


### PR DESCRIPTION
Adds a `SummonsData#canSummon` property that determines whether a scene is open and whether the user has permissions to summon. If not, then no summoning control is displayed in the `AbilityUseDialog` and the chat button is removed.

If user is trying to summon and actor that they do not have ownership of the will be shown an error.

Also introduces a check for file browser permission when creating token data if the token is set to use a wildcard image. If the user lacks permission here, then the token will fall back to using the portrait image and a warning will be displayed in the console.

Adds a new `SummonsData#fetchActor` data which handles locating the actor to be summoned. If the actor is in the world, then it just returns that version. If the associated actor is in a compendium, it will first search through world actors to find one with a matching `sourceId` and the `dnd5e.summonedCopy` flag set, summoning from the pre-imported version if available. Only then will it fall back on importing the actor from the compendium so long as the user has permission to do so.