### PR TITLE
[#3353, #3361, #3362] Add support for NPC hit dice based on HP formula

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -887,6 +887,7 @@
 "DND5E.HitDiceRoll": "Roll Hit Dice",
 "DND5E.HitDiceUsed": "Hit Dice Used",
 "DND5E.HitDiceWarn": "{name} has no available {formula} Hit Dice remaining!",
+"DND5E.HitDiceNPCWarn": "{name} has no available Hit Dice remaining!",
 "DND5E.Ideals": "Ideals",
 "DND5E.Identified": "Identified",
 "DND5E.Identifier": "Identifier",

--- a/module/applications/actor/short-rest.mjs
+++ b/module/applications/actor/short-rest.mjs
@@ -39,7 +39,14 @@ export default class ShortRestDialog extends Dialog {
     const context = super.getData();
     context.isGroup = this.actor.type === "group";
 
-    if ( foundry.utils.hasProperty(this.actor, "system.attributes.hd") ) {
+    if ( this.actor.type === "npc" ) {
+      const hd = this.actor.system.attributes.hd;
+      context.availableHD = { [`d${hd.denomination}`]: hd.value };
+      context.canRoll = hd.value > 0;
+      context.denomination = `d${hd.denomination}`;
+    }
+
+    else if ( foundry.utils.hasProperty(this.actor, "system.attributes.hd") ) {
       // Determine Hit Dice
       context.availableHD = this.actor.items.reduce((hd, item) => {
         if ( item.type === "class" ) {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -591,6 +591,7 @@ preLocalize("abilityConsumptionTypes", { sort: true });
  * @typedef {object} ActorSizeConfiguration
  * @property {string} label                   Localized label.
  * @property {string} abbreviation            Localized abbreviation.
+ * @property {number} hitDie                  Default hit die denomination for NPCs of this size.
  * @property {number} [token=1]               Default token size.
  * @property {number} [capacityMultiplier=1]  Multiplier used to calculate carrying capacities.
  */
@@ -603,33 +604,39 @@ DND5E.actorSizes = {
   tiny: {
     label: "DND5E.SizeTiny",
     abbreviation: "DND5E.SizeTinyAbbr",
+    hitDie: 4,
     token: 0.5,
     capacityMultiplier: 0.5
   },
   sm: {
     label: "DND5E.SizeSmall",
     abbreviation: "DND5E.SizeSmallAbbr",
+    hitDie: 6,
     dynamicTokenScale: 0.8
   },
   med: {
     label: "DND5E.SizeMedium",
-    abbreviation: "DND5E.SizeMediumAbbr"
+    abbreviation: "DND5E.SizeMediumAbbr",
+    hitDie: 8
   },
   lg: {
     label: "DND5E.SizeLarge",
     abbreviation: "DND5E.SizeLargeAbbr",
+    hitDie: 10,
     token: 2,
     capacityMultiplier: 2
   },
   huge: {
     label: "DND5E.SizeHuge",
     abbreviation: "DND5E.SizeHugeAbbr",
+    hitDie: 12,
     token: 3,
     capacityMultiplier: 4
   },
   grg: {
     label: "DND5E.SizeGargantuan",
     abbreviation: "DND5E.SizeGargantuanAbbr",
+    hitDie: 20,
     token: 4,
     capacityMultiplier: 8
   }

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -8,6 +8,8 @@ import CreatureTemplate from "./templates/creature.mjs";
 import DetailsFields from "./templates/details.mjs";
 import TraitsFields from "./templates/traits.mjs";
 
+const { BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
+
 /**
  * System data definition for NPCs.
  *
@@ -16,6 +18,8 @@ import TraitsFields from "./templates/traits.mjs";
  * @property {number} attributes.ac.flat         Flat value used for flat or natural armor calculation.
  * @property {string} attributes.ac.calc         Name of one of the built-in formulas to use.
  * @property {string} attributes.ac.formula      Custom formula to use.
+ * @property {object} attributes.hd
+ * @property {number} attributes.hd.spent        Number of hit dice spent.
  * @property {object} attributes.hp
  * @property {number} attributes.hp.value        Current hit points.
  * @property {number} attributes.hp.max          Maximum allowed HP value.
@@ -63,72 +67,75 @@ export default class NPCData extends CreatureTemplate {
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      attributes: new foundry.data.fields.SchemaField({
+      attributes: new SchemaField({
         ...AttributesFields.common,
         ...AttributesFields.creature,
-        ac: new foundry.data.fields.SchemaField({
-          flat: new foundry.data.fields.NumberField({integer: true, min: 0, label: "DND5E.ArmorClassFlat"}),
-          calc: new foundry.data.fields.StringField({initial: "default", label: "DND5E.ArmorClassCalculation"}),
+        ac: new SchemaField({
+          flat: new NumberField({integer: true, min: 0, label: "DND5E.ArmorClassFlat"}),
+          calc: new StringField({initial: "default", label: "DND5E.ArmorClassCalculation"}),
           formula: new FormulaField({deterministic: true, label: "DND5E.ArmorClassFormula"})
         }, {label: "DND5E.ArmorClass"}),
-        hp: new foundry.data.fields.SchemaField({
-          value: new foundry.data.fields.NumberField({
+        hd: new SchemaField({
+          spent: new NumberField({integer: true, min: 0, initial: 0})
+        }, {label: "DND5E.HitDice"}),
+        hp: new SchemaField({
+          value: new NumberField({
             nullable: false, integer: true, min: 0, initial: 10, label: "DND5E.HitPointsCurrent"
           }),
-          max: new foundry.data.fields.NumberField({
+          max: new NumberField({
             nullable: false, integer: true, min: 0, initial: 10, label: "DND5E.HitPointsMax"
           }),
-          temp: new foundry.data.fields.NumberField({integer: true, initial: 0, min: 0, label: "DND5E.HitPointsTemp"}),
-          tempmax: new foundry.data.fields.NumberField({integer: true, initial: 0, label: "DND5E.HitPointsTempMax"}),
+          temp: new NumberField({integer: true, initial: 0, min: 0, label: "DND5E.HitPointsTemp"}),
+          tempmax: new NumberField({integer: true, initial: 0, label: "DND5E.HitPointsTempMax"}),
           formula: new FormulaField({required: true, label: "DND5E.HPFormula"})
         }, {label: "DND5E.HitPoints"}),
         death: new RollConfigField({
-          success: new foundry.data.fields.NumberField({
+          success: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveSuccesses"
           }),
-          failure: new foundry.data.fields.NumberField({
+          failure: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveFailures"
           })
         }, {label: "DND5E.DeathSave"})
       }, {label: "DND5E.Attributes"}),
-      details: new foundry.data.fields.SchemaField({
+      details: new SchemaField({
         ...DetailsFields.common,
         ...DetailsFields.creature,
         type: new CreatureTypeField(),
-        environment: new foundry.data.fields.StringField({required: true, label: "DND5E.Environment"}),
-        cr: new foundry.data.fields.NumberField({
+        environment: new StringField({required: true, label: "DND5E.Environment"}),
+        cr: new NumberField({
           required: true, nullable: false, min: 0, initial: 1, label: "DND5E.ChallengeRating"
         }),
-        spellLevel: new foundry.data.fields.NumberField({
+        spellLevel: new NumberField({
           required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.SpellcasterLevel"
         }),
         source: new SourceField()
       }, {label: "DND5E.Details"}),
-      resources: new foundry.data.fields.SchemaField({
-        legact: new foundry.data.fields.SchemaField({
-          value: new foundry.data.fields.NumberField({
+      resources: new SchemaField({
+        legact: new SchemaField({
+          value: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.LegActRemaining"
           }),
-          max: new foundry.data.fields.NumberField({
+          max: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.LegActMax"
           })
         }, {label: "DND5E.LegAct"}),
-        legres: new foundry.data.fields.SchemaField({
-          value: new foundry.data.fields.NumberField({
+        legres: new SchemaField({
+          value: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.LegResRemaining"
           }),
-          max: new foundry.data.fields.NumberField({
+          max: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.LegResMax"
           })
         }, {label: "DND5E.LegRes"}),
-        lair: new foundry.data.fields.SchemaField({
-          value: new foundry.data.fields.BooleanField({required: true, label: "DND5E.LairAct"}),
-          initiative: new foundry.data.fields.NumberField({
+        lair: new SchemaField({
+          value: new BooleanField({required: true, label: "DND5E.LairAct"}),
+          initiative: new NumberField({
             required: true, integer: true, label: "DND5E.LairActionInitiative"
           })
         }, {label: "DND5E.LairActionLabel"})
       }, {label: "DND5E.Resources"}),
-      traits: new foundry.data.fields.SchemaField({
+      traits: new SchemaField({
         ...TraitsFields.common,
         ...TraitsFields.creature
       }, {label: "DND5E.Traits"})
@@ -219,11 +226,17 @@ export default class NPCData extends CreatureTemplate {
   prepareBaseData() {
     this.details.level = 0;
 
+    // Determine hit dice denomination & max from hit points formula
+    const [, max, denomination] = this.attributes.hp.formula?.match(/(\d*)d(\d+)/i) ?? [];
+    this.attributes.hd.max = Number(max ?? 1);
+    this.attributes.hd.denomination = Number(denomination ?? CONFIG.DND5E.actorSizes[this.traits.size]?.hitDie ?? 4);
+
     for ( const item of this.parent.items ) {
       // Class levels & hit dice
       if ( item.type === "class" ) {
         const classLevels = parseInt(item.system.levels) ?? 1;
         this.details.level += classLevels;
+        this.attributes.hd.max += classLevels;
       }
 
       // Attuned items
@@ -271,6 +284,9 @@ export default class NPCData extends CreatureTemplate {
     AttributesFields.prepareMovement.call(this);
     AttributesFields.prepareConcentration.call(this, rollData);
     TraitsFields.prepareResistImmune.call(this);
+
+    // Hit Dice
+    this.attributes.hd.value = Math.max(0, this.attributes.hd.max - this.attributes.hd.spent);
 
     // Hit Points
     const hpOptions = {

--- a/module/documents/advancement/hit-points.mjs
+++ b/module/documents/advancement/hit-points.mjs
@@ -41,6 +41,7 @@ export default class HitPointsAdvancement extends Advancement {
    * @returns {string}
    */
   get hitDie() {
+    if ( this.actor?.type === "npc" ) return `d${this.actor.system.attributes.hd.denomination}`;
     return this.item.system.hitDice;
   }
 


### PR DESCRIPTION
Calculates the hit dice max and denomination based on a NPC's HP formula with a fallback based on their size if necessary. On NPCs `HitPointAdvancement` will now determine the die size based on the NPC's hit die denomination rather than what is specified in the class.

Adjust the `Actor#rollHitDie` method to be able to handle rolling hit dice on NPCs and the resting methods to be able to properly recover NPC hit dice.

Closes #3353
Closes #3361 
Closes #3362