### PR TITLE
Keep the original token's sight.enabled value when transforming an actor

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2947,9 +2947,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     if ( !keepSelf ) {
       const sightSource = keepVision ? o.prototypeToken : source.prototypeToken;
-      for ( const k of ["range", "angle", "visionMode", "color", "attenuation", "brightness", "saturation", "contrast", "enabled"] ) {
+      for ( const k of ["range", "angle", "visionMode", "color", "attenuation", "brightness", "saturation", "contrast"] ) {
         d.prototypeToken.sight[k] = sightSource.sight[k];
       }
+      d.prototypeToken.sight.enabled = o.prototypeToken.sight.enabled;
       d.prototypeToken.detectionModes = sightSource.detectionModes;
 
       // Transfer ability scores


### PR DESCRIPTION
From a discussion on Discord, someone imported some beasts from the Monsters SRD compendium to wildshape into. When they did, the new token didn't have the Vision Enabled value checked because it wasn't enabled on the beast's prototype token they imported. While they can fix it by enabling vision on the beasts they import, it'd be a better UX if the system kept the original value of that particular token property rather than requiring the GM to update the prototype token of each beast they import for the Druid PC to wildshape into.