### PR TITLE
[#3772] Add configuration for CR-based summoning mode

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1743,7 +1743,7 @@
     "LabelPl": "Summons Profiles",
     "ChallengeRatingLabel": "Challenge Rating of {cr} or lower",
     "Empty": "Click above to add a profile.",
-    "EmptyDrop": "Click above to add a profile or drop an creature to summon here."
+    "EmptyDrop": "Click above to add a profile or drop a creature to summon here."
   },
   "Prompt": {
     "Label": "Summon Prompt",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1732,10 +1732,18 @@
       "Hint": "Modify to saving throw DCs on the summoned creature's abilities to match that of the summoner."
     }
   },
+  "Mode": {
+    "Label": "Mode",
+    "Hint": "Sets how the creatures that are to be summoned are specified.",
+    "CR": "By Challenge Rating & Type",
+    "Direct": "By Direct Link"
+  },
   "Profile": {
     "Label": "Summons Profile",
     "LabelPl": "Summons Profiles",
-    "Empty": "Click above to add a profile or drop an creature to summon here."
+    "ChallengeRatingLabel": "Challenge Rating of {cr} or lower",
+    "Empty": "Click above to add a profile.",
+    "EmptyDrop": "Click above to add a profile or drop an creature to summon here."
   },
   "Prompt": {
     "Label": "Summon Prompt",

--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -687,6 +687,11 @@
       padding-inline: 4px;
     }
     input::placeholder { opacity: .5; }
+    .details > label {
+      display: flex;
+      gap: 4px;
+      strong { align-self: center; }
+    }
   }
   .additional-tray {
     margin-block-start: 8px;

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -525,6 +525,10 @@
         gap: 4px;
         input { height: unset; }
         input::placeholder { opacity: .5; }
+        .sep {
+          flex: 0;
+          align-self: center;
+        }
       }
       .list-controls {
         flex: 0;

--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -224,8 +224,8 @@ export default class AbilityUseDialog extends Dialog {
         })
         .filter(f => f)
     );
