### PR TITLE
[#3250] Aggregate damage types before passing to `applyDamage`

### DIFF
--- a/module/dice/_module.mjs
+++ b/module/dice/_module.mjs
@@ -1,3 +1,4 @@
+export {default as aggregateDamageRolls} from "./aggregate-damage-rolls.mjs";
 export {default as D20Roll} from "./d20-roll.mjs";
 export {default as DamageRoll} from "./damage-roll.mjs";
 export * from "./dice.mjs";

--- a/module/dice/aggregate-damage-rolls.mjs
+++ b/module/dice/aggregate-damage-rolls.mjs
@@ -1,0 +1,77 @@
+/**
+ * Parse the provided rolls, splitting parts based on damage types & properties, taking flavor into account.
+ * @param {DamageRoll[]} rolls                   Evaluated damage rolls to aggregate.
+ * @param {object} [options={}]
+ * @param {boolean} [options.respectProperties]  Should damage properties also affect grouping?
+ * @returns {DamageRoll[]}
+ */
+export default function aggregateDamageRolls(rolls, { respectProperties }={}) {
+  const makeHash = (type, properties=[]) => [type, ...(respectProperties ? Array.from(properties).sort() : [])].join();
+
+  // Split rolls into new sets of terms based on damage type & properties
+  const types = new Map();
+  for ( const roll of rolls ) {
+    if ( !roll._evaluated ) throw new Error("Only evaluated rolls can be aggregated.");
+    for ( const chunk of chunkTerms(roll.terms, roll.options.type) ) {
+      const key = makeHash(chunk.type, roll.options.properties);
+      if ( !types.has(key) ) types.set(key, { type: chunk.type, properties: new Set(), terms: [] });
+      const data = types.get(key);
+      data.terms.push(new OperatorTerm({ operator: chunk.negative ? "-" : "+" }), ...chunk.terms);
+      if ( roll.options.properties ) data.properties = data.properties.union(new Set(roll.options.properties));
+    }
+  }
+
+  // Create new damage rolls based on the aggregated terms
+  const newRolls = [];
+  for ( const type of types.values() ) {
+    const roll = new CONFIG.Dice.DamageRoll();
+    roll.terms = type.terms;
+    roll._total = roll._evaluateTotal();
+    roll._evaluated = true;
+    roll.options = { type: type.type, properties: Array.from(type.properties) };
+    roll.resetFormula();
+    newRolls.push(roll);
+  }
+
+  return newRolls;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Split terms into groups based on operators. Addition & subtraction will split groups while multiplication and
+ * division will keep groups together. These groups also contain information on contained types written in flavor
+ * and whether they are negative.
+ * @param {RollTerm[]} terms  Terms to chunk.
+ * @param {string} type       Type specified in the roll as a whole which will be ignored if used as flavor.
+ * @returns {{ terms: RollTerm[], negative: boolean, type: string }[]}
+ */
+function chunkTerms(terms, type) {
+  const pushChunk = () => {
+    currentChunk.type ??= type;
+    chunks.push(currentChunk);
+    currentChunk = null;
+  };
+  const isValidType = t => ((t in CONFIG.DND5E.damageTypes) || (t in CONFIG.DND5E.healingTypes)) && (t !== type);
+  const chunks = [];
+  let currentChunk;
+  let negative = false;
+
+  for ( const term of terms ) {
+    // Plus or minus operators split chunks
+    if ( (term instanceof OperatorTerm) && ["+", "-"].includes(term.operator) ) {
+      if ( currentChunk ) pushChunk();
+      negative = term.operator === "-";
+      continue;
+    }
+
+    // All other terms get added to the current chunk
+    currentChunk ??= { terms: [], negative, type: null };
+    currentChunk.terms.push(term);
+    const flavor = term.flavor?.toLowerCase().trim();
+    if ( isValidType(flavor) ) currentChunk.type ??= flavor;
+  }
+
+  if ( currentChunk ) pushChunk();
+  return chunks;
+}

--- a/module/dice/aggregate-damage-rolls.mjs
+++ b/module/dice/aggregate-damage-rolls.mjs
@@ -43,7 +43,7 @@ export default function aggregateDamageRolls(rolls, { respectProperties }={}) {
  * division will keep groups together. These groups also contain information on contained types written in flavor
  * and whether they are negative.
  * @param {RollTerm[]} terms  Terms to chunk.
- * @param {string} type       Type specified in the roll as a whole which will be ignored if used as flavor.
+ * @param {string} type       Type specified in the roll as a whole.
  * @returns {{ terms: RollTerm[], negative: boolean, type: string }[]}
  */
 function chunkTerms(terms, type) {
@@ -51,8 +51,9 @@ function chunkTerms(terms, type) {
     currentChunk.type ??= type;
     chunks.push(currentChunk);
     currentChunk = null;
+    negative = false;
   };
-  const isValidType = t => ((t in CONFIG.DND5E.damageTypes) || (t in CONFIG.DND5E.healingTypes)) && (t !== type);
+  const isValidType = t => ((t in CONFIG.DND5E.damageTypes) || (t in CONFIG.DND5E.healingTypes));
   const chunks = [];
   let currentChunk;
   let negative = false;
@@ -61,7 +62,7 @@ function chunkTerms(terms, type) {
     // Plus or minus operators split chunks
     if ( (term instanceof OperatorTerm) && ["+", "-"].includes(term.operator) ) {
       if ( currentChunk ) pushChunk();
-      negative = term.operator === "-";
+      if ( term.operator === "-" ) negative = !negative;
       continue;
     }
 

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -1,6 +1,7 @@
 import { SummonsData } from "../data/item/fields/summons-field.mjs";
-import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
+import aggregateDamageRolls from "../dice/aggregate-damage-rolls.mjs";
 import DamageRoll from "../dice/damage-roll.mjs";
+import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
 
 export default class ChatMessage5e extends ChatMessage {
 
@@ -460,7 +461,7 @@ export default class ChatMessage5e extends ChatMessage {
    * @returns {Promise}
    */
   applyChatCardDamage(li, multiplier) {
-    const damages = this.rolls.map(roll => ({
+    const damages = aggregateDamageRolls(this.rolls, { respectProperties: true }).map(roll => ({
       value: roll.total,
       type: roll.options.type,
       properties: new Set(roll.options.properties ?? [])


### PR DESCRIPTION
Adds a new dice helper function `aggregateDamageRolls` which splits and re-combines damage rolls based on the roll's type, term flavor, and optionally any roll properties. This function is then used by `ChatMessage5e#applyChatCardDamage` before rolls are totaled to ensure that damage types are properly split.

The function starts by using a `chunkTerms` helper function which goes through the terms in a roll grouping into chunks based on the operators. Addition and subtraction cause new chunks to be created while multiplication and division are included in the same chunk. This is so that a damage type defined in flavor of a term can spread to other terms that it is multiplied or divided with. So if you have a formula `1d6 + 5 * 1d4[fire]` that has the overall type of piercing, the `1d6` will remaining piercing while the `5 * 1d4` will all be treated as fire.

Once the chunking is complete then chunks from all different rolls are combined into lists of terms grouped by type and properties (so long as the `respectProperties` option is set, otherwise they will only be grouped by type). These sets are then converted into new `DamageRoll`s with options set appropriately.