### PR TITLE
[#3705] Add option to completely replace map location page markers

### DIFF
--- a/module/canvas/map-location-control-icon.mjs
+++ b/module/canvas/map-location-control-icon.mjs
@@ -9,7 +9,17 @@ export default class MapLocationControlIcon extends PIXI.Container {
     this.size = size;
     this.style = style;
 
-    this.radius = size / 2;
+    this.renderMarker();
+    this.refresh();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Perform the actual rendering of the marker.
+   */
+  renderMarker() {
+    this.radius = this.size / 2;
     this.circle = [this.radius, this.radius, this.radius + 8];
     this.backgroundColor = this.style.backgroundColor;
     this.borderColor = this.style.borderHoverColor;
@@ -52,8 +62,6 @@ export default class MapLocationControlIcon extends PIXI.Container {
     // Border
     this.border = this.addChild(new PIXI.Graphics());
     this.border.visible = false;
-
-    this.refresh();
   }
 
   /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1,3 +1,4 @@
+import MapLocationControlIcon from "./canvas/map-location-control-icon.mjs";
 import * as advancement from "./documents/advancement/_module.mjs";
 import { preLocalize } from "./utils.mjs";
 
@@ -677,8 +678,10 @@ DND5E.tokenRingColors = {
 
 /**
  * Configuration data for a map marker style. Options not included will fall back to the value set in `default` style.
+ * Any additional styling options added will be passed into the custom marker class and be available for rendering.
  *
  * @typedef {object} MapLocationMarkerStyle
+ * @property {typeof PIXI.Container} [icon]  Map marker class used to render the icon.
  * @property {number} [backgroundColor]      Color of the background inside the circle.
  * @property {number} [borderColor]          Color of the border in normal state.
  * @property {number} [borderHoverColor]     Color of the border when hovering over the marker.
@@ -693,6 +696,7 @@ DND5E.tokenRingColors = {
  */
 DND5E.mapLocationMarker = {
   default: {
+    icon: MapLocationControlIcon,
     backgroundColor: 0xFBF8F5,
     borderColor: 0x000000,
     borderHoverColor: 0xFF5500,

--- a/module/data/journal/map.mjs
+++ b/module/data/journal/map.mjs
@@ -1,5 +1,3 @@
-import MapLocationControlIcon from "../../canvas/map-location-control-icon.mjs";
-
 /**
  * Data definition for Map Location journal entry pages.
  *
@@ -35,11 +33,11 @@ export default class MapLocationJournalPageData extends foundry.abstract.DataMod
    */
   getControlIcon(options) {
     if ( !this.code ) return;
-    const style = foundry.utils.mergeObject(
+    const { icon: IconClass, ...style } = foundry.utils.mergeObject(
       CONFIG.DND5E.mapLocationMarker.default,
       CONFIG.DND5E.mapLocationMarker[this.parent.getFlag("dnd5e", "mapMarkerStyle")] ?? {},
       {inplace: false}
     );
-    return new MapLocationControlIcon({code: this.code, ...options, ...style});
+    return new IconClass({code: this.code, ...options, ...style});
   }
 }


### PR DESCRIPTION
Map location marker style now includes an option for configuring the map marker icon class, so it can now be completely replaced in a style if desired.

This also moves the marker rendering code into a separate method in `MapLocationControlIcon` to make it easier for sub-classing markers to replace the rendering while retaining the other helpful parts of the class.

Closes #3705 