### PR TITLE
[#3291] Add setting to control chat card tray expansion

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2040,6 +2040,13 @@
     "Name": "Allow Summoning",
     "Hint": "Allow players to use summoning abilities to summon actors. Players must also have the Create Token core permission for this to work."
   },
+  "COLLAPSETRAYS": {
+    "Name": "Collapse Trays in Chat",
+    "Hint": "Automatically collapse damage, hit, and effect trays that appear in chat cards.",
+    "Always": "Collapse All",
+    "Older": "Collapse Older Trays",
+    "Never": "Expand All"
+  },
   "THEME": {
     "Name": "Theme",
     "Hint": "Theme that will apply to the UI and all sheets by default. Automatic will be determined by your browser or operating system settings."

--- a/module/applications/components/chat-tray-element.mjs
+++ b/module/applications/components/chat-tray-element.mjs
@@ -26,6 +26,7 @@ export default class ChatTrayElement extends HTMLElement {
   /*  Event Handlers                              */
   /* -------------------------------------------- */
 
+  /** @override */
   attributeChangedCallback(name, oldValue, newValue) {
     if ( name === "open" ) this._handleToggleOpen(newValue !== null);
   }

--- a/module/applications/components/chat-tray-element.mjs
+++ b/module/applications/components/chat-tray-element.mjs
@@ -1,0 +1,60 @@
+/**
+ * Custom element designed to display as a collapsible tray in chat.
+ */
+export default class ChatTrayElement extends HTMLElement {
+
+  static observedAttributes = ["open"];
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Is the tray expanded or collapsed?
+   * @type {boolean}
+   */
+  get open() {
+    return this.hasAttribute("open");
+  }
+
+  set open(open) {
+    if ( open ) this.setAttribute("open", "");
+    else this.removeAttribute("open");
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Handlers                              */
+  /* -------------------------------------------- */
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if ( name === "open" ) this._handleToggleOpen(newValue !== null);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle clicks to the collapsible header.
+   * @param {PointerEvent} event  Triggering click event.
+   */
+  _handleClickHeader(event) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    if ( !event.target.closest(".collapsible-content") ) this.toggleAttribute("open");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle changing the collapsed state of this element.
+   * @param {boolean} open  Is the element open?
+   */
+  _handleToggleOpen(open) {
+    this.dispatchEvent(new Event("toggle"));
+
+    this.querySelector(".collapsible")?.classList.toggle("collapsed", !open);
+
+    // Clear the height from the chat popout container so that it appropriately resizes.
+    const popout = this.closest(".chat-popout");
+    if ( popout ) popout.style.height = "";
+  }
+}

--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -1,4 +1,5 @@
 import { formatNumber } from "../../utils.mjs";
+import ChatTrayElement from "./chat-tray-element.mjs";
 
 /**
  * List of multiplier options as tuples containing their numeric value and rendered text.
@@ -9,7 +10,7 @@ const MULTIPLIERS = [[-1, "-1"], [0, "0"], [.25, "¼"], [.5, "½"], [1, "1"], [2
 /**
  * Application to handle applying damage from a chat card.
  */
-export default class DamageApplicationElement extends HTMLElement {
+export default class DamageApplicationElement extends ChatTrayElement {
 
   /* -------------------------------------------- */
   /*  Properties                                  */
@@ -119,7 +120,8 @@ export default class DamageApplicationElement extends HTMLElement {
     // Build the frame HTML only once
     if ( !this.targetList ) {
       const div = document.createElement("div");
-      div.classList.add("card-tray", "damage-tray", "collapsible", "collapsed");
+      div.classList.add("card-tray", "damage-tray", "collapsible");
+      if ( !this.open ) div.classList.add("collapsed");
       div.innerHTML = `
         <label class="roboto-upper">
           <i class="fa-solid fa-heart-crack"></i>
@@ -153,9 +155,7 @@ export default class DamageApplicationElement extends HTMLElement {
         b.addEventListener("click", this._onChangeTargetMode.bind(this))
       );
       if ( !this.chatMessage.getFlag("dnd5e", "targets")?.length ) this.targetSourceControl.hidden = true;
-      div.querySelector(".collapsible-content").addEventListener("click", event => {
-        event.stopImmediatePropagation();
-      });
+      div.addEventListener("click", this._handleClickHeader.bind(this));
     }
 
     this.targetingMode = this.targetSourceControl.hidden ? "selected" : "targeted";
@@ -372,7 +372,7 @@ export default class DamageApplicationElement extends HTMLElement {
       const options = this.getTargetOptions(target.dataset.targetUuid);
       await token?.applyDamage(this.damages, options);
     }
-    this.querySelector(".collapsible").dispatchEvent(new PointerEvent("click", { bubbles: true, cancelable: true }));
+    this.open = false;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -22,6 +22,8 @@ export default class ChatMessage5e extends ChatMessage {
    */
   _highlighted = null;
 
+  /* -------------------------------------------- */
+
   /**
    * Should the apply damage options appear?
    * @type {boolean}
@@ -31,6 +33,8 @@ export default class ChatMessage5e extends ChatMessage {
     if ( type && (type !== "damage") ) return false;
     return this.isRoll && this.isContentVisible && !!canvas.tokens?.controlled.length;
   }
+
+  /* -------------------------------------------- */
 
   /**
    * Should the select targets options appear?
@@ -71,7 +75,7 @@ export default class ChatMessage5e extends ChatMessage {
     }
 
     this._enrichChatCard(html[0]);
-    requestAnimationFrame(() => html.find(".card-tray, .effects-tray").each((i, el) => el.classList.add("collapsed")));
+    this._collapseTrays(html[0]);
 
     /**
      * A hook event that fires after dnd5e-specific chat message modifications have completed.
@@ -83,6 +87,28 @@ export default class ChatMessage5e extends ChatMessage {
     Hooks.callAll("dnd5e.renderChatMessage", this, html[0]);
 
     return html;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle collapsing or expanding trays depending on user settings.
+   * @param {HTMLElement} html  Rendered contents of the message.
+   */
+  _collapseTrays(html) {
+    let collapse;
+    switch ( game.settings.get("dnd5e", "autoCollapseChatTrays") ) {
+      case "always": collapse = true; break;
+      case "never": collapse = false; break;
+      // Collapse chat message trays older than 5 minutes
+      case "older": collapse = this.timestamp < Date.now() - (5 * 60 * 1000); break;
+    }
+    for ( const tray of html.querySelectorAll(".card-tray, .effects-tray") ) {
+      tray.classList.toggle("collapsed", collapse);
+    }
+    for ( const element of html.querySelectorAll("damage-application") ) {
+      element.toggleAttribute("open", !collapse);
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -193,6 +193,21 @@ export function registerSystemSettings() {
     }
   });
 
+  // Collapse Chat Card Trays
+  game.settings.register("dnd5e", "autoCollapseChatTrays", {
+    name: "SETTINGS.DND5E.COLLAPSETRAYS.Name",
+    hint: "SETTINGS.DND5E.COLLAPSETRAYS.Hint",
+    scope: "client",
+    config: true,
+    default: "older",
+    type: String,
+    choices: {
+      never: "SETTINGS.DND5E.COLLAPSETRAYS.Never",
+      older: "SETTINGS.DND5E.COLLAPSETRAYS.Older",
+      always: "SETTINGS.DND5E.COLLAPSETRAYS.Always"
+    }
+  });
+
   // Allow Polymorphing
   game.settings.register("dnd5e", "allowPolymorphing", {
     name: "SETTINGS.5eAllowPolymorphingN",


### PR DESCRIPTION
Adds a new setting allowing setting the initial expanded state of damage & effect application trays in chat cards. The settings are "Expand All" and "Collapse All" plus "Collapse Older", which expands newly created cards but collapses any cards more than five minutes old.

To better support the expanding trays, a new CardTrayElement has been added which adds support for the `open` attribute on card trays to explicitly control its behavior. This attribute matches the behavior of the `open` attribute on `<details>` elements, so adding or removing the attribute will open and close the tray, and toggling the `open` property will cause the attribute to be added or removed. The tray also fires off a `toggle` event that matches the one fired by `<details>`.