### PR TITLE
[#1351] Manage spell preparation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1356,6 +1356,7 @@
 "DND5E.SpeedConditions": "Speed Conditions",
 "DND5E.SpeedSpecial": "Special Movement",
 "DND5E.SpellAbility": "Spellcasting Ability",
+"DND5E.needToPrepareSpells": "Need to Prepare Spells",
 "DND5E.SpellAbilitySet": "Set as Primary Spellcasting Ability",
 "DND5E.SpellAdd": "Add Spell",
 "DND5E.SpellCantrip": "Cantrip",
@@ -1372,6 +1373,7 @@
 "DND5E.SpellComponents": "Spell Components",
 "DND5E.SpellCreate": "Create Spell",
 "DND5E.SpellDC": "Spell DC",
+"DND5E.spellPreparationLimit": "Prep.",
 "DND5E.SpellDetails": "Spell Details",
 "DND5E.SpellEffects": "Spell Effects",
 "DND5E.SpellHeader": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1410,6 +1410,7 @@
 "DND5E.SpellPrepAlways": "Always Prepared",
 "DND5E.SpellPreparation": "Spell Preparation",
 "DND5E.SpellPreparationMode": "Spell Preparation Mode",
+"DND5E.BoundSpellOrigin": "Bound spellcasting origin",
 "DND5E.SpellPrepared": "Prepared",
 "DND5E.SpellProgArt": "Artificer",
 "DND5E.SpellProgAvailable": "Available slots",

--- a/lang/en.json
+++ b/lang/en.json
@@ -310,6 +310,8 @@
 "DND5E.Armor": "Armor",
 "DND5E.ArmorClass": "Armor Class",
 "DND5E.ArmorClassEquipment": "Equipped Armor",
+"DND5E.ActiveSpellcastingClass" : "Active spell casting class",
+"DND5E.SpellPreparationLimitWarning" : "<p style=\"text-align: justify;\">The character <strong><em>{name}</em></strong> has an invalid spell preparation of {count}/{limit} for the class \"{class}\"</p>",
 "DND5E.ArmorClassFlat": "Flat",
 "DND5E.ArmorClassUnarmored": "Unarmored",
 "DND5E.ArmorClassNatural": "Natural Armor",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1414,7 +1414,7 @@
 "DND5E.SpellPrepAlways": "Always Prepared",
 "DND5E.SpellPreparation": "Spell Preparation",
 "DND5E.SpellPreparationMode": "Spell Preparation Mode",
-"DND5E.BoundSpellOrigin": "Bound spellcasting origin",
+"DND5E.SpellSourceClass": "Source Class",
 "DND5E.SpellPrepared": "Prepared",
 "DND5E.SpellProgArt": "Artificer",
 "DND5E.SpellProgAvailable": "Available slots",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1961,5 +1961,6 @@
   }
 },
 
-"SOURCE.BOOK.SRD": "System Reference Document 5.1"
+"SOURCE.BOOK.SRD": "System Reference Document 5.1",
+"SIDEBAR.SortModePriority": "Sort by priority"
 }

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -116,6 +116,10 @@
           font-family: var(--dnd5e-font-roboto-slab);
           font-weight: bold;
           font-size: var(--font-size-16);
+          &[data-item-valid="false"] {
+            font-weight: bolder;
+            color: var(--dnd5e-color-red);
+          }
         }
 
         .sign { color: var(--color-text-light-6); }

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -497,6 +497,11 @@
 
     .item {
       border-bottom: var(--dnd5e-border-dotted);
+      opacity: 1;
+      transition: opacity 500ms ease-out;
+      &[data-item-active="false"] {
+        opacity: 0.3;
+      }
       &:last-child { border: none; }
     }
   }

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -366,7 +366,10 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
         attack: { sign: Math.sign(attack) < 0 ? "-" : "+", value: Math.abs(attack) },
         primary: this.actor.system.attributes.spellcasting === sc.ability,
         save: ability?.dc ?? 0,
-        spellPreparationLimit: sc.spellPreparationLimit
+        spellCastingOrigin: item.system.identifier,
+        spellPreparationLimit: sc.spellPreparationLimit,
+        preparedSpellsCount: sc.preparedSpellsCount,
+        valid: (sc.spellPreparationLimit ?? 0) >= (sc.preparedSpellsCount ?? 0)
       });
     }
 
