### PR TITLE
[#3592] Add active effects for min/max skill check rolls

### DIFF
--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -40,6 +40,10 @@ const { Die, NumericTerm, OperatorTerm } = foundry.dice.terms;
  * @param {number} [options.fumble]              The value of d20 result which represents a critical failure
  * @param {(number)} [options.targetValue]       Assign a target value against which the result of this roll should be
  *                                               compared
+ *
+ * @param {number} [options.minimumRoll]         The lowest allowed result of a roll
+ * @param {number} [options.maximumRoll]         The highest allowed result of a roll
+ *
  * @param {boolean} [options.elvenAccuracy=false]      Allow Elven Accuracy to modify this roll?
  * @param {boolean} [options.halflingLucky=false]      Allow Halfling Luck to modify this roll?
  * @param {boolean} [options.reliableTalent=false]     Allow Reliable Talent to modify this roll?
@@ -175,7 +179,10 @@ export default class D20Roll extends Roll {
     if ( this.options.halflingLucky ) d20.modifiers.push("r1=1");
 
     // Reliable Talent
-    if ( this.options.reliableTalent ) d20.modifiers.push("min10");
+    if ( this.options.reliableTalent && !this.options.minimumRoll ) d20.modifiers.push("min10");
+
+    if ( this.options.minimumRoll ) d20.modifiers.push(`min${this.options.minimumRoll}`);
+    if ( this.options.maximumRoll ) d20.modifiers.push(`max${this.options.maximumRoll}`);
 
     // Handle Advantage or Disadvantage
     if ( this.hasAdvantage ) {

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -23,6 +23,9 @@ const { NumericTerm, OperatorTerm } = foundry.dice.terms;
  * @property {number} [targetValue]    The value of the d20 result which should represent a successful roll.
  * @property {string} [mastery]        Weapon mastery to use with an attack roll.
  *
+ * @property {number} [minimumRoll]    The minimum possible result of the d20.
+ * @property {number} [maximumRoll]    The maximum possible result of the d20.
+ *
  * ## Flags
  * @property {boolean} [elvenAccuracy]   Allow Elven Accuracy to modify this roll?
  * @property {boolean} [halflingLucky]   Allow Halfling Luck to modify this roll?
@@ -57,6 +60,7 @@ const { NumericTerm, OperatorTerm } = foundry.dice.terms;
 export async function d20Roll({
   parts=[], data={}, event,
   advantage, disadvantage, critical=20, fumble=1, targetValue, mastery,
+  minimumRoll, maximumRoll,
   elvenAccuracy, halflingLucky, reliableTalent,
   fastForward, ammunitionOptions, attackModes, chooseModifier=false, masteryOptions, template, title, dialogOptions,
   chatMessage=true, messageData={}, rollMode, flavor
@@ -83,6 +87,8 @@ export async function d20Roll({
     fumble,
     targetValue,
     mastery,
+    minimumRoll,
+    maximumRoll,
     elvenAccuracy,
     halflingLucky,
     reliableTalent

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1372,12 +1372,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     // Reliable Talent applies to any skill check we have full or better proficiency in
     const reliableTalent = (skl.value >= 1 && this.getFlag("dnd5e", "reliableTalent"));
 
+    const minimumRoll = reliableTalent ? Math.max(skl.check.minimum ?? 1, 10) : skl.check.minimum;
+    const maximumRoll = skl.check.maximum;
+
     // Roll and return
     const flavor = game.i18n.format("DND5E.SkillPromptTitle", {skill: CONFIG.DND5E.skills[skillId]?.label ?? ""});
     const rollData = foundry.utils.mergeObject({
       data: data,
       title: `${flavor}: ${this.name}`,
       flavor,
+      minimumRoll,
+      maximumRoll,
       chooseModifier: true,
       halflingLucky: this.getFlag("dnd5e", "halflingLucky"),
       reliableTalent,

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1372,8 +1372,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     // Reliable Talent applies to any skill check we have full or better proficiency in
     const reliableTalent = (skl.value >= 1 && this.getFlag("dnd5e", "reliableTalent"));
 
-    const minimumRoll = reliableTalent ? Math.max(skl.check.minimum ?? 1, 10) : skl.check.minimum;
-    const maximumRoll = skl.check.maximum;
+    const minimumRoll = reliableTalent ? Math.max(skl.roll.min ?? 1, 10) : skl.roll.min;
+    const maximumRoll = skl.roll.max;
 
     // Roll and return
     const flavor = game.i18n.format("DND5E.SkillPromptTitle", {skill: CONFIG.DND5E.skills[skillId]?.label ?? ""});


### PR DESCRIPTION
Added support for two new active effects to allow for the minimum or maximum possible result on a d20 roll for skill checks. I considered replacing how Reliable Talent works with this but realised there would be cascading changes that would be out of scope.

I never included it in the issue, however, the intention behind this is to support many homebrew features that set the minimum possible roll of specific skill checks, regardless of proficiency. While maximum was never included by anything I've seen, it was a simple addition and I can't see how it would be a negative to add.

Attribute Key | Change Mode | Effect Value
-|-|-
`system.skills.[abbreviation].check.minimum` | Upgrade | `[number]`
`system.skills.[abbreviation].check.maximum` | Downgrade | `[number]`