### PR TITLE
Remove features whose deprecation period ends with `3.2`

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -1,6 +1,5 @@
 import CharacterData from "../../data/actor/character.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
-import { setTheme } from "../../settings.mjs";
 import { formatNumber, simplifyBonus, staticID } from "../../utils.mjs";
 import ContextMenu5e from "../context-menu.mjs";
 import SheetConfig5e from "../sheet-config.mjs";

--- a/module/applications/components/adopted-stylesheet-mixin.mjs
+++ b/module/applications/components/adopted-stylesheet-mixin.mjs
@@ -30,6 +30,7 @@ export default function AdoptedStyleSheetMixin(Base) {
 
     /**
      * Retrieves the cached stylesheet, or generates a new one.
+     * @returns {CSSStyleSheet}
      * @protected
      */
     _getStyleSheet() {
@@ -50,5 +51,5 @@ export default function AdoptedStyleSheetMixin(Base) {
      * @abstract
      */
     _adoptStyleSheet(sheet) {}
-  }
+  };
 }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -642,25 +642,6 @@ DND5E.actorSizes = {
   }
 };
 preLocalize("actorSizes", { keys: ["label", "abbreviation"] });
-patchConfig("actorSizes", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" });
-
-/**
- * Default token image size for the values of `DND5E.actorSizes`.
- * @enum {number}
- * @deprecated since DnD5e 3.0, available until DnD5e 3.2
- */
-Object.defineProperty(DND5E, "tokenSizes", {
-  get() {
-    foundry.utils.logCompatibilityWarning(
-      "DND5E.tokenSizes has been deprecated and is now accessible through the .token property on DND5E.actorSizes.",
-      { since: "DnD5e 3.0", until: "DnD5e 3.2" }
-    );
-    return Object.entries(DND5E.actorSizes).reduce((obj, [k, v]) => {
-      obj[k] = v.token ?? 1;
-      return obj;
-    }, {});
-  }
-});
 
 /* -------------------------------------------- */
 /*  Canvas                                      */
@@ -816,7 +797,6 @@ DND5E.creatureTypes = {
   }
 };
 preLocalize("creatureTypes", { keys: ["label", "plural"], sort: true });
-patchConfig("creatureTypes", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" });
 
 /* -------------------------------------------- */
 
@@ -866,19 +846,6 @@ DND5E.itemRarity = {
   artifact: "DND5E.ItemRarityArtifact"
 };
 preLocalize("itemRarity");
-
-/* -------------------------------------------- */
-
-/**
- * The limited use periods that support a recovery formula.
- * @deprecated since DnD5e 3.1, available until DnD5e 3.3
- * @enum {string}
- */
-DND5E.limitedUseFormulaPeriods = {
-  charges: "DND5E.Charges",
-  dawn: "DND5E.Dawn",
-  dusk: "DND5E.Dusk"
-};
 
 /* -------------------------------------------- */
 
@@ -1147,7 +1114,6 @@ DND5E.consumableTypes = {
     label: "DND5E.ConsumableTrinket"
   }
 };
-patchConfig("consumableTypes", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" });
 preLocalize("consumableTypes", { key: "label", sort: true });
 preLocalize("consumableTypes.ammo.subtypes", { sort: true });
 preLocalize("consumableTypes.poison.subtypes", { sort: true });
@@ -1541,20 +1507,6 @@ preLocalize("currencies", { keys: ["label", "abbreviation"] });
 /* -------------------------------------------- */
 
 /**
- * Types of damage that are considered physical.
- * @deprecated since DnD5e 3.0, available until DnD5e 3.2
- * @enum {string}
- */
-DND5E.physicalDamageTypes = {
-  bludgeoning: "DND5E.DamageBludgeoning",
-  piercing: "DND5E.DamagePiercing",
-  slashing: "DND5E.DamageSlashing"
-};
-preLocalize("physicalDamageTypes", { sort: true });
-
-/* -------------------------------------------- */
-
-/**
  * Configuration data for damage types.
  *
  * @typedef {object} DamageTypeConfiguration
@@ -1652,7 +1604,6 @@ DND5E.damageTypes = {
     color: new Color(0x708090)
   }
 };
-patchConfig("damageTypes", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" });
 preLocalize("damageTypes", { keys: ["label"], sort: true });
 
 /* -------------------------------------------- */
@@ -1675,7 +1626,6 @@ DND5E.healingTypes = {
     color: new Color(0x4B66DE)
   }
 };
