### PR TITLE
[#3165] Prevent template placement if no scene is open

### DIFF
--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -91,8 +91,11 @@ export default class ChatMessage5e extends ChatMessage {
 
       // If the user is the message author or the actor owner, proceed
       let actor = game.actors.get(this.speaker.actor);
-      if ( actor && actor.isOwner ) return;
-      else if ( game.user.isGM || (this.user.id === game.user.id)) return;
+      if ( game.user.isGM || actor?.isOwner || (this.user.id === game.user.id) ) {
+        const template = chatCard[0].querySelector('button[data-action="placeTemplate"]');
+        if ( template && !game.user.can("TEMPLATE_CREATE") ) template.style.display = "none";
+        return;
+      }
 
       // Otherwise conceal action buttons except for saving throw
       const buttons = chatCard.find("button[data-action]:not(.apply-effect)");

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1102,7 +1102,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       // Do not suggest consuming your own uses if also consuming them through resources.
       if ( consume.target === this.id ) config.consumeUsage = null;
     }
-    if ( game.user.can("TEMPLATE_CREATE") && this.hasAreaTarget ) config.createMeasuredTemplate = target.prompt;
+    if ( game.user.can("TEMPLATE_CREATE") && this.hasAreaTarget && canvas.scene ) {
+      config.createMeasuredTemplate = target.prompt;
+    }
     if ( this.system.hasSummoning ) {
       config.createSummons = summons.prompt;
       config.summonsProfile = this.system.summons.profiles[0]._id;


### PR DESCRIPTION
Adds a check when preparing `ItemUseConfiguration` to ensure scene is open before presenting the option to place a template.

Also adds a check when rendering chat messages to ensure a scene is open and the user has permission to place template. The one limitation of the chat card change is that the button will not re-appear when a scene is opened, requiring a refresh to see the button. An alternate approach would be adding a style that hides the button if no scene is open, but that would require a class or property somewhere up the DOM that it could check, which isn't currently available.

Closes #3165