### PR TITLE
[#3242] Add level limits to summoning profiles

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1484,6 +1484,7 @@
     "Remove": "Remove Profile",
     "Summon": "Summon"
   },
+  "AdditionalSettings": "Additional Settings",
   "Bonuses": {
     "ArmorClass": {
       "Label": "Bonus Armor Class",
@@ -1524,6 +1525,13 @@
   "ItemChanges": {
     "Label": "Item Changes",
     "Hint": "Changes made to items on the summoned creature."
+  },
+  "Level": {
+    "Label": "Level Limit",
+    "Max": "Maximum Level",
+    "Min": "Minimum Level",
+    "Hint": "Range of levels required to use this profile.",
+    "IdentifierHint": "Identifier used to determine whether the character level or a specific class level should be used for profile level limits."
   },
   "Match": {
     "Attacks": {

--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -582,7 +582,6 @@
     .details {
       gap: 4px;
       input { height: unset; }
-      input::placeholder { opacity: .5; }
     }
     [data-action="delete-profile"] {
       --size: 26px;
@@ -599,6 +598,31 @@
       border: 1px dashed black;
       border-radius: 4px;
       padding-inline: 4px;
+    }
+    input::placeholder { opacity: .5; }
+  }
+  .additional-tray {
+    margin-block-start: 8px;
+
+    > label {
+      cursor: pointer;
+      display: flex;
+      justify-content: center;
+      gap: .25rem;
+      font-size: var(--font-size-11);
+
+      > span { flex: none; }
+      .fa-gears { color: var(--color-text-light-6); }
+
+      &::before, &::after {
+        content: "";
+        flex-basis: 50%;
+        border-top: 1px dotted var(--dnd5e-color-gold);
+        align-self: center;
+      }
+    }
+    .form-group:last-child {
+      margin-block-end: -3px;
     }
   }
 

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -123,6 +123,20 @@
     }
   }
 
+  .collapsible {
+    &.collapsed {
+      label .fa-caret-down { transform: rotate(-90deg); }
+      .collapsible-content { grid-template-rows: 0fr; }
+    }
+    .fa-caret-down { transition: transform 250ms ease; }
+    .collapsible-content {
+      display: grid;
+      grid-template-rows: 1fr;
+      transition: grid-template-rows 250ms ease;
+      > .wrapper { overflow: hidden; }
+    }
+  }
+
   .unlist {
     list-style: none;
     padding: 0;

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -451,18 +451,6 @@
     }
   }
 
