### PR TITLE
[#3663] Add option to hide advancement types from selection

### DIFF
--- a/module/applications/advancement/advancement-selection.mjs
+++ b/module/applications/advancement/advancement-selection.mjs
@@ -56,7 +56,7 @@ export default class AdvancementSelection extends Dialog {
         };
       }
       const advancement = config.documentClass;
-      if ( !config.validItemTypes?.has(this.item.type) ) continue;
+      if ( config.hidden || !config.validItemTypes?.has(this.item.type) ) continue;
       context.types[name] = {
         label: advancement.metadata.title,
         icon: advancement.metadata.icon,

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3134,6 +3134,7 @@ preLocalize("groupTypes");
  * @typedef {object} AdvancementTypeConfiguration
  * @property {typeof Advancement} documentClass  The advancement's document class.
  * @property {Set<string>} validItemTypes        What item types this advancement can be used with.
+ * @property {boolean} [hidden]                  Should this advancement type be hidden in the selection dialog?
  */
 
 const _ALL_ITEM_TYPES = ["background", "class", "race", "subclass"];


### PR DESCRIPTION
Adds the `hidden` option to advancement configuration which hides that advancement type in the selection dialog.

Closes #3663 