### PR TITLE
[#3071] Fix rendering issues with UP & DOWN item tooltips

### DIFF
--- a/module/tooltips.mjs
+++ b/module/tooltips.mjs
@@ -176,6 +176,23 @@ export default class Tooltips5e {
    * @protected
    */
   _positionItemTooltip(direction=TooltipManager.TOOLTIP_DIRECTIONS.LEFT) {
+    const pos = this.tooltip.getBoundingClientRect();
+    const dirs = TooltipManager.TOOLTIP_DIRECTIONS;
+    switch ( direction ) {
+      case dirs.UP:
+        if ( pos.y - TooltipManager.TOOLTIP_MARGIN_PX <= 0 ) direction = dirs.DOWN;
+        break;
+      case dirs.DOWN:
+        if ( pos.y + this.tooltip.offsetHeight > window.innerHeight ) direction = dirs.UP;
+        break;
+      case dirs.LEFT:
+        if ( pos.x - TooltipManager.TOOLTIP_MARGIN_PX <= 0 ) direction = dirs.RIGHT;
+        break;
+      case dirs.RIGHT:
+        if ( pos.x + this.tooltip.offsetWidth > window.innerWith ) direction = dirs.LEFT;
+        break;
+    }
+
     game.tooltip._setAnchor(direction);
 
     // Set overflowing styles for item tooltips.

--- a/module/tooltips.mjs
+++ b/module/tooltips.mjs
@@ -176,21 +176,7 @@ export default class Tooltips5e {
    * @protected
    */
   _positionItemTooltip(direction=TooltipManager.TOOLTIP_DIRECTIONS.LEFT) {
-    const tooltip = this.tooltip;
-    const { clientWidth, clientHeight } = document.documentElement;
-    const tooltipBox = tooltip.getBoundingClientRect();
-    const targetBox = game.tooltip.element.getBoundingClientRect();
-    const maxTop = clientHeight - tooltipBox.height;
-    const top = Math.min(maxTop, targetBox.bottom - ((targetBox.height + tooltipBox.height) / 2));
-    const left = targetBox.left - tooltipBox.width - game.tooltip.constructor.TOOLTIP_MARGIN_PX;
-    const right = targetBox.right + game.tooltip.constructor.TOOLTIP_MARGIN_PX;
-    const { RIGHT, LEFT } = TooltipManager.TOOLTIP_DIRECTIONS;
-    if ( (direction === LEFT) && (left < 0) ) direction = RIGHT;
-    else if ( (direction === RIGHT) && (right + targetBox.width > clientWidth) ) direction = LEFT;
-    tooltip.style.top = `${Math.max(0, top)}px`;
-    tooltip.style.right = "";
-    if ( direction === RIGHT ) tooltip.style.left = `${Math.min(right, clientWidth - tooltipBox.width)}px`;
-    else tooltip.style.left = `${Math.max(0, left)}px`;
+    game.tooltip._setAnchor(direction);
 
     // Set overflowing styles for item tooltips.
     if ( tooltip.classList.contains("item-tooltip") ) {

--- a/module/tooltips.mjs
+++ b/module/tooltips.mjs
@@ -172,10 +172,15 @@ export default class Tooltips5e {
 
   /**
    * Position a tooltip after rendering.
-   * @param {string} [direction="LEFT"]  The direction to position the tooltip.
+   * @param {string} [direction]  The direction to position the tooltip.
    * @protected
    */
-  _positionItemTooltip(direction=TooltipManager.TOOLTIP_DIRECTIONS.LEFT) {
+  _positionItemTooltip(direction) {
+    if ( !direction ) {
+      direction = TooltipManager.TOOLTIP_DIRECTIONS.LEFT;
+      game.tooltip._setAnchor(direction);
+    }
+
     const pos = this.tooltip.getBoundingClientRect();
     const dirs = TooltipManager.TOOLTIP_DIRECTIONS;
     switch ( direction ) {


### PR DESCRIPTION
Seems to be working for all cases I tested, but I'm not sure if there is some case that the original positioning code was written for that the normal core code doesn't take into account.

Closes #3071