### PR TITLE
Remove unneeded effects from races

### DIFF
--- a/packs/_source/races/dwarf/dwarf-features/dwarven-resilience.json
+++ b/packs/_source/races/dwarf/dwarf-features/dwarven-resilience.json
@@ -83,46 +83,15 @@
   },
   "flags": {},
   "img": "icons/creatures/abilities/stinger-poison-green.webp",
-  "effects": [
-    {
-      "_id": "hIaIpLxcMZSY3qXi",
-      "changes": [
-        {
-          "key": "system.traits.dr.value",
-          "mode": 2,
-          "value": "poison",
-          "priority": null
-        }
-      ],
-      "disabled": false,
-      "duration": {
-        "startTime": null,
-        "seconds": null,
-        "combat": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
-      },
-      "icon": "icons/creatures/abilities/stinger-poison-green.webp",
-      "origin": "Item.ufysTkqet2Ctmtyi",
-      "transfer": true,
-      "flags": {},
-      "tint": null,
-      "name": "Dwarven Resilience",
-      "description": "",
-      "statuses": [],
-      "_key": "!items.effects!ufysTkqet2Ctmtyi.hIaIpLxcMZSY3qXi"
-    }
-  ],
+  "effects": [],
   "folder": "bYq316CbmhMdFGG4",
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.1.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234474,
-    "modifiedTime": 1704824711401,
+    "modifiedTime": 1710190382300,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ufysTkqet2Ctmtyi"

--- a/packs/_source/races/gnome/gnome-features/tinker.json
+++ b/packs/_source/races/gnome/gnome-features/tinker.json
@@ -83,46 +83,15 @@
   },
   "flags": {},
   "img": "icons/commodities/tech/cog-steel.webp",
-  "effects": [
-    {
-      "_id": "CkQlNsLyTZGVbnKM",
-      "changes": [
-        {
-          "key": "system.traits.toolProf.value",
-          "mode": 2,
-          "value": "tinker",
-          "priority": null
-        }
-      ],
-      "disabled": false,
-      "duration": {
-        "startTime": null,
-        "seconds": null,
-        "combat": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
-      },
-      "icon": "icons/commodities/tech/cog-steel.webp",
-      "origin": "Item.koRPOLtj8XAFMwnW",
-      "transfer": true,
-      "flags": {},
-      "tint": null,
-      "name": "Tinker",
-      "description": "",
-      "statuses": [],
-      "_key": "!items.effects!koRPOLtj8XAFMwnW.CkQlNsLyTZGVbnKM"
-    }
-  ],
+  "effects": [],
   "folder": "AabmBKPsHt2BlNVK",
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.1.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234472,
-    "modifiedTime": 1704824711285,
+    "modifiedTime": 1710190424020,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!koRPOLtj8XAFMwnW"

--- a/packs/_source/races/gnome/rock-gnome.json
+++ b/packs/_source/races/gnome/rock-gnome.json
@@ -90,6 +90,23 @@
         },
         "level": 0,
         "title": "",
+        "icon": null,
+        "value": {}
+      },
+      {
+        "_id": "3iZH8gdahsVwLPbQ",
+        "type": "Trait",
+        "configuration": {
+          "mode": "default",
+          "allowReplacements": false,
+          "grants": [
+            "tool:art:tinker"
+          ],
+          "choices": [],
+          "hint": ""
+        },
+        "level": 0,
+        "title": "",
         "icon": null
       }
     ],
@@ -123,10 +140,10 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.1",
+    "systemVersion": "3.1.0",
     "coreVersion": "11.315",
     "createdTime": 1677181053374,
-    "modifiedTime": 1706819433552,
+    "modifiedTime": 1710190414679,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "sort": 0,

