### PR TITLE
[#3305] Enforce enchantment restrictions when dropping onto item

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -725,8 +725,14 @@
     }
   },
   "Label": "Enchantment",
+  "Items": {
+    "Label": "Enchanted Items",
+    "Entry": "{item} on {actor}",
+    "None": "Nothing Enchanted"
+  },
   "Warning": {
     "NoMagicalItems": "Items that are already magical cannot be enchanted.",
+    "NotOnActor": "Enchantments can only be added to items, not directly to actors.",
     "Override": "This value is being modified by an Enchantment and cannot be edited. Disable the enchantment in the effects tab to edit it.",
     "WrongType": "{incorrectType} items cannot be enchanted by this enchantment, only {allowedType} items are allowed."
   }

--- a/module/applications/item/enchantment-config.mjs
+++ b/module/applications/item/enchantment-config.mjs
@@ -74,7 +74,6 @@ export default class EnchantmentConfig extends DocumentSheet {
         const effect = await ActiveEffect.implementation.create({
           name: this.document.name,
           icon: this.document.img,
-          origin: this.document.uuid,
           "flags.dnd5e.type": "enchantment"
         }, { parent: this.document });
         effect.sheet.render(true);

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -739,10 +739,18 @@ export default class ItemSheet5e extends ItemSheet {
       || (this.item.uuid === effect.origin) ) return false;
     const effectData = effect.toObject();
     let keepOrigin = false;
+
+    // Validate against the enchantment's restraints on the origin item
     if ( effect.getFlag("dnd5e", "type") === "enchantment" ) {
+      const errors = effect.parent.system.enchantment?.canEnchant(this.item);
+      if ( errors?.length ) {
+        errors.forEach(err => ui.notifications.error(err.message));
+        return false;
+      }
       effectData.origin ??= effect.parent.uuid;
       keepOrigin = true;
     }
+
     return ActiveEffect.create(effectData, {parent: this.item, keepOrigin});
   }
 

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -113,10 +113,6 @@ export default class ItemSheet5e extends ItemSheet {
       isPhysical: item.system.hasOwnProperty("quantity"),
 
       // Action Details
-      availableActionTypes: Object.entries(CONFIG.DND5E.itemActionTypes).reduce((obj, [k, v]) => {
-        if ( k !== "ench" || !this.item.system.metadata?.enchantable ) obj[k] = v;
-        return obj;
-      }, {}),
       isHealing: item.system.actionType === "heal",
       isFlatDC: item.system.save?.scaling === "flat",
       isLine: ["line", "wall"].includes(item.system.target?.type),
@@ -135,6 +131,9 @@ export default class ItemSheet5e extends ItemSheet {
 
       // Advancement
       advancement: this._getItemAdvancement(item),
+
+      // Enchantment
+      enchantedItems: await item.system.enchantment?.getItems(),
 
       // Prepare Active Effects
       effects: EffectsElement.prepareCategories(item.effects, { parent: this.item }),
@@ -735,12 +734,16 @@ export default class ItemSheet5e extends ItemSheet {
    */
   async _onDropActiveEffect(event, data) {
     const effect = await ActiveEffect.implementation.fromDropData(data);
-    if ( !this.item.isOwner || !effect ) return false;
-    if ( (this.item.uuid === effect.parent?.uuid) || (this.item.uuid === effect.origin) ) return false;
-    return ActiveEffect.create({
-      ...effect.toObject(),
-      origin: this.item.uuid
-    }, {parent: this.item});
+    if ( !this.item.isOwner || !effect
+      || (this.item.uuid === effect.parent?.uuid)
+      || (this.item.uuid === effect.origin) ) return false;
+    const effectData = effect.toObject();
+    let keepOrigin = false;
+    if ( effect.getFlag("dnd5e", "type") === "enchantment" ) {
+      effectData.origin ??= effect.parent.uuid;
+      keepOrigin = true;
+    }
+    return ActiveEffect.create(effectData, {parent: this.item, keepOrigin});
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -3,7 +3,7 @@ import ActionTemplate from "./templates/action.mjs";
 import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ItemTypeTemplate from "./templates/item-type.mjs";
-import {default as EnchantmentField, EnchantmentData} from "./fields/enchantment-field.mjs";
+import { EnchantmentData } from "./fields/enchantment-field.mjs";
 import ItemTypeField from "./fields/item-type-field.mjs";
 
 const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
@@ -15,7 +15,6 @@ const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundr
  * @mixes ActivatedEffectTemplate
  * @mixes ActionTemplate
  *
- * @property {EnchantmentData} enchantment          Enchantment configuration associated with this type.
  * @property {object} prerequisites
  * @property {number} prerequisites.level           Character or class level required to choose this feature.
  * @property {Set<string>} properties               General properties of a feature item.
@@ -35,7 +34,6 @@ export default class FeatData extends ItemDataModel.mixin(
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
       type: new ItemTypeField({baseItem: false}, {label: "DND5E.ItemFeatureType"}),
-      enchantment: new EnchantmentField(),
       prerequisites: new SchemaField({
         level: new NumberField({integer: true, min: 0})
       }),
@@ -147,16 +145,6 @@ export default class FeatData extends ItemDataModel.mixin(
   /** @inheritdoc */
   get hasLimitedUses() {
     return this.isActive && (!!this.recharge.value || super.hasLimitedUses);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Is this feature an enchantment?
-   * @type {boolean}
-   */
-  get isEnchantment() {
-    return EnchantmentData.isEnchantment(this);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/fields/enchantment-field.mjs
+++ b/module/data/item/fields/enchantment-field.mjs
@@ -152,7 +152,7 @@ export class EnchantmentData extends foundry.abstract.DataModel {
    */
   async getItems() {
     return (await Promise.all(
-      Array.from(this.constructor.#appliedEnchantments.get(this.item.uuid) ?? [])
+      Array.from(EnchantmentData.#appliedEnchantments.get(this.item.uuid) ?? [])
         .map(uuid => fromUuid(uuid).then(ae => ae?.parent))
     )).filter(i => i);
   }
@@ -177,10 +177,10 @@ export class EnchantmentData extends foundry.abstract.DataModel {
    */
   static trackEnchantment(source, enchanted) {
     if ( enchanted.startsWith("Compendium.") ) return;
-    if ( !this.#appliedEnchantments.has(source) ) {
-      this.#appliedEnchantments.set(source, new Set());
+    if ( !EnchantmentData.#appliedEnchantments.has(source) ) {
+      EnchantmentData.#appliedEnchantments.set(source, new Set());
     }
-    const applied = this.#appliedEnchantments.get(source);
+    const applied = EnchantmentData.#appliedEnchantments.get(source);
     applied.add(enchanted);
   }
 
@@ -192,9 +192,8 @@ export class EnchantmentData extends foundry.abstract.DataModel {
    * @param {string} enchanted  UUID of the enchantment to stop tracking.
    */
   static untrackEnchantment(source, enchanted) {
-    if ( !this.#appliedEnchantments.has(source) ) return;
-    const applied = this.#appliedEnchantments.get(source);
-    applied.delete(enchanted);
+    if ( !EnchantmentData.#appliedEnchantments.has(source) ) return;
+    EnchantmentData.#appliedEnchantments.get(source).delete(enchanted);
   }
 }
 

--- a/module/data/item/fields/enchantment-field.mjs
+++ b/module/data/item/fields/enchantment-field.mjs
@@ -59,6 +59,16 @@ export class EnchantmentData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Enchantments available or applied.
+   * @type {ActiveEffect5e[]}
+   */
+  get enchantments() {
+    return this.item.effects.filter(ae => ae.getFlag("dnd5e", "type") === "enchantment");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Is this feature an enchantment?
    * @param {FeatData} data  Data for the feature.
    * @returns {boolean}
@@ -99,6 +109,16 @@ export class EnchantmentData extends foundry.abstract.DataModel {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Item to which this enchantment information belongs.
+   * @type {Item5e}
+   */
+  get item() {
+    return this.parent.parent;
+  }
+
+  /* -------------------------------------------- */
   /*  Helpers                                     */
   /* -------------------------------------------- */
 
@@ -122,6 +142,59 @@ export class EnchantmentData extends foundry.abstract.DataModel {
     }
 
     return errors.length ? errors : true;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Fetch the tracked enchanted items.
+   * @returns {Promise<Item5e[]>}
+   */
+  async getItems() {
+    return (await Promise.all(
+      Array.from(this.constructor.#appliedEnchantments.get(this.item.uuid) ?? [])
+        .map(uuid => fromUuid(uuid).then(ae => ae?.parent))
+    )).filter(i => i);
+  }
+
+  /* -------------------------------------------- */
+  /*  Static Registry                             */
+  /* -------------------------------------------- */
+
+  /**
+   * Registration of enchanted items mapped to a specific enchantment source. The map is keyed by the UUID of
+   * enchantment sources while the set contains UUID of items that source has enchanted.
+   * @type {Map<string, Set<string>>}
+   */
+  static #appliedEnchantments = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add a new enchantment effect to the list of tracked enchantments. Will not track enchanted items in compendiums.
+   * @param {string} source     UUID of the active effect origin for the enchantment.
+   * @param {string} enchanted  UUID of the enchantment to track.
+   */
+  static trackEnchantment(source, enchanted) {
+    if ( enchanted.startsWith("Compendium.") ) return;
+    if ( !this.#appliedEnchantments.has(source) ) {
+      this.#appliedEnchantments.set(source, new Set());
+    }
+    const applied = this.#appliedEnchantments.get(source);
+    applied.add(enchanted);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Stop tracking an enchantment.
+   * @param {string} source     UUID of the active effect origin for the enchantment.
+   * @param {string} enchanted  UUID of the enchantment to stop tracking.
+   */
+  static untrackEnchantment(source, enchanted) {
+    if ( !this.#appliedEnchantments.has(source) ) return;
+    const applied = this.#appliedEnchantments.get(source);
+    applied.delete(enchanted);
   }
 }
 

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -1,7 +1,6 @@
 import { filteredKeys } from "../../utils.mjs";
 import { ItemDataModel } from "../abstract.mjs";
 import { FormulaField } from "../fields.mjs";
-import {default as EnchantmentField, EnchantmentData} from "./fields/enchantment-field.mjs";
 import ActionTemplate from "./templates/action.mjs";
 import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
@@ -15,7 +14,6 @@ import ItemDescriptionTemplate from "./templates/item-description.mjs";
  * @property {number} level                      Base level of the spell.
  * @property {string} school                     Magical school to which this spell belongs.
  * @property {Set<string>} properties            General components and tags for this spell.
- * @property {EnchantmentData} enchantment       Enchantment configuration associated with this type.
  * @property {object} materials                  Details on material components required for this spell.
  * @property {string} materials.value            Description of the material components required for casting.
  * @property {boolean} materials.consumed        Are these material components consumed during casting?
@@ -41,7 +39,6 @@ export default class SpellData extends ItemDataModel.mixin(
       properties: new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {
         label: "DND5E.SpellComponents"
       }),
-      enchantment: new EnchantmentField(),
       materials: new foundry.data.fields.SchemaField({
         value: new foundry.data.fields.StringField({required: true, label: "DND5E.SpellMaterialsDescription"}),
         consumed: new foundry.data.fields.BooleanField({required: true, label: "DND5E.SpellMaterialsConsumed"}),
@@ -167,16 +164,6 @@ export default class SpellData extends ItemDataModel.mixin(
   /** @inheritdoc */
   get _typeCriticalThreshold() {
     return this.parent?.actor?.flags.dnd5e?.spellCriticalThreshold ?? Infinity;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Is this spell an enchantment?
-   * @type {boolean}
-   */
-  get isEnchantment() {
-    return EnchantmentData.isEnchantment(this);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -1,5 +1,6 @@
 import { ItemDataModel } from "../../abstract.mjs";
 import { FormulaField } from "../../fields.mjs";
+import {default as EnchantmentField, EnchantmentData} from "../fields/enchantment-field.mjs";
 import SummonsField from "../fields/summons-field.mjs";
 
 const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
@@ -7,23 +8,24 @@ const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foun
 /**
  * Data model template for item actions.
  *
- * @property {string} ability             Ability score to use when determining modifier.
- * @property {string} actionType          Action type as defined in `DND5E.itemActionTypes`.
- * @property {object} attack              Information how attacks are handled.
- * @property {string} attack.bonus        Numeric or dice bonus to attack rolls.
- * @property {boolean} attack.flat        Is the attack bonus the only bonus to attack rolls?
- * @property {string} chatFlavor          Extra text displayed in chat.
- * @property {object} critical            Information on how critical hits are handled.
- * @property {number} critical.threshold  Minimum number on the dice to roll a critical hit.
- * @property {string} critical.damage     Extra damage on critical hit.
- * @property {object} damage              Item damage formulas.
- * @property {string[][]} damage.parts    Array of damage formula and types.
- * @property {string} damage.versatile    Special versatile damage formula.
- * @property {string} formula             Other roll formula.
- * @property {object} save                Item saving throw data.
- * @property {string} save.ability        Ability required for the save.
- * @property {number} save.dc             Custom saving throw value.
- * @property {string} save.scaling        Method for automatically determining saving throw DC.
+ * @property {string} ability               Ability score to use when determining modifier.
+ * @property {string} actionType            Action type as defined in `DND5E.itemActionTypes`.
+ * @property {object} attack                Information how attacks are handled.
+ * @property {string} attack.bonus          Numeric or dice bonus to attack rolls.
+ * @property {boolean} attack.flat          Is the attack bonus the only bonus to attack rolls?
+ * @property {string} chatFlavor            Extra text displayed in chat.
+ * @property {object} critical              Information on how critical hits are handled.
+ * @property {number} critical.threshold    Minimum number on the dice to roll a critical hit.
+ * @property {string} critical.damage       Extra damage on critical hit.
+ * @property {object} damage                Item damage formulas.
+ * @property {string[][]} damage.parts      Array of damage formula and types.
+ * @property {string} damage.versatile      Special versatile damage formula.
+ * @property {EnchantmentData} enchantment  Enchantment configuration associated with this type.
+ * @property {string} formula               Other roll formula.
+ * @property {object} save                  Item saving throw data.
+ * @property {string} save.ability          Ability required for the save.
+ * @property {number} save.dc               Custom saving throw value.
+ * @property {string} save.scaling          Method for automatically determining saving throw DC.
  * @property {SummonsData} summons
  * @mixin
  */
@@ -48,6 +50,7 @@ export default class ActionTemplate extends ItemDataModel {
         parts: new ArrayField(new ArrayField(new StringField({nullable: true})), {required: true}),
         versatile: new FormulaField({required: true, label: "DND5E.VersatileDamage"})
       }, {label: "DND5E.Damage"}),
+      enchantment: new EnchantmentField(),
       formula: new FormulaField({required: true, label: "DND5E.OtherFormula"}),
       save: new SchemaField({
         ability: new StringField({required: true, blank: true, label: "DND5E.Ability"}),
@@ -234,6 +237,16 @@ export default class ActionTemplate extends ItemDataModel {
    */
   get hasSummoning() {
     return (this.actionType === "summ") && !!this.summons?.profiles.length;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Can this item enchant other items?
+   * @type {boolean}
+   */
+  get isEnchantment() {
+    return EnchantmentData.isEnchantment(this);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -376,16 +376,15 @@ export default class ActiveEffect5e extends ActiveEffect {
       return false;
     }
 
-    if ( !this.isAppliedEnchantment ) return;
-
-    // Otherwise validate against the enchantment's restraints on the origin item
-    const origin = await fromUuid(this.origin);
-    const errors = origin?.system.enchantment?.canEnchant(this.parent);
-    this.updateSource({ disabled: false });
-    if ( !errors?.length ) return;
-
-    errors.forEach(err => ui.notifications.error(err.message));
-    return false;
+    if ( this.isAppliedEnchantment ) {
+      const origin = await fromUuid(this.origin);
+      const errors = origin?.system.enchantment?.canEnchant(this.parent);
+      if ( errors?.length ) {
+        errors.forEach(err => console.error(err));
+        return false;
+      }
+      this.updateSource({ disabled: false });
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -400,7 +400,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   *allApplicableEffects() {
     for ( const effect of this.effects ) {
-      if ( effect.flags.dnd5e?.type === "enchantment" ) yield effect;
+      if ( effect.isAppliedEnchantment ) yield effect;
     }
   }
 

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -2,7 +2,7 @@
 <div class="form-group select">
     <label>{{ localize "DND5E.ItemActionType" }}</label>
     <select name="system.actionType">
-        {{ selectOptions availableActionTypes selected=system.actionType blank="" }}
+        {{ selectOptions config.itemActionTypes selected=system.actionType blank="" }}
     </select>
 </div>
 {{#if system.actionType}}
@@ -130,6 +130,23 @@
             {{ localize "DND5E.Enchantment.Action.Configure" }}
         </a>
     </div>
+</div>
+
+<div class="form-group enchanted-items">
+    <label>{{ localize "DND5E.Enchantment.Items.Label" }}</label>
+    <ul>
+        {{#each enchantedItems}}
+        <li>
+            {{#if actor}}
+            {{ localize "DND5E.Enchantment.Items.Entry" item=_source.name actor=actor.name }}
+            {{else}}
+            {{ _source.name }}
+            {{/if}}
+        </li>
+        {{else}}
+        <li>{{ localize "DND5E.Enchantment.Items.None" }}</li>
+        {{/each}}
+    </ul>
 </div>
 {{/if}}
 


### PR DESCRIPTION
When adding an enchantment to an item that accepts enchantments, the restrictions specified in the enchantment source will now be enforced. It will also prevent the creation of an enchantment effect directly on an actor.

Enchanted items in the world will register themselves with a static registry of all enchanted items so the enchantment items can easily determine what items they have enchanted.

Support has been added for items that might offer enchantments or receive them (to support a weapon that can enchant other weapons for example). This uses the `origin` data to track whether the enchantment effect is applied to the item or not. To this end the default origin for new enchantments isn't set like for normal effets. The origin is only set when an enchantment is dragged to another item. This ensures that the enchantment origin always matches the item doing the enchantment, even if that item was duplicated.