### PR TITLE
[#3374] Add enchantment active effect that modifies an item

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -679,6 +679,11 @@
 "DND5E.EffectApplyWarningConcentration": "Applying an effect that is being concentrated on by another character requires GM permissions.",
 "DND5E.EffectApplyWarningOwnership": "Effects cannot be applied to tokens you are not the owner of.",
 "DND5E.EffectsSearch": "Search effects",
+"DND5E.Enchantment": {
+  "Warning": {
+    "Override": "This value is being modified by an Enchantment and cannot be edited. Disable the enchantment in the effects tab to edit it."
+  }
+},
 "DND5E.Environment": "Environment",
 "DND5E.EquipmentBonus": "Magical Bonus",
 "DND5E.EquipmentClothing": "Clothing",

--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -183,8 +183,13 @@
             inset-inline-end: 0;
             padding: 6px;
           }
+          
+          &[aria-disabled] {
+            cursor: not-allowed;
+            &:hover { text-shadow: none; }
+          }
         }
-        &:hover .description-edit {
+        &:hover .description-edit:not[aria-disabled] {
           opacity: 100%;
         }
       }

--- a/module/applications/actor/base-config.mjs
+++ b/module/applications/actor/base-config.mjs
@@ -1,3 +1,5 @@
+import ActiveEffect5e from "../../documents/active-effect.mjs";
+
 /**
  * An abstract class containing common functionality between actor sheet configuration apps.
  * @extends {DocumentSheet}
@@ -48,9 +50,6 @@ export default class BaseConfigSheet extends DocumentSheet {
    * @internal
    */
   _addOverriddenChoices(prefix, path, overrides) {
-    const source = new Set(foundry.utils.getProperty(this.document._source, path) ?? []);
-    const current = foundry.utils.getProperty(this.document, path) ?? new Set();
-    const delta = current.symmetricDifference(source);
-    for ( const choice of delta ) overrides.push(`${prefix}.${choice}`);
+    ActiveEffect5e.addOverriddenChoices(this.document, prefix, path, overrides);
   }
 }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -1,3 +1,4 @@
+import ActiveEffect5e from "../../documents/active-effect.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
 import { filteredKeys, sortObjectEntries } from "../../utils.mjs";
 import ActorMovementConfig from "../actor/movement-config.mjs";