@@ -992,8 +995,13 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
    * @protected
    */
   _onToggleSpellcasting(event) {
-    const ability = event.currentTarget.closest("[data-ability]")?.dataset.ability;
-    this.actor.update({ "system.attributes.spellcasting": ability });
+    const sc = event.currentTarget.closest("[data-ability]")?.dataset;
+    this.actor.update(
+      {
+        "system.attributes.spellcasting": sc?.ability,
+        "system.attributes.activeSpellcastingClass": sc?.spellOrigin
+      }
+    );
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -365,7 +365,8 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
         ability: { sign: Math.sign(mod) < 0 ? "-" : "+", value: Math.abs(mod), ability: sc.ability },
         attack: { sign: Math.sign(attack) < 0 ? "-" : "+", value: Math.abs(attack) },
         primary: this.actor.system.attributes.spellcasting === sc.ability,
-        save: ability?.dc ?? 0
+        save: ability?.dc ?? 0,
+        spellPreparationLimit: sc.spellPreparationLimit
       });
     }
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -79,6 +79,7 @@ export default class CharacterData extends CreatureTemplate {
       attributes: new foundry.data.fields.SchemaField({
         ...AttributesFields.common,
         ...AttributesFields.creature,
+        activeSpellcastingClass: new StringField({ label: "DND5E.ActiveSpellcastingClass" }),
         ac: new SchemaField({
           flat: new NumberField({integer: true, min: 0, label: "DND5E.ArmorClassFlat"}),
           calc: new StringField({initial: "default", label: "DND5E.ArmorClassCalculation"}),

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -3,8 +3,9 @@ import { ItemDataModel } from "../abstract.mjs";
 import { AdvancementField, FormulaField, IdentifierField } from "../fields.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import StartingEquipmentTemplate from "./templates/starting-equipment.mjs";
+import SpellCastingFields from "./templates/spell-casting.mjs";
 
-const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
+const { ArrayField, NumberField, StringField } = foundry.data.fields;
 
 /**
  * Data definition for Class items.
@@ -37,12 +38,7 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
         required: true, nullable: false, integer: true, initial: 0, min: 0, label: "DND5E.HitDiceUsed"
       }),
       advancement: new ArrayField(new AdvancementField(), {label: "DND5E.AdvancementTitle"}),
-      spellcasting: new SchemaField({
-        progression: new StringField({
-          required: true, initial: "none", blank: false, label: "DND5E.SpellProgression"
-        }),
-        ability: new StringField({required: true, label: "DND5E.SpellAbility"})
-      }, {label: "DND5E.Spellcasting"}),
+      spellcasting: SpellCastingFields.spellCasting,
       wealth: new FormulaField({label: "DND5E.StartingEquipment.Wealth.Label"})
     });
   }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -36,6 +36,7 @@ export default class SpellData extends ItemDataModel.mixin(
         required: true, integer: true, initial: 1, min: 0, label: "DND5E.SpellLevel"
       }),
       school: new foundry.data.fields.StringField({required: true, label: "DND5E.SpellSchool"}),
+      boundOrigin: new foundry.data.fields.StringField({required: false, label: "DND5E.BoundSpellOrigin"}),
       properties: new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {
         label: "DND5E.SpellComponents"
       }),

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -157,7 +157,15 @@ export default class SpellData extends ItemDataModel.mixin(
 
   /** @inheritdoc */
   get _typeAbilityMod() {
-    return this.parent?.actor?.system.attributes.spellcasting || "int";
+    return this.parent?.system?.ability
+    || (
+      this.parent?.system?.boundOrigin
+        ? this.parent.actor?.classes[this.parent.system.boundOrigin]?.system?.spellcasting?.ability
+        : null
+    )
+    || this.parent?.actor?.activeSpellCastingClass?.system?.spellcasting?.ability
+    || this.parent?.actor?.system?.attributes?.spellcasting
+    || "int";
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -36,7 +36,7 @@ export default class SpellData extends ItemDataModel.mixin(
         required: true, integer: true, initial: 1, min: 0, label: "DND5E.SpellLevel"
       }),
       school: new foundry.data.fields.StringField({required: true, label: "DND5E.SpellSchool"}),
-      boundOrigin: new foundry.data.fields.StringField({required: false, label: "DND5E.BoundSpellOrigin"}),
+      sourceClass: new foundry.data.fields.StringField({label: "DND5E.SpellSourceClass"}),
       properties: new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {
         label: "DND5E.SpellComponents"
       }),

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -1,6 +1,7 @@
 import { ItemDataModel } from "../abstract.mjs";
 import { AdvancementField, IdentifierField } from "../fields.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
+import SpellCastingFields from "./templates/spell-casting.mjs";
 
 /**
  * Data definition for Subclass items.
@@ -22,12 +23,7 @@ export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTem
         required: true, label: "DND5E.ClassIdentifier", hint: "DND5E.ClassIdentifierHint"
       }),
       advancement: new foundry.data.fields.ArrayField(new AdvancementField(), {label: "DND5E.AdvancementTitle"}),
-      spellcasting: new foundry.data.fields.SchemaField({
-        progression: new foundry.data.fields.StringField({
-          required: true, initial: "none", blank: false, label: "DND5E.SpellProgression"
-        }),
-        ability: new foundry.data.fields.StringField({required: true, label: "DND5E.SpellAbility"})
-      }, {label: "DND5E.Spellcasting"})
+      spellcasting: SpellCastingFields.spellCasting
     });
   }
 }

--- a/module/data/item/templates/spell-casting.mjs
+++ b/module/data/item/templates/spell-casting.mjs
@@ -1,0 +1,37 @@
+const { SchemaField, StringField, BooleanField } = foundry.data.fields;
+
+/**
+ * Shared contents of the spellcasting schema.
+ */
+export default class SpellCastingFields {
+
+  /**
+   * Shared fields for spellcasting definition.
+   * @type {object}
+   * @property {string} progression
+   * @property {string} ability
+   * @property {boolean} needToPrepareSpells
+   */
+  static get spellCasting() {
+    return new SchemaField(
+      {
+        progression: new StringField({
+          required: true,
+          initial: "none",
+          blank: false,
+          label: "DND5E.SpellProgression"
+        }),
+        ability: new StringField({
+          required: true,
+          label: "DND5E.SpellAbility"
+        }),
+        needToPrepareSpells: new BooleanField({
+          required: false,
+          initial: false,
+          label: "DND5E.needToPrepareSpells"
+        })
+      },
+      { label: "DND5E.Spellcasting" }
+    );
+  }
+}

--- a/module/data/user/user-system-flags.mjs
+++ b/module/data/user/user-system-flags.mjs
@@ -40,7 +40,7 @@ export default class UserSystemFlags extends foundry.abstract.DataModel {
         tabs: new MappingField(new SchemaField({
           collapseSidebar: new BooleanField({ required: false }),
           group: new BooleanField({ required: false, initial: true }),
-          sort: new StringField({ required: false, initial: "m", choices: foundry.documents.BaseFolder.SORTING_MODES })
+          sort: new StringField({ required: false, initial: "m", choices: [...foundry.documents.BaseFolder.SORTING_MODES, "p"] })
         }))
       }))
     };

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -48,6 +48,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
+   * Get all origins which have spellcasting ability.
+   * @type {Array<Item5e>}
+   */
+  get spellCastingClasses() {
+    return Object.values(this.classes).filter(({system}) => system.spellcasting
+    && system.spellcasting.progression !== "none" );
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Is this Actor currently polymorphed into some other creature?
    * @type {boolean}
    */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -56,6 +56,19 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     && system.spellcasting.progression !== "none" );
   }
 
