### PR TITLE
[#3544] Add summoned creature list of item details tab

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1577,7 +1577,8 @@
     "Configure": "Configure Summons",
     "Place": "Place Summons",
     "Remove": "Remove Profile",
-    "Summon": "Summon"
+    "Summon": "Summon",
+    "View": "View Summon"
   },
   "Bonuses": {
     "ArmorClass": {

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -546,6 +546,7 @@ export default class ItemSheet5e extends ItemSheet {
         if ( override === "damage-control" ) html[0].querySelectorAll(".damage-control").forEach(e => e.remove());
       }
     }
+    html[0].querySelectorAll('[data-action="view"]').forEach(e => e.addEventListener("click", this._onView.bind(this)));
 
     // Advancement context menu
     const contextOptions = this._getAdvancementContextMenuOptions();
@@ -678,10 +679,20 @@ export default class ItemSheet5e extends ItemSheet {
         await enchantment.delete();
         this.render();
         break;
-      case "viewItem":
-        enchantment.parent.sheet.render(true);
-        break;
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle actions on a view sheet button.
+   * @param {PointerEvent} event  Triggering click event.
+   * @private
+   */
+  async _onView(event) {
+    event.preventDefault();
+    const doc = await fromUuid(event.currentTarget.dataset.uuid);
+    doc?.sheet.render(true);
   }
 
   /* -------------------------------------------- */

--- a/templates/items/parts/item-action.hbs
+++ b/templates/items/parts/item-action.hbs
@@ -145,7 +145,7 @@
                 </span>
                 <div class="list-controls flexrow">
                     {{#if item.isOwner}}
-                    <button type="button" class="enchantment-button unbutton" data-action="viewItem"
+                    <button type="button" class="unbutton" data-action="view" data-uuid="{{ item.uuid }}"
                             data-tooltip="DND5E.ItemView" aria-label="{{ localize 'DND5E.ItemView' }}">
                         <i class="fa-solid fa-eye" aria-hidden="true"></i>
                     </button>
@@ -178,6 +178,27 @@
             {{ localize "DND5E.Summoning.Prompt.Label" }}
         </label>
     </div>
+    {{#with system.summons.summonedCreatures as |summonedCreatures|}}
+    {{#if summonedCreatures.length}}
+    <ul class="separated-list dnd5e2">
+        {{#each summonedCreatures}}
+        <li class="item" data-summon-uuid="{{ uuid }}">
+            <div class="details flexrow">
+                <img class="gold-icon" src="{{ img }}" alt="{{ name }}">
+                <span class="name">{{ name }}</span>
+                <div class="list-controls flexrow">
+                    <button type="button" class="unbutton" data-action="view" data-uuid="{{ uuid }}"
+                            data-tooltip="DND5E.Summoning.Action.View"
+                            aria-label="{{ localize 'DND5E.Summoning.Action.View' }}">
+                        <i class="fa-solid fa-eye" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </div>
+        </li>
+        {{/each}}
+    </ul>
+    {{/if}}
+    {{/with}}
 </div>
 {{/if}}
 


### PR DESCRIPTION
Displays a list of creatures summoned by an item on its details tab similar to how enchantments are displayed. Currently the only control is to view the actor because un-summoning is yet to be implemented.

<img width="579" alt="Summoned Creatures List" src="https://github.com/foundryvtt/dnd5e/assets/19979839/2526767c-52ad-4821-9d20-69c3da1ed73b">
