### PR TITLE
[#3516] Fix SquareGrid & clamped deprecation warnings

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -49,9 +49,9 @@ Hooks.once("init", function() {
   console.log(`D&D 5e | Initializing the D&D Fifth Game System - Version ${dnd5e.version}\n${DND5E.ASCII}`);
 
   // TODO: Remove when v11 support is dropped.
-  CONFIG.compatibility.excludePatterns.push(/Math\.clamped/);
   CONFIG.compatibility.excludePatterns.push(/\{\{filePicker}}/);
   CONFIG.compatibility.excludePatterns.push(/foundry\.dice\.terms/);
+  if ( game.release.generation < 12 ) Math.clamp = Math.clamped;
 
   // Record Configuration Values
   CONFIG.DND5E = DND5E;
@@ -424,8 +424,10 @@ Hooks.once("ready", function() {
 /* -------------------------------------------- */
 
 Hooks.on("canvasInit", gameCanvas => {
-  gameCanvas.grid.diagonalRule = game.settings.get("dnd5e", "diagonalMovement");
-  SquareGrid.prototype.measureDistances = canvas.measureDistances;
+  if ( game.release.generation < 12 ) {
+    gameCanvas.grid.diagonalRule = game.settings.get("dnd5e", "diagonalMovement");
+    SquareGrid.prototype.measureDistances = canvas.measureDistances;
+  }
   CONFIG.Token.ringClass.pushToLoad(gameCanvas.loadTexturesOptions.additionalSources);
 });
 

--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -159,7 +159,7 @@ export default class GroupActorSheet extends ActorSheetMixin(ActorSheet) {
       const hp = member.system.attributes.hp;
       m.hp.current = hp.value + (hp.temp || 0);
       m.hp.max = Math.max(0, hp.effectiveMax);
-      m.hp.pct = Math.clamped((m.hp.current / m.hp.max) * 100, 0, 100).toFixed(2);
+      m.hp.pct = Math.clamp((m.hp.current / m.hp.max) * 100, 0, 100).toFixed(2);
       m.hp.color = dnd5e.documents.Actor5e.getHPColor(m.hp.current, m.hp.max).css;
       stats.currentHP += (m.hp.current * multiplier);
       stats.maxHP += (m.hp.max * multiplier);

--- a/module/applications/actor/hit-dice-config.mjs
+++ b/module/applications/actor/hit-dice-config.mjs
@@ -53,7 +53,7 @@ export default class ActorHitDiceConfig extends BaseConfigSheet {
       const current = button.parentElement.querySelector(".current");
       const max = button.parentElement.querySelector(".max");
       const direction = button.classList.contains("increment") ? 1 : -1;
-      current.value = Math.clamped(parseInt(current.value) + direction, 0, parseInt(max.value));
+      current.value = Math.clamp(parseInt(current.value) + direction, 0, parseInt(max.value));
     });
 
     html.find("button.roll-hd").click(this._onRollHitDie.bind(this));

--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -55,7 +55,7 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
 
     // Compute overall encumbrance
     const max = actorData.system.attributes.capacity.cargo;
-    const pct = Math.clamped((totalWeight * 100) / max, 0, 100);
+    const pct = Math.clamp((totalWeight * 100) / max, 0, 100);
     return {value: totalWeight.toNearest(0.1), max, pct};
   }
 

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -113,7 +113,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
     if ( isNaN(input.valueAsNumber) ) this.assignments[key] = 0;
     else {
       this.assignments[key] = Math.min(
-        Math.clamped(input.valueAsNumber, Number(input.min), Number(input.max)) - Number(input.dataset.initial),
+        Math.clamp(input.valueAsNumber, Number(input.min), Number(input.max)) - Number(input.dataset.initial),
         this.advancement.configuration.cap ?? Infinity
       );
     }

--- a/module/applications/award.mjs
+++ b/module/applications/award.mjs
@@ -178,7 +178,7 @@ export default class Award extends DialogMixin(FormApplication) {
 
       for ( let [key, amount] of Object.entries(amounts) ) {
         if ( !amount ) continue;
-        amount = Math.clamped(
+        amount = Math.clamp(
           // Divide amount between remaining destinations
           Math.floor(amount / remainingDestinations),
           // Ensure negative amounts aren't more than is contained in destination

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -292,7 +292,7 @@ export default class InventoryElement extends HTMLElement {
     const item = await this.getItem(itemId);
     const min = event.target.min !== "" ? Number(event.target.min) : -Infinity;
     const max = event.target.max !== "" ? Number(event.target.max) : Infinity;
-    const value = Math.clamped(event.target.valueAsNumber, min, max);
+    const value = Math.clamp(event.target.valueAsNumber, min, max);
     if ( !item || Number.isNaN(value) ) return;
 
     event.target.value = value;
@@ -331,7 +331,7 @@ export default class InventoryElement extends HTMLElement {
     let value = Number(input.value);
     if ( isNaN(value) ) return;
     value += action === "increase" ? 1 : -1;
-    input.value = Math.clamped(value, min, max);
+    input.value = Math.clamp(value, min, max);
     input.dispatchEvent(new Event("change"));
   }
 

--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -146,7 +146,7 @@ export default class AbilityUseDialog extends Dialog {
       const label = CONFIG.DND5E.spellLevels[i];
       const l = actor.system.spells[`spell${i}`] || {max: 0, override: null};
       let max = parseInt(l.override || l.max || 0);
-      let slots = Math.clamped(parseInt(l.value || 0), 0, max);
+      let slots = Math.clamp(parseInt(l.value || 0), 0, max);
       if ( max > 0 ) lmax = i;
       arr.push({
         key: `spell${i}`,

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -78,8 +78,8 @@ export default class Token5e extends Token {
     let displayMax = max + (tempmax > 0 ? tempmax : 0);
 
     // Allocate percentages of the total
-    const tempPct = Math.clamped(temp, 0, displayMax) / displayMax;
-    const colorPct = Math.clamped(value, 0, effectiveMax) / displayMax;
+    const tempPct = Math.clamp(temp, 0, displayMax) / displayMax;
+    const colorPct = Math.clamp(value, 0, effectiveMax) / displayMax;
     const hpColor = dnd5e.documents.Actor5e.getHPColor(value, effectiveMax);
 
     // Determine colors to use
@@ -90,7 +90,7 @@ export default class Token5e extends Token {
     const w = this.w;
     let h = Math.max((canvas.dimensions.size / 12), 8);
     if ( this.document.height >= 2 ) h *= 1.6;
-    const bs = Math.clamped(h / 8, 1, 2);
+    const bs = Math.clamp(h / 8, 1, 2);
     const bs1 = bs+1;
 
     // Overall bar container

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -191,7 +191,7 @@ export default class CharacterData extends CreatureTemplate {
     else {
       const required = xp.max - xp.min;
       const pct = Math.round((xp.value - xp.min) * 100 / required);
-      xp.pct = Math.clamped(pct, 0, 100);
+      xp.pct = Math.clamp(pct, 0, 100);
     }
 
     AttributesFields.prepareBaseArmorClass.call(this);

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -162,7 +162,7 @@ export default class AttributesFields {
     hp.effectiveMax = hp.max + (hp.tempmax ?? 0);
     hp.value = Math.min(hp.value, hp.effectiveMax);
     hp.damage = hp.effectiveMax - hp.value;
-    hp.pct = Math.clamped(hp.effectiveMax ? (hp.value / hp.effectiveMax) * 100 : 0, 0, 100);
+    hp.pct = Math.clamp(hp.effectiveMax ? (hp.value / hp.effectiveMax) * 100 : 0, 0, 100);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -232,7 +232,7 @@ export default class ContainerData extends ItemDataModel.mixin(
       context.value = await this.contentsCount;
       context.units = game.i18n.localize("DND5E.ItemContainerCapacityItems");
     }
-    context.pct = Math.clamped(context.max ? (context.value / context.max) * 100 : 0, 0, 100);
+    context.pct = Math.clamp(context.max ? (context.value / context.max) * 100 : 0, 0, 100);
     return context;
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -531,7 +531,7 @@ export default class ActiveEffect5e extends ActiveEffect {
     if ( event.button === 0 ) level++;
     else level--;
     const max = CONFIG.DND5E.conditionTypes.exhaustion.levels;
-    actor.update({ "system.attributes.exhaustion": Math.clamped(level, 0, max) });
+    actor.update({ "system.attributes.exhaustion": Math.clamp(level, 0, max) });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -538,10 +538,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     };
     encumbrance.max = encumbrance.thresholds.maximum;
     encumbrance.stops = {
-      encumbered: Math.clamped((encumbrance.thresholds.encumbered * 100) / encumbrance.max, 0, 100),
-      heavilyEncumbered: Math.clamped((encumbrance.thresholds.heavilyEncumbered * 100) / encumbrance.max, 0, 100)
+      encumbered: Math.clamp((encumbrance.thresholds.encumbered * 100) / encumbrance.max, 0, 100),
+      heavilyEncumbered: Math.clamp((encumbrance.thresholds.heavilyEncumbered * 100) / encumbrance.max, 0, 100)
     };
-    encumbrance.pct = Math.clamped((encumbrance.value * 100) / encumbrance.max, 0, 100);
+    encumbrance.pct = Math.clamp((encumbrance.value * 100) / encumbrance.max, 0, 100);
     encumbrance.encumbered = encumbrance.value > encumbrance.heavilyEncumbered;
   }
 
@@ -730,7 +730,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @param {object} progression   Spellcasting progression data.
    */
   static prepareLeveledSlots(spells, actor, progression) {
-    const levels = Math.clamped(progression.slot, 0, CONFIG.DND5E.maxLevel);
+    const levels = Math.clamp(progression.slot, 0, CONFIG.DND5E.maxLevel);
     const slots = CONFIG.DND5E.SPELL_SLOT_TABLE[Math.min(levels, CONFIG.DND5E.SPELL_SLOT_TABLE.length) - 1] ?? [];
     for ( const level of Array.fromRange(Object.keys(CONFIG.DND5E.spellLevels).length - 1, 1) ) {
       const slot = spells[`spell${level}`] ??= { value: 0 };
@@ -756,7 +756,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     // - x.value: Currently available slots
     // - x.override: Override number of available spell slots
 
-    let keyLevel = Math.clamped(progression[key], 0, CONFIG.DND5E.maxLevel);
+    let keyLevel = Math.clamp(progression[key], 0, CONFIG.DND5E.maxLevel);
     spells[key] ??= {};
     const override = Number.isNumeric(spells[key].override) ? parseInt(spells[key].override) : null;
 
@@ -947,7 +947,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     amount = amount > 0 ? Math.floor(amount) : Math.ceil(amount);
 
     const deltaTemp = amount > 0 ? Math.min(hp.temp, amount) : 0;
-    const deltaHP = Math.clamped(amount - deltaTemp, -hp.damage, hp.value);
+    const deltaHP = Math.clamp(amount - deltaTemp, -hp.damage, hp.value);
     const updates = {
       "system.attributes.hp.temp": hp.temp - deltaTemp,
       "system.attributes.hp.value": hp.value - deltaHP
@@ -1123,7 +1123,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Color}               The color used to represent the HP percentage
    */
   static getHPColor(current, max) {
-    const pct = Math.clamped(current, 0, max) / max;
+    const pct = Math.clamp(current, 0, max) / max;
     return Color.fromRGB([(1-(pct/2)), pct, 0]);
   }
 
@@ -1726,13 +1726,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       }
 
       // Increment successes
-      else details.updates = {"system.attributes.death.success": Math.clamped(successes, 0, 3)};
+      else details.updates = {"system.attributes.death.success": Math.clamp(successes, 0, 3)};
     }
 
     // Save failure
     else {
       let failures = (death.failure || 0) + (roll.isFumble ? 2 : 1);
-      details.updates = {"system.attributes.death.failure": Math.clamped(failures, 0, 3)};
+      details.updates = {"system.attributes.death.failure": Math.clamp(failures, 0, 3)};
       if ( failures >= 3 ) {  // 3 Failures = death
         details.chatString = "DND5E.DeathSaveFailure";
       }
@@ -2611,7 +2611,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
           }));
         }
 
-        const newValue = Math.clamped(uses.value + total, 0, uses.max);
+        const newValue = Math.clamp(uses.value + total, 0, uses.max);
         if ( newValue !== uses.value ) {
           const diff = newValue - uses.value;
           const isMax = newValue === uses.max;
@@ -3358,7 +3358,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const tokens = this.isToken ? [this.token] : this.getActiveTokens(true, true);
     if ( !tokens.length ) return;
 
-    const pct = Math.clamped(Math.abs(value) / this.system.attributes.hp.max, 0, 1);
+    const pct = Math.clamp(Math.abs(value) / this.system.attributes.hp.max, 0, 1);
     const fill = CONFIG.DND5E.tokenHPColors[key];
 
     for ( const token of tokens ) {

--- a/module/documents/actor/hit-dice.mjs
+++ b/module/documents/actor/hit-dice.mjs
@@ -106,7 +106,7 @@ export default class HitDice {
    * @type {number}
    */
   get pct() {
-    return Math.clamped(this.max ? (this.value / this.max) * 100 : 0, 0, 100);
+    return Math.clamp(this.max ? (this.value / this.max) * 100 : 0, 0, 100);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Moves the monkey patching of `measureDistances` on canvas behind a V12 check because this isn't needed anymore.

Replaces all uses of `Math.clamped` with `Math.clamp` and registers an alias in V11 to keep everything working. This avoids a bunch of deprecation warnings that weren't being properly suppressed and gets us ahead on the work when we go V12-only.

Closes #3516