### PR TITLE
[#3130] Modified roll CSS Position

### DIFF
--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -191,7 +191,7 @@
         gap: 1px;
 
         .roll {
-          position: unset;
+          position: relative;
           float: unset;
           margin: 0;
         }

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -191,7 +191,6 @@
         gap: 1px;
 
         .roll {
-          position: relative;
           float: unset;
           margin: 0;
         }


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/CSS/position#absolute "The element is positioned relative to its closest positioned ancestor (if any) or to the initial containing block." 
This was causing an issue where the exploded marker was being placed relative to message-content as it the last positioned ancestor for non-min or non-max rolls. (the color filter appeared to cause min and max rolls to have a containing block allowing them to position correctly.) This was fixed by adding a relative position to .roll (instead of unset) 
Closes #3130