### PR TITLE
[#3498] Add prone separately for sleeping/unconscious

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2486,7 +2486,7 @@ DND5E.consumableResources = [
  * @property {string} icon            Icon used to represent the condition on the token.
  * @property {string} [reference]     UUID of a journal entry with details on this condition.
  * @property {string} [special]       Set this condition as a special status effect under this name.
- * @property {Set<string>} [riders]   Additional conditions, by id, to apply as part of this condition.
+ * @property {string[]} [riders]      Additional conditions, by id, to apply as part of this condition.
  */
 
 /**

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2483,9 +2483,10 @@ DND5E.consumableResources = [
 
 /**
  * @typedef {object} _StatusEffectConfig5e
- * @property {string} icon         Icon used to represent the condition on the token.
- * @property {string} [reference]  UUID of a journal entry with details on this condition.
- * @property {string} [special]    Set this condition as a special status effect under this name.
+ * @property {string} icon            Icon used to represent the condition on the token.
+ * @property {string} [reference]     UUID of a journal entry with details on this condition.
+ * @property {string} [special]       Set this condition as a special status effect under this name.
+ * @property {Set<string>} [riders]   Additional conditions, by id, to apply as part of this condition.
  */
 
 /**
@@ -2621,7 +2622,8 @@ DND5E.conditionTypes = {
     label: "DND5E.ConUnconscious",
     icon: "systems/dnd5e/icons/svg/statuses/unconscious.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.UWw13ISmMxDzmwbd",
-    statuses: ["incapacitated", "prone"]
+    statuses: ["incapacitated"],
+    riders: new Set(["prone"])
   }
 };
 preLocalize("conditionTypes", { key: "label", sort: true });
@@ -2693,7 +2695,8 @@ DND5E.statusEffects = {
   sleeping: {
     name: "EFFECT.DND5E.StatusSleeping",
     icon: "systems/dnd5e/icons/svg/statuses/sleeping.svg",
-    statuses: ["incapacitated", "prone", "unconscious"]
+    statuses: ["incapacitated", "unconscious"],
+    riders: new Set(["prone"])
   },
   stable: {
     name: "EFFECT.DND5E.StatusStable",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2623,7 +2623,7 @@ DND5E.conditionTypes = {
     icon: "systems/dnd5e/icons/svg/statuses/unconscious.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.UWw13ISmMxDzmwbd",
     statuses: ["incapacitated"],
-    riders: new Set(["prone"])
+    riders: ["prone"]
   }
 };
 preLocalize("conditionTypes", { key: "label", sort: true });
@@ -2695,8 +2695,7 @@ DND5E.statusEffects = {
   sleeping: {
     name: "EFFECT.DND5E.StatusSleeping",
     icon: "systems/dnd5e/icons/svg/statuses/sleeping.svg",
-    statuses: ["incapacitated", "unconscious"],
-    riders: new Set(["prone"])
+    statuses: ["incapacitated", "unconscious"]
   },
   stable: {
     name: "EFFECT.DND5E.StatusStable",

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -415,7 +415,7 @@ export default class ActiveEffect5e extends ActiveEffect {
   /** @inheritdoc */
   _onCreate(data, options, userId) {
     super._onCreate(data, options, userId);
-    if ( this.active && (this.parent instanceof Actor) ) this.createRiderConditions();
+    if ( (userId === game.userId) && this.active && (this.parent instanceof Actor) ) this.createRiderConditions();
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -553,8 +553,23 @@ export default class ActiveEffect5e extends ActiveEffect {
     const actor = canvas.hud.token.object?.actor;
     if ( !actor ) return;
 
-    if ( target.dataset?.statusId === "exhaustion" ) ActiveEffect5e._manageExhaustion(event, actor);
-    else if ( target.dataset?.statusId === "concentrating" ) ActiveEffect5e._manageConcentration(event, actor);
+    const id = target.dataset?.statusId;
+    if ( id === "exhaustion" ) ActiveEffect5e._manageExhaustion(event, actor);
+    else if ( id === "concentrating" ) ActiveEffect5e._manageConcentration(event, actor);
+
+    if ( target.classList.contains("active") ) return;
+
+    const riders = CONFIG.statusEffects.find(e => e.id === id)?.riders;
+    if ( !riders ) return;
+
+    const createRider = async id => {
+      const existing = actor.effects.get(staticID(`dnd5e${id}`));
+      if ( existing ) return;
+      const effect = await ActiveEffect.implementation.fromStatusEffect(id);
+      return ActiveEffect.implementation.create(effect, { parent: actor, keepId: true });
+    };
+
+    Promise.all(Array.from(riders).map(createRider));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -367,7 +367,7 @@ export default class ActiveEffect5e extends ActiveEffect {
    * Create conditions that are applied separately from an effect.
    * @returns {Promise<ActiveEffect5e[]|void>}      Created rider effects.
    */
-  createRiderConditions() {
+  async createRiderConditions() {
     const riders = new Set(this.statuses.reduce((acc, status) => {
       const r = CONFIG.statusEffects.find(e => e.id === status)?.riders ?? [];
       return acc.concat(r);
@@ -415,7 +415,6 @@ export default class ActiveEffect5e extends ActiveEffect {
   /** @inheritdoc */
   _onCreate(data, options, userId) {
     super._onCreate(data, options, userId);
-
     if ( this.active && (this.parent instanceof Actor) ) this.createRiderConditions();
   }
 


### PR DESCRIPTION
Closes #3498.

Adds a `riders` property for add-on conditions that should be applied separately. 