### PR TITLE
[#2100] Implement HitDice helper class

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -245,8 +245,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     }, { value: 0, label: CONFIG.DND5E.movementTypes.walk });
 
     // Hit Dice
-    context.hd = { value: attributes.hd, max: this.actor.system.details.level };
-    context.hd.pct = Math.clamped(context.hd.max ? (context.hd.value / context.hd.max) * 100 : 0, 0, 100);
+    context.hd = attributes.hd;
 
     // Death Saves
     const plurals = new Intl.PluralRules(game.i18n.lang, { type: "ordinal" });

--- a/module/applications/actor/hit-dice-config.mjs
+++ b/module/applications/actor/hit-dice-config.mjs
@@ -26,7 +26,7 @@ export default class ActorHitDiceConfig extends BaseConfigSheet {
 
   /** @inheritDoc */
   getData(options) {
-    const classes = this.object.system.attributes.hd._classes;
+    const classes = this.object.system.attributes.hd.classes;
     return {
       classes: Array.from(classes).map(item => {
         return {

--- a/module/applications/actor/hit-dice-config.mjs
+++ b/module/applications/actor/hit-dice-config.mjs
@@ -26,20 +26,18 @@ export default class ActorHitDiceConfig extends BaseConfigSheet {
 
   /** @inheritDoc */
   getData(options) {
+    const classes = this.object.system.attributes.hd._classes;
     return {
-      classes: this.object.items.reduce((classes, item) => {
-        if (item.type === "class") {
-          classes.push({
-            classItemId: item.id,
-            name: item.name,
-            diceDenom: item.system.hitDice,
-            currentHitDice: item.system.levels - item.system.hitDiceUsed,
-            maxHitDice: item.system.levels,
-            canRoll: (item.system.levels - item.system.hitDiceUsed) > 0
-          });
-        }
-        return classes;
-      }, []).sort((a, b) => parseInt(b.diceDenom.slice(1)) - parseInt(a.diceDenom.slice(1)))
+      classes: Array.from(classes).map(item => {
+        return {
+          classItemId: item.id,
+          name: item.name,
+          diceDenom: item.system.hitDice,
+          currentHitDice: item.system.levels - item.system.hitDiceUsed,
+          maxHitDice: item.system.levels,
+          canRoll: (item.system.levels - item.system.hitDiceUsed) > 0
+        };
+      }).sort((a, b) => parseInt(b.diceDenom.slice(1)) - parseInt(a.diceDenom.slice(1)))
     };
   }
 
@@ -50,7 +48,7 @@ export default class ActorHitDiceConfig extends BaseConfigSheet {
     super.activateListeners(html);
 
     // Hook up -/+ buttons to adjust the current value in the form
-    html.find("button.increment,button.decrement").click(event => {
+    html.find("button.increment, button.decrement").click(event => {
       const button = event.currentTarget;
       const current = button.parentElement.querySelector(".current");
       const max = button.parentElement.querySelector(".max");

--- a/module/applications/actor/short-rest.mjs
+++ b/module/applications/actor/short-rest.mjs
@@ -28,7 +28,8 @@ export default class ShortRestDialog extends Dialog {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       template: "systems/dnd5e/templates/apps/short-rest.hbs",
-      classes: ["dnd5e", "dialog"]
+      classes: ["dnd5e", "dialog"],
+      height: "auto"
     });
   }
 
@@ -48,17 +49,11 @@ export default class ShortRestDialog extends Dialog {
 
     else if ( foundry.utils.hasProperty(this.actor, "system.attributes.hd") ) {
       // Determine Hit Dice
-      context.availableHD = this.actor.items.reduce((hd, item) => {
-        if ( item.type === "class" ) {
-          const {levels, hitDice, hitDiceUsed} = item.system;
-          const denom = hitDice ?? "d6";
-          const available = parseInt(levels ?? 1) - parseInt(hitDiceUsed ?? 0);
-          hd[denom] = denom in hd ? hd[denom] + available : available;
-        }
-        return hd;
-      }, {});
-      context.canRoll = this.actor.system.attributes.hd > 0;
-      context.denomination = this._denom;
+      context.availableHD = this.actor.system.attributes.hd.bySize;
+      context.canRoll = this.actor.system.attributes.hd.value > 0;
+
+      const dice = Object.entries(context.availableHD);
+      context.denomination = (context.availableHD[this._denom] > 0) ? this._denom : dice.find(([k, v]) => v > 0)?.[0];
     }
 
     // Determine rest type

--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -240,13 +240,9 @@ export default class AbilityUseDialog extends Dialog {
         target = item.actor;
         if ( ["smallest", "largest"].includes(consume.target) ) {
           label = game.i18n.localize(`DND5E.ConsumeHitDice${consume.target.capitalize()}Long`);
-          value = target.system.attributes.hd;
+          value = target.system.attributes.hd.value;
         } else {
-          value = Object.values(item.actor.classes ?? {}).reduce((acc, cls) => {
-            if ( cls.system.hitDice !== consume.target ) return acc;
-            const hd = cls.system.levels - cls.system.hitDiceUsed;
-            return acc + hd;
-          }, 0);
+          value = item.actor.system.attributes.hd.bySize[consume.target] ?? 0;
           label = `${game.i18n.localize("DND5E.HitDice")} (${consume.target})`;
         }
         break;

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -1,3 +1,4 @@
+import HitDice from "../../documents/actor/HitDice.mjs";
 import Proficiency from "../../documents/actor/proficiency.mjs";
 import { simplifyBonus } from "../../utils.mjs";
 import { FormulaField, LocalDocumentField } from "../fields.mjs";
@@ -168,20 +169,13 @@ export default class CharacterData extends CreatureTemplate {
 
   /** @inheritdoc */
   prepareBaseData() {
-    this.details.level = 0;
-    this.attributes.hd = 0;
+    this.attributes.hd = new HitDice(this.parent);
+    this.details.level = this.attributes.hd.total;
     this.attributes.attunement.value = 0;
 
     for ( const item of this.parent.items ) {
-      // Class levels & hit dice
-      if ( item.type === "class" ) {
-        const classLevels = parseInt(item.system.levels) || 1;
-        this.details.level += classLevels;
-        this.attributes.hd += classLevels - (parseInt(item.system.hitDiceUsed) || 0);
-      }
-
       // Attuned items
-      else if ( item.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED ) {
+      if ( item.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED ) {
         this.attributes.attunement.value += 1;
       }
     }

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -170,7 +170,7 @@ export default class CharacterData extends CreatureTemplate {
   /** @inheritdoc */
   prepareBaseData() {
     this.attributes.hd = new HitDice(this.parent);
-    this.details.level = this.attributes.hd.total;
+    this.details.level = this.attributes.hd.max;
     this.attributes.attunement.value = 0;
 
     for ( const item of this.parent.items ) {

--- a/module/documents/_module.mjs
+++ b/module/documents/_module.mjs
@@ -10,6 +10,7 @@ export {default as TokenDocument5e} from "./token.mjs";
 export {default as User5e} from "./user.mjs";
 
 // Helper Methods
+export {default as HitDice} from "./actor/HitDice.mjs";
 export {default as Proficiency} from "./actor/proficiency.mjs";
 export {default as SelectChoices} from "./actor/select-choices.mjs";
 export * as Trait from "./actor/trait.mjs";

--- a/module/documents/actor/HitDice.mjs
+++ b/module/documents/actor/HitDice.mjs
@@ -1,0 +1,172 @@
+/**
+ * Object describing the hit dice for an actor.
+ *
+ * @param {Actor5e} actor
+ */
+export default class HitDice {
+  constructor(actor) {
+    /**
+     * Store a reference to the actor.
+     * @type {Actor5e}
+     */
+    this.actor = actor;
+
+    /**
+     * Remaining hit dice.
+     * @type {number}
+     */
+    this.remaining = 0;
+
+    /**
+     * The actor's total amount of hit dice.
+     * @type {number}
+     */
+    this.total = 0;
+
+    /**
+     * All valid die sizes derived from all classes.
+     * @type {Set<number>}
+     */
+    this.sizes = new Set();
+
+    /**
+     * Store valid class items.
+     * @type {Set<Item5e>}
+     */
+    this._classes = new Set();
+
+    for (const item of Object.values(this.actor.classes)) {
+      if ( /^d[0-9]+$/.test(item.system.hitDice) ) {
+        this._classes.add(item);
+        this.remaining += item.system.levels - item.system.hitDiceUsed;
+        this.total += item.system.levels;
+        this.sizes.add(parseInt(item.system.hitDice.replace("d", "")));
+      }
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The smallest denomination.
+   * @type {string}
+   */
+  get smallest() {
+    return `d${this.smallestFace}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The smallest die size.
+   * @type {number}
+   */
+  get smallestFace() {
+    return this.sizes.size ? Math.min(...this.sizes) : 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The largest denomination.
+   * @type {string}
+   */
+  get largest() {
+    return `d${this.largestFace}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The largest die size.
+   * @type {number}
+   */
+  get largestFace() {
+    return this.sizes.size ? Math.max(...this.sizes) : 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The percentage of remaining hit dice.
+   * @type {number}
+   */
+  get pct() {
+    return Math.clamped(this.total ? (this.remaining / this.total) * 100 : 0, 0, 100);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Alias for the remaining hit dice.
+   * @type {number}
+   */
+  get value() {
+    return this.remaining;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Alias for the total amount of hit dice.
+   * @type {number}
+   */
+  get max() {
+    return this.total;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Return an object of remaining hit dice categorized by size.
+   * @returns {object}
+   */
+  get bySize() {
+    const hd = {};
+    this._classes.forEach(cls => {
+      const d = cls.system.hitDice;
+      const remaining = cls.system.levels - cls.system.hitDiceUsed;
+      hd[d] = ( d in hd ) ? hd[d] + remaining : remaining;
+    });
+    return hd;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Override the default `toString` method for backwards compatibility.
+   * @returns {number}    Remaining hit dice.
+   */
+  toString() {
+    return this.remaining;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create item updates for recovering hit dice during a rest.
+   * @param {object} [options]
+   * @param {number} [options.maxHitDice]   Maximum number of hit dice to recover.
+   * @param {boolean} [options.largest]     Whether to restore the largest hit dice first.
+   * @returns {object}                      Array of item updates and number of hit dice recovered.
+   */
+  createHitDiceUpdates({ maxHitDice, largest=true }={}) {
+    if ( !Number.isInteger(maxHitDice) ) maxHitDice = Math.max(Math.floor(this.total / 2), 1);
+    const classes = Array.from(this._classes).sort((a, b) => {
+      a = parseInt(a.system.hitDice.replace("d", ""));
+      b = parseInt(b.system.hitDice.replace("d", ""));
+      return largest ? (b - a) : (a - b);
+    });
+    const updates = [];
+    let recovered = 0;
+    for ( const item of classes ) {
+      const used = item.system.hitDiceUsed;
+      if ( (recovered < maxHitDice) && (used > 0) ) {
+        const delta = Math.min(used, maxHitDice - recovered);
+        recovered += delta;
+        updates.push({ _id: item.id, "system.hitDiceUsed": used - delta });
+      }
+    }
+    return { updates, hitDiceRecovered: recovered };
+  }
+}

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -86,7 +86,7 @@
                     </a>
                     <div class="attribute-value multiple">
                         <label class="hit-dice">
-                            <span data-tooltip="DND5E.HitDiceRemaining">{{system.attributes.hd}}</span>
+                            <span data-tooltip="DND5E.HitDiceRemaining">{{system.attributes.hd.value}}</span>
                             <span class="sep"> / </span>
                             <span data-tooltip="DND5E.HitDiceMax">{{system.details.level}}</span>
                         </label>


### PR DESCRIPTION
Redo of #2519.

Closes #2100.
Closes #1074.

Saves people from https://github.com/foundryvtt/dnd5e/issues/2100#issuecomment-1986962845.

This moves most hit dice related logic into a single class, which simplifies a lot of code throughout.