### PR TITLE
[#3248] Invert healing automatically in `calculateDamage`

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -857,15 +857,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * Options for damage application.
    *
    * @typedef {object} DamageApplicationOptions
-   * @property {number} [multiplier=1]    Amount by which to multiply all damage.
-   * @property {object|boolean} [ignore]  Set to `true` to ignore all damage modifiers. If set to an object, then
-   *                                      values can either be `true` to indicate that the all modifications of that
-   *                                      type should be ignored, or a set of specific damage types for which it should
-   *                                      be ignored.
+   * @property {number} [multiplier=1]         Amount by which to multiply all damage.
+   * @property {boolean} [invertHealing=true]  Automatically invert healing types to it heals, rather than damages.
+   * @property {object|boolean} [ignore]       Set to `true` to ignore all damage modifiers. If set to an object, then
+   *                                           values can either be `true` to indicate that the all modifications of
+   *                                           that type should be ignored, or a set of specific damage types for which
+   *                                           it should be ignored.
    * @property {boolean|Set<string>} [ignore.immunity]       Should this actor's damage immunity be ignored?
    * @property {boolean|Set<string>} [ignore.resistance]     Should this actor's damage resistance be ignored?
    * @property {boolean|Set<string>} [ignore.vulnerability]  Should this actor's damage vulnerability be ignored?
    * @property {boolean|Set<string>} [ignore.modification]   Should this actor's damage modification be ignored?
+   * @property {"damage"|"healing"} [only]     Apply only damage or healing parts. Untyped rolls will always be applied.
    */
 
   /**
@@ -980,11 +982,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       return !config.bypasses?.intersection(properties)?.size;
     };
 
+    const skipped = type => {
+      if ( only === "damage" ) return type in CONFIG.DND5E.healingTypes;
+      if ( only === "healing" ) return type in CONFIG.DND5E.damageTypes;
+      return true;
+    };
+
     const rollData = this.getRollData({deterministic: true});
 
     damages.forEach(d => {
       // Skip damage types with immunity
-      if ( !ignore("immunity", d.type) && hasEffect("di", d.type, d.properties) ) {
+      if ( skipped(d.type) || (!ignore("immunity", d.type) && hasEffect("di", d.type, d.properties)) ) {
         d.value = 0;
         return;
       }
@@ -1003,6 +1011,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
       // Apply type-specific damage vulnerability
       if ( !ignore("vulnerability", d.type) && hasEffect("dv", d.type, d.properties) ) damageMultiplier *= 2;
+
+      // Negate healing types
+      if ( (options.invertHealing !== false) && (d.type === "healing") ) damageMultiplier *= -1;
 
       d.value = d.value * damageMultiplier;
     });

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -453,7 +453,7 @@ export default class ChatMessage5e extends ChatMessage {
       properties: new Set(roll.options.properties ?? [])
     }));
     return Promise.all(canvas.tokens.controlled.map(t => {
-      return t.actor?.applyDamage(damages, { multiplier, ignore: true });
+      return t.actor?.applyDamage(damages, { multiplier, invertHealing: false, ignore: true });
     }));
   }
 


### PR DESCRIPTION
If a `DamageDescription` with the type `healing` is encountered in `Actor5e#calculateDamage` it will now be automatically inverted rather than relying on the `multiplier` option. This simplifies the usage of `applyDamage` and opens up the possibility of mixing damage and healing (if you wanted to do a risky healing feature that does 1d4 bludgeoning damage and heals 1d6, that is now possible).

This inversion is applied by default, but can be turned off by the new `invertHealing` option passed to `applyDamage`.

Another new option is `only`, which tells the damage system to only apply damaging or healing damage parts. This option should be useful for reworking the damage application interface to allow for three options: "Apply All", "Apply Damage", & "Apply Healing".