### PR TITLE
[#3772] Implement summoning based on CR

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1751,6 +1751,7 @@
   },
   "Warning": {
     "CreateActor": "You must have 'Create New Actors' permission in order to summon directly from a compendium.",
+    "CRV11": "Summoning based on creature challenge rating only works in Foundry V12 or higher.",
     "NoActor": "Actor cannot be found with UUID '{uuid}' to summon.",
     "NoOwnership": "You must have ownership of '{actor}' in order to summon it.",
     "NoProfile": "Cannot find summoning profile {profileId} on '{item}'.",

--- a/module/applications/components/checkbox.mjs
+++ b/module/applications/components/checkbox.mjs
@@ -130,11 +130,16 @@ export default class CheckboxElement extends AdoptedStyleSheetMixin(AbstractForm
 
   /* -------------------------------------------- */
 
+  /** @override */
+  get value() {
+    return super.value;
+  }
+
   /**
    * Override AbstractFormInputElement#value setter because we want to emit input/change events when the checked state
    * changes, and not when the value changes.
    * @override
-   * */
+   */
   set value(value) {
     this._setValue(value);
   }

--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -211,7 +211,7 @@ export default class AbilityUseDialog extends Dialog {
   static _createSummoningOptions(item) {
     const summons = item.system.summons;
     if ( !summons?.profiles.length ) return null;
-    const options = {};
+    const options = { mode: summons.mode };
     const rollData = item.getRollData();
     const level = summons.relevantLevel;
     options.profiles = Object.fromEntries(
@@ -433,6 +433,11 @@ export default class AbilityUseDialog extends Dialog {
     } else if ( data.beginConcentrating && !item.actor.system.attributes?.concentration?.limit ) {
       const locale = "DND5E.ConcentratingWarnLimitZero";
       warnings.push(game.i18n.localize(locale));
+    }
+
+    // Display warning about CR summoning in V11
+    if ( (game.release.generation < 12) && (data.summoningOptions?.mode === "cr") ) {
+      warnings.push(game.i18n.localize("DND5E.Summoning.Warning.CRV11"));
     }
 
     data.warnings = warnings;


### PR DESCRIPTION
Uses the new compendium browser in V12 to enable summoning based on CR and creature type. For V11 the ability use dialog will display a warning indicating that this functionality only works on V12.

Fixes a bug in `<dnd5e-checkbox>` that prevented it from returning its value.

Closes #3772