### PR TITLE
[#2773] Display limited spell uses on sheet

### DIFF
--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -342,6 +342,7 @@
         }
         input { text-align: end; }
       }
+      .spell-uses { display: none; }
 
       /* Item Recovery */
       .item-recovery { width: 60px; }
@@ -473,7 +474,8 @@
       }
 
       @container (min-width: 600px) {
-        .item-price, .item-formula { display: flex; }
+        .item-price, .item-formula, .spell-uses { display: flex; }
+        .subtitle-uses { display: none; }
       }
 
       @container (min-width: 650px) {

--- a/templates/actors/tabs/character-features.hbs
+++ b/templates/actors/tabs/character-features.hbs
@@ -127,7 +127,7 @@
                     <div class="item-detail item-uses {{#unless ctx.hasUses}}empty{{/unless}}">
                         {{#if ctx.hasUses}}
                         <input type="text" value="{{ item.system.uses.value }}" placeholder="0" data-dtype="Number"
-                               data-name="system.uses.value" inputmode="numeric" pattern="[0-9+=\-]*">
+                               data-name="system.uses.value" inputmode="numeric" pattern="[+=\-]?\d*">
                         <span class="separator">&sol;</span>
                         <span class="max">{{ item.system.uses.max }}</span>
                         {{/if}}

--- a/templates/actors/tabs/character-spells.hbs
+++ b/templates/actors/tabs/character-spells.hbs
@@ -61,12 +61,12 @@
             {{!-- Section Header --}}
             <div class="items-header header">
                 <h3 class="item-name spell-header">{{ localize label }}</h3>
-                <div class="item-header item-uses spell-uses">{{ localize "DND5E.Uses" }}</div>
                 <div class="item-header item-school">{{ localize "DND5E.SpellHeader.School" }}</div>
                 <div class="item-header item-usage">{{ localize "DND5E.SpellHeader.Time" }}</div>
                 <div class="item-header item-range">{{ localize "DND5E.SpellHeader.Range" }}</div>
                 <div class="item-header item-target">{{ localize "DND5E.SpellHeader.Target" }}</div>
                 <div class="item-header item-roll">{{ localize "DND5E.SpellHeader.Roll" }}</div>
+                <div class="item-header item-uses spell-uses">{{ localize "DND5E.Uses" }}</div>
                 <div class="item-header item-formula">{{ localize "DND5E.SpellHeader.Formula" }}</div>
                 <div class="item-header item-controls"></div>
                 {{#if (and usesSlots editable)}}
@@ -128,16 +128,6 @@
                         </div>
                     </div>
 
-                    {{!-- Spell Uses --}}
-                    <div class="item-detail item-uses spell-uses {{#unless ctx.hasUses}}empty{{/unless}}">
-                        {{#if ctx.hasUses}}
-                        <input type="text" value="{{ item.system.uses.value }}" placeholder="0" data-dtype="Number"
-                               data-name="system.uses.value" inputmode="numeric" pattern="[0-9+=\-]*">
-                        <span class="separator">&sol;</span>
-                        <span class="max">{{ item.system.uses.max }}</span>
-                        {{/if}}
-                    </div>
-
                     {{!-- Spell School --}}
                     <div class="item-detail item-school" data-tooltip="{{ item.labels.school }}"
                          aria-label="{{ item.labels.school }}">
@@ -182,6 +172,16 @@
                             </span>
                             <span class="value">{{ item.system.save.dc }}</span>
                         </div>
+                        {{/if}}
+                    </div>
+
+                    {{!-- Spell Uses --}}
+                    <div class="item-detail item-uses spell-uses {{#unless ctx.hasUses}}empty{{/unless}}">
+                        {{#if ctx.hasUses}}
+                        <input type="text" value="{{ item.system.uses.value }}" placeholder="0" data-dtype="Number"
+                               data-name="system.uses.value" inputmode="numeric" pattern="[+=\-]?\d*">
+                        <span class="separator">&sol;</span>
+                        <span class="max">{{ item.system.uses.max }}</span>
                         {{/if}}
                     </div>
 

--- a/templates/actors/tabs/character-spells.hbs
+++ b/templates/actors/tabs/character-spells.hbs
@@ -61,6 +61,7 @@
             {{!-- Section Header --}}
             <div class="items-header header">
                 <h3 class="item-name spell-header">{{ localize label }}</h3>
+                <div class="item-header item-uses spell-uses">{{ localize "DND5E.Uses" }}</div>
                 <div class="item-header item-school">{{ localize "DND5E.SpellHeader.School" }}</div>
                 <div class="item-header item-usage">{{ localize "DND5E.SpellHeader.Time" }}</div>
                 <div class="item-header item-range">{{ localize "DND5E.SpellHeader.Range" }}</div>
@@ -107,7 +108,14 @@
                         <img class="item-image gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
                         <div class="name name-stacked">
                             <span class="title">{{ item.name }}</span>
-                            <span class="subtitle">{{ item.labels.components.vsm }}</span>
+                            <span class="subtitle">
+                                {{ item.labels.components.vsm }}
+                                {{#if ctx.hasUses}}
+                                <span class="subtitle-uses">
+                                    — {{ item.system.uses.value }} &sol; {{ item.system.uses.max }}
+                                </span>
+                                {{/if}}
+                            </span>
                         </div>
                         <div class="tags">
                             {{#each item.labels.components.all}}
@@ -118,6 +126,16 @@
                             {{/if}}
                             {{/each}}
                         </div>
+                    </div>
+
+                    {{!-- Spell Uses --}}
+                    <div class="item-detail item-uses spell-uses {{#unless ctx.hasUses}}empty{{/unless}}">
+                        {{#if ctx.hasUses}}
+                        <input type="text" value="{{ item.system.uses.value }}" placeholder="0" data-dtype="Number"
+                               data-name="system.uses.value" inputmode="numeric" pattern="[0-9+=\-]*">
+                        <span class="separator">&sol;</span>
+                        <span class="max">{{ item.system.uses.max }}</span>
+                        {{/if}}
                     </div>
 
                     {{!-- Spell School --}}


### PR DESCRIPTION
Adds the uses as the first column on the player's spellbook tab. These uses only display when the spellbook is wide enough and are editable like in the features tab.

<img width="770" alt="Spell Uses - Wide" src="https://github.com/foundryvtt/dnd5e/assets/19979839/ee3a0a57-be7b-4461-9117-97040b4480cb">

If the sheet it too narrow, then the uses are instead displayed in the spell's subtitle alongside and required components. In the narrow mode they are not editable.

<img width="532" alt="Spell Uses - Narrow" src="https://github.com/foundryvtt/dnd5e/assets/19979839/ac2254a8-24c3-4066-b921-cc0674df0834">

Closes #2773