### PR TITLE
[#3604] Fix non-draggable content links in V11

### DIFF
--- a/module/applications/journal/class-page-sheet.mjs
+++ b/module/applications/journal/class-page-sheet.mjs
@@ -1,3 +1,4 @@
+import { linkForUuid } from "../../utils.mjs";
 import Actor5e from "../../documents/actor/actor.mjs";
 import Proficiency from "../../documents/actor/proficiency.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
@@ -179,8 +180,6 @@ export default class JournalClassPageSheet extends JournalPageSheet {
     if ( scaleValues.length ) cols.push({class: "scale", span: scaleValues.length});
     if ( spellProgression ) cols.push(...spellProgression.cols);
 
-    const makeLink = async uuid => (await fromUuid(uuid))?.toAnchor({classes: ["content-link"]}).outerHTML;
-
     const rows = [];
     for ( const level of Array.fromRange((CONFIG.DND5E.maxLevel - (initialLevel - 1)), initialLevel) ) {
       const features = [];
@@ -191,7 +190,7 @@ export default class JournalClassPageSheet extends JournalPageSheet {
             continue;
           case "ItemGrant":
             if ( advancement.configuration.optional ) continue;
-            features.push(...await Promise.all(advancement.configuration.items.map(i => makeLink(i.uuid))));
+            features.push(...await Promise.all(advancement.configuration.items.map(i => linkForUuid(i.uuid))));
             break;
         }
       }
@@ -315,8 +314,6 @@ export default class JournalClassPageSheet extends JournalPageSheet {
       { class: "features", span: 1 }
     ];
 
-    const makeLink = async uuid => (await fromUuid(uuid))?.toAnchor({classes: ["content-link"]}).outerHTML;
-
     const rows = [];
     for ( const level of Array.fromRange(CONFIG.DND5E.maxLevel, 1) ) {
       const features = [];
@@ -324,7 +321,7 @@ export default class JournalClassPageSheet extends JournalPageSheet {
         switch ( advancement.constructor.typeName ) {
           case "ItemGrant":
             if ( !advancement.configuration.optional ) continue;
-            features.push(...await Promise.all(advancement.configuration.items.map(i => makeLink(i.uuid))));
+            features.push(...await Promise.all(advancement.configuration.items.map(i => linkForUuid(i.uuid))));
             break;
         }
       }

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -497,7 +497,11 @@ function embedImagePage(config, label, options) {
   if ( showCaption || showCite ) {
     const figcaption = document.createElement("figcaption");
     if ( showCaption ) figcaption.innerHTML += `<strong class="embed-caption">${caption}</strong>`;
-    if ( showCite ) figcaption.innerHTML += `<cite>${config.doc.toAnchor().outerHTML}</cite>`;
+    if ( showCite ) {
+      const citeLink = config.doc.toAnchor();
+      if ( game.release.generation < 12 ) citeLink.setAttribute("draggable", true);
+      figcaption.innerHTML += `<cite>${citeLink.outerHTML}</cite>`;
+    }
     figure.insertAdjacentElement("beforeend", figcaption);
   }
   return figure;
@@ -684,7 +688,11 @@ function wrapEmbeddedText(enriched, config, label, options) {
   if ( showCaption || showCite ) {
     const figcaption = document.createElement("figcaption");
     if ( showCaption ) figcaption.innerHTML += `<strong class="embed-caption">${caption}</strong>`;
-    if ( showCite ) figcaption.innerHTML += `<cite>${config.doc.toAnchor().outerHTML}</cite>`;
+    if ( showCite ) {
+      const citeLink = config.doc.toAnchor();
+      if ( game.release.generation < 12 ) citeLink.setAttribute("draggable", true);
+      figcaption.innerHTML += `<cite>${citeLink.outerHTML}</cite>`;
+    }
     figure.insertAdjacentElement("beforeend", figcaption);
   }
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -225,6 +225,7 @@ export function linkForUuid(uuid, { tooltip }={}) {
   }
   const a = doc.toAnchor();
   if ( tooltip ) a.dataset.tooltip = tooltip;
+  if ( game.release.generation < 12 ) a.setAttribute("draggable", true);
   return a.outerHTML;
 }
 


### PR DESCRIPTION
Adds `draggable` attribute to content links created through embed citations and `linkForUuid` method when running V11 so they can be dragged.

Also modifies the class journal page to use `linkForUuid` rather than its own solution.

Closes #3604 