### PR TITLE
[#3444] Re-implement summoned item modifications using enchantments

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -41,7 +41,6 @@ export default class ActiveEffect5e extends ActiveEffect {
    */
   get isAppliedEnchantment() {
     return (this.getFlag("dnd5e", "type") === "enchantment")
-      && (this.parent.system.metadata?.enchantable === true)
       && !!this.origin && (this.origin !== this.parent.uuid);
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -423,10 +423,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   applyActiveEffects() {
     const overrides = {};
-    if ( !this.system?.metadata?.enchantable ) {
-      this.overrides = overrides;
-      return;
-    }
 
     // Organize non-disabled effects by their application priority
     const changes = [];


### PR DESCRIPTION
Rather than changing items on summoned actors directly, this now uses an enchantment with a fixed ID for those changes to ensure that it can be properly updated on re-summoning linked actors.

In order to get this to work on all actor types this removes the restriction on applying enchantments. Enchantments can still only be added manually to item types marked `enchantable`, but any enchantments created programatically on those items can be properly applied.

Closes #3444