### PR TITLE
[#3461] Added Overridden _onClickRight in token.mjs

### DIFF
--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -167,4 +167,11 @@ export default class Token5e extends Token {
     }
     return super._configureFilterEffect(statusId, active);
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onClickRight(event) {
+    return (canvas?.app?.view?.oncontextmenu) ? canvas.app.view.oncontextmenu(event) : super._onClickRight(event);
+  }
 }


### PR DESCRIPTION
There was an issue where during token placement if the user right clicked we expect the token placement to end, however since the token preview is under the cursor most of the time during placement we were activating the _onClickRight for the token which then does not activate the canvas.app.view.oncontextmenu. This was fix by overriding the Token5e _onClickRight so that if the canvas.app.view.oncontextmenu event is defined, it will call that event otherwise it will call the normal _onClickRight for Token which activates the hud.
Closes #3461