### PR TITLE
[#3717] Fix appended numbers not being incremented for placed tokens

### DIFF
--- a/module/canvas/token-placement.mjs
+++ b/module/canvas/token-placement.mjs
@@ -10,6 +10,9 @@
  *
  * @typedef {object} PlacementData
  * @property {PrototypeToken} prototypeToken
+ * @property {object} index
+ * @property {number} index.total             Index of the placement across all placements.
+ * @property {number} index.unique            Index of the placement across placements with the same original token.
  * @property {number} x
  * @property {number} y
  * @property {number} rotation
@@ -104,14 +107,19 @@ export default class TokenPlacement {
     this.#createPreviews();
     try {
       const placements = [];
+      let total = 0;
+      const uniqueTokens = new Map();
       while ( this.#currentPlacement < this.config.tokens.length - 1 ) {
         this.#currentPlacement++;
         const obj = canvas.tokens.preview.addChild(this.#previews[this.#currentPlacement].object);
         await obj.draw();
         obj.eventMode = "none";
         const placement = await this.#requestPlacement();
-        if ( placement ) placements.push(placement);
-        else obj.clear();
+        if ( placement ) {
+          uniqueTokens.set(placement.prototypeToken, (uniqueTokens.get(placement.prototypeToken) ?? -1) + 1);
+          placement.index = { total: total++, unique: uniqueTokens.get(placement.prototypeToken) };
+          placements.push(placement);
+        } else obj.clear();
       }
       return placements;
     } finally {
@@ -271,5 +279,23 @@ export default class TokenPlacement {
   async #onSkipPlacement(event) {
     await this.#finishPlacement(event);
     this.#events.resolve(false);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Adjust the appended number on an unlinked token to account for multiple placements.
+   * @param {TokenDocument|object} tokenDocument  Document or data object to adjust.
+   * @param {PlacementData} placement             Placement data associated with this token document.
+   */
+  static adjustAppendedNumber(tokenDocument, placement) {
+    const regex = new RegExp(/\((\d+)\)$/);
+    const match = tokenDocument.name?.match(regex);
+    if ( !match ) return;
+    const name = tokenDocument.name.replace(regex, `(${Number(match[1]) + placement.index.unique})`);
+    if ( tokenDocument instanceof TokenDocument ) tokenDocument.updateSource({ name });
+    else tokenDocument.name = name;
   }
 }

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -209,8 +209,10 @@ export default class GroupActor extends ActorDataModel.mixin(CurrencyTemplate) {
       });
       for ( const placement of placements ) {
         const actor = placement.prototypeToken.actor;
+        const appendNumber = !placement.prototypeToken.actorLink && placement.prototypeToken.appendNumber;
         delete placement.prototypeToken;
         const tokenDocument = await actor.getTokenDocument(placement);
+        if ( appendNumber ) TokenPlacement.adjustAppendedNumber(tokenDocument, placement);
         tokensData.push(tokenDocument.toObject());
       }
     } finally {

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -589,6 +589,7 @@ export class SummonsData extends foundry.abstract.DataModel {
       await tokenDocument.actor.createEmbeddedDocuments("ActiveEffect", newEffects, {keepId: true});
     } else {
       tokenDocument.delta.updateSource(actorUpdates);
+      if ( actor.prototypeToken.appendNumber ) TokenPlacement.adjustAppendedNumber(tokenDocument, placement);
     }
 
     return tokenDocument.toObject();


### PR DESCRIPTION
Since the core's code for appending numbers in `getTokenDocument` looks at the tokens currently in the scene, and token placement creates tokens in bulk, this modifies the generated numbers after the call to `getTokenDocument` to adjust them based on the index of the placed token.

To that end, this adds a `index` value to `PlacementData` which has a total index across all placements and an index for each unique original token, to avoid numbering issues with placement of mixed groups of actors.

Closes #3717 