### PR TITLE
[#3374] Add enchantment feature type, improve effects tab

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -128,7 +128,8 @@
 "DND5E.ActionAbbr": "A",
 "DND5E.ActionPl": "Actions",
 "DND5E.ActionAbil": "Ability Check",
-"DND5E.ActionHeal": "Healing",
+"DND5E.ActionEnch": "Enchant",
+"DND5E.ActionHeal": "Heal",
 "DND5E.ActionMSAK": "Melee Spell Attack",
 "DND5E.ActionMWAK": "Melee Weapon Attack",
 "DND5E.ActionOther": "Other",
@@ -680,6 +681,19 @@
 "DND5E.EffectApplyWarningOwnership": "Effects cannot be applied to tokens you are not the owner of.",
 "DND5E.EffectsSearch": "Search effects",
 "DND5E.Enchantment": {
+  "Action": {
+    "Create": "Create Enchantment",
+    "Delete": "Delete Enchantment",
+    "Disable": "Disable Enchantment",
+    "Edit": "Edit Enchantment",
+    "Enable": "Enable Enchantment"
+  },
+  "Category": {
+    "Active": "Active Enchantments",
+    "General": "Enchantments",
+    "Inactive": "Inactive Enchantments"
+  },
+  "Label": "Enchantment",
   "Warning": {
     "Override": "This value is being modified by an Enchantment and cannot be edited. Disable the enchantment in the effects tab to edit it."
   }

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -72,21 +72,41 @@ export default class EffectsElement extends HTMLElement {
 
   /**
    * Prepare the data structure for Active Effects which are currently applied to an Actor or Item.
-   * @param {ActiveEffect5e[]} effects  The array of Active Effect instances for which to prepare sheet data.
+   * @param {ActiveEffect5e[]} effects         The array of Active Effect instances for which to prepare sheet data.
+   * @param {object} [options={}]
+   * @param {Actor5e|Item5e} [options.parent]  Document that owns these active effects.
    * @returns {object}                  Data for rendering.
    */
-  static prepareCategories(effects) {
+  static prepareCategories(effects, { parent }={}) {
     // Define effect header categories
     const categories = {
+      enchantment: {
+        type: "enchantment",
+        label: game.i18n.localize("DND5E.Enchantment.Category.General"),
+        effects: [],
+        isEnchantment: true
+      },
       temporary: {
         type: "temporary",
         label: game.i18n.localize("DND5E.EffectTemporary"),
         effects: []
       },
+      enchantmentActive: {
+        type: "activeEnchantment",
+        label: game.i18n.localize("DND5E.Enchantment.Category.Active"),
+        effects: [],
+        isEnchantment: true
+      },
       passive: {
         type: "passive",
         label: game.i18n.localize("DND5E.EffectPassive"),
         effects: []
+      },
+      enchantmentInactive: {
+        type: "inactiveEnchantment",
+        label: game.i18n.localize("DND5E.Enchantment.Category.Inactive"),
+        effects: [],
+        isEnchantment: true
       },
       inactive: {
         type: "inactive",
@@ -103,14 +123,28 @@ export default class EffectsElement extends HTMLElement {
     };
 
     // Iterate over active effects, classifying them into categories
+    const enchantmentParent = (parent?.system.type?.value === "enchantment") || (parent?.system.actionType === "ench");
     for ( const e of effects ) {
       if ( (e.parent.system?.identified === false) && !game.user.isGM ) continue;
-      if ( e.isSuppressed ) categories.suppressed.effects.push(e);
+      if ( e.getFlag("dnd5e", "type") === "enchantment" ) {
+        if ( enchantmentParent ) categories.enchantment.effects.push(e);
+        else if ( e.disabled ) categories.enchantmentInactive.effects.push(e);
+        else categories.enchantmentActive.effects.push(e);
+      }
+      else if ( e.isSuppressed ) categories.suppressed.effects.push(e);
       else if ( e.disabled ) categories.inactive.effects.push(e);
       else if ( e.isTemporary ) categories.temporary.effects.push(e);
       else categories.passive.effects.push(e);
     }
+    categories.enchantment.hidden = !enchantmentParent;
+    categories.enchantmentActive.hidden = !categories.enchantmentActive.effects.length;
+    categories.enchantmentInactive.hidden = !categories.enchantmentInactive.effects.length;
     categories.suppressed.hidden = !categories.suppressed.effects.length;
+
+    for ( const category of Object.values(categories) ) {
+      category.localizationPrefix = category.isEnchantment ? "DND5E.Enchantment.Action." : "DND5E.Effect";
+    }
+
     return categories;
   }
 
@@ -245,12 +279,15 @@ export default class EffectsElement extends HTMLElement {
   async _onCreate(target) {
     const isActor = this.document instanceof Actor;
     const li = target.closest("li");
+    const flags = {};
+    if ( li.dataset.effectType.startsWith("enchantment") ) flags["dnd5e.type"] = "enchantment";
     return this.document.createEmbeddedDocuments("ActiveEffect", [{
       name: isActor ? game.i18n.localize("DND5E.EffectNew") : this.document.name,
       icon: isActor ? "icons/svg/aura.svg" : this.document.img,
       origin: this.document.uuid,
       "duration.rounds": li.dataset.effectType === "temporary" ? 1 : undefined,
-      disabled: li.dataset.effectType === "inactive"
+      disabled: ["inactive", "enchantmentInactive"].includes(li.dataset.effectType),
+      flags
     }]);
   }
 

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -112,6 +112,10 @@ export default class ItemSheet5e extends ItemSheet {
       isPhysical: item.system.hasOwnProperty("quantity"),
 
       // Action Details
+      availableActionTypes: Object.entries(CONFIG.DND5E.itemActionTypes).reduce((obj, [k, v]) => {
+        if ( k !== "ench" || !this.item.system.metadata?.enchantable ) obj[k] = v;
+        return obj;
+      }, {}),
       isHealing: item.system.actionType === "heal",
       isFlatDC: item.system.save?.scaling === "flat",
       isLine: ["line", "wall"].includes(item.system.target?.type),
@@ -132,7 +136,7 @@ export default class ItemSheet5e extends ItemSheet {
       advancement: this._getItemAdvancement(item),
 
       // Prepare Active Effects
-      effects: EffectsElement.prepareCategories(item.effects),
+      effects: EffectsElement.prepareCategories(item.effects, { parent: this.item }),
       elements: this.options.elements,
 
       concealDetails: !game.user.isGM && (this.document.system.identified === false)

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -829,10 +829,11 @@ DND5E.itemActionTypes = {
   rwak: "DND5E.ActionRWAK",
   msak: "DND5E.ActionMSAK",
   rsak: "DND5E.ActionRSAK",
+  abil: "DND5E.ActionAbil",
   save: "DND5E.ActionSave",
+  ench: "DND5E.ActionEnch",
   summ: "DND5E.ActionSumm",
   heal: "DND5E.ActionHeal",
-  abil: "DND5E.ActionAbil",
   util: "DND5E.ActionUtil",
   other: "DND5E.ActionOther"
 };
@@ -1241,6 +1242,13 @@ DND5E.featureTypes = {
   race: {
     label: "DND5E.Feature.Race"
   },
+  enchantment: {
+    label: "DND5E.Enchantment.Label",
+    subtypes: {
+      artificerInfusion: "DND5E.Feature.Class.ArtificerInfusion",
+      rune: "DND5E.Feature.Class.Rune"
+    }
+  },
   feat: {
     label: "DND5E.Feature.Feat"
   },
@@ -1255,6 +1263,7 @@ DND5E.featureTypes = {
 };
 preLocalize("featureTypes", { key: "label" });
 preLocalize("featureTypes.class.subtypes", { sort: true });
+preLocalize("featureTypes.enchantment.subtypes", { sort: true });
 preLocalize("featureTypes.supernaturalGift.subtypes", { sort: true });
 
 /* -------------------------------------------- */

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -360,11 +360,13 @@ export class ItemDataModel extends SystemDataModel {
 
   /**
    * @typedef {SystemDataModelMetadata} ItemDataModelMetadata
-   * @property {boolean} singleton  Should only a single item of this type be allowed on an actor?
+   * @property {boolean} enchantable  Can this item be modified by enchantment effects?
+   * @property {boolean} singleton    Should only a single item of this type be allowed on an actor?
    */
 
   /** @type {ItemDataModelMetadata} */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    enchantable: false,
     singleton: false
   }, {inplace: false}));
 

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -43,6 +43,13 @@ export default class ConsumableData extends ItemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    enchantable: true
+  }, {inplace: false}));
+
+  /* -------------------------------------------- */
   /*  Data Migrations                             */
   /* -------------------------------------------- */
 

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -40,6 +40,13 @@ export default class ContainerData extends ItemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    enchantable: true
+  }, {inplace: false}));
+
+  /* -------------------------------------------- */
   /*  Data Migrations                             */
   /* -------------------------------------------- */
 

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -63,6 +63,13 @@ export default class EquipmentData extends ItemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    enchantable: true
+  }, {inplace: false}));
+
+  /* -------------------------------------------- */
   /*  Migrations                                  */
   /* -------------------------------------------- */
 

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -26,6 +26,13 @@ export default class LootData extends ItemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    enchantable: true
+  }, {inplace: false}));
+
+  /* -------------------------------------------- */
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -42,6 +42,13 @@ export default class ToolData extends ItemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    enchantable: true
+  }, {inplace: false}));
+
+  /* -------------------------------------------- */
   /*  Migrations                                  */
   /* -------------------------------------------- */
 

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -44,6 +44,13 @@ export default class WeaponData extends ItemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    enchantable: true
+  }, {inplace: false}));
+
+  /* -------------------------------------------- */
   /*  Data Migrations                             */
   /* -------------------------------------------- */
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -411,6 +411,10 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   applyActiveEffects() {
     const overrides = {};
+    if ( !this.system?.metadata?.enchantable ) {
+      this.overrides = overrides;
+      return;
+    }
 
     // Organize non-disabled effects by their application priority
     const changes = [];

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -2,7 +2,7 @@
 <div class="form-group select">
     <label>{{ localize "DND5E.ItemActionType" }}</label>
     <select name="system.actionType">
-        {{selectOptions config.itemActionTypes selected=system.actionType blank=""}}
+        {{ selectOptions availableActionTypes selected=system.actionType blank="" }}
     </select>
 </div>
 {{#if system.actionType}}

--- a/templates/shared/active-effects.hbs
+++ b/templates/shared/active-effects.hbs
@@ -9,8 +9,9 @@
         <div class="effect-source">{{localize "DND5E.Duration"}}</div>
         <div class="item-controls effect-controls flexrow">
             {{#if @root.editable}}
-            <a class="effect-control" data-action="create" data-tooltip="DND5E.EffectCreate">
-                <i class="fas fa-plus"></i> {{localize "DND5E.Add"}}
+            <a class="effect-control" data-action="create" data-tooltip="{{ section.localizationPrefix }}Create"
+               aria-label="{{ localize (concat section.localizationPrefix 'Create') }}">
+                <i class="fas fa-plus" aria-hidden="true"></i> {{localize "DND5E.Add"}}
             </a>
             {{/if}}
         </div>
@@ -19,36 +20,38 @@
     {{#if section.info}}
     <ol class="info">
         {{#each section.info}}
-            <li class="notification info">{{this}}</li>
+            <li class="notification info">{{ this }}</li>
         {{/each}}
     </ol>
     {{/if}}
 
     <ol class="item-list">
         {{#each section.effects as |effect|}}
-        <li class="item effect flexrow" data-effect-id="{{effect.id}}"
-            {{~#if (and @root.actor (ne effect.target effect.parent))}} data-parent-id="{{effect.parent.id}}"{{/if}}>
+        <li class="item effect flexrow" data-effect-id="{{ effect.id }}"
+            {{~#if (and @root.actor (ne effect.target effect.parent))}} data-parent-id="{{ effect.parent.id }}"{{/if}}>
             <div class="item-name effect-name flexrow">
-                {{#if effect.img}}
-                <img class="item-image" src="{{ effect.img }}">
-                {{else}}
-                <img class="item-image" src="{{effect.icon}}">
-                {{/if}}
-                <h4>{{effect.name}}</h4>
+                <img class="item-image" src="{{ effect.icon }}">
+                <h4>{{ effect.name }}</h4>
             </div>
-            <div class="effect-source">{{effect.sourceName}}</div>
-            <div class="effect-duration">{{effect.duration.label}}</div>
+            <div class="effect-source">{{ effect.sourceName }}</div>
+            <div class="effect-duration">{{ effect.duration.label }}</div>
             <div class="item-controls effect-controls flexrow">
                 {{#if @root.editable}}
+                {{#unless (eq section.type "enchantment")}}
                 <a class="effect-control" data-action="toggle"
-                   data-tooltip="{{#if effect.disabled}}DND5E.EffectEnable{{else}}DND5E.EffectDisable{{/if}}">
-                    <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
+                   data-tooltip="{{ section.localizationPrefix }}{{ ifThen effect.disabled 'Enable' 'Disable' }}"
+                   aria-label="{{ localize (concat section.localizationPrefix
+                   (ifThen effect.disabled 'Enable' 'Disable')) }}">
+                    <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}" aria-hidden="true"></i>
                 </a>
-                <a class="effect-control" data-action="edit" data-tooltip="DND5E.EffectEdit">
-                    <i class="fas fa-edit"></i>
+                {{/unless}}
+                <a class="effect-control" data-action="edit" data-tooltip="{{ section.localizationPrefix }}Edit"
+                   aria-label="{{ localize (concat section.localizationPrefix 'Edit') }}">
+                    <i class="fas fa-edit" aria-hidden="true"></i>
                 </a>
-                <a class="effect-control" data-action="delete" data-tooltip="DND5E.EffectDelete">
-                    <i class="fas fa-trash"></i>
+                <a class="effect-control" data-action="delete" data-tooltip="{{ section.localizationPrefix }}Delete"
+                   aria-label="{{ localize (concat section.localizationPrefix 'Delete') }}">
+                    <i class="fas fa-trash" aria-hidden="true"></i>
                 </a>
                 {{/if}}
             </div>


### PR DESCRIPTION
Adds a new feature type "Enchantment" with sub-types matching the two existing enchantment types in class features: "Artificer Infusion" and "Rune". When this type is selected a new section appears in the effects tab for "Enchantments" that allows for creating a new enchantment active effect.

<img width="575" alt="Enchantment Item" src="https://github.com/foundryvtt/dnd5e/assets/19979839/523e7278-1f6b-4fab-8f73-7cd9253cf498">

Two new sections are added for other items listing "Active" and "Inactive" enchantments to keep them separate from other effects.

<img width="571" alt="Enchantment Effects Tab" src="https://github.com/foundryvtt/dnd5e/assets/19979839/c5cd47fb-b986-423b-9c35-fe4878f22816">

Added a new metadata property to `ItemDataModel` for `enchantable`, which determines whether enchantment active effects will be applied to this item. Items that are not enchantable can still hold enchantment active effects but they will not be able to modify the item.