### PR TITLE
[#3563] Add support for config-added transformation presets

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -841,6 +841,31 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
       return settings;
     };
 
+    const buttons = foundry.utils.mergeObject({
+      accept: {
+        icon: '<i class="fas fa-check"></i>',
+        label: game.i18n.localize("DND5E.PolymorphAcceptSettings"),
+        callback: html => this.actor.transformInto(sourceActor, rememberOptions(html))
+      },
+      ...Object.fromEntries(
+        Object.entries(CONFIG.DND5E.transformationPresets)
+          .sort((a, b) => a[1].order - b[1].order)
+          .map(([k, v]) => [k, {
+            icon: v.icon,
+            label: v.label,
+            callback: html => this.actor.transformInto(sourceActor, foundry.utils.mergeObject(
+              v.options,
+              { transformTokens: rememberOptions(html).transformTokens }
+            ))
+          }])
+      )
+    }, {
+      cancel: {
+        icon: '<i class="fas fa-times"></i>',
+        label: game.i18n.localize("Cancel")
+      }
+    });
+
     // Create and render the Dialog
     return new Dialog({
       title: game.i18n.localize("DND5E.PolymorphPromptTitle"),
@@ -851,41 +876,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
         isToken: this.actor.isToken
       },
       default: "accept",
-      buttons: {
-        accept: {
-          icon: '<i class="fas fa-check"></i>',
-          label: game.i18n.localize("DND5E.PolymorphAcceptSettings"),
-          callback: html => this.actor.transformInto(sourceActor, rememberOptions(html))
-        },
-        wildshape: {
-          icon: CONFIG.DND5E.transformationPresets.wildshape.icon,
-          label: CONFIG.DND5E.transformationPresets.wildshape.label,
-          callback: html => this.actor.transformInto(sourceActor, foundry.utils.mergeObject(
-            CONFIG.DND5E.transformationPresets.wildshape.options,
-            { transformTokens: rememberOptions(html).transformTokens }
-          ))
-        },
-        polymorph: {
-          icon: CONFIG.DND5E.transformationPresets.polymorph.icon,
-          label: CONFIG.DND5E.transformationPresets.polymorph.label,
-          callback: html => this.actor.transformInto(sourceActor, foundry.utils.mergeObject(
-            CONFIG.DND5E.transformationPresets.polymorph.options,
-            { transformTokens: rememberOptions(html).transformTokens }
-          ))
-        },
-        self: {
-          icon: CONFIG.DND5E.transformationPresets.polymorphSelf.icon,
-          label: CONFIG.DND5E.transformationPresets.polymorphSelf.label,
-          callback: html => this.actor.transformInto(sourceActor, foundry.utils.mergeObject(
-            CONFIG.DND5E.transformationPresets.polymorphSelf.options,
-            { transformTokens: rememberOptions(html).transformTokens }
-          ))
-        },
-        cancel: {
-          icon: '<i class="fas fa-times"></i>',
-          label: game.i18n.localize("Cancel")
-        }
-      }
+      buttons
     }, {
       classes: ["dialog", "dnd5e", "polymorph"],
       width: 900,

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2438,6 +2438,7 @@ preLocalize("polymorphEffectSettings", { sort: true });
  */
 DND5E.transformationPresets = {
   wildshape: {
+    order: 0.1,
     icon: '<i class="fas fa-paw"></i>',
     label: "DND5E.PolymorphWildShape",
     options: {
@@ -2450,6 +2451,7 @@ DND5E.transformationPresets = {
     }
   },
   polymorph: {
+    order: 0.2,
     icon: '<i class="fas fa-pastafarianism"></i>',
     label: "DND5E.Polymorph",
     options: {
@@ -2460,6 +2462,7 @@ DND5E.transformationPresets = {
     }
   },
   polymorphSelf: {
+    order: 0.3,
     icon: '<i class="fas fa-eye"></i>',
     label: "DND5E.PolymorphSelf",
     options: {


### PR DESCRIPTION
Adds support for additional transformation presets through the config.

An `order` property was added to each preset item in the config to preserve the existing order.