### PR TITLE
#3065 Modify Deterministic Removal in simplifyRollFormula

### DIFF
--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -248,7 +248,7 @@ export default class ChatMessage5e extends ChatMessage {
    * @param {HTMLDivElement} html  The roll tooltip markup.
    */
   _enrichRollTooltip(roll, html) {
-    const constant = Number(simplifyRollFormula(roll.formula, { deterministic: true }));
+    const constant = Number(simplifyRollFormula(roll._formula, { deterministic: true }));
     if ( !constant ) return;
     const sign = constant < 0 ? "-" : "+";
     const part = document.createElement("section");


### PR DESCRIPTION
There was an issue where our simplifyRollFormula Deterministic check would loop through the roll terms and remove any term marked as Deterministic. This caused an issue if a *, /, or % operator was used on a Deterministic term, as the Deterministic term was removed but not the operator and other term that can not be evaluated as those operators are dependent on the Deterministic term. The solution was to treat the operator and other term as Deterministic as well, and remove them. This does not affect *, /, and % used on constants.
Additionally modified _enrichRollTooltip in chat-message.mjs to pass _formula as this was the roll's original formula before evaluation where parenthesis are collapsed, providing a more accurate constant. 
Closes #3065