### PR TITLE
Update metrics values

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1736,15 +1736,15 @@ DND5E.encumbrance = {
   threshold: {
     encumbered: {
       imperial: 5,
-      metric: 2.2
+      metric: 2.5
     },
     heavilyEncumbered: {
       imperial: 10,
-      metric: 4.5
+      metric: 5
     },
     maximum: {
       imperial: 15,
-      metric: 6.8
+      metric: 7.5
     }
   },
   speedReduction: {


### PR DESCRIPTION
The metrics values have never been correct since the system was released. Here they are with the correct values.

Translations of books using the metrics system use a simplified version of the conversion, 2.5 for 5, for simplicity.

Close : https://github.com/foundryvtt/dnd5e/issues/3257 - https://github.com/foundryvtt/dnd5e/issues/1226 - https://github.com/foundryvtt/dnd5e/issues/1228