### PR TITLE
[#3183] Adjust rollDamage to return merged roll, rather than first

### DIFF
--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -217,7 +217,24 @@ export async function damageRoll({
 
   // Create a Chat Message
   if ( rolls?.length && chatMessage ) await CONFIG.Dice.DamageRoll.toMessage(rolls, messageData, { rollMode });
-  return returnMultiple ? rolls : rolls[0];
+  if ( returnMultiple ) return rolls;
+  if ( rolls?.length <= 1 ) return rolls[0];
+
+  const mergedRoll = new CONFIG.Dice.DamageRoll();
+  mergedRoll._total = 0;
+  for ( const roll of rolls ) {
+    if ( mergedRoll.terms.length ) {
+      const operator = new OperatorTerm({operator: "+"});
+      operator._evaluated = true;
+      mergedRoll.terms.push(operator);
+    }
+    mergedRoll.terms.push(...roll.terms);
+    mergedRoll._total += roll.total;
+    mergedRoll.options = foundry.utils.mergeObject(roll.options, mergedRoll.options, { inplace: false });
+  }
+  mergedRoll._evaluated = true;
+  mergedRoll.resetFormula();
+  return mergedRoll;
 }
 
 /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1702,8 +1702,8 @@ export default class Item5e extends SystemDocumentMixin(Item) {
      * A hook event that fires after a damage has been rolled for an Item.
      * @function dnd5e.rollDamage
      * @memberof hookEvents
-     * @param {Item5e} item       Item for which the roll was performed.
-     * @param {DamageRoll} rolls  The resulting rolls.
+     * @param {Item5e} item                    Item for which the roll was performed.
+     * @param {DamageRoll|DamageRoll[]} rolls  The resulting rolls (or single roll if `returnMultiple` is `false`).
      */
     if ( rolls || (rollConfig.returnMultiple && rolls?.length) ) Hooks.callAll("dnd5e.rollDamage", this, rolls);
 


### PR DESCRIPTION
In `3.0.0` we modified `Item5e#rollDamage` to support separate rolls for multiple damage parts and added `returnMultiple` option for backward compatibility. The issue with that initial implementation is that if `returnMultiple` is `false`, it returns the first roll made rather than matching previously behavior of having all the damage parts merged into a single roll.

This change alters the bahavior of `damageRoll` if `returnMultiple` is `false` and there are more than one roll to create a new merged roll from the evaulated rolls and return that.

The separate rolls are still stored in the chat message and used by the system, but the combined rolls are now available to modules that rely on the `dnd5e.rollDamage` hook or call `Item5e#rollDamage` directly.