### PR TITLE
Reinstate advancement data cleaning and ensure migrations are run before cleaning.

### DIFF
--- a/module/data/fields.mjs
+++ b/module/data/fields.mjs
@@ -42,6 +42,18 @@ export class AdvancementField extends foundry.data.fields.ObjectField {
     if ( cls ) return new cls(value, {parent: model, ...options});
     return foundry.utils.deepClone(value);
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Migrate this field's candidate source data.
+   * @param {object} sourceData   Candidate source data of the root model
+   * @param {any} fieldData       The value of this field within the source data
+   */
+  migrateSource(sourceData, fieldData) {
+    const cls = this.getModelForType(fieldData.type);
+    if ( cls ) cls.migrateDataSafe(fieldData);
+  }
 }
 
 /* -------------------------------------------- */
@@ -85,10 +97,38 @@ export class AdvancementDataField extends foundry.data.fields.ObjectField {
   /* -------------------------------------------- */
 
   /** @inheritdoc */
+  _cleanType(value, options) {
+    if ( !(typeof value === "object") ) value = {};
+
+    // Use a defined DataModel
+    const cls = this.getModel();
+    if ( cls ) return cls.cleanData(value, options);
+    if ( options.partial ) return value;
+
+    // Use the defined defaults
+    const defaults = this.getDefaults();
+    return foundry.utils.mergeObject(defaults, value, {inplace: false});
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
   initialize(value, model, options={}) {
     const cls = this.getModel();
     if ( cls ) return new cls(value, {parent: model, ...options});
     return foundry.utils.deepClone(value);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Migrate this field's candidate source data.
+   * @param {object} sourceData   Candidate source data of the root model
+   * @param {any} fieldData       The value of this field within the source data
+   */
+  migrateSource(sourceData, fieldData) {
+    const cls = this.getModel();
+    if ( cls ) cls.migrateDataSafe(fieldData);
   }
 }
 


### PR DESCRIPTION
Can go in 3.1.2 or 3.2, whichever you have a better feeling for.

This was a change we made in core to allow `DataField`s to recursively apply their own migrations/cleaning, and I never followed-up in the dnd5e repo. These `migrateSource` changes are in v11, it's not just a v12 thing, for the avoidance of doubt.