### PR TITLE
[#3622] Fix advancement when race uses legacy string value

### DIFF
--- a/module/applications/advancement/advancement-manager.mjs
+++ b/module/applications/advancement/advancement-manager.mjs
@@ -330,7 +330,7 @@ export default class AdvancementManager extends Application {
    * @private
    */
   createLevelChangeSteps(classItem, levelDelta) {
-    const raceItem = this.clone.system?.details?.race;
+    const raceItem = this.clone.system?.details?.race instanceof Item ? this.clone.system.details.race : null;
     const pushSteps = (flows, data) => this.steps.push(...flows.map(flow => ({ flow, ...data })));
     const getItemFlows = characterLevel => this.clone.items.contents.flatMap(i => {
       if ( ["class", "subclass", "race"].includes(i.type) ) return [];


### PR DESCRIPTION
Prevents a bug with advancement when `details.race` is populated by the legacy string value rather than a race item.

Closes #3622 