### PR TITLE
[#3512] Allow enchantments to be limited by level

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -145,6 +145,7 @@
 "DND5E.ActiveEffectOverrideWarning": "This value is being modified by an Active Effect and cannot be edited. Disable the effect to edit it.",
 "DND5E.Add": "Add",
 "DND5E.AdditionalControls": "Additional Controls",
+"DND5E.AdditionalSettings": "Additional Settings",
 "DND5E.AddEmbeddedItemPromptHint": "Do you want to add these items to your character sheet?",
 "DND5E.AdvancementAbilityScoreImprovementTitle": "Ability Score Improvement",
 "DND5E.AdvancementAbilityScoreImprovementHint": "Allow the player to increase one or more ability scores or take an optional feat.",
@@ -709,6 +710,9 @@
   "FIELDS": {
     "enchantment": {
       "label": "Enchantment Configuration",
+      "classIdentifier": {
+        "hint": "Identifier used to determine whether the character level or a specific class level should be used for enchantment level limits."
+      },
       "items": {
         "max": {
           "label": "Item Limit",
@@ -734,6 +738,9 @@
     }
   },
   "Label": "Enchantment",
+  "Level": {
+    "Hint": "Range of levels required to use this enchantment."
+  },
   "Items": {
     "Label": "Enchanted Items",
     "Entry": "{item} on {actor}",
@@ -1134,6 +1141,11 @@
 "DND5E.LevelActionDecrease": "Level Down",
 "DND5E.LevelActionIncrease": "Level Up",
 "DND5E.LevelCount": "{ordinal} Level",
+"DND5E.LevelLimit": {
+  "Label": "Level Limit",
+  "Max": "Maximum Level",
+  "Min": "Minimum Level"
+},
 "DND5E.LevelNumber": "Level {level}",
 "DND5E.LevelScaling": "Level Scaling",
 "DND5E.LimitedUses": "Limited Uses",
@@ -1564,7 +1576,6 @@
     "Remove": "Remove Profile",
     "Summon": "Summon"
   },
-  "AdditionalSettings": "Additional Settings",
   "Bonuses": {
     "ArmorClass": {
       "Label": "Bonus Armor Class",
@@ -1614,9 +1625,6 @@
     "Hint": "Changes made to items on the summoned creature."
   },
   "Level": {
-    "Label": "Level Limit",
-    "Max": "Maximum Level",
-    "Min": "Minimum Level",
     "Hint": "Range of levels required to use this profile.",
     "IdentifierHint": "Identifier used to determine whether the character level or a specific class level should be used for profile level limits."
   },

--- a/module/applications/item/enchantment-config.mjs
+++ b/module/applications/item/enchantment-config.mjs
@@ -24,6 +24,14 @@ export default class EnchantmentConfig extends DocumentSheet {
   /*  Properties                                  */
   /* -------------------------------------------- */
 
+  /**
+   * Expanded states for each enchantment.
+   * @type {Map<string, boolean>}
+   */
+  expandedEnchantments = new Map();
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   get title() {
     return `${game.i18n.localize("DND5E.Enchantment.Configuration")}: ${this.document.name}`;
@@ -41,9 +49,13 @@ export default class EnchantmentConfig extends DocumentSheet {
       return obj;
     }, {});
     context.enchantment = this.document.system.enchantment;
-    context.enchantments = this.document.effects.filter(e =>
-      (e.getFlag("dnd5e", "type") === "enchantment") && !e.isAppliedEnchantment
-    );
+    context.enchantments = this.document.effects.reduce((arr, e) => {
+      if ( (e.getFlag("dnd5e", "type") === "enchantment") && !e.isAppliedEnchantment ) arr.push({
+        id: e.id, uuid: e.uuid, flags: e.flags, collapsed: this.expandedEnchantments.get(e._id) ? "" : "collapsed"
+      });
+      return arr;
+    }, []);
+    context.isSpell = this.document.type === "spell";
     context.source = this.document.toObject().system.enchantment;
     return context;
   }
@@ -63,13 +75,29 @@ export default class EnchantmentConfig extends DocumentSheet {
         enchantmentId: event.target.closest("[data-enchantment-id]")?.dataset.enchantmentId
       } }));
     }
