### PR TITLE
[#1787] Support potentially unlinked spells in spell lists

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1931,6 +1931,12 @@
     "Type": {
       "Label": "Spell List Type",
       "Other": "Uncategorized"
+    },
+    "UnlinkedSpells": {
+      "Label": "Unlinked Spells",
+      "Add": "Add Unlinked Spell",
+      "Configuration": "Spell Configuration",
+      "Edit": "Edit Unlinked Spell"
     }
   },
   "Subclass": {

--- a/less/v1/journal.less
+++ b/less/v1/journal.less
@@ -162,10 +162,23 @@ p:empty:has(+ .content-embed), .content-embed + p:empty {
       padding-block: 0.35em 0;
       padding-inline: 2px;
 
-      .item-controls { flex: 0; }
+      .item-controls {
+        flex: 0;
+        flex-wrap: nowrap;
+        gap: 8px;
+      }
     }
     .items-list .item:not(:last-of-type) {
       border-bottom: 1px solid var(--color-border-light-secondary);
+    }
+
+    h3 {
+      justify-content: space-between;
+      a {
+        flex: 0;
+        padding-inline-end: 12px;
+        font-size: var(--font-size-14);
+      }
     }
   }
 }

--- a/module/applications/journal/spells-page-sheet.mjs
+++ b/module/applications/journal/spells-page-sheet.mjs
@@ -144,7 +144,7 @@ export default class JournalSpellListPageSheet extends JournalPageSheet {
       .map(spell => {
         const data = spell.unlinked ? spell : { spell };
         data.unlinked ??= unlinkedData[data.spell?.uuid];
-        data.name = data.spell?.name ?? data.unlinked?.name;
+        data.name = data.spell?.name ?? data.unlinked?.name ?? "";
         if ( data.spell ) {
           data.display = linkForUuid(data.spell.uuid, {
             tooltip: '<section class="loading"><i class="fas fa-spinner fa-spin-pulse"></i></section>'

--- a/module/applications/journal/spells-unlinked-config.mjs
+++ b/module/applications/journal/spells-unlinked-config.mjs
@@ -1,0 +1,65 @@
+/**
+ * Application for configuring a single unlinked spell in a spell list.
+ */
+export default class SpellsUnlinkedConfig extends DocumentSheet {
+  constructor(unlinkedId, object, options={}) {
+    super(object, options);
+    this.unlinkedId = unlinkedId;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["dnd5e", "unlinked-spell-config"],
+      template: "systems/dnd5e/templates/journal/page-spell-list-unlinked-config.hbs",
+      width: 400,
+      height: "auto",
+      sheetConfig: false
+    });
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * ID of the unlinked spell entry being edited.
+   * @type {string}
+   */
+  unlinkedId;
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  get title() {
+    return `${game.i18n.localize(
+      "JOURNALENTRYPAGE.DND5E.SpellList.UnlinkedSpells.Configuration")}: ${this.document.name}`;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  getData() {
+    const context = {
+      ...super.getData(),
+      ...this.document.system.unlinkedSpells.find(u => u._id === this.unlinkedId),
+      appId: this.id,
+      CONFIG: CONFIG.DND5E
+    };
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  _updateObject(event, formData) {
+    const unlinkedSpells = this.document.toObject().system.unlinkedSpells;
+    const editing = unlinkedSpells.find(s => s._id === this.unlinkedId);
+    foundry.utils.mergeObject(editing, formData);
+    this.document.update({"system.unlinkedSpells": unlinkedSpells});
+  }
+}

--- a/module/data/journal/spells.mjs
+++ b/module/data/journal/spells.mjs
@@ -48,7 +48,7 @@ export default class SpellListJournalPageData extends foundry.abstract.DataModel
       spells: new SetField(new StringField(), {label: "DND5E.ItemTypeSpellPl"}),
       unlinkedSpells: new ArrayField(new SchemaField({
         _id: new DocumentIdField({initial: () => foundry.utils.randomID()}),
-        name: new StringField({label: "Name"}),
+        name: new StringField({required: true, label: "Name"}),
         system: new SchemaField({
           level: new NumberField({min: 0, integer: true, label: "DND5E.Level"}),
           school: new StringField({label: "DND5E.School"})

--- a/module/data/journal/spells.mjs
+++ b/module/data/journal/spells.mjs
@@ -1,6 +1,23 @@
 import { IdentifierField } from "../fields.mjs";
+import SourceField from "../shared/source-field.mjs";
 
-const { HTMLField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { ArrayField, DocumentIdField, HTMLField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+
+/**
+ * Data needed to display spells that aren't able to be linked (outside SRD & current module).
+ *
+ * @typedef {object} UnlinkedSpellConfiguration
+ * @property {string} _id            Unique ID for this entry.
+ * @property {string} name           Name of the spell.
+ * @property {object} system
+ * @property {number} system.level   Spell level.
+ * @property {string} system.school  Spell school.
+ * @property {object} source
+ * @property {string} source.book    Book/publication where the spell originated.
+ * @property {string} source.page    Page or section where the spell can be found.
+ * @property {string} source.custom  Fully custom source label.
+ * @property {string} source.uuid    UUID of the spell, if available in another module.
+ */
 
 /**
  * Data model for spell list data.
@@ -11,6 +28,7 @@ const { HTMLField, SchemaField, SetField, StringField } = foundry.data.fields;
  * @property {object} description
  * @property {string} description.value  Description to display before spell list.
  * @property {Set<string>} spells        UUIDs of spells to display.
+ * @property {UnlinkedSpellConfiguration[]} unlinkedSpells  Unavailable spells that are entered manually.
  */
 export default class SpellListJournalPageData extends foundry.abstract.DataModel {
   static defineSchema() {
@@ -27,7 +45,16 @@ export default class SpellListJournalPageData extends foundry.abstract.DataModel
       description: new SchemaField({
         value: new HTMLField({label: "DND5E.Description"})
       }),
-      spells: new SetField(new StringField(), {label: "DND5E.ItemTypeSpellPl"})
+      spells: new SetField(new StringField(), {label: "DND5E.ItemTypeSpellPl"}),
+      unlinkedSpells: new ArrayField(new SchemaField({
+        _id: new DocumentIdField({initial: () => foundry.utils.randomID()}),
+        name: new StringField({label: "Name"}),
+        system: new SchemaField({
+          level: new NumberField({min: 0, integer: true, label: "DND5E.Level"}),
+          school: new StringField({label: "DND5E.School"})
+        }),
+        source: new SourceField({license: false, uuid: new StringField()})
+      }), {label: "JOURNALENTRYPAGE.DND5E.SpellList.UnlinkedSpells.Label"})
     };
   }
 

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -10,13 +10,15 @@ const { SchemaField, StringField } = foundry.data.fields;
  */
 export default class SourceField extends SchemaField {
   constructor(fields={}, options={}) {
-    super({
+    fields = {
       book: new StringField({label: "DND5E.SourceBook"}),
       page: new StringField({label: "DND5E.SourcePage"}),
       custom: new StringField({label: "DND5E.SourceCustom"}),
       license: new StringField({label: "DND5E.SourceLicense"}),
       ...fields
-    }, { label: "DND5E.Source", ...options });
+    };
+    Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);
+    super(fields, { label: "DND5E.Source", ...options });
   }
 
   /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -175,16 +175,18 @@ export function indexFromUuid(uuid) {
 
 /**
  * Creates an HTML document link for the provided UUID.
- * @param {string} uuid  UUID for which to produce the link.
- * @returns {string}     Link to the item or empty string if item wasn't found.
+ * @param {string} uuid               UUID for which to produce the link.
+ * @param {object} [options]
+ * @param {string} [options.tooltip]  Tooltip to add to the link.
+ * @returns {string}                  Link to the item or empty string if item wasn't found.
  */
-export function linkForUuid(uuid) {
-  if ( game.release.generation < 12 ) {
-    return TextEditor._createContentLink(["", "UUID", uuid]).outerHTML;
-  }
+export function linkForUuid(uuid, { tooltip }={}) {
+  let element;
+
+  if ( game.release.generation < 12 ) element = TextEditor._createContentLink(["", "UUID", uuid]);
 
   // TODO: When v11 support is dropped we can make this method async and return to using TextEditor._createContentLink.
-  if ( uuid.startsWith("Compendium.") ) {
+  else if ( uuid.startsWith("Compendium.") ) {
     let [, scope, pack, documentName, id] = uuid.split(".");
     if ( !CONST.PRIMARY_DOCUMENT_TYPES.includes(documentName) ) id = documentName;
     const data = {
@@ -193,9 +195,13 @@ export function linkForUuid(uuid) {
     };
     TextEditor._createLegacyContentLink("Compendium", [scope, pack, id].join("."), "", data);
     data.dataset.link = "";
-    return TextEditor.createAnchor(data).outerHTML;
+    element = TextEditor.createAnchor(data);
   }
-  return fromUuidSync(uuid).toAnchor().outerHTML;
+
+  else element = fromUuidSync(uuid).toAnchor();
+
+  if ( tooltip ) element.dataset.tooltip = tooltip;
+  return element.outerHTML;
 }
 
 /* -------------------------------------------- */
@@ -414,7 +420,7 @@ export function registerHandlebarsHelpers() {
     "dnd5e-concealSection": concealSection,
     "dnd5e-dataset": dataset,
     "dnd5e-groupedSelectOptions": groupedSelectOptions,
-    "dnd5e-linkForUuid": linkForUuid,
+    "dnd5e-linkForUuid": (uuid, options) => linkForUuid(uuid, options.hash),
     "dnd5e-itemContext": itemContext,
     "dnd5e-numberFormat": (context, options) => formatNumber(context, options.hash),
     "dnd5e-textFormat": formatText

--- a/templates/journal/page-spell-list-edit.hbs
+++ b/templates/journal/page-spell-list-edit.hbs
@@ -40,13 +40,26 @@
     </div>
 
     <div class="right spell-list">
-        <h3>{{ localize "ITEM.TypeSpellPl" }}</h3>
+        <h3 class="flexrow">
+            {{ localize "ITEM.TypeSpellPl" }}
+            <a data-action="add-unlinked" data-tooltip="JOURNALENTRYPAGE.DND5E.SpellList.UnlinkedSpells.Add"
+               aria-label="{{ localize 'JOURNALENTRYPAGE.DND5E.SpellList.UnlinkedSpells.Add' }}">
+                <i class="fa-solid fa-plus" inert></i>
+            </a>
+        </h3>
         <ol class="items-list">
             {{#each spells}}
-            <li class="item flexrow" data-item-uuid="{{this.uuid}}">
-                <div class="item-name">{{{ dnd5e-linkForUuid this.uuid }}}</div>
+            <li class="item flexrow" data-item-uuid="{{ spell.uuid }}" data-unlinked-id="{{ unlinked._id }}">
+                <div class="item-name">{{{ display }}}</div>
                 <div class="item-controls flexrow">
-                    <a class="item-control item-delete" data-tooltip="DND5E.ItemDelete"
+                    {{#if unlinked}}
+                    <a class="item-control" data-action="edit-unlinked"
+                       data-tooltip="JOURNALENTRYPAGE.DND5E.SpellList.UnlinkedSpells.Edit"
+                       aria-label="{{ localize 'JOURNALENTRYPAGE.DND5E.SpellList.UnlinkedSpells.Edit' }}">
+                        <i class="fa-solid fa-cog" inert></i>
+                    </a>
+                    {{/if}}
+                    <a class="item-control" data-action="delete" data-tooltip="DND5E.ItemDelete"
                        aria-label="{{ localize 'DND5E.ItemDelete' }}">
                         <i class="fa-solid fa-trash" inert></i>
                     </a>

--- a/templates/journal/page-spell-list-unlinked-config.hbs
+++ b/templates/journal/page-spell-list-unlinked-config.hbs
@@ -1,0 +1,44 @@
+<form autocomplete="off">
+    <fieldset>
+        <legend>{{ localize "TYPES.Item.spell" }}</legend>
+        <div class="form-group">
+            <label>{{ localize "Name" }}</label>
+            <input type="text" name="name" value="{{ name }}">
+        </div>
+        <div class="form-group">
+            <label>{{ localize "DND5E.SpellLevel" }}</label>
+            <select name="system.level">
+                {{ selectOptions CONFIG.spellLevels selected=system.level }}
+            </select>
+        </div>
+        <div class="form-group">
+            <label>{{ localize "DND5E.SpellSchool" }}</label>
+            <select name="system.school">
+                {{ selectOptions CONFIG.spellSchools selected=system.school labelAttr="label" blank="" }}
+            </select>
+        </div>
+    </fieldset>
+    <fieldset>
+        <legend>{{ localize "DND5E.Source" }}</legend>
+        <div class="form-group">
+            <label>{{ localize "DND5E.SourceBook" }}</label>
+            <input type="text" name="source.book" value="{{ source.book }}" list="{{ appId }}-books">
+            <datalist id="{{ appId }}-books">
+                {{selectOptions CONFIG.sourceBooks}}
+            </datalist>
+        </div>
+        <div class="form-group">
+            <label>{{ localize "DND5E.SourcePage" }}</label>
+            <input type="text" name="source.page" value="{{ source.page }}">
+        </div>
+        <div class="form-group">
+            <label>{{ localize "DND5E.SourceCustom" }}</label>
+            <input type="text" name="source.custom" value="{{ source.custom }}">
+        </div>
+        <div class="form-group">
+            <label>{{ localize "DND5E.SourceUUID" }}</label>
+            <input type="text" name="source.uuid" value="{{ source.uuid }}">
+        </div>
+    </fieldset>
+    <button type="submit"><i class="fa-regular fa-save"></i> {{ localize "Submit" }}</button>
+</form>

--- a/templates/journal/page-spell-list-view.hbs
+++ b/templates/journal/page-spell-list-view.hbs
@@ -13,21 +13,21 @@
         </select>
     </label>
     {{/unless}}
-    
+
     {{{ description }}}
-    
+
     {{#each sections}}
-        <h{{ @root.title.level3 }}>{{ header }}</h{{ @root.title.level3 }}>
-        <ul>
+    <h{{ @root.title.level3 }}>{{ header }}</h{{ @root.title.level3 }}>
+    <ul>
         {{#each spells}}
-            <li>{{{ dnd5e-linkForUuid uuid }}}</li>
+        <li>{{{ display }}}</li>
         {{/each}}
-        </ul>
+    </ul>
     {{else}}
-        <ul>
-            {{#each spells}}
-            <li>{{{ dnd5e-linkForUuid uuid }}}</li>
-            {{/each}}
-        </ul>
+    <ul>
+        {{#each spells}}
+        <li>{{{ display }}}</li>
+        {{/each}}
+    </ul>
     {{/each}}
 </div>


### PR DESCRIPTION
Adds a new `unlinkedSpells` array to spell list journal pages for holding information on spells that may potentially become unlinked. This is useful for when a spell list might need to include spells that aren't in the current module or in the SRD.

In order to properly display, this data structure contains the name of the spell, its level, and its school. It also contains the source object for tracking where the spell originated. This source object can contain a UUID so if the module that contains the spell is active it will display linked like the rest, but if the module is inactive then it will display as a static entry.

<img width="962" alt="Spell List Unlinked Spells" src="https://github.com/foundryvtt/dnd5e/assets/19979839/df49abc5-1b9e-4f7b-9643-b7645c7e209f">
