### PR TITLE
[#1787] Allow spell lists to be embedded

### DIFF
--- a/less/v1/journal.less
+++ b/less/v1/journal.less
@@ -262,7 +262,7 @@ p:empty:has(+ .content-embed), .content-embed + p:empty {
   }
 }
 
-.journal-entry-page.spells {
+.journal-entry-page.spells, .content-embed.spells {
   .grouping {
     font-size: var(--font-size-12);
  

--- a/templates/journal/page-spell-list-table.hbs
+++ b/templates/journal/page-spell-list-table.hbs
@@ -1,0 +1,18 @@
+<div>
+    <table class="spells">
+        <thead>
+            <tr>
+                <th>{{ localize "DND5E.SpellLevel" }}</th>
+                <th>{{ localize "TYPES.Item.spellPl" }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{#each sections}}
+            <tr>
+                <th scope="row">{{ header }}</th>
+                <td>{{{ spellList }}}</td>
+            </tr>
+            {{/each}}
+        </tbody>
+    </table>
+</div>

--- a/templates/journal/page-spell-list-view.hbs
+++ b/templates/journal/page-spell-list-view.hbs
@@ -1,16 +1,18 @@
 <div class="journal-page-content">
+    {{#unless embedRendering}}
     {{#if data.title.show}}
     <header>
         <h{{ title.level1 }}>{{ data.name }}</h{{ title.level1 }}>
     </header>
     {{/if}}
-    
+
     <label class="grouping">
         {{ localize "JOURNALENTRYPAGE.DND5E.SpellList.Grouping.Label" }}
         <select name="grouping">
             {{ selectOptions GROUPING_MODES selected=grouping localize=true }}
         </select>
     </label>
+    {{/unless}}
     
     {{{ description }}}
     


### PR DESCRIPTION
Spell list journal pages can now be embedded. By default they display just like the normal spell list page without the "Grouping" selector. It uses the page's default grouping by default, but that can be changed using `[[/embed UUID grouping=alphabetical]]` to explicitly set the grouping.

There is also a `table` option with changes the display to show the spell list in a table grouped by level.