### PR TITLE
[#1856] Allows HD & attribute consumption to be set on world items

### DIFF
--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -254,7 +254,7 @@
       .form-fields {
         flex-wrap: nowrap;
       }
-      &.consumption input {
+      &.consumption [name="system.consume.amount"] {
         flex: 0 0 32px;
       }
       span {

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -137,6 +137,7 @@ export default class ItemSheet5e extends ItemSheet {
       concealDetails: !game.user.isGM && (this.document.system.identified === false)
     });
     context.abilityConsumptionTargets = this._getItemConsumptionTargets();
+    context.abilityConsumptionManual = !item.isEmbedded && (this.item.system.consume?.type === "attribute");
 
     if ( ("properties" in item.system) && (item.type in CONFIG.DND5E.validProperties) ) {
       context.properties = item.system.validProperties.reduce((obj, k) => {
@@ -261,7 +262,7 @@ export default class ItemSheet5e extends ItemSheet {
     const consume = this.item.system.consume || {};
     if ( !consume.type ) return [];
     const actor = this.item.actor;
-    if ( !actor ) return {};
+    if ( !actor && (consume.type !== "hitDice") ) return {};
 
     // Ammunition
     if ( consume.type === "ammo" ) {

--- a/templates/items/parts/item-activation.hbs
+++ b/templates/items/parts/item-activation.hbs
@@ -150,9 +150,14 @@
         {{#if system.consume.type}}
             <input type="number" step="any" name="system.consume.amount" value="{{system.consume.amount}}"
                    data-tooltip="DND5E.ConsumeAmount">
+            {{#if abilityConsumptionManual}}
+            <input type="text" name="system.consume.target" value="{{ system.consume.target }}"
+                   data-tooltip="DND5E.ConsumeTarget">
+            {{else}}
             <select name="system.consume.target" data-tooltip="DND5E.ConsumeTarget">
                 {{selectOptions abilityConsumptionTargets selected=system.consume.target blank=""}}
             </select>
+            {{/if}}
         {{/if}}
         <select name="system.consume.type" data-tooltip="DND5E.ConsumeType">
             {{selectOptions config.abilityConsumptionTypes selected=system.consume.type blank=(localize "DND5E.None")}}


### PR DESCRIPTION
Displays the list of hit dice consumption options for items not in an actor so they can be selected.

For attributes, changes the select dropdown to a text input so the attribute can be entered or modified manually for non-embedded items.

<img width="916" alt="Screenshot 2024-03-25 at 12 51 59" src="https://github.com/foundryvtt/dnd5e/assets/19979839/40db1501-3dd7-468b-8279-7cc26a80a438">
