### PR TITLE
[#2728] Add hint to all advancement types

### DIFF
--- a/module/applications/advancement/advancement-config.mjs
+++ b/module/applications/advancement/advancement-config.mjs
@@ -85,7 +85,8 @@ export default class AdvancementConfig extends FormApplication {
       src: this.advancement.toObject(),
       default: {
         title: this.advancement.constructor.metadata.title,
-        icon: this.advancement.constructor.metadata.icon
+        icon: this.advancement.constructor.metadata.icon,
+        hint: ""
       },
       levels,
       showClassRestrictions: this.item.type === "class",

--- a/module/applications/advancement/size-flow.mjs
+++ b/module/applications/advancement/size-flow.mjs
@@ -19,7 +19,7 @@ export default class SizeFlow extends AdvancementFlow {
     const sizes = this.advancement.configuration.sizes;
     return foundry.utils.mergeObject(super.getData(), {
       singleSize: sizes.size === 1 ? sizes.first() : null,
-      hint: this.advancement.configuration.hint || this.advancement.automaticHint,
+      hint: this.advancement.hint || this.advancement.automaticHint,
       selectedSize: this.retainedData?.size ?? this.advancement.value.size,
       sizes: Array.from(sizes).reduce((obj, key) => {
         obj[key] = CONFIG.DND5E.actorSizes[key].label;

--- a/module/applications/advancement/trait-flow.mjs
+++ b/module/applications/advancement/trait-flow.mjs
@@ -38,7 +38,7 @@ export default class TraitFlow extends AdvancementFlow {
     this.chosen ??= await this.prepareInitialValue();
     const available = await this.advancement.availableChoices(this.chosen);
     return foundry.utils.mergeObject(super.getData(), {
-      hint: this.advancement.configuration.hint ? this.advancement.configuration.hint : Trait.localizedList({
+      hint: this.advancement.hint ? this.advancement.hint : Trait.localizedList({
         grants: this.advancement.configuration.grants, choices: this.advancement.configuration.choices
       }),
       slots: this.prepareTraitSlots(available),

--- a/module/applications/journal/class-page-sheet.mjs
+++ b/module/applications/journal/class-page-sheet.mjs
@@ -109,7 +109,7 @@ export default class JournalClassPageSheet extends JournalPageSheet {
         return (a.classRestriction !== "secondary") && (a.level === 1);
       });
       if ( !advancement ) return game.i18n.localize("None");
-      return advancement.configuration.hint || Trait.localizedList(advancement.configuration);
+      return advancement.hint || Trait.localizedList(advancement.configuration);
     };
     if ( traits.length ) {
       advancement.traits = {

--- a/module/data/advancement/base-advancement.mjs
+++ b/module/data/advancement/base-advancement.mjs
@@ -58,7 +58,7 @@ export default class BaseAdvancement extends SparseDataModel {
   /*  Data Migration                              */
   /* -------------------------------------------- */
 
-  /** @override */
+  /** @inheritDoc */
   static migrateData(source) {
     super.migrateData(source);
     if ( source.configuration?.hint ) source.hint = source.configuration.hint;

--- a/module/data/advancement/base-advancement.mjs
+++ b/module/data/advancement/base-advancement.mjs
@@ -1,6 +1,22 @@
 import { SparseDataModel } from "../abstract.mjs";
 import { AdvancementDataField } from "../fields.mjs";
 
+const { DocumentIdField, FilePathField, NumberField, StringField } = foundry.data.fields;
+
+/**
+ * Base data model for advancement.
+ *
+ * @property {string} _id               The advancement's ID.
+ * @property {string} type              Type of advancement.
+ * @property {*} configuration          Type-specific configuration data.
+ * @property {*} value                  Type-specific value data after the advancement is applied.
+ * @property {number} level             For single-level advancement, the level at which it should apply.
+ * @property {string} title             Optional custom title.
+ * @property {string} hint              Brief description of what the advancement does or guidance for the player.
+ * @property {string} icon              Optional custom icon.
+ * @property {string} classRestriction  Should this advancement apply at all times, only when on the first class on
+ *                                      an actor, or only on a class that is multi-classing?
+ */
 export default class BaseAdvancement extends SparseDataModel {
 
   /**
@@ -14,26 +30,38 @@ export default class BaseAdvancement extends SparseDataModel {
 
   /* -------------------------------------------- */
 
-  /** @inheritdoc */
+  /** @override */
   static defineSchema() {
     return {
-      _id: new foundry.data.fields.DocumentIdField({initial: () => foundry.utils.randomID()}),
-      type: new foundry.data.fields.StringField({
+      _id: new DocumentIdField({initial: () => foundry.utils.randomID()}),
+      type: new StringField({
         required: true, initial: this.typeName, validate: v => v === this.typeName,
         validationError: `must be the same as the Advancement type name ${this.typeName}`
       }),
       configuration: new AdvancementDataField(this, {required: true}),
       value: new AdvancementDataField(this, {required: true}),
-      level: new foundry.data.fields.NumberField({
+      level: new NumberField({
         integer: true, initial: this.metadata?.multiLevel ? undefined : 0, min: 0, label: "DND5E.Level"
       }),
-      title: new foundry.data.fields.StringField({initial: undefined, label: "DND5E.AdvancementCustomTitle"}),
-      icon: new foundry.data.fields.FilePathField({
+      title: new StringField({initial: undefined, label: "DND5E.AdvancementCustomTitle"}),
+      hint: new StringField({label: "DND5E.AdvancementHint"}),
+      icon: new FilePathField({
         initial: undefined, categories: ["IMAGE"], label: "DND5E.AdvancementCustomIcon"
       }),
-      classRestriction: new foundry.data.fields.StringField({
+      classRestriction: new StringField({
         initial: undefined, choices: ["primary", "secondary"], label: "DND5E.AdvancementClassRestriction"
       })
     };
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Migration                              */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static migrateData(source) {
+    super.migrateData(source);
+    if ( source.configuration?.hint ) source.hint = source.configuration.hint;
+    return source;
   }
 }

--- a/module/data/advancement/item-choice.mjs
+++ b/module/data/advancement/item-choice.mjs
@@ -23,7 +23,6 @@ const {
 /**
  * Configuration data for Item Choice advancement.
  *
- * @property {string} hint                                    Brief hint about the choice to be made.
  * @property {Record<number, ItemChoiceLevelConfig>} choices  Choices & config for specific levels.
  * @property {boolean} allowDrops                             Should players be able to drop non-listed items?
  * @property {string} type                                    Type of item allowed, if it should be restricted.
@@ -38,7 +37,6 @@ export class ItemChoiceConfigurationData extends foundry.abstract.DataModel {
   /** @inheritDoc */
   static defineSchema() {
     return {
-      hint: new StringField({label: "DND5E.AdvancementHint"}),
       choices: new MappingField(new SchemaField({
         count: new NumberField({integer: true, min: 0}),
         replacement: new BooleanField({label: "DND5E.AdvancementItemChoiceReplacement"})
@@ -63,6 +61,16 @@ export class ItemChoiceConfigurationData extends foundry.abstract.DataModel {
         level: new StringField({label: "DND5E.SpellLevel"})
       })
     };
+  }
+
+  /* -------------------------------------------- */
+
+  get hint() {
+    foundry.utils.logCompatibilityWarning(
+      "Advancement hints are now part of the base data model.",
+      { since: "DnD5e 3.3", until: "DnD5e 4.1" }
+    );
+    return this.parent.hint ?? "";
   }
 
   /* -------------------------------------------- */

--- a/module/data/advancement/size.mjs
+++ b/module/data/advancement/size.mjs
@@ -5,11 +5,20 @@ export class SizeConfigurationData extends foundry.abstract.DataModel {
   /** @inheritdoc */
   static defineSchema() {
     return {
-      hint: new foundry.data.fields.StringField({label: "DND5E.AdvancementHint"}),
       sizes: new foundry.data.fields.SetField(
         new foundry.data.fields.StringField(), {required: false, initial: ["med"], label: "DND5E.Size"}
       )
     };
+  }
+
+  /* -------------------------------------------- */
+
+  get hint() {
+    foundry.utils.logCompatibilityWarning(
+      "Advancement hints are now part of the base data model.",
+      { since: "DnD5e 3.3", until: "DnD5e 4.1" }
+    );
+    return this.parent.hint ?? "";
   }
 }
 

--- a/module/data/advancement/trait.mjs
+++ b/module/data/advancement/trait.mjs
@@ -10,7 +10,6 @@
 /**
  * Configuration data for the TraitAdvancement.
  *
- * @property {string} hint                Hint displayed instead of the automatically generated one.
  * @property {string} mode                Method by which this advancement modifies the actor's traits.
  * @property {boolean} allowReplacements  Whether all potential choices should be presented to the user if there
  *                                        are no more choices available in a more limited set.
@@ -20,7 +19,6 @@
 export class TraitConfigurationData extends foundry.abstract.DataModel {
   static defineSchema() {
     return {
-      hint: new foundry.data.fields.StringField({label: "DND5E.AdvancementHint"}),
       mode: new foundry.data.fields.StringField({initial: "default", label: "DND5E.AdvancementTraitMode"}),
       allowReplacements: new foundry.data.fields.BooleanField({
         required: true, label: "DND5E.AdvancementTraitAllowReplacements",
@@ -38,6 +36,16 @@ export class TraitConfigurationData extends foundry.abstract.DataModel {
         })
       }), {label: "DND5E.AdvancementTraitChoices"})
     };
+  }
+
+  /* -------------------------------------------- */
+
+  get hint() {
+    foundry.utils.logCompatibilityWarning(
+      "Advancement hints are now part of the base data model.",
+      { since: "DnD5e 3.3", until: "DnD5e 4.1" }
+    );
+    return this.parent.hint ?? "";
   }
 }
 

--- a/module/documents/advancement/trait.mjs
+++ b/module/documents/advancement/trait.mjs
@@ -80,7 +80,7 @@ export default class TraitAdvancement extends Advancement {
   /** @inheritdoc */
   summaryForLevel(level, { configMode=false }={}) {
     if ( configMode ) {
-      if ( this.configuration.hint ) return `<p>${this.configuration.hint}</p>`;
+      if ( this.hint ) return `<p>${this.hint}</p>`;
       return `<p>${Trait.localizedList({
         grants: this.configuration.grants, choices: this.configuration.choices
       })}</p>`;

--- a/templates/advancement/ability-score-improvement-flow.hbs
+++ b/templates/advancement/ability-score-improvement-flow.hbs
@@ -1,5 +1,6 @@
 <form id="{{appId}}" data-level="{{level}}" data-id="{{advancement.id}}" data-type="{{type}}">
     <h3>{{{this.title}}}</h3>
+    {{#if advancement.hint}}<p>{{ advancement.hint }}</p>{{/if}}
 
     <ul class="ability-scores {{#if feat}}disabled{{/if}}">
         {{#unless staticIncrease}}

--- a/templates/advancement/advancement-flow.hbs
+++ b/templates/advancement/advancement-flow.hbs
@@ -1,5 +1,5 @@
 <form>
-    <h3>{{{title}}}</h3>
-
-    {{{summary}}}
+    <h3>{{{ title }}}</h3>
+    {{#if advancement.hint}}<p>{{ advancement.hint }}</p>{{/if}}
+    {{{ summary }}}
 </form>

--- a/templates/advancement/hit-points-flow.hbs
+++ b/templates/advancement/hit-points-flow.hbs
@@ -1,5 +1,6 @@
 <form id="{{appId}}" data-level="{{level}}" data-id="{{advancement.id}}" data-type="{{type}}">
     <h3>{{{title}}}</h3>
+    {{#if hint}}<p>{{ hint }}</p>{{/if}}
 
     {{#if isFirstClassLevel}}
 

--- a/templates/advancement/item-choice-config.hbs
+++ b/templates/advancement/item-choice-config.hbs
@@ -1,10 +1,6 @@
 <form autocomplete="off" class="drop-target">
     <div class="left-column">
         {{> "dnd5e.advancement-controls" }}
-        <div class="form-group">
-            <label>{{ localize "DND5E.AdvancementHint" }}</label>
-            <textarea name="configuration.hint">{{ configuration.hint }}</textarea>
-        </div>
 
         <div class="form-group">
             <label>{{ localize "DND5E.AdvancementConfigureAllowDrops" }}</label>

--- a/templates/advancement/item-choice-flow.hbs
+++ b/templates/advancement/item-choice-flow.hbs
@@ -3,8 +3,8 @@
     <h3>{{{ title }}}</h3>
 
     <div class="drop-target">
-        {{#if advancement.configuration.hint}}
-        <p>{{ advancement.configuration.hint }}</p>
+        {{#if advancement.hint}}
+        <p>{{ advancement.hint }}</p>
         {{/if}}
 
         {{#if replaceable}}

--- a/templates/advancement/item-grant-flow.hbs
+++ b/templates/advancement/item-grant-flow.hbs
@@ -1,5 +1,6 @@
 <form id="{{ appId }}" data-level="{{ level }}" data-id="{{ advancement.id }}" data-type="{{ type }}">
     <h3>{{{ title }}}</h3>
+    {{#if advancement.hint}}<p>{{ advancement.hint }}</p>{{/if}}
 
     {{#if abilities.options}}
     <div class="form-group">

--- a/templates/advancement/parts/advancement-controls.hbs
+++ b/templates/advancement/parts/advancement-controls.hbs
@@ -1,27 +1,27 @@
 <div class="form-group">
-    <label>{{localize "DND5E.AdvancementCustomTitle"}}</label>
+    <label>{{ localize "DND5E.AdvancementCustomTitle" }}</label>
     <div class="form-fields">
-        <input type="text" name="title" value="{{src.title}}" placeholder="{{default.title}}">
+        <input type="text" name="title" value="{{ src.title }}" placeholder="{{ default.title }}">
     </div>
 </div>
 
 <div class="form-group">
-    <label>{{localize "DND5E.AdvancementCustomIcon"}}</label>
+    <label>{{ localize "DND5E.AdvancementCustomIcon" }}</label>
     <div class="form-fields">
-        {{filePicker type="image" target="icon"}}
-        <input type="text" name="icon" value="{{src.icon}}" placeholder="{{default.icon}}">
+        {{ filePicker type="image" target="icon" }}
+        <input type="text" name="icon" value="{{ src.icon }}" placeholder="{{ default.icon }}">
     </div>
 </div>
 
 {{#if showClassRestrictions}}
 <div class="form-group">
-    <label>{{localize "DND5E.AdvancementClassRestriction"}}</label>
+    <label>{{ localize "DND5E.AdvancementClassRestriction" }}</label>
     <div class="form-fields">
         <select name="classRestriction">
             {{#select classRestriction}}
-            <option value="">{{localize "DND5E.AdvancementClassRestrictionNone"}}</option>
-            <option value="primary">{{localize "DND5E.AdvancementClassRestrictionPrimary"}}</option>
-            <option value="secondary">{{localize "DND5E.AdvancementClassRestrictionSecondary"}}</option>
+            <option value="">{{ localize "DND5E.AdvancementClassRestrictionNone" }}</option>
+            <option value="primary">{{ localize "DND5E.AdvancementClassRestrictionPrimary" }}</option>
+            <option value="secondary">{{ localize "DND5E.AdvancementClassRestrictionSecondary" }}</option>
             {{/select}}
         </select>
     </div>
@@ -30,11 +30,16 @@
 
 {{#if showLevelSelector}}
 <div class="form-group">
-    <label>{{localize "DND5E.Level"}}</label>
+    <label>{{ localize "DND5E.Level" }}</label>
     <div class="form-fields">
         <select name="level" data-dtype="Number">
-            {{selectOptions levels selected=level}}
+            {{ selectOptions levels selected=level }}
         </select>
     </div>
 </div>
 {{/if}}
+
+<div class="form-group">
+    <label>{{ localize "DND5E.AdvancementHint" }}</label>
+    <textarea name="hint" {{~#if default.hint}} placeholder="{{ default.hint }}"{{/if}}>{{ hint }}</textarea>
+</div>

--- a/templates/advancement/scale-value-flow.hbs
+++ b/templates/advancement/scale-value-flow.hbs
@@ -1,5 +1,6 @@
 <form id="{{appId}}" data-level="{{level}}" data-id="{{advancement.id}}" data-type="{{type}}">
     <h3>{{{this.title}}}</h3>
+    {{#if advancement.hint}}<p>{{ advancement.hint }}</p>{{/if}}
 
     <p>
         <span class="initial-scale-value {{#unless initial}}none{{/unless}}">

--- a/templates/advancement/size-config.hbs
+++ b/templates/advancement/size-config.hbs
@@ -1,10 +1,4 @@
 <form autocomplete="off">
-    {{> "dnd5e.advancement-controls"}}
-
-    <div class="form-group">
-        <label>{{localize "DND5E.AdvancementHint"}}</label>
-        <textarea name="configuration.hint" placeholder="{{default.hint}}">{{configuration.hint}}</textarea>
-    </div>
-
-    {{> "dnd5e.trait-list" choices=sizes prefix="configuration.sizes"}}
+    {{> "dnd5e.advancement-controls" }}
+    {{> "dnd5e.trait-list" choices=sizes prefix="configuration.sizes" }}
 </form>

--- a/templates/advancement/trait-config.hbs
+++ b/templates/advancement/trait-config.hbs
@@ -21,11 +21,6 @@
             <p class="hint">{{localize "DND5E.AdvancementTraitAllowReplacementsHint"}}</p>
         </div>
 
-        <div class="form-group hint">
-            <label>{{localize "DND5E.AdvancementHint"}}</label>
-            <textarea name="configuration.hint" placeholder="{{default.hint}}">{{configuration.hint}}</textarea>
-        </div>
-
         <fieldset class="selected-trait">
             <legend>{{localize "DND5E.AdvancementTraitGrants"}}</legend>
             <p class="hint">{{localize "DND5E.AdvancementTraitGrantsHint"}}</p>


### PR DESCRIPTION
Adds `hint` to the top-level advancement data and migrates any existing hints from within the configuration data. Now if hints are set for any advancement it will display in the flow window.

Closes #2728 