### PR TITLE
[#3500] Allow module item types to appear in inventory

### DIFF
--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -54,7 +54,8 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
 
     // Categorize items as inventory, spellbook, features, and classes
     const inventory = {};
-    for ( const type of ["weapon", "equipment", "consumable", "tool", "container", "loot"] ) {
+    for ( const [type, model] of Object.entries(CONFIG.Item.dataModels) ) {
+      if ( !model.metadata?.inventoryItem ) continue;
       inventory[type] = {label: `${CONFIG.Item.typeLabels[type]}Pl`, items: [], dataset: {type}};
     }
 

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -360,13 +360,15 @@ export class ItemDataModel extends SystemDataModel {
 
   /**
    * @typedef {SystemDataModelMetadata} ItemDataModelMetadata
-   * @property {boolean} enchantable  Can this item be modified by enchantment effects?
-   * @property {boolean} singleton    Should only a single item of this type be allowed on an actor?
+   * @property {boolean} enchantable    Can this item be modified by enchantment effects?
+   * @property {boolean} inventoryItem  Should this item be listed with an actor's inventory?
+   * @property {boolean} singleton      Should only a single item of this type be allowed on an actor?
    */
 
   /** @type {ItemDataModelMetadata} */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     enchantable: false,
+    inventoryItem: true,
     singleton: false
   }, {inplace: false}));
 

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -368,7 +368,7 @@ export class ItemDataModel extends SystemDataModel {
   /** @type {ItemDataModelMetadata} */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     enchantable: false,
-    inventoryItem: true,
+    inventoryItem: false,
     singleton: false
   }, {inplace: false}));
 

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -46,7 +46,8 @@ export default class ConsumableData extends ItemDataModel.mixin(
 
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
-    enchantable: true
+    enchantable: true,
+    inventoryItem: true
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -43,7 +43,8 @@ export default class ContainerData extends ItemDataModel.mixin(
 
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
-    enchantable: true
+    enchantable: true,
+    inventoryItem: true
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -66,7 +66,8 @@ export default class EquipmentData extends ItemDataModel.mixin(
 
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
-    enchantable: true
+    enchantable: true,
+    inventoryItem: true
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -29,7 +29,8 @@ export default class LootData extends ItemDataModel.mixin(
 
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
-    enchantable: true
+    enchantable: true,
+    inventoryItem: true
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -45,7 +45,8 @@ export default class ToolData extends ItemDataModel.mixin(
 
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
-    enchantable: true
+    enchantable: true,
+    inventoryItem: true
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -47,7 +47,8 @@ export default class WeaponData extends ItemDataModel.mixin(
 
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
-    enchantable: true
+    enchantable: true,
+    inventoryItem: true
   }, {inplace: false}));
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Adds `inventoryItem` to metadata for item data models that allows them to automatically be listed in the inventory tab, as opposed to the former hard-coded list of types.