### PR TITLE
[#3242] Support summoning more than one creature at a time

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1512,6 +1512,9 @@
     }
   },
   "Configuration": "Summoning Configuration",
+  "Count": {
+    "Label": "Count"
+  },
   "CreatureChanges": {
     "Label": "Creature Changes",
     "Hint": "Changes that will be made to the creature being summoned. Any @ references used in the following formulas will be based on the summoner's stats. Summoned creature's stats can be referenced using @summon (e.g. @summon.attributes.hd.max to reference the creature's hit dice count)."
@@ -1524,7 +1527,7 @@
     "Label": "Creature Types",
     "Hint": "Summoned creature will be changed to this type. If more than one type is selected, then the player will be able to choose from these types when summoning."
   },
-  "DisplayName": "Display Name",
+  "DisplayName": "Profile Name",
   "DropHint": "Drop creature here",
   "ItemChanges": {
     "Label": "Item Changes",

--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -1,3 +1,5 @@
+import simplifyRollFormula from "../../dice/simplify-roll-formula.mjs";
+
 /**
  * A specialized Dialog subclass for ability usage.
  *
@@ -198,7 +200,12 @@ export default class AbilityUseDialog extends Dialog {
           const doc = profile.uuid ? fromUuidSync(profile.uuid) : null;
           const withinRange = ((profile.level.min ?? -Infinity) <= level) && (level <= (profile.level.max ?? Infinity));
           if ( !doc || !withinRange ) return null;
-          const label = profile.name ? profile.name : (doc?.name ?? "—");
+          let label = profile.name ? profile.name : (doc?.name ?? "—");
+          let count = simplifyRollFormula(Roll.replaceFormulaData(profile.count ?? "1", rollData));
+          if ( Number.isNumeric(count) ) {
+            count = parseInt(count);
+            if ( count > 1 ) label = `${count} x ${label}`;
+          } else if ( count ) label = `${count} x ${label}`;
           return [profile._id, label];
         })
         .filter(f => f)
@@ -457,7 +464,7 @@ export default class AbilityUseDialog extends Dialog {
     if ( !originalInput ) return;
 
     // If multiple profiles, replace with select element
-    if ( summoningData.profles ) {
+    if ( summoningData.profiles ) {
       const select = document.createElement("select");
       select.name = "summonsProfile";
       select.ariaLabel = game.i18n.localize("DND5E.Summoning.Profile.Label");

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -10,6 +10,8 @@
         {{#each profiles}}
         <li class="profile dnd5e2" data-profile-id="{{ id }}">
             <div class="details flexrow">
+                <input type="text" name="profiles.{{ id }}.count" value="{{ count }}" placeholder="1"
+                       aria-label="{{ localize 'DND5E.Summoning.Count.Label' }}">
                 {{#if document}}
                 {{{ dnd5e-linkForUuid uuid }}}
                 {{else}}


### PR DESCRIPTION
Adds summoning count formulas to summons profiles which allow specifying how many creatures are summoned, modifiable based on spell level or any other calculations required.

<img width="516" alt="Summoning Count Config" src="https://github.com/foundryvtt/dnd5e/assets/19979839/957d3851-8811-4934-bad0-b267e8a22a2b">

The ability use dialog has been updated to display how many of each profile will be summoned and will update dynamically when the spell level is changed.

<img width="421" alt="Summoning Count Prompt" src="https://github.com/foundryvtt/dnd5e/assets/19979839/17f0a1cc-4fda-4fb8-ae54-235312125a6e">
