### PR TITLE
[#3305] Add enchantment usage dialog & application tray

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -689,6 +689,7 @@
 "DND5E.EffectsSearch": "Search effects",
 "DND5E.Enchantment": {
   "Action": {
+    "Apply": "Apply Enchantment",
     "Configure": "Configure Enchantment",
     "Create": "Create Enchantment",
     "Delete": "Delete Enchantment",
@@ -703,6 +704,7 @@
     "Inactive": "Inactive Enchantments"
   },
   "Configuration": "Enchantment Configuration",
+  "DropArea": "Place item here to enchant it…",
   "FIELDS": {
     "enchantment": {
       "label": "Enchantment Configuration",
@@ -736,7 +738,12 @@
     "Entry": "{item} on {actor}",
     "None": "Nothing Enchanted"
   },
+  "Prompt": {
+    "Label": "Enchant Prompt",
+    "Hint": "Disable the enchantment prompt when item is used. First available enchantment will always be applied."
+  },
   "Warning": {
+    "ConcentrationEnded": "Cannot apply this enchantment because concentration has ended.",
     "NoMagicalItems": "Items that are already magical cannot be enchanted.",
     "NotOnActor": "Enchantments can only be added to items, not directly to actors.",
     "Override": "This value is being modified by an Enchantment and cannot be edited. Disable the enchantment in the effects tab to edit it.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -695,7 +695,8 @@
     "Delete": "Delete Enchantment",
     "Disable": "Disable Enchantment",
     "Edit": "Edit Enchantment",
-    "Enable": "Enable Enchantment"
+    "Enable": "Enable Enchantment",
+    "Remove": "Remove Enchantment"
   },
   "Category": {
     "Active": "Active Enchantments",

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -630,6 +630,11 @@ enchantment-application {
       align-items: center;
       gap: 6px;
 
+      &:not(:last-child) {
+        border-block-end: 1px dotted var(--color-border-light-2);
+        padding-block-end: 4px;
+      }
+
       > img {
         block-size: 32px;
         inline-size: 32px;

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -591,10 +591,44 @@
     }
   }
 
-  .targets + button {
+  .wrapper > button {
     margin: 3px;
     width: calc(100% - 6px);
     margin-block-start: 6px;
+  }
+
+  &.enchantment-tray {
+    .drop-area {
+      display: grid;
+      min-block-size: 40px;
+      margin: 4px;
+      border: 1px dashed var(--dnd5e-color-crimson);
+      border-radius: 4px;
+      padding-inline: 4px;
+      background: var(--dnd5e-color-card);
+
+      p {
+        place-content: center;
+        text-align: center;
+      }
+
+      .preview {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+
+        > img {
+          block-size: 32px;
+          inline-size: 32px;
+          flex: 0 0 32px;
+        }
+        > .name {
+          flex: 1;
+          font-family: var(--dnd5e-font-roboto-slab);
+          font-weight: bold;
+        }
+      }
+    }
   }
 }
 

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -596,40 +596,6 @@
     width: calc(100% - 6px);
     margin-block-start: 6px;
   }
-
-  &.enchantment-tray {
-    .drop-area {
-      display: grid;
-      min-block-size: 40px;
-      margin: 4px;
-      border: 1px dashed var(--dnd5e-color-crimson);
-      border-radius: 4px;
-      padding-inline: 4px;
-      background: var(--dnd5e-color-card);
-
-      p {
-        place-content: center;
-        text-align: center;
-      }
-
-      .preview {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-
-        > img {
-          block-size: 32px;
-          inline-size: 32px;
-          flex: 0 0 32px;
-        }
-        > .name {
-          flex: 1;
-          font-family: var(--dnd5e-font-roboto-slab);
-          font-weight: bold;
-        }
-      }
-    }
-  }
 }
 
 .hidden-dc { display: contents; }
@@ -637,6 +603,48 @@
 [data-display-challenge] {
   .hidden-dc { display: none; }
   .visible-dc { display: contents; }
+}
+
+/* ---------------------------------- */
+/*  Enchantment                       */
+/* ---------------------------------- */
+
+enchantment-application {
+  .drop-area {
+    display: grid;
+    gap: 4px;
+    min-block-size: 40px;
+    margin: 4px;
+    border: 1px dashed var(--dnd5e-color-crimson);
+    border-radius: 4px;
+    padding: 4px;
+    background: var(--dnd5e-color-card);
+
+    p {
+      place-content: center;
+      text-align: center;
+    }
+
+    .preview {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+
+      > img {
+        block-size: 32px;
+        inline-size: 32px;
+        flex: 0 0 32px;
+      }
+      > .name {
+        flex: 1;
+        font-family: var(--dnd5e-font-roboto-slab);
+        font-weight: bold;
+      }
+      > a {
+        flex: 0 0 20px;
+      }
+    }
+  }
 }
 
 /* ---------------------------------- */

--- a/module/applications/components/_module.mjs
+++ b/module/applications/components/_module.mjs
@@ -1,5 +1,6 @@
 import DamageApplicationElement from "./damage-application.mjs";
 import EffectsElement from "./effects.mjs";
+import EnchantmentApplicationElement from "./enchantment-application.mjs";
 import FiligreeBoxElement from "./filigree-box.mjs";
 import IconElement from "./icon.mjs";
 import InventoryElement from "./inventory.mjs";
@@ -12,12 +13,13 @@ window.customElements.define("damage-application", DamageApplicationElement);
 window.customElements.define("dnd5e-effects", EffectsElement);
 window.customElements.define("dnd5e-icon", IconElement);
 window.customElements.define("dnd5e-inventory", InventoryElement);
+window.customElements.define("enchantment-application", EnchantmentApplicationElement);
 window.customElements.define("filigree-box", FiligreeBoxElement);
 window.customElements.define("item-list-controls", ItemListControlsElement);
 window.customElements.define("proficiency-cycle", ProficiencyCycleElement);
 window.customElements.define("slide-toggle", SlideToggleElement);
 
 export {
-  AdoptedStyleSheetMixin, DamageApplicationElement, EffectsElement, IconElement, InventoryElement,
-  ItemListControlsElement, FiligreeBoxElement, ProficiencyCycleElement, SlideToggleElement
+  AdoptedStyleSheetMixin, DamageApplicationElement, EffectsElement, EnchantmentApplicationElement, IconElement,
+  InventoryElement, ItemListControlsElement, FiligreeBoxElement, ProficiencyCycleElement, SlideToggleElement
 };

--- a/module/applications/components/enchantment-application.mjs
+++ b/module/applications/components/enchantment-application.mjs
@@ -1,3 +1,5 @@
+import { EnchantmentData } from "../../data/item/fields/enchantment-field.mjs";
+
 /**
  * Application to handle applying enchantments to items from a chat card.
  */
@@ -57,12 +59,11 @@ export default class EnchantmentApplicationElement extends HTMLElement {
   /* -------------------------------------------- */
 
   /**
-   * Build a list of enchanted items.
+   * Build a list of enchanted items. Will be called whenever the enchanted items are changed in order to update
+   * the card list.
    */
   async buildItemList() {
-    const enchantedItems = (await Promise.all(
-      (this.chatMessage.getFlag("dnd5e", "enchanted") ?? []).map(uuid => fromUuid(uuid))
-    )).filter(i => i).map(enchantment => {
+    const enchantedItems = (await EnchantmentData.appliedEnchantments(this.enchantmentItem.uuid)).map(enchantment => {
       const item = enchantment.parent;
       const div = document.createElement("div");
       div.classList.add("preview");

--- a/module/applications/components/enchantment-application.mjs
+++ b/module/applications/components/enchantment-application.mjs
@@ -1,0 +1,155 @@
+/**
+ * Application to handle applying enchantments to items from a chat card.
+ */
+export default class EnchantmentApplicationElement extends HTMLElement {
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The chat message with which this enchantment is associated.
+   * @type {ChatMessage5e}
+   */
+  chatMessage;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Area where items can be dropped to enchant.
+   * @type {HTMLElement}
+   */
+  dropArea;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Dropped item to be enchanted.
+   * @type {Item5e}
+   */
+  #droppedItem;
+
+  get droppedItem() {
+    return this.#droppedItem;
+  }
+
+  set droppedItem(item) {
+    this.#droppedItem = item;
+    if ( this.#droppedItem ) {
+      this.dropArea.innerHTML = `
+        <div class="preview">
+          <img src="${item.img}" class="gold-icon" alt="${item.name}">
+          <span class="name">${item.name}</span>
+        </div>
+      `;
+    }
+    else this.dropArea.innerHTML = `<p>${game.i18n.localize("DND5E.Enchantment.DropArea")}</p>`;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Item providing the enchantment that will be applied.
+   * @type {Item5e}
+   */
+  get enchantmentItem() {
+    return this.chatMessage.getAssociatedItem();
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  connectedCallback() {
+    const messageId = this.closest("[data-message-id]")?.dataset.messageId;
+    this.chatMessage = game.messages.get(messageId);
+    if ( !this.chatMessage ) return;
+
+    // Build the frame HTML only once
+    if ( !this.dropArea ) {
+      const div = document.createElement("div");
+      div.classList.add("card-tray", "enchantment-tray", "collapsible", "collapsed");
+      div.innerHTML = `
+        <label class="roboto-upper">
+          <i class="fa-solid fa-wand-sparkles" inert></i>
+          <span>${game.i18n.localize("DND5E.ActionEnch")}</span>
+          <i class="fa-solid fa-caret-down" inert></i>
+        </label>
+        <div class="collapsible-content">
+          <div class="wrapper">
+            <div class="drop-area"></div>
+            <button class="apply-enchantment" type="button" data-action="applyEnchantment">
+              <i class="fa-solid fa-reply-all fa-flip-horizontal" inert></i>
+              ${game.i18n.localize("DND5E.Apply")}
+            </button>
+          </div>
+        </div>
+      `;
+      this.replaceChildren(div);
+      div.querySelector(".apply-enchantment").addEventListener("click", this._onApplyEnchantment.bind(this));
+      this.dropArea = div.querySelector(".drop-area");
+      div.querySelector(".collapsible-content").addEventListener("click", event => {
+        event.stopImmediatePropagation();
+      });
+      this.addEventListener("drop", this._onDrop.bind(this));
+    }
+
+    this.droppedItem = null;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Handlers                              */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle clicking the apply enchantment button.
+   * @param {PointerEvent} event  Triggering click event.
+   */
+  async _onApplyEnchantment(event) {
+    event.preventDefault();
+
+    const effect = this.enchantmentItem.effects.get(this.chatMessage.getFlag("dnd5e", "use.enchantmentProfile"));
+    if ( !effect ) return;
+
+    const concentrationId = this.chatMessage.getFlag("dnd5e", "use.concentrationId");
+    const concentration = effect.parent.actor.effects.get(concentrationId);
+    if ( concentrationId && !concentration ) {
+      ui.notifications.error("DND5E.Enchantment.Warning.ConcentrationEnded", { localize: true });
+      return;
+    }
+    if ( !game.user.isGM && concentration && !concentration.actor?.isOwner ) {
+      ui.notifications.error("DND5E.EffectApplyWarningConcentration", { localize: true });
+      return;
+    }
+
+    const effectData = effect.toObject();
+    effectData.origin = this.enchantmentItem.uuid;
+    const applied = await ActiveEffect.create(effectData, { parent: this.droppedItem, keepOrigin: true });
+    if ( concentration ) await concentration.addDependent(applied);
+
+    this.droppedItem = null;
+    this.querySelector(".collapsible").dispatchEvent(new PointerEvent("click", { bubbles: true, cancelable: true }));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle dropping an item onto the control.
+   * @param {Event} event  Triggering drop event.
+   */
+  async _onDrop(event) {
+    event.preventDefault();
+    const data = TextEditor.getDragEventData(event);
+    if ( data.type !== "Item" ) return;
+    const droppedItem = await Item.implementation.fromDropData(data);
+
+    // Validate against the enchantment's restraints on the origin item
+    const errors = this.enchantmentItem.system.enchantment?.canEnchant(droppedItem);
+    if ( errors?.length ) {
+      errors.forEach(err => ui.notifications.error(err.message));
+      return;
+    }
+
+    this.droppedItem = droppedItem;
+  }
+}

--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -190,9 +190,7 @@ export default class AbilityUseDialog extends Dialog {
     );
     if ( !enchantments.length ) return null;
     const options = {};
-    options.enchantments = Object.fromEntries(
-      enchantments.map(enchantment => [enchantment._id, enchantment.name])
-    );
+    options.enchantments = Object.fromEntries(enchantments.map(enchantment => [enchantment._id, enchantment.name]));
     if ( Object.values(options.enchantments).length <= 1 ) {
       options.enchantments = null;
       options.enchantment = enchantments[0]._id;

--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -61,6 +61,7 @@ export default class AbilityUseDialog extends Dialog {
       item,
       ...config,
       slotOptions: config.consumeSpellSlot ? this._createSpellSlotOptions(item.actor, item.system.level) : [],
+      enchantmentOptions: this._createEnchantmentOptions(item),
       summoningOptions: this._createSummoningOptions(item),
       resourceOptions: resourceOptions,
       resourceArray: Array.isArray(resourceOptions),
@@ -179,9 +180,32 @@ export default class AbilityUseDialog extends Dialog {
   /* -------------------------------------------- */
 
   /**
-   * Create an array of summoning profiles.
+   * Create details on enchantment that can be applied.
    * @param {Item5e} item  The item.
-   * @returns {{ profiles: object, creatureTypes: object }|null}   Array of select options.
+   * @returns {{ enchantments: object }|null}
+   */
+  static _createEnchantmentOptions(item) {
+    const enchantments = item.effects.filter(e =>
+      (e.getFlag("dnd5e", "type") === "enchantment") && !e.isAppliedEnchantment
+    );
+    if ( !enchantments.length ) return null;
+    const options = {};
+    options.enchantments = Object.fromEntries(
+      enchantments.map(enchantment => [enchantment._id, enchantment.name])
+    );
+    if ( Object.values(options.enchantments).length <= 1 ) {
+      options.enchantments = null;
+      options.enchantment = enchantments[0]._id;
+    }
+    return options;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create details on the summoning profiles and other related options.
+   * @param {Item5e} item  The item.
+   * @returns {{ profiles: object, creatureTypes: object }|null}
    */
   static _createSummoningOptions(item) {
     const summons = item.system.summons;

--- a/module/applications/item/enchantment-config.mjs
+++ b/module/applications/item/enchantment-config.mjs
@@ -41,7 +41,9 @@ export default class EnchantmentConfig extends DocumentSheet {
       return obj;
     }, {});
     context.enchantment = this.document.system.enchantment;
-    context.enchantments = this.document.effects.filter(e => e.getFlag("dnd5e", "type") === "enchantment");
+    context.enchantments = this.document.effects.filter(e =>
+      (e.getFlag("dnd5e", "type") === "enchantment") && !e.isAppliedEnchantment
+    );
     context.source = this.document.toObject().system.enchantment;
     return context;
   }

--- a/module/data/item/fields/enchantment-field.mjs
+++ b/module/data/item/fields/enchantment-field.mjs
@@ -155,10 +155,7 @@ export class EnchantmentData extends foundry.abstract.DataModel {
    * @returns {Promise<Item5e[]>}
    */
   async getItems() {
-    return (await Promise.all(
-      Array.from(EnchantmentData.#appliedEnchantments.get(this.item.uuid) ?? [])
-        .map(uuid => fromUuid(uuid).then(ae => ae?.parent))
-    )).filter(i => i);
+    return (await this.constructor.appliedEnchantments(this.item.uuid)).map(ae => ae?.parent);
   }
 
   /* -------------------------------------------- */
@@ -167,10 +164,23 @@ export class EnchantmentData extends foundry.abstract.DataModel {
 
   /**
    * Registration of enchanted items mapped to a specific enchantment source. The map is keyed by the UUID of
-   * enchantment sources while the set contains UUID of items that source has enchanted.
+   * enchantment sources while the set contains UUID of applied enchantment active effects.
    * @type {Map<string, Set<string>>}
    */
   static #appliedEnchantments = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Fetch the tracked enchanted items.
+   * @param {string} itemUuid  UUID of the item supplying the enchantments.
+   * @returns {Promise<ActiveEffect5e[]>}
+   */
+  static async appliedEnchantments(itemUuid) {
+    return Promise.all(
+      Array.from(EnchantmentData.#appliedEnchantments.get(itemUuid) ?? []).map(uuid => fromUuid(uuid))
+    ).then(a => a.filter(i => i));
+  }
 
   /* -------------------------------------------- */
 

--- a/module/data/item/fields/enchantment-field.mjs
+++ b/module/data/item/fields/enchantment-field.mjs
@@ -21,6 +21,7 @@ export default class EnchantmentField extends EmbeddedDataField {
  * @property {object} items
  * @property {string} items.max                   Maximum number of items that can have this enchantment.
  * @property {string} items.period                Frequency at which the enchantment be swapped.
+ * @property {boolean} prompt                     Should the player be prompted to apply an enchantment?
  * @property {object} restrictions
  * @property {boolean} restrictions.allowMagical  Allow enchantments to be applied to items that are already magical.
  * @property {string} restrictions.type           Item type to which this enchantment can be applied.
@@ -33,6 +34,9 @@ export class EnchantmentData extends foundry.abstract.DataModel {
       items: new SchemaField({
         max: new FormulaField({deterministic: true}),
         period: new StringField()
+      }),
+      prompt: new BooleanField({
+        initial: true, label: "DND5E.Enchantment.Prompt.Label", hint: "DND5E.Enchantment.Prompt.Hint"
       }),
       restrictions: new SchemaField({
         allowMagical: new BooleanField(),

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -423,6 +423,14 @@ export default class ActiveEffect5e extends ActiveEffect {
   _onCreate(data, options, userId) {
     super._onCreate(data, options, userId);
     if ( (userId === game.userId) && this.active && (this.parent instanceof Actor) ) this.createRiderConditions();
+    if ( game.users.activeGM?.isSelf && options.chatMessageOrigin ) {
+      const message = game.messages.get(options.chatMessageOrigin);
+      if ( message ) {
+        const enchantmentUuids = message.getFlag("dnd5e", "enchanted") ?? [];
+        enchantmentUuids.push(this.uuid);
+        message.setFlag("dnd5e", "enchanted", enchantmentUuids);
+      }
+    }
   }
 
   /* -------------------------------------------- */
@@ -476,6 +484,13 @@ export default class ActiveEffect5e extends ActiveEffect {
     super._onDelete(options, userId);
     if ( game.user === game.users.activeGM ) this.getDependents().forEach(e => e.delete());
     if ( this.isAppliedEnchantment ) EnchantmentData.untrackEnchantment(this.origin, this.uuid);
+    if ( game.users.activeGM?.isSelf && options.chatMessageOrigin ) {
+      const message = game.messages.get(options.chatMessageOrigin);
+      if ( message ) {
+        const enchantmentUuids = message.getFlag("dnd5e", "enchanted") ?? [];
+        message.setFlag("dnd5e", "enchanted", enchantmentUuids.filter(uuid => uuid !== this.uuid));
+      }
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -423,13 +423,9 @@ export default class ActiveEffect5e extends ActiveEffect {
   _onCreate(data, options, userId) {
     super._onCreate(data, options, userId);
     if ( (userId === game.userId) && this.active && (this.parent instanceof Actor) ) this.createRiderConditions();
-    if ( game.users.activeGM?.isSelf && options.chatMessageOrigin ) {
-      const message = game.messages.get(options.chatMessageOrigin);
-      if ( message ) {
-        const enchantmentUuids = message.getFlag("dnd5e", "enchanted") ?? [];
-        enchantmentUuids.push(this.uuid);
-        message.setFlag("dnd5e", "enchanted", enchantmentUuids);
-      }
+    if ( options.chatMessageOrigin ) {
+      document.body.querySelectorAll(`[data-message-id="${options.chatMessageOrigin}"] enchantment-application`)
+        .forEach(element => element.buildItemList());
     }
   }
 
@@ -484,12 +480,9 @@ export default class ActiveEffect5e extends ActiveEffect {
     super._onDelete(options, userId);
     if ( game.user === game.users.activeGM ) this.getDependents().forEach(e => e.delete());
     if ( this.isAppliedEnchantment ) EnchantmentData.untrackEnchantment(this.origin, this.uuid);
-    if ( game.users.activeGM?.isSelf && options.chatMessageOrigin ) {
-      const message = game.messages.get(options.chatMessageOrigin);
-      if ( message ) {
-        const enchantmentUuids = message.getFlag("dnd5e", "enchanted") ?? [];
-        message.setFlag("dnd5e", "enchanted", enchantmentUuids.filter(uuid => uuid !== this.uuid));
-      }
+    if ( options.chatMessageOrigin ) {
+      document.body.querySelectorAll(`[data-message-id="${options.chatMessageOrigin}"] enchantment-application`)
+        .forEach(element => element.buildItemList());
     }
   }
 

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -443,7 +443,8 @@ export default class ChatMessage5e extends ChatMessage {
     // Create the enchantment tray
     const enchantmentApplication = document.createElement("enchantment-application");
     enchantmentApplication.classList.add("dnd5e2");
-    html.querySelector(".message-content").appendChild(enchantmentApplication);
+    const afterElement = html.querySelector(".card-footer") ?? html.querySelector(".effects-tray");
+    afterElement.insertAdjacentElement("beforebegin", enchantmentApplication);
   }
 
   /* -------------------------------------------- */

--- a/templates/apps/ability-use.hbs
+++ b/templates/apps/ability-use.hbs
@@ -93,6 +93,24 @@
     </div>
     {{/if}}
 
+    {{#if (ne applyEnchantment null)}}
+    <div class="form-group">
+        <label class="checkbox">
+            <input type="checkbox" name="applyEnchantment" {{ checked applyEnchantment }}>
+            {{ localize "DND5E.Enchantment.Action.Apply" }}
+        </label>
+        {{#if enchantmentOptions.enchantments}}
+        <div class="form-fields">
+            <select name="enchantmentProfile" aria-label="{{ localize 'DND5E.Enchantment.Label' }}">
+                {{ selectOptions enchantmentOptions.enchantments selected=enchantmentProfile }}
+            </select>
+        </div>
+        {{else}}
+        <input type="hidden" name="enchantmentProfile" value="{{ enchantmentOptions.enchantment }}">
+        {{/if}}
+    </div>
+    {{/if}}
+
     {{#if (ne createSummons null)}}
     <div class="form-group">
         <label class="checkbox">

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -129,6 +129,10 @@
             <i class="fa-solid fa-gear" aria-hidden="true"></i>
             {{ localize "DND5E.Enchantment.Action.Configure" }}
         </a>
+        <label class="checkbox" data-tooltip="DND5E.Enchantment.Prompt.Hint">
+            <input type="checkbox" name="system.enchantment.prompt" {{ checked system.enchantment.prompt }}>
+            {{ localize "DND5E.Enchantment.Prompt.Label" }}
+        </label>
     </div>
 </div>
 


### PR DESCRIPTION
Introduces enchantment to the `AbilityUseDialog` using the `applyEnchantment` and `enchantmentProfile` options, with similar details to how summoning is handled.

<img width="414" alt="Enchantment Use Dialog" src="https://github.com/foundryvtt/dnd5e/assets/19979839/5f19e0aa-e158-4628-a6de-d610f62de592">

When enchantment is performed it adds a new "Enchant" tray to chat cards. This tray has a place to drop an item which is then enchanted when the apply button is pressed.

<img width="300" alt="Enchantment Tray - Empty" src="https://github.com/foundryvtt/dnd5e/assets/19979839/c93c207c-baef-495b-a32f-c3d25b7f0b57">
<img width="300" alt="Enchantment Tray - Full" src="https://github.com/foundryvtt/dnd5e/assets/19979839/1d1c8f60-babc-44b4-bcc6-317f7b42921d">

Enchantments are tracked with concentration, so if concentration on the enchanting spell ends then the enchantments will be removed.