### PR TITLE
[#3533]Added multiple enricher type classes to dark/character.less

### DIFF
--- a/less/v2/dark/character.less
+++ b/less/v2/dark/character.less
@@ -57,7 +57,7 @@
     .mod { color: var(--dnd5e-color-blue-white); }
   }
 
-  .content-link {
+  .content-link, .roll-link a, .reference-link a, .inline-roll, .award-link {
     background: var(--dnd5e-color-dark-gray);
     border-color: var(--dnd5e-border-dark)
   }


### PR DESCRIPTION
In dark/character.less:
    Added a ids under .roll-link
    Added a ids under .reference-link
    Added .inline-roll
    Added .award-link
    To .content-link added in #3531
Closes #3533

![Multiple enrichers](https://github.com/foundryvtt/dnd5e/assets/16993142/e27ad3a1-fb87-4204-a903-84111453718f)

Tested with
@UUID[Actor.PU5J4XCoeTeIViCA]{Newer}
[[/save dex]]
[[/r 5d20]]
[[/check dexterity athletics]]
[[/tool thief dex]]
[[/damage formula=2d6 type=fire]]
[[lookup @details.type.config.label]]
&Reference[prone]
[[/award 50gp 50xp]]