### PR TITLE
[#3590] Add additional enchantment restrictions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1224,6 +1224,14 @@
         "label": "Allow Magical",
         "hint": "Allow items that are already magical to be enchanted."
       },
+      "categories": {
+        "label": "Valid Categories",
+        "hint": "Specific item categories to which this enchantment can be applied."
+      },
+      "properties": {
+        "label": "Valid Properties",
+        "hint": "Specific item properties to which must be present for this enchantment can be applied."
+      },
       "type": {
         "label": "Item Type",
         "hint": "Type of item to which this enchantment can be applied.",
@@ -1247,7 +1255,9 @@
   },
   "Warning": {
     "ConcentrationEnded": "Cannot apply this enchantment because concentration has ended.",
+    "MissingProperty": "Item must have one of these properties to be enchanted: {validProperties}.",
     "NoMagicalItems": "Items that are already magical cannot be enchanted.",
+    "NoSubtype": "Only {allowedType} items can be enchanted by this enchantment, but this item doesn't have a sub-type.",
     "WrongType": "{incorrectType} items cannot be enchanted by this enchantment, only {allowedType} items are allowed."
   }
 },

--- a/module/applications/activity/enchant-sheet.mjs
+++ b/module/applications/activity/enchant-sheet.mjs
@@ -57,6 +57,7 @@ export default class EnchantSheet extends ActivitySheet {
       .map(effect => ({
         value: effect.id, label: effect.name, selected: appliedEnchantments.has(effect.id)
       }));
+
     const enchantableTypes = this.activity.enchantableTypes;
     context.typeOptions = [
       { value: "", label: game.i18n.localize("DND5E.ENCHANT.FIELDS.restrictions.type.Any") },
@@ -64,6 +65,14 @@ export default class EnchantSheet extends ActivitySheet {
         .filter(t => enchantableTypes.has(t))
         .map(value => ({ value, label: game.i18n.localize(CONFIG.Item.typeLabels[value]) }))
     ];
+
+    const type = context.source.restrictions.type;
+    const typeDataModel = CONFIG.Item.dataModels[type];
+    if ( typeDataModel ) context.categoryOptions = Object.entries(typeDataModel.itemCategories ?? {})
+      .map(([value, config]) => ({ value, label: foundry.utils.getType(config) === "string" ? config : config.label }));
+
+    context.propertyOptions = (CONFIG.DND5E.validProperties[type] ?? [])
+      .map(value => ({ value, label: CONFIG.DND5E.itemProperties[value]?.label ?? value }));
 
     return context;
   }

--- a/module/data/activity/enchant-data.mjs
+++ b/module/data/activity/enchant-data.mjs
@@ -22,8 +22,10 @@ const {
  * @property {object} enchant
  * @property {string} enchant.identifier    Class identifier that will be used to determine applicable level.
  * @property {object} restrictions
- * @property {boolean} restrictions.allowMagical  Allow enchantments to be applied to items that are already magical.
- * @property {string} restrictions.type           Item type to which this enchantment can be applied.
+ * @property {boolean} restrictions.allowMagical    Allow enchantments to be applied to items that are already magical.
+ * @property {Set<string>} restrictions.categories  Item categories to restrict to.
+ * @property {Set<string>} restrictions.properties  Item properties to restrict to.
+ * @property {string} restrictions.type             Item type to which this enchantment can be applied.
  */
 export default class EnchantActivityData extends BaseActivityData {
   /** @inheritDoc */
@@ -45,6 +47,8 @@ export default class EnchantActivityData extends BaseActivityData {
       }),
       restrictions: new SchemaField({
         allowMagical: new BooleanField(),
+        categories: new SetField(new StringField()),
+        properties: new SetField(new StringField()),
         type: new StringField()
       })
     };

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -165,6 +165,13 @@ export default class ConsumableData extends ItemDataModel.mixin(
 
   /* -------------------------------------------- */
 
+  /** @override */
+  static get itemCategories() {
+    return CONFIG.DND5E.consumableTypes;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * The proficiency multiplier for this item.
    * @returns {number}

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -260,6 +260,13 @@ export default class EquipmentData extends ItemDataModel.mixin(
 
   /* -------------------------------------------- */
 
+  /** @override */
+  static get itemCategories() {
+    return CONFIG.DND5E.equipmentTypes;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * The proficiency multiplier for this item.
    * @returns {number}

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -88,4 +88,11 @@ export default class LootData extends ItemDataModel.mixin(
       this.priceLabel
     ];
   }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static get itemCategories() {
+    return CONFIG.DND5E.lootTypes;
+  }
 }

--- a/module/data/item/templates/item-type.mjs
+++ b/module/data/item/templates/item-type.mjs
@@ -12,6 +12,22 @@ import SystemDataModel from "../../abstract.mjs";
 export default class ItemTypeTemplate extends SystemDataModel {
 
   /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Item categories used to populate `system.type.value`.
+   * @type {Record<string, string>}
+   */
+  static get itemCategories() {
+    return {};
+  }
+
+  get itemCategories() {
+    return this.constructor.itemCategories();
+  }
+
+  /* -------------------------------------------- */
   /*  Migrations                                  */
   /* -------------------------------------------- */
 

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -165,6 +165,13 @@ export default class ToolData extends ItemDataModel.mixin(
 
   /* -------------------------------------------- */
 
+  /** @override */
+  static get itemCategories() {
+    return CONFIG.DND5E.toolTypes;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * The proficiency multiplier for this item.
    * @returns {number}

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -331,6 +331,13 @@ export default class WeaponData extends ItemDataModel.mixin(
 
   /* -------------------------------------------- */
 
+  /** @override */
+  static get itemCategories() {
+    return CONFIG.DND5E.weaponTypes;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Does the Weapon implement a versatile damage roll as part of its usage?
    * @type {boolean}

--- a/templates/activity/parts/enchant-restrictions.hbs
+++ b/templates/activity/parts/enchant-restrictions.hbs
@@ -4,6 +4,12 @@
         {{#with fields.restrictions.fields as |fields|}}
         {{ formField fields.allowMagical value=../source.restrictions.allowMagical }}
         {{ formField fields.type value=../source.restrictions.type options=../typeOptions }}
+        {{#if ../categoryOptions}}
+        {{ formField fields.categories value=../source.restrictions.categories options=../categoryOptions }}
+        {{/if}}
+        {{#if ../propertyOptions}}
+        {{ formField fields.properties value=../source.restrictions.properties options=../propertyOptions }}
+        {{/if}}
         {{/with}}
     </fieldset>
 </section>


### PR DESCRIPTION
Adds an enchantment restriction based on item category that takes multiple options, allowing for restricting to categories such as "Simple Melee" weapons or "Heavy Armor". The category lists per-type are fetched from the data model using a new `itemCategories` static getter to make it easy for module-provided types to provide their own category lists.

Also adds a restriction based on item properties. Currently the restriction requires just one of the provided properties to be considered valid, but it might also make sense to require all of them or provide a toggle between those two modes.

Adds a new hook to the `canEnchant` method so modules can provide their own enchantment restrictions.

Closes #3590