### PR TITLE
[#3426] Add simple string interpolation to active effects

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -126,9 +126,9 @@ export default class ActiveEffect5e extends ActiveEffect {
       return changes;
     }
 
-    else if ( (targetType === "string") && (change.mode === modes.OVERRIDE) && change.value.includes("{{}}") ) {
+    else if ( (targetType === "string") && (change.mode === modes.OVERRIDE) && change.value.includes("{}") ) {
       change = foundry.utils.deepClone(change);
-      change.value = change.value.replace("{{}}", current ?? "");
+      change.value = change.value.replace("{}", current ?? "");
     }
 
     let delta;


### PR DESCRIPTION
Adds the option when apply and OVERRIDE change to a string value to include the original string value by using `{{}}`. So an effect with the change value of `Enhanced {{}}, +1` might be interpolated as `Enhanced Breastplate, +1` when applied.

Closes #3426