### PR TITLE
[#3635] Fix unconfigurable transfer value after effect is made a rider

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -336,7 +336,6 @@ export default class ActiveEffect5e extends ActiveEffect {
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    if ( (this.getFlag("dnd5e", "type") === "enchantment") || this.getFlag("dnd5e", "rider") ) this.transfer = false;
     if ( this.id === this.constructor.ID.EXHAUSTION ) this._prepareExhaustionLevel();
     if ( this.isAppliedEnchantment ) EnchantmentData.trackEnchantment(this.origin, this.uuid);
   }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -176,6 +176,15 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  *allApplicableEffects() {
+    for ( const effect of super.allApplicableEffects() ) {
+      if ( (effect.getFlag("dnd5e", "type") !== "enchantment") && !effect.getFlag("dnd5e", "rider") ) yield effect;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   prepareDerivedData() {
     const origin = this.getFlag("dnd5e", "summon.origin");
     // TODO: Replace with parseUuid once V11 support is dropped


### PR DESCRIPTION
Filters on `allApplicableEffects` rather than overriding the transfer value.

Closes #3635 