### PR TITLE
Update staves

### DIFF
--- a/packs/_source/items/weapon/staff-of-charming.json
+++ b/packs/_source/items/weapon/staff-of-charming.json
@@ -52,9 +52,9 @@
     "uses": {
       "value": 10,
       "max": "10",
-      "per": "charges",
+      "per": "dawn",
       "recovery": "1d8 + 2",
-      "prompt": true
+      "prompt": false
     },
     "consume": {
       "type": "",
@@ -78,7 +78,7 @@
       ],
       "versatile": "1d8 + @mod"
     },
-    "formula": "",
+    "formula": "1d20",
     "save": {
       "ability": "wis",
       "dc": null,
@@ -94,13 +94,13 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
       "value": "simpleM",
-      "baseItem": ""
+      "baseItem": "quarterstaff"
     },
     "unidentified": {
       "description": ""
@@ -124,11 +124,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233548,
-    "modifiedTime": 1715374591323,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719169301586,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!FeouSUPUlUhfgeRp"
 }

--- a/packs/_source/items/weapon/staff-of-fire.json
+++ b/packs/_source/items/weapon/staff-of-fire.json
@@ -52,9 +52,9 @@
     "uses": {
       "value": 10,
       "max": "10",
-      "per": "charges",
+      "per": "dawn",
       "recovery": "1d6 + 4",
-      "prompt": true
+      "prompt": false
     },
     "consume": {
       "type": "",
@@ -73,7 +73,7 @@
       "parts": [],
       "versatile": ""
     },
-    "formula": "",
+    "formula": "1d20",
     "save": {
       "ability": "dex",
       "dc": null,
@@ -89,6 +89,7 @@
       "conditions": ""
     },
     "properties": [
+      "foc",
       "mgc"
     ],
     "proficient": null,
@@ -109,7 +110,51 @@
     "magicalBonus": null,
     "enchantment": null
   },
-  "effects": [],
+  "effects": [
+    {
+      "name": "Staff of Fire",
+      "origin": "Compendium.dnd5e.items.Item.lsiR1hVfISlC5YoB",
+      "duration": {
+        "rounds": null,
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "disabled": false,
+      "flags": {},
+      "img": "icons/weapons/staves/staff-engraved-red.webp",
+      "_id": "jewb1yIhlxLetpCp",
+      "type": "base",
+      "system": {},
+      "changes": [
+        {
+          "key": "system.traits.dr.value",
+          "mode": 2,
+          "value": "fire",
+          "priority": null
+        }
+      ],
+      "description": "<p>You have resistance to fire damage while you hold this staff.</p>",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.327",
+        "systemId": "dnd5e",
+        "systemVersion": "3.2.1",
+        "createdTime": 1719169049848,
+        "modifiedTime": 1719169074838,
+        "lastModifiedBy": "dnd5ebuilder0000"
+      },
+      "_key": "!items.effects!lsiR1hVfISlC5YoB.jewb1yIhlxLetpCp"
+    }
+  ],
   "folder": "MLMTCAvKsuFE3vYA",
   "sort": 0,
   "ownership": {
@@ -118,11 +163,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233849,
-    "modifiedTime": 1715374640412,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719169306485,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!lsiR1hVfISlC5YoB"
 }

--- a/packs/_source/items/weapon/staff-of-frost.json
+++ b/packs/_source/items/weapon/staff-of-frost.json
@@ -52,9 +52,9 @@
     "uses": {
       "value": 10,
       "max": "10",
-      "per": "charges",
+      "per": "dawn",
       "recovery": "1d6 + 4",
-      "prompt": true
+      "prompt": false
     },
     "consume": {
       "type": "",
@@ -73,7 +73,7 @@
       "parts": [],
       "versatile": ""
     },
-    "formula": "",
+    "formula": "1d20",
     "save": {
       "ability": "",
       "dc": null,
@@ -89,6 +89,7 @@
       "conditions": ""
     },
     "properties": [
+      "foc",
       "mgc"
     ],
     "proficient": null,
@@ -109,7 +110,51 @@
     "magicalBonus": null,
     "enchantment": null
   },