--- a/packs/_source/races/halfling/halfling-features/lucky.json
+++ b/packs/_source/races/halfling/halfling-features/lucky.json
@@ -7,7 +7,7 @@
   "type": "feat",
   "system": {
     "description": {
-      "value": "<p>When you roll a 1 on the d20 for an attack roll, ability check, or saving throw, you can reroll the die and must use the new roll.</p><section id=\"secret-S04TPyvUh05Dz0Ng\" class=\"secret foundry-note\"><p><strong>Foundry Note</strong></p><p>This property can be enabled on your character sheet in the Special Traits configuration on the Attributes tab.</p></section>",
+      "value": "<p>When you roll a 1 on the d20 for an attack roll, ability check, or saving throw, you can reroll the die and must use the new roll.</p><section class=\"secret foundry-note\" id=\"secret-S04TPyvUh05Dz0Ng\"><p><strong>Foundry Note</strong></p><p>This property can be enabled on your character sheet in the Special Traits configuration on the Attributes tab.</p></section>",
       "chat": ""
     },
     "source": {
@@ -83,46 +83,15 @@
   },
   "flags": {},
   "img": "icons/sundries/gaming/dice-runed-brown.webp",
-  "effects": [
-    {
-      "_id": "3ZXTUDl62zDpvpai",
-      "changes": [
-        {
-          "key": "flags.dnd5e.halflingLucky",
-          "mode": 5,
-          "value": "true",
-          "priority": null
-        }
-      ],
-      "disabled": false,
-      "duration": {
-        "startTime": null,
-        "seconds": null,
-        "combat": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
-      },
-      "icon": "icons/sundries/gaming/dice-runed-brown.webp",
-      "origin": "Item.LOMdcNAGWh5xpfm4",
-      "transfer": true,
-      "flags": {},
-      "tint": null,
-      "name": "Lucky",
-      "description": "",
-      "statuses": [],
-      "_key": "!items.effects!LOMdcNAGWh5xpfm4.3ZXTUDl62zDpvpai"
-    }
-  ],
+  "effects": [],
   "folder": "kbtbKofcv13crhke",
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.1.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234467,
-    "modifiedTime": 1704824711173,
+    "modifiedTime": 1710190479094,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!LOMdcNAGWh5xpfm4"

--- a/packs/_source/races/tiefling/tiefling-features/hellish-resistance.json
+++ b/packs/_source/races/tiefling/tiefling-features/hellish-resistance.json
@@ -83,46 +83,15 @@
   },
   "flags": {},
   "img": "icons/magic/air/fog-gas-smoke-swirling-orange.webp",
-  "effects": [
-    {
-      "_id": "0rAhv7npcNmDcQ3B",
-      "changes": [
-        {
-          "key": "system.traits.dr.value",
-          "mode": 2,
-          "value": "fire",
-          "priority": null
-        }
-      ],
-      "disabled": false,
-      "duration": {
-        "startTime": null,
-        "seconds": null,
-        "combat": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
-      },
-      "icon": "icons/magic/air/fog-gas-smoke-swirling-orange.webp",
-      "origin": "Item.q71Pe1F8RRtEJt8Q",
-      "transfer": true,
-      "flags": {},
-      "tint": null,
-      "name": "Hellish Resistance",
-      "description": "",
-      "statuses": [],
-      "_key": "!items.effects!q71Pe1F8RRtEJt8Q.0rAhv7npcNmDcQ3B"
-    }
-  ],
+  "effects": [],
   "folder": "uTOlS6Wk9xGuCs7Z",
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.1.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234473,
-    "modifiedTime": 1704824711386,
+    "modifiedTime": 1710190496431,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!q71Pe1F8RRtEJt8Q"


### PR DESCRIPTION
- Removed effect that granted poison resistance from dwarf feature. Dwarf race already had this.
- Removed effect that granted Tinker's Tools proficiency (poorly) from gnome feature.
- Added Tinker's Tools proficiency in gnome race.
- Removed effect that set the Halfling Lucky special trait from halfling feature. This is inline with how the Half-Orc is set up, and the feature already included a note on how to set it up manually.
- Removed effect that granted fire resistance from tiefling feature. Tiefling race already had this.