-  &.collapsed {
-    label .fa-caret-down { transform: rotate(-90deg); }
-    .collapsible-content { grid-template-rows: 0fr; }
-  }
-
-  .collapsible-content {
-    display: grid;
-    grid-template-rows: 1fr;
-    transition: grid-template-rows 250ms ease;
-    > .wrapper { overflow: hidden; }
-  }
-
   .target-source-control {
     &:not([hidden]) { display: flex; }
     justify-content: space-evenly;

--- a/module/applications/item/summoning-config.mjs
+++ b/module/applications/item/summoning-config.mjs
@@ -23,6 +23,14 @@ export default class SummoningConfig extends DocumentSheet {
   /* -------------------------------------------- */
 
   /**
+   * Expanded states for each profile.
+   * @type {Map<string, boolean>}
+   */
+  expandedProfiles = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
    * Shortcut to the summoning profiles.
    * @type {object[]}
    */
@@ -44,8 +52,9 @@ export default class SummoningConfig extends DocumentSheet {
   /** @inheritDoc */
   async getData(options={}) {
     const context = await super.getData(options);
+    context.isSpell = this.document.type === "spell";
     context.profiles = this.profiles.map(p => {
-      const profile = { id: p._id, ...p };
+      const profile = { id: p._id, ...p, collapsed: this.expandedProfiles.get(p._id) ? "" : "collapsed" };
       if ( p.uuid ) profile.document = fromUuidSync(p.uuid);
       return profile;
     }).sort((lhs, rhs) =>
@@ -81,6 +90,17 @@ export default class SummoningConfig extends DocumentSheet {
 
     for ( const element of html.querySelectorAll("multi-select") ) {
       element.addEventListener("change", this._onChangeInput.bind(this));
+    }
+
+    for ( const element of html.querySelectorAll(".collapsible") ) {
+      element.addEventListener("click", event => {
+        if ( event.target.closest(".collapsible-content") ) return;
+        event.currentTarget.classList.toggle("collapsed");
+        this.expandedProfiles.set(
+          event.target.closest("[data-profile-id]").dataset.profileId,
+          !event.currentTarget.classList.contains("collapsed")
+        );
+      });
     }
   }
 

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -1,5 +1,5 @@
 import TokenPlacement from "../../../canvas/token-placement.mjs";
-import { FormulaField } from "../../fields.mjs";
+import { FormulaField, IdentifierField } from "../../fields.mjs";
 
 const {
   ArrayField, BooleanField, DocumentIdField, NumberField, SchemaField, SetField, StringField
@@ -20,10 +20,13 @@ export default class SummonsField extends foundry.data.fields.EmbeddedDataField 
  * Information for a single summoned creature.
  *
  * @typedef {object} SummonsProfile
- * @property {string} _id    Unique ID for this profile.
- * @property {number} count  Number of creatures to summon.
- * @property {string} name   Display name for this profile if it differs from actor's name.
- * @property {string} uuid   UUID of the actor to summon.
+ * @property {string} _id        Unique ID for this profile.
+ * @property {number} count      Number of creatures to summon.
+ * @property {object} level
+ * @property {number} level.min  Minimum level at which this profile can be used.
+ * @property {number} level.max  Maximum level at which this profile can be used.
+ * @property {string} name       Display name for this profile if it differs from actor's name.
+ * @property {string} uuid       UUID of the actor to summon.
  */
 
 /**
@@ -35,6 +38,8 @@ export default class SummonsField extends foundry.data.fields.EmbeddedDataField 
  * @property {string} bonuses.attackDamage  Formula for bonus added to damage for attacks.
  * @property {string} bonuses.saveDamage    Formula for bonus added to damage for saving throws.
  * @property {string} bonuses.healing       Formula for bonus added to healing.
+ * @property {string} classIdentifier       Class identifier that will be used to determine applicable level.
+ * @property {Set<string>} creatureSizes    Set of creature sizes that will be set on summoned creature.
  * @property {Set<string>} creatureTypes    Set of creature types that will be set on summoned creature.
  * @property {object} match
  * @property {boolean} match.attacks        Match the to hit values on summoned actor's attack to the summoner.
@@ -64,6 +69,7 @@ export class SummonsData extends foundry.abstract.DataModel {
           label: "DND5E.Summoning.Bonuses.Healing.Label", hint: "DND5E.Summoning.Bonuses.Healing.Hint"
         })
       }),
+      classIdentifier: new IdentifierField(),
       creatureSizes: new SetField(new StringField(), {
         label: "DND5E.Summoning.CreatureSizes.Label", hint: "DND5E.Summoning.CreatureSizes.Hint"
       }),
@@ -84,6 +90,10 @@ export class SummonsData extends foundry.abstract.DataModel {
       profiles: new ArrayField(new SchemaField({
         _id: new DocumentIdField({initial: () => foundry.utils.randomID()}),
         count: new NumberField({integer: true, min: 1}),
+        level: new SchemaField({
+          min: new NumberField({integer: true, min: 0}),
+          max: new NumberField({integer: true, min: 0})
+        }),
         name: new StringField(),
         uuid: new StringField()
       })),

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -8,7 +8,7 @@
     </h3>
     <ul class="profiles flexcol">
         {{#each profiles}}
-        <li class="profile" data-profile-id="{{ id }}">
+        <li class="profile dnd5e2" data-profile-id="{{ id }}">
             <div class="details flexrow">
                 {{#if document}}
                 {{{ dnd5e-linkForUuid uuid }}}
@@ -28,11 +28,41 @@
             </div>
             <input type="hidden" name="profiles.{{ id }}._id" value="{{ id }}">
             <input type="hidden" name="profiles.{{ id }}.uuid" value="{{ uuid }}">
+            <div class="additional-tray collapsible {{ collapsed }}">
+                <label class="roboto-upper">
+                    <i class="fa-solid fa-gears" inert></i>
+                    <span>{{ localize "DND5E.Summoning.AdditionalSettings" }}</span>
+                    <i class="fas fa-caret-down" inert></i>
+                </label>
+                <div class="collapsible-content">
+                    <div class="wrapper">
+                        <div class="form-group">
+                            <label>{{ localize "DND5E.Summoning.Level.Label" }}</label>
+                            <div class="form-fields">
+                                <input type="number" name="profiles.{{ id }}.level.min" min="1" step="1" placeholder="0"
+                                       value="{{ level.min }}" aria-label="{{ localize 'DND5E.Summoning.Level.Min' }}">
+                                <span class="sep">&ndash;</span>
+                                <input type="number" name="profiles.{{ id }}.level.max" min="1" step="1" placeholder="∞"
+                                       value="{{ level.max }}" aria-label="{{ localize 'DND5E.Summoning.Level.Max' }}">
+                            </div>
+                            <p class="hint">{{ localize "DND5E.Summoning.Level.Hint" }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </li>
         {{else}}
         <li class="empty">{{ localize "DND5E.Summoning.Profile.Empty" }}</li>
         {{/each}}
     </ul>
+
+    {{#unless @root.isSpell}}
+    <div class="form-group">
+        <label>{{ localize "DND5E.ClassIdentifier" }}</label>
+        <input type="text" name="classIdentifier" value="{{ summons.classIdentifier }}">
+        <p class="hint">{{ localize "DND5E.Summoning.Level.IdentifierHint" }}</p>
+    </div>
+    {{/unless}}
 
     <h3 class="form-header">{{ localize "DND5E.Summoning.CreatureChanges.Label" }}</h3>
     <p class="hint">{{ localize "DND5E.Summoning.CreatureChanges.Hint" }}</p>


### PR DESCRIPTION
Adds a minimum and maximum level to each summoning profile hidden beneath an "Additional Settings" tray. These values determine whether the profile will be visible for a given spell, character, or class level.

<img width="514" alt="Summoning Level Limit Config" src="https://github.com/foundryvtt/dnd5e/assets/19979839/13aa9daf-7d06-4189-b9e1-05ee28b11ece">

For summoning on a spell item, it will always use the spell's level. On all other items it uses the character level by default unless a class identifier is entered, in which case it will use that class's level.

<img width="513" alt="Summoning Level Limit Identifier" src="https://github.com/foundryvtt/dnd5e/assets/19979839/8a7d29ea-98b1-4114-868c-bba2fc66a655">

The ability use dialog has been updated to dynamically refresh the list of summoning profiles as the casting level is changed.