### PR TITLE
Fix damage migration bludgeoning all parts in partial updates to system.damage

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -460,7 +460,7 @@ export default class ItemSheet5e extends ItemSheet {
 
     // Handle Damage array
     const damage = formData.system?.damage;
-    if ( damage ) damage.parts = Object.values(damage?.parts || {}).map(d => [d[0] || "", d[1] || ""]);
+    if ( damage?.parts ) damage.parts = Object.values(damage.parts || {}).map(d => [d[0] || "", d[1] || ""]);
 
     // Handle properties
     if ( foundry.utils.hasProperty(formData, "system.properties") ) {

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -69,7 +69,6 @@ export default class ActionTemplate extends ItemDataModel {
     ActionTemplate.#migrateAttack(source);
     ActionTemplate.#migrateCritical(source);
     ActionTemplate.#migrateSave(source);
-    ActionTemplate.#migrateDamage(source);
   }
 
   /* -------------------------------------------- */
@@ -126,18 +125,6 @@ export default class ActionTemplate extends ItemDataModel {
       if ( source.save.dc === "" ) source.save.dc = null;
       else if ( Number.isNumeric(source.save.dc) ) source.save.dc = Number(source.save.dc);
     }
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Migrate damage parts.
-   * @param {object} source  The candidate source data from which the model will be constructed.
-   */
-  static #migrateDamage(source) {
-    if ( !("damage" in source) ) return;
-    source.damage ??= {};
-    source.damage.parts ??= [];
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
If updating only `system.damage.versatile` then `damage.parts` get yeeted.

Especially apparent if an effect (per 3.2) overrides and thus disables the damage parts in the item sheet.