-    if ( Object.values(options.profiles).every(p => p.startsWith("1 x ")) ) {
-      Object.entries(options.profiles).forEach(([k, v]) => options.profiles[k] = v.replace("1 x ", ""));
+    if ( Object.values(options.profiles).every(p => p.startsWith("1 × ")) ) {
+      Object.entries(options.profiles).forEach(([k, v]) => options.profiles[k] = v.replace("1 × ", ""));
     }
     if ( Object.values(options.profiles).length <= 1 ) {
       options.profile = Object.keys(options.profiles)[0];

--- a/module/applications/item/summoning-config.mjs
+++ b/module/applications/item/summoning-config.mjs
@@ -53,9 +53,18 @@ export default class SummoningConfig extends DocumentSheet {
   async getData(options={}) {
     const context = await super.getData(options);
     context.isSpell = this.document.type === "spell";
+    context.modes = {
+      cr: "DND5E.Summoning.Mode.CR"
+    };
     context.profiles = this.profiles.map(p => {
       const profile = { id: p._id, ...p, collapsed: this.expandedProfiles.get(p._id) ? "" : "collapsed" };
       if ( p.uuid ) profile.document = fromUuidSync(p.uuid);
+      if ( this.document.system.summons.mode === "cr" ) {
+        profile.creatureTypes = Object.entries(CONFIG.DND5E.creatureTypes).reduce((obj, [k, c]) => {
+          obj[k] = { label: c.label, selected: p.types.has(k) ? "selected" : "" };
+          return obj;
+        }, {});
+      }
       return profile;
     }).sort((lhs, rhs) =>
       (lhs.name || lhs.document?.name || "").localeCompare(rhs.name || rhs.document?.name || "", game.i18n.lang)

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -616,7 +616,7 @@ export class SummonsData extends foundry.abstract.DataModel {
     let label;
     if ( profile.name ) label = profile.name;
     else {
-      switch (this.mode) {
+      switch ( this.mode ) {
         case "cr":
           const cr = simplifyBonus(profile.cr, rollData);
           label = game.i18n.format("DND5E.Summoning.Profile.ChallengeRatingLabel", { cr: formatCR(cr) });
@@ -632,8 +632,8 @@ export class SummonsData extends foundry.abstract.DataModel {
     let count = simplifyRollFormula(Roll.replaceFormulaData(profile.count ?? "1", rollData));
     if ( Number.isNumeric(count) ) {
       count = parseInt(count);
-      label = `${count} x ${label}`;
-    } else if ( count ) label = `${count} x ${label}`;
+      label = `${count} × ${label}`;
+    } else if ( count ) label = `${count} × ${label}`;
 
     return label;
   }

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -1,5 +1,6 @@
 import TokenPlacement from "../../../canvas/token-placement.mjs";
-import { staticID } from "../../../utils.mjs";
+import simplifyRollFormula from "../../../dice/simplify-roll-formula.mjs";
+import { formatCR, simplifyBonus, staticID } from "../../../utils.mjs";
 import { FormulaField, IdentifierField } from "../../fields.mjs";
 
 const {
@@ -21,13 +22,15 @@ export default class SummonsField extends EmbeddedDataField {
  * Information for a single summoned creature.
  *
  * @typedef {object} SummonsProfile
- * @property {string} _id        Unique ID for this profile.
- * @property {string} count      Formula for the number of creatures to summon.
+ * @property {string} _id         Unique ID for this profile.
+ * @property {string} count       Formula for the number of creatures to summon.
+ * @property {string} cr          Formula for the CR of summoned creatures if in CR mode.
  * @property {object} level
- * @property {number} level.min  Minimum level at which this profile can be used.
- * @property {number} level.max  Maximum level at which this profile can be used.
- * @property {string} name       Display name for this profile if it differs from actor's name.
- * @property {string} uuid       UUID of the actor to summon.
+ * @property {number} level.min   Minimum level at which this profile can be used.
+ * @property {number} level.max   Maximum level at which this profile can be used.
+ * @property {string} name        Display name for this profile if it differs from actor's name.
+ * @property {Set<string>} types  Types of summoned creatures if in CR mode.
+ * @property {string} uuid        UUID of the actor to summon if in default mode.
  */
 
 /**
@@ -47,6 +50,7 @@ export default class SummonsField extends EmbeddedDataField {
  * @property {boolean} match.attacks        Match the to hit values on summoned actor's attack to the summoner.
  * @property {boolean} match.proficiency    Match proficiency on summoned actor to the summoner.
  * @property {boolean} match.saves          Match the save DC on summoned actor's abilities to the summoner.
+ * @property {""|"cr"} mode                 Method of determining what type of creature is summoned.
  * @property {SummonsProfile[]} profiles    Information on creatures that can be summoned.
  * @property {boolean} prompt               Should the player be prompted to place the summons?
  */
@@ -92,14 +96,17 @@ export class SummonsData extends foundry.abstract.DataModel {
           label: "DND5E.Summoning.Match.Saves.Label", hint: "DND5E.Summoning.Match.Saves.Hint"
         })
       }),
+      mode: new StringField({label: "DND5E.Summoning.Mode.Label", hint: "DND5E.Summoning.Mode.Hint"}),
       profiles: new ArrayField(new SchemaField({
         _id: new DocumentIdField({initial: () => foundry.utils.randomID()}),
         count: new FormulaField(),
+        cr: new FormulaField({deterministic: true}),
         level: new SchemaField({
           min: new NumberField({integer: true, min: 0}),
           max: new NumberField({integer: true, min: 0})
         }),
         name: new StringField(),
+        types: new SetField(new StringField()),
         uuid: new StringField()
       })),
       prompt: new BooleanField({
@@ -593,6 +600,42 @@ export class SummonsData extends foundry.abstract.DataModel {
     }
 
     return tokenDocument.toObject();
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Determine the label for a profile in the ability use dialog.
+   * @param {SummonsProfile} profile  Profile for which to generate the label.
+   * @param {object} rollData         Roll data used to prepare the count.
+   * @returns {string}
+   */
+  getProfileLabel(profile, rollData) {
+    let label;
+    if ( profile.name ) label = profile.name;
+    else {
+      switch (this.mode) {
+        case "cr":
+          const cr = simplifyBonus(profile.cr, rollData);
+          label = game.i18n.format("DND5E.Summoning.Profile.ChallengeRatingLabel", { cr: formatCR(cr) });
+          break;
+        default:
+          const doc = fromUuidSync(profile.uuid);
+          if ( doc ) label = doc.name;
+          break;
+      }
+    }
+    label ??= "—";
+
+    let count = simplifyRollFormula(Roll.replaceFormulaData(profile.count ?? "1", rollData));
+    if ( Number.isNumeric(count) ) {
+      count = parseInt(count);
+      label = `${count} x ${label}`;
+    } else if ( count ) label = `${count} x ${label}`;
+
+    return label;
   }
 
   /* -------------------------------------------- */

--- a/templates/apps/ability-use.hbs
+++ b/templates/apps/ability-use.hbs
@@ -123,7 +123,7 @@
         <input type="hidden" name="summonsProfile" value="{{ summoningOptions.profile }}">
         {{/if}}
     </div>
-    
+
     {{#if summoningOptions.creatureSizes}}
     <div class="form-group">
         <label>{{ localize "DND5E.Size" }}</label>

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -18,7 +18,7 @@
             <div class="details flexrow">
                 <input type="text" name="profiles.{{ id }}.count" value="{{ count }}" placeholder="1"
                     aria-label="{{ localize 'DND5E.Summoning.Count.Label' }}">
-                <span class="sep">x</span>
+                <span class="sep">&times;</span>
                 {{#if (eq @root.summons.mode "cr")}}
                 <label>
                     <strong>{{ localize 'DND5E.AbbreviationCR' }}</strong>

--- a/templates/apps/summoning-config.hbs
+++ b/templates/apps/summoning-config.hbs
@@ -6,18 +6,32 @@
             {{ localize 'DND5E.Summoning.Action.Add' }}
         </button>
     </h3>
+    <div class="form-group">
+        <label>{{ localize "DND5E.Summoning.Mode.Label" }}</label>
+        <select name="mode">
+            {{ selectOptions modes selected=summons.mode localize=true blank=(localize "DND5E.Summoning.Mode.Direct") }}
+        </select>
+    </div>
     <ul class="dnd5e2 separated-list profiles flexcol">
         {{#each profiles}}
         <li class="profile dnd5e2" data-profile-id="{{ id }}">
             <div class="details flexrow">
                 <input type="text" name="profiles.{{ id }}.count" value="{{ count }}" placeholder="1"
-                       aria-label="{{ localize 'DND5E.Summoning.Count.Label' }}">
+                    aria-label="{{ localize 'DND5E.Summoning.Count.Label' }}">
+                <span class="sep">x</span>
+                {{#if (eq @root.summons.mode "cr")}}
+                <label>
+                    <strong>{{ localize 'DND5E.AbbreviationCR' }}</strong>
+                    <input type="text" name="profiles.{{ id }}.cr" value="{{ cr }}">
+                </label>
+                {{else}}
                 {{#if document}}
                 {{{ dnd5e-linkForUuid uuid }}}
                 {{else}}
                 <div class="drop-area">
-                    {{localize "DND5E.Summoning.DropHint"}}
+                    {{ localize "DND5E.Summoning.DropHint" }}
                 </div>
+                {{/if}}
                 {{/if}}
                 <input type="text" name="profiles.{{ id }}.name" value="{{ name }}" aria-label="{{ localize 'Name' }}"
                        placeholder="{{#if document}}{{ document.name }}{{else}}
@@ -40,6 +54,16 @@
                 </label>
                 <div class="collapsible-content">
                     <div class="wrapper">
+                        {{#if (eq @root.summons.mode "cr")}}
+                        <div class="form-group">
+                            <label>{{ localize "DND5E.Summoning.CreatureTypes.Label" }}</label>
+                            <multi-select name="profiles.{{ id }}.types">
+                                {{#each creatureTypes}}
+                                <option value="{{ @key }}" {{ selected }}>{{ label }}</option>
+                                {{/each}}
+                            </multi-select>
+                        </div>
+                        {{/if}}
                         <div class="form-group">
                             <label>{{ localize "DND5E.LevelLimit.Label" }}</label>
                             <div class="form-fields">
@@ -56,7 +80,10 @@
             </div>
         </li>
         {{else}}
-        <li class="empty">{{ localize "DND5E.Summoning.Profile.Empty" }}</li>
+        <li class="empty">
+            {{#unless summons.mode}}{{ localize "DND5E.Summoning.Profile.EmptyDrop" }}
+            {{~else}}{{ localize "DND5E.Summoning.Profile.Empty" }}{{/unless}}
+        </li>
         {{/each}}
     </ul>
 


### PR DESCRIPTION
Adds an alternate mode to summoning allowing for specifying CR and type of summoned creatures rather than a specific document link. This CR can be a single value or a formula so it can change with level.

<img width="737" alt="Summoning by Challenge Rating" src="https://github.com/foundryvtt/dnd5e/assets/19979839/08e5a8dc-ad67-4035-ab7e-6161f11c0d9c">

This does not include the actual summoning functionality, since that will be dependent on the compendium browser.