### PR TITLE
[#3345] Add Place Members buttons to group to place into scene

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -845,6 +845,7 @@
     "one": "Member",
     "other": "Members"
   },
+  "PlaceMembers": "Place Members",
   "Primary": {
     "Remove": "Remove as Primary Party",
     "Set": "Set as Primary Party"

--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -295,22 +295,25 @@ export default class GroupActorSheet extends ActorSheetMixin(ActorSheet) {
         const award = new Award(this.object, { savedDestinations: this.actor.getFlag("dnd5e", "awardDestinations") });
         award.render(true);
         break;
-      case "removeMember":
-        const removeMemberId = button.closest("li.group-member").dataset.actorId;
-        this.object.system.removeMember(removeMemberId);
-        break;
       case "longRest":
-        this.object.longRest({ advanceTime: true });
+        this.actor.longRest({ advanceTime: true });
         break;
       case "movementConfig":
         const movementConfig = new ActorMovementConfig(this.object);
         movementConfig.render(true);
         break;
+      case "placeMembers":
+        this.actor.system.placeMembers();
+        break;
+      case "removeMember":
+        const removeMemberId = button.closest("li.group-member").dataset.actorId;
+        this.actor.system.removeMember(removeMemberId);
+        break;
       case "rollQuantities":
-        this.object.system.rollQuantities();
+        this.actor.system.rollQuantities();
         break;
       case "shortRest":
-        this.object.shortRest({ advanceTime: true });
+        this.actor.shortRest({ advanceTime: true });
         break;
     }
   }

