### PR TITLE
[#3519] Fix enchantment links not working in compendiums

### DIFF
--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -571,10 +571,11 @@
   }
 
   .separated-list {
-    .content-link, .drop-area {
+    .content-link, .drop-area, .name {
       flex: 0 0 175px;
       display: flex;
       align-items: center;
+      align-content: center;
     }
     .drop-area {
       border: 1px dashed black;

--- a/module/applications/item/enchantment-config.mjs
+++ b/module/applications/item/enchantment-config.mjs
@@ -69,6 +69,7 @@ export default class EnchantmentConfig extends DocumentSheet {
   async _updateObject(event, { action, enchantmentId, ...formData }) {
     await this.document.update({"system.enchantment": formData});
 
+    const enchantment = this.document.effects.get(enchantmentId);
     switch ( action ) {
       case "add-enchantment":
         const effect = await ActiveEffect.implementation.create({
@@ -79,8 +80,10 @@ export default class EnchantmentConfig extends DocumentSheet {
         effect.sheet.render(true);
         break;
       case "delete-enchantment":
-        const enchantment = this.document.effects.get(enchantmentId);
         enchantment?.deleteDialog();
+        break;
+      case "edit-enchantment":
+        enchantment?.sheet.render(true);
         break;
     }
   }

--- a/templates/apps/enchantment-config.hbs
+++ b/templates/apps/enchantment-config.hbs
@@ -10,8 +10,13 @@
         {{#each enchantments}}
         <li class="enchantment" data-enchantment-id="{{ id }}">
             <div class="details flexrow">
-                {{{ dnd5e-linkForUuid uuid }}}
+                <span class="name">{{ name }}</span>
                 <div class="list-controls flexrow">
+                    <button type="button" class="unbutton" data-action="edit-enchantment"
+                            data-tooltip="DND5E.Enchantment.Action.Edit"
+                            aria-label="{{ localize 'DND5E.Enchantment.Action.Edit' }}">
+                        <i class="fa-solid fa-pen-to-square fa-fw" inert></i>
+                    </button>
                     <button type="button" class="unbutton" data-action="delete-enchantment"
                             data-tooltip="DND5E.Enchantment.Action.Delete"
                             aria-label="{{ localize 'DND5E.Enchantment.Action.Delete' }}">


### PR DESCRIPTION
Adjust how enchantments are listed in the enchantment configuration app. Now, the name is listed as plain text and an edit button on the right side allows for opening the active effect sheet.

<img width="513" alt="Screenshot 2024-05-06 at 11 02 43" src="https://github.com/foundryvtt/dnd5e/assets/19979839/6a9c416b-7497-4954-a50d-3f9c9ed24b1b">

Closes #3519