### PR TITLE
[#3380] Added .content-link to dark/character.less

### DIFF
--- a/less/v2/dark/character.less
+++ b/less/v2/dark/character.less
@@ -56,4 +56,9 @@
     .label { font-weight: bold; }
     .mod { color: var(--dnd5e-color-blue-white); }
   }
+
+  .content-link {
+    background: var(--dnd5e-color-dark-gray);
+    border-color: var(--dnd5e-border-dark)
+  }
 }


### PR DESCRIPTION
Added .content-link to dark/character.less
Sets the background to dnd5e-color-dark-gray and the boarder to dnd5e-border-dark predefined values. 
Closes #3380

![Content-links](https://github.com/foundryvtt/dnd5e/assets/16993142/4d7bfaf3-e7f0-446e-bf49-f862475ad045)
