### PR TITLE
[#3763] Select spellcasting ability based on spell's associated class

### DIFF
--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -157,7 +157,9 @@ export default class SpellData extends ItemDataModel.mixin(
 
   /** @inheritdoc */
   get _typeAbilityMod() {
-    return this.parent?.actor?.system.attributes.spellcasting || "int";
+    return this.parent?.actor?.spellcastingClasses[this.sourceClass]?.spellcasting.ability
+      ?? this.parent?.actor?.system.attributes.spellcasting
+      ?? "int";
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -158,7 +158,7 @@ export default class SpellData extends ItemDataModel.mixin(
   /** @inheritdoc */
   get _typeAbilityMod() {
     return this.parent?.actor?.spellcastingClasses[this.sourceClass]?.spellcasting.ability
-      ?? this.parent?.actor?.system.attributes.spellcasting
+      ?? this.parent?.actor?.system.attributes?.spellcasting
       ?? "int";
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -21,14 +21,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @type {Record<string, Item5e>}
    * @private
    */
-  #classes;
+  _classes;
 
   /**
    * Cached spellcasting classes.
    * @type {Record<string, Item5e>}
    * @private
    */
-  #spellcastingClasses;
+  _spellcastingClasses;
 
   /**
    * Mapping of item source IDs to the items.
@@ -45,9 +45,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @type {Record<string, Item5e>}
    */
   get classes() {
-    if ( this.#classes !== undefined ) return this.#classes;
-    if ( !["character", "npc"].includes(this.type) ) return this.#classes = {};
-    return this.#classes = this.items.filter(item => item.type === "class").reduce((obj, cls) => {
+    if ( this._classes !== undefined ) return this._classes;
+    if ( !["character", "npc"].includes(this.type) ) return this._classes = {};
+    return this._classes = this.items.filter(item => item.type === "class").reduce((obj, cls) => {
       obj[cls.identifier] = cls;
       return obj;
     }, {});
@@ -60,8 +60,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @type {Record<string, Item5e>}
    */
   get spellcastingClasses() {
-    if ( this.#spellcastingClasses !== undefined ) return this.#spellcastingClasses;
-    return this.#spellcastingClasses = Object.entries(this.classes).reduce((obj, [identifier, cls]) => {
+    if ( this._spellcastingClasses !== undefined ) return this._spellcastingClasses;
+    return this._spellcastingClasses = Object.entries(this.classes).reduce((obj, [identifier, cls]) => {
       if ( cls.spellcasting && (cls.spellcasting.progression !== "none") ) obj[identifier] = cls;
       return obj;
     }, {});
@@ -177,8 +177,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @internal
    */
   _clearCachedValues() {
-    this.#classes = undefined;
-    this.#spellcastingClasses = undefined;
+    this._classes = undefined;
+    this._spellcastingClasses = undefined;
   }
 
   /* --------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -732,7 +732,8 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     // Actor spell-DC based scaling
     if ( save.scaling === "spell" ) {
-      save.dc = this.isOwned ? this.actor.system.attributes.spelldc : null;
+      save.dc = this.isOwned ? this.actor.system.abilities?.[this.system.abilityMod]?.dc
+        ?? this.actor.system.attributes.spelldc : null;
     }
 
     // Ability-score based scaling


### PR DESCRIPTION
Modifies `_typeAbilityMod` property on `SpellData` to first check the associated spellcasting class if specified on the spell before falling back to the global spellcasting ability.

Also made a change to `Item5e#getSaveDC` to first ask the item for its ability to use for the DC before falling back to the global spell DC.

Closes #3763 