### PR TITLE
[#3475] Moved getRollData method from character to creature

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -244,19 +244,6 @@ export default class CharacterData extends CreatureTemplate {
   /*  Helpers                                     */
   /* -------------------------------------------- */
 
-  /** @inheritdoc */
-  getRollData({ deterministic=false }={}) {
-    const data = super.getRollData({ deterministic });
-    data.classes = {};
-    for ( const [identifier, cls] of Object.entries(this.parent.classes) ) {
-      data.classes[identifier] = {...cls.system};
-      if ( cls.subclass ) data.classes[identifier].subclass = cls.subclass.system;
-    }
-    return data;
-  }
-
-  /* -------------------------------------------- */
-
   /**
    * Checks whether the item with the given relative UUID has been favorited
    * @param {string} favoriteId  The relative UUID of the item to check.

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -167,6 +167,21 @@ export default class CreatureTemplate extends CommonTemplate {
       };
     }
   }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  getRollData({ deterministic=false }={}) {
+    const data = super.getRollData({ deterministic });
+    data.classes = {};
+    for ( const [identifier, cls] of Object.entries(this.parent.classes) ) {
+      data.classes[identifier] = {...cls.system};
+      if ( cls.subclass ) data.classes[identifier].subclass = cls.subclass.system;
+    }
+    return data;
+  }
 }
 
 /* -------------------------------------------- */


### PR DESCRIPTION
Moved the getRollData method, which retrieved the class and subclass, from character to creature, which is inherited by both character and npc.
Closes #3475