### PR TITLE
[#2111, #3259] Move encumbrance calcs & add multipliers & bonuses

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -192,6 +192,7 @@ export default class CharacterData extends CreatureTemplate {
     }
 
     AttributesFields.prepareBaseArmorClass.call(this);
+    AttributesFields.prepareBaseEncumbrance.call(this);
   }
 
   /* -------------------------------------------- */
@@ -220,6 +221,7 @@ export default class CharacterData extends CreatureTemplate {
     const { originalSaves } = this.parent.getOriginalStats();
 
     this.prepareAbilities({ rollData, originalSaves });
+    AttributesFields.prepareEncumbrance.call(this, rollData);
     AttributesFields.prepareExhaustionLevel.call(this);
     AttributesFields.prepareMovement.call(this);
     AttributesFields.prepareConcentration.call(this, rollData);

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -256,6 +256,7 @@ export default class NPCData extends CreatureTemplate {
     }
 
     AttributesFields.prepareBaseArmorClass.call(this);
+    AttributesFields.prepareBaseEncumbrance.call(this);
   }
 
   /* -------------------------------------------- */
@@ -278,6 +279,7 @@ export default class NPCData extends CreatureTemplate {
     const { originalSaves } = this.parent.getOriginalStats();
 
     this.prepareAbilities({ rollData, originalSaves });
+    AttributesFields.prepareEncumbrance.call(this, rollData);
     AttributesFields.prepareExhaustionLevel.call(this);
     AttributesFields.prepareMovement.call(this);
     AttributesFields.prepareConcentration.call(this, rollData);

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -180,7 +180,7 @@ export default class AttributesFields {
     const sizeConfig = CONFIG.DND5E.actorSizes[
       keys[this.parent.flags.dnd5e?.powerfulBuild ? Math.min(index + 1, keys.length - 1) : index]
     ];
-    const mod = sizeConfig?.capacityMultiplier ?? sizeConfig?.token ?? 1;
+    const sizeMod = sizeConfig?.capacityMultiplier ?? sizeConfig?.token ?? 1;
     let maximumMultiplier;
 
     const calculateThreshold = threshold => {
@@ -191,7 +191,7 @@ export default class AttributesFields {
         * simplifyBonus(encumbrance.multipliers.overall, rollData);
       if ( threshold === "maximum" ) maximumMultiplier = multiplier;
       if ( this.parent.type === "vehicle" ) base = this.attributes.capacity.cargo;
-      else multiplier *= (config.threshold[threshold]?.[unitSystem] ?? 1) * mod;
+      else multiplier *= (config.threshold[threshold]?.[unitSystem] ?? 1) * sizeMod;
       return (base * multiplier).toNearest(0.1) + bonus;
     };
 
@@ -203,7 +203,7 @@ export default class AttributesFields {
       maximum: calculateThreshold("maximum")
     };
     encumbrance.max = encumbrance.thresholds.maximum;
-    encumbrance.mod = (mod * maximumMultiplier).toNearest(0.1);
+    encumbrance.mod = (sizeMod * maximumMultiplier).toNearest(0.1);
     encumbrance.stops = {
       encumbered: Math.clamp((encumbrance.thresholds.encumbered * 100) / encumbrance.max, 0, 100),
       heavilyEncumbered: Math.clamp((encumbrance.thresholds.heavilyEncumbered * 100) / encumbrance.max, 0, 100)

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -119,13 +119,17 @@ export default class AttributesFields {
   /* -------------------------------------------- */
 
   /**
-   * Adjust exhaustion level based on Active Effects.
-   * @this {CharacterData|NPCData}
+   * Initialize base encumbrance fields to be targeted by active effects.
+   * @this {CharacterData|NPCData|VehicleData}
    */
-  static prepareExhaustionLevel() {
-    const exhaustion = this.parent.effects.get(ActiveEffect5e.ID.EXHAUSTION);
-    const level = exhaustion?.getFlag("dnd5e", "exhaustionLevel");
-    this.attributes.exhaustion = Number.isFinite(level) ? level : 0;
+  static prepareBaseEncumbrance() {
+    const encumbrance = this.attributes.encumbrance ??= {};
+    encumbrance.multipliers = {
+      encumbered: "1", heavilyEncumbered: "1", maximum: "1", overall: "1"
+    };
+    encumbrance.bonuses = {
+      encumbered: "", heavilyEncumbered: "", maximum: "", overall: ""
+    };
   }
 
   /* -------------------------------------------- */
@@ -141,6 +145,83 @@ export default class AttributesFields {
     const ability = this.abilities?.[abilityId] || {};
     const bonus = simplifyBonus(concentration.bonuses.save, rollData);
     concentration.save = (ability.save ?? 0) + bonus;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Calculate encumbrance details for an Actor.
+   * @this {CharacterData|NPCData|VehicleData}
+   * @param {object} rollData  The Actor's roll data.
+   */
+  static prepareEncumbrance(rollData) {
+    const config = CONFIG.DND5E.encumbrance;
+    const encumbrance = this.attributes.encumbrance ??= {};
+    const baseUnits = CONFIG.DND5E.encumbrance.baseUnits[this.parent.type]
+      ?? CONFIG.DND5E.encumbrance.baseUnits.default;
+    const unitSystem = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
+
+    // Get the total weight from items
+    let weight = this.parent.items
+      .filter(item => !item.container)
+      .reduce((weight, item) => weight + (item.system.totalWeightIn?.(baseUnits[unitSystem]) ?? 0), 0);
+
+    // [Optional] add Currency Weight (for non-transformed actors)
+    const currency = this.currency;
+    if ( game.settings.get("dnd5e", "currencyWeight") && currency ) {
+      const numCoins = Object.values(currency).reduce((val, denom) => val + Math.max(denom, 0), 0);
+      const currencyPerWeight = config.currencyPerWeight[unitSystem];
+      weight += numCoins / currencyPerWeight;
+    }
+
+    // Determine the Encumbrance size class
+    const keys = Object.keys(CONFIG.DND5E.actorSizes);
+    const index = keys.findIndex(k => k === this.traits.size);
+    const sizeConfig = CONFIG.DND5E.actorSizes[
+      keys[this.parent.flags.dnd5e?.powerfulBuild ? Math.min(index + 1, keys.length - 1) : index]
+    ];
+    const mod = sizeConfig?.capacityMultiplier ?? sizeConfig?.token ?? 1;
+    let maximumMultiplier;
+
+    const calculateThreshold = threshold => {
+      let base = this.abilities.str?.value ?? 10;
+      const bonus = simplifyBonus(encumbrance.bonuses?.[threshold], rollData)
+        + simplifyBonus(encumbrance.bonuses?.overall, rollData);
+      let multiplier = simplifyBonus(encumbrance.multipliers[threshold], rollData)
+        * simplifyBonus(encumbrance.multipliers.overall, rollData);
+      if ( threshold === "maximum" ) maximumMultiplier = multiplier;
+      if ( this.parent.type === "vehicle" ) base = this.attributes.capacity.cargo;
+      else multiplier *= (config.threshold[threshold]?.[unitSystem] ?? 1) * mod;
+      return (base * multiplier).toNearest(0.1) + bonus;
+    };
+
+    // Populate final Encumbrance values
+    encumbrance.value = weight.toNearest(0.1);
+    encumbrance.thresholds = {
+      encumbered: calculateThreshold("encumbered"),
+      heavilyEncumbered: calculateThreshold("heavilyEncumbered"),
+      maximum: calculateThreshold("maximum")
+    };
+    encumbrance.max = encumbrance.thresholds.maximum;
+    encumbrance.mod = (mod * maximumMultiplier).toNearest(0.1);
+    encumbrance.stops = {
+      encumbered: Math.clamp((encumbrance.thresholds.encumbered * 100) / encumbrance.max, 0, 100),
+      heavilyEncumbered: Math.clamp((encumbrance.thresholds.heavilyEncumbered * 100) / encumbrance.max, 0, 100)
+    };
+    encumbrance.pct = Math.clamp((encumbrance.value * 100) / encumbrance.max, 0, 100);
+    encumbrance.encumbered = encumbrance.value > encumbrance.heavilyEncumbered;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Adjust exhaustion level based on Active Effects.
+   * @this {CharacterData|NPCData}
+   */
+  static prepareExhaustionLevel() {
+    const exhaustion = this.parent.effects.get(ActiveEffect5e.ID.EXHAUSTION);
+    const level = exhaustion?.getFlag("dnd5e", "exhaustionLevel");
+    this.attributes.exhaustion = Number.isFinite(level) ? level : 0;
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -150,6 +150,7 @@ export default class VehicleData extends CommonTemplate {
   prepareBaseData() {
     this.attributes.prof = 0;
     AttributesFields.prepareBaseArmorClass.call(this);
+    AttributesFields.prepareBaseEncumbrance.call(this);
   }
 
   /* -------------------------------------------- */
@@ -160,6 +161,7 @@ export default class VehicleData extends CommonTemplate {
     const { originalSaves } = this.parent.getOriginalStats();
 
     this.prepareAbilities({ rollData, originalSaves });
+    AttributesFields.prepareEncumbrance.call(this, rollData);
     AttributesFields.prepareHitPoints.call(this, this.attributes.hp);
   }
 }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -21,7 +21,17 @@ export default class ActiveEffect5e extends ActiveEffect {
    * Additional key paths to properties added during base data preparation that should be treated as formula fields.
    * @type {Set<string>}
    */
-  static FORMULA_FIELDS = new Set(["system.attributes.ac.bonus"]);
+  static FORMULA_FIELDS = new Set([
+    "system.attributes.ac.bonus",
+    "system.attributes.encumbrance.bonuses.encumbered",
+    "system.attributes.encumbrance.bonuses.heavilyEncumbered",
+    "system.attributes.encumbrance.bonuses.maximum",
+    "system.attributes.encumbrance.bonuses.overall",
+    "system.attributes.encumbrance.multipliers.encumbered",
+    "system.attributes.encumbrance.multipliers.heavilyEncumbered",
+    "system.attributes.encumbrance.multipliers.maximum",
+    "system.attributes.encumbrance.multipliers.overall"
+  ]);
 
   /* -------------------------------------------- */
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -195,7 +195,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     this._prepareSkills(rollData, globalBonuses, checkBonus, originalSkills);
     this._prepareTools(rollData, globalBonuses, checkBonus);
     this._prepareArmorClass();
-    this._prepareEncumbrance();
     this._prepareInitiative(rollData, checkBonus);
     this._prepareSpellcasting();
   }
@@ -503,62 +502,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     // Compute total AC and return
     ac.bonus = simplifyBonus(ac.bonus, rollData);
     ac.value = ac.base + ac.shield + ac.bonus + ac.cover;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Prepare the level and percentage of encumbrance for an Actor.
-   * Optionally include the weight of carried currency by applying the standard rule from the PHB pg. 143.
-   * Mutates the value of the `system.attributes.encumbrance` object.
-   * @protected
-   */
-  _prepareEncumbrance() {
-    const config = CONFIG.DND5E.encumbrance;
-    const encumbrance = this.system.attributes.encumbrance ??= {};
-    const baseUnits = CONFIG.DND5E.encumbrance.baseUnits[this.type] ?? CONFIG.DND5E.encumbrance.baseUnits.default;
-    const unitSystem = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
-
-    // Get the total weight from items
-    let weight = this.items
-      .filter(item => !item.container)
-      .reduce((weight, item) => weight + (item.system.totalWeightIn?.(baseUnits[unitSystem]) ?? 0), 0);
-
-    // [Optional] add Currency Weight (for non-transformed actors)
-    const currency = this.system.currency;
-    if ( game.settings.get("dnd5e", "currencyWeight") && currency ) {
-      const numCoins = Object.values(currency).reduce((val, denom) => val + Math.max(denom, 0), 0);
-      const currencyPerWeight = config.currencyPerWeight[unitSystem];
-      weight += numCoins / currencyPerWeight;
-    }
-
-    // Determine the Encumbrance size class
-    const keys = Object.keys(CONFIG.DND5E.actorSizes);
-    const index = keys.findIndex(k => k === this.system.traits.size);
-    const sizeConfig = CONFIG.DND5E.actorSizes[
-      keys[this.flags.dnd5e?.powerfulBuild ? Math.min(index + 1, keys.length - 1) : index]
-    ];
-    const mod = sizeConfig?.capacityMultiplier ?? sizeConfig?.token ?? 1;
-
-    const calculateThreshold = multiplier => this.type === "vehicle"
-      ? this.system.attributes.capacity.cargo
-      : ((this.system.abilities.str?.value ?? 10) * multiplier * mod).toNearest(0.1);
-
-    // Populate final Encumbrance values
-    encumbrance.mod = mod;
-    encumbrance.value = weight.toNearest(0.1);
-    encumbrance.thresholds = {
-      encumbered: calculateThreshold(config.threshold.encumbered[unitSystem]),
-      heavilyEncumbered: calculateThreshold(config.threshold.heavilyEncumbered[unitSystem]),
-      maximum: calculateThreshold(config.threshold.maximum[unitSystem])
-    };
-    encumbrance.max = encumbrance.thresholds.maximum;
-    encumbrance.stops = {
-      encumbered: Math.clamp((encumbrance.thresholds.encumbered * 100) / encumbrance.max, 0, 100),
-      heavilyEncumbered: Math.clamp((encumbrance.thresholds.heavilyEncumbered * 100) / encumbrance.max, 0, 100)
-    };
-    encumbrance.pct = Math.clamp((encumbrance.value * 100) / encumbrance.max, 0, 100);
-    encumbrance.encumbered = encumbrance.value > encumbrance.heavilyEncumbered;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Moves the encumbrance calculation logic into `AttributesFields` to be called by individual data models.

Also adds bonuses and multiplier fields that can be used to modify encumbrance in a more fine-grained level using active effects. There are formulas targeting the three encumbrance thresholds and one that applies to all three thresholds.

Closes #3259