### PR TITLE
[#3280] expose damageApplication for use by modules

### DIFF
--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -359,16 +359,15 @@ export default class ChatMessage5e extends ChatMessage {
     `;
     html.querySelector(".message-content").appendChild(roll);
 
-    if ( game.user.isGM ) {
-      const damageApplication = document.createElement("damage-application");
-      damageApplication.classList.add("dnd5e2");
-      damageApplication.damages = aggregateDamageRolls(rolls, { respectProperties: true }).map(roll => ({
-        value: roll.total,
-        type: roll.options.type,
-        properties: new Set(roll.options.properties ?? [])
-      }));
-      html.querySelector(".message-content").appendChild(damageApplication);
-    }
+    const damageApplication = document.createElement("damage-application");
+    damageApplication.classList.add("dnd5e2");
+    if ( !game.user.isGM ) damageApplication.classList.add("hidden");
+    damageApplication.damages = aggregateDamageRolls(rolls, { respectProperties: true }).map(roll => ({
+      value: roll.total,
+      type: roll.options.type,
+      properties: new Set(roll.options.properties ?? [])
+    }));
+    html.querySelector(".message-content").appendChild(damageApplication);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
[#3280]
A small change to hide, instead of never create, the damage-application element on damage chat cards for non GMs. The intent of this is to expose this feature to modules, should they want to make it available to users other than the GM and/or modify it in some capacity. 

I am unsure if this is all that would need to change to make this usable by modules, but I tested simply removing the 'hidden' class used by this PR on a render hook with a module, and it worked as imagined.