### PR TITLE
[#3320] Add option to convert spell to scroll from context menu

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -494,6 +494,9 @@ Hooks.on("chatMessage", (app, message, data) => dnd5e.applications.Award.chatMes
 Hooks.on("renderActorDirectory", (app, html, data) => documents.Actor5e.onRenderActorDirectory(html));
 Hooks.on("getActorDirectoryEntryContext", documents.Actor5e.addDirectoryContextOptions);
 
+Hooks.on("getCompendiumEntryContext", documents.Item5e.addCompendiumContextOptions);
+Hooks.on("getItemDirectoryEntryContext", documents.Item5e.addDirectoryContextOptions);
+
 Hooks.on("applyTokenStatusEffect", canvas.Token5e.onApplyTokenStatusEffect);
 Hooks.on("targetToken", canvas.Token5e.onTargetToken);
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -1211,8 +1211,11 @@
 "DND5E.NewDayHint": "Recover limited use abilities which recharge \"per day\"?",
 "DND5E.SaveBonus": "Saving Throw Bonus",
 "DND5E.SaveGlobalBonusHint": "This bonus applies to all saving throws made by this actor.",
-"DND5E.ScrollDetails": "Scroll Details",
-"DND5E.ScrollRequiresConcentration": "Requires Concentration",
+"DND5E.Scroll": {
+  "CreateScroll": "Create Scroll",
+  "Details": "Scroll Details",
+  "RequiresConcentration": "Requires Concentration"
+},
 "DND5E.Senses": "Senses",
 "DND5E.SensesConfig": "Configure Senses",
 "DND5E.SensesConfigHint": "Configure any special sensory perception abilities that this actor possesses.",

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -1,3 +1,4 @@
+import Item5e from "../../documents/item.mjs";
 import {parseInputDelta} from "../../utils.mjs";
 import CurrencyManager from "../currency-manager.mjs";
 import ContextMenu5e from "../context-menu.mjs";
@@ -201,6 +202,16 @@ export default class InventoryElement extends HTMLElement {
         icon: "<i class='fas fa-trash fa-fw'></i>",
         condition: () => item.isOwner,
         callback: li => this._onAction(li[0], "delete")
+      },
+      {
+        name: "DND5E.Scroll.CreateScroll",
+        icon: '<i class="fa-solid fa-scroll"></i>',
+        callback: async li => {
+          const data = await Item5e.createScrollFromSpell(item);
+          Item5e.createDocuments([data.toObject()], { parent: this.actor });
+        },
+        condition: li => (item.type === "spell") && this.actor?.isOwner,
+        group: "action"
       },
       {
         name: "DND5E.ConcentrationBreak",

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -206,10 +206,7 @@ export default class InventoryElement extends HTMLElement {
       {
         name: "DND5E.Scroll.CreateScroll",
         icon: '<i class="fa-solid fa-scroll"></i>',
-        callback: async li => {
-          const data = await Item5e.createScrollFromSpell(item);
-          Item5e.createDocuments([data.toObject()], { parent: this.actor });
-        },
+        callback: async li => Item5e.create(await Item5e.createScrollFromSpell(item), { parent: this.actor }),
         condition: li => (item.type === "spell") && this.actor?.isOwner,
         group: "action"
       },

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2573,6 +2573,58 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /**
+   * Add additional system-specific compendium context menu options for Item documents.
+   * @param {jQuery} html            The compendium HTML.
+   * @param {object{}} entryOptions  The default array of context menu options.
+   */
+  static addCompendiumContextOptions(html, entryOptions) {
+    const makeUuid = li => {
+      const pack = li[0].closest("[data-pack]")?.dataset.pack;
+      return `Compendium.${pack}.Item.${li.data("documentId")}`;
+    };
+    entryOptions.push({
+      name: "DND5E.Scroll.CreateScroll",
+      icon: '<i class="fa-solid fa-scroll"></i>',
+      callback: async li => {
+        const spell = await fromUuid(makeUuid(li));
+        const data = await Item5e.createScrollFromSpell(spell);
+        Item5e.createDocuments([data.toObject()]);
+      },
+      condition: li => {
+        const item = fromUuidSync(makeUuid(li));
+        return (item?.type === "spell") && game.user.hasPermission("ITEM_CREATE");
+      },
+      group: "system"
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add additional system-specific sidebar directory context menu options for Item documents.
+   * @param {jQuery} html            The sidebar HTML.
+   * @param {object[]} entryOptions  The default array of context menu options.
+   */
+  static addDirectoryContextOptions(html, entryOptions) {
+    entryOptions.push({
+      name: "DND5E.Scroll.CreateScroll",
+      icon: '<i class="fa-solid fa-scroll"></i>',
+      callback: async li => {
+        const spell = game.items.get(li.data("documentId"));
+        const data = await Item5e.createScrollFromSpell(spell);
+        Item5e.createDocuments([data.toObject()]);
+      },
+      condition: li => {
+        const item = game.items.get(li.data("documentId"));
+        return (item.type === "spell") && game.user.hasPermission("ITEM_CREATE");
+      },
+      group: "system"
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Prepare creation data for the provided items and any items contained within them. The data created by this method
    * can be passed to `createDocuments` with `keepId` always set to true to maintain links to container contents.
    * @param {Item5e[]} items                     Items to create.
@@ -2682,11 +2734,11 @@ export default class Item5e extends SystemDocumentMixin(Item) {
           scrollIntro,
           "<hr>",
           `<h3>${itemData.name} (${game.i18n.format("DND5E.LevelNumber", {level})})</h3>`,
-          isConc ? `<p><em>${game.i18n.localize("DND5E.ScrollRequiresConcentration")}</em></p>` : null,
+          isConc ? `<p><em>${game.i18n.localize("DND5E.Scroll.RequiresConcentration")}</em></p>` : null,
           "<hr>",
           description.value,
           "<hr>",
-          `<h3>${game.i18n.localize("DND5E.ScrollDetails")}</h3>`,
+          `<h3>${game.i18n.localize("DND5E.Scroll.Details")}</h3>`,
           "<hr>",
           scrollDetails
         ].filterJoin("");
@@ -2696,7 +2748,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
           "<p><em>",
           CONFIG.DND5E.spellLevels[level] ?? level,
           "&Reference[Spell Scroll]",
-          isConc ? `, ${game.i18n.localize("DND5E.ScrollRequiresConcentration")}` : null,
+          isConc ? `, ${game.i18n.localize("DND5E.Scroll.RequiresConcentration")}` : null,
           "</em></p>",
           description.value
         ].filterJoin("");

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2587,8 +2587,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       icon: '<i class="fa-solid fa-scroll"></i>',
       callback: async li => {
         const spell = await fromUuid(makeUuid(li));
-        const data = await Item5e.createScrollFromSpell(spell);
-        Item5e.createDocuments([data.toObject()]);
+        Item5e.create(await Item5e.createScrollFromSpell(spell));
       },
       condition: li => {
         const item = fromUuidSync(makeUuid(li));
@@ -2611,8 +2610,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       icon: '<i class="fa-solid fa-scroll"></i>',
       callback: async li => {
         const spell = game.items.get(li.data("documentId"));
-        const data = await Item5e.createScrollFromSpell(spell);
-        Item5e.createDocuments([data.toObject()]);
+        Item5e.create(await Item5e.createScrollFromSpell(spell));
       },
       condition: li => {
         const item = game.items.get(li.data("documentId"));


### PR DESCRIPTION
Adds context menu options to the sidebar directory and compendium listing that will create a new scroll in the sidebar, and to the actor's inventory that will create a new scroll on the actor.

Closes #3320