### PR TITLE
[#2597] Add identifier field to background, add identifier input

### DIFF
--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -1,5 +1,5 @@
 import { ItemDataModel } from "../abstract.mjs";
-import { AdvancementField } from "../fields.mjs";
+import { AdvancementField, IdentifierField } from "../fields.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import StartingEquipmentTemplate from "./templates/starting-equipment.mjs";
 
@@ -8,12 +8,14 @@ import StartingEquipmentTemplate from "./templates/starting-equipment.mjs";
  * @mixes ItemDescriptionTemplate
  * @mixes StartingEquipmentTemplate
  *
+ * @property {string} identifier     Identifier slug for this background.
  * @property {object[]} advancement  Advancement objects for this background.
  */
 export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionTemplate, StartingEquipmentTemplate) {
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
+      identifier: new IdentifierField({required: true, label: "DND5E.Identifier"}),
       advancement: new foundry.data.fields.ArrayField(new AdvancementField(), {label: "DND5E.AdvancementTitle"})
     });
   }

--- a/templates/items/background.hbs
+++ b/templates/items/background.hbs
@@ -41,6 +41,16 @@
         {{!-- Details Tab --}}
         <div class="tab details" data-group="primary" data-tab="details">
 
+            {{!-- Identifier --}}
+            <div class="form-group">
+                <label>{{ localize "DND5E.Identifier" }}</label>
+                <div class="form-fields">
+                    <input type="text" name="system.identifier" value="{{ system.identifier }}"
+                           placeholder="{{ item.identifier }}">
+                </div>
+                <p class="hint">{{ localize "DND5E.IdentifierError" }}</p>
+            </div>
+
             {{!-- Starting Equipment --}}
             <h3 class="form-header">
                 {{ localize "DND5E.StartingEquipment.Title" }}

--- a/templates/items/class.hbs
+++ b/templates/items/class.hbs
@@ -45,11 +45,12 @@
             <div class="form-group">
                 <label>{{ localize "DND5E.Identifier" }}</label>
                 <div class="form-fields">
-                    <input type="text" name="system.identifier" value="{{system.identifier}}"
-                           placeholder="{{item.identifier}}">
+                    <input type="text" name="system.identifier" value="{{ system.identifier }}"
+                           placeholder="{{ item.identifier }}">
                 </div>
                 <p class="hint">
-                    {{{localize "DND5E.ClassIdentifierHint" identifier=item.identifier}}}
+                    {{{ localize "DND5E.ClassIdentifierHint" identifier=item.identifier }}}
+                    {{ localize "DND5E.IdentifierError" }}
                 </p>
             </div>
 

--- a/templates/items/race.hbs
+++ b/templates/items/race.hbs
@@ -24,6 +24,7 @@
     {{!-- Item Sheet Navigation --}}
     <nav class="sheet-navigation tabs" data-group="primary">
         <a class="item active" data-tab="description">{{localize "DND5E.Description"}}</a>
+        <a class="item" data-tab="details">{{ localize "DND5E.Details" }}</a>
         <a class="item" data-tab="advancement">{{localize "DND5E.AdvancementTitle"}}</a>
     </nav>
 
@@ -67,6 +68,21 @@
 
             {{editor enriched.description target="system.description.value" button=true editable=editable
                      engine="prosemirror" collaborate=false}}
+        </div>
+
+        {{!-- Details Tab --}}
+        <div class="tab details" data-group="primary" data-tab="details">
+
+            {{!-- Identifier --}}
+            <div class="form-group">
+                <label>{{ localize "DND5E.Identifier" }}</label>
+                <div class="form-fields">
+                    <input type="text" name="system.identifier" value="{{ system.identifier }}"
+                           placeholder="{{ item.identifier }}">
+                </div>
+                <p class="hint">{{ localize "DND5E.IdentifierError" }}</p>
+            </div>
+
         </div>
 
         {{!-- Advancement Tab --}}

--- a/templates/items/subclass.hbs
+++ b/templates/items/subclass.hbs
@@ -47,6 +47,7 @@
                 <div class="form-fields">
                     <input type="text" name="system.identifier" value="{{system.identifier}}" placeholder="{{item.identifier}}">
                 </div>
+                <p class="hint">{{ localize "DND5E.IdentifierError" }}</p>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
Adds `identifier` to the data for backgrounds so it can be set. Adds identifier input to the background and race sheets, which includes adding a new details tab to race sheets. Also added the identifier restrictions to the hint beneath each identifier input.

Closes #2597 