-  "effects": [],
+  "effects": [
+    {
+      "name": "Staff of Frost",
+      "origin": "Compendium.dnd5e.items.Item.xEtBeZjJnkDXojQM",
+      "duration": {
+        "rounds": null,
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "disabled": false,
+      "flags": {},
+      "img": "icons/weapons/staves/staff-ornate-engraved-blue.webp",
+      "_id": "cY6gjrYWTbo4ezzH",
+      "type": "base",
+      "system": {},
+      "changes": [
+        {
+          "key": "system.traits.dr.value",
+          "mode": 2,
+          "value": "cold",
+          "priority": null
+        }
+      ],
+      "description": "<p>You have resistance to cold damage while you hold this staff.</p>",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.327",
+        "systemId": "dnd5e",
+        "systemVersion": "3.2.1",
+        "createdTime": 1719169175692,
+        "modifiedTime": 1719169195077,
+        "lastModifiedBy": "dnd5ebuilder0000"
+      },
+      "_key": "!items.effects!xEtBeZjJnkDXojQM.cY6gjrYWTbo4ezzH"
+    }
+  ],
   "folder": "MLMTCAvKsuFE3vYA",
   "sort": 0,
   "ownership": {
@@ -118,11 +163,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233964,
-    "modifiedTime": 1715374657924,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719169310995,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!xEtBeZjJnkDXojQM"
 }

--- a/packs/_source/items/weapon/staff-of-healing.json
+++ b/packs/_source/items/weapon/staff-of-healing.json
@@ -52,7 +52,7 @@
     "uses": {
       "value": 10,
       "max": "10",
-      "per": "charges",
+      "per": "dawn",
       "recovery": "1d6 + 4",
       "prompt": true
     },
@@ -63,7 +63,7 @@
       "scale": false
     },
     "ability": "",
-    "actionType": "heal",
+    "actionType": "other",
     "chatFlavor": "",
     "critical": {
       "threshold": null,
@@ -73,7 +73,7 @@
       "parts": [],
       "versatile": ""
     },
-    "formula": "",
+    "formula": "1d20",
     "save": {
       "ability": "",
       "dc": null,
@@ -89,6 +89,7 @@
       "conditions": ""
     },
     "properties": [
+      "foc",
       "mgc"
     ],
     "proficient": null,
@@ -118,11 +119,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233689,
-    "modifiedTime": 1715374614391,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719169314650,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!WLVQJVpCWiPkCAtZ"
 }

--- a/packs/_source/items/weapon/staff-of-power.json
+++ b/packs/_source/items/weapon/staff-of-power.json
@@ -52,9 +52,9 @@
     "uses": {
       "value": 20,
       "max": "20",
-      "per": "charges",
+      "per": "dawn",
       "recovery": "2d8 + 4",
-      "prompt": true
+      "prompt": false
     },
     "consume": {
       "type": "",
@@ -78,7 +78,7 @@
       ],
       "versatile": "1d8 + @mod"
     },
-    "formula": "",
+    "formula": "1d20",
     "save": {
       "ability": "",
       "dc": null,
@@ -94,13 +94,14 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "foc",
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
       "value": "simpleM",
-      "baseItem": ""
+      "baseItem": "quarterstaff"
     },
     "unidentified": {
       "description": ""
@@ -124,6 +125,24 @@
           "mode": 2,
           "value": "2",
           "priority": null
+        },
+        {
+          "key": "system.bonuses.abilities.save",
+          "mode": 2,
+          "value": "2",
+          "priority": null
+        },
+        {
+          "key": "system.bonuses.msak.attack",
+          "mode": 2,
+          "value": "2",
+          "priority": null
+        },
+        {
+          "key": "system.bonuses.rsak.attack",
+          "mode": 2,
+          "value": "2",
+          "priority": null
         }
       ],
       "disabled": false,
@@ -136,14 +155,27 @@
         "startRound": null,
         "startTurn": null
       },
-      "icon": "icons/weapons/staves/staff-skull-brown.webp",
       "origin": "Compendium.dnd5e.items.eM5gEe4SEOvA2Y9t",
       "transfer": true,
       "flags": {},
-      "tint": null,
-      "name": "+2 to AC",
-      "description": "",
+      "tint": "#ffffff",
+      "name": "Staff of Power",
+      "description": "<p>While holding this staff, you gain a +2 bonus to Armor Class, saving throws, and spell attack rolls.</p>",
       "statuses": [],
