### PR TITLE
Remove statuses that the actor is immune against

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -206,6 +206,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     this._prepareArmorClass();
     this._prepareInitiative(rollData, checkBonus);
     this._prepareSpellcasting();
+
+    // Apply condition immunities
+    if ( game.release.generation >= 12 ) {
+      const conditionImmunities = this.system.traits?.ci?.value;
+      if ( conditionImmunities ) {
+        for ( const condition of conditionImmunities ) this.statuses.delete(condition);
+      }
+    }
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Perhaps there is a better place to handle this. Or perhaps we prevent toggling of statuses in the first place if the actor is immune against them: but that is a bit more tricky considering implicit statuses and also the fact that petrified adds poison and disease immunities.