### PR TITLE
Don't display scrolling combat text if the token is secret

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3341,7 +3341,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const fill = CONFIG.DND5E.tokenHPColors[key];
 
     for ( const token of tokens ) {
-      if ( !token.object?.visible || !token.object?.renderable ) continue;
+      if ( !token.object?.visible || token.isSecret ) continue;
       if ( token.hasDynamicRing ) token.flashRing(key);
       const t = token.object;
       canvas.interface.createScrollingText(t.center, value.signedString(), {


### PR DESCRIPTION
Related core changes: https://github.com/foundryvtt/foundry-vtt/pull/2478