### PR TITLE
[#3300] Add setting to allow players to use Damage Application methods

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -6872,6 +6872,10 @@
       "Hint": "Make critical hits more deadly by multiplying non-dice modifiers in addition to rolled dice."
     }
   },
+  "DAMAGE": {
+    "Hint": "Allow players to use the damage application method in damage rolls.",
+    "Name": "Player Damage Application"
+  },
   "DEFAULTSKILLS": {
     "Name": "Default Skills",
     "Hint": "The default skills that appear on NPC sheets regardless of level of proficiency."

--- a/module/applications/components/targeted-application-mixin.mjs
+++ b/module/applications/components/targeted-application-mixin.mjs
@@ -120,7 +120,8 @@ export default function TargetedApplicationMixin(Base) {
     buildTargetsList() {
       if ( this.shouldBuildTargetList === false ) return;
       const targetedTokens = new Map();
-      switch ( this.targetingMode ) {
+      const mode = game.user.isGM ? this.targetingMode : "selected";
+      switch ( mode ) {
         case "targeted":
           for ( const descriptor of this.chatMessage?.system?.targets ?? [] ) {
             const { actor, token } = TargetsField.resolve(descriptor);

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -271,6 +271,16 @@ export function registerSystemSettings() {
     type: Boolean
   });
 
+  // Allow players using damage tray
+  game.settings.register("dnd5e", "allowPlayerDamageApplication", {
+    name: "SETTINGS.DND5E.DAMAGE.Name",
+    hint: "SETTINGS.DND5E.DAMAGE.Hint",
+    scope: "world",
+    config: true,
+    default: true,
+    type: Boolean
+  });
+
   // Allow Polymorphing
   game.settings.register("dnd5e", "allowPolymorphing", {
     name: "SETTINGS.DND5E.PERMISSIONS.AllowTransformation.Name",


### PR DESCRIPTION
Adds a setting that lets a GM toggle whether players can also use the damage application options.

Intentionally enabled by default.

On the player side, this will only allow for Selected Tokens to have damage applied. The GM side is unchanged.

Closes #3300.