-patchConfig("healingTypes", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" });
 preLocalize("healingTypes", { keys: ["label"] });
 
 /* -------------------------------------------- */
@@ -1810,15 +1760,6 @@ DND5E.encumbrance = {
     metric: 1000 // 1000 kg in a metric ton
   }
 };
-Object.defineProperty(DND5E.encumbrance, "strMultiplier", {
-  get() {
-    foundry.utils.logCompatibilityWarning(
-      "`DND5E.encumbrance.strMultiplier` has been moved to `DND5E.encumbrance.threshold.maximum`.",
-      { since: "DnD5e 3.0", until: "DnD5e 3.2" }
-    );
-    return this.threshold.maximum;
-  }
-});
 preLocalize("encumbrance.effects", { key: "name" });
 
 /* -------------------------------------------- */
@@ -2315,7 +2256,6 @@ DND5E.spellSchools = {
   }
 };
 preLocalize("spellSchools", { key: "label", sort: true });
-patchConfig("spellSchools", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" });
 
 /* -------------------------------------------- */
 
@@ -2369,47 +2309,6 @@ DND5E.weaponTypes = {
   siege: "DND5E.WeaponSiege"
 };
 preLocalize("weaponTypes");
-
-/* -------------------------------------------- */
-
-/**
- * A subset of weapon properties that determine the physical characteristics of the weapon.
- * These properties are used for determining physical resistance bypasses.
- * @deprecated since DnD5e 3.0, available until DnD5e 3.2
- * @enum {string}
- */
-DND5E.physicalWeaponProperties = {
-  ada: "DND5E.WeaponPropertiesAda",
-  mgc: "DND5E.WeaponPropertiesMgc",
-  sil: "DND5E.WeaponPropertiesSil"
-};
-preLocalize("physicalWeaponProperties", { sort: true });
-
-/* -------------------------------------------- */
-
-/**
- * The set of weapon property flags which can exist on a weapon.
- * @deprecated since DnD5e 3.0, available until DnD5e 3.2
- * @enum {string}
- */
-DND5E.weaponProperties = {
-  ...DND5E.physicalWeaponProperties,
-  amm: "DND5E.WeaponPropertiesAmm",
-  fin: "DND5E.WeaponPropertiesFin",
-  fir: "DND5E.WeaponPropertiesFir",
-  foc: "DND5E.WeaponPropertiesFoc",
-  hvy: "DND5E.WeaponPropertiesHvy",
-  lgt: "DND5E.WeaponPropertiesLgt",
-  lod: "DND5E.WeaponPropertiesLod",
-  rch: "DND5E.WeaponPropertiesRch",
-  rel: "DND5E.WeaponPropertiesRel",
-  ret: "DND5E.WeaponPropertiesRet",
-  spc: "DND5E.WeaponPropertiesSpc",
-  thr: "DND5E.WeaponPropertiesThr",
-  two: "DND5E.WeaponPropertiesTwo",
-  ver: "DND5E.WeaponPropertiesVer"
-};
-preLocalize("weaponProperties", { sort: true });
 
 /* -------------------------------------------- */
 
@@ -2708,7 +2607,6 @@ DND5E.conditionTypes = {
   }
 };
 preLocalize("conditionTypes", { key: "label", sort: true });
