### PR TITLE
Fix previous/next Combat turn causing an error if there are no combatants

### DIFF
--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -17,7 +17,7 @@ export default class Combat5e extends Combat {
     const previous = this.combatant;
     await super.nextTurn();
     if ( previous && (previous !== this.combatant) ) previous.refreshDynamicRing();
-    this.combatant.refreshDynamicRing();
+    this.combatant?.refreshDynamicRing();
     return this;
   }
 
@@ -28,7 +28,7 @@ export default class Combat5e extends Combat {
     const previous = this.combatant;
     await super.previousTurn();
     if ( previous && (previous !== this.combatant) ) previous.refreshDynamicRing();
-    this.combatant.refreshDynamicRing();
+    this.combatant?.refreshDynamicRing();
     return this;
   }
 


### PR DESCRIPTION
Fixes:
```
combat.mjs:20 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'refreshDynamicRing')
    at Combat5e.nextTurn (combat.mjs:20:20)
    at async CombatTracker5e._onCombatControl (foundry.js:90534:17)
```