### PR TITLE
[#3511] Add additional effects that ride along with enchantments

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -751,8 +751,8 @@
     "Hint": "Disable the enchantment prompt when item is used. First available enchantment will always be applied."
   },
   "Riders": {
-    "Label": "Ride Along Effects",
-    "Hint": "These additional effects will be added when this enchantment is added, and removed when it is removed."
+    "Label": "Additional Effects",
+    "Hint": "These additional effects will be added to the enchanted item when this enchantment is added, and removed when the enchantment is removed."
   },
   "Warning": {
     "ConcentrationEnded": "Cannot apply this enchantment because concentration has ended.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -750,7 +750,7 @@
     "Label": "Enchant Prompt",
     "Hint": "Disable the enchantment prompt when item is used. First available enchantment will always be applied."
   },
-  "RideAlong": {
+  "Riders": {
     "Label": "Ride Along Effects",
     "Hint": "These additional effects will be added when this enchantment is added, and removed when it is removed."
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -750,6 +750,10 @@
     "Label": "Enchant Prompt",
     "Hint": "Disable the enchantment prompt when item is used. First available enchantment will always be applied."
   },
+  "RideAlong": {
+    "Label": "Ride Along Effects",
+    "Hint": "These additional effects will be added when this enchantment is added, and removed when it is removed."
+  },
   "Warning": {
     "ConcentrationEnded": "Cannot apply this enchantment because concentration has ended.",
     "NoMagicalItems": "Items that are already magical cannot be enchanted.",

--- a/module/applications/item/enchantment-config.mjs
+++ b/module/applications/item/enchantment-config.mjs
@@ -118,7 +118,7 @@ export default class EnchantmentConfig extends DocumentSheet {
         foundry.utils.setProperty(updates, "flags.dnd5e.enchantment.riders", []);
       }
       // End bug fix
-      riderIds.add(...foundry.utils.getProperty(updates, "flags.dnd5e.enchantment.riders", []));
+      riderIds.add(...(foundry.utils.getProperty(updates, "flags.dnd5e.enchantment.riders") ?? []));
       return updates;
     });
     for ( const effect of this.document.effects ) {

--- a/module/applications/item/enchantment-config.mjs
+++ b/module/applications/item/enchantment-config.mjs
@@ -64,8 +64,8 @@ export default class EnchantmentConfig extends DocumentSheet {
       uuid: effect.uuid,
       flags: effect.flags,
       collapsed: this.expandedEnchantments.get(effect.id) ? "" : "collapsed",
-      rideAlong: effects.map(({ id, name }) => ({
-        id, name, selected: effect.flags.dnd5e?.enchantment?.rideAlong?.includes(id) ? "selected" : ""
+      riders: effects.map(({ id, name }) => ({
+        id, name, selected: effect.flags.dnd5e?.enchantment?.riders?.includes(id) ? "selected" : ""
       }))
     }));
 
@@ -110,21 +110,21 @@ export default class EnchantmentConfig extends DocumentSheet {
 
     await this.document.update({"system.enchantment": data});
 
-    const rideAlongIds = new Set();
+    const riderIds = new Set();
     const effectsChanges = Object.entries(effects ?? {}).map(([_id, changes]) => {
       const updates = { _id, ...changes };
       // Fix bug with <multi-select> in V11
-      if ( !foundry.utils.hasProperty(updates, "flags.dnd5e.enchantment.rideAlong") ) {
-        foundry.utils.setProperty(updates, "flags.dnd5e.enchantment.rideAlong", []);
+      if ( !foundry.utils.hasProperty(updates, "flags.dnd5e.enchantment.riders") ) {
+        foundry.utils.setProperty(updates, "flags.dnd5e.enchantment.riders", []);
       }
       // End bug fix
-      rideAlongIds.add(...foundry.utils.getProperty(updates, "flags.dnd5e.enchantment.rideAlong", []));
+      riderIds.add(...foundry.utils.getProperty(updates, "flags.dnd5e.enchantment.riders", []));
       return updates;
     });
     for ( const effect of this.document.effects ) {
       if ( effect.getFlag("dnd5e", "type") === "enchantment" ) continue;
-      if ( rideAlongIds.has(effect.id) ) effectsChanges.push({ _id: effect.id, "flags.dnd5e.rideAlong": true });
-      else effectsChanges.push({ _id: effect.id, "flags.dnd5e.-=rideAlong": null });
+      if ( riderIds.has(effect.id) ) effectsChanges.push({ _id: effect.id, "flags.dnd5e.rider": true });
+      else effectsChanges.push({ _id: effect.id, "flags.dnd5e.-=rider": null });
     }
     if ( effectsChanges.length ) await this.document.updateEmbeddedDocuments("ActiveEffect", effectsChanges);
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -327,7 +327,7 @@ export default class ActiveEffect5e extends ActiveEffect {
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    if ( this.getFlag("dnd5e", "type") === "enchantment" || this.getFlag("dnd5e", "rider") ) this.transfer = false;
+    if ( (this.getFlag("dnd5e", "type") === "enchantment") || this.getFlag("dnd5e", "rider") ) this.transfer = false;
     if ( this.id === this.constructor.ID.EXHAUSTION ) this._prepareExhaustionLevel();
     if ( this.isAppliedEnchantment ) EnchantmentData.trackEnchantment(this.origin, this.uuid);
   }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1498,9 +1498,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       config: CONFIG.DND5E,
       tokenId: token?.uuid || null,
       item: this,
-      effects: this.effects.filter(e =>
-        (e.getFlag("dnd5e", "type") !== "enchantment") && !e.getFlag("dnd5e", "rideAlong")
-      ),
+      effects: this.effects.filter(e => (e.getFlag("dnd5e", "type") !== "enchantment") && !e.getFlag("dnd5e", "rider")),
       data: await this.system.getCardData(),
       labels: this.labels,
       hasAttack: this.hasAttack,

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1498,7 +1498,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       config: CONFIG.DND5E,
       tokenId: token?.uuid || null,
       item: this,
-      effects: this.effects.filter(e => e.getFlag("dnd5e", "type") !== "enchantment"),
+      effects: this.effects.filter(e =>
+        (e.getFlag("dnd5e", "type") !== "enchantment") && !e.getFlag("dnd5e", "rideAlong")
+      ),
       data: await this.system.getCardData(),
       labels: this.labels,
       hasAttack: this.hasAttack,

--- a/templates/apps/enchantment-config.hbs
+++ b/templates/apps/enchantment-config.hbs
@@ -41,13 +41,13 @@
                             <p class="hint">{{ localize "DND5E.Enchantment.Level.Hint" }}</p>
                         </div>
                         <div class="form-group">
-                            <label>{{ localize "DND5E.Enchantment.RideAlong.Label" }}</label>
-                            <multi-select name="effects.{{ id }}.flags.dnd5e.enchantment.rideAlong">
-                                {{#each rideAlong}}
+                            <label>{{ localize "DND5E.Enchantment.Riders.Label" }}</label>
+                            <multi-select name="effects.{{ id }}.flags.dnd5e.enchantment.riders">
+                                {{#each riders}}
                                 <option value="{{ id }}" {{ selected }}>{{ name }}</option>
                                 {{/each}}
                             </multi-select>
-                            <p class="hint">{{ localize "DND5E.Enchantment.RideAlong.Hint" }}</p>
+                            <p class="hint">{{ localize "DND5E.Enchantment.Riders.Hint" }}</p>
                         </div>
                     </div>
                 </div>

--- a/templates/apps/enchantment-config.hbs
+++ b/templates/apps/enchantment-config.hbs
@@ -40,6 +40,15 @@
                             </div>
                             <p class="hint">{{ localize "DND5E.Enchantment.Level.Hint" }}</p>
                         </div>
+                        <div class="form-group">
+                            <label>{{ localize "DND5E.Enchantment.RideAlong.Label" }}</label>
+                            <multi-select name="effects.{{ id }}.flags.dnd5e.enchantment.rideAlong">
+                                {{#each rideAlong}}
+                                <option value="{{ id }}" {{ selected }}>{{ name }}</option>
+                                {{/each}}
+                            </multi-select>
+                            <p class="hint">{{ localize "DND5E.Enchantment.RideAlong.Hint" }}</p>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Enchantments can now define one or more effects that will be added whenever the enchantment is added and removed when the enchantment is removed. These are configured in the enchantment config.

<img width="517" alt="Enchantment Ride Along Effects" src="https://github.com/foundryvtt/dnd5e/assets/19979839/4c809757-8d9a-49f8-9ddc-b86abcf21765">

In order to prevent any effects used as ride along effects from being transfered to the actor when not necessary, they get the `rideAlong` flag which is removed when applied. This prevents these effects from being transfered to the actor or being offered in the chat card. This separate flag allows for transfer and non-transfer ride along effects.

Closes #3511 