### PR TITLE
[#2094, #3537] Convert target value into formula, move prep logic

### DIFF
--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -155,16 +155,6 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
   }
 
   /* -------------------------------------------- */
-  /*  Data Validation                             */
-  /* -------------------------------------------- */
-
-  /** @inheritdoc */
-  validate(options={}) {
-    if ( this.constructor._enableV10Validation === false ) return true;
-    return super.validate(options);
-  }
-
-  /* -------------------------------------------- */
   /*  Socket Event Handlers                       */
   /* -------------------------------------------- */
 
@@ -191,6 +181,14 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
 
   /* -------------------------------------------- */
   /*  Data Validation                             */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  validate(options={}) {
+    if ( this.constructor._enableV10Validation === false ) return true;
+    return super.validate(options);
+  }
+
   /* -------------------------------------------- */
 
   /** @inheritdoc */
@@ -516,8 +514,7 @@ export class ItemDataModel extends SystemDataModel {
    * @returns {object}
    */
   getRollData({ deterministic=false }={}) {
-    if ( !this.parent.actor ) return null;
-    const actorRollData = this.parent.actor.getRollData({ deterministic });
+    const actorRollData = this.parent.actor?.getRollData({ deterministic }) ?? {};
     const data = { ...actorRollData, item: { ...this } };
     return data;
   }

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -202,7 +202,6 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   /** @inheritdoc */
   static _migrateData(source) {
     super._migrateData(source);
-    if ( ("activation" in source) && !source.activation.type ) source.activation.type = "";
     ActivatedEffectTemplate.#migrateFormulaFields(source);
     ActivatedEffectTemplate.#migrateRanges(source);
     ActivatedEffectTemplate.#migrateTargets(source);
@@ -234,7 +233,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   static #migrateRanges(source) {
     if ( !("range" in source) ) return;
     source.range ??= {};
-    if ( ["none", null].includes(source.range.units) ) source.range.units = "";
+    if ( source.range.units === "none" ) source.range.units = "";
     if ( typeof source.range.long === "string" ) {
       if ( source.range.long === "" ) source.range.long = null;
       else if ( Number.isNumeric(source.range.long) ) source.range.long = Number(source.range.long);
@@ -259,8 +258,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
     if ( !("target" in source) ) return;
     source.target ??= {};
     if ( source.target.value === "" ) source.target.value = null;
-    if ( source.target.units === null ) source.target.units = "";
-    if ( ["none", null].includes(source.target.type) ) source.target.type = "";
+    if ( source.target.type === "none" ) source.target.type = "";
   }
 
   /* -------------------------------------------- */
@@ -288,7 +286,6 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   static #migrateConsume(source) {
     if ( !("consume" in source) ) return;
     source.consume ??= {};
-    if ( source.consume.type === null ) source.consume.type = "";
     const amount = source.consume.amount;
     if ( typeof amount === "string" ) {
       if ( amount === "" ) source.consume.amount = null;

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -179,7 +179,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
    * @param {object} options.rollData  Roll data to use to evaluate the formula.
    */
   _prepareFinalFormula(keyPath, { label, rollData }) {
-    let value = foundry.utils.getProperty(this, keyPath);
+    const value = foundry.utils.getProperty(this, keyPath);
     if ( !value ) return;
     const property = game.i18n.localize(label);
     try {
@@ -202,7 +202,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   /** @inheritdoc */
   static _migrateData(source) {
     super._migrateData(source);
-    if ( ("activation" in source) && !source.activation.type ) source.activation.type = null;
+    if ( ("activation" in source) && !source.activation.type ) source.activation.type = "";
     ActivatedEffectTemplate.#migrateFormulaFields(source);
     ActivatedEffectTemplate.#migrateRanges(source);
     ActivatedEffectTemplate.#migrateTargets(source);
@@ -234,7 +234,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   static #migrateRanges(source) {
     if ( !("range" in source) ) return;
     source.range ??= {};
-    if ( ["none", ""].includes(source.range.units) ) source.range.units = null;
+    if ( ["none", null].includes(source.range.units) ) source.range.units = "";
     if ( typeof source.range.long === "string" ) {
       if ( source.range.long === "" ) source.range.long = null;
       else if ( Number.isNumeric(source.range.long) ) source.range.long = Number(source.range.long);
@@ -260,7 +260,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
     source.target ??= {};
     if ( source.target.value === "" ) source.target.value = null;
     if ( source.target.units === null ) source.target.units = "";
-    if ( ["none", ""].includes(source.target.type) ) source.target.type = null;
+    if ( ["none", null].includes(source.target.type) ) source.target.type = "";
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -1,5 +1,8 @@
+import { replaceFormulaData } from "../../../utils.mjs";
 import SystemDataModel from "../../abstract.mjs";
 import { FormulaField } from "../../fields.mjs";
+
+const { BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
  * Data model template for items that can be used as some sort of action.
@@ -13,7 +16,7 @@ import { FormulaField } from "../../fields.mjs";
  * @property {string} duration.units        Time duration period as defined in `DND5E.timePeriods`.
  * @property {number} cover                 Amount of cover does this item affords to its crew on a vehicle.
  * @property {object} target                Effect's valid targets.
- * @property {number} target.value          Length or radius of target depending on targeting mode selected.
+ * @property {string} target.value          Length or radius of target depending on targeting mode selected.
  * @property {number} target.width          Width of line when line type is selected.
  * @property {string} target.units          Units used for value and width as defined in `DND5E.distanceUnits`.
  * @property {string} target.type           Targeting mode as defined in `DND5E.targetTypes`.
@@ -36,39 +39,39 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   /** @inheritdoc */
   static defineSchema() {
     return {
-      activation: new foundry.data.fields.SchemaField({
-        type: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.ItemActivationType"}),
-        cost: new foundry.data.fields.NumberField({required: true, label: "DND5E.ItemActivationCost"}),
-        condition: new foundry.data.fields.StringField({required: true, label: "DND5E.ItemActivationCondition"})
+      activation: new SchemaField({
+        type: new StringField({required: true, blank: true, label: "DND5E.ItemActivationType"}),
+        cost: new NumberField({required: true, label: "DND5E.ItemActivationCost"}),
+        condition: new StringField({required: true, label: "DND5E.ItemActivationCondition"})
       }, {label: "DND5E.ItemActivation"}),
-      duration: new foundry.data.fields.SchemaField({
+      duration: new SchemaField({
         value: new FormulaField({required: true, deterministic: true, label: "DND5E.Duration"}),
-        units: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.DurationType"})
+        units: new StringField({required: true, blank: true, label: "DND5E.DurationType"})
       }, {label: "DND5E.Duration"}),
-      cover: new foundry.data.fields.NumberField({
+      cover: new NumberField({
         required: true, nullable: true, min: 0, max: 1, label: "DND5E.Cover"
       }),
-      crewed: new foundry.data.fields.BooleanField({label: "DND5E.Crewed"}),
-      target: new foundry.data.fields.SchemaField({
-        value: new foundry.data.fields.NumberField({required: true, min: 0, label: "DND5E.TargetValue"}),
-        width: new foundry.data.fields.NumberField({required: true, min: 0, label: "DND5E.TargetWidth"}),
-        units: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.TargetUnits"}),
-        type: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.TargetType"}),
-        prompt: new foundry.data.fields.BooleanField({initial: true, label: "DND5E.TemplatePrompt"})
+      crewed: new BooleanField({label: "DND5E.Crewed"}),
+      target: new SchemaField({
+        value: new FormulaField({required: true, deterministic: true, label: "DND5E.TargetValue"}),
+        width: new NumberField({required: true, min: 0, label: "DND5E.TargetWidth"}),
+        units: new StringField({required: true, blank: true, label: "DND5E.TargetUnits"}),
+        type: new StringField({required: true, blank: true, label: "DND5E.TargetType"}),
+        prompt: new BooleanField({initial: true, label: "DND5E.TemplatePrompt"})
       }, {label: "DND5E.Target"}),
-      range: new foundry.data.fields.SchemaField({
-        value: new foundry.data.fields.NumberField({required: true, min: 0, label: "DND5E.RangeNormal"}),
-        long: new foundry.data.fields.NumberField({required: true, min: 0, label: "DND5E.RangeLong"}),
-        units: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.RangeUnits"})
+      range: new SchemaField({
+        value: new NumberField({required: true, min: 0, label: "DND5E.RangeNormal"}),
+        long: new NumberField({required: true, min: 0, label: "DND5E.RangeLong"}),
+        units: new StringField({required: true, blank: true, label: "DND5E.RangeUnits"})
       }, {label: "DND5E.Range"}),
       uses: new this.ItemUsesField({}, {label: "DND5E.LimitedUses"}),
-      consume: new foundry.data.fields.SchemaField({
-        type: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.ConsumeType"}),
-        target: new foundry.data.fields.StringField({
+      consume: new SchemaField({
+        type: new StringField({required: true, blank: true, label: "DND5E.ConsumeType"}),
+        target: new StringField({
           required: true, nullable: true, initial: null, label: "DND5E.ConsumeTarget"
         }),
-        amount: new foundry.data.fields.NumberField({required: true, integer: true, label: "DND5E.ConsumeAmount"}),
-        scale: new foundry.data.fields.BooleanField({label: "DND5E.ConsumeScaling"})
+        amount: new NumberField({required: true, integer: true, label: "DND5E.ConsumeAmount"}),
+        scale: new BooleanField({label: "DND5E.ConsumeScaling"})
       }, {label: "DND5E.ConsumeTitle"})
     };
   }
@@ -79,18 +82,18 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
    * Extension of SchemaField used to track item uses.
    * @internal
    */
-  static ItemUsesField = class ItemUsesField extends foundry.data.fields.SchemaField {
+  static ItemUsesField = class ItemUsesField extends SchemaField {
     constructor(extraSchema, options) {
       super(SystemDataModel.mergeSchema({
-        value: new foundry.data.fields.NumberField({
+        value: new NumberField({
           required: true, min: 0, integer: true, label: "DND5E.LimitedUsesAvailable"
         }),
         max: new FormulaField({required: true, deterministic: true, label: "DND5E.LimitedUsesMax"}),
-        per: new foundry.data.fields.StringField({
+        per: new StringField({
           required: true, nullable: true, blank: false, initial: null, label: "DND5E.LimitedUsesPer"
         }),
         recovery: new FormulaField({required: true, label: "DND5E.RecoveryFormula"}),
-        prompt: new foundry.data.fields.BooleanField({initial: true, label: "DND5E.LimitedUsesPrompt"})
+        prompt: new BooleanField({initial: true, label: "DND5E.LimitedUsesPrompt"})
       }, extraSchema), options);
     }
   };
@@ -113,6 +116,52 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
    * Prepare activated effect data, should be called during `prepareFinalData` stage.
    */
   prepareFinalActivatedEffectData() {
+    // Initial data modifications
+    if ( ["inst", "perm"].includes(this.duration.units) ) this.duration.value = null;
+    if ( [null, "self"].includes(this.target.type) ) this.target.value = this.target.units = null;
+    else if ( this.target.units === "touch" ) this.target.value = null;
+    if ( [null, "touch", "self"].includes(this.range.units) ) this.range.value = this.range.long = null;
+
+    // Prepare duration, targets, and max uses formulas
+    const rollData = this.getRollData({ deterministic: true });
+    this._prepareFinalFormula("duration.value", { label: "DND5E.Duration", rollData });
+    this._prepareFinalFormula("target.value", { label: "DND5E.TargetValue", rollData });
+    this._prepareFinalFormula("uses.max", { label: "DND5E.UsesMax", rollData });
+
+    // Prepare labels
+    this.parent.labels ??= {};
+    this.parent.labels.duration = [this.duration.value, CONFIG.DND5E.timePeriods[this.duration.units]].filterJoin(" ");
+    this.parent.labels.activation = this.activation.type ? [
+      (this.activation.type in CONFIG.DND5E.staticAbilityActivationTypes) ? null : this.activation.cost,
+      CONFIG.DND5E.abilityActivationTypes[this.activation.type]
+    ].filterJoin(" ") : "";
+
+    if ( this.hasTarget ) {
+      const target = [this.target.value];
+      if ( this.hasAreaTarget ) {
+        if ( this.target.units in CONFIG.DND5E.movementUnits ) {
+          target.push(game.i18n.localize(`DND5E.Dist${this.target.units.capitalize()}Abbr`));
+        }
+        else target.push(CONFIG.DND5E.distanceUnits[this.target.units]);
+      }
+      target.push(CONFIG.DND5E.targetTypes[this.target.type]);
+      this.parent.labels.target = target.filterJoin(" ");
+    }
+
+    if ( this.isActive && this.range.units ) {
+      const range = [this.range.value, this.range.long ? `/ ${this.range.long}` : null];
+      if ( this.range.units in CONFIG.DND5E.movementUnits ) {
+        range.push(game.i18n.localize(`DND5E.Dist${this.range.units.capitalize()}Abbr`));
+      }
+      else range.push(CONFIG.DND5E.distanceUnits[this.range.units]);
+      this.parent.labels.range = range.filterJoin(" ");
+    } else this.parent.labels.range = game.i18n.localize("DND5E.None");
+
+    if ( this.recharge ) this.parent.labels.recharge = `${game.i18n.localize("DND5E.Recharge")} [${
+      `${this.recharge.value}${parseInt(this.recharge.value) < 6 ? "+" : ""}`
+    }]`;
+
+    // Substitute source UUIDs in consumption targets
     if ( !this.parent.isEmbedded ) return;
     if ( ["ammo", "charges", "material"].includes(this.consume.type) && this.consume.target.includes(".") ) {
       const item = this.parent.actor.sourcedItems?.get(this.consume.target);
@@ -121,12 +170,39 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
-  /*  Migrations                                  */
+
+  /**
+   * Prepare a specific final formula, passing resolution errors to actor if available.
+   * @param {string} keyPath           Path within system data to where the property can be found.
+   * @param {object} options
+   * @param {string} options.label     Localizable name for the property to display in warnings.
+   * @param {object} options.rollData  Roll data to use to evaluate the formula.
+   */
+  _prepareFinalFormula(keyPath, { label, rollData }) {
+    let value = foundry.utils.getProperty(this, keyPath);
+    if ( !value ) return;
+    const property = game.i18n.localize(label);
+    try {
+      foundry.utils.setProperty(
+        this, keyPath, Roll.safeEval(replaceFormulaData(value, rollData, { actor: this.parent.actor, property }))
+      );
+    } catch(err) {
+      if ( this.parent.isEmbedded ) {
+        const message = game.i18n.format("DND5E.FormulaMalformedError", { property, name: this.parent.name });
+        this.parent.actor._preparationWarnings.push({ message, link: this.parent.uuid, type: "error" });
+        console.error(message, err);
+      }
+    }
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Migration                              */
   /* -------------------------------------------- */
 
   /** @inheritdoc */
   static _migrateData(source) {
     super._migrateData(source);
+    if ( ("activation" in source) && !source.activation.type ) source.activation.type = null;
     ActivatedEffectTemplate.#migrateFormulaFields(source);
     ActivatedEffectTemplate.#migrateRanges(source);
     ActivatedEffectTemplate.#migrateTargets(source);
@@ -158,7 +234,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
   static #migrateRanges(source) {
     if ( !("range" in source) ) return;
     source.range ??= {};
-    if ( source.range.units === null ) source.range.units = "";
+    if ( ["none", ""].includes(source.range.units) ) source.range.units = null;
     if ( typeof source.range.long === "string" ) {
       if ( source.range.long === "" ) source.range.long = null;
       else if ( Number.isNumeric(source.range.long) ) source.range.long = Number(source.range.long);
@@ -184,7 +260,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
     source.target ??= {};
     if ( source.target.value === "" ) source.target.value = null;
     if ( source.target.units === null ) source.target.units = "";
-    if ( source.target.type === null ) source.target.type = "";
+    if ( ["none", ""].includes(source.target.type) ) source.target.type = null;
   }
 
   /* -------------------------------------------- */

--- a/templates/items/parts/item-activation.hbs
+++ b/templates/items/parts/item-activation.hbs
@@ -37,8 +37,8 @@
     <label>{{ localize "DND5E.Target" }}</label>
     <div class="form-fields">
         {{#if system.hasScalarTarget}}
-            <input type="number" step="any" name="system.target.value"
-                   value="{{system.target.value}}" placeholder="&mdash;">
+            <input type="text" name="system.target.value" value="{{source.target.value}}"
+                   placeholder="&mdash;" data-formula-editor>
         {{/if}}
         {{#if system.hasAreaTarget}}
             <select name="system.target.units" data-tooltip="DND5E.TargetUnits">


### PR DESCRIPTION
Converts the targets value into a formula field so spells can change their values as they upcast. In order to support this and reduce code duplication the formula resolution logic used by max uses & duration fields was moved into its own method. All of the activated effect template data preparation was also moved into the data model at the same time.

In order to ensure these formulas resolve properly using item data for non-embedded items (Bless should show targets even when not on an actor), this modifies `getRollData` to always return item data even for non-embedded items.

In addition, the `replaceFormulaData` method has been moved from `Item5e` into utils to make it more generally available.

Closes #3537