### PR TITLE
[#3623] Fix vehicle currency weight & merge encumbrance calcs

### DIFF
--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -31,31 +31,6 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
   /*  Context Preparation                         */
   /* -------------------------------------------- */
 
-  /**
-   * Compute the total weight of the vehicle's cargo.
-   * @param {number} totalWeight    The cumulative item weight from inventory items
-   * @param {object} actorData      The data object for the Actor being rendered
-   * @returns {{max: number, value: number, pct: number}}
-   * @private
-   */
-  _computeEncumbrance(totalWeight, actorData) {
-
-    // Compute currency weight
-    const totalCoins = Object.values(actorData.system.currency).reduce((acc, denom) => acc + denom, 0);
-
-    const currencyPerWeight = game.settings.get("dnd5e", "metricWeightUnits")
-      ? CONFIG.DND5E.encumbrance.currencyPerWeight.metric
-      : CONFIG.DND5E.encumbrance.currencyPerWeight.imperial;
-    totalWeight += totalCoins / currencyPerWeight;
-
-    // Compute overall encumbrance
-    const max = actorData.system.attributes.capacity.cargo;
-    const pct = Math.clamp((totalWeight * 100) / max, 0, 100);
-    return {value: totalWeight.toNearest(0.1), max, pct};
-  }
-
-  /* -------------------------------------------- */
-
   /** @override */
   _getMovementSpeed(actorData, largestPrimary=true) {
     return super._getMovementSpeed(actorData, largestPrimary);
@@ -211,11 +186,7 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
       }
     };
 
-    const baseUnits = CONFIG.DND5E.encumbrance.baseUnits[this.actor.type] ?? CONFIG.DND5E.encumbrance.baseUnits.default;
-    const units = game.settings.get("dnd5e", "metricWeightUnits") ? baseUnits.metric : baseUnits.imperial;
-
     // Classify items owned by the vehicle and compute total cargo weight
-    let totalWeight = 0;
     for ( const item of context.items ) {
       const ctx = context.itemContext[item.id] ??= {};
       this._prepareCrewedItem(item, ctx);
@@ -223,7 +194,6 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
       // Handle cargo explicitly
       const isCargo = item.flags.dnd5e?.vehicleCargo === true;
       if ( isCargo ) {
-        totalWeight += item.system.totalWeightin?.(units) ?? 0;
         cargo.cargo.items.push(item);
         continue;
       }
@@ -243,7 +213,6 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
           else features.actions.items.push(item);
           break;
         default:
-          totalWeight += item.system.totalWeightIn?.(units) ?? 0;
           cargo.cargo.items.push(item);
       }
     }
@@ -252,7 +221,7 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
     context.inventoryFilters = false;
     context.features = Object.values(features);
     context.cargo = Object.values(cargo);
-    context.encumbrance = this._computeEncumbrance(totalWeight, context);
+    context.encumbrance = context.system.attributes.encumbrance;
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -161,7 +161,9 @@ export default class VehicleData extends CommonTemplate {
     const { originalSaves } = this.parent.getOriginalStats();
 
     this.prepareAbilities({ rollData, originalSaves });
-    AttributesFields.prepareEncumbrance.call(this, rollData);
+    AttributesFields.prepareEncumbrance.call(this, rollData, { validateItem: item =>
+      (item.flags.dnd5e?.vehicleCargo === true) || !["weapon", "equipment"].includes(item.type)
+    });
     AttributesFields.prepareHitPoints.call(this, this.attributes.hp);
   }
 }


### PR DESCRIPTION
Currency on vehicles we being treated as if it were measured in tons rather than pounds, so this adds a conversion to ensure the currently always ends up in the correct weight units.

Also removed some duplicate encumbrance calculation from vehicle sheets so there is only once set of encumbrance data for vehicles. This required passing a method into `prepareEncumbrance` that allows individual actor types to determine what items are included in the calculation.