### PR TITLE
[#1833] Add level prerequisite to feature items used by item choice

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1144,7 +1144,7 @@
     "prerequisites": {
       "level": {
         "label": "Required Level",
-        "hint": "Character or class level required to select this feature as part of a choice advancement."
+        "hint": "Character or class level required to select this feature when levelling up."
       }
     }
   }

--- a/lang/en.json
+++ b/lang/en.json
@@ -196,6 +196,7 @@
 "DND5E.AdvancementItemChoiceTitle": "Choose Items",
 "DND5E.AdvancementItemChoiceHint": "Present the player with a choice of items (such as equipment, features, or spells) that they can choose for their character at one or more levels.",
 "DND5E.AdvancementItemChoiceChosen": "Chosen: {current} of {max}",
+"DND5E.AdvancementItemChoiceFeatureLevelWarning": "Must be at least level {level} to take this feature.",
 "DND5E.AdvancementItemChoiceLevelsHint": "Specify how many choices are allowed at each level.",
 "DND5E.AdvancementItemChoicePreviouslyChosenWarning": "This item has already been chosen at a previous level.",
 "DND5E.AdvancementItemChoiceSpellLevelAvailable": "Any Available Level",
@@ -1137,6 +1138,17 @@
 "DND5E.PolymorphWildShape": "Wild Shape",
 "DND5E.Portrait": "Portrait",
 "DND5E.Prepared": "Prepared",
+"DND5E.Prerequisites": {
+  "Header": "Feature Prerequisites",
+  "FIELDS": {
+    "prerequisites": {
+      "level": {
+        "label": "Required Level",
+        "hint": "Character or class level required to select this feature as part of a choice advancement."
+      }
+    }
+  }
+},
 "DND5E.Price": "Price",
 "DND5E.Proficiency": "Proficiency",
 "DND5E.ProficiencyBonus": "Proficiency Bonus",

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -69,7 +69,8 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
       if ( i ) {
         i.checked = this.selected.has(i.uuid);
         i.disabled = !i.checked && choices.full;
-        if ( !previouslySelected.has(i.uuid) ) items.push(i);
+        const validLevel = (i.system.prerequisites.level ?? -Infinity) <= this.level;
+        if ( !previouslySelected.has(i.uuid) && validLevel ) items.push(i);
       }
       return items;
     }, []);
@@ -144,6 +145,14 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
         ui.notifications.error("DND5E.AdvancementItemChoicePreviouslyChosenWarning", {localize: true});
         return null;
       }
+    }
+
+    // If a feature has a level pre-requisite, make sure it is less than or equal to current level
+    if ( (item.system.prerequisites?.level ?? -Infinity) >= this.level ) {
+      ui.notifications.error(game.i18n.format("DND5E.AdvancementItemChoiceFeatureLevelWarning", {
+        level: item.system.prerequisites.level
+      }));
+      return null;
     }
 
     // If spell level is restricted to available level, ensure the spell is of the appropriate level

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -5,6 +5,8 @@ import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ItemTypeTemplate from "./templates/item-type.mjs";
 import ItemTypeField from "./fields/item-type-field.mjs";
 
