### PR TITLE
[#3358] Properly handle temporary hit points in `applyDamage`

### DIFF
--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -546,10 +546,14 @@
       }
     }
 
-    .calculated-damage {
+    .calculated {
       padding-inline-end: 4px;
       font-size: var(--font-size-14);
       font-weight: bold;
+      color: var(--dnd5e-color-application-damage);
+
+      &.healing { color: var(--dnd5e-color-application-healing); }
+      &.temp { color: var(--dnd5e-color-application-temp); }
     }
 
     .damage-multipliers {

--- a/less/variables.less
+++ b/less/variables.less
@@ -58,6 +58,9 @@
   --dnd5e-color-failure: #6e0000;
   --dnd5e-color-failure-background: #ffdddd;
   --dnd5e-color-failure-critical: red;
+  --dnd5e-color-application-damage: #9c5b47;
+  --dnd5e-color-application-healing: #3c7f58;
+  --dnd5e-color-application-temp: #007F7F;
   --dnd5e-background-10: rgb(0 0 0 / 10%);
   --dnd5e-background-5: rgb(0 0 0 / 5%);
   --dnd5e-background-card: var(--dnd5e-color-card);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -921,7 +921,11 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( !damages ) return this;
 
     // Round damage towards zero
-    let amount = damages.reduce((acc, d) => acc + d.value, 0);
+    let { amount, temp } = damages.reduce((acc, d) => {
+      if ( d.type === "temphp" ) acc.temp += d.value;
+      else acc.amount += d.value;
+      return acc;
+    }, { amount: 0, temp: 0 });
     amount = amount > 0 ? Math.floor(amount) : Math.ceil(amount);
 
     const deltaTemp = amount > 0 ? Math.min(hp.temp, amount) : 0;
@@ -930,6 +934,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       "system.attributes.hp.temp": hp.temp - deltaTemp,
       "system.attributes.hp.value": hp.value - deltaHP
     };
+
+    if ( temp > updates["system.attributes.hp.temp"] ) updates["system.attributes.hp.temp"] = temp;
 
     /**
      * A hook event that fires before damage is applied to an actor.


### PR DESCRIPTION
Any damage rolls with the `temphp` type are now not included in the total damage and instead split off. Then, after any damage is applied to current & temporary HP, that temp value is used to set the new temporary HP floor.

The damage application interface has been adjusted to display temp HP separately from other changes. The display of normal damage has also changed to add subtle colors (red for damage, green for healing, blue for temp HP). The signs have also been adjusted, so healing will always have a "+", damage will always have a "-", and temp HP will be unsigned.

These changes should make it more clear what each of the numbers represents, but just in case this also adds tooltips to each number.

Closes #3358 