### PR TITLE
[#1833] Check level restriction for feats in ASIAdvancement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -152,6 +152,7 @@
 "DND5E.AdvancementAbilityScoreImprovementCapDisplay.one": "Max {points} point per score",
 "DND5E.AdvancementAbilityScoreImprovementCapDisplay.other": "Max {points} points per score",
 "DND5E.AdvancementAbilityScoreImprovementFeatHint": "Drop a feat here to choose one instead of an ability score improvement.",
+"DND5E.AdvancementAbilityScoreImprovementFeatLevelWarning": "Must be at least level {level} to take this feat.",
 "DND5E.AdvancementAbilityScoreImprovementFeatWarning": "Only features with the 'feat' type can be selected.",
 "DND5E.AdvancementAbilityScoreImprovementFixed": "Fixed Improvement",
 "DND5E.AdvancementAbilityScoreImprovementLockedHint": "Scores cannot be modified with a feat selected.",

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -203,6 +203,14 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
       return null;
     }
 
+    // If a feat has a level pre-requisite, make sure it is less than or equal to current character level
+    if ( (item.system.prerequisites?.level ?? -Infinity) >= this.advancement.actor.system.details.level ) {
+      ui.notifications.error(game.i18n.format("DND5E.AdvancementAbilityScoreImprovementFeatLevelWarning", {
+        level: item.system.prerequisites.level
+      }));
+      return null;
+    }
+
     this.feat = item;
     this.render();
   }

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -204,7 +204,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
     }
 
     // If a feat has a level pre-requisite, make sure it is less than or equal to current character level
-    if ( (item.system.prerequisites?.level ?? -Infinity) >= this.advancement.actor.system.details.level ) {
+    if ( (item.system.prerequisites?.level ?? -Infinity) > this.advancement.actor.system.details.level ) {
       ui.notifications.error(game.i18n.format("DND5E.AdvancementAbilityScoreImprovementFeatLevelWarning", {
         level: item.system.prerequisites.level
       }));

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -148,7 +148,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     }
 
     // If a feature has a level pre-requisite, make sure it is less than or equal to current level
-    if ( (item.system.prerequisites?.level ?? -Infinity) >= this.level ) {
+    if ( (item.system.prerequisites?.level ?? -Infinity) > this.level ) {
       ui.notifications.error(game.i18n.format("DND5E.AdvancementItemChoiceFeatureLevelWarning", {
         level: item.system.prerequisites.level
       }));


### PR DESCRIPTION
Uses the new level prerequisite data on feature items when adding a feat using the `AbilityScoreImprovementAdvancement`. This uses the overall character level rather than the specific class level.