### PR TITLE
[#3565] Move Award button to group actor control bar

### DIFF
--- a/templates/actors/group-sheet.hbs
+++ b/templates/actors/group-sheet.hbs
@@ -46,11 +46,6 @@
                         {{ numberInput xp.value name="system.details.xp.value" min=0 step=1
                            placeholder=(dnd5e-numberFormat xp.derived) }}
                     </div>
-                    <footer class="attribute-footer">
-                        <a class="action-button" data-action="award">
-                            <i class="fa-solid fa-trophy"></i> {{localize "DND5E.Award.Action"}}
-                        </a>
-                    </footer>
                 </li>
                 {{/if}}
             </ul>

--- a/templates/actors/tabs/group-members.hbs
+++ b/templates/actors/tabs/group-members.hbs
@@ -1,6 +1,11 @@
 {{#if isGM}}
 <menu class="member-controls flexrow">
     <li>
+        <button type="button" class="action-button" data-action="award">
+            <i class="fa-solid fa-trophy" inert></i> {{ localize "DND5E.Award.Action" }}
+        </button>
+    </li>
+    <li>
         <button type="button" class="action-button" data-action="placeMembers">
             <i class="fa-solid fa-location-dot" inert></i> {{localize "DND5E.Group.PlaceMembers"}}
         </button>


### PR DESCRIPTION
Makes the award button available even when XP tracking is disabled.

<img width="631" alt="Screenshot 2024-05-15 at 09 40 34" src="https://github.com/foundryvtt/dnd5e/assets/19979839/6a53a591-06f2-4829-86e5-619518b72d73">
