### PR TITLE
[#3038] Add setting to disable concentration

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1846,6 +1846,8 @@
 "SETTINGS.5eMetricL": "Replaces all reference to lbs with kgs and updates the encumbrance calculations to use metric weight units.",
 "SETTINGS.5eNoAdvancementsN": "Disable level-up automation",
 "SETTINGS.5eNoAdvancementsL": "Do not prompt for level-up or character creation choices.",
+"SETTINGS.5eNoConcentrationN": "Disable concentration tracking",
+"SETTINGS.5eNoConcentrationL": "Disable the system's automated tracking of concentration.",
 "SETTINGS.5eNoExpL": "Remove experience bars from character sheets.",
 "SETTINGS.5eNoExpN": "Disable Experience Tracking",
 "SETTINGS.5eProfBonus": "PHB: Bonus (+2, +3, +4, +5, +6)",

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3258,7 +3258,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
       if ( Number.isInteger(changes.total) && (changes.total !== 0) ) {
         this._displayTokenEffect(changes);
-        if ( (userId === game.userId) && (changes.total < 0) ) {
+        if ( !game.settings.get("dnd5e", "disableConcentration") && (userId === game.userId) && (changes.total < 0) ) {
           this.challengeConcentration({ dc: this.getConcentrationDC(-changes.total) });
         }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1119,7 +1119,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       config.createSummons = summons.prompt;
       config.summonsProfile = this.system.summons.profiles[0]._id;
     }
-    if ( this.requiresConcentration ) {
+    if ( this.requiresConcentration && !game.settings.get("dnd5e", "disableConcentration") ) {
       config.beginConcentrating = true;
       const { effects } = this.actor.concentration;
       const limit = this.actor.system.attributes?.concentration?.limit ?? 0;

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -170,6 +170,16 @@ export function registerSystemSettings() {
     type: Boolean
   });
 
+  // Disable Concentration Tracking
+  game.settings.register("dnd5e", "disableConcentration", {
+    name: "SETTINGS.5eNoConcentrationN",
+    hint: "SETTINGS.5eNoConcentrationL",
+    scope: "world",
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
   // Collapse Item Cards (by default)
   game.settings.register("dnd5e", "autoCollapseItemCards", {
     name: "SETTINGS.5eAutoCollapseCardN",


### PR DESCRIPTION
Closes #3038.

When enabled, removing concentration from the AbilityUseDialog and not causing any prompts for conc saves seems more than sufficient.