### PR TITLE
[#3242] Setup Giant Insect, Create Undead, & Dancing Lights summons

### DIFF
--- a/packs/_source/monsters/summons/arcane-eye.json
+++ b/packs/_source/monsters/summons/arcane-eye.json
@@ -3,7 +3,7 @@
   "name": "Arcane Eye",
   "type": "npc",
   "_id": "tuHyePQ9GazMTyc0",
-  "img": "",
+  "img": null,
   "system": {
     "currency": {
       "pp": 0,
@@ -507,7 +507,7 @@
     "appendNumber": false,
     "prependAdjective": false,
     "texture": {
-      "src": "",
+      "src": null,
       "scaleX": 1,
       "scaleY": 1,
       "offsetX": 0,
@@ -612,7 +612,7 @@
       "_key": "!actors.effects!tuHyePQ9GazMTyc0.VUI3PxyI4LH2J8tm"
     }
   ],
-  "sort": 0,
+  "sort": 500000,
   "ownership": {
     "default": 0
   },
@@ -622,7 +622,7 @@
     "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1712086234744,
-    "modifiedTime": 1712086336550,
+    "modifiedTime": 1714077048621,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!tuHyePQ9GazMTyc0"

--- a/packs/_source/monsters/summons/arcane-hand.json
+++ b/packs/_source/monsters/summons/arcane-hand.json
@@ -3,7 +3,7 @@
   "name": "Arcane Hand",
   "type": "npc",
   "_id": "iHj5Tkm6HRgXuaWP",
-  "img": "",
+  "img": null,
   "system": {
     "currency": {
       "pp": 0,
@@ -507,7 +507,7 @@
     "appendNumber": false,
     "prependAdjective": false,
     "texture": {
-      "src": "",
+      "src": null,
       "scaleX": 1,
       "scaleY": 1,
       "offsetX": 0,
@@ -993,7 +993,7 @@
     }
   ],
   "effects": [],
-  "sort": 0,
+  "sort": 400000,
   "ownership": {
     "default": 0
   },
@@ -1003,7 +1003,7 @@
     "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1712086409403,
-    "modifiedTime": 1712086936053,
+    "modifiedTime": 1714077048621,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!iHj5Tkm6HRgXuaWP"

--- a/packs/_source/monsters/summons/arcane-sword.json
+++ b/packs/_source/monsters/summons/arcane-sword.json
@@ -3,7 +3,7 @@
   "name": "Arcane Sword",
   "type": "npc",
   "_id": "Tac7eq0AXJco0nml",
-  "img": "",
+  "img": null,
   "system": {
     "currency": {
       "pp": 0,
@@ -507,7 +507,7 @@
     "appendNumber": false,
     "prependAdjective": false,
     "texture": {
-      "src": "",
+      "src": null,
       "scaleX": 1,
       "scaleY": 1,
       "offsetX": 0,
@@ -688,7 +688,7 @@
     }
   ],
   "effects": [],
-  "sort": 0,
+  "sort": 200000,
   "ownership": {
     "default": 0
   },
@@ -698,7 +698,7 @@
     "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1712086414546,
-    "modifiedTime": 1712087113879,
+    "modifiedTime": 1714077048621,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!Tac7eq0AXJco0nml"

--- a/packs/_source/monsters/summons/dancing-lights-medium.json
+++ b/packs/_source/monsters/summons/dancing-lights-medium.json
@@ -1,9 +1,8 @@
 {
   "folder": "89daM0oezivxN75Y",
-  "name": "Unseen Servant",
+  "name": "Dancing Lights (medium)",
   "type": "npc",
-  "_id": "BTQz2q4JJVQn8W5W",
-  "img": null,
+  "img": "",
   "system": {
     "currency": {
       "pp": 0,
@@ -14,7 +13,7 @@
     },
     "abilities": {
       "str": {
-        "value": 2,
+        "value": 0,
         "proficient": 0,
         "max": null,
         "bonuses": {
@@ -386,11 +385,11 @@
       "movement": {
         "burrow": null,
         "climb": null,
-        "fly": null,
+        "fly": 60,
         "swim": null,
-        "walk": 15,
+        "walk": null,
         "units": null,
-        "hover": false
+        "hover": true
       },
       "attunement": {
         "max": 3
@@ -418,15 +417,15 @@
         "limit": 1
       },
       "ac": {
-        "flat": 10,
+        "flat": 0,
         "calc": "flat"
       },
       "hd": {
         "spent": 0
       },
       "hp": {
-        "value": 1,
-        "max": 1,
+        "value": 0,
+        "max": 0,
         "temp": 0,
         "tempmax": 0,
         "formula": ""
@@ -501,18 +500,19 @@
     }
   },
   "prototypeToken": {
-    "name": "Unseen Servant",
+    "name": "Dancing Lights",
     "displayName": 0,
     "actorLink": false,
     "appendNumber": false,
     "prependAdjective": false,
     "texture": {
-      "src": null,
+      "src": "",
       "scaleX": 1,
       "scaleY": 1,
       "offsetX": 0,
       "offsetY": 0,
-      "rotation": 0
+      "rotation": 0,
+      "tint": null
     },
     "width": 1,
     "height": 1,
@@ -532,7 +532,7 @@
       "angle": 360,
       "bright": 0,
       "coloration": 1,
-      "dim": 0,
+      "dim": 10,
       "attenuation": 0.5,
       "luminosity": 0.5,
       "saturation": 0,
@@ -547,7 +547,8 @@
       "darkness": {
         "min": 0,
         "max": 1
-      }
+      },
+      "color": null
     },
     "sight": {
       "enabled": false,
@@ -557,44 +558,30 @@
       "attenuation": 0.1,
       "brightness": 0,
       "saturation": 0,
-      "contrast": 0
+      "contrast": 0,
+      "color": null
     },
     "detectionModes": [],
-    "flags": {},
+    "flags": {
+      "dnd5e": {
+        "tokenRing": {
+          "enabled": false,
+          "textures": {
+            "subject": ""
+          },
+          "scaleCorrection": 1,
+          "colors": {
+            "ring": "",
+            "background": ""
+          },
+          "effects": 1
+        }
+      }
+    },
     "randomImg": false
   },
   "items": [],
-  "effects": [
-    {
-      "name": "Invisible",
-      "_id": "huO2iAgLJJHGXWix",
-      "icon": "systems/dnd5e/icons/svg/statuses/invisible.svg",
-      "statuses": [
-        "invisible"
-      ],
-      "description": "<ul><li>An invisible creature is impossible to see without the aid of magic or a special sense. For the purpose of hiding, the creature is heavily obscured. The creature's location can be detected by any noise it makes or any tracks it leaves.</li><li>Attack rolls against the creature have disadvantage, and the creature's attack rolls have advantage.</li></ul>",
-      "changes": [],
-      "disabled": false,
-      "duration": {
-        "startTime": 0,
-        "seconds": null,
-        "combat": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
-      },
-      "origin": null,
-      "transfer": false,
-      "flags": {
-        "core": {
-          "sourceId": "Actor.eIQIKf1xngnKcRpg.ActiveEffect.dnd5einvisible00"
-        }
-      },
-      "_key": "!actors.effects!BTQz2q4JJVQn8W5W.huO2iAgLJJHGXWix"
-    }
-  ],
-  "sort": 100000,
+  "effects": [],
   "ownership": {
     "default": 0
   },
@@ -603,9 +590,11 @@
     "systemId": "dnd5e",
     "systemVersion": "3.2.0",
     "coreVersion": "11.315",
-    "createdTime": 1712088776020,
-    "modifiedTime": 1714077048621,
+    "createdTime": 1714076980309,
+    "modifiedTime": 1714077051730,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
-  "_key": "!actors!BTQz2q4JJVQn8W5W"
+  "_id": "JNmHqTwkWayvkH37",
+  "sort": 300000,
+  "_key": "!actors!JNmHqTwkWayvkH37"
 }

--- a/packs/_source/monsters/summons/dancing-lights-tiny.json
+++ b/packs/_source/monsters/summons/dancing-lights-tiny.json
@@ -1,9 +1,9 @@
 {
   "folder": "89daM0oezivxN75Y",
-  "name": "Unseen Servant",
+  "name": "Dancing Lights (tiny)",
   "type": "npc",
-  "_id": "BTQz2q4JJVQn8W5W",
-  "img": null,
+  "_id": "UrXp9O9N7DvdH9nL",
+  "img": "",
   "system": {
     "currency": {
       "pp": 0,
@@ -14,7 +14,7 @@
     },
     "abilities": {
       "str": {
-        "value": 2,
+        "value": 0,
         "proficient": 0,
         "max": null,
         "bonuses": {
@@ -386,11 +386,11 @@
       "movement": {
         "burrow": null,
         "climb": null,
-        "fly": null,
+        "fly": 60,
         "swim": null,
-        "walk": 15,
+        "walk": null,
         "units": null,
-        "hover": false
+        "hover": true
       },
       "attunement": {
         "max": 3
@@ -418,15 +418,15 @@
         "limit": 1
       },
       "ac": {
-        "flat": 10,
+        "flat": 0,
         "calc": "flat"
       },
       "hd": {
         "spent": 0
       },
       "hp": {
-        "value": 1,
-        "max": 1,
+        "value": 0,
+        "max": 0,
         "temp": 0,
         "tempmax": 0,
         "formula": ""
@@ -470,7 +470,7 @@
       }
     },
     "traits": {
-      "size": "med",
+      "size": "tiny",
       "di": {
         "bypasses": [],
         "value": [],
@@ -501,21 +501,22 @@
     }
   },
   "prototypeToken": {
-    "name": "Unseen Servant",
+    "name": "Dancing Lights",
     "displayName": 0,
     "actorLink": false,
     "appendNumber": false,
     "prependAdjective": false,
     "texture": {
-      "src": null,
+      "src": "",
       "scaleX": 1,
       "scaleY": 1,
       "offsetX": 0,
       "offsetY": 0,
-      "rotation": 0
+      "rotation": 0,
+      "tint": null
     },
-    "width": 1,
-    "height": 1,
+    "width": 0.5,
+    "height": 0.5,
     "lockRotation": false,
     "rotation": 0,
     "alpha": 1,
@@ -532,7 +533,7 @@
       "angle": 360,
       "bright": 0,
       "coloration": 1,
-      "dim": 0,
+      "dim": 10,
       "attenuation": 0.5,
       "luminosity": 0.5,
       "saturation": 0,
@@ -547,7 +548,8 @@
       "darkness": {
         "min": 0,
         "max": 1
-      }
+      },
+      "color": null
     },
     "sight": {
       "enabled": false,
@@ -557,44 +559,31 @@
       "attenuation": 0.1,
       "brightness": 0,
       "saturation": 0,
-      "contrast": 0
+      "contrast": 0,
+      "color": null
     },
     "detectionModes": [],
-    "flags": {},
+    "flags": {
+      "dnd5e": {
+        "tokenRing": {
+          "enabled": false,
+          "textures": {
+            "subject": ""
+          },
+          "scaleCorrection": 1,
+          "colors": {
+            "ring": "",
+            "background": ""
+          },
+          "effects": 1
+        }
+      }
+    },
     "randomImg": false
   },
   "items": [],
-  "effects": [
-    {
-      "name": "Invisible",
-      "_id": "huO2iAgLJJHGXWix",
-      "icon": "systems/dnd5e/icons/svg/statuses/invisible.svg",
-      "statuses": [
-        "invisible"
-      ],
-      "description": "<ul><li>An invisible creature is impossible to see without the aid of magic or a special sense. For the purpose of hiding, the creature is heavily obscured. The creature's location can be detected by any noise it makes or any tracks it leaves.</li><li>Attack rolls against the creature have disadvantage, and the creature's attack rolls have advantage.</li></ul>",
-      "changes": [],
-      "disabled": false,
-      "duration": {
-        "startTime": 0,
-        "seconds": null,
-        "combat": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
-      },
-      "origin": null,
-      "transfer": false,
-      "flags": {
-        "core": {
-          "sourceId": "Actor.eIQIKf1xngnKcRpg.ActiveEffect.dnd5einvisible00"
-        }
-      },
-      "_key": "!actors.effects!BTQz2q4JJVQn8W5W.huO2iAgLJJHGXWix"
-    }
-  ],
-  "sort": 100000,
+  "effects": [],
+  "sort": 700000,
   "ownership": {
     "default": 0
   },
@@ -603,9 +592,9 @@
     "systemId": "dnd5e",
     "systemVersion": "3.2.0",
     "coreVersion": "11.315",
-    "createdTime": 1712088776020,
-    "modifiedTime": 1714077048621,
+    "createdTime": 1714076980309,
+    "modifiedTime": 1714077054767,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
-  "_key": "!actors!BTQz2q4JJVQn8W5W"
+  "_key": "!actors!UrXp9O9N7DvdH9nL"
 }

--- a/packs/_source/monsters/summons/mage-hand.json
+++ b/packs/_source/monsters/summons/mage-hand.json
@@ -3,7 +3,7 @@
   "name": "Mage Hand",
   "type": "npc",
   "_id": "zwT2WjWo7cTm2631",
-  "img": "",
+  "img": null,
   "system": {
     "currency": {
       "pp": 0,
@@ -507,7 +507,7 @@
     "appendNumber": false,
     "prependAdjective": false,
     "texture": {
-      "src": "",
+      "src": null,
       "scaleX": 1,
       "scaleY": 1,
       "offsetX": 0,
@@ -565,7 +565,7 @@
   },
   "items": [],
   "effects": [],
-  "sort": 0,
+  "sort": 600000,
   "ownership": {
     "default": 0
   },
@@ -575,7 +575,7 @@
     "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1712088725222,
-    "modifiedTime": 1712088790215,
+    "modifiedTime": 1714077048621,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!zwT2WjWo7cTm2631"

--- a/packs/_source/spells/4th-level/giant-insect.json
+++ b/packs/_source/spells/4th-level/giant-insect.json
@@ -52,7 +52,7 @@
       "scale": false
     },
     "ability": "",
-    "actionType": "util",
+    "actionType": "summ",
     "attackBonus": "",
     "chatFlavor": "",
     "critical": {
@@ -90,7 +90,60 @@
       "somatic",
       "concentration"
     ],
-    "crewed": false
+    "crewed": false,
+    "summons": {
+      "prompt": true,
+      "bonuses": {
+        "ac": "",
+        "hd": "",
+        "hp": "",
+        "attackDamage": "",
+        "saveDamage": "",
+        "healing": ""
+      },
+      "profiles": [
+        {
+          "count": "10",
+          "name": "",
+          "_id": "xLVPgOloyb3QJ0i1",
+          "uuid": "Compendium.dnd5e.monsters.Actor.Hn8FFLEzscgT7azz",
+          "level": {
+            "min": null,
+            "max": null
+          }
+        },
+        {
+          "count": "",
+          "name": "",
+          "_id": "zzh3sTByUIvUYVvE",
+          "uuid": "Compendium.dnd5e.monsters.Actor.GxgIVRX5GbVTifiF",
+          "level": {
+            "min": null,
+            "max": null
+          }
+        },
+        {
+          "count": "3",
+          "name": "",
+          "_id": "Mjp51GLFAYyA6NgW",
+          "uuid": "Compendium.dnd5e.monsters.Actor.v99wOosUJjUgcUNF",
+          "level": {
+            "min": null,
+            "max": null
+          }
+        },
+        {
+          "count": "5",
+          "name": "",
+          "_id": "LkxYBiqNIyzUJxuH",
+          "uuid": "Compendium.dnd5e.monsters.Actor.4tl0s2SnaLjkoDiI",
+          "level": {
+            "min": null,
+            "max": null
+          }
+        }
+      ]
+    }
   },
   "sort": 0,
   "flags": {},
@@ -99,10 +152,10 @@
   "folder": "5auWSClKMDUIV5Ni",
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234177,
-    "modifiedTime": 1704823524872,
+    "modifiedTime": 1714077185843,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!czXrVRx6XYRWsHAi"

--- a/packs/_source/spells/6th-level/create-undead.json
+++ b/packs/_source/spells/6th-level/create-undead.json
@@ -52,7 +52,7 @@
       "scale": false
     },
     "ability": "",
-    "actionType": "util",
+    "actionType": "summ",
     "attackBonus": "",
     "chatFlavor": "",
     "critical": {
@@ -90,7 +90,60 @@
       "somatic",
       "material"
     ],
-    "crewed": false
+    "crewed": false,
+    "summons": {
+      "prompt": true,
+      "bonuses": {
+        "ac": "",
+        "hd": "",
+        "hp": "",
+        "attackDamage": "",
+        "saveDamage": "",
+        "healing": ""
+      },
+      "profiles": [
+        {
+          "count": "@item.level - 6",
+          "name": "",
+          "_id": "GGQa2fXx4sJFOhCv",
+          "uuid": "Compendium.dnd5e.monsters.Actor.IyIybE5t2adMEVUM",
+          "level": {
+            "min": 8,
+            "max": null
+          }
+        },
+        {
+          "count": "@item.level - 3",
+          "name": "",
+          "_id": "439tNP7qngefOmVd",
+          "uuid": "Compendium.dnd5e.monsters.Actor.OBujQLLPSmlJiZnL",
+          "level": {
+            "min": null,
+            "max": null
+          }
+        },
+        {
+          "count": "@item.level - 7",
+          "name": "",
+          "_id": "8377f4szK4aEYLqD",
+          "uuid": "Compendium.dnd5e.monsters.Actor.t8WYD7ak07X7xpx8",
+          "level": {
+            "min": 9,
+            "max": null
+          }
+        },
+        {
+          "count": "@item.level - 6",
+          "name": "",
+          "_id": "1wXs9fpxffiMlT1j",
+          "uuid": "Compendium.dnd5e.monsters.Actor.rbyp54px2D0ql4QK",
+          "level": {
+            "min": 8,
+            "max": null
+          }
+        }
+      ]
+    }
   },
   "sort": 0,
   "flags": {},
@@ -99,10 +152,10 @@
   "folder": "0pdesvXqKd55VOh2",
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234100,
-    "modifiedTime": 1704823522820,
+    "modifiedTime": 1714076897049,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!E4NXux0RHvME1XgP"

--- a/packs/_source/spells/cantrip/dancing-lights.json
+++ b/packs/_source/spells/cantrip/dancing-lights.json
@@ -52,7 +52,7 @@
       "scale": false
     },
     "ability": "",
-    "actionType": "util",
+    "actionType": "summ",
     "attackBonus": "",
     "chatFlavor": "",
     "critical": {
@@ -91,7 +91,40 @@
       "material",
       "concentration"
     ],
-    "crewed": false
+    "crewed": false,
+    "summons": {
+      "prompt": true,
+      "bonuses": {
+        "ac": "",
+        "hd": "",
+        "hp": "",
+        "attackDamage": "",
+        "saveDamage": "",
+        "healing": ""
+      },
+      "profiles": [
+        {
+          "count": "",
+          "name": "",
+          "_id": "VCE7UzvbkVLU3yGQ",
+          "uuid": "Compendium.dnd5e.monsters.Actor.JNmHqTwkWayvkH37",
+          "level": {
+            "min": null,
+            "max": null
+          }
+        },
+        {
+          "count": "4",
+          "name": "",
+          "_id": "HC2PKEK56d2l8mFi",
+          "uuid": "Compendium.dnd5e.monsters.Actor.UrXp9O9N7DvdH9nL",
+          "level": {
+            "min": null,
+            "max": null
+          }
+        }
+      ]
+    }
   },
   "sort": 0,
   "flags": {},
@@ -100,10 +133,10 @@
   "folder": "Z8kZlnggh1PtuF3Y",
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.0.0",
+    "systemVersion": "3.2.0",
     "coreVersion": "11.315",
     "createdTime": 1661787234094,
-    "modifiedTime": 1704823522707,
+    "modifiedTime": 1714077073151,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!CAxSzHWizrafT033"


### PR DESCRIPTION
Sets up summoning for three more SRD spells. For dancing lights, this adds two actors for whether you decide to have your lights split into 4 or in a single blob.