### PR TITLE
[#3591] Modified await in enrichers.mjs

### DIFF
--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -370,7 +370,7 @@ async function enrichDamage(config, label, options) {
     if ( config.average === true ) {
       const minRoll = Roll.create(config.formula).evaluate({ minimize: true, async: true });
       const maxRoll = Roll.create(config.formula).evaluate({ maximize: true, async: true });
-      localizationData.average = Math.floor((await minRoll.total + await maxRoll.total) / 2);
+      localizationData.average = Math.floor(((await minRoll).total + (await maxRoll).total) / 2);
     } else if ( Number.isNumeric(config.average) ) {
       localizationData.average = config.average;
     }


### PR DESCRIPTION
There was an issue where in V12 a promise was being passed back for an async min and max roll. We then tried to await the result using await minroll.total causing us to try to get the total from a promise object and await the total, giving a undefined result (then a NAN from math operations). This was not happening in V11 as when the roll option minimize or maximize was passed, async was set to false and the roll was synchronous. This was fixed by adding parentheses around (await minRoll) and then accessing total.
Closes #3591