### PR TITLE
Migrate ItemGrant & Choice to store items as objects rather than UUIDs

### DIFF
--- a/module/applications/advancement/advancement-config.mjs
+++ b/module/applications/advancement/advancement-config.mjs
@@ -68,7 +68,7 @@ export default class AdvancementConfig extends FormApplication {
   /** @inheritdoc */
   async close(options={}) {
     await super.close(options);
-    delete this.advancement.apps[this.appId];
+    delete this.advancement?.apps[this.appId];
   }
 
   /* -------------------------------------------- */
@@ -164,7 +164,7 @@ export default class AdvancementConfig extends FormApplication {
     if ( !uuidToDelete ) return;
     const items = foundry.utils.getProperty(this.advancement.configuration, this.options.dropKeyPath);
     const updates = { configuration: await this.prepareConfigurationUpdate({
-      [this.options.dropKeyPath]: items.filter(uuid => uuid !== uuidToDelete)
+      [this.options.dropKeyPath]: items.filter(i => i.uuid !== uuidToDelete)
     }) };
     await this.advancement.update(updates);
   }
@@ -207,12 +207,14 @@ export default class AdvancementConfig extends FormApplication {
     }
 
     // Abort if this uuid exists already
-    if ( existingItems.includes(item.uuid) ) {
+    if ( existingItems.find(i => i.uuid === item.uuid) ) {
       ui.notifications.warn("DND5E.AdvancementItemGrantDuplicateWarning", {localize: true});
       return null;
     }
 
-    await this.advancement.update({[`configuration.${this.options.dropKeyPath}`]: [...existingItems, item.uuid]});
+    await this.advancement.update({[`configuration.${this.options.dropKeyPath}`]: [
+      ...existingItems, { uuid: item.uuid }
+    ]});
   }
 
   /* -------------------------------------------- */

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -20,7 +20,7 @@ export default class ItemChoiceConfig extends AdvancementConfig {
 
   /** @inheritdoc */
   getData(options={}) {
-    const indexes = this.advancement.configuration.pool.map(uuid => fromUuidSync(uuid));
+    const indexes = this.advancement.configuration.pool.map(i => fromUuidSync(i.uuid));
     const context = {
       ...super.getData(options),
       showContainerWarning: indexes.some(i => i?.type === "container"),
@@ -50,10 +50,10 @@ export default class ItemChoiceConfig extends AdvancementConfig {
 
     // Ensure items are still valid if type restriction or spell restriction are changed
     const pool = [];
-    for ( const uuid of (configuration.pool ?? this.advancement.configuration.pool) ) {
-      if ( this.advancement._validateItemType(await fromUuid(uuid), {
+    for ( const item of (configuration.pool ?? this.advancement.configuration.pool) ) {
+      if ( this.advancement._validateItemType(await fromUuid(item.uuid), {
         type: configuration.type, restriction: configuration.restriction ?? {}, strict: false
-      }) ) pool.push(uuid);
+      }) ) pool.push(item);
     }
     configuration.pool = pool;
 

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -42,7 +42,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
       this.retainedData?.items.map(i => foundry.utils.getProperty(i, "flags.dnd5e.sourceId"))
         ?? Object.values(this.advancement.value[this.level] ?? {})
     );
-    this.pool ??= await Promise.all(this.advancement.configuration.pool.map(uuid => fromUuid(uuid)));
+    this.pool ??= await Promise.all(this.advancement.configuration.pool.map(i => fromUuid(i.uuid)));
     if ( !this.dropped ) {
       this.dropped = [];
       for ( const data of this.retainedData?.items ?? [] ) {

--- a/module/applications/advancement/item-grant-config.mjs
+++ b/module/applications/advancement/item-grant-config.mjs
@@ -20,7 +20,7 @@ export default class ItemGrantConfig extends AdvancementConfig {
   /** @inheritdoc */
   getData(options={}) {
     const context = super.getData(options);
-    const indexes = context.configuration.items.map(uuid => fromUuidSync(uuid));
+    const indexes = context.configuration.items.map(i => fromUuidSync(i.uuid));
     context.showContainerWarning = indexes.some(i => i?.type === "container");
     context.showSpellConfig = indexes.some(i => i?.type === "spell");
     return context;

--- a/module/applications/advancement/item-grant-flow.mjs
+++ b/module/applications/advancement/item-grant-flow.mjs
@@ -25,7 +25,7 @@ export default class ItemGrantFlow extends AdvancementFlow {
     const checked = new Set(Object.values(added ?? {}));
     return {
       optional: this.advancement.configuration.optional,
-      items: (await Promise.all(config.map(uuid => fromUuid(uuid)))).reduce((arr, item) => {
+      items: (await Promise.all(config.map(i => fromUuid(i.uuid)))).reduce((arr, item) => {
         if ( !item ) return arr;
         item.checked = added ? checked.has(item.uuid) : true;
         arr.push(item);

--- a/module/data/advancement/item-choice.mjs
+++ b/module/data/advancement/item-choice.mjs
@@ -2,6 +2,7 @@ import { MappingField } from "../fields.mjs";
 import SpellConfigurationData from "./spell-config.mjs";
 
 export default class ItemChoiceConfigurationData extends foundry.abstract.DataModel {
+  /** @inheritDoc */
   static defineSchema() {
     return {
       hint: new foundry.data.fields.StringField({label: "DND5E.AdvancementHint"}),
@@ -16,7 +17,9 @@ export default class ItemChoiceConfigurationData extends foundry.abstract.DataMo
         blank: false, nullable: true, initial: null,
         label: "DND5E.AdvancementItemChoiceType", hint: "DND5E.AdvancementItemChoiceTypeHint"
       }),
-      pool: new foundry.data.fields.ArrayField(new foundry.data.fields.StringField(), {label: "DOCUMENT.Items"}),
+      pool: new foundry.data.fields.ArrayField(new foundry.data.fields.SchemaField({
+        uuid: new foundry.data.fields.StringField()
+      }), {label: "DOCUMENT.Items"}),
       spell: new foundry.data.fields.EmbeddedDataField(SpellConfigurationData, {nullable: true, initial: null}),
       restriction: new foundry.data.fields.SchemaField({
         type: new foundry.data.fields.StringField({label: "DND5E.Type"}),
@@ -24,5 +27,17 @@ export default class ItemChoiceConfigurationData extends foundry.abstract.DataMo
         level: new foundry.data.fields.StringField({label: "DND5E.SpellLevel"})
       })
     };
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Migrations                             */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static migrateData(source) {
+    if ( "pool" in source ) {
+      source.pool = source.pool.map(i => foundry.utils.getType(i) === "string" ? { uuid: i } : i);
+    }
+    return source;
   }
 }

--- a/module/data/advancement/item-grant.mjs
+++ b/module/data/advancement/item-grant.mjs
@@ -1,12 +1,12 @@
 import SpellConfigurationData from "./spell-config.mjs";
 
 export default class ItemGrantConfigurationData extends foundry.abstract.DataModel {
-  /** @inheritdoc */
+  /** @inheritDoc */
   static defineSchema() {
     return {
-      items: new foundry.data.fields.ArrayField(new foundry.data.fields.StringField(), {
-        required: true, label: "DOCUMENT.Items"
-      }),
+      items: new foundry.data.fields.ArrayField(new foundry.data.fields.SchemaField({
+        uuid: new foundry.data.fields.StringField()
+      }), {required: true, label: "DOCUMENT.Items"}),
       optional: new foundry.data.fields.BooleanField({
         required: true, label: "DND5E.AdvancementItemGrantOptional", hint: "DND5E.AdvancementItemGrantOptionalHint"
       }),
@@ -14,5 +14,17 @@ export default class ItemGrantConfigurationData extends foundry.abstract.DataMod
         required: true, nullable: true, initial: null
       })
     };
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Migrations                             */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static migrateData(source) {
+    if ( "items" in source ) {
+      source.items = source.items.map(i => foundry.utils.getType(i) === "string" ? { uuid: i } : i);
+    }
+    return source;
   }
 }

--- a/module/data/fields.mjs
+++ b/module/data/fields.mjs
@@ -85,22 +85,6 @@ export class AdvancementDataField extends foundry.data.fields.ObjectField {
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  _cleanType(value, options) {
-    if ( !(typeof value === "object") ) value = {};
-
-    // Use a defined DataModel
-    const cls = this.getModel();
-    if ( cls ) return cls.cleanData(value, options);
-    if ( options.partial ) return value;
-
-    // Use the defined defaults
-    const defaults = this.getDefaults();
-    return foundry.utils.mergeObject(defaults, value, {inplace: false});
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritdoc */
   initialize(value, model, options={}) {
     const cls = this.getModel();
     if ( cls ) return new cls(value, {parent: model, ...options});

--- a/module/documents/advancement/item-choice.mjs
+++ b/module/documents/advancement/item-choice.mjs
@@ -58,7 +58,7 @@ export default class ItemChoiceAdvancement extends ItemGrantAdvancement {
   summaryForLevel(level, { configMode=false }={}) {
     const items = this.value.added?.[level];
     if ( !items || configMode ) return "";
-    return Object.values(items).reduce((html, uuid) => html + game.dnd5e.utils.linkForUuid(uuid), "");
+    return Object.values(items).reduce((html, i) => html + game.dnd5e.utils.linkForUuid(i.uuid), "");
   }
 
   /* -------------------------------------------- */

--- a/module/documents/advancement/item-grant.mjs
+++ b/module/documents/advancement/item-grant.mjs
@@ -49,7 +49,7 @@ export default class ItemGrantAdvancement extends Advancement {
   summaryForLevel(level, { configMode=false }={}) {
     // Link to compendium items
     if ( !this.value.added || configMode ) {
-      return this.configuration.items.reduce((html, uuid) => html + dnd5e.utils.linkForUuid(uuid), "");
+      return this.configuration.items.reduce((html, i) => html + dnd5e.utils.linkForUuid(i.uuid), "");
     }
 
     // Link to items on the actor

--- a/templates/advancement/item-choice-config.hbs
+++ b/templates/advancement/item-choice-config.hbs
@@ -73,11 +73,12 @@
                 <li class="items-header flexrow"><h3 class="item-name">{{localize "DOCUMENT.Items"}}</h3></li>
                 <ol class="item-list">
                 {{#each configuration.pool}}
-                <li class="item flexrow" data-item-uuid="{{this}}">
-                    <div class="item-name">{{{dnd5e-linkForUuid this}}}</div>
+                <li class="item flexrow" data-item-uuid="{{ uuid }}">
+                    <div class="item-name">{{{ dnd5e-linkForUuid uuid }}}</div>
                     <div class="item-controls flexrow">
-                        <a class="item-control item-action" data-action="delete" title="{{localize 'DND5E.ItemDelete'}}">
-                            <i class="fas fa-trash"></i>
+                        <a class="item-control item-action" data-action="delete" data-tooltip="DND5E.ItemDelete"
+                           aria-label="{{ localize 'DND5E.ItemDelete' }}">
+                            <i class="fas fa-trash" inert></i>
                         </a>
                     </div>
                 </li>

--- a/templates/advancement/item-grant-config.hbs
+++ b/templates/advancement/item-grant-config.hbs
@@ -17,11 +17,12 @@
             <li class="items-header flexrow"><h3 class="item-name">{{localize "DOCUMENT.Items"}}</h3></li>
             <ol class="item-list">
             {{#each configuration.items}}
-            <li class="item flexrow" data-item-uuid="{{this}}">
-                <div class="item-name">{{{dnd5e-linkForUuid this}}}</div>
+            <li class="item flexrow" data-item-uuid="{{ uuid }}">
+                <div class="item-name">{{{ dnd5e-linkForUuid uuid }}}</div>
                 <div class="item-controls flexrow">
-                    <a class="item-control item-action" data-action="delete" data-tooltip="DND5E.ItemDelete">
-                        <i class="fas fa-trash"></i>
+                    <a class="item-control item-action" data-action="delete" data-tooltip="DND5E.ItemDelete"
+                       aria-label="{{ localize 'DND5E.ItemDelete' }}">
+                        <i class="fas fa-trash" inert></i>
                     </a>
                 </div>
             </li>


### PR DESCRIPTION
Necessary migration to allow for additional per-object configuration of granted items or choices. Now granted & chosen items are represented by and object with a `uuid` value, rather than a straight UUID string.

May be a breaking change for any custom migrations relying on the drop functionality built in to `AdvancementConfig` which now assumes objects rather than strings as the target value. This could be made to not be a breaking change if we added some extra handling to detect the field type of the target (about a 3 line change if desired), but I'm not sure anyone is relying on this at the moment.

Had to remove `AdvancementDataField#_cleanType` which was interfering with the migrations, but I don't think it is necessary because cleaning is handled during the sub-model initialization.