### PR TITLE
[#2623] Separate ability score locking from fixed improvements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -148,21 +148,48 @@
 "DND5E.AdditionalControls": "Additional Controls",
 "DND5E.AdditionalSettings": "Additional Settings",
 "DND5E.AddEmbeddedItemPromptHint": "Do you want to add these items to your character sheet?",
-"DND5E.AdvancementAbilityScoreImprovementTitle": "Ability Score Improvement",
-"DND5E.AdvancementAbilityScoreImprovementHint": "Allow the player to increase one or more ability scores or take an optional feat.",
-"DND5E.AdvancementAbilityScoreImprovementCap": "Point Cap",
-"DND5E.AdvancementAbilityScoreImprovementCapHint": "Maximum number of points a player can assign to a single score.",
-"DND5E.AdvancementAbilityScoreImprovementCapDisplay.one": "Max {points} point per score",
-"DND5E.AdvancementAbilityScoreImprovementCapDisplay.other": "Max {points} points per score",
-"DND5E.AdvancementAbilityScoreImprovementFeatHint": "Drop a feat here to choose one instead of an ability score improvement.",
-"DND5E.AdvancementAbilityScoreImprovementFeatLevelWarning": "Must be at least level {level} to take this feat.",
-"DND5E.AdvancementAbilityScoreImprovementFeatWarning": "Only features with the 'feat' type can be selected.",
-"DND5E.AdvancementAbilityScoreImprovementFixed": "Fixed Improvement",
-"DND5E.AdvancementAbilityScoreImprovementLockedHint": "Scores cannot be modified with a feat selected.",
-"DND5E.AdvancementAbilityScoreImprovementPoints": "Points",
-"DND5E.AdvancementAbilityScoreImprovementPointsHint": "Number of points that can be assigned to any ability score that doesn't have a fixed improvement set.",
-"DND5E.AdvancementAbilityScoreImprovementPointsRemaining.one": "{points} Point Remaining",
-"DND5E.AdvancementAbilityScoreImprovementPointsRemaining.other": "{points} Points Remaining",
+"DND5E.Advancement": {
+  "AbilityScoreImprovement": {
+    "Title": "Ability Score Improvement",
+    "Hint": "Allow the player to increase one or more ability scores or take an optional feat.",
+    "CapDisplay": {
+      "one": "Max {points} point per score",
+      "other": "Max {points} points per score"
+    },
+    "Feat": {
+      "Hint": "Drop a feat here to choose one instead of an ability score improvement."
+    },
+    "FIELDS": {
+      "cap": {
+        "label": "Point Cap",
+        "hint": "Maximum number of points a player can assign to a single score."
+      },
+      "locked": {
+        "label": "Locked",
+        "hint": "Ability cannot be improved."
+      },
+      "fixed": {
+        "label": "Fixed Improvement",
+        "hint": "Abilities that are improved by a fixed amount and cannot be manually improved during the process."
+      },
+      "points": {
+        "label": "Points",
+        "hint": "Number of points that can be assigned to any ability score that doesn't have a fixed improvement set.",
+        "decrease": "Decrease Points",
+        "increase": "Increase Points"
+      }
+    },
+    "LockedHint": "Scores cannot be modified with a feat selected.",
+    "PointsRemaining": {
+      "one": "{points} Point Remaining",
+      "other": "{points} Points Remaining"
+    },
+    "Warning": {
+      "Level": "Must be at least level {level} to take this feat.",
+      "Type": "Only features with the \"feat\" type can be selected."
+    }
+  }
+},
 "DND5E.AdvancementChoices": "choices",
 "DND5E.AdvancementClassRestriction": "Class Restriction",
 "DND5E.AdvancementClassRestrictionNone": "All Classes",

--- a/less/v1/advancement.less
+++ b/less/v1/advancement.less
@@ -148,7 +148,7 @@
           text-align: start;
           align-self: end;
         }
-        label {
+        label:first-child {
           grid-area: label;
           font-size: var(--font-size-18);
         }
@@ -165,7 +165,7 @@
         }
         .minus { grid-area: minus; }
         .plus { grid-area: plus; }
