### PR TITLE
[#3526] Apply dnd5e2 journal styles in journal editor

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -502,13 +502,15 @@ Hooks.on("renderChatLog", (app, html, data) => {
 });
 Hooks.on("renderChatPopout", (app, html, data) => documents.Item5e.chatListeners(html));
 
-Hooks.on("chatMessage", (app, message, data) => dnd5e.applications.Award.chatMessage(message));
+Hooks.on("chatMessage", (app, message, data) => applications.Award.chatMessage(message));
 
 Hooks.on("renderActorDirectory", (app, html, data) => documents.Actor5e.onRenderActorDirectory(html));
 Hooks.on("getActorDirectoryEntryContext", documents.Actor5e.addDirectoryContextOptions);
 
 Hooks.on("getCompendiumEntryContext", documents.Item5e.addCompendiumContextOptions);
 Hooks.on("getItemDirectoryEntryContext", documents.Item5e.addDirectoryContextOptions);
+
+Hooks.on("renderJournalPageSheet", applications.journal.JournalSheet5e.onRenderJournalPageSheet);
 
 Hooks.on("applyTokenStatusEffect", canvas.Token5e.onApplyTokenStatusEffect);
 Hooks.on("targetToken", canvas.Token5e.onTargetToken);

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -2,13 +2,13 @@
 /*  Journal v2 Styles                 */
 /* ---------------------------------- */
 
-.sheet.journal-entry.dnd5e2-journal {
+.sheet.dnd5e2-journal {
   .window-resizable-handle {
     bottom: 1px;
     right: 1px;
   }
 
-  .scrollable {
+  &.journal-entry .scrollable, &.journal-entry-page.editor-content {
     scrollbar-width: thin;
     scrollbar-color: var(--dnd5e-color-gold) transparent;
 
@@ -24,7 +24,7 @@
   }
 
   /* Background Texture & Headings */
-  .journal-entry-content {
+  &.journal-entry .journal-entry-content, &.journal-entry-page .window-content {
     background: url("ui/texture1.webp") no-repeat top center / auto 770px,
       var(--dnd5e-color-parchment) url("ui/texture2.webp") no-repeat bottom center / auto 704px;
 
@@ -46,7 +46,7 @@
   }
 
   /* Page Title */
-  .journal-header .title {
+  &.journal-entry .journal-header .title {
     border: 1px transparent;
     transition: all 250ms ease;
     font-size: var(--font-size-46);
@@ -66,7 +66,7 @@
   }
 
   /* Edit Button */
-  .edit-container .editor-edit {
+  &.journal-entry .edit-container .editor-edit {
     background: transparent;
     border: none;
     box-shadow: none;

--- a/module/applications/journal/journal-sheet.mjs
+++ b/module/applications/journal/journal-sheet.mjs
@@ -23,7 +23,7 @@ export default class JournalSheet5e extends JournalSheet {
 
   /* -------------------------------------------- */
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   _getPageData() {
     const pageData = super._getPageData();
 
@@ -41,5 +41,22 @@ export default class JournalSheet5e extends JournalSheet {
     }
 
     return pageData;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add class to journal pages also.
+   * @param {JournalPageSheet} page  The journal page application.
+   * @param {jQuery} jQuery          The rendered Application HTML.
+   * @param {object} context         Rendering context provided.
+   */
+  static onRenderJournalPageSheet(page, jQuery, context) {
+    if ( page.object.parent.sheet instanceof JournalSheet5e ) {
+      let element;
+      if ( context.editable ) element = jQuery[0];
+      else element = jQuery[0].parentElement;
+      element?.classList.add("dnd5e2-journal");
+    }
   }
 }


### PR DESCRIPTION
Updates the journal styles to appear within the journal editor.

<img width="887" alt="Screenshot 2024-05-02 at 15 17 50" src="https://github.com/foundryvtt/dnd5e/assets/19979839/705f0dd8-b2fa-43d8-a088-dc3ffeaa99e2">

Because the new journal styles are based on a class added by the new `JournalSheet5e` and not by the pages themselves, it was necessary to add a rendering hook that detected if the journal the page belongs to uses the new system sheet and then adds the necessary class to the editor.

Currently the styles are scoped to apply to all journal page editors, rather than just text pages where they are really needed. If this is undesired, we can add an additional `.text` class to the selectors so they only apply when appropriate.

Closes #3526