### PR TITLE
[#3730] Add selection system for choosing options from browser

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -434,6 +434,27 @@
     "HasDarkvision": "Has Darkvision",
     "HasSpellcasting": "Has Spellcasting"
   },
+  "Loading": "Loading…",
+  "Selection": {
+    "Label": "Selected: {summary}",
+    "Select": "Select",
+    "Summary": {
+      "Max": "<span class=\"value\">{value}</span> of up to {max}",
+      "Min": "<span class=\"value\">{value}</span> of at least {min}",
+      "Range": "<span class=\"value\">{value}</span> of {min} to {max}",
+      "Single": "<span class=\"value\">{value}</span> of {max}"
+    },
+    "Warning": {
+      "Document": {
+        "one": "document",
+        "other": "documents"
+      },
+      "Max": "Must select at most {max} {document}, {value} selected.",
+      "Min": "Must select at least {min} {document}, {value} selected.",
+      "Range": "Must select between {min} and {max} documents, {value} selected.",
+      "Single": "Must select {max} {document}, {value} selected."
+    }
+  },
   "Types": {
     "Label": "Types"
   },

--- a/less/v2/compendium-browser.less
+++ b/less/v2/compendium-browser.less
@@ -7,12 +7,23 @@
       "sidebar results"
       "sidebar footer";
     grid-template-columns: 200px auto;
-    grid-template-rows: auto 0px;
+    grid-template-rows: auto 2.75rem;
     height: calc(100% - var(--header-height));
 
-    .sidebar { grid-area: sidebar; }
-    [data-application-part="results"] { grid-area: results; }
-    [data-application-part="footer"] { grid-area: footer; }
+    &:has(> .footer:empty) { grid-template-rows: auto 0px; }
+
+    .sidebar {
+      grid-area: sidebar;
+      z-index: 3;
+    }
+    [data-application-part="results"] {
+      grid-area: results;
+      z-index: 1;
+    }
+    [data-application-part="footer"] {
+      grid-area: footer;
+      z-index: 2;
+    }
   }
 
   .sidebar {
@@ -21,6 +32,8 @@
     gap: 6px;
     padding-block: 3px;
     padding-inline: 2px;
+    background-color: var(--dnd5e-background-card);
+    box-shadow: 0 0 12px var(--dnd5e-shadow-15);
 
     h3 {
       width: 100%;
@@ -95,6 +108,10 @@
       }
     }
 
+    .selection {
+      width: 46px;
+      padding-inline: 8px;
+    }
     .icon {
       width: calc(var(--icon-size) + 8px);
       padding: 4px;
@@ -103,6 +120,19 @@
         width: var(--icon-size);
         height: var(--icon-size);
       }
+    }
+  }
+
+  .footer:not(:empty) {
+    height: 2.75rem;
+    padding-block: 4px;
+    padding-inline: 8px;
+    box-shadow: 0 0 8px var(--dnd5e-shadow-15);
+
+    .count {
+      .value { font-weight: bold; }
+      &:not(.invalid) .value { color: var(--dnd5e-color-green); }
+      &.invalid .value { color: var(--dnd5e-color-maroon); }
     }
   }
 }

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -449,7 +449,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
    * @param {string} type  The item type.
    * @protected
    */
-  _onFindItem(type) {
+  async _onFindItem(type) {
     if ( game.release.generation < 12 ) {
       switch ( type ) {
         case "class": game.packs.get(CONFIG.DND5E.sourcePacks.CLASSES)?.render(true); break;
@@ -457,10 +457,8 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
         case "background": game.packs.get(CONFIG.DND5E.sourcePacks.BACKGROUNDS)?.render(true); break;
       }
     } else {
-      new CompendiumBrowser({
-        filters: { locked: { types: new Set([type]) } },
-        selection: { min: 1, max: 1 }
-      }).render(true);
+      const result = await CompendiumBrowser.selectOne({ filters: { locked: { types: new Set([type]) } } });
+      if ( result ) this._onDropItemCreate(await fromUuid(result));
     }
   }
 

--- a/templates/compendium/browser-entry.hbs
+++ b/templates/compendium/browser-entry.hbs
@@ -1,5 +1,9 @@
 <tr data-uuid="{{ entry.uuid }}">
-    <!-- TODO: Selection column here if set -->
+    {{#if displaySelection}}
+    <td class="selection">
+        <input type="checkbox" name="selected" value="{{ entry.uuid }}" {{ checked selected }}>
+    </td>
+    {{/if}}
     <td class="icon">
         {{#if entry.img}}
         <img class="gold-icon" loading="lazy" src="{{ entry.img }}" alt="{{ entry.name }}">

--- a/templates/compendium/browser-footer.hbs
+++ b/templates/compendium/browser-footer.hbs
@@ -1,3 +1,10 @@
-<div>
-    <!-- TODO: Display selection limits & select button -->
+<div class="flexrow">
+    {{~#if displaySelection}}
+    <div class="count {{ invalid }}">
+        {{{ localize "DND5E.CompendiumBrowser.Selection.Label" summary=summary }}}
+    </div>
+    <button type="submit">
+        {{ localize "DND5E.CompendiumBrowser.Selection.Select" }}
+    </button>
+    {{/if~}}
 </div>

--- a/templates/compendium/browser-results.hbs
+++ b/templates/compendium/browser-results.hbs
@@ -2,14 +2,16 @@
     <table>
         <thead>
             <tr>
-                <!-- TODO: Selection header here if set -->
+                {{#if displaySelection}}
+                <th scope="col" class="selection"></th>
+                {{/if}}
                 <th scope="col" class="icon"></th>
                 <th scope="col" class="name">{{ localize "DND5E.CompendiumBrowser.Column.Name" }}</th>
             </tr>
         </thead>
         <tbody>
             <tr class="results-loading">
-                <td colspan="2"><!-- TODO: Update colspan to ensure spans full width -->
+                <td colspan="{{ ifThen displaySelection '3' '2' }}"><!-- TODO: Update colspan to ensure spans full width -->
                     <i class="fa-solid fa-spinner fa-spin-pulse" inert></i>
                     {{ localize "DND5E.CompendiumBrowser.Loading" }}
                 </td>


### PR DESCRIPTION
Adds a selection interface and API for making choices within the compendium browser and returning those results to another part of the application for further use. This uses the new API for the controls for adding race, background, and classes to a character sheet.

The Compendium Browser application options get a new `selection` object with the minimum and maximum number of items that can be selected. If either of these are defined then checkboxes appear in the results list and a new footer which displays the number of selected documents and contains the submit button.

<img width="1036" alt="Compendium Browser - Selection" src="https://github.com/foundryvtt/dnd5e/assets/19979839/5021468a-9d0e-4c33-b4f0-78be24960e03">

To make this easy to interact with a pair of new factor methods have been added: `select` and `selectOne`. The `select` method takes the provided options and returns a set of UUIDs or `null` if no selection was made. The `selectOne` wraps that method and sets the minimum and maximum both to `1` and then returns a single UUID string rather than a set.