### PR TITLE
[#3607, #3608, #3610] Improve Table of Contents application

### DIFF
--- a/less/v1/journal.less
+++ b/less/v1/journal.less
@@ -70,6 +70,9 @@
 
       li {
         font-size: var(--font-size-16);
+        &.special-entry > a {
+          font-weight: bold;
+        }
       }
     }
 

--- a/module/applications/journal/table-of-contents.mjs
+++ b/module/applications/journal/table-of-contents.mjs
@@ -41,38 +41,55 @@ export default class TableOfContentsCompendium extends Compendium {
       const flags = entry.flags?.dnd5e;
       if ( !flags ) continue;
       const type = flags.type ?? "chapter";
+
       if ( type === "header" ) {
         const page = entry.pages.contents[0];
         context.header = {
-          title: page?.name,
+          title: flags.title ?? page?.name,
           content: page?.text.content
         };
-      } else if ( type === "special" ) {
-        specialEntries.push({
-          type,
-          ...entry.toObject(),
-          showPages: flags.showPages,
+        continue;
+      }
+
+      const data = {
+        type,
+        id: entry.id,
+        name: flags.title ?? entry.name,
+        pages: Array.from(entry.pages).map(({ flags, id, name, sort }) => ({
+          name: flags.dnd5e?.title ?? name,
+          id,
+          entryId: entry.id,
+          sort,
           flags
-        });
+        })),
+        flags
+      };
+
+      if ( type === "special" ) {
+        data.showPages = flags.showPages ?? !flags.append;
+        specialEntries.push(data);
       } else {
-        context.chapters.push({
-          type,
-          ...entry.toObject(),
-          order: (this.constructor.TYPES[type] ?? 200) + (flags.position ?? 0),
-          showPages: (flags.showPages !== false) && ((flags.showPages === true)
-            || ((entry.pages.size > 1) && (type === "chapter"))),
-          flags
-        });
+        data.order = (this.constructor.TYPES[type] ?? 200) + (flags.position ?? 0);
+        data.showPages = (flags.showPages !== false) && ((flags.showPages === true) || (type === "chapter"));
+        context.chapters.push(data);
       }
     }
-    context.chapters.sort((lhs, rhs) => lhs.order - rhs.order);
 
+    context.chapters.sort((lhs, rhs) => lhs.order - rhs.order);
     for ( const entry of specialEntries ) {
       const append = entry.flags.append;
+      const order = entry.flags.order;
       if ( append ) {
-        context.chapters[append - 1].pages.push({_id: entry._id, name: entry.name, entry: true});
+        context.chapters[append - 1].pages.push({ ...entry, sort: order, entry: true });
       } else {
         context.chapters.push(entry);
+      }
+    }
+
+    for ( const chapter of context.chapters ) {
+      chapter.pages.sort((lhs, rhs) => lhs.sort - rhs.sort);
+      for ( const page of chapter.pages ) {
+        if ( page.pages ) page.pages.sort((lhs, rhs) => lhs.sort - rhs.sort);
       }
     }
 

--- a/templates/journal/table-of-contents.hbs
+++ b/templates/journal/table-of-contents.hbs
@@ -1,36 +1,36 @@
+{{#*inline "pages"}}
+<ul class="pages">
+    {{#each pages}}
+    {{#unless flags.dnd5e.tocHidden}}
+    <li class="{{#if (and showPages pages.length)}}child-pages{{/if}} {{#if entry}}special-entry{{/if}}">
+        <a class="journal-entry-page-link"
+           {{~#if entry}} data-document-id="{{ id }}" data-entry-id="{{ id }}"
+           {{~else}} data-page-id="{{ id }}" {{#if entryId}}data-entry-id="{{ entryId }}"{{/if}}{{/if}}>{{ name }}</a>
+        {{#if (and showPages pages.length)}}{{> "pages" }}{{/if}}
+    </li>
+    {{/unless}}
+    {{/each}}
+</ul>
+{{/inline}}
+
 <article>
     {{#if header}}
     <aside>
         <header>
-            <h2>{{header.title}}</h2>
+            <h2>{{ header.title }}</h2>
         </header>
-        <section>{{{header.content}}}</section>
+        <section>{{{ header.content }}}</section>
     </aside>
     {{/if}}
     <div class="contents">
         <header>
-            <h2>{{localize "DND5E.Contents"}}</h2>
+            <h2>{{ localize "DND5E.Contents" }}</h2>
         </header>
         <section>
             {{#each chapters}}
-            <div class="chapter" data-document-id="{{_id}}" data-entry-id="{{_id}}">
-                <h3><a class="journal-entry-link">{{name}}</a></h3>
-                {{#if showPages}}
-                <ul class="pages">
-                    {{#each pages}}
-                    <li>
-                        {{#if entry}}
-                        <strong>
-                            <a class="journal-entry-page-link" data-document-id="{{_id}}"
-                               data-entry-id="{{_id}}">{{name}}</a>
-                        </strong>
-                        {{else}}
-                        <a class="journal-entry-page-link" data-page-id="{{_id}}">{{name}}</a>
-                        {{/if}}
-                    </li>
-                    {{/each}}
-                </ul>
-                {{/if}}
+            <div class="chapter" data-document-id="{{ id }}" data-entry-id="{{ id }}">
+                <h3><a class="journal-entry-link">{{ name }}</a></h3>
+                {{#if (and showPages pages.length)}}{{> "pages" }}{{/if}}
             </div>
             {{/each}}
         </section>


### PR DESCRIPTION
Sorts all pages displayed in the table of contents using their `order` property, rather than just using their storage order.

Special pages appended to another chapter can now include an `order` property to determine where they are sorted relative to the other pages in the chapter. They can also explicitly set `showPages` to `true` to display their own pages.

A `title` flag has been added for journal entries which replaces the journal entry's normal title.

Closes #3607 
Closes #3608 
Closes #3610 