### PR TITLE
[#893] Hide options in ability use dialog when summoning from chat

### DIFF
--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -34,8 +34,9 @@ export default class AbilityUseDialog extends Dialog {
    *
    * @typedef {object} AbilityUseDialogOptions
    * @property {object} [button]
-   * @property {string} [button.icon]   Icon used for the activation button.
-   * @property {string} [button.label]  Label used for the activation button.
+   * @property {string} [button.icon]     Icon used for the activation button.
+   * @property {string} [button.label]    Label used for the activation button.
+   * @property {string} [disableScaling]  Should spell or resource scaling be disabled?
    */
 
   /**
@@ -64,14 +65,14 @@ export default class AbilityUseDialog extends Dialog {
         options: concentrationOptions,
         optional: (concentrationOptions.length < limit) ? "—" : null
       },
-      scaling: item.usageScaling,
+      scaling: options.disableScaling ? null : item.usageScaling,
       note: this._getAbilityUseNote(item, config),
       title: game.i18n.format("DND5E.AbilityUseHint", {
         type: game.i18n.localize(CONFIG.Item.typeLabels[item.type]),
         name: item.name
       })
     };
-    this._getAbilityUseWarnings(data);
+    this._getAbilityUseWarnings(data, options);
 
     // Render the ability usage template
     const html = await renderTemplate("systems/dnd5e/templates/apps/ability-use.hbs", data);
@@ -123,6 +124,8 @@ export default class AbilityUseDialog extends Dialog {
       return acc;
     }, []);
   }
+
+  /* -------------------------------------------- */
 
   /**
    * Create an array of spell slot options for a select.
@@ -306,14 +309,15 @@ export default class AbilityUseDialog extends Dialog {
 
   /**
    * Get the ability usage warnings to display.
-   * @param {object} data  Template data for the AbilityUseDialog. **Will be mutated**
+   * @param {object} data                           Template data for the AbilityUseDialog. **Will be mutated**
+   * @param {AbilityUseDialogOptions} [options={}]  Additional options for displaying the dialog.
    * @private
    */
-  static _getAbilityUseWarnings(data) {
+  static _getAbilityUseWarnings(data, options={}) {
     const warnings = [];
     const item = data.item;
     const { quantity, level, consume, preparation } = item.system;
-    const scale = item.usageScaling;
+    const scale = options.disableScaling ? null : item.usageScaling;
     const levels = [level];
 
     if ( item.type === "spell" ) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2123,6 +2123,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     // Otherwise show the item use dialog to get the profile
     else {
       const config = await AbilityUseDialog.create(item, {
+        beginConcentrating: null,
         consumeResource: null,
         consumeSpellSlot: null,
         consumeUsage: null,
@@ -2132,7 +2133,8 @@ export default class Item5e extends SystemDocumentMixin(Item) {
         button: {
           icon: '<i class="fa-solid fa-spaghetti-monster-flying"></i>',
           label: game.i18n.localize("DND5E.Summoning.Action.Summon")
-        }
+        },
+        disableScaling: true
       });
       if ( !config?.summonsProfile ) return;
       summonsProfile = config.summonsProfile;


### PR DESCRIPTION
Hides spell upcasting, spell warning, and the concentration checkbox when summoning from chat:

<img width="415" alt="Screenshot 2024-03-15 at 17 25 41" src="https://github.com/foundryvtt/dnd5e/assets/19979839/70f68aeb-8175-48a7-ad23-0e3daf755448">
