### PR TITLE
[#3269] Add spell components back to chat cards

### DIFF
--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -113,6 +113,7 @@ export default class SpellData extends ItemDataModel.mixin(
     const context = await super.getCardData(enrichmentOptions);
     context.isSpell = true;
     context.subtitle = [this.parent.labels.level, CONFIG.DND5E.spellSchools[this.school]?.label].filterJoin(" &bull; ");
+    if ( this.parent.labels.components.vsm ) context.tags = [this.parent.labels.components.vsm, ...context.tags];
     return context;
   }
 


### PR DESCRIPTION
Adds spell components to spell listing:

<img width="295" alt="Screenshot 2024-03-25 at 11 26 36" src="https://github.com/foundryvtt/dnd5e/assets/19979839/b00aa9fe-9bd5-4aac-afd6-4099bf839e2b">

Also considered adding the full names, but that felt a bit long:

<img width="297" alt="Screenshot 2024-03-25 at 11 26 40" src="https://github.com/foundryvtt/dnd5e/assets/19979839/117373b1-a025-487c-a2ba-604c7fe02e21">

Closes #3269