-patchConfig("conditionTypes", "label", { since: "DnD5e 3.0", until: "DnD5e 3.2" });
 
 /* -------------------------------------------- */
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -850,6 +850,19 @@ preLocalize("itemRarity");
 /* -------------------------------------------- */
 
 /**
+ * The limited use periods that support a recovery formula.
+ * @deprecated since DnD5e 3.1, available until DnD5e 3.3
+ * @enum {string}
+ */
+DND5E.limitedUseFormulaPeriods = {
+  charges: "DND5E.Charges",
+  dawn: "DND5E.Dawn",
+  dusk: "DND5E.Dusk"
+};
+
+/* -------------------------------------------- */
+
+/**
  * Configuration data for limited use periods.
  *
  * @typedef {object} LimitedUsePeriodConfiguration

--- a/module/data/fields.mjs
+++ b/module/data/fields.mjs
@@ -359,7 +359,7 @@ export class MappingField extends foundry.data.fields.ObjectField {
   _validateType(value, options={}) {
     if ( foundry.utils.getType(value) !== "Object" ) throw new Error("must be an Object");
     const errors = this._validateValues(value, options);
-    if ( !foundry.utils.isEmpty(errors) ) throw new foundry.data.fields.ModelValidationError(errors);
+    if ( !foundry.utils.isEmpty(errors) ) throw new foundry.data.validation.DataModelValidationError(errors);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -82,23 +82,6 @@ export default class ContainerData extends ItemDataModel.mixin(
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 
-  /** @inheritdoc */
-  prepareDerivedData() {
-    const system = this;
-    Object.defineProperty(this.capacity, "weightless", {
-      get() {
-        foundry.utils.logCompatibilityWarning(
-          "The `system.capacity.weightless` value on containers has migrated to the 'weightlessContents' property.",
-          { since: "DnD5e 3.0", until: "DnD5e 3.2" }
-        );
-        return system.properties.has("weightlessContents");
-      },
-      configurable: true
-    });
-  }
-
-  /* -------------------------------------------- */
-
   /** @inheritDoc */
   async getFavoriteData() {
     const data = super.getFavoriteData();

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -239,19 +239,4 @@ export default class EquipmentData extends ItemDataModel.mixin(
     const isProficient = (itemProf === true) || actorProfs.has(itemProf) || actorProfs.has(this.type.baseItem);
     return Number(isProficient);
   }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Does this armor impose disadvantage on stealth checks?
-   * @type {boolean}
-   * @deprecated since DnD5e 3.0, available until DnD5e 3.2
-   */
-  get stealth() {
-    foundry.utils.logCompatibilityWarning(
-      "The `system.stealth` value on equipment has migrated to the 'stealthDisadvantage' property.",
-      { since: "DnD5e 3.0", until: "DnD5e 3.2" }
-    );
-    return this.properties.has("stealthDisadvantage");
-  }
 }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -188,22 +188,4 @@ export default class SpellData extends ItemDataModel.mixin(
   get proficiencyMultiplier() {
     return 1;
   }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Provide a backwards compatible getter for accessing `components`.
-   * @deprecated since v3.0.
-   * @type {object}
-   */
-  get components() {
-    foundry.utils.logCompatibilityWarning(
-      "The `system.components` property has been deprecated in favor of a standardized `system.properties` property.",
-      { since: "DnD5e 3.0", until: "DnD5e 3.2", once: true }
-    );
-    return this.properties.reduce((acc, p) => {
-      acc[p] = true;
-      return acc;
-    }, {});
-  }
 }

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -338,27 +338,4 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   get isActive() {
     return !!this.activation.type;
   }
