### PR TITLE
[#3453] Adjust how finesse is applied

### DIFF
--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -134,11 +134,11 @@ export default class WeaponData extends ItemDataModel.mixin(
 
   /** @inheritdoc */
   get _typeAbilityMod() {
-    if ( ["simpleR", "martialR"].includes(this.type.value) ) return "dex";
-
-    const abilities = this.parent?.actor?.system.abilities;
-    if ( this.properties.has("fin") && abilities ) {
-      return (abilities.dex?.mod ?? 0) >= (abilities.str?.mod ?? 0) ? "dex" : "str";
+    const abi = this.parent?.actor?.system.abilities ?? {};
+    const t0 = {simpleM: "str", martialM: "str", simpleR: "dex", martialR: "dex"}[this.type.value];
+    if ( t0 && this.properties.has("fin") && abi.dex && abi.str ) {
+      const t1 = (t0 === "str") ? "dex" : "str";
+      return (abi[t1].mod > abi[t0].mod) ? t1 : t0;
     }
 
     return null;

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -134,14 +134,9 @@ export default class WeaponData extends ItemDataModel.mixin(
 
   /** @inheritdoc */
   get _typeAbilityMod() {
-    const abi = this.parent?.actor?.system.abilities ?? {};
-    const t0 = {simpleM: "str", martialM: "str", simpleR: "dex", martialR: "dex"}[this.type.value];
-    if ( t0 && this.properties.has("fin") && abi.dex && abi.str ) {
-      const t1 = (t0 === "str") ? "dex" : "str";
-      return (abi[t1].mod > abi[t0].mod) ? t1 : t0;
-    }
-
-    return null;
+    const { str, dex } = this.parent?.actor?.system.abilities ?? {};
+    if ( this.properties.has("fin") && str && dex ) return (dex.mod > str.mod) ? "dex" : "str";
+    return { simpleM: "str", martialM: "str", simpleR: "dex", martialR: "dex" }[this.type.value] ?? null;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Closes #3453.

To summarize finesse:
> When making an attack with a finesse weapon, you use your choice of your Strength or Dexterity modifier for the attack and damage rolls. You must use the same modifier for both rolls.

There is no mention of the weapon needing to be a melee weapon.

Two changes in this PR:
- Finesse properly applies to ranged weapons when the Strength is greater than the Dexterity modifier.
- The alternative ability modifier is only used if *strictly* greater, not if equal.