### PR TITLE
[#3242] Allow referencing summoned creature's stats in bonuses

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1509,7 +1509,7 @@
   "Configuration": "Summoning Configuration",
   "CreatureChanges": {
     "Label": "Creature Changes",
-    "Hint": "Changes that will be made to the creature being summoned. Any @ references used in the following formulas will be based on the summoner's stats."
+    "Hint": "Changes that will be made to the creature being summoned. Any @ references used in the following formulas will be based on the summoner's stats. Summoned creature's stats can be referenced using @summon (e.g. @summon.attributes.hd.max to reference the creature's hit dice count)."
   },
   "CreatureTypes": {
     "Label": "Creature Types",

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -260,7 +260,7 @@ export class SummonsData extends foundry.abstract.DataModel {
    */
   async getChanges(actor, profile, options) {
     const updates = { effects: [], items: [] };
-    const rollData = this.item.getRollData();
+    const rollData = { ...this.item.getRollData(), summon: actor.getRollData() };
     const prof = rollData.attributes?.prof ?? 0;
 
     // Add flags


### PR DESCRIPTION
Allows the creature's roll data to be referenced within bonus formulas using `@summon.*` format. This allows implementing a feature like Mighty Summoner using `@summon.attributes.hd.max * 2`.