@@ -143,9 +144,14 @@ export default class ItemSheet5e extends ItemSheet {
     }
 
     if ( ("properties" in item.system) && (item.type in CONFIG.DND5E.validProperties) ) {
+      const overrides = this._getItemOverrides();
       context.properties = item.system.validProperties.reduce((obj, k) => {
         const v = CONFIG.DND5E.itemProperties[k];
-        obj[k] = { label: v.label, selected: item.system.properties.has(k) };
+        obj[k] = {
+          label: v.label,
+          selected: item.system.properties.has(k),
+          disabled: overrides?.includes(`properties.${k}`)
+        };
         return obj;
       }, {});
       if ( item.type !== "spell" ) context.properties = sortObjectEntries(context.properties, "label");
@@ -353,6 +359,22 @@ export default class ItemSheet5e extends ItemSheet {
   /* -------------------------------------------- */
 
   /**
+   * Retrieve the list of fields that are currently modified by Active Effects on the Item.
+   * @returns {string[]}
+   * @protected
+   */
+  _getItemOverrides() {
+    const overrides = Object.keys(foundry.utils.flattenObject(this.item.overrides ?? {}));
+    this.item.system.getItemOverrides?.(overrides);
+    if ( "properties" in this.item.system ) {
+      ActiveEffect5e.addOverriddenChoices(this.item, "properties", "system.properties", overrides);
+    }
+    return overrides;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Get the Array of item properties which are used in the small sidebar of the description tab.
    * @returns {string[]}   List of property labels to be shown.
    * @private
@@ -434,7 +456,7 @@ export default class ItemSheet5e extends ItemSheet {
     // Handle properties
     if ( foundry.utils.hasProperty(formData, "system.properties") ) {
       const keys = new Set(Object.keys(formData.system.properties));
-      const preserve = this.object.system.properties.difference(keys);
+      const preserve = new Set(this.item._source.system.properties ?? []).difference(keys);
       formData.system.properties = [...filteredKeys(formData.system.properties), ...preserve];
     }
 
@@ -492,9 +514,20 @@ export default class ItemSheet5e extends ItemSheet {
         if ( t.dataset.action ) this._onAdvancementAction(t, t.dataset.action);
       });
       html.find(".description-edit").click(event => {
+        if ( event.currentTarget.ariaDisabled ) return;
         this.editingDescriptionTarget = event.currentTarget.dataset.target;
         this.render();
       });
+      for ( const override of this._getItemOverrides() ) {
+        for ( const element of html[0].querySelectorAll(`[name="${override}"]`) ) {
+          element.disabled = true;
+          element.dataset.tooltip = "DND5E.Enchantment.Warning.Override";
+        }
+        for ( const element of html[0].querySelectorAll(`[data-target="${override}"]`) ) {
+          element.ariaDisabled = true;
+          element.dataset.tooltip = "DND5E.Enchantment.Warning.Override";
+        }
+      }
     }
 
     // Advancement context menu

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -367,7 +367,7 @@ export default class ItemSheet5e extends ItemSheet {
     const overrides = Object.keys(foundry.utils.flattenObject(this.item.overrides ?? {}));
     this.item.system.getItemOverrides?.(overrides);
     if ( "properties" in this.item.system ) {
-      ActiveEffect5e.addOverriddenChoices(this.item, "properties", "system.properties", overrides);
+      ActiveEffect5e.addOverriddenChoices(this.item, "system.properties", "system.properties", overrides);
     }
     return overrides;
   }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -278,6 +278,7 @@ export default class ActiveEffect5e extends ActiveEffect {
    */
   determineSuppression() {
     this.isSuppressed = false;
+    if ( this.getFlag("dnd5e", "type") === "enchantment" ) return;
     if ( this.parent instanceof dnd5e.documents.Item5e ) this.isSuppressed = this.parent.areEffectsSuppressed;
   }
 
@@ -306,6 +307,7 @@ export default class ActiveEffect5e extends ActiveEffect {
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    if ( this.getFlag("dnd5e", "type") === "enchantment" ) this.transfer = false;
     if ( this.id === this.constructor.ID.EXHAUSTION ) this._prepareExhaustionLevel();
   }
 
@@ -600,6 +602,26 @@ export default class ActiveEffect5e extends ActiveEffect {
       if ( effect ) arr.push(effect);
       return arr;
     }, []);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Helper method to add choices that have been overridden by an active effect. Used to determine what fields might
+   * need to be disabled because they are overridden by an active effect in a way not easily determined by looking at
+   * the `Document#overrides` data structure.
+   * @param {Actor5e|Item5e} doc  Document from which to determine the overrides.
+   * @param {string} prefix       The initial form prefix under which the choices are grouped.
+   * @param {string} path         Path in document data.
+   * @param {string[]} overrides  The list of fields that are currently modified by Active Effects. *Will be mutated.*
+   */
+  static addOverriddenChoices(doc, prefix, path, overrides) {
+    const source = new Set(foundry.utils.getProperty(doc._source, path) ?? []);
+    const current = foundry.utils.getProperty(doc, path) ?? new Set();
+    const delta = current.symmetricDifference(source);
+    for ( const choice of delta ) overrides.push(`${prefix}.${choice}`);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -143,7 +143,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /** @inheritDoc */
   prepareEmbeddedDocuments() {
     this.sourcedItems = new Map();
+    this._embeddedPreparation = true;
     super.prepareEmbeddedDocuments();
+    delete this._embeddedPreparation;
   }
 
   /* --------------------------------------------- */

--- a/templates/items/consumable.hbs
+++ b/templates/items/consumable.hbs
@@ -110,8 +110,7 @@
                 {{/if}}
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
-                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }}>
                     {{ label }}
                 </label>
                 {{/each}}

--- a/templates/items/consumable.hbs
+++ b/templates/items/consumable.hbs
@@ -110,7 +110,9 @@
                 {{/if}}
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{@key}}" {{checked selected}}> {{ label }}
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
+                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    {{ label }}
                 </label>
                 {{/each}}
             </div>

