### PR TITLE
[#3534] Add summoner modifier into summoned flags

### DIFF
--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -302,6 +302,7 @@ export class SummonsData extends foundry.abstract.DataModel {
     // Add flags
     actorUpdates["flags.dnd5e.summon"] = {
       level: this.relevantLevel,
+      mod: rollData.mod,
       origin: this.item.uuid,
       profile: profile._id
     };


### PR DESCRIPTION
Simply adds the `@mod` value from the summoning item to be used as `@flags.dnd5e.summon.mod` on the summoned creature.

Closes #3534