+  /**
+   * Get the actual active spell casting class.
+   * @type {Item5e}
+   */
+  get activeSpellCastingClass() {
+    if (this.system.attributes.activeSpellcastingClass
+      && this.classes[this.system.attributes.activeSpellcastingClass]) {
+      return this.classes[this.system.attributes.activeSpellcastingClass];
+    }
+    return Object.values(this.classes).find(({system}) => system.spellcasting
+    && system.spellcasting.progression !== "none" );
+  }
+
   /* -------------------------------------------- */
 
   /**

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -48,12 +48,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
-   * Get all origins which have spellcasting ability.
-   * @type {Array<Item5e>}
+   * Get all classes which have spellcasting ability.
+   * @type {Record<string, Item5e>}
    */
-  get spellCastingClasses() {
-    return Object.values(this.classes).filter(({system}) => system.spellcasting
-    && system.spellcasting.progression !== "none" );
+  get spellcastingClasses() {
+    return Object.entries(this.classes).reduce((obj, [identifier, cls]) => {
+      if ( cls.spellcasting && (cls.spellcasting.progression !== "none") ) obj[identifier] = cls;
+      return obj;
+    }, {});
   }
 
   /**

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -345,29 +345,17 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /**
-   * Get available spellcasting origins.
-   * @type {Array<Item5e>|null}
-   */
-  get availableSpellCastingOrigins() {
-    if (this.type !== "spell" | !this.parent) return;
-    return this.parent.spellCastingClasses.map(({name, system}) => ({name, value: system.identifier}));
-  }
-
-  /* -------------------------------------------- */
-
-  /**
    * Is this spell linked to the active spell casting ?
    * @type {boolean}
    */
   get isActiveSpellCasting() {
     if (this.type !== "spell" || !this.parent) return;
     return this.system?.preparation?.mode === "innate"
-    || this.parent.activeSpellCastingClass?.system?.identifier === this.system.boundOrigin;
+    || this.parent.activeSpellCastingClass?.system?.identifier === this.system.sourceClass;
   }
-
+  
   /* -------------------------------------------- */
-
-  /**
+  
    * Spellcasting details for a class or subclass.
    *
    * @typedef {object} SpellcastingDescription

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -345,6 +345,17 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /**
+   * Get available spellcasting origins.
+   * @type {Array<Item5e>|null}
+   */
+  get availableSpellCastingOrigins() {
+    if (this.type !== "spell" | !this.parent) return;
+    return this.parent.spellCastingClasses.map(({name, system}) => ({name, value: system.identifier}));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Spellcasting details for a class or subclass.
    *
    * @typedef {object} SpellcastingDescription

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -356,6 +356,18 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /**
+   * Is this spell linked to the active spell casting ?
+   * @type {boolean}
+   */
+  get isActiveSpellCasting() {
+    if (this.type !== "spell" || !this.parent) return;
+    return this.system?.preparation?.mode === "innate"
+    || this.parent.activeSpellCastingClass?.system?.identifier === this.system.boundOrigin;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Spellcasting details for a class or subclass.
    *
    * @typedef {object} SpellcastingDescription
@@ -392,6 +404,11 @@ export default class Item5e extends SystemDocumentMixin(Item) {
           this.system.levels / (CONFIG.DND5E.spellcastingTypes.leveled.progression[finalSC.progression].divisor || 1)
         )
       );
+      finalSC.preparedSpellsCount = this.parent.items.filter(x => x.type === "spell"
+      && x.system?.level > 0
+      && x.system?.boundOrigin === this.system.identifier
+      && x.system?.preparation?.mode === "prepared"
+      && x.system?.preparation?.prepared).length;
     }
 
     // Temp method for determining spellcasting type until this data is available directly using advancement
@@ -739,7 +756,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     // Actor spell-DC based scaling
     if ( save.scaling === "spell" ) {
-      save.dc = this.isOwned ? this.actor.system.attributes.spelldc : null;
+      save.dc = this._getSpellDC();
     }
 
     // Ability-score based scaling
@@ -1102,6 +1119,33 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     Hooks.callAll("dnd5e.useItem", item, config, options, templates ?? null, effects, summoned ?? null);
 
     return cardData;
+  }
+
+  /**
+   * Get the spell DC first selected ability (if not default),
+   * then from the bound spell caster (if bound),
+   * or finally from the current active spell caster class (if any)
+   * @returns {number}
+   */
+  _getSpellDC() {
+    if (this.isOwned) {
+
+      if (this.system.ability && this.parent?.system?.abilities?.[this.system.ability]?.dc) {
+        return this.parent.system.abilities[this.system.ability]?.dc;
+      }
+
+      const sc = (
+        this.system?.boundOrigin
+          ? this.parent?.classes?.[this.system.boundOrigin]
+          : null
+      )
+      ?? this.parent?.activeSpellCastingClass;
+      return sc?.system?.spellcasting?.ability
+        ? this.parent?.system?.abilities?.[sc.system.spellcasting.ability]?.dc
+        : this.parent?.actor?.system?.attributes?.spellcasting?.dc;
+
+    }
+    return null;
   }
 
   /**

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -383,6 +383,17 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     if ( !finalSC ) return null;
     finalSC.levels = this.isEmbedded ? (this.system.levels ?? this.class?.system.levels) : null;
 
+    if (spellcasting.needToPrepareSpells && this.parent
+      && CONFIG.DND5E.spellcastingTypes.leveled.progression[finalSC.progression]) {
+      finalSC.spellPreparationLimit = Math.max(
+        1,
+        this.parent.system.abilities[finalSC.ability].mod
+        + Math.ceil(
+          this.system.levels / (CONFIG.DND5E.spellcastingTypes.leveled.progression[finalSC.progression].divisor || 1)
+        )
+      );
+    }
+
     // Temp method for determining spellcasting type until this data is available directly using advancement
     if ( CONFIG.DND5E.spellcastingTypes[finalSC.progression] ) finalSC.type = finalSC.progression;
     else finalSC.type = Object.entries(CONFIG.DND5E.spellcastingTypes).find(([type, data]) => {

--- a/packs/_source/classes/cleric.json
+++ b/packs/_source/classes/cleric.json
@@ -389,7 +389,8 @@
     ],
     "spellcasting": {
       "progression": "full",
-      "ability": "wis"
+      "ability": "wis",
+      "needToPrepareSpells": true
     },
     "startingEquipment": [
       {

--- a/packs/_source/classes/druid.json
+++ b/packs/_source/classes/druid.json
@@ -404,7 +404,8 @@
     ],
     "spellcasting": {
       "progression": "full",
-      "ability": "wis"
+      "ability": "wis",
+      "needToPrepareSpells": true
     },
     "startingEquipment": [
       {

--- a/packs/_source/classes/paladin.json
+++ b/packs/_source/classes/paladin.json
@@ -492,7 +492,8 @@
     ],
     "spellcasting": {
       "progression": "half",
-      "ability": "cha"
+      "ability": "cha",
+      "needToPrepareSpells": true
     },
     "startingEquipment": [
       {

--- a/packs/_source/classes/wizard.json
+++ b/packs/_source/classes/wizard.json
@@ -348,7 +348,8 @@
     ],
     "spellcasting": {
       "progression": "full",
-      "ability": "int"
+      "ability": "int",
+      "needToPrepareSpells": true
     },
     "startingEquipment": [
       {

--- a/templates/actors/tabs/character-spells.hbs
+++ b/templates/actors/tabs/character-spells.hbs
@@ -27,6 +27,12 @@
                 <span class="label">{{ localize "DND5E.SpellDC" }}</span>
                 <span class="value">{{ save }}</span>
             </div>
+            {{#if spellPreparationLimit}}
+                <div class="save">
+                    <span class="label">{{ localize "DND5E.spellPreparationLimit" }}</span>
+                    <span class="value">{{ spellPreparationLimit }}</span>
+                </div>
+            {{/if}}
         </div>
     </div>
     {{/each}}

--- a/templates/actors/tabs/character-spells.hbs
+++ b/templates/actors/tabs/character-spells.hbs
@@ -45,7 +45,7 @@
 <{{ elements.inventory }} class="inventory-element" v2>
 
     {{!-- Searching & Filtering --}}
-    <item-list-controls for="spellbook" label="{{ localize "DND5E.SpellsSearch" }}" sort="toggle" collection="items"
+    <item-list-controls for="spellbook" label="{{ localize "DND5E.SpellsSearch" }}" sort="multi" sortValues="apm" collection="items"
                         keep-empty>
         <datalist>
             <option value="action">{{ localize "DND5E.Action" }}</option>
@@ -104,7 +104,9 @@
 
                 {{!-- Spells --}}
                 <li class="item" data-item-id="{{ item.id }}" data-entry-id="{{ item.id }}"
-                    data-item-name="{{ item.name }}" data-item-sort="{{ item.sort }}" data-item-active="{{ item.isActiveSpellCasting }}">
+                data-item-name="{{ item.name }}" data-item-sort="{{ item.sort }}" data-item-active="{{ item.isActiveSpellCasting }}" 
+                    data-item-preparation-mode="{{ item.system.preparation.mode }}"
+                    data-item-preparation-prepared="{{ item.system.preparation.prepared }}">
 
                     {{!-- Spell Name --}}
                     <div class="item-name item-action item-tooltip {{ @root.rollableClass }}" role="button"

--- a/templates/actors/tabs/character-spells.hbs
+++ b/templates/actors/tabs/character-spells.hbs
@@ -1,7 +1,10 @@
 {{!-- Spellcasting --}}
 <section class="top">
     {{#each spellcasting}}
-    <div class="spellcasting card {{#if primary}}primary{{/if}}" data-ability="{{ ability.ability }}">
+    <div class="spellcasting card {{#if primary}}primary{{/if}}"
+    data-ability="{{ ability.ability }}"
+    data-spell-origin="{{ spellCastingOrigin }}"
+    data-prep-valid="{{ valid }}">
         <div class="header">
             <h3>{{ label }}</h3>
             <button type="button" class="radio-button" data-action="spellcasting"
@@ -30,7 +33,7 @@
             {{#if spellPreparationLimit}}
                 <div class="save">
                     <span class="label">{{ localize "DND5E.spellPreparationLimit" }}</span>
-                    <span class="value">{{ spellPreparationLimit }}</span>
+                    <span class="value" data-item-valid="{{ valid }}">{{ preparedSpellsCount }} / {{ spellPreparationLimit }}</span>
                 </div>
             {{/if}}
         </div>
@@ -101,7 +104,7 @@
 
                 {{!-- Spells --}}
                 <li class="item" data-item-id="{{ item.id }}" data-entry-id="{{ item.id }}"
-                    data-item-name="{{ item.name }}" data-item-sort="{{ item.sort }}">
+                    data-item-name="{{ item.name }}" data-item-sort="{{ item.sort }}" data-item-active="{{ item.isActiveSpellCasting }}">
 
                     {{!-- Spell Name --}}
                     <div class="item-name item-action item-tooltip {{ @root.rollableClass }}" role="button"

--- a/templates/items/parts/item-spellcasting.hbs
+++ b/templates/items/parts/item-spellcasting.hbs
@@ -15,3 +15,10 @@
         </select>
     </div>
 </div>
+
+<div class="form-group">
+    <label>{{localize "DND5E.needToPrepareSpells"}}</label>
+    <div class="form-fields">
+        <input type="checkbox" name="system.spellcasting.needToPrepareSpells" {{ checked system.spellcasting.needToPrepareSpells }}>
+    </div>
+</div>

--- a/templates/items/spell.hbs
+++ b/templates/items/spell.hbs
@@ -104,6 +104,22 @@
                     </select>
                 </div>
             </div>
+            {{!-- Bound Spellcasting Origin --}}
+            {{#if document.parent}}
+            <div class="form-group input-select">
+                <label>{{ localize "DND5E.BoundSpellOrigin" }}</label>
+                <div class="form-fields">
+                    <select name="system.boundOrigin">
+                        {{#select system.boundOrigin}}
+                        <option value=""></option>
+                        {{#each document.availableSpellCastingOrigins as |scs|}}
+                        <option value="{{scs.value}}">{{scs.name}}</option>
+                        {{/each}}
+                        {{/select}}
+                    </select>
+                </div>
+            </div>
+            {{/if}}
 
             <h3 class="form-header">{{ localize "DND5E.SpellCastingHeader" }}</h3>
 

--- a/templates/items/spell.hbs
+++ b/templates/items/spell.hbs
@@ -104,18 +104,15 @@
                     </select>
                 </div>
             </div>
-            {{!-- Bound Spellcasting Origin --}}
-            {{#if document.parent}}
+
+            {{!-- Source Class --}}
+            {{#if isEmbedded}}
             <div class="form-group input-select">
-                <label>{{ localize "DND5E.BoundSpellOrigin" }}</label>
+                <label>{{ localize "DND5E.SpellSourceClass" }}</label>
                 <div class="form-fields">
-                    <select name="system.boundOrigin">
-                        {{#select system.boundOrigin}}
-                        <option value=""></option>
-                        {{#each document.availableSpellCastingOrigins as |scs|}}
-                        <option value="{{scs.value}}">{{scs.name}}</option>
-                        {{/each}}
-                        {{/select}}
+                    <select name="system.sourceClass">
+                        {{selectOptions document.parent.spellcastingClasses selected=system.sourceClass
+                                        labelAttr="name" blank=""}}
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
- Count the prepared spells linked to a specific class
- Send warning if the number of spells exceeds the limit.
- Bind the spell statistics to the linked class and no longer to the active spell casting
- Separate spell list display according to current active spellcasting