+      "_stats": {
+        "coreVersion": "12.327",
+        "systemId": null,
+        "systemVersion": null,
+        "createdTime": null,
+        "modifiedTime": 1719169411762,
+        "lastModifiedBy": "dnd5ebuilder0000",
+        "compendiumSource": null,
+        "duplicateSource": null
+      },
+      "img": "icons/weapons/staves/staff-skull-brown.webp",
+      "type": "base",
+      "system": {},
+      "sort": 0,
       "_key": "!items.effects!eM5gEe4SEOvA2Y9t.313kehq7ifkqiz2u"
     }
   ],
@@ -155,11 +187,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233783,
-    "modifiedTime": 1715374627567,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719169439166,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!eM5gEe4SEOvA2Y9t"
 }

--- a/packs/_source/items/weapon/staff-of-striking.json
+++ b/packs/_source/items/weapon/staff-of-striking.json
@@ -5,7 +5,7 @@
   "img": "icons/weapons/staves/staff-simple-brown.webp",
   "system": {
     "description": {
-      "value": "<p><em>(Requires attunement)</em></p><p>This staff can be wielded as a magic quarterstaff that grants a +3 bonus to attack and damage rolls made with it.</p><p>The staff has 10 charges. When you hit with a melee attack using it, you can expend up to 3 of its charges. For each charge you expend, the target takes an extra 1d6 force damage. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll a d20. On a 1, the staff becomes a nonmagical quarterstaff.</p><section class=\"secret foundry-note\" id=\"secret-Fp8PZmbsQFbsmSHS\"><p><strong>Foundry Note</strong></p><p>The Other Formula button has been configured to roll 1d6. Use to calculate any additional force damage.</p></section>",
+      "value": "<p><em>(Requires attunement)</em></p><p>This staff can be wielded as a magic quarterstaff that grants a +3 bonus to attack and damage rolls made with it.</p><p>The staff has 10 charges. When you hit with a melee attack using it, you can expend up to 3 of its charges. For each charge you expend, the target takes an extra [[/damage 1d6 force]] damage. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll a d20. On a 1, the staff becomes a nonmagical quarterstaff.</p>",
       "chat": ""
     },
     "source": {
@@ -52,9 +52,9 @@
     "uses": {
       "value": 10,
       "max": "10",
-      "per": "charges",
+      "per": "dawn",
       "recovery": "1d6 + 4",
-      "prompt": true
+      "prompt": false
     },
     "consume": {
       "type": "",
@@ -78,7 +78,7 @@
       ],
       "versatile": "1d8 + @mod"
     },
-    "formula": "1d6",
+    "formula": "1d20",
     "save": {
       "ability": "",
       "dc": null,
@@ -94,13 +94,14 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "foc",
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
       "value": "simpleM",
-      "baseItem": ""
+      "baseItem": "quarterstaff"
     },
     "unidentified": {
       "description": ""
@@ -124,11 +125,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233677,
-    "modifiedTime": 1715374611975,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719169562300,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!URun3vYrXKJJdAJe"
 }

--- a/packs/_source/items/weapon/staff-of-swarming-insects.json
+++ b/packs/_source/items/weapon/staff-of-swarming-insects.json
@@ -33,28 +33,28 @@
       "condition": ""
     },
     "duration": {
-      "value": "",
-      "units": ""
+      "value": "10",
+      "units": "minute"
     },
     "cover": null,
     "target": {
-      "value": null,
+      "value": "30",
       "width": null,
-      "units": "",
-      "type": "self",
-      "prompt": true
+      "units": "ft",
+      "type": "radius",
+      "prompt": false
     },
     "range": {
-      "value": 30,
+      "value": null,
       "long": null,
-      "units": "ft"
+      "units": "self"
     },
     "uses": {
       "value": 10,
       "max": "10",
-      "per": "charges",
+      "per": "dawn",
       "recovery": "1d6 + 4",
-      "prompt": true
+      "prompt": false
     },
     "consume": {
       "type": "",
@@ -63,7 +63,7 @@
       "scale": false
     },
     "ability": "",
-    "actionType": "util",
+    "actionType": "save",
     "chatFlavor": "",
     "critical": {
       "threshold": null,
@@ -73,7 +73,7 @@
       "parts": [],
       "versatile": ""
     },
-    "formula": "",
+    "formula": "1d20",
     "save": {
       "ability": "con",
       "dc": null,
@@ -89,6 +89,7 @@
       "conditions": ""
     },
     "properties": [
+      "foc",
       "mgc"
     ],
     "proficient": null,
@@ -118,11 +119,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233733,
-    "modifiedTime": 1715374623341,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719169668488,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!bod1dKzbAkAm21Ho"
 }

