### PR TITLE
Sleight of Hand Typo in Roll Formulas

### DIFF
--- a/wiki/Roll-Formulas.md
+++ b/wiki/Roll-Formulas.md
@@ -272,7 +272,7 @@
 
 `@skills.rel` - Religion
 
-`@skills.stl` - Slight of Hand
+`@skills.slt` - Sleight of Hand
 
 `@skills.ste` - Stealth
 


### PR DESCRIPTION
Updated from  #3817

Link: https://github.com/foundryvtt/dnd5e/wiki/Roll-Formulas#skills

Typo:
@skills.stl - Slight of Hand

Change:
@skills.slt - Sleight of Hand

----
The more correct way to contribute to the wiki not what was done before.