--- a/module/canvas/token-placement.mjs
+++ b/module/canvas/token-placement.mjs
@@ -105,7 +105,7 @@ export default class TokenPlacement {
     try {
       const placements = [];
       while ( this.#currentPlacement < this.config.tokens.length - 1 ) {
-        this.#currentPlacement += 1;
+        this.#currentPlacement++;
         const obj = canvas.tokens.preview.addChild(this.#previews[this.#currentPlacement].object);
         await obj.draw();
         const placement = await this.#requestPlacement();
@@ -127,6 +127,7 @@ export default class TokenPlacement {
     this.#previews = [];
     for ( const prototypeToken of this.config.tokens ) {
       const tokenData = prototypeToken.toObject();
+      tokenData.sight.enabled = false;
       tokenData._id = foundry.utils.randomID();
       if ( tokenData.randomImg ) tokenData.texture.src = prototypeToken.actor.img;
       const cls = getDocumentClass("Token");
@@ -171,7 +172,8 @@ export default class TokenPlacement {
 
   /**
    * Activate listeners for the placement preview.
-   * @returns {Promise<PlacementData>}  A promise that resolves with the final placement if created.
+   * @returns {Promise<PlacementData|false>}  A promise that resolves with the final placement if created,
+   *                                          or false if the placement was skipped.
    */
   #requestPlacement() {
     return new Promise((resolve, reject) => {

--- a/module/canvas/token-placement.mjs
+++ b/module/canvas/token-placement.mjs
@@ -9,6 +9,7 @@
  * Data for token placement on the scene.
  *
  * @typedef {object} PlacementData
+ * @property {PrototypeToken} prototypeToken
  * @property {number} x
  * @property {number} y
  * @property {number} rotation
@@ -32,6 +33,14 @@ export default class TokenPlacement {
    * @type {TokenPlacementConfiguration}
    */
   config;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Index of the token configuration currently being placed in the scene.
+   * @param {number}
+   */
+  #currentPlacement = -1;
 
   /* -------------------------------------------- */
 
@@ -94,7 +103,15 @@ export default class TokenPlacement {
   async place() {
     this.#createPreviews();
     try {
-      return await this.#activatePreviewListeners();
+      const placements = [];
+      while ( this.#currentPlacement < this.config.tokens.length - 1 ) {
+        this.#currentPlacement += 1;
+        const obj = canvas.tokens.preview.addChild(this.#previews[this.#currentPlacement].object);
+        obj.draw();
+        const placement = await this.#requestPlacement();
+        if ( placement ) placements.push(placement);
+      }
+      return placements;
     } finally {
       this.#destroyPreviews();
     }
@@ -113,9 +130,8 @@ export default class TokenPlacement {
       if ( tokenData.randomImg ) tokenData.texture.src = prototypeToken.actor.img;
       const cls = getDocumentClass("Token");
       const doc = new cls(tokenData, { parent: canvas.scene });
-      this.#placements.push({ x: 0, y: 0, rotation: tokenData.rotation ?? 0 });
+      this.#placements.push({ prototypeToken, x: 0, y: 0, rotation: tokenData.rotation ?? 0 });
       this.#previews.push(doc);
-      doc.object.draw();
     }
   }
 
@@ -154,23 +170,24 @@ export default class TokenPlacement {
 
   /**
    * Activate listeners for the placement preview.
-   * @returns {Promise}  A promise that resolves with the final placement if created.
+   * @returns {Promise<PlacementData>}  A promise that resolves with the final placement if created.
    */
-  #activatePreviewListeners() {
+  #requestPlacement() {
     return new Promise((resolve, reject) => {
       this.#events = {
-        cancel: this.#onCancelPlacement.bind(this),
         confirm: this.#onConfirmPlacement.bind(this),
         move: this.#onMovePlacement.bind(this),
         resolve,
         reject,
-        rotate: this.#onRotatePlacement.bind(this)
+        rotate: this.#onRotatePlacement.bind(this),
+        skip: this.#onSkipPlacement.bind(this)
+
       };
 
       // Activate listeners
       canvas.stage.on("mousemove", this.#events.move);
       canvas.stage.on("mousedown", this.#events.confirm);
-      canvas.app.view.oncontextmenu = this.#events.cancel;
+      canvas.app.view.oncontextmenu = this.#events.skip;
       canvas.app.view.onwheel = this.#events.rotate;
     });
   }
@@ -182,7 +199,6 @@ export default class TokenPlacement {
    * @param {Event} event  Triggering event that ended the placement.
    */
   async #finishPlacement(event) {
-    canvas.tokens._onDragLeftCancel(event);
     canvas.stage.off("mousemove", this.#events.move);
     canvas.stage.off("mousedown", this.#events.confirm);
     canvas.app.view.oncontextmenu = null;
@@ -199,17 +215,18 @@ export default class TokenPlacement {
     event.stopPropagation();
     if ( this.#throttle ) return;
     this.#throttle = true;
-    const preview = this.#previews[0];
+    const idx = this.#currentPlacement;
+    const preview = this.#previews[idx];
     const adjustment = this.#getSnapAdjustment(preview);
     const point = event.data.getLocalPosition(canvas.tokens);
     const center = canvas.grid.getCenter(point.x - adjustment.x, point.y - adjustment.y);
     preview.updateSource({
-      x: center[0] + adjustment.x - Math.round((this.config.tokens[0].width * canvas.dimensions.size) / 2),
-      y: center[1] + adjustment.y - Math.round((this.config.tokens[0].height * canvas.dimensions.size) / 2)
+      x: center[0] + adjustment.x - Math.round((this.config.tokens[idx].width * canvas.dimensions.size) / 2),
+      y: center[1] + adjustment.y - Math.round((this.config.tokens[idx].height * canvas.dimensions.size) / 2)
     });
-    this.#placements[0].x = preview.x;
-    this.#placements[0].y = preview.y;
-    preview.object.refresh();
+    this.#placements[idx].x = preview.x;
+    this.#placements[idx].y = preview.y;
+    canvas.tokens.preview.children[this.#currentPlacement]?.refresh();
     requestAnimationFrame(() => this.#throttle = false);
   }
 
@@ -224,10 +241,10 @@ export default class TokenPlacement {
     event.stopPropagation();
     const delta = canvas.grid.type > CONST.GRID_TYPES.SQUARE ? 30 : 15;
     const snap = event.shiftKey ? delta : 5;
-    const preview = this.#previews[0];
-    this.#placements[0].rotation += snap * Math.sign(event.deltaY);
-    preview.updateSource({ rotation: this.#placements[0].rotation });
-    preview.object.refresh();
+    const preview = this.#previews[this.#currentPlacement];
+    this.#placements[this.#currentPlacement].rotation += snap * Math.sign(event.deltaY);
+    preview.updateSource({ rotation: this.#placements[this.#currentPlacement].rotation });
+    canvas.tokens.preview.children[this.#currentPlacement]?.refresh();
   }
 
   /* -------------------------------------------- */
@@ -238,17 +255,17 @@ export default class TokenPlacement {
    */
   async #onConfirmPlacement(event) {
     await this.#finishPlacement(event);
-    this.#events.resolve(this.#placements);
+    this.#events.resolve(this.#placements[this.#currentPlacement]);
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Cancel placement when the right mouse button is clicked.
+   * Skip placement when the right mouse button is clicked.
    * @param {Event} event  Triggering mouse event.
    */
-  async #onCancelPlacement(event) {
+  async #onSkipPlacement(event) {
     await this.#finishPlacement(event);
-    this.#events.reject();
+    this.#events.resolve(false);
   }
 }

--- a/module/canvas/token-placement.mjs
+++ b/module/canvas/token-placement.mjs
@@ -107,7 +107,7 @@ export default class TokenPlacement {
       while ( this.#currentPlacement < this.config.tokens.length - 1 ) {
         this.#currentPlacement += 1;
         const obj = canvas.tokens.preview.addChild(this.#previews[this.#currentPlacement].object);
-        obj.draw();
+        await obj.draw();
         const placement = await this.#requestPlacement();
         if ( placement ) placements.push(placement);
       }
@@ -127,6 +127,7 @@ export default class TokenPlacement {
     this.#previews = [];
     for ( const prototypeToken of this.config.tokens ) {
       const tokenData = prototypeToken.toObject();
+      tokenData._id = foundry.utils.randomID();
       if ( tokenData.randomImg ) tokenData.texture.src = prototypeToken.actor.img;
       const cls = getDocumentClass("Token");
       const doc = new cls(tokenData, { parent: canvas.scene });

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -1,3 +1,4 @@
+import TokenPlacement from "../../canvas/token-placement.mjs";
 import { ActorDataModel } from "../abstract.mjs";
 import { FormulaField } from "../fields.mjs";
 import CurrencyTemplate from "../shared/currency.mjs";
@@ -187,6 +188,34 @@ export default class GroupActor extends ActorDataModel.mixin(CurrencyTemplate) {
     const membersCollection = this.toObject().members;
     membersCollection.push({ actor: actor.id });
     return this.parent.update({"system.members": membersCollection});
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Place all members in the group on the current scene.
+   */
+  async placeMembers() {
+    if ( !game.user.isGM || !canvas.scene ) return;
+    const minimized = !this.parent.sheet._minimized;
+    await this.parent.sheet.minimize();
+    const tokensData = [];
+
+    try {
+      const placements = await TokenPlacement.place({
+        tokens: Object.values(this.members).map(m => m.actor.prototypeToken)
+      });
+      for ( const placement of placements ) {
+        const actor = placement.prototypeToken.actor;
+        delete placement.prototypeToken;
+        const tokenDocument = await actor.getTokenDocument(placement);
+        tokensData.push(tokenDocument.toObject());
+      }
+    } finally {
+      if ( minimized ) this.parent.sheet.maximize();
+    }
+
+    await canvas.scene.createEmbeddedDocuments("Token", tokensData);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -424,6 +424,7 @@ export class SummonsData extends foundry.abstract.DataModel {
       ui.notifications.warn("DND5E.Summoning.Warning.Wildcard", { localize: true });
     }
 
+    delete placement.prototypeToken;
     const tokenDocument = await actor.getTokenDocument(foundry.utils.mergeObject(placement, tokenUpdates));
     tokenDocument.delta.updateSource(actorUpdates);
 

--- a/templates/actors/tabs/group-members.hbs
+++ b/templates/actors/tabs/group-members.hbs
@@ -1,6 +1,11 @@
 {{#if isGM}}
 <menu class="member-controls flexrow">
     <li>
+        <button type="button" class="action-button" data-action="placeMembers">
+            <i class="fa-solid fa-location-dot" inert></i> {{localize "DND5E.Group.PlaceMembers"}}
+        </button>
+    </li>
+    <li>
         <button type="button" class="action-button rest-button" data-action="shortRest">
             <i class="fa-solid fa-utensils" inert></i> {{localize "DND5E.ShortRest"}}
         </button>


### PR DESCRIPTION
Includes modifications to the `TokenPlacement` class to fully support multiple token placements. The functionality of that system has been changed slightly so right clicking will now skip the current placement, but not cancel the whole process. This should allow skipping certain group members when placing the group.

There is a current limitation that prevents the already placed tokens from displaying in the scene.

Closes #3345 