### PR TITLE
[#3650, #3651] Fix references to `sourceId` in V12

### DIFF
--- a/module/applications/actor/sheet-mixin.mjs
+++ b/module/applications/actor/sheet-mixin.mjs
@@ -27,7 +27,7 @@ export default Base => class extends Base {
    * @returns {Promise<Item5e>|null}  If a duplicate was found, returns the adjusted item stack.
    */
   _onDropStackConsumables(itemData) {
-    const droppedSourceId = itemData.flags.core?.sourceId;
+    const droppedSourceId = itemData._stats?.compendiumSource ?? itemData.flags.core?.sourceId;
     if ( itemData.type !== "consumable" || !droppedSourceId ) return null;
     const similarItem = this.actor.items.find(i => {
       const sourceId = i.getFlag("core", "sourceId");

--- a/module/applications/source-config.mjs
+++ b/module/applications/source-config.mjs
@@ -32,7 +32,8 @@ export default class SourceConfig extends DocumentSheet {
     context.appId = this.id;
     context.CONFIG = CONFIG.DND5E;
     context.source = foundry.utils.getProperty(this.document, this.options.keyPath);
-    context.sourceUuid = foundry.utils.getProperty(this.document, "flags.core.sourceId");
+    context.sourceUuid = this.document._stats.compendiumSource
+      ?? foundry.utils.getProperty(this.document, "flags.core.sourceId");
     context.hasSourceId = !!(await fromUuid(context.sourceUuid));
     return context;
   }

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -385,7 +385,8 @@ export class ItemDataModel extends SystemDataModel {
   /** @inheritDoc */
   prepareBaseData() {
     if ( this.parent.isEmbedded ) {
-      const sourceId = this.parent.flags.dnd5e?.sourceId ?? this.parent.flags.core?.sourceId;
+      const sourceId = this.parent.flags.dnd5e?.sourceId ?? this.parent._stats.compendiumSource
+        ?? this.parent.flags.core?.sourceId;
       if ( sourceId ) this.parent.actor?.sourcedItems?.set(sourceId, this.parent);
     }
   }

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -305,7 +305,11 @@ export class SummonsData extends foundry.abstract.DataModel {
       });
     } else {
       // Template actor (linked) found in world, create a copy for this user's item.
-      return actor.clone({"flags.dnd5e.summonedCopy": true, "flags.core.sourceId": actor.uuid}, {save: true});
+      return actor.clone({
+        "flags.dnd5e.summonedCopy": true,
+        "flags.core.sourceId": actor.uuid,
+        "_stats.compendiumSource": actor.uuid
+      }, {save: true});
     }
   }
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -706,6 +706,7 @@ function _synchronizeActorSpells(actor, spellsMap) {
     const {preparation, uses, save} = spell.toObject().system;
     Object.assign(spellData.system, {preparation, uses});
     spellData.system.save.dc = save.dc;
+    foundry.utils.setProperty(spellData, "_stats.compendiumSource", source.uuid);
     foundry.utils.setProperty(spellData, "flags.core.sourceId", source.uuid);
 
     // Record spells to be deleted and created

--- a/utils/packs.mjs
+++ b/utils/packs.mjs
@@ -76,7 +76,10 @@ function packageCommand() {
  */
 function cleanPackEntry(data, { clearSourceId=true, ownership=0 }={}) {
   if ( data.ownership ) data.ownership = { default: ownership };
-  if ( clearSourceId ) delete data.flags?.core?.sourceId;
+  if ( clearSourceId ) {
+    delete data._stats?.compendiumSource;
+    delete data.flags?.core?.sourceId;
+  }
   delete data.flags?.importSource;
   delete data.flags?.exportSource;
   if ( data._stats?.lastModifiedBy ) data._stats.lastModifiedBy = "dnd5ebuilder0000";


### PR DESCRIPTION
V12 has a compatibility lookup when accessing `sourceId` using `getFlag`, but there is a number of places in the codebase we are getting that property directly so that compatibility shim doesn't apply.

Closes #3650 
Closes #3651