### PR TITLE
[#3305] Add ability for enchantments to add rider items

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -749,8 +749,14 @@
     "Entry": "{item} on  <em>{actor}</em>"
   },
   "Riders": {
-    "Label": "Additional Effects",
-    "Hint": "These additional effects will be added to the enchanted item when this enchantment is added, and removed when the enchantment is removed."
+    "Effect": {
+      "Label": "Additional Effects",
+      "Hint": "These additional effects will be added to the enchanted item when this enchantment is added, and removed when the enchantment is removed."
+    },
+    "Item": {
+      "Label": "Additional Items",
+      "Hint": "These additional items will be added to the actor when an item is enchanted and removed when it loses its enchantment."
+    }
   },
   "Warning": {
     "ConcentrationEnded": "Cannot apply this enchantment because concentration has ended.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -755,7 +755,7 @@
     },
     "Item": {
       "Label": "Additional Items",
-      "Hint": "These additional items will be added to the actor when an item is enchanted and removed when it loses its enchantment."
+      "Hint": "These additional items will be added to the creature when one of its items is enchanted, and will be removed if the enchantment is ever removed."
     }
   },
   "Warning": {

--- a/less/elements.less
+++ b/less/elements.less
@@ -192,3 +192,12 @@ item-list-controls search {
   flex-wrap: wrap;
   .tag { cursor: pointer; }
 }
+
+/* ---------------------------------- */
+/*  Document Tags                     */
+/* ---------------------------------- */
+
+document-tags:has(> .content-link) {
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -473,8 +473,6 @@
 
   button {
     background: var(--dnd5e-background-card);
-    font-family: var(--dnd5e-font-roboto);
-    font-weight: bold;
     font-size: var(--font-size-13);
     text-transform: uppercase;
     padding: 3px;
@@ -485,6 +483,10 @@
     justify-content: center;
     gap: .25rem;
 
+    &:not(.fas, .far, .fa-solid, .fa-regular, .fa-light, .fa-duotone, .fa-thin) {
+      font-family: var(--dnd5e-font-roboto);
+      font-weight: bold;
+    }
     &:disabled {
       cursor: default;
       color: var(--color-text-dark-inactive);

--- a/module/applications/item/enchantment-config.mjs
+++ b/module/applications/item/enchantment-config.mjs
@@ -65,9 +65,10 @@ export default class EnchantmentConfig extends DocumentSheet {
       name: effect.name,
       flags: effect.flags,
       collapsed: this.expandedEnchantments.get(effect.id) ? "" : "collapsed",
-      riders: effects.map(({ id, name }) => ({
-        id, name, selected: effect.flags.dnd5e?.enchantment?.riders?.includes(id) ? "selected" : ""
-      }))
+      riderEffects: effects.map(({ id, name }) => ({
+        id, name, selected: effect.flags.dnd5e?.enchantment?.riders?.effect?.includes(id) ? "selected" : ""
+      })),
+      riderItems: effect.flags.dnd5e?.enchantment?.riders?.item?.join(",") ?? ""
     }));
 
     return context;
@@ -115,11 +116,11 @@ export default class EnchantmentConfig extends DocumentSheet {
     const effectsChanges = Object.entries(effects ?? {}).map(([_id, changes]) => {
       const updates = { _id, ...changes };
       // Fix bug with <multi-select> in V11
-      if ( !foundry.utils.hasProperty(updates, "flags.dnd5e.enchantment.riders") ) {
-        foundry.utils.setProperty(updates, "flags.dnd5e.enchantment.riders", []);
+      if ( !foundry.utils.hasProperty(updates, "flags.dnd5e.enchantment.riders.effect") ) {
+        foundry.utils.setProperty(updates, "flags.dnd5e.enchantment.riders.effect", []);
       }
       // End bug fix
-      riderIds.add(...(foundry.utils.getProperty(updates, "flags.dnd5e.enchantment.riders") ?? []));
+      riderIds.add(...(foundry.utils.getProperty(updates, "flags.dnd5e.enchantment.riders.effect") ?? []));
       return updates;
     });
     for ( const effect of this.document.effects ) {

--- a/module/data/item/fields/enchantment-field.mjs
+++ b/module/data/item/fields/enchantment-field.mjs
@@ -16,6 +16,18 @@ export default class EnchantmentField extends EmbeddedDataField {
 }
 
 /**
+ * Data stored in "enchantment" flag on enchantment active effects.
+ *
+ * @typedef {object} EnchantmentProfile
+ * @property {object} level
+ * @property {number} level.min        Minimum level at which this profile can be used.
+ * @property {number} level.max        Maximum level at which this profile can be used.
+ * @property {object} riders
+ * @property {string[]} riders.effect  IDs of other effects on this item that will be added with this enchantment.
+ * @property {string[]} riders.item    UUIDs of items that will be added with this enchantment.
+ */
+
+/**
  * Data model for enchantment configuration.
  *
  * @property {string} classIdentifier             Class identifier that will be used to determine applicable level.

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -216,6 +216,7 @@ export function indexFromUuid(uuid) {
  */
 export function linkForUuid(uuid, { tooltip }={}) {
   let doc = fromUuidSync(uuid);
+  if ( !doc ) return "";
   if ( uuid.startsWith("Compendium.") && !(doc instanceof foundry.abstract.Document) ) {
     const {collection} = foundry.utils.parseUuid(uuid);
     const cls = collection.documentClass;

--- a/templates/apps/enchantment-config.hbs
+++ b/templates/apps/enchantment-config.hbs
@@ -46,13 +46,21 @@
                             <p class="hint">{{ localize "DND5E.Enchantment.Level.Hint" }}</p>
                         </div>
                         <div class="form-group">
-                            <label>{{ localize "DND5E.Enchantment.Riders.Label" }}</label>
-                            <multi-select name="effects.{{ id }}.flags.dnd5e.enchantment.riders">
-                                {{#each riders}}
+                            <label>{{ localize "DND5E.Enchantment.Riders.Effect.Label" }}</label>
+                            <multi-select name="effects.{{ id }}.flags.dnd5e.enchantment.riders.effect">
+                                {{#each riderEffects}}
                                 <option value="{{ id }}" {{ selected }}>{{ name }}</option>
                                 {{/each}}
                             </multi-select>
-                            <p class="hint">{{ localize "DND5E.Enchantment.Riders.Hint" }}</p>
+                            <p class="hint">{{ localize "DND5E.Enchantment.Riders.Effect.Hint" }}</p>
+                        </div>
+                        <div class="form-group">
+                            <label>{{ localize "DND5E.Enchantment.Riders.Item.Label" }}</label>
+                            <document-tags name="effects.{{ id }}.flags.dnd5e.enchantment.riders.item" type="Item"
+                                value="{{ riderItems }}">
+                                {{~#each flags.dnd5e.enchantment.riders.item}}{{{ dnd5e-linkForUuid this }}}{{/each~}}
+                            </document-tags>
+                            <p class="hint">{{ localize "DND5E.Enchantment.Riders.Item.Hint" }}</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Adds rider items referenced by UUID that are added to a parent actor when one of their items is enchanted and removed when it is disenchanted.

Includes a backported version of `<document-tags>` from V12 as the interface for this to avoid having to implement something new.