### PR TITLE
[#1856, #3342] Allow UUIDs to be used as consumption targets

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -462,6 +462,10 @@
 "DND5E.ConcentrationConfigurationHint": "Configure concentration modifiers and bonuses which apply to this creature.",
 "DND5E.ConsumeTitle": "Resource Consumption",
 "DND5E.ConsumeAmount": "Consumption Amount",
+"DND5E.ConsumeHint": {
+  "Attribute": "Attribute to consume (e.g. currency.gp)",
+  "Item": "UUID of consumption target in compendium"
+},
 "DND5E.ConsumeTarget": "Consumption Target",
 "DND5E.ConsumeType": "Consumption Category",
 "DND5E.ConsumeAmmunition": "Ammunition",

--- a/lang/en.json
+++ b/lang/en.json
@@ -464,7 +464,7 @@
 "DND5E.ConsumeAmount": "Consumption Amount",
 "DND5E.ConsumeHint": {
   "Attribute": "Attribute to consume (e.g. currency.gp)",
-  "Item": "UUID of consumption target in compendium"
+  "Item": "UUID of target in compendium"
 },
 "DND5E.ConsumeTarget": "Consumption Target",
 "DND5E.ConsumeType": "Consumption Category",

--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -250,17 +250,20 @@
       }
     }
 
