### PR TITLE
[#3305] Allow "Enchant Prompt" to still enchant if prompt is shown

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -748,10 +748,6 @@
     "Entry": "{item} on {actor}",
     "None": "Nothing Enchanted"
   },
-  "Prompt": {
-    "Label": "Enchant Prompt",
-    "Hint": "Disable the enchantment prompt when item is used. First available enchantment will always be applied."
-  },
   "Riders": {
     "Label": "Additional Effects",
     "Hint": "These additional effects will be added to the enchanted item when this enchantment is added, and removed when the enchantment is removed."

--- a/module/data/item/fields/enchantment-field.mjs
+++ b/module/data/item/fields/enchantment-field.mjs
@@ -22,7 +22,6 @@ export default class EnchantmentField extends EmbeddedDataField {
  * @property {object} items
  * @property {string} items.max                   Maximum number of items that can have this enchantment.
  * @property {string} items.period                Frequency at which the enchantment be swapped.
- * @property {boolean} prompt                     Should the player be prompted to apply an enchantment?
  * @property {object} restrictions
  * @property {boolean} restrictions.allowMagical  Allow enchantments to be applied to items that are already magical.
  * @property {string} restrictions.type           Item type to which this enchantment can be applied.
@@ -36,9 +35,6 @@ export class EnchantmentData extends foundry.abstract.DataModel {
       items: new SchemaField({
         max: new FormulaField({deterministic: true}),
         period: new StringField()
-      }),
-      prompt: new BooleanField({
-        initial: true, label: "DND5E.Enchantment.Prompt.Label", hint: "DND5E.Enchantment.Prompt.Hint"
       }),
       restrictions: new SchemaField({
         allowMagical: new BooleanField(),

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -980,7 +980,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * Configuration data for an item usage being prepared.
    *
    * @typedef {object} ItemUseConfiguration
-   * @property {boolean} applyEnchantment           Should this item apply an enchantment?
    * @property {boolean} createMeasuredTemplate     Should this item create a template?
    * @property {boolean} createSummons              Should this item create a summoned creature?
    * @property {boolean} consumeResource            Should this item consume a (non-ammo) resource?
@@ -1051,7 +1050,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     if ( (options.configureDialog !== false) && needsConfiguration ) {
       const configuration = await AbilityUseDialog.create(item, config);
       if ( !configuration ) return;
-      if ( !configuration.applyEnchantment ) configuration.enchantmentProfile = null;
       foundry.utils.mergeObject(config, configuration);
     }
 
@@ -1206,16 +1204,16 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @returns {ItemUseConfiguration}  Configuration data for the roll.
    */
   _getUsageConfig() {
-    const { consume, uses, enchantment, summons, target, level, preparation } = this.system;
+    const { consume, uses, summons, target, level, preparation } = this.system;
 
     const config = {
-      applyEnchantment: null,
       createMeasuredTemplate: null,
       createSummons: null,
       consumeResource: null,
       consumeSpellSlot: null,
       consumeUsage: null,
       enchantmentProfile: null,
+      promptEnchantment: null,
       slotLevel: null,
       summonsProfile: null,
       resourceAmount: null,
@@ -1241,8 +1239,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       config.createMeasuredTemplate = target.prompt;
     }
     if ( this.system.isEnchantment ) {
-      config.applyEnchantment = enchantment?.prompt ?? true;
-      config.enchantmentProfile = EnchantmentData.availableEnchantments(this)[0]?.id;
+      const availableEnchantments = EnchantmentData.availableEnchantments(this);
+      config.promptEnchantment = availableEnchantments.length > 1;
+      config.enchantmentProfile = availableEnchantments[0]?.id;
     }
     if ( this.system.hasSummoning && this.system.summons.canSummon && canvas.scene ) {
       config.createSummons = summons.prompt;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -986,6 +986,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @property {boolean} consumeSpellSlot           Should this item (a spell) consume a spell slot?
    * @property {boolean} consumeUsage               Should this item consume its limited uses or recharge?
    * @property {string} enchantmentProfile          ID of the enchantment to apply.
+   * @property {boolean} promptEnchantment          Does an enchantment profile need to be selected?
    * @property {string|number|null} slotLevel       The spell slot type or level to consume by default.
    * @property {string|null} summonsProfile         ID of the summoning profile to use.
    * @property {number|null} resourceAmount         The amount to consume by default when scaling with consumption.

--- a/templates/apps/ability-use.hbs
+++ b/templates/apps/ability-use.hbs
@@ -93,8 +93,6 @@
     </div>
     {{/if}}
 
-    {{#if (ne applyEnchantment null)}}
-    <input type="hidden" name="applyEnchantment" value="true" data-dtype="Boolean">
     {{#if enchantmentOptions.profiles}}
     <div class="form-group">
         <label>{{ localize "DND5E.Enchantment.Label" }}
@@ -107,7 +105,6 @@
     </div>
     {{else if enchantmentOptions.profile}}
     <input type="hidden" name="enchantmentProfile" value="{{ enchantmentOptions.profile }}">
-    {{/if}}
     {{/if}}
 
     {{#if (ne createSummons null)}}

--- a/templates/apps/ability-use.hbs
+++ b/templates/apps/ability-use.hbs
@@ -94,21 +94,20 @@
     {{/if}}
 
     {{#if (ne applyEnchantment null)}}
+    <input type="hidden" name="applyEnchantment" value="true" data-dtype="Boolean">
+    {{#if enchantmentOptions.profiles}}
     <div class="form-group">
-        <label class="checkbox">
-            <input type="checkbox" name="applyEnchantment" {{ checked applyEnchantment }}>
-            {{ localize "DND5E.Enchantment.Action.Apply" }}
+        <label>{{ localize "DND5E.Enchantment.Label" }}
         </label>
-        {{#if enchantmentOptions.profiles}}
         <div class="form-fields">
             <select name="enchantmentProfile" aria-label="{{ localize 'DND5E.Enchantment.Label' }}">
                 {{ selectOptions enchantmentOptions.profiles selected=enchantmentProfile }}
             </select>
         </div>
-        {{else}}
-        <input type="hidden" name="enchantmentProfile" value="{{ enchantmentOptions.profile }}">
-        {{/if}}
     </div>
+    {{else if enchantmentOptions.profile}}
+    <input type="hidden" name="enchantmentProfile" value="{{ enchantmentOptions.profile }}">
+    {{/if}}
     {{/if}}
 
     {{#if (ne createSummons null)}}

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -129,10 +129,6 @@
             <i class="fa-solid fa-gear" aria-hidden="true"></i>
             {{ localize "DND5E.Enchantment.Action.Configure" }}
         </a>
-        <label class="checkbox" data-tooltip="DND5E.Enchantment.Prompt.Hint">
-            <input type="checkbox" name="system.enchantment.prompt" {{ checked system.enchantment.prompt }}>
-            {{ localize "DND5E.Enchantment.Prompt.Label" }}
-        </label>
     </div>
 </div>
 


### PR DESCRIPTION
Unchecking "Enchant Prompt" is useful when there is only a single enchantment available at any given time to help players to avoid seeing the ability use dialog if no other configuration is required, but if the dialog is shown then it requires the player to click "Apply Enchantment" or else the enchantment area won't appear in chat. For a more streamlined approach it would probably be simpler to just remove that checkbox so the enchantment area is always shown in chat if there is enchantments available. In this case the ability use dialog is only necessary when there is more than one enchantment profile to select.