--- a/templates/items/container.hbs
+++ b/templates/items/container.hbs
@@ -83,8 +83,7 @@
                 <label>{{ localize "DND5E.ItemContainerProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
-                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }}>
                     {{ label }}
                 </label>
                 {{/each}}

--- a/templates/items/container.hbs
+++ b/templates/items/container.hbs
@@ -83,7 +83,9 @@
                 <label>{{ localize "DND5E.ItemContainerProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{@key}}" {{checked selected}}> {{ label }}
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
+                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    {{ label }}
                 </label>
                 {{/each}}
             </div>

--- a/templates/items/equipment.hbs
+++ b/templates/items/equipment.hbs
@@ -116,7 +116,9 @@
                 <label>{{ localize "DND5E.ItemEquipmentProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{@key}}" {{checked selected}}> {{ label }}
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
+                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    {{ label }}
                 </label>
                 {{/each}}
             </div>

--- a/templates/items/equipment.hbs
+++ b/templates/items/equipment.hbs
@@ -116,8 +116,7 @@
                 <label>{{ localize "DND5E.ItemEquipmentProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
-                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }}>
                     {{ label }}
                 </label>
                 {{/each}}

--- a/templates/items/loot.hbs
+++ b/templates/items/loot.hbs
@@ -89,7 +89,9 @@
                 <label>{{ localize "DND5E.ItemLootProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{@key}}" {{checked selected}}> {{ label }}
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
+                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    {{ label }}
                 </label>
                 {{/each}}
             </div>

--- a/templates/items/loot.hbs
+++ b/templates/items/loot.hbs
@@ -89,8 +89,7 @@
                 <label>{{ localize "DND5E.ItemLootProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
-                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }}>
                     {{ label }}
                 </label>
                 {{/each}}

--- a/templates/items/tool.hbs
+++ b/templates/items/tool.hbs
@@ -93,8 +93,7 @@
                 <label>{{ localize "DND5E.ItemToolProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
-                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }}>
                     {{ label }}
                 </label>
                 {{/each}}

--- a/templates/items/tool.hbs
+++ b/templates/items/tool.hbs
@@ -93,7 +93,9 @@
                 <label>{{ localize "DND5E.ItemToolProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{@key}}" {{checked selected}}> {{ label }}
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
+                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    {{ label }}
                 </label>
                 {{/each}}
             </div>

--- a/templates/items/weapon.hbs
+++ b/templates/items/weapon.hbs
@@ -112,8 +112,7 @@
                 <label>{{ localize "DND5E.ItemWeaponProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
-                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }}>
                     {{ label }}
                 </label>
                 {{/each}}

--- a/templates/items/weapon.hbs
+++ b/templates/items/weapon.hbs
@@ -112,7 +112,9 @@
                 <label>{{ localize "DND5E.ItemWeaponProperties" }}</label>
                 {{#each properties}}
                 <label class="checkbox">
-                    <input type="checkbox" name="system.properties.{{@key}}" {{checked selected}}> {{ label }}
+                    <input type="checkbox" name="system.properties.{{ @key }}" {{ checked selected }} {{#if disabled~}}
+                           disabled data-tooltip="{{ localize 'DND5E.Enchantment.Warning.Override' }}"{{/if}}>
+                    {{ label }}
                 </label>
                 {{/each}}
             </div>


### PR DESCRIPTION
Active Effects created with `flags.dnd5e.type` of `enchantment` will now apply to the item in which they are included, not the actor.

The existing item sheets will now identify fields that have been modified by an enchantment effect and disable them, similar to how field are disabled in actor configs.

<img width="836" alt="Enchantment Effect" src="https://github.com/foundryvtt/dnd5e/assets/19979839/4ea55aae-8874-41f0-8366-1b4caf918180">

### Followup Work
- [ ] Distinguish enchantments from other active effects in an item's effect list
- [ ] Add ability to create enchantments without manually setting the flag