### PR TITLE
Selective ability score improvement (first step to "true feat")

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -156,6 +156,7 @@
 "DND5E.AdvancementAbilityScoreImprovementFixed": "Fixed Improvement",
 "DND5E.AdvancementAbilityScoreImprovementLockedHint": "Scores cannot be modified with a feat selected.",
 "DND5E.AdvancementAbilityScoreImprovementPoints": "Points",
+"DND5E.AdvancementAbilityScoreImprovementAmong": "among",
 "DND5E.AdvancementAbilityScoreImprovementPointsHint": "Number of points that can be assigned to any ability score that doesn't have a fixed improvement set.",
 "DND5E.AdvancementAbilityScoreImprovementPointsRemaining.one": "{points} Point Remaining",
 "DND5E.AdvancementAbilityScoreImprovementPointsRemaining.other": "{points} Points Remaining",

--- a/less/v1/advancement.less
+++ b/less/v1/advancement.less
@@ -123,6 +123,9 @@
         label {
           grid-area: label;
           font-size: var(--font-size-18);
+          display: flex;
+          flex-direction: row;
+          align-items: center;
         }
         a {
           font-size: var(--font-size-16);

--- a/module/applications/advancement/ability-score-improvement-config.mjs
+++ b/module/applications/advancement/ability-score-improvement-config.mjs
@@ -19,9 +19,12 @@ export default class AbilityScoreImprovementConfig extends AdvancementConfig {
     const abilities = Object.entries(CONFIG.DND5E.abilities).reduce((obj, [key, data]) => {
       if ( !this.advancement.canImprove(key) ) return obj;
       const fixed = this.advancement.configuration.fixed[key] ?? 0;
+      const allowed = this.advancement.configuration.allowed[key] ?? true;
       obj[key] = {
         key,
+        allowed,
         name: `configuration.fixed.${key}`,
+        allowedPath: `configuration.allowed.${key}`,
         label: data.label,
         value: fixed,
         canIncrease: true,

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -55,28 +55,32 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
 
     const formatter = new Intl.NumberFormat(game.i18n.lang, { signDisplay: "always" });
 
-    const abilities = Object.entries(CONFIG.DND5E.abilities).reduce((obj, [key, data]) => {
-      if ( !this.advancement.canImprove(key) ) return obj;
-      const ability = this.advancement.actor.system.abilities[key];
-      const assignment = this.assignments[key] ?? 0;
-      const fixed = this.advancement.configuration.fixed[key] ?? 0;
-      const value = Math.min(ability.value + ((fixed || assignment) ?? 0), ability.max);
-      const max = fixed ? value : Math.min(value + points.available, ability.max);
-      obj[key] = {
-        key, max, value,
-        name: `abilities.${key}`,
-        label: data.label,
-        initial: ability.value,
-        min: fixed ? max : ability.value,
-        delta: (value - ability.value) ? formatter.format(value - ability.value) : null,
-        showDelta: true,
-        isDisabled: !!this.feat,
-        isFixed: !!fixed || (ability.value >= ability.max),
-        canIncrease: (value < max) && (assignment < points.cap) && !fixed && !this.feat,
-        canDecrease: (value > ability.value) && !fixed && !this.feat
-      };
-      return obj;
-    }, {});
+    const abilities = Object.entries(CONFIG.DND5E.abilities)
+      .filter(([key]) => this.advancement.configuration.allowed[key] ?? true)
+      .reduce((obj, [key, data]) => {
+        if ( !this.advancement.canImprove(key) ) return obj;
+        const ability = this.advancement.actor.system.abilities[key];
+        const assignment = this.assignments[key] ?? 0;
+        const fixed = this.advancement.configuration.fixed[key] ?? 0;
+        const allowed = this.advancement.configuration.allowed[key] ?? true;
+        const value = Math.min(ability.value + ((fixed || assignment) ?? 0), ability.max);
+        const max = fixed ? value : Math.min(value + points.available, ability.max);
+        obj[key] = {
+          allowed,
+          key, max, value,
+          name: `abilities.${key}`,
+          label: data.label,
+          initial: ability.value,
+          min: fixed ? max : ability.value,
+          delta: (value - ability.value) ? formatter.format(value - ability.value) : null,
+          showDelta: true,
+          isDisabled: !!this.feat,
+          isFixed: !!fixed || (ability.value >= ability.max),
+          canIncrease: (value < max) && (assignment < points.cap) && !fixed && !this.feat,
+          canDecrease: (value > ability.value) && !fixed && !this.feat
+        };
+        return obj;
+      }, {});
 
     const pluralRules = new Intl.PluralRules(game.i18n.lang);
     return foundry.utils.mergeObject(super.getData(), {

--- a/module/data/advancement/ability-score-improvement.mjs
+++ b/module/data/advancement/ability-score-improvement.mjs
@@ -20,6 +20,10 @@ export class AbilityScoreImprovementConfigurationData extends foundry.abstract.D
         new foundry.data.fields.NumberField({nullable: false, integer: true, initial: 0}),
         {label: "DND5E.AdvancementAbilityScoreImprovementFixed"}
       ),
+      allowed: new MappingField(
+        new foundry.data.fields.BooleanField({nullable: false, initial: true}),
+        {label: "DND5E.AdvancementAbilityScoreImprovementAllowed"}
+      ),
       cap: new foundry.data.fields.NumberField({
         integer: true, min: 1, initial: 2, label: "DND5E.AdvancementAbilityScoreImprovementCap",
         hint: "DND5E.AdvancementAbilityScoreImprovementCapHint"

--- a/module/documents/advancement/ability-score-improvement.mjs
+++ b/module/documents/advancement/ability-score-improvement.mjs
@@ -105,10 +105,23 @@ export default class AbilityScoreImprovementAdvancement extends Advancement {
         const name = CONFIG.DND5E.abilities[key]?.label ?? key;
         return `<span class="tag">${name} <strong>${formatter.format(value)}</strong></span>`;
       });
-      if ( this.configuration.points ) entries.push(`<span class="tag">${
-        game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementPoints")}: <strong>${
-        this.configuration.points}</strong></span>`
-      );
+      if ( this.configuration.points ) {
+        const selection = Object.keys(
+          this.configuration.allowed
+        ).map(key => ({key, value: this.configuration.allowed[key]}));
+        let among;
+        if (selection.some(({value}) => !value)) {
+          among = ` ${
+            game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementAmong")
+          } ${
+            selection.filter(({value}) => value).map(({key}) => CONFIG.DND5E.abilities[key]?.label ?? key).join(", ")
+          }`;
+        }
+        entries.push(`<span class="tag">${
+          game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementPoints")}: <strong>${
+          this.configuration.points}</strong>${among}</span>`
+        );
+      }
       return entries.filterJoin("\n");
     }
 

--- a/templates/advancement/ability-score-improvement-config.hbs
+++ b/templates/advancement/ability-score-improvement-config.hbs
@@ -15,7 +15,7 @@
             {{localize "DND5E.AdvancementAbilityScoreImprovementPointsHint"}}
         </li>
         {{#each abilities}}
-        {{> "dnd5e.advancement-ability-score-control" this canAdjust=true}}
+        {{> "dnd5e.advancement-ability-score-control" this canAdjust=true canAllow=@root.points.value}}
         {{/each}}
     </ul>
 </form>

--- a/templates/advancement/parts/advancement-ability-score-control.hbs
+++ b/templates/advancement/parts/advancement-ability-score-control.hbs
@@ -1,5 +1,12 @@
 <li data-score="{{key}}">
-    <label>{{label}}</label>
+    <label>
+        {{#if allowedPath}}
+            {{#if canAllow}}
+            <input type="checkbox" name="{{allowedPath}}" {{checked allowed}} data-tooltip="DND5E.AdvancementAbilityScoreImprovementAllowed">
+            {{/if}}
+        {{/if}}
+        {{label}}
+    </label>
     {{#if canAdjust}}
     <a class="adjustment-button" {{~#if canDecrease}}data-action="decrease"{{else}}aria-disabled="true"{{/if}}>
         <i class="fas fa-minus"></i>

--- a/templates/items/parts/item-advancement.hbs
+++ b/templates/items/parts/item-advancement.hbs
@@ -84,6 +84,7 @@
                 </div>
                 {{/if}}
                 {{#if this.summary}}
+                {{log this.summary}}
                 <div class="item-summary">
                     {{{this.summary}}}
                 </div>


### PR DESCRIPTION
- Add checkbox for each ability in the ability score improvement to limit the abilities which could be improved by "free" points.
- First step to manage feats with ability score improvement like "Athlete" or "Fey Touched"