### PR TITLE
[#3412] Allow specifying creature size during summoning

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1511,9 +1511,13 @@
     "Label": "Creature Changes",
     "Hint": "Changes that will be made to the creature being summoned. Any @ references used in the following formulas will be based on the summoner's stats. Summoned creature's stats can be referenced using @summon (e.g. @summon.attributes.hd.max to reference the creature's hit dice count)."
   },
+  "CreatureSizes": {
+    "Label": "Creature Sizes",
+    "Hint": "Summoned creature and token will be changed to this size. If more than one size is selected, then the player will be able to choose from these sizes when summoning."
+  },
   "CreatureTypes": {
     "Label": "Creature Types",
-    "Hint": "Summoned creature will be changed to this type. If more than one type is selected, then player will be able to choose from these types when summoning."
+    "Hint": "Summoned creature will be changed to this type. If more than one type is selected, then the player will be able to choose from these types when summoning."
   },
   "DisplayName": "Display Name",
   "DropHint": "Drop creature here",

--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -602,7 +602,8 @@
     }
   }
 
-  multi-select .tags .tag {
-    cursor: pointer;
+  multi-select .tags {
+    flex-wrap: wrap;
+    .tag { cursor: pointer; }
   }
 }

--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -191,8 +191,12 @@ export default class AbilityUseDialog extends Dialog {
       return obj;
     }, {});
     else options.profile = summons.profiles[0]._id;
+    if ( summons.creatureSizes.size > 1 ) options.creatureSizes = summons.creatureSizes.reduce((obj, k) => {
+      obj[k] = CONFIG.DND5E.actorSizes[k]?.label;
+      return obj;
+    }, {});
     if ( summons.creatureTypes.size > 1 ) options.creatureTypes = summons.creatureTypes.reduce((obj, k) => {
-      obj[k] = CONFIG.DND5E.creatureTypes[k].label;
+      obj[k] = CONFIG.DND5E.creatureTypes[k]?.label;
       return obj;
     }, {});
     return options;

--- a/module/applications/item/summoning-config.mjs
+++ b/module/applications/item/summoning-config.mjs
@@ -52,6 +52,10 @@ export default class SummoningConfig extends DocumentSheet {
       (lhs.name || lhs.document?.name || "").localeCompare(rhs.name || rhs.document?.name || "", game.i18n.lang)
     );
     context.summons = this.document.system.summons;
+    context.creatureSizes = Object.entries(CONFIG.DND5E.actorSizes).reduce((obj, [k, c]) => {
+      obj[k] = { label: c.label, selected: context.summons?.creatureSizes.has(k) ? "selected" : "" };
+      return obj;
+    }, {});
     context.creatureTypes = Object.entries(CONFIG.DND5E.creatureTypes).reduce((obj, [k, c]) => {
       obj[k] = { label: c.label, selected: context.summons?.creatureTypes.has(k) ? "selected" : "" };
       return obj;
@@ -85,6 +89,7 @@ export default class SummoningConfig extends DocumentSheet {
   /** @inheritDoc */
   _getSubmitData(...args) {
     const data = foundry.utils.expandObject(super._getSubmitData(...args));
+    data.creatureSizes ??= [];
     data.creatureTypes ??= [];
     data.profiles = Object.values(data.profiles ?? {});
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2166,7 +2166,8 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     else needsConfiguration = true;
 
     // More than one creature type requires configuration
-    if ( item.system.summons.creatureTypes.size > 1 ) needsConfiguration = true;
+    if ( item.system.summons.creatureSizes.size > 1
+      || item.system.summons.creatureTypes.size > 1 ) needsConfiguration = true;
 
     // Show the item use dialog to get the profile and other options
     if ( needsConfiguration ) {

--- a/templates/apps/ability-use.hbs
+++ b/templates/apps/ability-use.hbs
@@ -109,6 +109,17 @@
         <input type="hidden" name="summonsProfile" value="{{ summoningOptions.profile }}">
         {{/if}}
     </div>
+    
+    {{#if summoningOptions.creatureSizes}}
+    <div class="form-group">
+        <label>{{ localize "DND5E.Size" }}</label>
+        <div class="form-fields">
+            <select name="summonsOptions.creatureSize">
+                {{ selectOptions summoningOptions.creatureSizes }}
+            </select>
+        </div>
+    </div>
+    {{/if}}
 
     {{#if summoningOptions.creatureTypes}}
     <div class="form-group">

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -52,6 +52,15 @@
         <p class="hint">{{ localize "DND5E.Summoning.Bonuses.HitPoints.Hint" }}</p>
     </div>
     <div class="form-group">
+        <label>{{ localize "DND5E.Summoning.CreatureSizes.Label" }}</label>
+        <multi-select name="creatureSizes">
+            {{#each creatureSizes}}
+            <option value="{{ @key }}" {{ selected }}>{{ label }}</option>
+            {{/each}}
+        </multi-select>
+        <p class="hint">{{ localize "DND5E.Summoning.CreatureSizes.Hint" }}</p>
+    </div>
+    <div class="form-group">
         <label>{{ localize "DND5E.Summoning.CreatureTypes.Label" }}</label>
         <multi-select name="creatureTypes">
             {{#each creatureTypes}}


### PR DESCRIPTION
Similar to the recent change adding selection of creature types during summoning, this adds creature size to the options. When a size is selected both the actor details and the token will be adjusted to the appropriate size.

<img width="514" alt="Creature Size - Dialog" src="https://github.com/foundryvtt/dnd5e/assets/19979839/87a72424-5541-41b9-8c6c-f5daa2f4cb08">

<img width="416" alt="Creature Size - Config" src="https://github.com/foundryvtt/dnd5e/assets/19979839/786e8e99-3978-46a6-a931-4c3c9f1d878f">

Closes #3412