### PR TITLE
[#3158, #3250] Use `aggregateDamageRolls` to improve chat damage previews

### DIFF
--- a/module/dice/aggregate-damage-rolls.mjs
+++ b/module/dice/aggregate-damage-rolls.mjs
@@ -70,7 +70,10 @@ function chunkTerms(terms, type) {
     currentChunk ??= { terms: [], negative, type: null };
     currentChunk.terms.push(term);
     const flavor = term.flavor?.toLowerCase().trim();
-    if ( isValidType(flavor) ) currentChunk.type ??= flavor;
+    if ( isValidType(flavor) ) {
+      currentChunk.type ??= flavor;
+      term.options.flavor = "";
+    }
   }
 
   if ( currentChunk ) pushChunk();


### PR DESCRIPTION
Switch to using the `aggregateDamageRolls` function while enriching damage tooltips to get damage split into groups by type. The method for creating breakdowns no longer needs to worry about types.

The `aggregateDamageRolls` function has been modified to strip out any damage-type flavor for the resulting terms (preserving other flavor) so that it doesn't clutter up the final formula displayed.

This change also allows us to rely on the damage total from each aggregated roll which means the totals per-type are always accurate. There is still some trouble with how multiplication and division are displayed in the roll breakdown, but the totals should now always be correct.

<img width="297" alt="Damager Aggregation (before)" src="https://github.com/foundryvtt/dnd5e/assets/19979839/f5d3216f-e8a6-46ac-aa6c-19ed744cc215">
<img width="297" alt="Damage Aggregation (after)" src="https://github.com/foundryvtt/dnd5e/assets/19979839/62d10b8d-a6f6-4fe9-ac43-938a5ecdc642">
