### PR TITLE
Document the Enchantment active effects

### DIFF
--- a/wiki/Enchantment.md
+++ b/wiki/Enchantment.md
@@ -39,3 +39,430 @@ Once configuration is complete, enchantment is very easy. Simply activate the fe
 ![Enchantment Chat Message](https://raw.githubusercontent.com/foundryvtt/dnd5e/publish-wiki/wiki/images/enchantment/enchantment-chat-message.jpg)
 
 In the activation chat message a drop area will appear. Any player may drop an item in this area to enchant that item and the enchanted items will be listed. GMs or the player who owns the item will have access to the "Remove Enchantment" button in the chat card which will quickly remove the enchantment. Enchantments can also be removed by breaking concentration if they are from a concentration effect, or by enter the "Effects" tab on the item and manually deleting the enchantment.
+
+## Enchantment Active Effects
+
+This describes how to create Active Effects used as an Enchantment. This differs from the [Active Effect Guide](Active-Effect-Guide) in that these are changes to items instead of the actors. If you're creating an Active Effect to add to the Additional Effects section when configuring an Enchantment, then use that guide.
+
+Because of the differences in item types, there are separate sections for each type that can be enchanted. This uses the same [Legend](Active-Effect-Guide#legend) that the Active Effect Guide does in addition to:
+
+- `[string]` - A string value
+- `[file]` - A file path, e.g. `icons/svg/mystery-man.svg`
+
+### Common Examples
+
+These examples are common across item types, meaning they'll work equally well for a Weapon or Equipment.
+
+```
+name
+img
+system.description.value
+system.description.chat
+```
+
+#### Changing the Name
+
+You can reference the original name using a pair of curly brackets (`{}`) and the `override` change mode (e.g. `{}, +1` for a +1 weapon).
+
+| Attribute Key | Change Mode | Effect Value | Roll Data? |
+| ------------- | ----------- | ------------ | ---------- |
+| `name`        | Override    | `[string]`   | No         |
+
+#### Changing the Icon
+
+| Attribute Key | Change Mode | Effect Value | Roll Data? |
+| ------------- | ----------- | ------------ | ---------- |
+| `img`         | Override    | `[file]`     | No         |
+
+#### Changing the Description
+
+You can reference the original description using a pair of curly brackets (`{}`) and the `override` change mode (e.g. `{} <p>Some more description</p>`).
+
+| Attribute Key              | Change Mode | Effect Value | Roll Data? |
+| -------------------------- | ----------- | ------------ | ---------- |
+| `system.description.value` | Override    | `[string]`   | No         |
+
+### Weapon Examples
+
+```
+system.proficient
+system.properties
+system.magicalBonus
+```
+
+#### Grant Proficiency with the Weapon
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.proficient` | Upgrade     | `1`          | No         |
+
+#### Add Weapon Properties
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.properties` | Add         | `[string]`   | No         |
+
+> <details>
+> <summary>Weapon Properties</summary>
+>
+> | Weapon Property | Abbreviation |
+> | --------------- | ------------ |
+> | Adamantine      | `ada` |
+> | Ammunition      | `amm` |
+> | Finesse         | `fin` |
+> | Firearm         | `fir` |
+> | Focus           | `foc` |
+> | Heavy           | `hvy` |
+> | Light           | `lgt` |
+> | Loading         | `lod` |
+> | Magical         | `mgc` |
+> | Reach           | `rch` |
+> | Reload          | `rel` |
+> | Returning       | `ret` |
+> | Silvered        | `sil` |
+> | Special         | `spc` |
+> | Thrown          | `thr` |
+> | Two-Handed      | `two` |
+> | Versatile       | `ver` |
+>
+> Source: `CONFIG.DND5E.validProperties.weapon`
+>
+> </details>
+
+#### Make Weapon Magical
+
+Make the weapon magical by adding the Magical property and an optional Magical Bonus that will be added to attack and damage rolls.
+
+| Attribute Key         | Change Mode | Effect Value | Roll Data? |
+| --------------------- | ----------- | ------------ | ---------- |
+| `system.properties`   | Add         | `mgc`        | No         |
+| `system.magicalBonus` | Override    | `[number]`   | No         |
+
+### Equipment Examples
+
+```
+system.proficient
+       properties
+       armor.value
+             magicalBonus
+             dex
+       strength
+```
+
+#### Grant Proficiency with the Equipment
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.proficient` | Upgrade     | `1`          | No         |
+
+#### Add Equipment Properties
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.properties` | Add         | `[string]`   | No         |
+
+> <details>
+> <summary>Equipment Properties</summary>
+>
+> | Equipment Property   | Abbreviation          |
+> | -------------------- | --------------------- |
+> | Concentration        | `concentration`       |
+> | Magical              | `mgc`                 |
+> | Stealth Disadvantage | `stealthDisadvantage` |
+>
+> Source: `CONFIG.DND5E.validProperties.equipment`
+>
+> </details>
+
+#### Make Armor Magical
+
+Make the armor magical by adding the Magical property and an optional Magical Bonus that will be added to AC.
+
+| Attribute Key         | Change Mode | Effect Value | Roll Data? |
+| --------------------- | ----------- | ------------ | ---------- |
+| `system.properties`   | Add         | `mgc`        | No         |
+| `system.magicalBonus` | Override    | `[number]`   | No         |
+
+### Tool Examples
+
+```
+system.properties
+       proficient
+       ability
+       bonus
+       chatFlavor
+```
+
+#### Grant Proficiency with the Tool
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.proficient` | Upgrade     | `1`          | No         |
+
+#### Add Tool Properties
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.properties` | Add         | `[string]`   | No         |
+
+> <details>
+> <summary>Tool Properties</summary>
+>
+> | Tool Property   | Abbreviation          |
+> | -------------------- | --------------------- |
+> | Concentration        | `concentration`       |
+> | Magical              | `mgc`                 |
+>
+> Source: `CONFIG.DND5E.validProperties.tool`
+>
+> </details>
+
+#### Add Bonus to Tool
+
+| Attribute Key  | Change Mode | Effect Value | Roll Data? |
+| -------------- | ----------- | ------------ | ---------- |
+| `system.bonus` | Add         | `[formula]`  | Yes        |
+
+### Consumable Examples
+
+```
+system.properties
+       magicalBonus
+```
+
+#### Add Consumable Properties
+
+Some consumable types have different properties so there are different lists calling those out below.
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.properties` | Add         | `[string]`   | No         |
+
+> <details>
+> <summary>Ammunition Properties</summary>
+>
+> | Ammunition Property | Abbreviation |
+> | ------------------- | ------------ |
+> | Adamantine          | `ada`        |
+> | Magical             | `mgc`        |
+> | Silvered            | `sil`        |
+>
+> Source: `CONFIG.DND5E.validProperties.consumable` and `CONFIG.DND5E.itemProperties` that have `isPhysical: true`
+>
+> </details>
+
+> <details>
+> <summary>Scroll Properties</summary>
+>
+> | Scroll Property | Abbreviation    |
+> | --------------- | --------------- |
+> | Concentration   | `concentration` |
+> | Magical         | `mgc`           |
+> | Ritual          | `ritual`        |
+> | Somatic         | `somatic`       |
+> | Verbal          | `verbal`        |
+>
+> Source: `CONFIG.DND5E.validProperties.consumable` and `CONFIG.DND5E.validProperties.spell` minus `material`
+>
+> </details>
+
+> <details>
+> <summary>Consumable Properties</summary>
+>
+> | Consumable Property | Abbreviation          |
+> | ------------------- | --------------------- |
+> | Magical             | `mgc`                 |
+>
+> Source: `CONFIG.DND5E.validProperties.consumable`
+>
+> </details>
+
+#### Make Ammunition Magical
+
+Make ammunition magical by adding the Magical property and an optional Magical Bonus that will be added to the attack/damage rolls.
+
+| Attribute Key         | Change Mode | Effect Value | Roll Data? |
+| --------------------- | ----------- | ------------ | ---------- |
+| `system.properties`   | Add         | `mgc`        | No         |
+| `system.magicalBonus` | Override    | `[number]`   | No         |
+
+### Container Examples
+
+```
+system.properties
+       capacity.value
+                type
+```
+
+#### Add Container Properties
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.properties` | Add         | `[string]`   | No         |
+
+> <details>
+> <summary>Container Properties</summary>
+>
+> | Container Property  | Abbreviation         |
+> | ------------------- | -------------------- |
+> | Magical             | `mgc`                |
+> | Weightless Contents | `weightlessContents` |
+>
+> Source: `CONFIG.DND5E.validProperties.container`
+>
+> </details>
+
+#### Make Contents Weightless
+
+| Attribute Key       | Change Mode | Effect Value         | Roll Data? |
+| ------------------- | ----------- | -------------------- | ---------- |
+| `system.properties` | Add         | `weightlessContents` | No         |
+
+### Loot Examples
+
+```
+system.properties
+```
+
+#### Add Loot Properties
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.properties` | Add         | `[string]`   | No         |
+
+> <details>
+> <summary>Loot Properties</summary>
+>
+> | Loot Property | Abbreviation |
+> | ------------- | ------------ |
+> | Magical       | `mgc`        |
+>
+> Source: `CONFIG.DND5E.validProperties.loot`
+>
+> </details>
+
+### Common Usage Examples
+
+This documents the Usage section on item sheets, common to many item types.
+
+```
+system.activation.type
+                  cost
+                  condition
+       target.value
+              width
+              units
+              type
+              prompt
+       range.value
+             long
+             units
+       duration.value
+                units
+       uses.value
+            max
+            per
+            recovery
+            prompt
+       consume.type
+               target
+               amount
+               scale
+```
+
+#### Double the Normal and Long Range
+
+| Attribute Key        | Change Mode | Effect Value | Roll Data? |
+| -------------------- | ----------- | ------------ | ---------- |
+| `system.range.value` | Multiply    | `2`          | No         |
+| `system.range.long`  | Multiply    | `2`          | No         |
+
+#### Add Charges to be Used By Additional Items
+
+| Attribute Key        | Change Mode | Effect Value | Roll Data? |
+| -------------------- | ----------- | ------------ | ---------- |
+| `system.uses.max`    | Override    | `[formula]`  | Yes        |
+| `system.uses.per`    | Override    | `charges`    | No         |
+| `system.uses.prompt` | Override    | `false`      | No         |
+
+> <details>
+> <summary>Uses Per Values</summary>
+>
+> | Uses Per   | Abbreviation |
+> | ---------- | ------------ |
+> | Short Rest | `sr`         |
+> | Long Rest  | `lr`         |
+> | Day        | `day`        |
+> | Charges    | `charges`    |
+> | Dawn       | `dawn`       |
+> | Dusk       | `dusk`       |
+>
+> Source: `CONFIG.DND5E.limitedUsePeriods`
+>
+> </details>
+
+> [!warning]
+> **Never** alter the `system.uses.value` attributes with an enchantment as this **will** cause issues.
+
+### Common Action Examples
+
+This documents the Action section on item sheets, common to many item types.
+
+```
+system.actionType
+       ability
+       attack.bonus
+              flat
+       critical.threshold
+                damage
+       damage.parts
+              versatile
+       formula
+       save.ability
+            dc
+            scaling
+       chatFlavor
+```
+
+#### Set Critical Hit Threshold
+
+| Attribute Key               | Change Mode | Effect Value | Roll Data? |
+| --------------------------- | ----------- | ------------ | ---------- |
+| `system.critical.threshold` | Downgrade   | `[number]`   | No         |
+
+#### Add Extra Critical Hit Damage
+
+| Attribute Key            | Change Mode | Effect Value | Roll Data? |
+| ------------------------ | ----------- | ------------ | ---------- |
+| `system.critical.damage` | Add         | `[formula]`  | Yes        |
+
+#### Add Extra Damage
+
+Since damage is both a roll formula and damage type, you need to include both when adding extra damage.
+
+| Attribute Key         | Change Mode | Effect Value        | Roll Data? |
+| --------------------- | ----------- | ------------------- | ---------- |
+| `system.damage.parts` | Add         | `[["2d6", "fire"]]` | Yes        |
+
+> <details>
+> <summary>Damage Types</summary>
+>
+> | Damage Type | Abbreviation  |
+> | ----------  | ------------- |
+> | Acid        | `acid`        |
+> | Bludgeoning | `bludgeoning` |
+> | Cold        | `cold`        |
+> | Fire        | `fire`        |
+> | Force       | `force`       |
+> | Lightning   | `lightning`   |
+> | Necrotic    | `necrotic`    |
+> | Piercing    | `piercing`    |
+> | Poison      | `poison`      |
+> | Psychic     | `psychic`     |
+> | Radiant     | `radiant`     |
+> | Slashing    | `slashing`    |
+> | Thunder     | `thunder`     |
+>
+> Source: `CONFIG.DND5E.damageTypes`
+>
+> </details>

--- a/wiki/Enchantment.md
+++ b/wiki/Enchantment.md
@@ -115,7 +115,6 @@ The valid effect values depend on the item type, and in the case of consumables 
 > | Versatile       | `ver` |
 >
 > Source: `CONFIG.DND5E.validProperties.weapon`
->
 > </details>
 
 > <details>
@@ -128,7 +127,6 @@ The valid effect values depend on the item type, and in the case of consumables 
 > | Stealth Disadvantage | `stealthDisadvantage` |
 >
 > Source: `CONFIG.DND5E.validProperties.equipment`
->
 > </details>
 
 > <details>
@@ -140,7 +138,6 @@ The valid effect values depend on the item type, and in the case of consumables 
 > | Magical              | `mgc`                 |
 >
 > Source: `CONFIG.DND5E.validProperties.tool`
->
 > </details>
 
 > <details>
@@ -153,7 +150,6 @@ The valid effect values depend on the item type, and in the case of consumables 
 > | Silvered            | `sil`        |
 >
 > Source: `CONFIG.DND5E.validProperties.consumable` and `CONFIG.DND5E.itemProperties` that have `isPhysical: true`
->
 > </details>
 
 > <details>
@@ -168,7 +164,6 @@ The valid effect values depend on the item type, and in the case of consumables 
 > | Verbal          | `verbal`        |
 >
 > Source: `CONFIG.DND5E.validProperties.consumable` and `CONFIG.DND5E.validProperties.spell` minus `material`
->
 > </details>
 
 > <details>
@@ -179,7 +174,6 @@ The valid effect values depend on the item type, and in the case of consumables 
 > | Magical             | `mgc`                 |
 >
 > Source: `CONFIG.DND5E.validProperties.consumable`
->
 > </details>
 
 > <details>
@@ -191,7 +185,6 @@ The valid effect values depend on the item type, and in the case of consumables 
 > | Weightless Contents | `weightlessContents` |
 >
 > Source: `CONFIG.DND5E.validProperties.container`
->
 > </details>
 
 > <details>
@@ -202,7 +195,6 @@ The valid effect values depend on the item type, and in the case of consumables 
 > | Magical       | `mgc`        |
 >
 > Source: `CONFIG.DND5E.validProperties.loot`
->
 > </details>
 
 ### Weapon Examples
@@ -358,7 +350,6 @@ system.activation.type
 > | Dusk       | `dusk`       |
 >
 > Source: `CONFIG.DND5E.limitedUsePeriods`
->
 > </details>
 
 > [!warning]
@@ -424,5 +415,4 @@ Since damage is both a roll formula and damage type, you need to include both wh
 > | Thunder     | `thunder`     |
 >
 > Source: `CONFIG.DND5E.damageTypes`
->
 > </details>

--- a/wiki/Enchantment.md
+++ b/wiki/Enchantment.md
@@ -57,7 +57,8 @@ These examples are common across item types, meaning they'll work equally well f
 name
 img
 system.description.value
-system.description.chat
+                   chat
+       properties
 ```
 
 #### Changing the Name
@@ -82,21 +83,9 @@ You can reference the original description using a pair of curly brackets (`{}`)
 | -------------------------- | ----------- | ------------ | ---------- |
 | `system.description.value` | Override    | `[string]`   | No         |
 
-### Weapon Examples
+#### Adding Item Properties
 
-```
-system.proficient
-system.properties
-system.magicalBonus
-```
-
-#### Grant Proficiency with the Weapon
-
-| Attribute Key       | Change Mode | Effect Value | Roll Data? |
-| ------------------- | ----------- | ------------ | ---------- |
-| `system.proficient` | Upgrade     | `1`          | No         |
-
-#### Add Weapon Properties
+The valid effect values depend on the item type, and in the case of consumables the subtype, which are documented below.
 
 | Attribute Key       | Change Mode | Effect Value | Roll Data? |
 | ------------------- | ----------- | ------------ | ---------- |
@@ -129,38 +118,6 @@ system.magicalBonus
 >
 > </details>
 
-#### Make Weapon Magical
-
-Make the weapon magical by adding the Magical property and an optional Magical Bonus that will be added to attack and damage rolls.
-
-| Attribute Key         | Change Mode | Effect Value | Roll Data? |
-| --------------------- | ----------- | ------------ | ---------- |
-| `system.properties`   | Add         | `mgc`        | No         |
-| `system.magicalBonus` | Override    | `[number]`   | No         |
-
-### Equipment Examples
-
-```
-system.proficient
-       properties
-       armor.value
-             magicalBonus
-             dex
-       strength
-```
-
-#### Grant Proficiency with the Equipment
-
-| Attribute Key       | Change Mode | Effect Value | Roll Data? |
-| ------------------- | ----------- | ------------ | ---------- |
-| `system.proficient` | Upgrade     | `1`          | No         |
-
-#### Add Equipment Properties
-
-| Attribute Key       | Change Mode | Effect Value | Roll Data? |
-| ------------------- | ----------- | ------------ | ---------- |
-| `system.properties` | Add         | `[string]`   | No         |
-
 > <details>
 > <summary>Equipment Properties</summary>
 >
@@ -174,37 +131,6 @@ system.proficient
 >
 > </details>
 
-#### Make Armor Magical
-
-Make the armor magical by adding the Magical property and an optional Magical Bonus that will be added to AC.
-
-| Attribute Key         | Change Mode | Effect Value | Roll Data? |
-| --------------------- | ----------- | ------------ | ---------- |
-| `system.properties`   | Add         | `mgc`        | No         |
-| `system.magicalBonus` | Override    | `[number]`   | No         |
-
-### Tool Examples
-
-```
-system.properties
-       proficient
-       ability
-       bonus
-       chatFlavor
-```
-
-#### Grant Proficiency with the Tool
-
-| Attribute Key       | Change Mode | Effect Value | Roll Data? |
-| ------------------- | ----------- | ------------ | ---------- |
-| `system.proficient` | Upgrade     | `1`          | No         |
-
-#### Add Tool Properties
-
-| Attribute Key       | Change Mode | Effect Value | Roll Data? |
-| ------------------- | ----------- | ------------ | ---------- |
-| `system.properties` | Add         | `[string]`   | No         |
-
 > <details>
 > <summary>Tool Properties</summary>
 >
@@ -216,27 +142,6 @@ system.properties
 > Source: `CONFIG.DND5E.validProperties.tool`
 >
 > </details>
-
-#### Add Bonus to Tool
-
-| Attribute Key  | Change Mode | Effect Value | Roll Data? |
-| -------------- | ----------- | ------------ | ---------- |
-| `system.bonus` | Add         | `[formula]`  | Yes        |
-
-### Consumable Examples
-
-```
-system.properties
-       magicalBonus
-```
-
-#### Add Consumable Properties
-
-Some consumable types have different properties so there are different lists calling those out below.
-
-| Attribute Key       | Change Mode | Effect Value | Roll Data? |
-| ------------------- | ----------- | ------------ | ---------- |
-| `system.properties` | Add         | `[string]`   | No         |
 
 > <details>
 > <summary>Ammunition Properties</summary>
@@ -277,29 +182,6 @@ Some consumable types have different properties so there are different lists cal
 >
 > </details>
 
-#### Make Ammunition Magical
-
-Make ammunition magical by adding the Magical property and an optional Magical Bonus that will be added to the attack/damage rolls.
-
-| Attribute Key         | Change Mode | Effect Value | Roll Data? |
-| --------------------- | ----------- | ------------ | ---------- |
-| `system.properties`   | Add         | `mgc`        | No         |
-| `system.magicalBonus` | Override    | `[number]`   | No         |
-
-### Container Examples
-
-```
-system.properties
-       capacity.value
-                type
-```
-
-#### Add Container Properties
-
-| Attribute Key       | Change Mode | Effect Value | Roll Data? |
-| ------------------- | ----------- | ------------ | ---------- |
-| `system.properties` | Add         | `[string]`   | No         |
-
 > <details>
 > <summary>Container Properties</summary>
 >
@@ -312,24 +194,6 @@ system.properties
 >
 > </details>
 
-#### Make Contents Weightless
-
-| Attribute Key       | Change Mode | Effect Value         | Roll Data? |
-| ------------------- | ----------- | -------------------- | ---------- |
-| `system.properties` | Add         | `weightlessContents` | No         |
-
-### Loot Examples
-
-```
-system.properties
-```
-
-#### Add Loot Properties
-
-| Attribute Key       | Change Mode | Effect Value | Roll Data? |
-| ------------------- | ----------- | ------------ | ---------- |
-| `system.properties` | Add         | `[string]`   | No         |
-
 > <details>
 > <summary>Loot Properties</summary>
 >
@@ -340,6 +204,102 @@ system.properties
 > Source: `CONFIG.DND5E.validProperties.loot`
 >
 > </details>
+
+### Weapon Examples
+
+```
+system.proficient
+       magicalBonus
+```
+
+#### Grant Proficiency with the Weapon
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.proficient` | Upgrade     | `1`          | No         |
+
+#### Make Weapon Magical
+
+Make the weapon magical by adding the Magical property and an optional Magical Bonus that will be added to attack and damage rolls.
+
+| Attribute Key         | Change Mode | Effect Value | Roll Data? |
+| --------------------- | ----------- | ------------ | ---------- |
+| `system.properties`   | Add         | `mgc`        | No         |
+| `system.magicalBonus` | Override    | `[number]`   | No         |
+
+### Equipment Examples
+
+```
+system.proficient
+       armor.value
+             magicalBonus
+             dex
+       strength
+```
+
+#### Grant Proficiency with the Equipment
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.proficient` | Upgrade     | `1`          | No         |
+
+#### Make Armor Magical
+
+Make the armor magical by adding the Magical property and an optional Magical Bonus that will be added to AC.
+
+| Attribute Key         | Change Mode | Effect Value | Roll Data? |
+| --------------------- | ----------- | ------------ | ---------- |
+| `system.properties`   | Add         | `mgc`        | No         |
+| `system.magicalBonus` | Override    | `[number]`   | No         |
+
+### Tool Examples
+
+```
+system.proficient
+       ability
+       bonus
+       chatFlavor
+```
+
+#### Grant Proficiency with the Tool
+
+| Attribute Key       | Change Mode | Effect Value | Roll Data? |
+| ------------------- | ----------- | ------------ | ---------- |
+| `system.proficient` | Upgrade     | `1`          | No         |
+
+#### Add Bonus to Tool
+
+| Attribute Key  | Change Mode | Effect Value | Roll Data? |
+| -------------- | ----------- | ------------ | ---------- |
+| `system.bonus` | Add         | `[formula]`  | Yes        |
+
+### Consumable Examples
+
+```
+system.magicalBonus
+```
+
+#### Make Ammunition Magical
+
+Make ammunition magical by adding the Magical property and an optional Magical Bonus that will be added to the attack/damage rolls.
+
+| Attribute Key         | Change Mode | Effect Value | Roll Data? |
+| --------------------- | ----------- | ------------ | ---------- |
+| `system.properties`   | Add         | `mgc`        | No         |
+| `system.magicalBonus` | Override    | `[number]`   | No         |
+
+### Container Examples
+
+```
+system.capacity.value
+                type
+```
+
+#### Make Contents Weightless
+
+| Attribute Key       | Change Mode | Effect Value         | Roll Data? |
+| ------------------- | ----------- | -------------------- | ---------- |
+| `system.properties` | Add         | `weightlessContents` | No         |
 
 ### Common Usage Examples
 

--- a/wiki/Enchantment.md
+++ b/wiki/Enchantment.md
@@ -1,4 +1,4 @@
-![Up to date as of 3.2.0](https://img.shields.io/static/v1?label=dnd5e&message=3.2.0&color=informational)
+![Up to date as of 3.3.0](https://img.shields.io/static/v1?label=dnd5e&message=3.3.0&color=informational)
 
 The D&D system includes an item activation method that allows for adding enchantments to items. These enchantments can modify the stats of an item (such as *Magic Weapon* giving a mundane weapon a +1 magical bonus), carry effects that apply to an actor (such as the *Fire Rune* granting a player double proficiency on tool checks), and carry items that are added to the actor (such as the *Arcane Propulsive Armor* give the player a set of gauntlets that can be used to attack).
 
@@ -42,7 +42,7 @@ In the activation chat message a drop area will appear. Any player may drop an i
 
 ## Enchantment Active Effects
 
-This describes how to create Active Effects used as an Enchantment. This differs from the [Active Effect Guide](Active-Effect-Guide) in that these are changes to items instead of the actors. If you're creating an Active Effect to add to the Additional Effects section when configuring an Enchantment, then use that guide.
+This describes how to create Active Effects used as Enchantments. This differs from the [Active Effect Guide](Active-Effect-Guide) in that these are changes to items instead of the actors. If you're creating an Active Effect to add to the Additional Effects section when configuring an Enchantment, then use that guide.
 
 Because of the differences in item types, there are separate sections for each type that can be enchanted. This uses the same [Legend](Active-Effect-Guide#legend) that the Active Effect Guide does in addition to:
 


### PR DESCRIPTION
Similar to the Active Effect Guide, add a section to the Enchantment wiki page to document the active effects. It has some common sections (i.e. Common Examples, Common Usage Examples, and Common Action Examples) plus sections for those item types that have other things in their data model an enchantment could realistically change. Not surprisingly, the Loot type doesn't have its own section since it doesn't have much to begin with and is covered by the Common Examples section.

There are some parts of the data model I decided to leave out since I didn't think they made sense to change in an enchantment or were very unlikely to be changed:

- `system.source`
- `system.type`
- `system.identified` and `unidentified`
- `system.quantity`, `weight`, `price`, and `rarity`
- `system.attunement`, `attuned`, and `equipped`
- anything only shown on vehicle items (e.g. `system.armor` on weapons)