### PR TITLE
[#3799] Add option to register source books directly in manifest

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -22,6 +22,7 @@ import * as enrichers from "./module/enrichers.mjs";
 import * as migrations from "./module/migration.mjs";
 import * as utils from "./module/utils.mjs";
 import {ModuleArt} from "./module/module-art.mjs";
+import registerModuleData from "./module/module-registration.mjs";
 import Tooltips5e from "./module/tooltips.mjs";
 
 /* -------------------------------------------- */
@@ -84,8 +85,9 @@ Hooks.once("init", function() {
   // Register System Settings
   registerSystemSettings();
 
-  // Configure module art
+  // Configure module art & register module data
   game.dnd5e.moduleArt = new ModuleArt();
+  registerModuleData();
 
   // Configure tooltips
   game.dnd5e.tooltips = new Tooltips5e();

--- a/module/module-registration.mjs
+++ b/module/module-registration.mjs
@@ -1,0 +1,33 @@
+/**
+ * Scan module manifests for any data that should be integrated into the system configuration.
+ */
+export default function registerModuleData() {
+  console.groupCollapsed("D&D 5e | Registering Module Data");
+  for ( const module of game.modules ) {
+    if ( !module.active ) continue;
+    try {
+      const complete = methods.map(m => m(module)).filter(r => r);
+      if ( complete.length ) {
+        console.log(`D&D 5e | Registered ${module.title} data: ${complete.join(", ")}`);
+      }
+    } catch(err) {
+      console.error(`D&D 5e | Error registering ${module.title}\n`, err.message);
+    }
+  }
+  console.groupEnd();
+}
+
+const methods = [registerSourceBooks];
+
+/* -------------------------------------------- */
+
+/**
+ * Register module source books from `flags.sourceBooks`.
+ * @param {Module} module  Module from which to register data.
+ * @returns {string|void}  Description of the data registered.
+ */
+function registerSourceBooks(module) {
+  if ( !module.flags.dnd5e?.sourceBooks ) return;
+  Object.assign(CONFIG.DND5E.sourceBooks, module.flags.sourceBooks);
+  return "source book";
+}


### PR DESCRIPTION
Adds a registration step for modules that detects declarations in active modules and automatically integrates them during system preparation.

The only declaration currently supported is `dnd5e.sourceBooks`, which declares source books in the same format as the `sourceBooks` config object in the system. The key is a abbreviated name for the source and the value is the full name, which can be a localization string.

Closes #3799 