-
-  /* -------------------------------------------- */
-  /*  Deprecations                                */
-  /* -------------------------------------------- */
-
-  /**
-   * @deprecated since DnD5e 3.0, available until DnD5e 3.2
-   * @ignore
-   */
-  get activatedEffectChatProperties() {
-    foundry.utils.logCompatibilityWarning(
-      "ActivatedEffectTemplate#activatedEffectChatProperties is deprecated. "
-      + "Please use ActivatedEffectTemplate#activatedEffectCardProperties.",
-      { since: "DnD5e 3.0", until: "DnD5e 3.2", once: true }
-    );
-    return [
-      this.parent.labels.activation + (this.activation.condition ? ` (${this.activation.condition})` : ""),
-      this.parent.labels.target,
-      this.parent.labels.range,
-      this.parent.labels.duration
-    ];
-  }
-
 }

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -78,21 +78,4 @@ export default class EquippableItemTemplate extends SystemDataModel {
     const attunement = this.attunement !== CONFIG.DND5E.attunementTypes.REQUIRED;
     return attunement && this.properties.has("mgc") && this.validProperties.has("mgc");
   }
-
-  /* -------------------------------------------- */
-  /*  Deprecations                                */
-  /* -------------------------------------------- */
-
-  /**
-   * @deprecated since DnD5e 3.0, available until DnD5e 3.2
-   * @ignore
-   */
-  get equippableItemChatProperties() {
-    foundry.utils.logCompatibilityWarning(
-      "EquippableItemTemplate#equippableItemChatProperties is deprecated. "
-      + "Please use EquippableItemTemplate#equippableItemCardProperties.",
-      { since: "DnD5e 3.0", until: "DnD5e 3.2", once: true }
-    );
-    return this.equippableItemCardProperties;
-  }
 }

--- a/module/data/item/templates/identifiable.mjs
+++ b/module/data/item/templates/identifiable.mjs
@@ -57,18 +57,6 @@ export default class IdentifiableTemplate extends SystemDataModel {
     if ( !this.identified && this.unidentified.name ) {
       this.parent.name = this.unidentified.name;
     }
-
-    const description = this.unidentified.description ?? null;
-    Object.defineProperty(this.description, "unidentified", {
-      get() {
-        foundry.utils.logCompatibilityWarning(
-          "Item's unidentified description has moved to `system.unidentified.description`.",
-          { since: "DnD5e 3.0", until: "DnD5e 3.2" }
-        );
-        return description;
-      },
-      configurable: true
-    });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -1,4 +1,3 @@
-import EffectsElement from "../applications/components/effects.mjs";
 import { FormulaField } from "../data/fields.mjs";
 import { staticID } from "../utils.mjs";
 
@@ -623,61 +622,5 @@ export default class ActiveEffect5e extends ActiveEffect {
     const current = foundry.utils.getProperty(doc, path) ?? new Set();
     const delta = current.symmetricDifference(source);
     for ( const choice of delta ) overrides.push(`${prefix}.${choice}`);
-  }
-
-  /* -------------------------------------------- */
-  /*  Deprecations                                */
-  /* -------------------------------------------- */
-
-  /**
-   * Manage Active Effect instances through the Actor Sheet via effect control buttons.
-   * @param {MouseEvent} event      The left-click event on the effect control
-   * @param {Actor5e|Item5e} owner  The owning document which manages this effect
-   * @returns {Promise|null}        Promise that resolves when the changes are complete.
-   * @deprecated since 3.0, targeted for removal in 3.2
-   */
-  static onManageActiveEffect(event, owner) {
-    foundry.utils.logCompatibilityWarning(
-      "ActiveEffects5e#onManageActiveEffect has been deprecated in favor of the new dnd5e-effects element.",
-      { since: "DnD5e 3.0", until: "DnD5e 3.2" }
-    );
-    event.preventDefault();
-    const a = event.currentTarget;
-    const li = a.closest("li");
-    if ( li.dataset.parentId ) owner = owner.items.get(li.dataset.parentId);
-    const effect = li.dataset.effectId ? owner.effects.get(li.dataset.effectId) : null;
-    switch ( a.dataset.action ) {
-      case "create":
-        const isActor = owner instanceof Actor;
-        return owner.createEmbeddedDocuments("ActiveEffect", [{
-          name: isActor ? game.i18n.localize("DND5E.EffectNew") : owner.name,
-          icon: isActor ? "icons/svg/aura.svg" : owner.img,
-          origin: owner.uuid,
-          "duration.rounds": li.dataset.effectType === "temporary" ? 1 : undefined,
-          disabled: li.dataset.effectType === "inactive"
-        }]);
-      case "edit":
-        return effect.sheet.render(true);
-      case "delete":
-        return effect.deleteDialog();
-      case "toggle":
-        return effect.update({disabled: !effect.disabled});
-    }
-  }
-
-  /* --------------------------------------------- */
-
-  /**
-   * Prepare the data structure for Active Effects which are currently applied to an Actor or Item.
-   * @param {ActiveEffect5e[]} effects  The array of Active Effect instances to prepare sheet data for
-   * @returns {object}                  Data for rendering
-   * @deprecated since 3.0, targeted for removal in 3.2
-   */
-  static prepareActiveEffectCategories(effects) {
-    foundry.utils.logCompatibilityWarning(
-      "ActiveEffects5e#prepareActiveEffectCategories has been deprecated in favor of EffectsElement#prepareCategories.",
-      { since: "DnD5e 3.0", until: "DnD5e 3.2" }
-    );
-    return EffectsElement.prepareCategories(effects);
   }
 }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -917,14 +917,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const hp = this.system.attributes.hp;
     if ( !hp ) return this; // Group actors don't have HP at the moment
 
