### PR TITLE
[#2111, #3551] Split attunement & attuned, add optional attunement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -312,6 +312,7 @@
 "DND5E.Attunement": "Attunement",
 "DND5E.AttunementMax": "Maximum Attuned Items",
 "DND5E.AttunementNone": "Attunement Not Required",
+"DND5E.AttunementOptional": "Optional Attunement",
 "DND5E.AttunementRequired": "Attunement Required",
 "DND5E.AttunementAttuned": "Attuned",
 "DND5E.AttunementOverride": "Override attunement",

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1036,10 +1036,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
    */
   _onDropResetData(itemData) {
     if ( !itemData.system ) return;
-    ["equipped", "proficient", "prepared"].forEach(k => delete itemData.system[k]);
-    if ( "attunement" in itemData.system ) {
-      itemData.system.attunement = Math.min(itemData.system.attunement, CONFIG.DND5E.attunementTypes.REQUIRED);
-    }
+    ["attuned", "equipped", "proficient", "prepared"].forEach(k => delete itemData.system[k]);
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -343,9 +343,6 @@ export default class ActorSheet5eCharacter2 extends ActorSheet5eCharacter {
     });
     if ( foundry.utils.isEmpty(context.senses) ) delete context.senses;
 
-    // Inventory
-    this._prepareItems(context);
-
     // Spellcasting
     context.spellcasting = [];
     const msak = simplifyBonus(this.actor.system.bonuses.msak.attack, context.rollData);

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -68,18 +68,15 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
       // Item details
       const ctx = context.itemContext[item.id] ??= {};
       ctx.isStack = Number.isNumeric(quantity) && (quantity !== 1);
-      ctx.attunement = {
-        [CONFIG.DND5E.attunementTypes.REQUIRED]: {
-          icon: "fa-sun",
-          cls: "not-attuned",
-          title: "DND5E.AttunementRequired"
-        },
-        [CONFIG.DND5E.attunementTypes.ATTUNED]: {
-          icon: "fa-sun",
-          cls: "attuned",
-          title: "DND5E.AttunementAttuned"
-        }
-      }[item.system.attunement];
+      if ( item.system.attunement ) ctx.attunement = item.system.attuned ? {
+        icon: "fa-sun",
+        cls: "attuned",
+        title: "DND5E.AttunementAttuned"
+      } : {
+        icon: "fa-sun",
+        cls: "not-attuned",
+        title: CONFIG.DND5E.attunementTypes[item.system.attunement]
+      };
 
       // Prepare data needed to display expanded sections
       ctx.isExpanded = this._expanded.has(item.id);

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -222,10 +222,9 @@ export default class InventoryElement extends HTMLElement {
     if ( !this.actor || (this.actor.type === "group") ) return options;
 
     // Toggle Attunement State
-    if ( ("attunement" in item.system) && (item.system.attunement !== CONFIG.DND5E.attunementTypes.NONE) ) {
-      const isAttuned = item.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED;
+    if ( item.system.attunement ) {
       options.push({
-        name: isAttuned ? "DND5E.ContextMenuActionUnattune" : "DND5E.ContextMenuActionAttune",
+        name: item.system.attuned ? "DND5E.ContextMenuActionUnattune" : "DND5E.ContextMenuActionAttune",
         icon: "<i class='fas fa-sun fa-fw'></i>",
         condition: () => item.isOwner,
         callback: li => this._onAction(li[0], "attune"),
@@ -358,10 +357,7 @@ export default class InventoryElement extends HTMLElement {
 
     switch ( action ) {
       case "attune":
-        const isAttuned = item.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED;
-        return item.update({
-          "system.attunement": CONFIG.DND5E.attunementTypes[isAttuned ? "REQUIRED" : "ATTUNED"]
-        });
+        return item.update({"system.attuned": !item.system.attuned});
       case "create":
         if ( this.document.type === "container" ) return;
         return this._onCreate(target);

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -313,17 +313,18 @@ preLocalize("alignments");
 
 /**
  * An enumeration of item attunement types.
- * @enum {number}
+ * @enum {string}
  */
 DND5E.attunementTypes = {
-  NONE: 0,
-  REQUIRED: 1,
-  ATTUNED: 2
+  required: "DND5E.AttunementRequired",
+  optional: "DND5E.AttunementOptional"
 };
+preLocalize("attunementTypes");
 
 /**
  * An enumeration of item attunement states.
  * @type {{"0": string, "1": string, "2": string}}
+ * @deprecated since 3.2, available until 3.4
  */
 DND5E.attunements = {
   0: "DND5E.AttunementNone",

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -174,10 +174,7 @@ export default class CharacterData extends CreatureTemplate {
     this.attributes.attunement.value = 0;
 
     for ( const item of this.parent.items ) {
-      // Attuned items
-      if ( item.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED ) {
-        this.attributes.attunement.value += 1;
-      }
+      if ( item.system.attuned ) this.attributes.attunement.value += 1;
     }
 
     // Character proficiency bonus

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -240,9 +240,7 @@ export default class NPCData extends CreatureTemplate {
       }
 
       // Attuned items
-      else if ( item.system.attunement === CONFIG.DND5E.attunementTypes.ATTUNED ) {
-        this.attributes.attunement.value += 1;
-      }
+      else if ( item.system.attuned ) this.attributes.attunement.value += 1;
     }
 
     // Kill Experience

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -79,6 +79,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.prepareDerivedEquippableData();
     if ( !this.type.value ) return;
     const config = CONFIG.DND5E.consumableTypes[this.type.value];
     if ( config ) {

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -85,6 +85,14 @@ export default class ContainerData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    this.prepareDerivedEquippableData();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   async getFavoriteData() {
     const data = super.getFavoriteData();
     const capacity = await this.computeCapacity();

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -152,6 +152,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.prepareDerivedEquippableData();
     this.armor.value = (this._source.armor.value ?? 0) + (this.magicAvailable ? (this.armor.magicalBonus ?? 0) : 0);
     this.type.label = CONFIG.DND5E.equipmentTypes[this.type.value]
       ?? game.i18n.localize(CONFIG.Item.typeLabels.equipment);

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -1,25 +1,27 @@
 import SystemDataModel from "../../abstract.mjs";
 
+const { BooleanField, StringField } = foundry.data.fields;
+
 /**
  * Data model template with information on items that can be attuned and equipped.
  *
- * @property {number} attunement  Attunement information as defined in `DND5E.attunementTypes`.
- * @property {boolean} equipped   Is this item equipped on its owning actor.
+ * @property {string} attunement  Attunement information as defined in `DND5E.attunementTypes`.
+ * @property {boolean} attuned    Is this item attuned on its owning actor?
+ * @property {boolean} equipped   Is this item equipped on its owning actor?
  * @mixin
  */
 export default class EquippableItemTemplate extends SystemDataModel {
   /** @inheritdoc */
   static defineSchema() {
     return {
-      attunement: new foundry.data.fields.NumberField({
-        required: true, integer: true, initial: CONFIG.DND5E.attunementTypes.NONE, label: "DND5E.Attunement"
-      }),
-      equipped: new foundry.data.fields.BooleanField({required: true, label: "DND5E.Equipped"})
+      attunement: new StringField({required: true, label: "DND5E.Attunement"}),
+      attuned: new BooleanField({label: "DND5E.Attuned"}),
+      equipped: new BooleanField({required: true, label: "DND5E.Equipped"})
     };
   }
 
   /* -------------------------------------------- */
-  /*  Migrations                                  */
+  /*  Data Migrations                             */
   /* -------------------------------------------- */
 
   /** @inheritdoc */
@@ -36,8 +38,11 @@ export default class EquippableItemTemplate extends SystemDataModel {
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateAttunement(source) {
-    if ( (source.attuned === undefined) || (source.attunement !== undefined) ) return;
-    source.attunement = source.attuned ? CONFIG.DND5E.attunementTypes.ATTUNED : CONFIG.DND5E.attunementTypes.NONE;
+    switch ( source.attunement ) {
+      case 2: source.attuned = true;
+      case 1: source.attunement = "required"; break;
+      case 0: source.attunement = ""; break;
+    }
   }
 
   /* -------------------------------------------- */
@@ -52,6 +57,17 @@ export default class EquippableItemTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /**
+   * Ensure items that cannot be attuned are not marked as attuned.
+   */
+  prepareDerivedEquippableData() {
+    if ( !this.attunement ) this.attuned = false;
+  }
+
+  /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
 
@@ -60,9 +76,8 @@ export default class EquippableItemTemplate extends SystemDataModel {
    * @type {string[]}
    */
   get equippableItemCardProperties() {
-    const req = CONFIG.DND5E.attunementTypes.REQUIRED;
     return [
-      this.attunement === req ? CONFIG.DND5E.attunements[req] : null,
+      this.attunement === "required" ? CONFIG.DND5E.attunementTypes.required : null,
       game.i18n.localize(this.equipped ? "DND5E.Equipped" : "DND5E.Unequipped"),
       ("proficient" in this) ? CONFIG.DND5E.proficiencyLevels[this.prof?.multiplier || 0] : null
     ];
@@ -75,7 +90,7 @@ export default class EquippableItemTemplate extends SystemDataModel {
    * @type {boolean}
    */
   get magicAvailable() {
-    const attunement = this.attunement !== CONFIG.DND5E.attunementTypes.REQUIRED;
+    const attunement = this.attuned || (this.attunement !== "required");
     return attunement && this.properties.has("mgc") && this.validProperties.has("mgc");
   }
 }

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -80,6 +80,7 @@ export default class ToolData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.prepareDerivedEquippableData();
     this.type.label = CONFIG.DND5E.toolTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.tool);
   }
 

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -91,6 +91,7 @@ export default class WeaponData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.prepareDerivedEquippableData();
     this.type.label = CONFIG.DND5E.weaponTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.weapon);
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -462,7 +462,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const requireEquipped = (this.type !== "consumable")
       || ["rod", "trinket", "wand"].includes(this.system.type.value);
     if ( requireEquipped && (this.system.equipped === false) ) return true;
-    return this.system.attuned || (this.system.attunement !== "required");
+    return !this.system.attuned && (this.system.attunement === "required");
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -462,7 +462,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const requireEquipped = (this.type !== "consumable")
       || ["rod", "trinket", "wand"].includes(this.system.type.value);
     if ( requireEquipped && (this.system.equipped === false) ) return true;
-    return this.system.attunement === CONFIG.DND5E.attunementTypes.REQUIRED;
+    return this.system.attuned || (this.system.attunement !== "required");
   }
 
   /* -------------------------------------------- */

--- a/templates/items/consumable.hbs
+++ b/templates/items/consumable.hbs
@@ -94,11 +94,17 @@
             </div>
             {{/if}}
 
-            <div class="form-group">
+            <div class="form-group input-select">
                 <label>{{localize "DND5E.Attunement"}}</label>
-                <select name="system.attunement" data-dtype="Number">
-                    {{selectOptions config.attunements selected=system.attunement}}
-                </select>
+                <div class="form-fields">
+                    <input type="checkbox" name="system.attuned" {{ checked system.attuned }}
+                           {{ disabled (not system.attunement) }}
+                           data-tooltip="DND5E.Attuned" aria-label="{{ localize 'DND5E.Attuned' }}">
+                    <select name="system.attunement">
+                        {{selectOptions config.attunementTypes selected=system.attunement
+                                        blank=(localize "DND5E.AttunementNone")}}
+                    </select>
+                </div>
             </div>
 
             {{!-- Consumable Properties --}}

--- a/templates/items/equipment.hbs
+++ b/templates/items/equipment.hbs
@@ -95,11 +95,17 @@
             </div>
 
             {{#unless system.isMountable}}
-            <div class="form-group">
+            <div class="form-group input-select">
                 <label>{{localize "DND5E.Attunement"}}</label>
-                <select name="system.attunement" data-dtype="Number">
-                    {{selectOptions config.attunements selected=system.attunement}}
-                </select>
+                <div class="form-fields">
+                    <input type="checkbox" name="system.attuned" {{ checked system.attuned }}
+                           {{ disabled (not system.attunement) }}
+                           data-tooltip="DND5E.Attuned" aria-label="{{ localize 'DND5E.Attuned' }}">
+                    <select name="system.attunement">
+                        {{selectOptions config.attunementTypes selected=system.attunement
+                                        blank=(localize "DND5E.AttunementNone")}}
+                    </select>
+                </div>
             </div>
 
             <div class="form-group">

--- a/templates/items/tool.hbs
+++ b/templates/items/tool.hbs
@@ -101,11 +101,17 @@
                 {{/each}}
             </div>
 
-            <div class="form-group">
+            <div class="form-group input-select">
                 <label>{{localize "DND5E.Attunement"}}</label>
-                <select name="system.attunement" data-dtype="Number">
-                    {{selectOptions config.attunements selected=system.attunement}}
-                </select>
+                <div class="form-fields">
+                    <input type="checkbox" name="system.attuned" {{ checked system.attuned }}
+                           {{ disabled (not system.attunement) }}
+                           data-tooltip="DND5E.Attuned" aria-label="{{ localize 'DND5E.Attuned' }}">
+                    <select name="system.attunement">
+                        {{selectOptions config.attunementTypes selected=system.attunement
+                                        blank=(localize "DND5E.AttunementNone")}}
+                    </select>
+                </div>
             </div>
 
             {{!-- Tool Proficiency --}}

--- a/templates/items/weapon.hbs
+++ b/templates/items/weapon.hbs
@@ -91,11 +91,17 @@
             </div>
 
             {{#unless system.isMountable}}
-            <div class="form-group">
+            <div class="form-group input-select">
                 <label>{{localize "DND5E.Attunement"}}</label>
-                <select name="system.attunement" data-dtype="Number">
-                    {{selectOptions config.attunements selected=system.attunement}}
-                </select>
+                <div class="form-fields">
+                    <input type="checkbox" name="system.attuned" {{ checked system.attuned }}
+                           {{ disabled (not system.attunement) }}
+                           data-tooltip="DND5E.Attuned" aria-label="{{ localize 'DND5E.Attuned' }}">
+                    <select name="system.attunement">
+                        {{selectOptions config.attunementTypes selected=system.attunement
+                                        blank=(localize "DND5E.AttunementNone")}}
+                    </select>
+                </div>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
Splits `system.attunement` into two values, `attunement` which takes a string to indicate what kind of attunement is required, and `attuned` which is a `boolean` indicating whether the item is currently attuned.

This change allows simplification of a lot of the logic for attuning/un-attuning and for resetting attunement for dropped items.

This also adds the "Optional Attunement" mode that is used for the Spell Gem items and some 3rd party content. If attunement is optional then active effects and magical bonuses won't be suppressed if the item isn't attuned.

Also fixes a bug causing `_prepareItems` from being called twice on the new character sheets.

Closes #2111
Closes #3551