### PR TITLE
[#3707] Fixes marker font, add shadow color, improve documentation

### DIFF
--- a/module/canvas/_module.mjs
+++ b/module/canvas/_module.mjs
@@ -1,6 +1,7 @@
 export {default as AbilityTemplate} from "./ability-template.mjs";
 export * as detectionModes from "./detection-modes/_module.mjs";
 export {measureDistances} from "./grid.mjs";
+export {default as MapLocationControlIcon} from "./map-location-control-icon.mjs";
 export {default as Note5e} from "./note.mjs";
 export {default as Token5e} from "./token.mjs";
 export {default as TokenPlacement} from "./token-placement.mjs";

--- a/module/canvas/map-location-control-icon.mjs
+++ b/module/canvas/map-location-control-icon.mjs
@@ -1,3 +1,6 @@
+/**
+ * Custom control icon used to display Map Location journal pages when pinned to the map.
+ */
 export default class MapLocationControlIcon extends PIXI.Container {
   constructor({code, size=40, ...style}={}, ...args) {
     super(...args);
@@ -20,7 +23,7 @@ export default class MapLocationControlIcon extends PIXI.Container {
     // Drop Shadow
     this.shadow = this.addChild(new PIXI.Graphics());
     this.shadow.clear()
-      .beginFill(this.style.borderColor, 0.65)
+      .beginFill(this.style.shadowColor, 0.65)
       .drawCircle(this.radius + 8, this.radius + 8, this.radius + 10)
       .endFill();
     this.shadow.filters = [new PIXI.filters.BlurFilter(16)];
@@ -86,7 +89,7 @@ export default class MapLocationControlIcon extends PIXI.Container {
     style.dropShadow = false;
     style.fill = Color.from(this.style.textColor);
     style.strokeThickness = 0;
-    style.fontFamily = ["Roboto Slab", "Signika"];
+    style.fontFamily = ["Signika"];
     if ( this.style.fontFamily ) style.fontFamily.unshift(this.style.fontFamily);
     style.fontSize = characterCount > 2 ? size * .5 : size * .6;
     return style;

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -676,15 +676,28 @@ DND5E.tokenRingColors = {
 /* -------------------------------------------- */
 
 /**
+ * Configuration data for a map marker style. Options not included will fall back to the value set in `default` style.
+ *
+ * @typedef {object} MapLocationMarkerStyle
+ * @property {number} [backgroundColor]      Color of the background inside the circle.
+ * @property {number} [borderColor]          Color of the border in normal state.
+ * @property {number} [borderHoverColor]     Color of the border when hovering over the marker.
+ * @property {string} [fontFamily]           Font used for rendering the code on the marker.
+ * @property {number} [shadowColor]          Color of the shadow under the marker.
+ * @property {number} [textColor]            Color of the text on the marker.
+ */
+
+/**
  * Settings used to render map location markers on the canvas.
- * @type {object}
+ * @enum {MapLocationMarkerStyle}
  */
 DND5E.mapLocationMarker = {
   default: {
     backgroundColor: 0xFBF8F5,
     borderColor: 0x000000,
     borderHoverColor: 0xFF5500,
-    font: null,
+    fontFamily: "Roboto Slab",
+    shadowColor: 0x000000,
     textColor: 0x000000
   }
 };


### PR DESCRIPTION
The font family for marker styles now uses the `fontFamily` param, rather than just `font`, so it will be properly used by the marker.

Adjusted drawing to have a separate `shadowColor` parameter rather than using `borderColor` so that different border colors can be used without affecting the shadow.

Closes #3707