### PR TITLE
[#3245] Special handling for concentration icon and 'passive' items

### DIFF
--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -264,6 +264,8 @@ export default class AbilityUseDialog extends Dialog {
   static _getAbilityUseNote(item, config) {
     const { quantity, recharge, uses } = item.system;
 
+    if ( !item.isActive ) return "";
+
     // Zero quantity
     if ( quantity <= 0 ) return game.i18n.localize("DND5E.AbilityUseUnavailableHint");
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -410,11 +410,15 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     // Item Properties
     if ( this.system.properties ) {
-      this.labels.properties = Array.from(this.system.properties).map(prop => ({
-        abbr: prop,
-        label: CONFIG.DND5E.itemProperties[prop]?.label,
-        icon: CONFIG.DND5E.itemProperties[prop]?.icon
-      }));
+      this.labels.properties = this.system.properties.reduce((acc, prop) => {
+        if ( (prop === "concentration") && !this.requiresConcentration ) return acc;
+        acc.push({
+          abbr: prop,
+          label: CONFIG.DND5E.itemProperties[prop]?.label,
+          icon: CONFIG.DND5E.itemProperties[prop]?.icon
+        });
+        return acc;
+      }, []);
     }
 
     // Specialized preparation per Item type


### PR DESCRIPTION
Closes #3245.

Additionally added a check for `Item5e#isActive` since ability use notes should not matter for inactive items (this could cause the "no uses left" note to show up when an item had 0 quantity or 0 uses).