### PR TITLE
[#2780] Allow default concept compendiums to be defined

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -1,6 +1,5 @@
 import CharacterData from "../../data/actor/character.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
-import { setTheme } from "../../settings.mjs";
 import { formatNumber, simplifyBonus, staticID } from "../../utils.mjs";
 import ContextMenu5e from "../context-menu.mjs";
 import SheetConfig5e from "../sheet-config.mjs";
@@ -967,9 +966,9 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
    */
   _onFindItem(type) {
     switch ( type ) {
-      case "class": game.packs.get("dnd5e.classes").render(true); break;
-      case "race": game.packs.get("dnd5e.races").render(true); break;
-      case "background": game.packs.get("dnd5e.backgrounds").render(true); break;
+      case "class": game.packs.get(CONFIG.DND5E.sourcePacks.CLASSES)?.render(true); break;
+      case "race": game.packs.get(CONFIG.DND5E.sourcePacks.RACES)?.render(true); break;
+      case "background": game.packs.get(CONFIG.DND5E.sourcePacks.BACKGROUNDS)?.render(true); break;
     }
   }
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2344,7 +2344,10 @@ preLocalize("weaponProperties", { sort: true });
  * @enum {string}
  */
 DND5E.sourcePacks = {
-  ITEMS: "dnd5e.items"
+  BACKGROUNDS: "dnd5e.backgrounds",
+  CLASSES: "dnd5e.classes",
+  ITEMS: "dnd5e.items",
+  RACES: "dnd5e.races"
 };
 
 /* -------------------------------------------- */


### PR DESCRIPTION
Takes advantage of the existing `CONFIG.DND5E.sourcePacks` object to define packs for backgrounds, classes, and races.

Closes #2780 