### PR TITLE
[#3342] Set up SRD class feature consumption using UUIDs

### DIFF
--- a/packs/_source/classfeatures/bard/bard-features/superior-inspiration.json
+++ b/packs/_source/classfeatures/bard/bard-features/superior-inspiration.json
@@ -17,9 +17,9 @@
       "license": "CC-BY-4.0"
     },
     "activation": {
-      "type": "",
+      "type": "special",
       "cost": null,
-      "condition": ""
+      "condition": "When you roll initiative and have no uses of Bardic Inspiration"
     },
     "duration": {
       "value": "",
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.hpLNiGq7y67d2EHA",
+      "amount": -1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234356,
-    "modifiedTime": 1704824715825,
+    "modifiedTime": 1712173377397,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!GBYN5rH4nh1ocRlY"

--- a/packs/_source/classfeatures/cleric/cleric-features/channel-divinity-turn-undead.json
+++ b/packs/_source/classfeatures/cleric/cleric-features/channel-divinity-turn-undead.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.YpiLQEKGalROn7iJ",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234428,
-    "modifiedTime": 1704824719088,
+    "modifiedTime": 1712173400630,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!r91UIgwFdHwkXdia"

--- a/packs/_source/classfeatures/cleric/life-domain-features/channel-divinity-preserve-life.json
+++ b/packs/_source/classfeatures/cleric/life-domain-features/channel-divinity-preserve-life.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.YpiLQEKGalROn7iJ",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -93,10 +93,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234408,
-    "modifiedTime": 1704824718140,
+    "modifiedTime": 1712173414310,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!hEymt45rICi4f9eL"

--- a/packs/_source/classfeatures/monk/monk-features/deflect-missiles.json
+++ b/packs/_source/classfeatures/monk/monk-features/deflect-missiles.json
@@ -7,7 +7,7 @@
   "type": "feat",
   "system": {
     "description": {
-      "value": "<p>Starting at 3rd level, you can use your reaction to deflect or catch the missile when you are hit by a ranged weapon attack. When you do so, the damage you take from the attack is reduced by 1d10 + your Dexterity modifier + your monk level.</p><p>If you reduce the damage to 0, you can catch the missile if it is small enough for you to hold in one hand and you have at least one hand free. If you catch a missile in this way, you can spend 1 @UUID[Compendium.dnd5e.classfeatures.Item.10b6z2W1txNkrGP7]{Ki} point to make a ranged attack with the weapon or piece of ammunition you just caught, as part of the same reaction. You make this attack with proficiency, regardless of your weapon proficiencies, and the missile counts as a monk weapon for the attack, which has a normal range of 20 feet and a long range of 60 feet.</p><section class=\"secret foundry-note\" id=\"secret-ilfImwMJMJ8c9dEF\"><p><strong>Foundry Note</strong></p><p>The reduce damage roll is calculated by the Other Formula.</p></section>",
+      "value": "<p>Starting at 3rd level, you can use your reaction to deflect or catch the missile when you are hit by a ranged weapon attack. When you do so, the damage you take from the attack is reduced by [[/r 1d10 + @abilities.dex.mod + @classes.monk.levels]]{1d10 + your Dexterity modifier + your monk level}.</p><p>If you reduce the damage to 0, you can catch the missile if it is small enough for you to hold in one hand and you have at least one hand free. If you catch a missile in this way, you can spend 1 @UUID[Compendium.dnd5e.classfeatures.Item.10b6z2W1txNkrGP7]{Ki} point to make a ranged attack with the weapon or piece of ammunition you just caught, as part of the same reaction. You make this attack with proficiency, regardless of your weapon proficiencies, and the missile counts as a monk weapon for the attack, which has a normal range of 20 feet and a long range of 60 feet.</p>",
       "chat": ""
     },
     "source": {
@@ -19,7 +19,7 @@
     "activation": {
       "type": "reaction",
       "cost": 1,
-      "condition": "Can be thrown back using 1 ki point"
+      "condition": ""
     },
     "duration": {
       "value": "",
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.10b6z2W1txNkrGP7",
+      "amount": 1,
       "scale": false
     },
     "ability": "dex",
@@ -68,7 +68,7 @@
       ],
       "versatile": ""
     },
-    "formula": "1d10 + @mod + @classes.monk.levels",
+    "formula": "",
     "save": {
       "ability": "",
       "dc": null,
@@ -76,7 +76,7 @@
     },
     "type": {
       "value": "class",
-      "subtype": ""
+      "subtype": "ki"
     },
     "requirements": "Monk 3",
     "recharge": {
@@ -93,10 +93,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234421,
-    "modifiedTime": 1704824718710,
+    "modifiedTime": 1712173646267,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!mzweVbnsJPQiVkAe"

--- a/packs/_source/classfeatures/monk/monk-features/diamond-soul.json
+++ b/packs/_source/classfeatures/monk/monk-features/diamond-soul.json
@@ -17,9 +17,9 @@
       "license": "CC-BY-4.0"
     },
     "activation": {
-      "type": "",
+      "type": "none",
       "cost": null,
-      "condition": ""
+      "condition": "Whenever you make a saving throw and fail"
     },
     "duration": {
       "value": "",
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.10b6z2W1txNkrGP7",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -119,10 +119,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234336,
-    "modifiedTime": 1704824714963,
+    "modifiedTime": 1712173494587,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!7D2EkLdISwShEDlN"

--- a/packs/_source/classfeatures/monk/monk-features/flurry-of-blows.json
+++ b/packs/_source/classfeatures/monk/monk-features/flurry-of-blows.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.10b6z2W1txNkrGP7",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234331,
-    "modifiedTime": 1704824714725,
+    "modifiedTime": 1712173509095,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!5MwNlVZK7m6VolOH"

--- a/packs/_source/classfeatures/monk/monk-features/patient-defense.json
+++ b/packs/_source/classfeatures/monk/monk-features/patient-defense.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.10b6z2W1txNkrGP7",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234380,
-    "modifiedTime": 1704824716879,
+    "modifiedTime": 1712173520209,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!TDglPcxIVEzvVSgK"

--- a/packs/_source/classfeatures/monk/monk-features/step-of-the-wind.json
+++ b/packs/_source/classfeatures/monk/monk-features/step-of-the-wind.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.10b6z2W1txNkrGP7",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234443,
-    "modifiedTime": 1704824719918,
+    "modifiedTime": 1712173528595,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!yrSFIGTaQOH2PFRI"

--- a/packs/_source/classfeatures/monk/monk-features/stunning-strike.json
+++ b/packs/_source/classfeatures/monk/monk-features/stunning-strike.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.10b6z2W1txNkrGP7",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -113,10 +113,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234427,
-    "modifiedTime": 1706153505443,
+    "modifiedTime": 1712173537477,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!pvRc6GAu1ok6zihC"

--- a/packs/_source/classfeatures/monk/way-of-the-open-hand-features/quivering-palm.json
+++ b/packs/_source/classfeatures/monk/way-of-the-open-hand-features/quivering-palm.json
@@ -1,6 +1,6 @@
 {
   "_id": "h1gM8SH3BNRtFevE",
-  "name": "Ki: Quivering Palm",
+  "name": "Quivering Palm",
   "ownership": {
     "default": 0
   },
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.10b6z2W1txNkrGP7",
+      "amount": 3,
       "scale": false
     },
     "ability": "",
@@ -93,10 +93,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234407,
-    "modifiedTime": 1704824718109,
+    "modifiedTime": 1712173665151,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!h1gM8SH3BNRtFevE"

--- a/packs/_source/classfeatures/paladin/oath-of-devotion-features/channel-divinity-sacred-weapon.json
+++ b/packs/_source/classfeatures/paladin/oath-of-devotion-features/channel-divinity-sacred-weapon.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.8M7uOPhbTxoxxJSo",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234441,
-    "modifiedTime": 1704824719806,
+    "modifiedTime": 1712173711431,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!xNN0JMKqlG4hKVYu"

--- a/packs/_source/classfeatures/paladin/oath-of-devotion-features/channel-divinity-turn-the-unholy.json
+++ b/packs/_source/classfeatures/paladin/oath-of-devotion-features/channel-divinity-turn-the-unholy.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.8M7uOPhbTxoxxJSo",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234389,
-    "modifiedTime": 1704824717378,
+    "modifiedTime": 1712173705464,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ZdwGlsJNtc7pGFCd"

--- a/packs/_source/classfeatures/ranger/hunter-features/volley.json
+++ b/packs/_source/classfeatures/ranger/hunter-features/volley.json
@@ -1,6 +1,6 @@
 {
   "_id": "l7W6JB9yWLLLtQKP",
-  "name": "Multiattack: Volley",
+  "name": "Volley",
   "ownership": {
     "default": 0
   },
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234416,
-    "modifiedTime": 1704824718513,
+    "modifiedTime": 1712173733428,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!l7W6JB9yWLLLtQKP"

--- a/packs/_source/classfeatures/sorcerer/metamagic/careful-spell.json
+++ b/packs/_source/classfeatures/sorcerer/metamagic/careful-spell.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.LBKChJY5n02Afhnq",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234445,
-    "modifiedTime": 1704824720000,
+    "modifiedTime": 1712173798792,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!zElYrOcCFFMhB6Xl"

--- a/packs/_source/classfeatures/sorcerer/metamagic/distant-spell.json
+++ b/packs/_source/classfeatures/sorcerer/metamagic/distant-spell.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.LBKChJY5n02Afhnq",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234349,
-    "modifiedTime": 1704824715537,
+    "modifiedTime": 1712173805183,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!DZpAa3LzMNBexbmX"

--- a/packs/_source/classfeatures/sorcerer/metamagic/empowered-spell.json
+++ b/packs/_source/classfeatures/sorcerer/metamagic/empowered-spell.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.LBKChJY5n02Afhnq",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234358,
-    "modifiedTime": 1704824715971,
+    "modifiedTime": 1712173813354,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!IWpe0Y9uAStHGiH1"

--- a/packs/_source/classfeatures/sorcerer/metamagic/extended-spell.json
+++ b/packs/_source/classfeatures/sorcerer/metamagic/extended-spell.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.LBKChJY5n02Afhnq",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234434,
-    "modifiedTime": 1704824719374,
+    "modifiedTime": 1712173819972,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!tQxlKyAx9sgPrbgj"

--- a/packs/_source/classfeatures/sorcerer/metamagic/heightened-spell.json
+++ b/packs/_source/classfeatures/sorcerer/metamagic/heightened-spell.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.LBKChJY5n02Afhnq",
+      "amount": 3,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234433,
-    "modifiedTime": 1704824719353,
+    "modifiedTime": 1712173825806,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!tNG2qi9zhmXEkecA"

--- a/packs/_source/classfeatures/sorcerer/metamagic/quickened-spell.json
+++ b/packs/_source/classfeatures/sorcerer/metamagic/quickened-spell.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.LBKChJY5n02Afhnq",
+      "amount": 2,
       "scale": false
     },
     "ability": null,
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234422,
-    "modifiedTime": 1704824718793,
+    "modifiedTime": 1712173832045,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!nViGf6bZ6DQAJhkw"

--- a/packs/_source/classfeatures/sorcerer/metamagic/subtle-spell.json
+++ b/packs/_source/classfeatures/sorcerer/metamagic/subtle-spell.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.LBKChJY5n02Afhnq",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234403,
-    "modifiedTime": 1704824717922,
+    "modifiedTime": 1712173838167,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!fXa0DMhoVLtbBu9l"

--- a/packs/_source/classfeatures/sorcerer/metamagic/twinned-spell.json
+++ b/packs/_source/classfeatures/sorcerer/metamagic/twinned-spell.json
@@ -46,9 +46,9 @@
       "prompt": true
     },
     "consume": {
-      "type": "",
-      "target": null,
-      "amount": null,
+      "type": "charges",
+      "target": "Compendium.dnd5e.classfeatures.Item.LBKChJY5n02Afhnq",
+      "amount": 1,
       "scale": false
     },
     "ability": "",
@@ -88,10 +88,10 @@
   "sort": 0,
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234375,
-    "modifiedTime": 1704824716687,
+    "modifiedTime": 1712173849087,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!Qb391hakCfmH4w8p"

--- a/packs/_source/classfeatures/sorcerer/sorcerer-features/metamagic.json
+++ b/packs/_source/classfeatures/sorcerer/sorcerer-features/metamagic.json
@@ -7,7 +7,7 @@
   "type": "feat",
   "system": {
     "description": {
-      "value": "<p>At 3rd level, you gain the ability to twist your spells to suit your needs. You gain two of the following Metamagic options of your choice. You gain another one at 10th and 17th level. You can use only one Metamagic option on a spell when you cast it, unless otherwise noted.</p>\n<p>@UUID[Compendium.dnd5e.classfeatures.Item.zElYrOcCFFMhB6Xl]{Careful Spell}</p>\n<p>@UUID[Compendium.dnd5e.classfeatures.Item.DZpAa3LzMNBexbmX]{Distant Spell}</p>\n<p>@UUID[Compendium.dnd5e.classfeatures.Item.IWpe0Y9uAStHGiH1]{Empowered Spell}</p>\n<p>@UUID[Compendium.dnd5e.classfeatures.Item.tQxlKyAx9sgPrbgj]{Extended Spell}</p>\n<p>@UUID[Compendium.dnd5e.classfeatures.Item.tNG2qi9zhmXEkecA]{Heightened Spell}</p>\n<p>@UUID[Compendium.dnd5e.classfeatures.Item.nViGf6bZ6DQAJhkw]{Quickened Spell}</p>\n<p>@UUID[Compendium.dnd5e.classfeatures.Item.fXa0DMhoVLtbBu9l]{Subtle Spell}</p>\n<p>@UUID[Compendium.dnd5e.classfeatures.Item.Qb391hakCfmH4w8p]{Twinned Spell}</p>\n<section class=\"secret foundry-note\">\n<p><strong>Foundry Note</strong></p>\n<p>You can drag your choices from the above onto your character sheet and it will automatically update.</p>\n</section>",
+      "value": "<p>At 3rd level, you gain the ability to twist your spells to suit your needs. You gain two of the following Metamagic options of your choice. You gain another one at 10th and 17th level. You can use only one Metamagic option on a spell when you cast it, unless otherwise noted.</p><p>@UUID[Compendium.dnd5e.classfeatures.Item.zElYrOcCFFMhB6Xl]{Careful Spell}</p><p>@UUID[Compendium.dnd5e.classfeatures.Item.DZpAa3LzMNBexbmX]{Distant Spell}</p><p>@UUID[Compendium.dnd5e.classfeatures.Item.IWpe0Y9uAStHGiH1]{Empowered Spell}</p><p>@UUID[Compendium.dnd5e.classfeatures.Item.tQxlKyAx9sgPrbgj]{Extended Spell}</p><p>@UUID[Compendium.dnd5e.classfeatures.Item.tNG2qi9zhmXEkecA]{Heightened Spell}</p><p>@UUID[Compendium.dnd5e.classfeatures.Item.nViGf6bZ6DQAJhkw]{Quickened Spell}</p><p>@UUID[Compendium.dnd5e.classfeatures.Item.fXa0DMhoVLtbBu9l]{Subtle Spell}</p><p>@UUID[Compendium.dnd5e.classfeatures.Item.Qb391hakCfmH4w8p]{Twinned Spell}</p>",
       "chat": ""
     },
     "source": {
@@ -88,10 +88,10 @@
   "effects": [],
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234343,
-    "modifiedTime": 1704824715301,
+    "modifiedTime": 1712173778106,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!9Uh7uTDNZ04oTJsL"


### PR DESCRIPTION
Adds UUIDs to all class features that need to consume uses from another item (channel divinity, ki abilities, metamagic, etc).

Also adjusted Monk's deflect missiles to use an inline roll rather than the Other Formula field for calculating the damage reduction so the player only has to activate if they want to spend the ki point to throw the missile back.