### PR TITLE
[#3616] Fix attunement not being settable when attuned is set by enchantment

### DIFF
--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -79,7 +79,6 @@ export default class ConsumableData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.prepareDerivedEquippableData();
     if ( !this.type.value ) return;
     const config = CONFIG.DND5E.consumableTypes[this.type.value];
     if ( config ) {
@@ -94,6 +93,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareFinalData() {
     this.prepareFinalActivatedEffectData();
+    this.prepareFinalEquippableData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -85,9 +85,8 @@ export default class ContainerData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  prepareDerivedData() {
-    super.prepareDerivedData();
-    this.prepareDerivedEquippableData();
+  prepareFinalData() {
+    this.prepareFinalEquippableData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -152,7 +152,6 @@ export default class EquipmentData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.prepareDerivedEquippableData();
     this.armor.value = (this._source.armor.value ?? 0) + (this.magicAvailable ? (this.armor.magicalBonus ?? 0) : 0);
     this.type.label = CONFIG.DND5E.equipmentTypes[this.type.value]
       ?? game.i18n.localize(CONFIG.Item.typeLabels.equipment);
@@ -163,6 +162,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareFinalData() {
     this.prepareFinalActivatedEffectData();
+    this.prepareFinalEquippableData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -63,7 +63,7 @@ export default class EquippableItemTemplate extends SystemDataModel {
   /**
    * Ensure items that cannot be attuned are not marked as attuned.
    */
-  prepareDerivedEquippableData() {
+  prepareFinalEquippableData() {
     if ( !this.attunement ) this.attuned = false;
   }
 

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -80,8 +80,14 @@ export default class ToolData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.prepareDerivedEquippableData();
     this.type.label = CONFIG.DND5E.toolTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.tool);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareFinalData() {
+    this.prepareFinalEquippableData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -91,7 +91,6 @@ export default class WeaponData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.prepareDerivedEquippableData();
     this.type.label = CONFIG.DND5E.weaponTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.weapon);
   }
 
@@ -100,6 +99,7 @@ export default class WeaponData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareFinalData() {
     this.prepareFinalActivatedEffectData();
+    this.prepareFinalEquippableData();
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Had to move the preparation of equipped data to the final step to ensure it is only called once after enchantments have been applied, otherwise it would set `attuned` to `false` before the enchantment changed `attunement` to `required`.

Closes #3616 