### PR TITLE
[#3311] Fix bug with rolling upcast damage, fix Magic Missile scaling

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1661,11 +1661,11 @@ export default class Item5e extends SystemDocumentMixin(Item) {
         else level = this.actor.system.details.spellLevel;
         rollConfigs.forEach(c => this._scaleCantripDamage(c.parts, scaling.formula, level, rollData));
       }
-      else if ( spellLevel && (scaling.mode === "level") && (scaling.formula || c.parts.length) ) {
-        rollConfigs.forEach(c =>
-          this._scaleSpellDamage(c.parts, this.system.level, spellLevel, scaling.formula || c.parts[0], rollData)
-        );
-      }
+      else if ( spellLevel && (scaling.mode === "level") ) rollConfigs.forEach(c => {
+        if ( scaling.formula || c.parts.length ) {
+          this._scaleSpellDamage(c.parts, this.system.level, spellLevel, scaling.formula || c.parts[0], rollData);
+        }
+      });
     }
 
     // Add damage bonus formula

--- a/packs/_source/spells/1st-level/magic-missile.json
+++ b/packs/_source/spells/1st-level/magic-missile.json
@@ -87,12 +87,13 @@
       "prepared": false
     },
     "scaling": {
-      "mode": "level",
+      "mode": "none",
       "formula": ""
     },
     "properties": [
       "vocal",
-      "somatic"
+      "somatic",
+      "mgc"
     ],
     "crewed": false
   },
@@ -103,10 +104,10 @@
   "folder": "ERuXllkhTQF51rDJ",
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.1.1",
     "coreVersion": "11.315",
     "createdTime": 1661787234065,
-    "modifiedTime": 1704823521820,
+    "modifiedTime": 1711128581683,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!41JIhpDyM9Anm7cs"


### PR DESCRIPTION
Fix spell scaling from checking a property that doesn't exist. Also adjusts Magic Missile to not have spell scaling so it doesn't upcast incorrectly.