--- a/packs/_source/items/weapon/staff-of-the-magi.json
+++ b/packs/_source/items/weapon/staff-of-the-magi.json
@@ -50,11 +50,11 @@
       "units": "ft"
     },
     "uses": {
-      "value": 10,
+      "value": 50,
       "max": "50",
-      "per": "charges",
+      "per": "dawn",
       "recovery": "4d6 + 2",
-      "prompt": true
+      "prompt": false
     },
     "consume": {
       "type": "",
@@ -78,7 +78,7 @@
       ],
       "versatile": "1d8 + @mod"
     },
-    "formula": "",
+    "formula": "1d20",
     "save": {
       "ability": "",
       "dc": null,
@@ -94,13 +94,14 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "foc",
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
       "value": "simpleM",
-      "baseItem": ""
+      "baseItem": "quarterstaff"
     },
     "unidentified": {
       "description": ""
@@ -115,7 +116,57 @@
     "summons": null,
     "enchantment": null
   },
-  "effects": [],
+  "effects": [
+    {
+      "name": "Staff of the Magi",
+      "origin": "Compendium.dnd5e.items.Item.l3V7V8VCXpmAAysQ",
+      "duration": {
+        "rounds": null,
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "disabled": false,
+      "flags": {},
+      "img": "icons/weapons/staves/staff-engraved-red.webp",
+      "_id": "eppPFRx8i3sCHN2E",
+      "type": "base",
+      "system": {},
+      "changes": [
+        {
+          "key": "system.bonuses.msak.attack",
+          "mode": 2,
+          "value": "2",
+          "priority": null
+        },
+        {
+          "key": "system.bonuses.rsak.attack",
+          "mode": 2,
+          "value": "2",
+          "priority": null
+        }
+      ],
+      "description": "<p>While holding this staff, you gain a +2 bonus to spell attack rolls.</p>",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.327",
+        "systemId": "dnd5e",
+        "systemVersion": "3.2.1",
+        "createdTime": 1719169698066,
+        "modifiedTime": 1719169728114,
+        "lastModifiedBy": "dnd5ebuilder0000"
+      },
+      "_key": "!items.effects!l3V7V8VCXpmAAysQ.eppPFRx8i3sCHN2E"
+    }
+  ],
   "folder": "MLMTCAvKsuFE3vYA",
   "sort": 0,
   "ownership": {
@@ -124,11 +175,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233842,
-    "modifiedTime": 1715374638909,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719169749057,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!l3V7V8VCXpmAAysQ"
 }

--- a/packs/_source/items/weapon/staff-of-the-python.json
+++ b/packs/_source/items/weapon/staff-of-the-python.json
@@ -41,11 +41,11 @@
       "value": null,
       "width": null,
       "units": "",
-      "type": "self",
+      "type": "",
       "prompt": true
     },
     "range": {
-      "value": 60,
+      "value": 10,
       "long": null,
       "units": "ft"
     },
@@ -62,8 +62,8 @@
       "amount": null,
       "scale": false
     },
-    "ability": null,
-    "actionType": "util",
+    "ability": "",
+    "actionType": "",
     "chatFlavor": "",
     "critical": {
       "threshold": null,
@@ -89,6 +89,7 @@
       "conditions": ""
     },
     "properties": [
+      "foc",
       "mgc"
     ],
     "proficient": null,
@@ -118,11 +119,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233626,
-    "modifiedTime": 1715374601724,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719169878818,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!MOeFq5MLAQzVQC7z"
 }

--- a/packs/_source/items/weapon/staff-of-the-woodlands.json
+++ b/packs/_source/items/weapon/staff-of-the-woodlands.json
@@ -52,9 +52,9 @@
     "uses": {
       "value": 10,
       "max": "10",
-      "per": "charges",
+      "per": "dawn",
       "recovery": "1d6 + 4",
-      "prompt": true
+      "prompt": false
     },
     "consume": {
       "type": "",
@@ -78,7 +78,7 @@
       ],
       "versatile": "1d8 + @mod"
     },
-    "formula": "",
+    "formula": "1d20",
     "save": {
       "ability": "",
       "dc": null,
@@ -94,13 +94,14 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "foc",
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
       "value": "simpleM",
-      "baseItem": ""
+      "baseItem": "quarterstaff"
     },
     "unidentified": {
       "description": ""
@@ -115,7 +116,57 @@
     "summons": null,
     "enchantment": null
   },