+const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+
 /**
  * Data definition for Feature items.
  * @mixes ItemDescriptionTemplate
@@ -12,6 +14,8 @@ import ItemTypeField from "./fields/item-type-field.mjs";
  * @mixes ActivatedEffectTemplate
  * @mixes ActionTemplate
  *
+ * @property {object} prerequisites
+ * @property {number} prerequisites.level           Character or class level required to choose this feature.
  * @property {Set<string>} properties               General properties of a feature item.
  * @property {string} requirements                  Actor details required to use this feature.
  * @property {object} recharge                      Details on how a feature can roll for recharges.
@@ -21,19 +25,26 @@ import ItemTypeField from "./fields/item-type-field.mjs";
 export default class FeatData extends ItemDataModel.mixin(
   ItemDescriptionTemplate, ItemTypeTemplate, ActivatedEffectTemplate, ActionTemplate
 ) {
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.Prerequisites"];
+
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
       type: new ItemTypeField({baseItem: false}, {label: "DND5E.ItemFeatureType"}),
-      properties: new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {
+      prerequisites: new SchemaField({
+        level: new NumberField({integer: true, min: 0})
+      }),
+      properties: new SetField(new StringField(), {
         label: "DND5E.ItemFeatureProperties"
       }),
-      requirements: new foundry.data.fields.StringField({required: true, nullable: true, label: "DND5E.Requirements"}),
-      recharge: new foundry.data.fields.SchemaField({
-        value: new foundry.data.fields.NumberField({
+      requirements: new StringField({required: true, nullable: true, label: "DND5E.Requirements"}),
+      recharge: new SchemaField({
+        value: new NumberField({
           required: true, integer: true, min: 1, label: "DND5E.FeatureRechargeOn"
         }),
-        charged: new foundry.data.fields.BooleanField({required: true, label: "DND5E.Charged"})
+        charged: new BooleanField({required: true, label: "DND5E.Charged"})
       }, {label: "DND5E.FeatureActionRecharge"})
     });
   }

--- a/templates/items/feat.hbs
+++ b/templates/items/feat.hbs
@@ -39,28 +39,28 @@
     <section class="sheet-body">
 
         {{!-- Description Tab --}}
-        {{> "dnd5e.item-description"}}
+        {{> "dnd5e.item-description" }}
 
         {{!-- Details Tab --}}
         <div class="tab details" data-group="primary" data-tab="details">
-            <h3 class="form-header">{{localize "DND5E.ItemFeatureDetails"}}</h3>
+            <h3 class="form-header">{{ localize "DND5E.ItemFeatureDetails" }}</h3>
 
             {{!-- Feature Type --}}
             <div class="form-group">
-                <label>{{localize "DND5E.ItemFeatureType"}}</label>
+                <label>{{ localize "DND5E.ItemFeatureType" }}</label>
                 <select name="system.type.value">
-                    {{selectOptions config.featureTypes selected=system.type.value blank="" labelAttr="label"}}
+                    {{ selectOptions config.featureTypes selected=system.type.value blank="" labelAttr="label" }}
                 </select>
             </div>
 
             {{#if itemSubtypes}}
             <div class="form-group">
                 <label>
-                    {{localize "DND5E.ItemFeatureSubtype"
-                               category=(lookup (lookup config.featureTypes system.type.value) "label")}}
+                    {{ localize "DND5E.ItemFeatureSubtype"
+                                category=(lookup (lookup config.featureTypes system.type.value) "label") }}
                 </label>
                 <select name="system.type.subtype">
-                    {{selectOptions itemSubtypes selected=system.type.subtype blank=""}}
+                    {{ selectOptions itemSubtypes selected=system.type.subtype blank="" }}
                 </select>
             </div>
             {{/if}}
@@ -70,9 +70,17 @@
                 <label>{{ localize "DND5E.ItemFeatureProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{@key}}" {{checked selected}}> {{ label }}
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }}> {{ label }}
                 </label>
                 {{/each}}
+            </div>
+
+            <h3 class="form-header">{{ localize "DND5E.Prerequisites.Header" }}</h3>
+
+            <div class="form-group">
+                <label>{{ localize "DND5E.Prerequisites.FIELDS.prerequisites.level.label" }}</label>
+                {{ numberInput system.prerequisites.level name="system.prerequisites.level" step=1 }}
+                <p class="hint">{{ localize "DND5E.Prerequisites.FIELDS.prerequisites.level.hint" }}</p>
             </div>
 
             <h3 class="form-header">{{ localize "DND5E.FeatureUsage" }}</h3>


### PR DESCRIPTION
Adds a new `prerequisites.level` field to feature items which indicates which class or character level at which the item can be taken.

This data is then used by `ItemChoiceAdvancement` to only display or support drops from features if their meet the level requirement.

Closes #1833