+
+    for ( const element of html.querySelectorAll(".collapsible") ) {
+      element.addEventListener("click", event => {
+        if ( event.target.closest(".collapsible-content") ) return;
+        event.currentTarget.classList.toggle("collapsed");
+        this.expandedEnchantments.set(
+          event.target.closest("[data-enchantment-id]").dataset.enchantmentId,
+          !event.currentTarget.classList.contains("collapsed")
+        );
+      });
+    }
   }
 
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async _updateObject(event, { action, enchantmentId, ...formData }) {
-    await this.document.update({"system.enchantment": formData});
+  async _updateObject(event, formData) {
+    const { action, effects, enchantmentId, ...data } = foundry.utils.expandObject(formData);
+
+    await this.document.update({"system.enchantment": data});
+
+    const effectsChanges = Object.entries(effects ?? {}).map(([_id, changes]) => ({ _id, ...changes }));
+    if ( effectsChanges.length ) await this.document.updateEmbeddedDocuments("ActiveEffect", effectsChanges);
 
     switch ( action ) {
       case "add-enchantment":

--- a/module/applications/item/enchantment-config.mjs
+++ b/module/applications/item/enchantment-config.mjs
@@ -50,8 +50,9 @@ export default class EnchantmentConfig extends DocumentSheet {
     }, {});
     context.enchantment = this.document.system.enchantment;
     context.enchantments = this.document.effects.reduce((arr, e) => {
+      const { id, uuid, flags } = e;
       if ( (e.getFlag("dnd5e", "type") === "enchantment") && !e.isAppliedEnchantment ) arr.push({
-        id: e.id, uuid: e.uuid, flags: e.flags, collapsed: this.expandedEnchantments.get(e._id) ? "" : "collapsed"
+        id, uuid, flags, collapsed: this.expandedEnchantments.get(id) ? "" : "collapsed"
       });
       return arr;
     }, []);

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -4,6 +4,7 @@ import ClassData from "../data/item/class.mjs";
 import ContainerData from "../data/item/container.mjs";
 import EquipmentData from "../data/item/equipment.mjs";
 import SpellData from "../data/item/spell.mjs";
+import { EnchantmentData } from "../data/item/fields/enchantment-field.mjs";
 import PhysicalItemTemplate from "../data/item/templates/physical-item.mjs";
 import {d20Roll, damageRoll} from "../dice/dice.mjs";
 import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
@@ -1220,9 +1221,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     }
     if ( this.system.isEnchantment ) {
       config.applyEnchantment = enchantment?.prompt ?? true;
-      config.enchantmentProfile = this.effects.find(e =>
-        (e.getFlag("dnd5e", "type") === "enchantment") && !e.isAppliedEnchantment
-      )?.id;
+      config.enchantmentProfile = EnchantmentData.availableEnchantments(this)[0]?.id;
     }
     if ( this.system.hasSummoning && this.system.summons.canSummon && canvas.scene ) {
       config.createSummons = summons.prompt;

--- a/templates/apps/ability-use.hbs
+++ b/templates/apps/ability-use.hbs
@@ -99,14 +99,14 @@
             <input type="checkbox" name="applyEnchantment" {{ checked applyEnchantment }}>
             {{ localize "DND5E.Enchantment.Action.Apply" }}
         </label>
-        {{#if enchantmentOptions.enchantments}}
+        {{#if enchantmentOptions.profiles}}
         <div class="form-fields">
             <select name="enchantmentProfile" aria-label="{{ localize 'DND5E.Enchantment.Label' }}">
-                {{ selectOptions enchantmentOptions.enchantments selected=enchantmentProfile }}
+                {{ selectOptions enchantmentOptions.profiles selected=enchantmentProfile }}
             </select>
         </div>
         {{else}}
-        <input type="hidden" name="enchantmentProfile" value="{{ enchantmentOptions.enchantment }}">
+        <input type="hidden" name="enchantmentProfile" value="{{ enchantmentOptions.profile }}">
         {{/if}}
     </div>
     {{/if}}

--- a/templates/apps/enchantment-config.hbs
+++ b/templates/apps/enchantment-config.hbs
@@ -19,11 +19,43 @@
                     </button>
                 </div>
             </div>
+            <div class="additional-tray collapsible {{ collapsed }}">
+                <label class="roboto-upper">
+                    <i class="fa-solid fa-gears" inert></i>
+                    <span>{{ localize "DND5E.AdditionalSettings" }}</span>
+                    <i class="fas fa-caret-down" inert></i>
+                </label>
+                <div class="collapsible-content">
+                    <div class="wrapper">
+                        <div class="form-group">
+                            <label>{{ localize "DND5E.LevelLimit.Label" }}</label>
+                            <div class="form-fields">
+                                <input type="number" name="effects.{{ id }}.flags.dnd5e.enchantment.level.min"
+                                       min="1" step="1" placeholder="0" value="{{ flags.dnd5e.enchantment.level.min }}"
+                                       aria-label="{{ localize 'DND5E.LevelLimit.Min' }}">
+                                <span class="sep">&ndash;</span>
+                                <input type="number" name="effects.{{ id }}.flags.dnd5e.enchantment.level.max"
+                                       min="1" step="1" placeholder="∞" value="{{ flags.dnd5e.enchantment.level.max }}"
+                                       aria-label="{{ localize 'DND5E.LevelLimit.Max' }}">
+                            </div>
+                            <p class="hint">{{ localize "DND5E.Enchantment.Level.Hint" }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </li>
         {{else}}
         <li class="empty">{{ localize "DND5E.Enchantment.Category.Empty" }}</li>
         {{/each}}
     </ul>
+
+    {{#unless @root.isSpell}}
+    <div class="form-group">
+        <label>{{ localize "DND5E.ClassIdentifier" }}</label>
+        <input type="text" name="classIdentifier" value="{{ enchantment.classIdentifier }}">
+        <p class="hint">{{ localize "DND5E.Enchantment.FIELDS.enchantment.classIdentifier.hint" }}</p>
+    </div>
+    {{/unless}}
 
     <h3 class="form-header">{{ localize "DND5E.Enchantment.FIELDS.enchantment.restrictions.label" }}</h3>
     <div class="form-group">

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -35,19 +35,19 @@
             <div class="additional-tray collapsible {{ collapsed }}">
                 <label class="roboto-upper">
                     <i class="fa-solid fa-gears" inert></i>
-                    <span>{{ localize "DND5E.Summoning.AdditionalSettings" }}</span>
+                    <span>{{ localize "DND5E.AdditionalSettings" }}</span>
                     <i class="fas fa-caret-down" inert></i>
                 </label>
                 <div class="collapsible-content">
                     <div class="wrapper">
                         <div class="form-group">
-                            <label>{{ localize "DND5E.Summoning.Level.Label" }}</label>
+                            <label>{{ localize "DND5E.LevelLimit.Label" }}</label>
                             <div class="form-fields">
                                 <input type="number" name="profiles.{{ id }}.level.min" min="1" step="1" placeholder="0"
-                                       value="{{ level.min }}" aria-label="{{ localize 'DND5E.Summoning.Level.Min' }}">
+                                       value="{{ level.min }}" aria-label="{{ localize 'DND5E.LevelLimit.Min' }}">
                                 <span class="sep">&ndash;</span>
                                 <input type="number" name="profiles.{{ id }}.level.max" min="1" step="1" placeholder="∞"
-                                       value="{{ level.max }}" aria-label="{{ localize 'DND5E.Summoning.Level.Max' }}">
+                                       value="{{ level.max }}" aria-label="{{ localize 'DND5E.LevelLimit.Max' }}">
                             </div>
                             <p class="hint">{{ localize "DND5E.Summoning.Level.Hint" }}</p>
                         </div>


### PR DESCRIPTION
Adds `min` and `max` level limits as flags to the enchantment effects that are used to limit when those enchantments appear. This is based off spell level if it is a spell, or either character or class level for other items depending on whether a class identifier is provided.

<img width="514" alt="Enchantment Level Limits" src="https://github.com/foundryvtt/dnd5e/assets/19979839/f6301673-3a58-44b4-a603-dad7040f5cfc">

If the "Enchantment Prompt" option is not checked, then the system will take level restrictions into account when selecting which enchantment to provide. This should make it easy to configure a feature like "Enhanced Defense" artificer infusion which swaps enchantments depending on artifier level, without requiring the player to view the ability use dialog everytime they want to use the infusion.

Closes #3512 