-  "effects": [],
+  "effects": [
+    {
+      "name": "Staff of the Woodlands",
+      "origin": "Compendium.dnd5e.items.Item.caEn3ixCUFBnHTx6",
+      "duration": {
+        "rounds": null,
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "disabled": false,
+      "flags": {},
+      "img": "icons/weapons/staves/staff-simple-spiral-green.webp",
+      "_id": "ySNgKEIdpRR6Eyc7",
+      "type": "base",
+      "system": {},
+      "changes": [
+        {
+          "key": "system.bonuses.msak.attack",
+          "mode": 2,
+          "value": "2",
+          "priority": null
+        },
+        {
+          "key": "system.bonuses.rsak.attack",
+          "mode": 2,
+          "value": "2",
+          "priority": null
+        }
+      ],
+      "description": "<p>While holding this staff, you have a +2 bonus to spell attack rolls.</p>",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.327",
+        "systemId": "dnd5e",
+        "systemVersion": "3.2.1",
+        "createdTime": 1719169909481,
+        "modifiedTime": 1719169939044,
+        "lastModifiedBy": "dnd5ebuilder0000"
+      },
+      "_key": "!items.effects!caEn3ixCUFBnHTx6.ySNgKEIdpRR6Eyc7"
+    }
+  ],
   "folder": "MLMTCAvKsuFE3vYA",
   "sort": 0,
   "ownership": {
@@ -124,11 +175,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233738,
-    "modifiedTime": 1715374624270,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719169900732,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!caEn3ixCUFBnHTx6"
 }

