### PR TITLE
Add missing param level to Character Sheet aria-label string

### DIFF
--- a/templates/actors/character-sheet-2.hbs
+++ b/templates/actors/character-sheet-2.hbs
@@ -52,7 +52,7 @@
         <div class="right">
 
             {{!-- Level --}}
-            <div class="level" aria-label="{{ localize "DND5E.LevelNumber" }}">{{ system.details.level }}</div>
+            <div class="level" aria-label="{{ localize "DND5E.LevelNumber" level=system.details.level }}">{{ system.details.level }}</div>
 
             {{!-- Inspiration --}}
             <button type="button" class="inspiration unbutton" data-action="toggleInspiration"


### PR DESCRIPTION
The parameter `level` was missing from the `aria-label="{{ localize "DND5E.LevelNumber" }}"` in Character Sheet v2

Close #3752 