### PR TITLE
[#3326] Add option to create spell scrolls with reduced description

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2261,7 +2261,7 @@ patchConfig("spellSchools", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" })
 /* -------------------------------------------- */
 
 /**
- * Spell scroll item ID within the `DND5E.sourcePacks` compendium for each level.
+ * Spell scroll item ID within the `DND5E.sourcePacks` compendium or a full UUID for each spell level.
  * @enum {string}
  */
 DND5E.spellScrollIds = {
@@ -3355,6 +3355,7 @@ DND5E.rules = {
   consumables: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.UEPAcZFzQ5x196zE",
   itemspells: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.DABoaeeF6w31UCsj",
   charges: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.NLRXcgrpRCfsA5mO",
+  spellscroll: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.gi8IKhtOlBVhMJrN",
   creaturetags: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.9jV1fFF163dr68vd",
   telepathy: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.geTidcFIYWuUvD2L",
   legendaryactions: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.C1awOyZh78pq1xmY",

--- a/packs/_source/rules/appendix-e-rules.json
+++ b/packs/_source/rules/appendix-e-rules.json
@@ -10830,6 +10830,44 @@
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!journal.pages!NizgRXLNUqtdlC1s.qKmqbRFE9n2Up5bF"
+    },
+    {
+      "sort": 20675000,
+      "name": "Spell Scroll",
+      "type": "rule",
+      "_id": "gi8IKhtOlBVhMJrN",
+      "title": {
+        "show": true,
+        "level": 2
+      },
+      "image": {},
+      "text": {
+        "format": 1,
+        "content": "<p>A spell scroll bears the words of a single spell, written in a mystical cipher. If the spell is on your class’s spell list, you can read the scroll and cast its spell without providing any material components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell’s normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</p><p>If the spell is on your class’s spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC equals 10 + the spell’s level. On a failed check, the spell disappears from the scroll with no other effect.</p><p>The level of the spell on the scroll determines the spell’s saving throw DC and attack bonus, as well as the scroll’s rarity, as shown in the Spell Scroll table.</p><table><caption>Spell Scroll</caption><thead><tr><th scope=\"col\">Spell Level</th><th scope=\"col\">Rarity</th><th scope=\"col\">Save DC</th><th scope=\"col\">Attack Bonus</th></tr></thead><tbody><tr><th scope=\"row\">Cantrip</th><td>Common</td><td>13</td><td>+5</td></tr><tr><th scope=\"row\">1st</th><td>Common</td><td>13</td><td>+5</td></tr><tr><th scope=\"row\">2nd</th><td>Uncommon</td><td>13</td><td>+5</td></tr><tr><th scope=\"row\">3rd</th><td>Uncommon</td><td>15</td><td>+7</td></tr><tr><th scope=\"row\">4th</th><td>Rare</td><td>15</td><td>+7</td></tr><tr><th scope=\"row\">5th</th><td>Rare</td><td>17</td><td>+9</td></tr><tr><th scope=\"row\">6th</th><td>Very rare</td><td>17</td><td>+9</td></tr><tr><th scope=\"row\">7th</th><td>Very rare</td><td>18</td><td>+10</td></tr><tr><th scope=\"row\">8th</th><td>Very rare</td><td>18</td><td>+10</td></tr><tr><th scope=\"row\">9th</th><td>Legendary</td><td>19</td><td>+11</td></tr></tbody></table><p>A wizard spell on a <em>spell scroll</em> can be copied just as spells in spellbooks can be copied. When a spell is copied from a <em>spell scroll</em>, the copier must succeed on an Intelligence (Arcana) check with a DC equal to 10 + the spell’s level. If the check succeeds, the spell is successfully copied. Whether the check succeeds or fails, the <em>spell scroll</em> is destroyed.</p>",
+        "markdown": ""
+      },
+      "video": {
+        "controls": true,
+        "volume": 0.5
+      },
+      "src": null,
+      "system": {
+        "tooltip": "",
+        "type": "rule"
+      },
+      "ownership": {
+        "default": -1
+      },
+      "flags": {},
+      "_stats": {
+        "systemId": "dnd5e",
+        "systemVersion": "3.2.0",
+        "coreVersion": "11.315",
+        "createdTime": 1711217829430,
+        "modifiedTime": 1711218278065,
+        "lastModifiedBy": "dnd5ebuilder0000"
+      },
+      "_key": "!journal.pages!NizgRXLNUqtdlC1s.gi8IKhtOlBVhMJrN"
     }
   ],
   "folder": null,
@@ -10839,10 +10877,10 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1704059808409,
-    "modifiedTime": 1706217746263,
+    "modifiedTime": 1711218278065,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_id": "NizgRXLNUqtdlC1s",

--- a/packs/_source/rules/chapter-11-dm-tools.json
+++ b/packs/_source/rules/chapter-11-dm-tools.json
@@ -181,7 +181,7 @@
       },
       "text": {
         "format": 1,
-        "content": "<p>Magic items are gleaned from the hoards of conquered monsters or discovered in long-lost vaults. Such items grant capabilities a character could rarely have otherwise, or they complement their owner's capabilities in wondrous ways.</p><h2>Attunement</h2><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.UQ65OwIyGK65eiOK inline]</p><h2>Wearing and Wielding Items</h2><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.iPB8mGKuQx3X0Z2J inline]</p><h2>Activating an Item</h2><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.PqHSxFUwaXHL7kSz inline]</p><h2>Magic Items A-Z</h2><p>Magic items are presented in alphabetical order. A magic item's description gives the item's name, its category, its rarity, and its magical properties.</p><p>@UUID[Compendium.dnd5e.rules.JournalEntry.sfJtvPjEs50Ruzi4]{Magic Items A-Z}</p><h2>Sentient Magic Items</h2><p>Some magic items possess sentience and personality. Such an item might be possessed, haunted by the spirit of a previous owner, or self-aware thanks to the magic used to create it. In any case, the item behaves like a character, complete with personality quirks, ideals, bonds, and sometimes flaws. A sentient item might be a cherished ally to its wielder or a continual thorn in the side.</p><p>Most sentient items are weapons. Other kinds of items can manifest sentience, but consumable items such as potions and scrolls are never sentient.</p><p>Sentient magic items function as NPCs under the GM's control. Any activated property of the item is under the item's control, not its wielder's. As long as the wielder maintains a good relationship with the item, the wielder can access those properties normally. If the relationship is strained, the item can suppress its activated properties or even turn them against the wielder.</p><h3>Creating Sentient Magic Items</h3><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.Kh16IbKZRyEer1ju inline]</p><h3>Conflict</h3><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.S48JxKMOF2ZmAfav inline]</p><h2>Artifacts</h2><p>@UUID[Compendium.dnd5e.items.Item.1RwJWOAeyoideLKe]{Orb of Dragonkind}</p>",
+        "content": "<p>Magic items are gleaned from the hoards of conquered monsters or discovered in long-lost vaults. Such items grant capabilities a character could rarely have otherwise, or they complement their owner's capabilities in wondrous ways.</p><h2>Attunement</h2><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.UQ65OwIyGK65eiOK inline]</p><h2>Wearing and Wielding Items</h2><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.iPB8mGKuQx3X0Z2J inline]</p><h2>Activating an Item</h2><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.PqHSxFUwaXHL7kSz inline]</p><h2>Magic Items A-Z</h2><p>Magic items are presented in alphabetical order. A magic item's description gives the item's name, its category, its rarity, and its magical properties.</p><p>@UUID[Compendium.dnd5e.rules.JournalEntry.sfJtvPjEs50Ruzi4]{Magic Items A-Z}</p><h3>Spell Scrolls</h3><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.gi8IKhtOlBVhMJrN inline]</p><h2>Sentient Magic Items</h2><p>Some magic items possess sentience and personality. Such an item might be possessed, haunted by the spirit of a previous owner, or self-aware thanks to the magic used to create it. In any case, the item behaves like a character, complete with personality quirks, ideals, bonds, and sometimes flaws. A sentient item might be a cherished ally to its wielder or a continual thorn in the side.</p><p>Most sentient items are weapons. Other kinds of items can manifest sentience, but consumable items such as potions and scrolls are never sentient.</p><p>Sentient magic items function as NPCs under the GM's control. Any activated property of the item is under the item's control, not its wielder's. As long as the wielder maintains a good relationship with the item, the wielder can access those properties normally. If the relationship is strained, the item can suppress its activated properties or even turn them against the wielder.</p><h3>Creating Sentient Magic Items</h3><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.Kh16IbKZRyEer1ju inline]</p><h3>Conflict</h3><p>@Embed[Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.S48JxKMOF2ZmAfav inline]</p><h2>Artifacts</h2><p>@UUID[Compendium.dnd5e.items.Item.1RwJWOAeyoideLKe]{Orb of Dragonkind}</p>",
         "markdown": ""
       },
       "_id": "YHsuCV4IZZZoyDap",
@@ -199,10 +199,10 @@
       "flags": {},
       "_stats": {
         "systemId": "dnd5e",
-        "systemVersion": "3.0.0",
+        "systemVersion": "3.2.0",
         "coreVersion": "11.315",
         "createdTime": null,
-        "modifiedTime": 1705191662357,
+        "modifiedTime": 1711218115742,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!journal.pages!t6scHTmpmHBTZGTX.YHsuCV4IZZZoyDap"
@@ -257,10 +257,10 @@
   },
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1660925148884,
-    "modifiedTime": 1705193612784,
+    "modifiedTime": 1711218115742,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "folder": null,


### PR DESCRIPTION
Adds a configuration object that is passed to `createScrollFromSpell` to allow for more customization of the creation process. Right now it has a single option `explanation` which controls how much of the spell scroll rules are included in the created scroll.

- `full`: Existing functionality including entire spell scroll rules
- `reference`: Adds scroll level, reference link to rules, and potentially a concentration note to beginning of description
- `none`: Just includes the original spell description

<img width="1166" alt="Three versions of a spell scroll created from Detect Magic. The full option with all the spell scroll rules to the left, the reference option on the top right, and the none option on the bottom right" src="https://github.com/foundryvtt/dnd5e/assets/19979839/ef40bf27-4701-4083-a815-b3d7b316abaa">

In order to support `reference` mod a non-level-specific version of the spell scroll rules have been added to the magic items section of the SRD rules and a reference of `&Reference[Spell Scroll]`.

Closes #3326 