### PR TITLE
#3098 Removed armor check for Stealth Disadvantage

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1343,7 +1343,8 @@ DND5E.validProperties = {
   ]),
   equipment: new Set([
     "concentration",
-    "mgc"
+    "mgc",
+    "stealthDisadvantage"
   ]),
   feat: new Set([
     "concentration",

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -246,7 +246,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
   /** @inheritdoc */
   get validProperties() {
     const valid = super.validProperties;
-    if ( this.isArmor ) valid.add("stealthDisadvantage");
+    valid.add("stealthDisadvantage");
     return valid;
   }
 }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -240,13 +240,4 @@ export default class EquipmentData extends ItemDataModel.mixin(
     );
     return this.properties.has("stealthDisadvantage");
   }
-
-  /* -------------------------------------------- */
-
-  /** @inheritdoc */
-  get validProperties() {
-    const valid = super.validProperties;
-    valid.add("stealthDisadvantage");
-    return valid;
-  }
 }


### PR DESCRIPTION
Removed Armor check from validProperties for stealthDisadvantage for equipment.
This allows all equipment to be marked with stealthDisadvantage.
Closes #3098