### PR TITLE
[#893] Add damage & healing bonuses to summoning configuration

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1391,9 +1391,27 @@
     "Remove": "Remove Profile",
     "Summon": "Summon"
   },
-  "ArmorClass": {
-    "Label": "Bonus Armor Class",
-    "Hint": "Bonus to the Armor Class set on the summoned creature added to what is specified in their statblock."
+  "Bonuses": {
+    "ArmorClass": {
+      "Label": "Bonus Armor Class",
+      "Hint": "Bonus to the Armor Class set on the summoned creature added to what is specified in their statblock."
+    },
+    "Attack": {
+      "Label": "Bonus Attack Damage",
+      "Hint": "Additional damage done by the creature's attacks."
+    },
+    "Healing": {
+      "Label": "Bonus Healing",
+      "Hint": "Additional healing provided by healing abilities."
+    },
+    "HitPoints": {
+      "Label": "Bonus Hit Points",
+      "Hint": "Additional hit points added to the creature on top of what is specified in their statblock."
+    },
+    "Saves": {
+      "Label": "Bonus Save Damage",
+      "Hint": "Additional damage done by the creature's abilities that require saving throws."
+    }
   },
   "Configuration": "Summoning Configuration",
   "CreatureChanges": {
@@ -1402,10 +1420,6 @@
   },
   "DisplayName": "Display Name",
   "DropHint": "Drop creature here",
-  "HitPoints": {
-    "Label": "Bonus Hit Points",
-    "Hint": "Additional hit points added to the creature on top of what is specified in their statblock."
-  },
   "ItemChanges": {
     "Label": "Item Changes",
     "Hint": "Changes made to items on the summoned creature."

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -42,14 +42,14 @@
         <p class="hint">{{ localize "DND5E.Summoning.Match.Proficiency.Hint" }}</p>
     </div>
     <div class="form-group">
-        <label>{{ localize "DND5E.Summoning.ArmorClass.Label" }}</label>
+        <label>{{ localize "DND5E.Summoning.Bonuses.ArmorClass.Label" }}</label>
         <input type="text" name="bonuses.ac" value="{{ summons.bonuses.ac }}">
-        <p class="hint">{{ localize "DND5E.Summoning.ArmorClass.Hint" }}</p>
+        <p class="hint">{{ localize "DND5E.Summoning.Bonuses.ArmorClass.Hint" }}</p>
     </div>
     <div class="form-group">
-        <label>{{ localize "DND5E.Summoning.HitPoints.Label" }}</label>
+        <label>{{ localize "DND5E.Summoning.Bonuses.HitPoints.Label" }}</label>
         <input type="text" name="bonuses.hp" value="{{ summons.bonuses.hp }}">
-        <p class="hint">{{ localize "DND5E.Summoning.HitPoints.Hint" }}</p>
+        <p class="hint">{{ localize "DND5E.Summoning.Bonuses.HitPoints.Hint" }}</p>
     </div>
 
     <h3 class="form-header">{{ localize "DND5E.Summoning.ItemChanges.Label" }}</h3>
@@ -63,5 +63,20 @@
         <label>{{ localize "DND5E.Summoning.Match.Saves.Label" }}</label>
         <input type="checkbox" name="match.saves" {{ checked summons.match.saves }}>
         <p class="hint">{{ localize "DND5E.Summoning.Match.Saves.Hint" }}</p>
+    </div>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Summoning.Bonuses.Attack.Label" }}</label>
+        <input type="text" name="bonuses.attackDamage" value="{{ summons.bonuses.attackDamage }}">
+        <p class="hint">{{ localize "DND5E.Summoning.Bonuses.Attack.Hint" }}</p>
+    </div>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Summoning.Bonuses.Saves.Label" }}</label>
+        <input type="text" name="bonuses.saveDamage" value="{{ summons.bonuses.saveDamage }}">
+        <p class="hint">{{ localize "DND5E.Summoning.Bonuses.Saves.Hint" }}</p>
+    </div>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Summoning.Bonuses.Healing.Label" }}</label>
+        <input type="text" name="bonuses.healing" value="{{ summons.bonuses.healing }}">
+        <p class="hint">{{ localize "DND5E.Summoning.Bonuses.Healing.Hint" }}</p>
     </div>
 </form>


### PR DESCRIPTION
Adds three bonuses that add to attack damage, saving throw damage, and healing. Formula data in these is resolved at summoning time based on the summoner stats so something like `@item.level` can be used to add the spell's level of damage to an attack.