### PR TITLE
[#1192] Hide dex tiebreakers in combat tracker

### DIFF
--- a/module/applications/combat/combat-tracker.mjs
+++ b/module/applications/combat/combat-tracker.mjs
@@ -1,8 +1,20 @@
+import { formatNumber } from "../../utils.mjs";
+
 /**
  * An extension of the base CombatTracker class to provide some 5e-specific functionality.
  * @extends {CombatTracker}
  */
 export default class CombatTracker5e extends CombatTracker {
+  async getData(options={}) {
+    const context = await super.getData(options);
+    context.turns.forEach(turn => {
+      turn.initiative = formatNumber(Number(turn.initiative), { maximumFractionDigits: 0 });
+    });
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritdoc */
   async _onCombatantControl(event) {
     const btn = event.currentTarget;


### PR DESCRIPTION
Modifies context preparation on CombatTracker5e to drop any decimal digits after the initiative value.