### PR TITLE
[#1015, #1372] Add damage application tray to chat cards

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1545,6 +1545,7 @@
 "DND5E.TMP": "TMP",
 "DND5E.ToHit": "To Hit",
 "DND5E.Tokens": {
+  "NoneTargeted": "No Tokens Targeted",
   "Selected": "Selected",
   "Targeted": "Targeted"
 },

--- a/lang/en.json
+++ b/lang/en.json
@@ -1544,6 +1544,10 @@
 "DND5E.TimeYear": "Years",
 "DND5E.TMP": "TMP",
 "DND5E.ToHit": "To Hit",
+"DND5E.Tokens": {
+  "Selected": "Selected",
+  "Targeted": "Targeted"
+},
 "DND5E.TokenRings": {
   "BackgroundColor": "Background Color",
   "Effects": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1545,6 +1545,7 @@
 "DND5E.TMP": "TMP",
 "DND5E.ToHit": "To Hit",
 "DND5E.Tokens": {
+  "NoneSelected": "No Tokens Selected",
   "NoneTargeted": "No Tokens Targeted",
   "Selected": "Selected",
   "Targeted": "Targeted"

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -409,71 +409,136 @@
       margin-right: .25rem;
     }
   }
+}
 
-  /* Effects Tray */
-  .effects-tray {
-    margin-top: .125rem;
-    &:has(> ul:empty) { display: none; }
+/* Damage & Effects Trays */
+.dnd5e2 :is(.card-tray, .effects-tray) {
+  margin-top: .125rem;
+  &:has(> ul:empty) { display: none; }
+  &.damage-tray { margin-block-start: 8px; }
 
-    label {
-      cursor: pointer;
+  > label {
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    gap: .25rem;
+    font-size: var(--font-size-11);
+
+    > span { flex: none; }
+    .fa-bolt, .fa-heart-crack { color: var(--color-text-light-6); }
+    .fa-caret-down { transition: all 250ms ease; }
+
+    &::before, &::after {
+      content: "";
+      flex-basis: 50%;
+      border-top: 1px dotted var(--dnd5e-color-gold);
+      align-self: center;
+    }
+  }
+
+  &.collapsed label .fa-caret-down { transform: rotate(-90deg); }
+
+  .collapsible-content {
+    overflow: hidden;
+    transition: all 250ms ease;
+  }
+
+  .effects, .targets {
+    display: flex;
+    flex-direction: column;
+
+    .effect, .target {
       display: flex;
+      gap: .5rem;
+      align-items: center;
+      padding-bottom: .25rem;
+      margin-bottom: .25rem;
+      border-bottom: 1px solid var(--color-border-light-1);
+
+      &:last-child {
+        padding: 0;
+        margin: 0;
+        border: none;
+      }
+  
+      > img {
+        width: 32px;
+        height: 32px;
+      }
+
+      .name-stacked { flex: 1; }
+    }
+  }
+
+  .effects .effect {
+    > button {
+      width: 28px;
+      height: 28px;
+      display: flex;
+      align-items: center;
       justify-content: center;
-      gap: .25rem;
-      font-size: var(--font-size-11);
+      padding: 0 0 0 4px;
+      font-size: var(--font-size-12);
+    }
+  }
 
-      > span { flex: none; }
-      .fa-bolt { color: var(--color-text-light-6); }
-      .fa-caret-down { transition: all 250ms ease; }
+  .targets .target {
+    flex-wrap: wrap;
 
-      &::before, &::after {
-        content: "";
-        flex-basis: 50%;
-        border-top: 1px dotted var(--dnd5e-color-gold);
-        align-self: center;
-      }
+    .calculated-damage {
+      padding-inline-end: 4px;
+      font-size: var(--font-size-14);
+      font-weight: bold;
     }
 
-    &.collapsed label .fa-caret-down { transform: rotate(-90deg); }
+    .damage-multipliers {
+      flex: 1 0 100%;
+      display: grid;
+      grid-template-columns: repeat(6, 1fr);
+      gap: 2px;
+      font-size: var(--font-size-10);
 
-    .effects {
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
-      transition: all 250ms ease;
+      li {
+        border: 1px solid var(--color-border-light-2);
+        border-radius: 3px;
+        background: var(--dnd5e-background-card);
+        box-shadow: 0 0 8px var(--dnd5e-shadow-15);
+      }
 
-      .effect {
+      label {
         display: flex;
-        gap: .5rem;
         align-items: center;
-        padding-bottom: .25rem;
-        margin-bottom: .25rem;
-        border-bottom: 1px solid var(--color-border-light-1);
+        justify-content: center;
+        gap: 4px;
+        padding: 3px;
+      }
+      span::before {
+        content: "\f00d";
+        padding-inline-end: 2px;
+        color: var(--dnd5e-color-tan);
+        font-family: var(--font-awesome);
+        font-weight: 900;
+      }
+      input {
+        appearance: none;
+        top: 0;
+        margin: 0;
+        padding: 0;
+        width: 8px;
+        height: 8px;
+        border-radius: 10px;
+        background-color: var(--dnd5e-color-faint);
 
-        &:last-child {
-          padding: 0;
-          margin: 0;
-          border: none;
-        }
-
-        > img {
-          width: 32px;
-          height: 32px;
-        }
-
-        .name-stacked { flex: 1; }
-
-        > button {
-          width: 28px;
-          height: 28px;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          padding: 0 0 0 4px;
-          font-size: var(--font-size-12);
+        &:checked {
+          background-color: var(--dnd5e-color-crimson);
         }
       }
     }
+  }
+
+  .targets + button {
+    width: calc(100% - 1px);
+    margin-block-start: 6px;
   }
 }
 

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -444,7 +444,7 @@
   }
 
   .target-source-control {
-    display: flex;
+    &:not([hidden]) { display: flex; }
     justify-content: space-evenly;
     gap: 4px;
     margin-block-start: 1px;
@@ -483,6 +483,10 @@
       }
 
       .name-stacked { flex: 1; }
+    }
+    > .none {
+      text-align: center;
+      margin-block: 4px;
     }
   }
 

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -443,6 +443,22 @@
     transition: all 250ms ease;
   }
 
+  .target-source-control {
+    display: flex;
+    justify-content: space-evenly;
+    gap: 4px;
+    margin-block-start: 1px;
+
+    button {
+      width: unset;
+      font-size: var(--font-size-10);
+      &:hover, &:focus, &[aria-pressed="true"] {
+        box-shadow: none;
+        text-shadow: 0 0 5px var(--color-shadow-highlight);
+      }
+    }
+  }
+
   .effects, .targets {
     display: flex;
     flex-direction: column;
@@ -492,52 +508,50 @@
     }
 
     .damage-multipliers {
-      flex: 1 0 100%;
+      flex: 1 0 calc(100% - 6px);
       display: grid;
-      grid-template-columns: repeat(6, 1fr);
+      grid-template-columns: auto repeat(6, 1fr);
       gap: 2px;
-      font-size: var(--font-size-10);
+      margin-inline: 3px;
+      font-size: var(--font-size-11);
 
-      li {
-        border: 1px solid var(--color-border-light-2);
-        border-radius: 3px;
-        background: var(--dnd5e-background-card);
-        box-shadow: 0 0 8px var(--dnd5e-shadow-15);
-      }
-
-      label {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 4px;
-        padding: 3px;
-      }
-      span::before {
+      &::before {
         content: "\f00d";
+        align-self: center;
         padding-inline-end: 2px;
         color: var(--dnd5e-color-tan);
         font-family: var(--font-awesome);
         font-weight: 900;
       }
-      input {
-        appearance: none;
-        top: 0;
-        margin: 0;
-        padding: 0;
-        width: 8px;
-        height: 8px;
-        border-radius: 10px;
-        background-color: var(--dnd5e-color-faint);
+      
+      button {
+        width: 100%;
+        border-radius: 3px;
+        padding: 2px;
+        font-size: inherit;
+        line-height: unset;
+        cursor: pointer;
 
-        &:checked {
-          background-color: var(--dnd5e-color-crimson);
+        &::after {
+          content: "";
+          display: block;
+          width: 8px;
+          height: 8px;
+          border-radius: 8px;
+          background-color: var(--dnd5e-color-faint);
+        }
+
+        &[aria-pressed="true"] {
+          border-color: var(--dnd5e-color-crimson);
+          &::after { background-color: var(--dnd5e-color-crimson); }
         }
       }
     }
   }
 
   .targets + button {
-    width: calc(100% - 1px);
+    margin: 3px;
+    width: calc(100% - 6px);
     margin-block-start: 6px;
   }
 }

--- a/module/applications/components/_module.mjs
+++ b/module/applications/components/_module.mjs
@@ -1,3 +1,4 @@
+import DamageApplicationElement from "./damage-application.mjs";
 import EffectsElement from "./effects.mjs";
 import FiligreeBoxElement from "./filigree-box.mjs";
 import IconElement from "./icon.mjs";
@@ -7,15 +8,16 @@ import ProficiencyCycleElement from "./proficiency-cycle.mjs";
 import SlideToggleElement from "./slide-toggle.mjs";
 import AdoptedStyleSheetMixin from "./adopted-stylesheet-mixin.mjs";
 
+window.customElements.define("damage-application", DamageApplicationElement);
 window.customElements.define("dnd5e-effects", EffectsElement);
 window.customElements.define("dnd5e-icon", IconElement);
 window.customElements.define("dnd5e-inventory", InventoryElement);
-window.customElements.define("item-list-controls", ItemListControlsElement);
 window.customElements.define("filigree-box", FiligreeBoxElement);
+window.customElements.define("item-list-controls", ItemListControlsElement);
 window.customElements.define("proficiency-cycle", ProficiencyCycleElement);
 window.customElements.define("slide-toggle", SlideToggleElement);
 
 export {
-  AdoptedStyleSheetMixin, EffectsElement, IconElement, InventoryElement, ItemListControlsElement, FiligreeBoxElement,
-  ProficiencyCycleElement, SlideToggleElement
+  AdoptedStyleSheetMixin, DamageApplicationElement, EffectsElement, IconElement, InventoryElement,
+  ItemListControlsElement, FiligreeBoxElement, ProficiencyCycleElement, SlideToggleElement
 };

--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -1,0 +1,231 @@
+/**
+ * List of multiplier options as tuples containing their numeric value and rendered text.
+ * @type {[number, string][]}
+ */
+const MULTIPLIERS = [[-1, "-1"], [0, "0"], [.25, "¼"], [.5, "½"], [1, "1"], [2, "2"]];
+
+/**
+ * Application to handle applying damage from a chat card.
+ */
+export default class DamageApplicationElement extends HTMLElement {
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The apply damage button within the element.
+   * @type {HTMLButtonElement}
+   */
+  applyButton;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The chat message with which this damage is associated.
+   * @type {ChatMessage5e}
+   */
+  chatMessage;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Damage descriptions that will be applied by this application.
+   * @type {DamageDescription[]}
+   */
+  damages = [];
+
+  /* -------------------------------------------- */
+
+  /**
+   * The list of application targets.
+   * @type {HTMLUListElement}
+   */
+  targetList;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Options for each application target.
+   * @type {Map<string, DamageApplicationOptions>}
+   */
+  #targetOptions = new Map();
+
+  /**
+   * Options for a specific target.
+   * @param {string} uuid  UUID of the targeted token.
+   * @returns {DamageApplicationOptions}
+   */
+  targetOptions(uuid) {
+    if ( !this.#targetOptions.has(uuid) ) this.#targetOptions.set(uuid, { multiplier: 1 });
+    return this.#targetOptions.get(uuid);
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  async connectedCallback() {
+    // Fetch the associated chat message
+    const messageId = this.closest("[data-message-id]")?.dataset.messageId;
+    this.chatMessage = game.messages.get(messageId);
+    if ( !this.chatMessage ) return;
+
+    // Build the frame HTML only once
+    if ( !this.targetList ) {
+      const div = document.createElement("div");
+      div.classList.add("card-tray", "damage-tray", "collapsible");
+      div.innerHTML = `
+        <label class="roboto-upper">
+          <i class="fa-solid fa-heart-crack"></i>
+          <span>${game.i18n.localize("DND5E.Apply")}</span>
+          <i class="fa-solid fa-caret-down"></i>
+        </label>
+        <div class="collapsible-content">
+          <!-- TODO: For GM users, add switch between Targeted & Selected tokens -->
+          <ul class="targets unlist"></ul>
+          <button class="apply-damage" type="button" data-action="applyDamage">
+            <i class="fa-solid fa-reply-all fa-flip-horizontal"></i>
+            ${game.i18n.localize("DND5E.Apply")}
+          </button>
+        </div>
+      `;
+      this.replaceChildren(div);
+      this.applyButton = div.querySelector(".apply-damage");
+      this.applyButton.addEventListener("click", this._onApplyDamage.bind(this));
+      this.targetList = div.querySelector(".targets");
+      div.querySelector(".collapsible-content").addEventListener("click", event => {
+        event.stopImmediatePropagation();
+      });
+    }
+
+    // TODO: Fetch list of targeted tokens
+    const targetedTokens = ["Scene.N0f8tURZUeuPKHH2.Token.tZwBXZDPpYHSwnEv.Actor.KO931H2sXBlaABzx"];
+    for ( const uuid of targetedTokens ) {
+      const entry = await this.buildTargetListEntry(uuid);
+      if ( entry ) this.targetList.append(entry);
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create a list entry for a single target.
+   * @param {string} uuid  UUID of the token represented by this entry.
+   * @returns {HTMLLIElement|void}
+   */
+  async buildTargetListEntry(uuid) {
+    const token = await fromUuid(uuid);
+    if ( !token ) return;
+
+    // Calculate damage to apply
+    const targetOptions = this.targetOptions(uuid);
+    const { total } = this.calculateDamage(token, targetOptions);
+
+    const li = document.createElement("li");
+    li.classList.add("target");
+    li.dataset.targetUuid = uuid;
+    li.innerHTML = `
+      <img class="gold-icon" alt="${token.name}" src="${token.img}">
+      <div class="name-stacked">
+        <span class="title">${token.name}</span>
+        <!-- TODO: List resistances, etc. applied -->
+      </div>
+      <div class="calculated-damage">
+        ${total}
+      </div>
+      <menu class="damage-multipliers unlist"></menu>
+    `;
+
+    const menu = li.querySelector("menu");
+    for ( const [value, display] of MULTIPLIERS ) {
+      const entry = document.createElement("li");
+      entry.innerHTML = `
+        <label>
+          <span>${display}</span>
+          <input type="radio" name="multiplier/${this.chatMessage.id}/${uuid}" value="${value}"
+                 ${value === targetOptions.multiplier ? " checked" : ""}>
+        </label>
+      `;
+      menu.append(entry);
+    }
+
+    li.addEventListener("change", this._onChangeOptions.bind(this));
+
+    return li;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Calculate the total damage that will be applied to an actor.
+   * @param {Actor5e} actor
+   * @param {DamageApplicationOptions} options
+   * @returns {{total: number, damages: DamageDescription[]}}
+   */
+  calculateDamage(actor, options) {
+    const damages = actor.calculateDamage(this.damages, options);
+
+    let total = damages.reduce((acc, d) => acc + d.value, 0);
+    total = total > 0 ? Math.floor(total) : Math.ceil(total);
+
+    return { total, damages };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Refresh the damage total on a list entry based on modified options.
+   * @param {string} uuid
+   * @param {DamageApplicationOptions} options
+   */
+  async refreshListEntry(uuid, options) {
+    const entry = this.targetList.querySelector(`[data-target-uuid="${uuid}"]`);
+    const token = await fromUuid(uuid);
+    if ( !token || !entry ) return;
+
+    const { total } = this.calculateDamage(token, options);
+    entry.querySelector(".calculated-damage").innerText = total;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Handlers                              */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle clicking the apply damage button.
+   * @param {PointerEvent} event  Triggering click event.
+   */
+  async _onApplyDamage(event) {
+    event.preventDefault();
+    for ( const target of this.targetList.querySelectorAll("[data-target-uuid]") ) {
+      const token = await fromUuid(target.dataset.targetUuid);
+      const options = this.targetOptions(target.dataset.targetUuid);
+      await token?.applyDamage(this.damages, options);
+    }
+    this.querySelector(".collapsible").dispatchEvent(new PointerEvent("click", { bubbles: true, cancelable: true }));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle clicking a multiplier button or resistance toggle.
+   * @param {PointerEvent} event  Triggering click event.
+   */
+  _onChangeOptions(event) {
+    event.preventDefault();
+    const uuid = event.target.closest("[data-target-uuid]")?.dataset.targetUuid;
+    if ( !uuid ) return;
+
+    const options = this.targetOptions(uuid);
+
+    // Set multiplier
+    if ( event.target.name.startsWith("multiplier") ) {
+      options.multiplier = Number(event.target.value);
+    }
+
+    // TODO: Set imm/res/vul ignore & downgrade
+
+    this.refreshListEntry(uuid, options);
+  }
+}

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -369,14 +369,16 @@ export default class ChatMessage5e extends ChatMessage {
     `;
     html.querySelector(".message-content").appendChild(roll);
 
-    const damageApplication = document.createElement("damage-application");
-    damageApplication.classList.add("dnd5e2");
-    damageApplication.damages = aggregateDamageRolls(rolls, { respectProperties: true }).map(roll => ({
-      value: roll.total,
-      type: roll.options.type,
-      properties: new Set(roll.options.properties ?? [])
-    }));
-    html.querySelector(".message-content").appendChild(damageApplication);
+    if ( game.user.isGM || this.getFlag("dnd5e", "targets")?.map(t => fromUuidSync(t.uuid)).some(t => t.isOwner) ) {
+      const damageApplication = document.createElement("damage-application");
+      damageApplication.classList.add("dnd5e2");
+      damageApplication.damages = aggregateDamageRolls(rolls, { respectProperties: true }).map(roll => ({
+        value: roll.total,
+        type: roll.options.type,
+        properties: new Set(roll.options.properties ?? [])
+      }));
+      html.querySelector(".message-content").appendChild(damageApplication);
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -60,11 +60,11 @@ export default class ChatMessage5e extends ChatMessage {
     else requestAnimationFrame(() => {
       html.find(".description.collapsible .details").each((i, el) => el.style.height = `${el.scrollHeight}px`);
     });
-    html.find(".effects-tray").each((i, el) => {
+    this._enrichChatCard(html[0]);
+    html.find(".card-tray, .effects-tray").each((i, el) => {
       el.classList.add("collapsed");
       el.querySelector(".collapsible-content").style.height = "0";
     });
-    this._enrichChatCard(html[0]);
 
     /**
      * A hook event that fires after dnd5e-specific chat message modifications have completed.
@@ -367,6 +367,15 @@ export default class ChatMessage5e extends ChatMessage {
       </div>
     `;
     html.querySelector(".message-content").appendChild(roll);
+
+    const damageApplication = document.createElement("damage-application");
+    damageApplication.classList.add("dnd5e2");
+    damageApplication.damages = aggregateDamageRolls(rolls, { respectProperties: true }).map(roll => ({
+      value: roll.total,
+      type: roll.options.type,
+      properties: new Set(roll.options.properties ?? [])
+    }));
+    html.querySelector(".message-content").appendChild(damageApplication);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -60,11 +60,12 @@ export default class ChatMessage5e extends ChatMessage {
     else requestAnimationFrame(() => {
       html.find(".description.collapsible .details").each((i, el) => el.style.height = `${el.scrollHeight}px`);
     });
+
     this._enrichChatCard(html[0]);
-    html.find(".card-tray, .effects-tray").each((i, el) => {
+    requestAnimationFrame(() => html.find(".card-tray, .effects-tray").each((i, el) => {
       el.classList.add("collapsed");
       el.querySelector(".collapsible-content").style.height = "0";
-    });
+    }));
 
     /**
      * A hook event that fires after dnd5e-specific chat message modifications have completed.

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -369,7 +369,7 @@ export default class ChatMessage5e extends ChatMessage {
     `;
     html.querySelector(".message-content").appendChild(roll);
 
-    if ( game.user.isGM || this.getFlag("dnd5e", "targets")?.map(t => fromUuidSync(t.uuid)).some(t => t.isOwner) ) {
+    if ( game.user.isGM ) {
       const damageApplication = document.createElement("damage-application");
       damageApplication.classList.add("dnd5e2");
       damageApplication.damages = aggregateDamageRolls(rolls, { respectProperties: true }).map(roll => ({

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2161,7 +2161,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     event.preventDefault();
     const header = event.currentTarget;
-    const card = header.closest(".chat-card");
+    const card = header.closest(".message-content");
     const content = card.querySelector(".card-content:not(.details)");
     if ( content ) content.style.display = content.style.display === "none" ? "block" : "none";
     if ( header.classList.contains("collapsible") ) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1604,10 +1604,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   async rollDamage({critical, event=null, spellLevel=null, versatile=false, options={}}={}) {
     if ( !this.hasDamage ) throw new Error("You may not make a Damage Roll with this Item.");
-    const messageData = {
-      "flags.dnd5e.roll": {type: "damage", itemId: this.id, itemUuid: this.uuid},
-      speaker: ChatMessage.getSpeaker({actor: this.actor})
-    };
 
     // Get roll data
     const dmg = this.system.damage;
@@ -1631,13 +1627,19 @@ export default class Item5e extends SystemDocumentMixin(Item) {
         top: event ? event.clientY - 80 : null,
         left: window.innerWidth - 710
       },
-      messageData
+      messageData: {
+        "flags.dnd5e": {
+          targets: this._formatAttackTargets(),
+          roll: {type: "damage", itemId: this.id, itemUuid: this.uuid}
+        },
+        speaker: ChatMessage.getSpeaker({actor: this.actor})
+      }
     };
 
     // Adjust damage from versatile usage
     if ( versatile && dmg.versatile ) {
       rollConfigs[0].parts[0] = dmg.versatile;
-      messageData["flags.dnd5e.roll"].versatile = true;
+      rollConfig.messageData["flags.dnd5e.roll"].versatile = true;
     }
 
     // Add magical damage if available

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1527,7 +1527,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       },
       messageData: {
         "flags.dnd5e": {
-          targets: this._formatAttackTargets(),
+          targets: this.constructor._formatAttackTargets(),
           roll: { type: "attack", itemId: this.id, itemUuid: this.uuid }
         },
         speaker: ChatMessage.getSpeaker({actor: this.actor})
@@ -1578,7 +1578,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @returns {TargetDescriptor5e[]}
    * @protected
    */
-  _formatAttackTargets() {
+  static _formatAttackTargets() {
     const targets = new Map();
     for ( const token of game.user.targets ) {
       const { name, img, system, uuid } = token.actor ?? {};
@@ -1629,7 +1629,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       },
       messageData: {
         "flags.dnd5e": {
-          targets: this._formatAttackTargets(),
+          targets: this.constructor._formatAttackTargets(),
           roll: {type: "damage", itemId: this.id, itemUuid: this.uuid}
         },
         speaker: ChatMessage.getSpeaker({actor: this.actor})

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -2,6 +2,7 @@ import { formatNumber, simplifyBonus } from "./utils.mjs";
 import Award from "./applications/award.mjs";
 import { damageRoll } from "./dice/_module.mjs";
 import * as Trait from "./documents/actor/trait.mjs";
+import Item5e from "./documents/item.mjs";
 
 const slugify = value => value?.slugify().replaceAll("-", "");
 
@@ -1017,7 +1018,6 @@ async function rollDamage(event, speaker) {
   const { formula, damageType } = target.dataset;
 
   const title = game.i18n.localize("DND5E.DamageRoll");
-  const messageData = { "flags.dnd5e.roll.type": "damage", speaker };
   const rollConfig = {
     rollConfigs: [{
       parts: [formula],
@@ -1026,7 +1026,13 @@ async function rollDamage(event, speaker) {
     flavor: `${title} (${game.i18n.localize(CONFIG.DND5E.damageTypes[damageType]?.label ?? damageType)})`,
     event,
     title,
-    messageData
+    messageData: {
+      "flags.dnd5e": {
+        targets: Item5e._formatAttackTargets(),
+        roll: {type: "damage"}
+      },
+      speaker
+    }
   };
 
   if ( Hooks.call("dnd5e.preRollDamage", undefined, rollConfig) === false ) return;

--- a/templates/chat/item-card.hbs
+++ b/templates/chat/item-card.hbs
@@ -140,7 +140,7 @@
     {{/if}}
 
     {{!-- Applicable Effects --}}
-    <div class="effects-tray collapsible">
+    <div class="card-tray effects-tray collapsible">
         <label class="roboto-upper">
             <i class="fas fa-bolt"></i>
             <span>{{ localize "DND5E.Effects" }}</span>


### PR DESCRIPTION
Introduces a new `DamageApplicationElement` that is inserted into chat cards to handle applying damage to actors. It features two targeting modes, one that uses the tokens that were targeted when the damage was rolled and another that uses the currently selected tokens on the scene. For players the application will only display if one of their tokens was targeted by the damage. They will only see targeted selection mode and only the tokens of theirs that were targeted will be listed.

<img width="279" alt="Damage Application V2" src="https://github.com/foundryvtt/dnd5e/assets/19979839/ce5c2eda-1ede-464f-b669-b67c338419f8">

Each target lists the amount of damage calculated after resistances, immunities, and vulnerabilities are taken into account. Beneath that are a list of multiplier controls that appear for each target, make it easy to apply damage changes outside the automatic ones. Changes to the damage from these buttons is automatically reflected in the total number.

Closes #1015

### Future Work
- [ ] Display resistances, immunities, and vulnerabilities that are affecting the damage total
- [ ] Add ability to bypass certain resistances/immunities/vulnerabilities