### PR TITLE
[#3647] Display enchanted item count & limit on enchantment cards

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -717,6 +717,7 @@
   },
   "Configuration": "Enchantment Configuration",
   "DropArea": "Place item here to enchant it…",
+  "Enchanted": "{current} &sol; {max} enchanted",
   "FIELDS": {
     "enchantment": {
       "label": "Enchantment Configuration",
@@ -752,7 +753,7 @@
     "Hint": "Range of levels required to use this enchantment."
   },
   "Items": {
-    "Entry": "{item} on  <em>{actor}</em>"
+    "Entry": "{item} on <em>{actor}</em>"
   },
   "Riders": {
     "Effect": {

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -660,7 +660,7 @@ enchantment-application {
     margin-inline-end: 4px;
     font-size: var(--font-size-10);
     text-align: end;
-    font-variant: small-caps;
+    text-transform: uppercase;
   }
 }
 

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -613,11 +613,12 @@
 /* ---------------------------------- */
 
 enchantment-application {
+  margin: 4px;
+
   .drop-area {
     display: grid;
     gap: 4px;
     min-block-size: 40px;
-    margin: 4px;
     border: 1px dashed var(--dnd5e-color-crimson);
     border-radius: 4px;
     padding: 4px;
@@ -652,6 +653,14 @@ enchantment-application {
         flex: 0 0 20px;
       }
     }
+  }
+
+  .count-area {
+    margin-block-start: 2px;
+    margin-inline-end: 4px;
+    font-size: var(--font-size-10);
+    text-align: end;
+    font-variant: small-caps;
   }
 }
 

--- a/module/applications/components/enchantment-application.mjs
+++ b/module/applications/components/enchantment-application.mjs
@@ -18,6 +18,14 @@ export default class EnchantmentApplicationElement extends HTMLElement {
   /* -------------------------------------------- */
 
   /**
+   * Area where the enchantment limit & current count is displayed.
+   * @type {HTMLElement}
+   */
+  countArea;
+
+  /* -------------------------------------------- */
+
+  /**
    * Area where items can be dropped to enchant.
    * @type {HTMLElement}
    */
@@ -53,6 +61,30 @@ export default class EnchantmentApplicationElement extends HTMLElement {
       this.addEventListener("click", this._onRemoveEnchantment.bind(this));
     }
 
+    // Calculate the maximum targets
+    let item = this.enchantmentItem;
+    const spellLevel = this.chatMessage.getFlag("dnd5e", "use.spellLevel");
+    if ( spellLevel ) {
+      item = item.clone({ "system.level": spellLevel });
+      item.prepareData();
+      item.prepareFinalAttributes();
+    }
+    const maxTargets = item.system.target?.value;
+    if ( maxTargets ) {
+      if ( !this.countArea ) {
+        const div = document.createElement("div");
+        div.classList.add("count-area");
+        this.querySelector(".enchantment-control").append(div);
+        this.countArea = this.querySelector(".count-area");
+      }
+      this.countArea.innerHTML = game.i18n.format("DND5E.Enchantment.Enchanted", {
+        current: '<span class="current">0</span>',
+        max: `<span class="max">${maxTargets}<span>`
+      });
+    } else if ( this.countArea ) {
+      this.countArea.remove();
+    }
+
     this.buildItemList();
   }
 
@@ -86,6 +118,9 @@ export default class EnchantmentApplicationElement extends HTMLElement {
       this.dropArea.replaceChildren(...enchantedItems);
     } else {
       this.dropArea.innerHTML = `<p>${game.i18n.localize("DND5E.Enchantment.DropArea")}</p>`;
+    }
+    if ( this.countArea ) {
+      this.countArea.querySelector(".current").innerText = enchantedItems.length;
     }
   }
 


### PR DESCRIPTION
Adds a small display beneath the enchantment area on chat cards that displays the number of items that can be enchanted and the number currently enchanted. The enchantment limit is based off the target field on the enchanting item and scales with spell level.

<img width="298" alt="Screenshot 2024-05-31 at 16 27 29" src="https://github.com/foundryvtt/dnd5e/assets/19979839/83609376-280b-4cc5-80e6-e09b72126a8d">

Closes #3647