### PR TITLE
Wiki updates for 3.2.x

### DIFF
--- a/wiki/Modifying-Your-Game-with-Scripts.md
+++ b/wiki/Modifying-Your-Game-with-Scripts.md
@@ -7,17 +7,17 @@ Scripts can be added to your World manifest, or the manifest of a Module, such a
 >[!NOTE]
 >These world scripts are written to modify the base dnd5e system only, and may need other considerations to integrate with any modules you may be using.
 
-In order to use a script you must:  
-- have a Javascript file you want to add to your world or module, and   
+In order to use a script you must:
+- have a Javascript file you want to add to your world or module, and
 - edit the world or module's manifest to point to your Javascript code.
 
-Your Javascript file will usually live within the directory for the world or module in which it is used, but in reality, it could live anywhere in your Foundry userdata folder (see [Where Is My Data Stored?](https://foundryvtt.com/article/configuration/#where-user-data) on the Foundry KB for more information).  
+Your Javascript file will usually live within the directory for the world or module in which it is used, but in reality, it could live anywhere in your Foundry userdata folder (see [Where Is My Data Stored?](https://foundryvtt.com/article/configuration/#where-user-data) on the Foundry KB for more information).
 
-This guide assumes that your Javascript is in the root of the world's directory (i.e. `Data/worlds/my-world/my-script.js`), and will be adding the script to your World.  
+This guide assumes that your Javascript is in the root of the world's directory (i.e. `Data/worlds/my-world/my-script.js`), and will be adding the script to your World.
 If you would instead like to add the script to a module, you can follow the guide below, replacing any use of "world" with "module", assuming your Javascript is in the root folder of the module's directory (i.e. `Data/modules/my-module/my-script.js`).
 
 # Adding a script to your manifest
-To include your Javascript file in your world, first, shut down the World in Foundry, then:
+To include your Javascript file in your world, first, shut down Foundry completely, then:
 
 1. Navigate to your world's directory in your user data folder.
 2. Open world.json in a text editor (Visual Studio Code is a good choice, but almost any editor will do).
@@ -35,13 +35,13 @@ To include your Javascript file in your world, first, shut down the World in Fou
 
 
 # Examples
-Scripts rely on Hooks to automatically execute, see [Hooks](Hooks.md) for system specific Hooks that you can use, or the [Foundry API](https://foundryvtt.com/api/modules/hookEvents.html) for Hooks provided by the Core Foundry Software.  
-The examples below modify different aspects of the dnd5e system's configuration, to explore the configuration to see what you can modify, open the Console with F12 and type in `CONFIG.DND5E` then hit Enter.  
-Need Help? Feel free to jump in the Foundry VTT discord's [#dnd5e](https://discord.com/channels/170995199584108546/670336046164213761) or [#macro-polo](https://discord.com/channels/170995199584108546/699750150674972743) channels for assistance from the community. 
+Scripts rely on Hooks to automatically execute, see [Hooks](Hooks.md) for system specific Hooks that you can use, or the [Foundry API](https://foundryvtt.com/api/modules/hookEvents.html) for Hooks provided by the Core Foundry Software.
+The examples below modify different aspects of the dnd5e system's configuration, to explore the configuration to see what you can modify, open the Console with F12 and type in `CONFIG.DND5E` then hit Enter.
+Need Help? Feel free to jump in the Foundry VTT discord's [#dnd5e](https://discord.com/channels/170995199584108546/670336046164213761) or [#macro-polo](https://discord.com/channels/170995199584108546/699750150674972743) channels for assistance from the community.
 
 ## Add a new Ability
 ```js
-/// Add a new Ability
+// Add a new Ability
 Hooks.once("init", () => {
   CONFIG.DND5E.abilities.grt = {
     label: "Grit",
@@ -57,9 +57,9 @@ Hooks.once("init", () => {
 
 ## Add a new Skill
 ```js
-/// Add a new Skill
+// Add a new Skill
 Hooks.once("init", () => {
-  CONFIG.DND5E.skills.bfp = {
+  CONFIG.DND5E.skills.backflip = {
     label: "Backflip",
     ability: "dex",
     fullKey: "backflip", // Full key used in enrichers
@@ -71,7 +71,7 @@ Hooks.once("init", () => {
 
 ## Add a new Damage Type
 ```js
-/// Adds a new "plasma" damage type that will be selectable as a new type of damage for weapons and a new type of resistance for actors.
+// Adds a new "plasma" damage type that will be selectable as a new type of damage for weapons and a new type of resistance for actors.
 Hooks.once("init", () => {
   CONFIG.DND5E.damageTypes.plasma = {
     label: "Plasma",
@@ -82,7 +82,7 @@ Hooks.once("init", () => {
 
 ## Add a new Weapon Property
 ```js
-/// Adds a new "Laser" Weapon Property and Physical Property for resistance bypass
+// Adds a new "Laser" Weapon Property and Physical Property for resistance bypass
 Hooks.once("init", () => {
   CONFIG.DND5E.itemProperties.laser = {
     label: "Laser",
@@ -94,17 +94,17 @@ Hooks.once("init", () => {
 
 ## Remove a Weapon Property
 ```js
-/// Removes the Firearm Weapon Property
+// Removes the Firearm Weapon Property
 Hooks.once("init", () => {
   CONFIG.DND5E.validProperties.weapon.delete("fir");
 });
 ```
 
-## Add a new Spell School  
+## Add a new Spell School
 ```js
-/// Add a new Spell School that can be selected in Spell Items
+// Add a new Spell School that can be selected in Spell Items
 Hooks.once("init", () => {
-  CONFIG.DND5E.spellSchools.psi = {
+  CONFIG.DND5E.spellSchools.psionics = {
     label: "Psionics",
     icon: "…",
     fullKey: "psionics", // Full key used in enrichers
@@ -115,7 +115,7 @@ Hooks.once("init", () => {
 
 ## Add a new Class Feature Type
 ```js
-/// Adds a new "Blood Curse" class feature type
+// Adds a new "Blood Curse" class feature type
 Hooks.once("init", () => {
   CONFIG.DND5E.featureTypes.class.subtypes.bloodCurse = "Blood Curse";
 });
@@ -123,7 +123,7 @@ Hooks.once("init", () => {
 
 ## Add new Feature Item Type and Subtypes
 ```js
-/// Adds in a new feature type, similar to "Class Feature" called "Martial Exploit", with 3 different subtypes for it.
+// Adds in a new feature type, similar to "Class Feature" called "Martial Exploit", with 3 different subtypes for it.
 Hooks.once("init", () => {
   CONFIG.DND5E.featureTypes.marexploit = {
     label: "Martial Exploit",
@@ -138,7 +138,7 @@ Hooks.once("init", () => {
 
 ## Add a new Armor Calculation
 ```js
-/// Add a new AC Calculation
+// Add a new AC Calculation
 Hooks.once("init", () => {
   CONFIG.DND5E.armorClasses.fortitude = {
     label: "Fortitude",
@@ -149,57 +149,57 @@ Hooks.once("init", () => {
 
 ## Change the Max Level Cap
 ```js
-/// Increases the Maximum Level for a Player Actor to 30
+// Increases the Maximum Level for a Player Actor to 30
 Hooks.once("init", () => {
   CONFIG.DND5E.maxLevel = 30;
 });
 ```
 
-## Modify Languages 
-### Add a language  
+## Modify Languages
+### Add a language
 The "Cool Speech" language will be available at the top level (with Druidic and Thieves' Cant), "Super Common" will appear under the Standard category, and "Uncommon" will appear under the Exotic category.
 ```js
 Hooks.once("init", () => {
-    CONFIG.DND5E.languages.coolspeech = "Cool Speech";
-    CONFIG.DND5E.languages.standard.children.supercommon = "Super Common";
-    CONFIG.DND5E.languages.exotic.children.uncommon = "Uncommon";
+  CONFIG.DND5E.languages.coolspeech = "Cool Speech";
+  CONFIG.DND5E.languages.standard.children.supercommon = "Super Common";
+  CONFIG.DND5E.languages.exotic.children.uncommon = "Uncommon";
 });
 ```
 
-### Add languages with children to the Standard or Exotic language families  
-"Gibberish" will be a subfamily of the Standard language family with child languages "High Gibberish" and "Gibberish", and "Nonsense" will be a subfamily of the Exotic language family with child languages "Old Nonsense" and "New Nonsense".  
+### Add languages with children to the Standard or Exotic language families
+"Gibberish" will be a subfamily of the Standard language family with child languages "High Gibberish" and "Gibberish", and "Nonsense" will be a subfamily of the Exotic language family with child languages "Old Nonsense" and "New Nonsense".
 ```js
-Hooks.once("setup", () => {
-    CONFIG.DND5E.languages.standard.children.gibberish = {
-        label: "Gibberish",
-        children: {
-            gibberish: "Gibberish",
-            highgibberish: "High Gibberish"
-        }
-    },
-    CONFIG.DND5E.languages.exotic.children.nonsense = {
-        label: "Nonsense",
-        children: {
-            oldnonsense: "Old Nonsense",
-            newnonsense: "New Nonsense"
-        }
+Hooks.once("init", () => {
+  CONFIG.DND5E.languages.standard.children.gibberish = {
+    label: "Gibberish",
+    children: {
+      gibberish: "Gibberish",
+      highgibberish: "High Gibberish"
     }
+  };
+  CONFIG.DND5E.languages.exotic.children.nonsense = {
+    label: "Nonsense",
+    children: {
+      oldnonsense: "Old Nonsense",
+      newnonsense: "New Nonsense"
+    }
+  };
 });
 ```
 
 ### Delete languages
 ```js
 Hooks.once("init", () => {
-    delete CONFIG.DND5E.languages.druidic;
-    delete CONFIG.DND5E.languages.standard.children.dwarvish;
-    delete CONFIG.DND5E.languages.exotic.children.aarakocra;
-    delete CONFIG.DND5E.languages.exotic.children.primordial.children.aquan;
+  delete CONFIG.DND5E.languages.druidic;
+  delete CONFIG.DND5E.languages.standard.children.dwarvish;
+  delete CONFIG.DND5E.languages.exotic.children.aarakocra;
+  delete CONFIG.DND5E.languages.exotic.children.primordial.children.aquan;
 });
 ```
 
 ## Add new Item Activation Cost Types
 ```js
-/// Adds in options to display in the Activation Cost dropdown
+// Adds in options to display in the Activation Cost dropdown
 Hooks.once("init", () => {
   CONFIG.DND5E.abilityActivationTypes.crithit = "Critical Hit";
   CONFIG.DND5E.abilityActivationTypes.attack = "On Attack";
@@ -212,15 +212,13 @@ Hooks.once("init", () => {
 
 ## Add new Weapon Types
 You will need a compendium (a [shared compendium module](https://foundryvtt.com/article/module-maker/) works well for this) in which you store a base item, just like the system already has the 'Items SRD' compendium with all the different weapons.
-Then, for each item you want to add as a new 'base weapon', copy the uuid from the item's header - right-click the book icon. Do not left-click. 
-Note that the uuid should be tweaked slightly, it should not be the full uuid but instead of this form: `module-scope.compendium-id.item-id`  
-e.g the full UUID of the Shortsword is `Compendium.dnd5e.items.Item.osLzOwQdPtrK3rQH` but in the world script only `dnd5e.items.osLzOwQdPtrK3rQH` would be used.
+Then, for each item you want to add as a new 'base weapon', copy the uuid from the item's header - right-click the book icon. Do not left-click.
 
 ```js
-/// Adds new Weapon types of Hand Cannon and Magnum
+// Adds new Weapon types of Hand Cannon and Magnum
 Hooks.once("init", () => {
-  CONFIG.DND5E.weaponIds.handCannon = "module-scope.compendium-id.item-id";
-  CONFIG.DND5E.weaponIds.magnum = "module-scope.compendium-id.item-id";
+  CONFIG.DND5E.weaponIds.handCannon = "uuid";
+  CONFIG.DND5E.weaponIds.magnum = "uuid";
   // etc etc
 });
 
@@ -229,9 +227,9 @@ Hooks.once("init", () => {
 ## Add new Tool Proficiencies
 Similar to the Weapon Types above, an item in a compendium will need to be referenced to create a new Tool Proficiency
 ```js
-/// Adds new Tool Proficiency for Hacking Tools
+// Adds new Tool Proficiency for Hacking Tools
 Hooks.once("init", () => {
-  CONFIG.DND5E.toolIds.hacking = "module-scope.compendium-id.item-id";
+  CONFIG.DND5E.toolIds.hacking = "uuid";
 });
 ```
 

--- a/wiki/Roll-Formulas.md
+++ b/wiki/Roll-Formulas.md
@@ -1,4 +1,4 @@
-![Up to date as of 3.1.0](https://img.shields.io/static/v1?label=dnd5e&message=3.1.0&color=informational)
+![Up to date as of 3.2.0](https://img.shields.io/static/v1?label=dnd5e&message=3.2.0&color=informational)
 
 > <details><summary>To explore the data model within Foundry to find the properties detailed below, here are a few approaches:</summary>
 >
@@ -94,7 +94,21 @@
 
 #### Hit Dice
 
-`@attributes.hd` - The actor's current number of remaining hit dice.
+`@attributes.hd.value` - The actor's current number of remaining hit dice.
+
+`@attributes.hd.max` - The actor's total amount of hit dice.
+
+`@attributes.hd.largest` - The denomination of the actor's largest hit die (e.g. "d8").
+
+`@attributes.hd.smallest` - The denomination of the actor's smallest hit die (e.g. "d8").
+
+`@attributes.hd.largestFace` - The size of the actor's largest hit die (e.g. the "8" of "d8").
+
+`@attributes.hd.smallestFace` - The size of the actor's smallest hit die (e.g. the "8" of "d8").
+
+`@attributes.hd.bySize.[denom]` - How many remaining hit dice the actor has of the specific denomination, e.g., `@attributes.hd.bySize.d6` for the number of remaining d6 hit dice.
+
+`@attributes.hd.pct` - The percentage of remaining hit dice (current over maximum).
 
 #### Hit Points
 


### PR DESCRIPTION


- [x] Update Roll Data wiki for 3.2 (hit dice).
- [x] World script wiki should say to shut down foundry, not just the world.
- [x] Change language hook to 'init'.
- [x] The world script wiki no longer needs to instruct users to manicure the uuid.
- [x] Add note about the syntax for element removal from Sets.
- [x] Update with information on #3559.