-    if ( foundry.utils.getType(options) !== "Object" ) {
-      foundry.utils.logCompatibilityWarning(
-        "Actor5e.applyDamage now takes an options object as its second parameter with `multiplier` as an parameter.",
-        { since: "DnD5e 3.0", until: "DnD5e 3.2" }
-      );
-      options = { multiplier: options };
-    }
-
     if ( Number.isNumeric(damages) ) {
       damages = [{ value: damages }];
       options.ignore ??= true;
@@ -2774,22 +2766,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
   /* -------------------------------------------- */
   /*  Conversion & Transformation                 */
-  /* -------------------------------------------- */
-
-  /**
-   * Convert all carried currency to the highest possible denomination using configured conversion rates.
-   * See CONFIG.DND5E.currencies for configuration.
-   * @returns {Promise<Actor5e>}
-   * @deprecated since DnD5e 3.0, targeted for removal in DnD5e 3.2.
-   */
-  convertCurrency() {
-    foundry.utils.logCompatibilityWarning(
-      "Actor5e.convertCurrency has been moved to CurrencyManager.convertCurrency.",
-      { since: "DnD5e 3.0", until: "DnD5e 3.2" }
-    );
-    return CurrencyManager.convertCurrency(this);
-  }
-
   /* -------------------------------------------- */
 
   /**

--- a/module/documents/actor/trait.mjs
+++ b/module/documents/actor/trait.mjs
@@ -274,7 +274,7 @@ export function getBaseItem(identifier, { indexOnly=false, fullItem=false }={}) 
           foundry.utils.setProperty(entry, "system.type.value", val);
           foundry.utils.logCompatibilityWarning(
             `The '${field}' property has been deprecated in favor of a standardized \`system.type.value\` property.`,
-            { since: "DnD5e 3.0", until: "DnD5e 3.2", once: true }
+            { since: "DnD5e 3.0", until: "DnD5e 3.4", once: true }
           );
         }
       }

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -1,5 +1,4 @@
 import TokenSystemFlags from "../data/token/token-system-flags.mjs";
-import { staticID } from "../utils.mjs";
 import SystemFlagsMixin from "./mixins/flags.mjs";
 
 /**


### PR DESCRIPTION
This extends the deprecation period for `getBaseItem` indexes another 2 versions because fixing this requires a compendium migration and there are still people who haven't done that.