### PR TITLE
[#3865] Add setting for default skills.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2132,8 +2132,6 @@
 "SETTINGS.5eCriticalModifiersL": "Make critical hits more deadly by multiplying non-dice modifiers in addition to rolled dice.",
 "SETTINGS.5eCurWtL": "Carried currency affects character encumbrance following the rules on PHB pg. 143.",
 "SETTINGS.5eCurWtN": "Apply Currency Weight",
-"SETTINGS.5eDefaultSkillsN": "Default Skills",
-"SETTINGS.5eDefaultSkillsH": "The default skills that appear on NPC sheets regardless of level of proficiency.",
 "SETTINGS.5eDiagEuclidean": "Euclidean (7.07 ft. Diagonal)",
 "SETTINGS.5eDiagL": "Configure which diagonal movement rule should be used for games within this system.",
 "SETTINGS.5eDiagN": "Diagonal Movement Rule",
@@ -2190,6 +2188,10 @@
     "Always": "Collapse All",
     "Older": "Collapse Older Trays",
     "Never": "Expand All"
+  },
+  "DEFAULTSKILLS": {
+    "Name": "Default Skills",
+    "Hint": "The default skills that appear on NPC sheets regardless of level of proficiency."
   },
   "THEME": {
     "Name": "Theme",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2132,6 +2132,8 @@
 "SETTINGS.5eCriticalModifiersL": "Make critical hits more deadly by multiplying non-dice modifiers in addition to rolled dice.",
 "SETTINGS.5eCurWtL": "Carried currency affects character encumbrance following the rules on PHB pg. 143.",
 "SETTINGS.5eCurWtN": "Apply Currency Weight",
+"SETTINGS.5eDefaultSkillsN": "Default Skills",
+"SETTINGS.5eDefaultSkillsH": "The default skills that appear on NPC sheets regardless of level of proficiency.",
 "SETTINGS.5eDiagEuclidean": "Euclidean (7.07 ft. Diagonal)",
 "SETTINGS.5eDiagL": "Configure which diagonal movement rule should be used for games within this system.",
 "SETTINGS.5eDiagN": "Diagonal Movement Rule",

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -116,7 +116,10 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     }, {});
 
     // Skills & Tools
-    context.skills = Object.fromEntries(Object.entries(context.skills).filter(([, v]) => v.value));
+    const skillSetting = new Set(game.settings.get("dnd5e", "defaultSkills"));
+    context.skills = Object.fromEntries(Object.entries(context.skills).filter(([k, v]) => {
+      return v.value || skillSetting.has(k);
+    }));
 
     // Senses
     context.senses.passivePerception = {

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -118,7 +118,7 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     // Skills & Tools
     const skillSetting = new Set(game.settings.get("dnd5e", "defaultSkills"));
     context.skills = Object.fromEntries(Object.entries(context.skills).filter(([k, v]) => {
-      return v.value || skillSetting.has(k);
+      return v.value || skillSetting.has(k) || !!v.bonuses.check || !!v.bonuses.passive;
     }));
 
     // Senses

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -116,7 +116,7 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     }, {});
 
     // Skills & Tools
-    const skillSetting = game.release.generation < 12 ? new Set() : new Set(game.settings.get("dnd5e", "defaultSkills"));
+    const skillSetting = new Set(game.settings.get("dnd5e", "defaultSkills"));
     context.skills = Object.fromEntries(Object.entries(context.skills).filter(([k, v]) => {
       return v.value || skillSetting.has(k);
     }));

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -116,7 +116,7 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     }, {});
 
     // Skills & Tools
-    const skillSetting = new Set(game.settings.get("dnd5e", "defaultSkills"));
+    const skillSetting = game.release.generation < 12 ? new Set() : new Set(game.settings.get("dnd5e", "defaultSkills"));
     context.skills = Object.fromEntries(Object.entries(context.skills).filter(([k, v]) => {
       return v.value || skillSetting.has(k);
     }));

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -118,7 +118,7 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     // Skills & Tools
     const skillSetting = new Set(game.settings.get("dnd5e", "defaultSkills"));
     context.skills = Object.fromEntries(Object.entries(context.skills).filter(([k, v]) => {
-      return v.value || skillSetting.has(k) || !!v.bonuses.check || !!v.bonuses.passive;
+      return v.value || skillSetting.has(k) || v.bonuses.check || v.bonuses.passive;
     }));
 
     // Senses

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -340,19 +340,18 @@ export function registerSystemSettings() {
     default: true
   });
 
-  if (game.release.generation >= 12) {
-    game.settings.register("dnd5e", "defaultSkills", {
-      name: "SETTINGS.DND5E.DEFAULTSKILLS.Name",
-      hint: "SETTINGS.DND5E.DEFAULTSKILLS.Hint",
-      type: new foundry.data.fields.SetField(
-        new foundry.data.fields.StringField({
-          choices: () => CONFIG.DND5E.skills
-        })
-      ),
-      default: [],
-      config: true
-    });
-  }
+  // NPC sheet default skills
+  game.settings.register("dnd5e", "defaultSkills", {
+    name: "SETTINGS.DND5E.DEFAULTSKILLS.Name",
+    hint: "SETTINGS.DND5E.DEFAULTSKILLS.Hint",
+    type: new foundry.data.fields.SetField(
+      new foundry.data.fields.StringField({
+        choices: () => CONFIG.DND5E.skills
+      })
+    ),
+    default: [],
+    config: true
+  });
 }
 
 /**

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -342,14 +342,12 @@ export function registerSystemSettings() {
 
   if (game.release.generation >= 12) {
     game.settings.register("dnd5e", "defaultSkills", {
-      name: "SETTINGS.5eDefaultSkillsN",
-      hint: "SETTINGS.5eDefaultSkillsH",
+      name: "SETTINGS.DND5E.DEFAULTSKILLS.Name",
+      hint: "SETTINGS.DND5E.DEFAULTSKILLS.Hint",
       type: new foundry.data.fields.SetField(
         new foundry.data.fields.StringField({
           choices: () => CONFIG.DND5E.skills
-        }), {
-          type: "checkboxes"
-        }
+        })
       ),
       default: [],
       config: true

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -339,6 +339,22 @@ export function registerSystemSettings() {
     type: Boolean,
     default: true
   });
+
+  if (game.release.generation >= 12) {
+    game.settings.register("dnd5e", "defaultSkills", {
+      name: "SETTINGS.5eDefaultSkillsN",
+      hint: "SETTINGS.5eDefaultSkillsH",
+      type: new foundry.data.fields.SetField(
+        new foundry.data.fields.StringField({
+          choices: () => CONFIG.DND5E.skills
+        }), {
+          type: "checkboxes"
+        }
+      ),
+      default: [],
+      config: true
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Adds a setting for skills that appear on NPC sheets regardless of level of proficiency.

Using a `DataField` for the setting, so requires v12.

Closes #3865.

![image](https://github.com/user-attachments/assets/18651041-0021-41db-a1ca-58c9cd079834)
