### PR TITLE
[#3425] Add syntax to remove Set entry using active effect

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -212,8 +212,13 @@ export default class ActiveEffect5e extends ActiveEffect {
   /** @inheritdoc */
   _applyAdd(actor, change, current, delta, changes) {
     if ( current instanceof Set ) {
-      if ( Array.isArray(delta) ) delta.forEach(item => current.add(item));
-      else current.add(delta);
+      const handle = v => {
+        const neg = v.replace(/^\s*-\s*/, "");
+        if ( neg !== v ) current.delete(neg);
+        else current.add(v);
+      };
+      if ( Array.isArray(delta) ) delta.forEach(item => handle(item));
+      else handle(delta);
       return;
     }
     super._applyAdd(actor, change, current, delta, changes);


### PR DESCRIPTION
Simply checks whether an value that is being added to a set starts with a `-` and potentially some white space and if so, removes that entry from the set rather than adding it.

Closes #3425