--- a/packs/_source/items/weapon/staff-of-thunder-and-lightning.json
+++ b/packs/_source/items/weapon/staff-of-thunder-and-lightning.json
@@ -5,7 +5,7 @@
   "img": "icons/weapons/staves/staff-ornate-engraved-blue.webp",
   "system": {
     "description": {
-      "value": "<p><em>(Requires attunement)</em></p>\n<p>This staff can be wielded as a magic quarterstaff that grants a +2 bonus to attack and damage rolls made with it. It also has the following additional properties. When one of these properties is used, it can't be used again until the next dawn.</p>\n<p><strong>Lightning</strong>. When you hit with a melee attack using the staff, you can cause the target to take an extra 2d6 lightning damage.</p>\n<p><strong>Thunder</strong>. When you hit with a melee attack using the staff, you can cause the staff to emit a crack of thunder, audible out to 300 feet. The target you hit must succeed on a DC 17 Constitution saving throw or become stunned until the end of your next turn.</p>\n<p><strong>Lightning Strike</strong>. You can use an action to cause a bolt of lightning to leap from the staff's tip in a line that is 5 feet wide and 120 feet long. Each creature in that line must make a DC 17 Dexterity saving throw, taking 9d6 lightning damage on a failed save, or half as much damage on a successful one.</p>\n<p><strong>Thunderclap</strong>. You can use an action to cause the staff to issue a deafening thunderclap, audible out to 600 feet. Each creature within 60 feet of you (not including you) must make a DC 17 Constitution saving throw. On a failed save, a creature takes 2d6 thunder damage and becomes deafened for 1 minute. On a successful save, a creature takes half damage and isn't deafened.</p>\n<p><strong>Thunder and Lightning</strong>. You can use an action to use the Lightning Strike and Thunderclap properties at the same time. Doing so doesn't expend the daily use of those properties, only the use of this one.</p>",
+      "value": "<p><em>(Requires attunement)</em></p><p>This staff can be wielded as a magic quarterstaff that grants a +2 bonus to attack and damage rolls made with it. It also has the following additional properties. When one of these properties is used, it can't be used again until the next dawn.</p><p><strong>Lightning</strong>. When you hit with a melee attack using the staff, you can cause the target to take an extra [[/damage 2d6 lightning]] damage.</p><p><strong>Thunder</strong>. When you hit with a melee attack using the staff, you can cause the staff to emit a crack of thunder, audible out to 300 feet. The target you hit must succeed on a [[/save dc=17 con]] saving throw or become &amp;Reference[stunned] until the end of your next turn.</p><p><strong>Lightning Strike</strong>. You can use an action to cause a bolt of lightning to leap from the staff's tip in a line that is 5 feet wide and 120 feet long. Each creature in that line must make a [[/save dc=17 dex]] saving throw, taking [[/damage 9d6 lightning]] damage on a failed save, or half as much damage on a successful one.</p><p><strong>Thunderclap</strong>. You can use an action to cause the staff to issue a deafening thunderclap, audible out to 600 feet. Each creature within 60 feet of you (not including you) must make a [[/save dc=17 con]] saving throw. On a failed save, a creature takes [[/damage 2d6 thunder]] damage and becomes &amp;Reference[deafened] for 1 minute. On a successful save, a creature takes half damage and isn't deafened.</p><p><strong>Thunder and Lightning</strong>. You can use an action to use the Lightning Strike and Thunderclap properties at the same time. Doing so doesn't expend the daily use of those properties, only the use of this one.</p>",
       "chat": ""
     },
     "source": {
@@ -62,7 +62,7 @@
       "amount": null,
       "scale": false
     },
-    "ability": null,
+    "ability": "",
     "actionType": "mwak",
     "chatFlavor": "",
     "critical": {
@@ -94,13 +94,14 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "foc",
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
       "value": "simpleM",
-      "baseItem": ""
+      "baseItem": "quarterstaff"
     },
     "unidentified": {
       "description": ""
@@ -124,11 +125,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233541,
-    "modifiedTime": 1715374590385,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719170049372,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!F6v3Q7dz1SlpLTMf"
 }

--- a/packs/_source/items/weapon/staff-of-withering.json
+++ b/packs/_source/items/weapon/staff-of-withering.json
@@ -5,7 +5,7 @@
   "img": "icons/weapons/staves/staff-skull-brown.webp",
   "system": {
     "description": {
-      "value": "<p><em>(Requires attunement)</em></p><p>This staff has 3 charges and regains 1d3 expended charges daily at dawn.</p><p>The staff can be wielded as a magic quarterstaff. On a hit, it deals damage as a normal quarterstaff, and you can expend 1 charge to deal an extra 2d10 necrotic damage to the target. In addition, the target must succeed on a DC 15 Constitution saving throw or have disadvantage for 1 hour on any ability check or saving throw that uses Strength or Constitution.</p><section class=\"secret foundry-note\" id=\"secret-Qm70cZsiRYZFY5b9\"><p><strong>Foundry Note</strong></p><p>The Other Formula button has been configured to roll the staff's necrotic damage if required.</p></section>",
+      "value": "<p><em>(Requires attunement)</em></p><p>This staff has 3 charges and regains 1d3 expended charges daily at dawn.</p><p>The staff can be wielded as a magic quarterstaff. On a hit, it deals damage as a normal quarterstaff, and you can expend 1 charge to deal an extra [[/damage 2d10 necrotic]] damage to the target. In addition, the target must succeed on a DC 15 Constitution saving throw or have disadvantage for 1 hour on any ability check or saving throw that uses Strength or Constitution.</p>",
       "chat": ""
     },
     "source": {
@@ -52,9 +52,9 @@
     "uses": {
       "value": 3,
       "max": "3",
-      "per": "charges",
+      "per": "dawn",
       "recovery": "1d3",
-      "prompt": true
+      "prompt": false
     },
     "consume": {
       "type": "",
@@ -78,7 +78,7 @@
       ],
       "versatile": "1d8 + @mod"
     },
-    "formula": "2d10",
+    "formula": "",
     "save": {
       "ability": "con",
       "dc": 15,
@@ -94,13 +94,14 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "foc",
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
       "value": "simpleM",
-      "baseItem": ""
+      "baseItem": "quarterstaff"
     },
     "unidentified": {
       "description": ""
@@ -124,11 +125,12 @@
   "flags": {},
   "_stats": {
     "systemId": "dnd5e",
-    "systemVersion": "3.2.0",
-    "coreVersion": "11.315",
+    "systemVersion": "3.2.1",
+    "coreVersion": "12.327",
     "createdTime": 1661787233917,
-    "modifiedTime": 1715374653724,
-    "lastModifiedBy": "dnd5ebuilder0000"
+    "modifiedTime": 1719170205112,
+    "lastModifiedBy": "dnd5ebuilder0000",
+    "duplicateSource": null
   },
   "_key": "!items!uHL99JKLUpTKAbz8"
 }


### PR DESCRIPTION
Updates various magical staves/quarterstaves in the Items srd pack.
- This does not add 'quarterstaff' as base item unless the staff explicitly states it can be wielded as a quarterstaff.