### PR TITLE
[#3544] Add static registry of summoned creatures in world

### DIFF
--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -529,7 +529,7 @@ export class SummonsData extends foundry.abstract.DataModel {
 
   /**
    * Registration of summoned creatures mapped to a specific summoner. The map is keyed by the UUID of
-   * summoned actor while the set contains UUID of actors that have been summoned.
+   * summoner while the set contains UUID of actors that have been summoned.
    * @type {Map<string, Set<string>>}
    */
   static #summonedCreatures = new Map();
@@ -565,10 +565,9 @@ export class SummonsData extends foundry.abstract.DataModel {
   /**
    * Stop tracking a summoned creature.
    * @param {string} summoner  UUID of the actor who performed the summoning.
-   * @param {string} summoned  UUID of the summoned creature to track.
+   * @param {string} summoned  UUID of the summoned creature to stop tracking.
    */
   static untrackSummon(summoner, summoned) {
-    if ( !SummonsData.#summonedCreatures.has(summoner) ) return;
-    SummonsData.#summonedCreatures.get(summoner).delete(summoned);
+    SummonsData.#summonedCreatures.get(summoner)?.delete(summoned);
   }
 }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -178,7 +178,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /** @inheritDoc */
   prepareDerivedData() {
     const origin = this.getFlag("dnd5e", "summon.origin");
-    if ( origin ) SummonsData.trackSummon(origin.split(".Item.")[0], this.uuid);
+    // TODO: Replace with parseUuid once V11 support is dropped
+    if ( origin && this.token?.id ) SummonsData.trackSummon(origin.split(".Item.")[0], this.uuid);
 
     if ( (this.system.modelProvider !== dnd5e) || (this.type === "group") ) return;
 
@@ -3324,6 +3325,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     super._onDelete(options, userId);
 
     const origin = this.getFlag("dnd5e", "summon.origin");
+    // TODO: Replace with parseUuid once V11 support is dropped
     if ( origin ) SummonsData.untrackSummon(origin.split(".Item.")[0], this.uuid);
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2183,7 +2183,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
           }
           break;
         case "summon":
-          if ( spellLevel ) item = item.clone({ "system.level": spellLevel });
+          if ( spellLevel ) item = item.clone({ "system.level": spellLevel }, { keepId: true });
           await this._onChatCardSummon(message, item);
           break;
         case "toolCheck":

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -1,3 +1,4 @@
+import { SummonsData } from "../data/item/fields/summons-field.mjs";
 import TokenSystemFlags from "../data/token/token-system-flags.mjs";
 import SystemFlagsMixin from "./mixins/flags.mjs";
 
@@ -255,5 +256,18 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
       options.easing = CONFIG.Token.ringClass.easeTwoPeaks;
     }
     this.object.ring.flashColor(Color.from(color), options);
+  }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+
+    const origin = this.actor.getFlag("dnd5e", "summon.origin");
+    // TODO: Replace with parseUuid once V11 support is dropped
+    if ( origin ) SummonsData.untrackSummon(origin.split(".Item.")[0], this.actor.uuid);
   }
 }


### PR DESCRIPTION
Similar to what is implemented for Enchantments, this introduces a static registry within `SummonsData` where each summoned actor can register to make it easy to determine what creatures each actor or item have summoned.

Adds `SummonsData#summonedCreatures` which returns what creatures were summoned by that item, and `Actor5e#summonedCreatures` getter which returns all creatures summoned by that actor.

Also fixes a bug where sometimes `flags.dnd5e.summons.origin` wouldn't get the proper UUID for summons created using the chat message button.