-    .form-group.uses-per, .form-group.consumption {
+    .form-group.uses-per {
       .form-fields {
         flex-wrap: nowrap;
-      }
-      &.consumption [name="system.consume.amount"] {
-        flex: 0 0 32px;
       }
       span {
         flex: 0 0 16px;
         margin: 0 4px 0 0;
       }
+    }
+    .form-group.consumption .form-fields {
+      flex-wrap: wrap;
+      > * { margin: 0; }
+      [name="system.consume.amount"] { flex: 0 0 32px; }
+      [name="system.consume.type"] { flex: 0 0 100%; }
     }
     span.sep {
       flex: 0 0 8px;

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -137,7 +137,10 @@ export default class ItemSheet5e extends ItemSheet {
       concealDetails: !game.user.isGM && (this.document.system.identified === false)
     });
     context.abilityConsumptionTargets = this._getItemConsumptionTargets();
-    context.abilityConsumptionManual = !item.isEmbedded && (this.item.system.consume?.type === "attribute");
+    if ( !item.isEmbedded && foundry.utils.isEmpty(context.abilityConsumptionTargets) ) {
+      context.abilityConsumptionHint = (this.item.system.consume?.type === "attribute")
+        ? "DND5E.ConsumeHint.Attribute" : "DND5E.ConsumeHint.Item";
+    }
 
     if ( ("properties" in item.system) && (item.type in CONFIG.DND5E.validProperties) ) {
       context.properties = item.system.validProperties.reduce((obj, k) => {

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -375,6 +375,18 @@ export class ItemDataModel extends SystemDataModel {
   static ITEM_TOOLTIP_TEMPLATE = "systems/dnd5e/templates/items/parts/item-tooltip.hbs";
 
   /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareBaseData() {
+    if ( this.parent.isEmbedded ) {
+      const sourceId = this.parent.flags.dnd5e?.sourceId ?? this.parent.flags.core?.sourceId;
+      if ( sourceId ) this.parent.actor.sourcedItems?.set(sourceId, this.parent);
+    }
+  }
+
+  /* -------------------------------------------- */
   /*  Helpers                                     */
   /* -------------------------------------------- */
 

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -70,6 +70,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.prepareActivatedEffectData();
     if ( !this.type.value ) return;
     const config = CONFIG.DND5E.consumableTypes[this.type.value];
     if ( config ) {

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -70,7 +70,6 @@ export default class ConsumableData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.prepareActivatedEffectData();
     if ( !this.type.value ) return;
     const config = CONFIG.DND5E.consumableTypes[this.type.value];
     if ( config ) {
@@ -78,6 +77,13 @@ export default class ConsumableData extends ItemDataModel.mixin(
     } else {
       this.type.label = game.i18n.localize(CONFIG.Item.typeLabels.consumable);
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareFinalData() {
+    this.prepareFinalActivatedEffectData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -143,10 +143,16 @@ export default class EquipmentData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.prepareActivatedEffectData();
     this.armor.value = (this._source.armor.value ?? 0) + (this.magicAvailable ? (this.armor.magicalBonus ?? 0) : 0);
     this.type.label = CONFIG.DND5E.equipmentTypes[this.type.value]
       ?? game.i18n.localize(CONFIG.Item.typeLabels.equipment);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareFinalData() {
+    this.prepareFinalActivatedEffectData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -143,6 +143,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.prepareActivatedEffectData();
     this.armor.value = (this._source.armor.value ?? 0) + (this.magicAvailable ? (this.armor.magicalBonus ?? 0) : 0);
     this.type.label = CONFIG.DND5E.equipmentTypes[this.type.value]
       ?? game.i18n.localize(CONFIG.Item.typeLabels.equipment);

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -45,13 +45,19 @@ export default class FeatData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.prepareActivatedEffectData();
 
     if ( this.type.value ) {
       const config = CONFIG.DND5E.featureTypes[this.type.value];
       if ( config ) this.type.label = config.subtypes?.[this.type.subtype] ?? null;
       else this.type.label = game.i18n.localize(CONFIG.Item.typeLabels.feat);
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareFinalData() {
+    this.prepareFinalActivatedEffectData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -44,12 +44,13 @@ export default class FeatData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareDerivedData() {
-    if ( !this.type.value ) return;
-    const config = CONFIG.DND5E.featureTypes[this.type.value];
-    if ( config ) {
-      this.type.label = config.subtypes?.[this.type.subtype] ?? null;
-    } else {
-      this.type.label = game.i18n.localize(CONFIG.Item.typeLabels.feat);
+    super.prepareDerivedData();
+    this.prepareActivatedEffectData();
+
+    if ( this.type.value ) {
+      const config = CONFIG.DND5E.featureTypes[this.type.value];
+      if ( config ) this.type.label = config.subtypes?.[this.type.subtype] ?? null;
+      else this.type.label = game.i18n.localize(CONFIG.Item.typeLabels.feat);
     }
   }
 

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -103,8 +103,14 @@ export default class SpellData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.prepareActivatedEffectData();
     this.properties.add("mgc");
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareFinalData() {
+    this.prepareFinalActivatedEffectData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -103,6 +103,7 @@ export default class SpellData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.prepareActivatedEffectData();
     this.properties.add("mgc");
   }
 

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -108,6 +108,21 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Prepare activated effect data.
+   */
+  prepareActivatedEffectData() {
+    if ( !this.parent.isEmbedded ) return;
+    if ( ["ammo", "charges", "material"].includes(this.consume.type) && this.consume.target.includes(".") ) {
+      const item = this.parent.actor.items.find(i =>
+        (i.flags.core?.sourceId === this.consume.target) || (i.flags.dnd5e?.sourceId === this.consume.target)
+      );
+      if ( item ) this.consume.target = item.id;
+    }
+  }
+
+  /* -------------------------------------------- */
   /*  Migrations                                  */
   /* -------------------------------------------- */
 

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -110,14 +110,12 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
-   * Prepare activated effect data.
+   * Prepare activated effect data, should be called during `prepareFinalData` stage.
    */
-  prepareActivatedEffectData() {
+  prepareFinalActivatedEffectData() {
     if ( !this.parent.isEmbedded ) return;
     if ( ["ammo", "charges", "material"].includes(this.consume.type) && this.consume.target.includes(".") ) {
-      const item = this.parent.actor.items.find(i =>
-        (i.flags.core?.sourceId === this.consume.target) || (i.flags.dnd5e?.sourceId === this.consume.target)
-      );
+      const item = this.parent.actor.sourcedItems?.get(this.consume.target);
       if ( item ) this.consume.target = item.id;
     }
   }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -82,6 +82,7 @@ export default class WeaponData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.prepareActivatedEffectData();
     this.type.label = CONFIG.DND5E.weaponTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.weapon);
   }
 

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -82,8 +82,14 @@ export default class WeaponData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.prepareActivatedEffectData();
     this.type.label = CONFIG.DND5E.weaponTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.weapon);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareFinalData() {
+    this.prepareFinalActivatedEffectData();
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -22,6 +22,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   _classes;
 
+  /**
+   * Mapping of item source IDs to the items.
+   * @type {Map<string, Item5e>}
+   */
+  sourcedItems = this.sourcedItems;
+
   /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
@@ -130,6 +136,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     this._preparationWarnings = [];
     super.prepareData();
     this.items.forEach(item => item.prepareFinalAttributes());
+  }
+
+  /* --------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareEmbeddedDocuments() {
+    this.sourcedItems = new Map();
+    super.prepareEmbeddedDocuments();
   }
 
   /* --------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -644,6 +644,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * Otherwise, it will be called at the end of `Item5e#prepareDerivedData`.
    */
   prepareFinalAttributes() {
+    this.system.prepareFinalData?.();
 
     // Proficiency
     this._prepareProficiency();

--- a/templates/items/parts/item-activation.hbs
+++ b/templates/items/parts/item-activation.hbs
@@ -149,10 +149,10 @@
     <div class="form-fields">
         {{#if system.consume.type}}
             <input type="number" step="any" name="system.consume.amount" value="{{system.consume.amount}}"
-                   data-tooltip="DND5E.ConsumeAmount">
+                   data-tooltip="DND5E.ConsumeAmount" placeholder="{{ localize 'DND5E.QuantityAbbr' }}">
             {{#if abilityConsumptionHint}}
             <input type="text" name="system.consume.target" value="{{ system.consume.target }}"
-                   data-tooltip="{{ abilityConsumptionHint }}">
+                   placeholder="{{ localize abilityConsumptionHint }}">
             {{else}}
             <select name="system.consume.target" data-tooltip="DND5E.ConsumeTarget">
                 {{selectOptions abilityConsumptionTargets selected=system.consume.target blank=""}}

--- a/templates/items/parts/item-activation.hbs
+++ b/templates/items/parts/item-activation.hbs
@@ -150,9 +150,9 @@
         {{#if system.consume.type}}
             <input type="number" step="any" name="system.consume.amount" value="{{system.consume.amount}}"
                    data-tooltip="DND5E.ConsumeAmount">
-            {{#if abilityConsumptionManual}}
+            {{#if abilityConsumptionHint}}
             <input type="text" name="system.consume.target" value="{{ system.consume.target }}"
-                   data-tooltip="DND5E.ConsumeTarget">
+                   data-tooltip="{{ abilityConsumptionHint }}">
             {{else}}
             <select name="system.consume.target" data-tooltip="DND5E.ConsumeTarget">
                 {{selectOptions abilityConsumptionTargets selected=system.consume.target blank=""}}


### PR DESCRIPTION
Items with the consumption modes of ammo, item uses, and resource will now be display their target as a text input field which accepts an item UUID. When the item is then added to an actor, it will search for an item on the actor with a matching `sourceId` and set that item's ID as its consumption target. This should allow for pre-configuring consumption in compendium items.

Closes #1856 
Closes #3342