### PR TITLE
[#3500] Allow ordering of inventory categories to be set

### DIFF
--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -54,8 +54,10 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
 
     // Categorize items as inventory, spellbook, features, and classes
     const inventory = {};
-    for ( const [type, model] of Object.entries(CONFIG.Item.dataModels) ) {
-      if ( !model.metadata?.inventoryItem ) continue;
+    const inventoryTypes = Object.entries(CONFIG.Item.dataModels)
+      .filter(([, model]) => model.metadata?.inventoryItem)
+      .sort(([, lhs], [, rhs]) => (lhs.metadata.inventoryOrder - rhs.metadata.inventoryOrder));
+    for ( const [type] of inventoryTypes ) {
       inventory[type] = {label: `${CONFIG.Item.typeLabels[type]}Pl`, items: [], dataset: {type}};
     }
 

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -362,6 +362,7 @@ export class ItemDataModel extends SystemDataModel {
    * @typedef {SystemDataModelMetadata} ItemDataModelMetadata
    * @property {boolean} enchantable    Can this item be modified by enchantment effects?
    * @property {boolean} inventoryItem  Should this item be listed with an actor's inventory?
+   * @property {number} inventoryOrder  Order this item appears in the actor's inventory, smaller numbers are earlier.
    * @property {boolean} singleton      Should only a single item of this type be allowed on an actor?
    */
 
@@ -369,6 +370,7 @@ export class ItemDataModel extends SystemDataModel {
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     enchantable: false,
     inventoryItem: false,
+    inventoryOrder: Infinity,
     singleton: false
   }, {inplace: false}));
 

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -47,7 +47,8 @@ export default class ConsumableData extends ItemDataModel.mixin(
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     enchantable: true,
-    inventoryItem: true
+    inventoryItem: true,
+    inventoryOrder: 300
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -44,7 +44,8 @@ export default class ContainerData extends ItemDataModel.mixin(
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     enchantable: true,
-    inventoryItem: true
+    inventoryItem: true,
+    inventoryOrder: 500
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -67,7 +67,8 @@ export default class EquipmentData extends ItemDataModel.mixin(
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     enchantable: true,
-    inventoryItem: true
+    inventoryItem: true,
+    inventoryOrder: 200
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -30,7 +30,8 @@ export default class LootData extends ItemDataModel.mixin(
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     enchantable: true,
-    inventoryItem: true
+    inventoryItem: true,
+    inventoryOrder: 600
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -49,7 +49,8 @@ export default class ToolData extends ItemDataModel.mixin(
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     enchantable: true,
-    inventoryItem: true
+    inventoryItem: true,
+    inventoryOrder: 400
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -48,7 +48,8 @@ export default class WeaponData extends ItemDataModel.mixin(
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     enchantable: true,
-    inventoryItem: true
+    inventoryItem: true,
+    inventoryOrder: 100
   }, {inplace: false}));
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Introduces a new `inventoryOrder` metadata property that is used to specify which order inventory categories will appear. This value will only be used if `inventoryItem` is also set in the metadata. If not specified, category will be sorted to the end of the list.