### PR TITLE
Allow for null/undefined prerequisites value in items when advancing

### DIFF
--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -69,7 +69,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
       if ( i ) {
         i.checked = this.selected.has(i.uuid);
         i.disabled = !i.checked && choices.full;
-        const validLevel = (i.system.prerequisites.level ?? -Infinity) <= this.level;
+        const validLevel = (i.system.prerequisites?.level ?? -Infinity) <= this.level;
         if ( !previouslySelected.has(i.uuid) && validLevel ) items.push(i);
       }
       return items;


### PR DESCRIPTION
Fixes #3483.

Did a search for other uses of the prerequisites field, and the rest all appear to have the null-optional-chaining `?` on them