### PR TITLE
[#3418] Add enchantment configuration & restrictions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -682,6 +682,7 @@
 "DND5E.EffectsSearch": "Search effects",
 "DND5E.Enchantment": {
   "Action": {
+    "Configure": "Configure Enchantment",
     "Create": "Create Enchantment",
     "Delete": "Delete Enchantment",
     "Disable": "Disable Enchantment",
@@ -690,12 +691,44 @@
   },
   "Category": {
     "Active": "Active Enchantments",
+    "Empty": "No enchantments have been created, use the button above to create one.",
     "General": "Enchantments",
     "Inactive": "Inactive Enchantments"
   },
+  "Configuration": "Enchantment Configuration",
+  "FIELDS": {
+    "enchantment": {
+      "label": "Enchantment Configuration",
+      "items": {
+        "max": {
+          "label": "Item Limit",
+          "hint": "Formula for the maximum number of items that can have this enchantment.",
+          "hintSource": "Formula for the maximum number of enchantments of this type that can be active at a time."
+        },
+        "period": {
+          "label": "Replacement Period",
+          "hint": "How frequently the enchantments of this type can be re-bound to different items."
+        }
+      },
+      "restrictions": {
+        "label": "Restrictions",
+        "hint": "Restrictions on the type of item to which this enchantment can be applied.",
+        "allowMagical": {
+          "label": "Allow Magical",
+          "hint": "Allow items that are already magical to be enchanted."
+        },
+        "type": {
+          "label": "Item Type",
+          "hint": "Type of item to which this enchantment can be applied."
+        }
+      }
+    }
+  },
   "Label": "Enchantment",
   "Warning": {
-    "Override": "This value is being modified by an Enchantment and cannot be edited. Disable the enchantment in the effects tab to edit it."
+    "NoMagicalItems": "Items that are already magical cannot be enchanted.",
+    "Override": "This value is being modified by an Enchantment and cannot be edited. Disable the enchantment in the effects tab to edit it.",
+    "WrongType": "{incorrectType} items cannot be enchanted by this enchantment, only {allowedType} items are allowed."
   }
 },
 "DND5E.Environment": "Environment",
@@ -1722,6 +1755,7 @@
 "DND5E.UsesMax": "Maximum Uses",
 "DND5E.UsesPeriod": "Recovery Period",
 "DND5E.UsesPeriods": {
+  "AtWill": "At Will",
   "Charges": "Charges",
   "ChargesAbbreviation": "Charges",
   "Dawn": "Dawn",
@@ -1732,6 +1766,7 @@
   "DuskAbbreviation": "Dusk",
   "Lr": "Long Rest",
   "LrAbbreviation": "LR",
+  "Never": "Never",
   "Sr": "Short Rest",
   "SrAbbreviation": "SR"
 },

--- a/lang/en.json
+++ b/lang/en.json
@@ -702,8 +702,7 @@
       "items": {
         "max": {
           "label": "Item Limit",
-          "hint": "Formula for the maximum number of items that can have this enchantment.",
-          "hintSource": "Formula for the maximum number of enchantments of this type that can be active at a time."
+          "hint": "Formula for the maximum number of enchantments of this type that can be active at a time."
         },
         "period": {
           "label": "Replacement Period",

--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -357,7 +357,7 @@
     }
   }
 
-  .summoning.form-group {
+  :is(.enchantment, .summoning).form-group {
     .config-button {
       opacity: 1;
       font-size: var(--font-size-12);
@@ -549,10 +549,10 @@
 }
 
 /* ----------------------------------------- */
-/*  Summoning Configuration                  */
+/*  Enchantment & Summoning Configuration    */
 /* ----------------------------------------- */
 
-.dnd5e.summoning-config {
+.dnd5e:is(.enchantment-config, .summoning-config) {
   max-block-size: 90vh;
 
   .unbutton {
@@ -565,35 +565,12 @@
     &:hover { text-shadow: 0 0 8px var(--color-shadow-primary); }
     &:focus-visible { outline: 2px solid black; }
   }
-
   .form-header {
     justify-content: space-between;
     button { flex: unset; }
   }
 
-  ul.profiles {
-    padding: 0;
-    list-style: none;
-    gap: 12px;
-  }
-  li.profile {
-    position: relative;
-    padding: 8px;
-    background: var(--dnd5e-color-card);
-    border: 2px solid var(--dnd5e-color-gold);
-    border-radius: 4px;
-    box-shadow: 0 0 4px var(--dnd5e-shadow-45);
-
-    .details {
-      gap: 4px;
-      input { height: unset; }
-    }
-    [data-action="delete-profile"] {
-      --size: 26px;
-      flex: 0 0 var(--size);
-      block-size: var(--size);
-      inline-size: var(--size);
-    }
+  .separated-list {
     .content-link, .drop-area {
       flex: 0 0 175px;
       display: flex;

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -398,6 +398,42 @@
   }
 
   /* ---------------------------------- */
+  /*  Lists                             */
+  /* ---------------------------------- */
+
+  .separated-list, &.separated-list {
+    padding: 0;
+    list-style: none;
+    gap: 12px;
+
+    > li:not(.empty) {
+      position: relative;
+      padding: 8px;
+      background: var(--dnd5e-color-card);
+      border: 2px solid var(--dnd5e-color-gold);
+      border-radius: 4px;
+      box-shadow: 0 0 4px var(--dnd5e-shadow-45);
+
+      .details {
+        gap: 4px;
+        input { height: unset; }
+        input::placeholder { opacity: .5; }
+      }
+      .list-controls {
+        justify-content: flex-end;
+        gap: inherit;
+
+        button {
+          --size: 26px;
+          flex: 0 0 var(--size);
+          block-size: var(--size);
+          inline-size: var(--size);
+        }
+      }
+    }
+  }
+
+  /* ---------------------------------- */
   /*  Form Elements                     */
   /* ---------------------------------- */
 

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -123,7 +123,7 @@ export default class EffectsElement extends HTMLElement {
     };
 
     // Iterate over active effects, classifying them into categories
-    const enchantmentParent = (parent?.system.type?.value === "enchantment") || (parent?.system.actionType === "ench");
+    const enchantmentParent = parent?.system.isEnchantment;
     for ( const e of effects ) {
       if ( (e.parent.system?.identified === false) && !game.user.isGM ) continue;
       if ( e.getFlag("dnd5e", "type") === "enchantment" ) {

--- a/module/applications/item/enchantment-config.mjs
+++ b/module/applications/item/enchantment-config.mjs
@@ -66,22 +66,18 @@ export default class EnchantmentConfig extends DocumentSheet {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async _updateObject(event, formData) {
-    const { action, enchantmentId } = formData;
-    delete formData.action;
-    delete formData.enchantmentId;
-
+  async _updateObject(event, { action, enchantmentId, ...formData }) {
     await this.document.update({"system.enchantment": formData});
 
     switch ( action ) {
       case "add-enchantment":
-        const effect = await this.document.createEmbeddedDocuments("ActiveEffect", [{
+        const effect = await ActiveEffect.implementation.create({
           name: this.document.name,
           icon: this.document.img,
           origin: this.document.uuid,
           "flags.dnd5e.type": "enchantment"
-        }]);
-        effect[0].sheet.render(true);
+        }, { parent: this.document });
+        effect.sheet.render(true);
         break;
       case "delete-enchantment":
         const enchantment = this.document.effects.get(enchantmentId);

--- a/module/applications/item/enchantment-config.mjs
+++ b/module/applications/item/enchantment-config.mjs
@@ -1,0 +1,92 @@
+import { EnchantmentData } from "../../data/item/fields/enchantment-field.mjs";
+
+/**
+ * Application for configuring enchantment information for an item.
+ */
+export default class EnchantmentConfig extends DocumentSheet {
+
+  /** @inheritDoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["dnd5e", "enchantment-config"],
+      dragDrop: [{ dropSelector: "form" }],
+      template: "systems/dnd5e/templates/apps/enchantment-config.hbs",
+      width: 500,
+      height: "auto",
+      sheetConfig: false,
+      closeOnSubmit: false,
+      submitOnChange: true,
+      submitOnClose: true
+    });
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  get title() {
+    return `${game.i18n.localize("DND5E.Enchantment.Configuration")}: ${this.document.name}`;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async getData(options={}) {
+    const context = await super.getData(options);
+    context.enchantableTypes = EnchantmentData.enchantableTypes.reduce((obj, k) => {
+      obj[k] = game.i18n.localize(CONFIG.Item.typeLabels[k]);
+      return obj;
+    }, {});
+    context.enchantment = this.document.system.enchantment;
+    context.enchantments = this.document.effects.filter(e => e.getFlag("dnd5e", "type") === "enchantment");
+    context.source = this.document.toObject().system.enchantment;
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Handling                              */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  activateListeners(jQuery) {
+    super.activateListeners(jQuery);
+    const html = jQuery[0];
+
+    for ( const element of html.querySelectorAll("[data-action]") ) {
+      element.addEventListener("click", event => this.submit({ updateData: {
+        action: event.target.dataset.action,
+        enchantmentId: event.target.closest("[data-enchantment-id]")?.dataset.enchantmentId
+      } }));
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _updateObject(event, formData) {
+    const { action, enchantmentId } = formData;
+    delete formData.action;
+    delete formData.enchantmentId;
+
+    await this.document.update({"system.enchantment": formData});
+
+    switch ( action ) {
+      case "add-enchantment":
+        const effect = await this.document.createEmbeddedDocuments("ActiveEffect", [{
+          name: this.document.name,
+          icon: this.document.img,
+          origin: this.document.uuid,
+          "flags.dnd5e.type": "enchantment"
+        }]);
+        effect[0].sheet.render(true);
+        break;
+      case "delete-enchantment":
+        const enchantment = this.document.effects.get(enchantmentId);
+        enchantment?.deleteDialog();
+        break;
+    }
+  }
+}

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -9,6 +9,7 @@ import AdvancementMigrationDialog from "../advancement/advancement-migration-dia
 import Accordion from "../accordion.mjs";
 import EffectsElement from "../components/effects.mjs";
 import SourceConfig from "../source-config.mjs";
+import EnchantmentConfig from "./enchantment-config.mjs";
 import StartingEquipmentConfig from "./starting-equipment-config.mjs";
 import SummoningConfig from "./summoning-config.mjs";
 
@@ -595,6 +596,9 @@ export default class ItemSheet5e extends ItemSheet {
     const button = event.currentTarget;
     let app;
     switch ( button.dataset.action ) {
+      case "enchantment":
+        app = new EnchantmentConfig(this.item);
+        break;
       case "movement":
         app = new ActorMovementConfig(this.item, { keyPath: "system.movement" });
         break;

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -888,7 +888,7 @@ DND5E.limitedUseFormulaPeriods = {
  * @typedef {object} LimitedUsePeriodConfiguration
  * @property {string} label           Localized label.
  * @property {string} abbreviation    Shorthand form of the label.
- * @property {boolean} [formula]      Whether this limited use period restores chargs via formula.
+ * @property {boolean} [formula]      Whether this limited use period restores charges via formula.
  */
 
 /**
@@ -926,6 +926,25 @@ DND5E.limitedUsePeriods = {
 };
 preLocalize("limitedUsePeriods", { keys: ["label", "abbreviation"] });
 patchConfig("limitedUsePeriods", "label", { since: "DnD5e 3.1", until: "DnD5e 3.3" });
+
+/* -------------------------------------------- */
+
+/**
+ * Periods at which enchantments can be re-bound to new items.
+ * @enum {{ label: string }}
+ */
+DND5E.enchantmentPeriods = {
+  sr: {
+    label: "DND5E.UsesPeriods.Sr"
+  },
+  lr: {
+    label: "DND5E.UsesPeriods.Lr"
+  },
+  atwill: {
+    label: "DND5E.UsesPeriods.AtWill"
+  }
+};
+preLocalize("enchantmentPeriods", { key: "label" });
 
 /* -------------------------------------------- */
 

--- a/module/data/item/_module.mjs
+++ b/module/data/item/_module.mjs
@@ -25,6 +25,7 @@ export {
   ToolData,
   WeaponData
 };
+export {default as EnchantmentField, EnchantmentData, EnchantmentError} from "./fields/enchantment-field.mjs";
 export {default as ItemTypeField} from "./fields/item-type-field.mjs";
 export {default as SummonsField, SummonsData} from "./fields/summons-field.mjs";
 export {default as ActionTemplate} from "./templates/action.mjs";

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -3,6 +3,7 @@ import ActionTemplate from "./templates/action.mjs";
 import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ItemTypeTemplate from "./templates/item-type.mjs";
+import {default as EnchantmentField, EnchantmentData} from "./fields/enchantment-field.mjs";
 import ItemTypeField from "./fields/item-type-field.mjs";
 
 const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
@@ -14,6 +15,7 @@ const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundr
  * @mixes ActivatedEffectTemplate
  * @mixes ActionTemplate
  *
+ * @property {EnchantmentData} enchantment          Enchantment configuration associated with this type.
  * @property {object} prerequisites
  * @property {number} prerequisites.level           Character or class level required to choose this feature.
  * @property {Set<string>} properties               General properties of a feature item.
@@ -27,12 +29,13 @@ export default class FeatData extends ItemDataModel.mixin(
 ) {
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.Prerequisites"];
+  static LOCALIZATION_PREFIXES = ["DND5E.Enchantment", "DND5E.Prerequisites"];
 
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
       type: new ItemTypeField({baseItem: false}, {label: "DND5E.ItemFeatureType"}),
+      enchantment: new EnchantmentField(),
       prerequisites: new SchemaField({
         level: new NumberField({integer: true, min: 0})
       }),
@@ -144,6 +147,27 @@ export default class FeatData extends ItemDataModel.mixin(
   /** @inheritdoc */
   get hasLimitedUses() {
     return this.isActive && (!!this.recharge.value || super.hasLimitedUses);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this feature an enchantment?
+   * @type {boolean}
+   */
+  get isEnchantment() {
+    return EnchantmentData.isEnchantment(this);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does this feature represent a group of individual enchantments (e.g. the "Infuse Item" feature stores data about
+   * all of the character's infusions).
+   * @type {boolean}
+   */
+  get isEnchantmentSource() {
+    return EnchantmentData.isEnchantmentSource(this);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/fields/enchantment-field.mjs
+++ b/module/data/item/fields/enchantment-field.mjs
@@ -1,0 +1,135 @@
+import { FormulaField } from "../../fields.mjs";
+
+const { BooleanField, EmbeddedDataField, SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * A field for storing summons data.
+ */
+export default class EnchantmentField extends EmbeddedDataField {
+  /**
+   * Construct an enchantment field.
+   * @param {object} [options={}]  Options to configure this field's behavior.
+   */
+  constructor(options={}) {
+    super(EnchantmentData, foundry.utils.mergeObject({ required: false, nullable: true, initial: null }, options));
+  }
+}
+
+/**
+ * Data model for enchantment configuration.
+ *
+ * @property {object} items
+ * @property {string} items.max                   Maximum number of items that can have this enchantment.
+ * @property {string} items.period                Frequently at which the enchantment be swapped.
+ * @property {object} restrictions
+ * @property {boolean} restrictions.allowMagical  Allow enchantments to be applied to items that are already magical.
+ * @property {string} restrictions.type           Item type to which this enchantment can be applied.
+ */
+export class EnchantmentData extends foundry.abstract.DataModel {
+
+  /** @inheritDoc */
+  static defineSchema() {
+    return {
+      items: new SchemaField({
+        max: new FormulaField({deterministic: true})
+      }),
+      restrictions: new SchemaField({
+        allowMagical: new BooleanField(),
+        type: new StringField()
+      })
+    };
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * List of item types that are enchantable.
+   * @type {Set<string>}
+   */
+  static get enchantableTypes() {
+    return Object.entries(CONFIG.Item.dataModels).reduce((set, [k, v]) => {
+      if ( v.metadata?.enchantable ) set.add(k);
+      return set;
+    }, new Set());
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this feature an enchantment?
+   * @param {FeatData} data  Data for the feature.
+   * @returns {boolean}
+   */
+  static isEnchantment(data) {
+    return (data.actionType === "ench") || (data.type?.value === "enchantment");
+  }
+
+  /**
+   * Is this feature an enchantment?
+   * @type {boolean}
+   */
+  get isEnchantment() {
+    return EnchantmentData.isEnchantment(this.parent);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does this feature represent a group of individual enchantments (e.g. the "Infuse Item" feature stores data about
+   * all of the character's infusions).
+   * @param {FeatData} data  Data for the feature.
+   * @returns {boolean}
+   */
+  static isEnchantmentSource(data) {
+    return !this.isEnchantment(data)
+      && CONFIG.DND5E.featureTypes[data.type?.value]?.subtypes?.[data.type?.subtype]
+      && (data.type?.subtype in CONFIG.DND5E.featureTypes.enchantment.subtypes);
+  }
+
+  /**
+   * Does this feature represent a group of individual enchantments (e.g. the "Infuse Item" feature stores data about
+   * all of the character's infusions).
+   * @type {boolean}
+   */
+  get isEnchantmentSource() {
+    return EnchantmentData.isEnchantmentSource(this.parent);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Determine whether the provided item can be enchanted based on this enchantment's restrictions.
+   * @param {Item5e} item  Item that might be enchanted.
+   * @returns {true|EnchantmentError[]}
+   */
+  canEnchant(item) {
+    const errors = [];
+
+    if ( !this.restrictions.allowMagical && item.system.properties?.has("mgc") ) {
+      errors.push(new EnchantmentError(game.i18n.localize("DND5E.Enchantment.Warning.NoMagicalItems")));
+    }
+
+    if ( this.restrictions.type && (item.type !== this.restrictions.type) ) {
+      errors.push(new EnchantmentError(game.i18n.format("DND5E.Enchantment.Warning.WrongType", {
+        incorrectType: game.i18n.localize(CONFIG.Item.typeLabels[item.type]),
+        allowedType: game.i18n.localize(CONFIG.Item.typeLabels[this.restrictions.type])
+      })));
+    }
+
+    return errors.length ? errors : true;
+  }
+}
+
+/**
+ * Error to throw when an item cannot be enchanted.
+ */
+export class EnchantmentError extends Error {
+  constructor(...args) {
+    super(...args);
+    this.name = "EnchantmentError";
+  }
+}

--- a/module/data/item/fields/enchantment-field.mjs
+++ b/module/data/item/fields/enchantment-field.mjs
@@ -20,7 +20,7 @@ export default class EnchantmentField extends EmbeddedDataField {
  *
  * @property {object} items
  * @property {string} items.max                   Maximum number of items that can have this enchantment.
- * @property {string} items.period                Frequently at which the enchantment be swapped.
+ * @property {string} items.period                Frequency at which the enchantment be swapped.
  * @property {object} restrictions
  * @property {boolean} restrictions.allowMagical  Allow enchantments to be applied to items that are already magical.
  * @property {string} restrictions.type           Item type to which this enchantment can be applied.
@@ -31,7 +31,8 @@ export class EnchantmentData extends foundry.abstract.DataModel {
   static defineSchema() {
     return {
       items: new SchemaField({
-        max: new FormulaField({deterministic: true})
+        max: new FormulaField({deterministic: true}),
+        period: new StringField()
       }),
       restrictions: new SchemaField({
         allowMagical: new BooleanField(),

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -3,7 +3,7 @@ import { staticID } from "../../../utils.mjs";
 import { FormulaField, IdentifierField } from "../../fields.mjs";
 
 const {
-  ArrayField, BooleanField, DocumentIdField, NumberField, SchemaField, SetField, StringField
+  ArrayField, BooleanField, DocumentIdField, EmbeddedDataField, NumberField, SchemaField, SetField, StringField
 } = foundry.data.fields;
 
 /**
@@ -11,7 +11,7 @@ const {
  *
  * @param {object} [options={}]  Options to configure this field's behavior.
  */
-export default class SummonsField extends foundry.data.fields.EmbeddedDataField {
+export default class SummonsField extends EmbeddedDataField {
   constructor(options={}) {
     super(SummonsData, foundry.utils.mergeObject({ required: false, nullable: true, initial: null }, options));
   }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -1,6 +1,7 @@
 import { filteredKeys } from "../../utils.mjs";
 import { ItemDataModel } from "../abstract.mjs";
 import { FormulaField } from "../fields.mjs";
+import {default as EnchantmentField, EnchantmentData} from "./fields/enchantment-field.mjs";
 import ActionTemplate from "./templates/action.mjs";
 import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
@@ -14,6 +15,7 @@ import ItemDescriptionTemplate from "./templates/item-description.mjs";
  * @property {number} level                      Base level of the spell.
  * @property {string} school                     Magical school to which this spell belongs.
  * @property {Set<string>} properties            General components and tags for this spell.
+ * @property {EnchantmentData} enchantment       Enchantment configuration associated with this type.
  * @property {object} materials                  Details on material components required for this spell.
  * @property {string} materials.value            Description of the material components required for casting.
  * @property {boolean} materials.consumed        Are these material components consumed during casting?
@@ -39,6 +41,7 @@ export default class SpellData extends ItemDataModel.mixin(
       properties: new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {
         label: "DND5E.SpellComponents"
       }),
+      enchantment: new EnchantmentField(),
       materials: new foundry.data.fields.SchemaField({
         value: new foundry.data.fields.StringField({required: true, label: "DND5E.SpellMaterialsDescription"}),
         consumed: new foundry.data.fields.BooleanField({required: true, label: "DND5E.SpellMaterialsConsumed"}),
@@ -164,6 +167,16 @@ export default class SpellData extends ItemDataModel.mixin(
   /** @inheritdoc */
   get _typeCriticalThreshold() {
     return this.parent?.actor?.flags.dnd5e?.spellCriticalThreshold ?? Infinity;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this spell an enchantment?
+   * @type {boolean}
+   */
+  get isEnchantment() {
+    return EnchantmentData.isEnchantment(this);
   }
 
   /* -------------------------------------------- */

--- a/templates/apps/enchantment-config.hbs
+++ b/templates/apps/enchantment-config.hbs
@@ -1,0 +1,41 @@
+<form autocomplete="off">
+    <h3 class="form-header flexrow">
+        {{ localize "DND5E.Enchantment.Category.General" }}
+        <button type="button" class="unbutton" data-action="add-enchantment">
+            <i class="fa-solid fa-plus" aria-hidden="true"></i>
+            {{ localize 'DND5E.Enchantment.Action.Create' }}
+        </button>
+    </h3>
+    <ul class="dnd5e2 separated-list enchantments flexcol">
+        {{#each enchantments}}
+        <li class="enchantment" data-enchantment-id="{{ id }}">
+            <div class="details flexrow">
+                {{{ dnd5e-linkForUuid uuid }}}
+                <div class="list-controls flexrow">
+                    <button type="button" class="unbutton" data-action="delete-enchantment"
+                            data-tooltip="DND5E.Enchantment.Action.Delete"
+                            aria-label="{{ localize 'DND5E.Enchantment.Action.Delete' }}">
+                        <i class="fa-solid fa-trash fa-fw" inert></i>
+                    </button>
+                </div>
+            </div>
+        </li>
+        {{else}}
+        <li class="empty">{{ localize "DND5E.Enchantment.Category.Empty" }}</li>
+        {{/each}}
+    </ul>
+
+    <h3 class="form-header">{{ localize "DND5E.Enchantment.FIELDS.enchantment.restrictions.label" }}</h3>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Enchantment.FIELDS.enchantment.restrictions.allowMagical.label" }}</label>
+        <input type="checkbox" name="restrictions.allowMagical" {{ checked enchantment.restrictions.allowMagical }}>
+        <p class="hint">{{ localize "DND5E.Enchantment.FIELDS.enchantment.restrictions.allowMagical.hint" }}</p>
+    </div>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Enchantment.FIELDS.enchantment.restrictions.type.label" }}</label>
+        <select name="restrictions.type">
+            {{ selectOptions enchantableTypes selected=enchantment.restrictions.type blank="" }}
+        </select>
+        <p class="hint">{{ localize "DND5E.Enchantment.FIELDS.enchantment.restrictions.type.hint" }}</p>
+    </div>
+</form>

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -4,9 +4,9 @@
         <button type="button" class="unbutton" data-action="add-profile">
             <i class="fa-solid fa-plus" aria-hidden="true"></i>
             {{ localize 'DND5E.Summoning.Action.Add' }}
-        </a>
+        </button>
     </h3>
-    <ul class="profiles flexcol">
+    <ul class="dnd5e2 separated-list profiles flexcol">
         {{#each profiles}}
         <li class="profile dnd5e2" data-profile-id="{{ id }}">
             <div class="details flexrow">
@@ -20,11 +20,13 @@
                 <input type="text" name="profiles.{{ id }}.name" value="{{ name }}" aria-label="{{ localize 'Name' }}"
                        placeholder="{{#if document}}{{ document.name }}{{else}}
                        {{~ localize 'DND5E.Summoning.DisplayName' }}{{/if}}">
-                <button type="button" class="unbutton" data-action="delete-profile"
-                        data-tooltip="DND5E.Summoning.Action.Remove"
-                        aria-label="{{ localize 'DND5E.Summoning.Action.Remove' }}">
-                    <i class="fa-solid fa-trash fa-fw" inert></i>
-                </button>
+                <div class="list-controls">
+                    <button type="button" class="unbutton" data-action="delete-profile"
+                            data-tooltip="DND5E.Summoning.Action.Remove"
+                            aria-label="{{ localize 'DND5E.Summoning.Action.Remove' }}">
+                        <i class="fa-solid fa-trash fa-fw" inert></i>
+                    </button>
+                </div>
             </div>
             <input type="hidden" name="profiles.{{ id }}._id" value="{{ id }}">
             <input type="hidden" name="profiles.{{ id }}.uuid" value="{{ uuid }}">

--- a/templates/items/feat.hbs
+++ b/templates/items/feat.hbs
@@ -83,6 +83,26 @@
                 <p class="hint">{{ localize "DND5E.Prerequisites.FIELDS.prerequisites.level.hint" }}</p>
             </div>
 
+            {{#if system.isEnchantmentSource}}
+            <h3 class="form-header">{{ localize "DND5E.Enchantment.Label" }}</h3>
+
+            <div class="form-group">
+                <label>{{ localize "DND5E.Enchantment.FIELDS.enchantment.items.max.label" }}</label>
+                <input type="text" name="system.enchantment.items.max" value="{{ source.enchantment.items.max }}">
+                <p class="hint">{{ localize "DND5E.Enchantment.FIELDS.enchantment.items.max.hintSource" }}</p>
+            </div>
+            
+            <div class="form-group">
+                <label>{{ localize "DND5E.Enchantment.FIELDS.enchantment.items.period.label" }}</label>
+                <select name="system.enchantment.items.period">
+                    {{ selectOptions config.enchantmentPeriods selected=system.enchantment.items.period
+                                     labelAttr="label" blank=(localize "DND5E.UsesPeriods.Never") }}
+                </select>
+                <p class="hint">{{ localize "DND5E.Enchantment.FIELDS.enchantment.items.period.hint" }}</p>
+            </div>
+
+            {{/if}}
+
             <h3 class="form-header">{{ localize "DND5E.FeatureUsage" }}</h3>
 
             {{!-- Item Activation Template --}}

--- a/templates/items/feat.hbs
+++ b/templates/items/feat.hbs
@@ -89,7 +89,7 @@
             <div class="form-group">
                 <label>{{ localize "DND5E.Enchantment.FIELDS.enchantment.items.max.label" }}</label>
                 <input type="text" name="system.enchantment.items.max" value="{{ source.enchantment.items.max }}">
-                <p class="hint">{{ localize "DND5E.Enchantment.FIELDS.enchantment.items.max.hintSource" }}</p>
+                <p class="hint">{{ localize "DND5E.Enchantment.FIELDS.enchantment.items.max.hint" }}</p>
             </div>
             
             <div class="form-group">

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -120,6 +120,19 @@
     </div>
 </div>
 
+{{!-- Enchantment --}}
+{{#if system.isEnchantment}}
+<div class="form-group enchantment">
+    <label>{{ localize "DND5E.Enchantment.Label" }}</label>
+    <div class="form-fields">
+        <a class="config-button" data-action="enchantment">
+            <i class="fa-solid fa-gear" aria-hidden="true"></i>
+            {{ localize "DND5E.Enchantment.Action.Configure" }}
+        </a>
+    </div>
+</div>
+{{/if}}
+
 {{!-- Summoning --}}
 {{#if (eq system.actionType "summ")}}
 <div class="form-group summoning">


### PR DESCRIPTION
Adds a new `EnchantmentData` embedded data model onto `feat` & `spell` items that contains configuration data for enchantments. This includes a number of helper methods to determine if an item represents an enchantment or enchantment source.

<img width="520" alt="Enchantment Config" src="https://github.com/foundryvtt/dnd5e/assets/19979839/92b1b4a1-c4f4-42d9-8602-14a09eb2d03b">

For enchantments, restrictions are added for whether the enchantment can be applied to magical items and what types of items it can apply to. There is also a `canEnchant` method that takes an item and determines whether it meets the required criteria.

<img width="573" alt="Enchantment Source Configuration" src="https://github.com/foundryvtt/dnd5e/assets/19979839/c317d455-795a-4d5a-a098-f15108b78189">

For enchantment sources there is a formula for the maximum number of enchantments in effect at a time and the period at which enchanted items can be re-bound.

Closes #3418