-        input {
+        > input {
           grid-area: value;
           height: 1.5em;
           border: none;
@@ -178,6 +178,18 @@
           font-weight: bold;
           i {
             font-size: var(--font-size-12);
+          }
+        }
+        .locked {
+          grid-column: 1 / -1;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin: 0;
+          font-size: var(--font-size-12);
+          > input {
+            width: 14px;
+            height: 14px;
           }
         }
       }

--- a/module/applications/advancement/ability-score-improvement-config.mjs
+++ b/module/applications/advancement/ability-score-improvement-config.mjs
@@ -13,6 +13,8 @@ export default class AbilityScoreImprovementConfig extends AdvancementConfig {
   }
 
   /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
 
   /** @inheritdoc */
   getData() {
@@ -23,6 +25,7 @@ export default class AbilityScoreImprovementConfig extends AdvancementConfig {
         key,
         name: `configuration.fixed.${key}`,
         label: data.label,
+        locked: this.advancement.configuration.locked.has(key),
         value: fixed,
         canIncrease: true,
         canDecrease: true
@@ -35,13 +38,23 @@ export default class AbilityScoreImprovementConfig extends AdvancementConfig {
       points: {
         key: "points",
         name: "configuration.points",
-        label: game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementPoints"),
+        label: game.i18n.localize("DND5E.Advancement.AbilityScoreImprovement.FIELDS.points.label"),
         min: 0,
         value: this.advancement.configuration.points,
         canIncrease: true,
         canDecrease: this.advancement.configuration.points > 0
       }
     });
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners & Handlers                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async prepareConfigurationUpdate(configuration) {
+    configuration.locked = configuration.locked?.filter(l => l);
+    return configuration;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -43,9 +43,10 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
 
   /** @inheritdoc */
   async getData() {
+    console.log(this.assignments);
     const points = {
       assigned: Object.keys(CONFIG.DND5E.abilities).reduce((assigned, key) => {
-        if ( !this.advancement.canImprove(key) || this.advancement.configuration.fixed[key] ) return assigned;
+        if ( !this.advancement.canImprove(key) || this.advancement.configuration.locked.has(key) ) return assigned;
         return assigned + (this.assignments[key] ?? 0);
       }, 0),
       cap: this.advancement.configuration.cap ?? Infinity,
@@ -60,20 +61,21 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
       const ability = this.advancement.actor.system.abilities[key];
       const assignment = this.assignments[key] ?? 0;
       const fixed = this.advancement.configuration.fixed[key] ?? 0;
-      const value = Math.min(ability.value + ((fixed || assignment) ?? 0), ability.max);
-      const max = fixed ? value : Math.min(value + points.available, ability.max);
+      const locked = this.advancement.configuration.locked.has(key);
+      const value = Math.min(ability.value + fixed + assignment, ability.max);
+      const max = locked ? value : Math.min(value + points.available, ability.max);
+      const min = Math.min(ability.value + fixed, ability.max);
       obj[key] = {
-        key, max, value,
+        key, max, min, value,
         name: `abilities.${key}`,
         label: data.label,
-        initial: ability.value,
-        min: fixed ? max : ability.value,
+        initial: ability.value + fixed,
         delta: (value - ability.value) ? formatter.format(value - ability.value) : null,
         showDelta: true,
         isDisabled: !!this.feat,
-        isFixed: !!fixed || (ability.value >= ability.max),
-        canIncrease: (value < max) && (assignment < points.cap) && !fixed && !this.feat,
-        canDecrease: (value > ability.value) && !fixed && !this.feat
+        isLocked: !!locked || (ability.value >= ability.max),
+        canIncrease: (value < max) && ((fixed + assignment) < points.cap) && !locked && !this.feat,
+        canDecrease: (value > (ability.value + fixed)) && !locked && !this.feat
       };
       return obj;
     }, {});
@@ -84,10 +86,10 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
       feat: this.feat,
       staticIncrease: !this.advancement.configuration.points,
       pointCap: game.i18n.format(
-        `DND5E.AdvancementAbilityScoreImprovementCapDisplay.${pluralRules.select(points.cap)}`, {points: points.cap}
+        `DND5E.Advancement.AbilityScoreImprovement.CapDisplay.${pluralRules.select(points.cap)}`, {points: points.cap}
       ),
       pointsRemaining: game.i18n.format(
-        `DND5E.AdvancementAbilityScoreImprovementPointsRemaining.${pluralRules.select(points.available)}`,
+        `DND5E.Advancement.AbilityScoreImprovement.PointsRemaining.${pluralRules.select(points.available)}`,
         {points: points.available}
       )
     });
