### PR TITLE
[#3320, #3321] Add configuration dialog for spell scroll creation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1212,8 +1212,15 @@
 "DND5E.SaveBonus": "Saving Throw Bonus",
 "DND5E.SaveGlobalBonusHint": "This bonus applies to all saving throws made by this actor.",
 "DND5E.Scroll": {
+  "CreateFrom": "Create Scroll from {spell}",
   "CreateScroll": "Create Scroll",
   "Details": "Scroll Details",
+  "Explanation": {
+    "Label": "Explanation",
+    "Hint": "Amount of the rules on using spell scrolls to include in the created scroll.",
+    "Complete": "Complete",
+    "Reference": "Reference"
+  },
   "RequiresConcentration": "Requires Concentration"
 },
 "DND5E.Senses": "Senses",

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -985,7 +985,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
     if ( (itemData.type === "spell")
       && (this._tabs[0].active === "inventory" || this.actor.type === "vehicle") ) {
       const scroll = await Item5e.createScrollFromSpell(itemData);
-      return scroll.toObject();
+      return scroll?.toObject?.();
     }
 
     // Clean up data

--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -410,7 +410,7 @@ export default class GroupActorSheet extends ActorSheetMixin(ActorSheet) {
     // Create a Consumable spell scroll on the Inventory tab
     if ( itemData.type === "spell" ) {
       const scroll = await Item5e.createScrollFromSpell(itemData);
-      return scroll.toObject();
+      return scroll?.toObject?.();
     }
 
     // Stack identical consumables

--- a/module/data/user/user-system-flags.mjs
+++ b/module/data/user/user-system-flags.mjs
@@ -20,6 +20,8 @@ const { BooleanField, ForeignDocumentField, NumberField, SchemaField, SetField, 
  * A custom model to validate system flags on User Documents.
  *
  * @property {Set<string>} awardDestinations                  Saved targets from previous use of /award command.
+ * @property {object} creation
+ * @property {string} creation.scrollExplanation              Default explanation mode for spell scrolls.
  * @property {Record<string, SheetPreferences5e>} sheetPrefs  The User's sheet preferences.
  */
 export default class UserSystemFlags extends foundry.abstract.DataModel {
@@ -29,6 +31,9 @@ export default class UserSystemFlags extends foundry.abstract.DataModel {
       awardDestinations: new SetField(
         new ForeignDocumentField(foundry.documents.BaseActor, { idOnly: true }), { required: false }
       ),
+      creation: new SchemaField({
+        scrollExplanation: new StringField({initial: "reference"})
+      }),
       sheetPrefs: new MappingField(new SchemaField({
         width: new NumberField({ integer: true, positive: true }),
         height: new NumberField({ integer: true, positive: true }),

--- a/templates/apps/spell-scroll-dialog.hbs
+++ b/templates/apps/spell-scroll-dialog.hbs
@@ -1,0 +1,29 @@
+<form>
+    <div class="form-group">
+        <label>{{ localize "TYPES.Item.spell" }}</label>
+        <div class="form-fields">
+            {{{ anchor }}}
+        </div>
+    </div>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Scroll.Explanation.Label" }}</label>
+        <div class="form-fields">
+            <select name="explanation">
+                {{#select explanation}}
+                <option value="full">{{ localize "DND5E.Scroll.Explanation.Complete" }}</option>
+                <option value="reference">{{ localize "DND5E.Scroll.Explanation.Reference" }}</option>
+                <option value="none">{{ localize "DND5E.None" }}</option>
+                {{/select}}
+            </select>
+        </div>
+        <p class="hint">{{ localize "DND5E.Scroll.Explanation.Hint" }}</p>
+    </div>
+    <div class="form-group">
+        <label>{{ localize "DND5E.SpellLevel" }}</label>
+        <div class="form-fields">
+            <select name="level" data-dtype="Number">
+                {{ selectOptions spellLevels selected=level name="level" }}
+            </select>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
Creating spell scrolls will now display a dialog with options for how much explanation & the level of the created scroll:

<img width="412" alt="Spell Scroll Prompt" src="https://github.com/foundryvtt/dnd5e/assets/19979839/953eebdd-6979-4c71-b1c1-2e5ff8f1232a">

Saves the explanation setting in user preferences so it doesn't have to be set every time.