### PR TITLE
[#1372] Add display of resistances, etc. in damage application

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -574,6 +574,16 @@
 "DND5E.Damage": "Damage",
 "DND5E.DamageAcid": "Acid",
 "DND5E.DamageAll": "All Damage",
+"DND5E.DamageApplication": {
+  "Change": {
+    "Modification": "{type} Modification",
+    "Immunity": "{type} Immunity",
+    "Resistance": "{type} Resistance",
+    "Vulnerability": "{type} Vulnerability"
+  },
+  "Downgrading": "Downgrading {source} to Resistance",
+  "Ignoring": "Ignoring {source}"
+},
 "DND5E.DamageBludgeoning": "Bludgeoning",
 "DND5E.DamageCold": "Cold",
 "DND5E.DamageFire": "Fire",

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -505,6 +505,20 @@
   .targets .target {
     flex-wrap: wrap;
 
+    .change-source {
+      width: 16px;
+      padding: 2px;
+      border-radius: 4px;
+      display: grid;
+      grid-template-areas: "overlay";
+      font-size: inherit;
+      > * { grid-area: overlay; }
+      > dnd5e-icon { display: block; }
+      > i { color: red; }
+      &:not([aria-pressed="true"]) .fa-slash { display: none; }
+      &:not([aria-pressed="mixed"]) .fa-chevron-down { display: none; }
+    }
+
     .calculated-damage {
       padding-inline-end: 4px;
       font-size: var(--font-size-14);

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -516,7 +516,12 @@
       > dnd5e-icon { display: block; }
       > i { color: red; }
       &:not([aria-pressed="true"]) .fa-slash { display: none; }
-      &:not([aria-pressed="mixed"]) .fa-chevron-down { display: none; }
+      &:not([aria-pressed="mixed"]) .fa-arrow-turn-down { display: none; }
+      .fa-arrow-turn-down {
+        position: relative;
+        left: 8px;
+        top: -1px;
+      }
     }
 
     .calculated-damage {

--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -223,8 +223,8 @@ export default class DamageApplicationElement extends HTMLElement {
         <button class="change-source unbutton" type="button" data-type="${type}" data-change="${change}"
                 data-tooltip="${label}" aria-label="${label}" aria-pressed="${pressed}">
           <dnd5e-icon src="${icon}" inert></dnd5e-icon>
-          <i class="fa-solid fa-slash inert"></i>
-          <i class="fa-solid fa-chevron-down" inert></i>
+          <i class="fa-solid fa-slash" inert></i>
+          <i class="fa-solid fa-arrow-turn-down" inert></i>
         </button>
       `;
       return acc;

--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -206,7 +206,29 @@ export default class DamageApplicationElement extends HTMLElement {
 
     // Calculate damage to apply
     const targetOptions = this.getTargetOptions(uuid);
-    const { total } = this.calculateDamage(token, targetOptions);
+    const { total, active } = this.calculateDamage(token, targetOptions);
+
+    const types = [];
+    for ( const [change, values] of Object.entries(active) ) {
+      for ( const type of values ) {
+        const config = CONFIG.DND5E.damageTypes[type] ?? CONFIG.DND5E.healingTypes[type];
+        if ( !config ) continue;
+        const data = { type, change, icon: config.icon };
+        types.push(data);
+      }
+    }
+    const changeSources = types.reduce((acc, {type, change, icon}) => {
+      const { label, pressed } = this.getChangeSourceOptions(type, change, targetOptions);
+      acc += `
+        <button class="change-source unbutton" type="button" data-type="${type}" data-change="${change}"
+                data-tooltip="${label}" aria-label="${label}" aria-pressed="${pressed}">
+          <dnd5e-icon src="${icon}" inert></dnd5e-icon>
+          <i class="fa-solid fa-slash inert"></i>
+          <i class="fa-solid fa-chevron-down" inert></i>
+        </button>
+      `;
+      return acc;
+    }, "");
 
     const li = document.createElement("li");
     li.classList.add("target");
@@ -215,7 +237,7 @@ export default class DamageApplicationElement extends HTMLElement {
       <img class="gold-icon" alt="${token.name}" src="${token.img}">
       <div class="name-stacked">
         <span class="title">${token.name}</span>
-        <!-- TODO: List resistances, etc. applied -->
+        ${changeSources ? `<span class="subtitle">${changeSources}</span>` : ""}
       </div>
       <div class="calculated-damage">
         ${total}
@@ -246,15 +268,58 @@ export default class DamageApplicationElement extends HTMLElement {
    * Calculate the total damage that will be applied to an actor.
    * @param {Actor5e} actor
    * @param {DamageApplicationOptions} options
-   * @returns {{total: number, damages: DamageDescription[]}}
+   * @returns {{total: number, active: Record<string, Set<string>>}}
    */
   calculateDamage(actor, options) {
     const damages = actor.calculateDamage(this.damages, options);
 
-    let total = damages.reduce((acc, d) => acc + d.value, 0);
+    let total = 0;
+    let active = { modification: new Set(), resistance: new Set(), vulnerability: new Set(), immunity: new Set() };
+    for ( const damage of damages ) {
+      total += damage.value;
+      if ( damage.active.modification ) active.modification.add(damage.type);
+      if ( damage.active.resistance ) active.resistance.add(damage.type);
+      if ( damage.active.vulnerability ) active.vulnerability.add(damage.type);
+      if ( damage.active.immunity ) active.immunity.add(damage.type);
+    }
     total = total > 0 ? Math.floor(total) : Math.ceil(total);
 
-    return { total, damages };
+    // Add values from options to prevent active changes from being lost when re-rendering target list
+    const union = t => {
+      if ( foundry.utils.getType(options.ignore?.[t]) === "Set" ) active[t] = active[t].union(options.ignore[t]);
+    };
+    union("modification");
+    union("resistance");
+    union("vulnerability");
+    union("immunity");
+    if ( foundry.utils.getType(options.downgrade) === "Set" ) {
+      active.immunity = active.immunity.union(options.downgrade);
+    }
+
+    return { total, active };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the label and pressed value for a specific change source.
+   * @param {string} type                       Damage type represented by this source.
+   * @param {string} change                     Change type (e.g. resistance, immunity, etc.).
+   * @param {DamageApplicationOptions} options  Options object from which to determine final values.
+   * @returns {{label: string, pressed: string}}
+   */
+  getChangeSourceOptions(type, change, options) {
+    let mode = "active";
+    if ( options.ignore?.[change]?.has(type) ) mode = "ignore";
+    else if ( (change === "immunity") && options.downgrade?.has(type) ) mode = "downgrade";
+
+    let label = game.i18n.format(`DND5E.DamageApplication.Change.${change.capitalize()}`, {
+      type: CONFIG.DND5E.damageTypes[type]?.label ?? CONFIG.DND5E.healingTypes[type]?.label
+    });
+    if ( mode === "ignore" ) label = game.i18n.format("DND5E.DamageApplication.Ignoring", { source: label });
+    if ( mode === "downgrade" ) label = game.i18n.format("DND5E.DamageApplication.Downgrading", { source: label });
+
+    return { label, pressed: mode === "active" ? "false" : mode === "ignore" ? "true" : "mixed" };
   }
 
   /* -------------------------------------------- */
@@ -274,6 +339,14 @@ export default class DamageApplicationElement extends HTMLElement {
       if ( pressedMultiplier ) pressedMultiplier.ariaPressed = false;
       const toPress = entry.querySelector(`[value="${options.multiplier}"]`);
       if ( toPress ) toPress.ariaPressed = true;
+    }
+
+    for ( const element of entry.querySelectorAll(".change-source") ) {
+      const { type, change } = element.dataset;
+      const { label, pressed } = this.getChangeSourceOptions(type, change, options);
+      element.dataset.tooltip = label;
+      element.ariaLabel = label;
+      element.ariaPressed = pressed;
     }
   }
 
@@ -314,7 +387,29 @@ export default class DamageApplicationElement extends HTMLElement {
       options.multiplier = Number(button.value);
     }
 
-    // TODO: Set imm/res/vul ignore & downgrade
+    // Set imm/res/vul ignore & downgrade
+    else if ( button.classList.contains("change-source") ) {
+      const { type, change } = button.dataset;
+      if ( change === "immunity" ) {
+        if ( options.ignore?.immunity?.has(type) ) {
+          options.ignore.immunity.delete(type);
+          options.downgrade ??= new Set();
+          options.downgrade.add(type);
+        } else if ( options.downgrade?.has(type) ) {
+          options.downgrade.delete(type);
+        } else {
+          options.ignore ??= {};
+          options.ignore[change] ??= new Set();
+          options.ignore[change].add(type);
+        }
+      }
+      else if ( options.ignore?.[change]?.has(type) ) options.ignore[change].delete(type);
+      else {
+        options.ignore ??= {};
+        options.ignore[change] ??= new Set();
+        options.ignore[change].add(type);
+      }
+    }
 
     const token = fromUuidSync(uuid);
     const entry = this.targetList.querySelector(`[data-target-uuid="${token.uuid}"]`);


### PR DESCRIPTION
Displays what resistances, immunities, vulnerabilities, and modifications are modifying the damage to be applied. Each of these can be clicked on to ignore that source of change or, if it is an immunity, downgrade it. The total damage that will be applied is updated as you click these buttons just like the multiplier buttons below.

<img width="295" alt="Damage Application - Immunity" src="https://github.com/foundryvtt/dnd5e/assets/19979839/755c9988-8fe8-4697-bbb4-22d20b646ea9">
<img width="296" alt="Damage Application - Bypassing Immunity" src="https://github.com/foundryvtt/dnd5e/assets/19979839/911a9c84-e250-4a1c-bb8f-baa5c79136d3">

Closes #1372