@@ -114,7 +116,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
     else {
       this.assignments[key] = Math.min(
         Math.clamp(input.valueAsNumber, Number(input.min), Number(input.max)) - Number(input.dataset.initial),
-        this.advancement.configuration.cap ?? Infinity
+        (this.advancement.configuration.cap - (this.advancement.configuration.fixed[key] ?? 0)) ?? Infinity
       );
     }
     this.render();
@@ -199,13 +201,13 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
     const item = await Item.implementation.fromDropData(data);
 
     if ( (item.type !== "feat") || (item.system.type.value !== "feat") ) {
-      ui.notifications.error("DND5E.AdvancementAbilityScoreImprovementFeatWarning", {localize: true});
+      ui.notifications.error("DND5E.Advancement.AbilityScoreImprovement.Warning.Type", {localize: true});
       return null;
     }
 
     // If a feat has a level pre-requisite, make sure it is less than or equal to current character level
     if ( (item.system.prerequisites?.level ?? -Infinity) > this.advancement.actor.system.details.level ) {
-      ui.notifications.error(game.i18n.format("DND5E.AdvancementAbilityScoreImprovementFeatLevelWarning", {
+      ui.notifications.error(game.i18n.format("DND5E.Advancement.AbilityScoreImprovement.Warning.Level", {
         level: item.system.prerequisites.level
       }));
       return null;

--- a/module/applications/journal/class-page-sheet.mjs
+++ b/module/applications/journal/class-page-sheet.mjs
@@ -186,7 +186,7 @@ export default class JournalClassPageSheet extends JournalPageSheet {
       for ( const advancement of item.advancement.byLevel[level] ) {
         switch ( advancement.constructor.typeName ) {
           case "AbilityScoreImprovement":
-            features.push(game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementTitle"));
+            features.push(game.i18n.localize("DND5E.Advancement.AbilityScoreImprovement.Title"));
             continue;
           case "ItemGrant":
             if ( advancement.configuration.optional ) continue;

--- a/module/data/advancement/ability-score-improvement.mjs
+++ b/module/data/advancement/ability-score-improvement.mjs
@@ -1,29 +1,30 @@
 import { SparseDataModel } from "../abstract.mjs";
 import { MappingField } from "../fields.mjs";
 
+const { NumberField, SetField, StringField } = foundry.data.fields;
+
 /**
  * Data model for the Ability Score Improvement advancement configuration.
  *
- * @property {number} points                 Number of points that can be assigned to any score.
+ * @property {number} cap                    Maximum number of points that can be assigned to a single score.
+ * @property {Set<string>} locked            Abilities that cannot be changed by this advancement.
  * @property {Object<string, number>} fixed  Number of points automatically assigned to a certain score.
+ * @property {number} points                 Number of points that can be assigned to any score.
  */
 export class AbilityScoreImprovementConfigurationData extends foundry.abstract.DataModel {
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.Advancement.AbilityScoreImprovement"];
+
+  /* -------------------------------------------- */
+
   /** @inheritdoc */
   static defineSchema() {
     return {
-      points: new foundry.data.fields.NumberField({
-        integer: true, min: 0, initial: 0,
-        label: "DND5E.AdvancementAbilityScoreImprovementPoints",
-        hint: "DND5E.AdvancementAbilityScoreImprovementPointsHint"
-      }),
-      fixed: new MappingField(
-        new foundry.data.fields.NumberField({nullable: false, integer: true, initial: 0}),
-        {label: "DND5E.AdvancementAbilityScoreImprovementFixed"}
-      ),
-      cap: new foundry.data.fields.NumberField({
-        integer: true, min: 1, initial: 2, label: "DND5E.AdvancementAbilityScoreImprovementCap",
-        hint: "DND5E.AdvancementAbilityScoreImprovementCapHint"
-      })
+      cap: new NumberField({ integer: true, min: 1, initial: 2 }),
+      fixed: new MappingField(new NumberField({ nullable: false, integer: true, initial: 0 })),
+      locked: new SetField(new StringField()),
+      points: new NumberField({ integer: true, min: 0, initial: 0 })
     };
   }
 }
@@ -31,7 +32,7 @@ export class AbilityScoreImprovementConfigurationData extends foundry.abstract.D
 /**
  * Data model for the Ability Score Improvement advancement value.
  *
- * @property {string} type  When on a class, whether the player chose ASI or a Feat.
+ * @property {string} type             When on a class, whether the player chose ASI or a Feat.
  * @property {Object<string, number>}  Points assigned to individual scores.
  * @property {Object<string, string>}  Feat that was selected.
  */
@@ -39,13 +40,11 @@ export class AbilityScoreImprovementValueData extends SparseDataModel {
   /** @inheritdoc */
   static defineSchema() {
     return {
-      type: new foundry.data.fields.StringField({
-        required: true, initial: "asi", choices: ["asi", "feat"]
-      }),
-      assignments: new MappingField(new foundry.data.fields.NumberField({
+      type: new StringField({ required: true, initial: "asi", choices: ["asi", "feat"] }),
+      assignments: new MappingField(new NumberField({
         nullable: false, integer: true
       }), {required: false, initial: undefined}),
-      feat: new MappingField(new foundry.data.fields.StringField(), {
+      feat: new MappingField(new StringField(), {
         required: false, initial: undefined, label: "DND5E.Feature.Feat"
       })
     };

--- a/module/documents/advancement/ability-score-improvement.mjs
+++ b/module/documents/advancement/ability-score-improvement.mjs
@@ -20,8 +20,8 @@ export default class AbilityScoreImprovementAdvancement extends Advancement {
       },
       order: 20,
       icon: "systems/dnd5e/icons/svg/ability-score-improvement.svg",
-      title: game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementTitle"),
-      hint: game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementHint"),
+      title: game.i18n.localize("DND5E.Advancement.AbilityScoreImprovement.Title"),
+      hint: game.i18n.localize("DND5E.Advancement.AbilityScoreImprovement.Hint"),
       apps: {
         config: AbilityScoreImprovementConfig,
         flow: AbilityScoreImprovementFlow
@@ -106,7 +106,7 @@ export default class AbilityScoreImprovementAdvancement extends Advancement {
         return `<span class="tag">${name} <strong>${formatter.format(value)}</strong></span>`;
       });
       if ( this.configuration.points ) entries.push(`<span class="tag">${
-        game.i18n.localize("DND5E.AdvancementAbilityScoreImprovementPoints")}: <strong>${
+        game.i18n.localize("DND5E.Advancement.AbilityScoreImprovement.FIELDS.points.label")}: <strong>${
         this.configuration.points}</strong></span>`
       );
       return entries.filterJoin("\n");

--- a/templates/advancement/ability-score-improvement-config.hbs
+++ b/templates/advancement/ability-score-improvement-config.hbs
@@ -1,21 +1,21 @@
-<form autocomplete="off" data-id="{{_id}}" data-type="{{type}}">
-    {{> "dnd5e.advancement-controls"}}
+<form autocomplete="off" data-id="{{ _id }}" data-type="{{ type }}">
+    {{> "dnd5e.advancement-controls" }}
     <div class="form-group">
-        <label>{{localize "DND5E.AdvancementAbilityScoreImprovementCap"}}</label>
+        <label>{{ localize "DND5E.Advancement.AbilityScoreImprovement.FIELDS.cap.label" }}</label>
         <div class="form-fields">
-            <input type="number" name="configuration.cap" value="{{configuration.cap}}" min="1" step="1"
-                         placeholder="{{localize 'None'}}">
+            <input type="number" name="configuration.cap" value="{{ configuration.cap }}" min="1" step="1"
+                         placeholder="{{ localize 'None' }}">
         </div>
-        <p class="hint">{{localize "DND5E.AdvancementAbilityScoreImprovementCapHint"}}</p>
+        <p class="hint">{{ localize "DND5E.Advancement.AbilityScoreImprovement.FIELDS.cap.hint" }}</p>
     </div>
 
     <ul class="ability-scores">
-        {{> "dnd5e.advancement-ability-score-control" points canAdjust=true}}
+        {{> "dnd5e.advancement-ability-score-control" points canAdjust=true }}
         <li class="hint">
-            {{localize "DND5E.AdvancementAbilityScoreImprovementPointsHint"}}
+            {{ localize "DND5E.Advancement.AbilityScoreImprovement.FIELDS.points.hint" }}
         </li>
         {{#each abilities}}
-        {{> "dnd5e.advancement-ability-score-control" this canAdjust=true}}
+        {{> "dnd5e.advancement-ability-score-control" this canAdjust=true canLock=true }}
         {{/each}}
     </ul>
 </form>

--- a/templates/advancement/ability-score-improvement-flow.hbs
+++ b/templates/advancement/ability-score-improvement-flow.hbs
@@ -1,36 +1,37 @@
-<form id="{{appId}}" data-level="{{level}}" data-id="{{advancement.id}}" data-type="{{type}}">
-    <h3>{{{this.title}}}</h3>
+<form id="{{ appId }}" data-level="{{ level }}" data-id="{{ advancement.id }}" data-type="{{ type }}">
+    <h3>{{{ this.title }}}</h3>
 
     <ul class="ability-scores {{#if feat}}disabled{{/if}}">
         {{#unless staticIncrease}}
         <label>
             {{#if feat}}
-            {{localize "DND5E.AdvancementAbilityScoreImprovementLockedHint"}}
+            {{ localize "DND5E.Advancement.AbilityScoreImprovement.LockedHint" }}
             {{else}}
             {{ pointsRemaining }}
-            {{#if advancement.configuration.cap}}<p class="cap">{{pointCap}}</p>{{/if}}
+            {{#if advancement.configuration.cap}}<p class="cap">{{ pointCap }}</p>{{/if}}
             {{/if}}
         </label>
         {{/unless}}
         {{#each abilities}}
-        {{> "dnd5e.advancement-ability-score-control" this canAdjust=(not @root.staticIncrease)}}
+        {{> "dnd5e.advancement-ability-score-control" this canAdjust=(not @root.staticIncrease) }}
         {{/each}}
     </ul>
 
     {{#if advancement.allowFeat}}
-        <h3>{{localize "DND5E.Feature.Feat"}}</h3>
+        <h3>{{ localize "DND5E.Feature.Feat" }}</h3>
 
         <div class="item-name flexrow drop-area {{#unless feat}}empty{{/unless}}">
             {{#if feat}}
-            <div class="item-image" style="background-image: url('{{feat.img}}');"></div>
+            <div class="item-image" style="background-image: url('{{ feat.img }}');"></div>
             <h4>
-                <a data-uuid="{{feat.uuid}}">{{feat.name}}</a>
+                <a data-uuid="{{ feat.uuid }}">{{ feat.name }}</a>
             </h4>
-            <a class="item-control" data-action="delete" title="{{localize 'DND5E.ItemDelete'}}">
-                <i class="fas fa-trash"></i>
+            <a class="item-control" data-action="delete" data-tooltip="DND5E.ItemDelete"
+               aria-label="{{ localize 'DND5E.ItemDelete' }}">
+                <i class="fas fa-trash" inert></i>
             </a>
             {{else}}
-            {{localize "DND5E.AdvancementAbilityScoreImprovementFeatHint"}}
+            {{ localize "DND5E.Advancement.AbilityScoreImprovement.Feat.Hint" }}
             {{/if}}
         </div>
     {{/if}}

--- a/templates/advancement/parts/advancement-ability-score-control.hbs
+++ b/templates/advancement/parts/advancement-ability-score-control.hbs
@@ -1,23 +1,34 @@
-<li data-score="{{key}}">
-    <label>{{label}}</label>
+<li data-score="{{ key }}">
+    <label>{{ label }}</label>
     {{#if canAdjust}}
-    <a class="adjustment-button" {{~#if canDecrease}}data-action="decrease"{{else}}aria-disabled="true"{{/if}}>
-        <i class="fas fa-minus"></i>
+    <a class="adjustment-button" {{~#if canDecrease}}data-action="decrease"{{else}}aria-disabled="true"{{/if}}
+       data-tooltip="DND5E.Advancement.AbilityScoreImprovement.FIELDS.points.decrease"
+       aria-label="{{ localize 'DND5E.Advancement.AbilityScoreImprovement.FIELDS.points.decrease' }}">
+        <i class="fas fa-minus" inert></i>
     </a>
     {{/if}}
-    <input name="{{name}}" type="number" min="{{min}}" max="{{max}}"
-           step="1" value="{{value}}" data-initial="{{initial}}"
-           {{#if isFixed}}readonly aria-readonly="true"{{/if}} {{disabled isDisabled}}>
+    <input name="{{ name }}" type="number" min="{{ min }}" max="{{ max }}"
+           step="1" value="{{ value }}" data-initial="{{ initial }}"
+           {{#if isLocked}}readonly aria-readonly="true"{{/if}} {{ disabled isDisabled }}>
     {{#if canAdjust}}
-    <a class="adjustment-button" {{~#if canIncrease}} data-action="increase"{{else}} aria-disabled="true"{{/if}}>
-        <i class="fas fa-plus"></i>
+    <a class="adjustment-button" {{~#if canIncrease}} data-action="increase"{{else}} aria-disabled="true"{{/if}}
+       data-tooltip="DND5E.Advancement.AbilityScoreImprovement.FIELDS.points.increase"
+       aria-label="{{ localize 'DND5E.Advancement.AbilityScoreImprovement.FIELDS.points.increase' }}">
+        <i class="fas fa-plus" inert></i>
     </a>
+    {{/if}}
+    {{#if canLock}}
+    <label class="locked">
+        <span>{{ localize "DND5E.Advancement.AbilityScoreImprovement.FIELDS.locked.label" }}</span>
+        <input type="checkbox" name="configuration.locked" value="{{ key }}" {{ checked locked }}>
+    </label>
     {{/if}}
     {{#if showDelta}}
     <div class="delta">
         {{#if delta}}{{delta}}{{else}}&nbsp;{{/if}}
-        {{#if isFixed}}
-        <i class="fa-solid fa-lock" data-tooltip="DND5E.AdvancementAbilityScoreImprovementFixed"></i>
+        {{#if isLocked}}
+        <i class="fa-solid fa-lock" data-tooltip="DND5E.Advancement.AbilityScoreImprovement.FIELDS.fixed.label"
+           aria-label="{{ localize 'DND5E.Advancement.AbilityScoreImprovement.FIELDS.fixed.label' }}"></i>
         {{/if}}
     </div>
     {{/if}}


### PR DESCRIPTION
Previously if you granted an ability score a fixed improvement it also locked that score so it cannot be improved further. This moves the list of locked ability scores into a separate list so scores without fixed improvements can be locked, and scores with fixed improvements can still be improved further.

<img width="886" alt="Ability Score Improvement Locking" src="https://github.com/foundryvtt/dnd5e/assets/19979839/b6e2593b-245c-482b-8d80-e56bdaec086d">

This is a slightly breaking change because fixed improvements that were previously locked will no longer be so.