### PR TITLE
[#1964] Add basic activity configuration sheet

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -390,7 +390,10 @@ function expandAttributeList(attributes) {
 /**
  * Perform one-time pre-localization and sorting of some configuration objects
  */
-Hooks.once("i18nInit", () => utils.performPreLocalization(CONFIG.DND5E));
+Hooks.once("i18nInit", () => {
+  utils.performPreLocalization(CONFIG.DND5E);
+  Localization.localizeDataModel(dnd5e.documents.activity.UtilityActivity);
+});
 
 /* -------------------------------------------- */
 /*  Foundry VTT Ready                           */

--- a/lang/en.json
+++ b/lang/en.json
@@ -146,7 +146,17 @@
 "DND5E.ActionWarningNoItem": "The requested item {item} no longer exists on Actor {name}",
 "DND5E.ActionWarningNoToken": "You must have one or more controlled Tokens in order to use this option.",
 
+"DND5E.Activation": {
+  "Category": {
+    "Standard": "Standard",
+    "Time": "Time",
+    "Monster": "Monster"
+  }
+},
+
 "DND5E.ACTIVITY": {
+  "Label": "Activity",
+  "LabelPl": "Activities",
   "FIELDS": {
     "activation": {
       "label": "Activation",
@@ -195,6 +205,12 @@
         "label": "Duration Value",
         "hint": "Value of the duration in the specified units, if applicable."
       }
+    },
+    "img": {
+      "label": "Icon"
+    },
+    "name": {
+      "label": "Name"
     },
     "range": {
       "label": "Range",
@@ -264,6 +280,12 @@
         }
       }
     }
+  },
+  "SECTIONS": {
+    "Activation": "Activation",
+    "Effect": "Effect",
+    "Identity": "Identity",
+    "Time": "Time"
   },
   "Utility": {
     "Title": "Utility"
@@ -447,7 +469,17 @@
 "DND5E.AttunementAttuned": "Attuned",
 "DND5E.AttunementOverride": "Override attunement",
 "DND5E.Attuned": "Attuned",
-"DND5E.AreaOfEffect": "Area of Effect",
+"DND5E.AreaOfEffect": {
+  "Label": "Area of EFfect",
+  "Size": {
+    "Label": "Size",
+    "Height": "Height",
+    "Length": "Length",
+    "Radius": "Radius",
+    "Thickness": "Thickness",
+    "Width": "Width"
+  }
+},
 "DND5E.Armor": "Armor",
 "DND5E.ArmorClass": "Armor Class",
 "DND5E.ArmorClassEquipment": "Equipped Armor",
@@ -705,6 +737,38 @@
 "DND5E.ConsumableUnitWarn": "units remaining",
 "DND5E.ConsumableLastChargeWarn": "This is the last charge of this unit and consuming it will also reduce the item's quantity by 1",
 "DND5E.ConsumableWithoutCharges": "available units to use",
+"DND5E.Consumption": {
+  "Action": {
+    "Add": "Add Consumption Target",
+    "Delete": "Delete Consumption Target"
+  },
+  "Scaling": {
+    "Amount": "Amount",
+    "Automatic": "Automatic",
+    "None": "No Scaling",
+    "SlotLevel": "Slot Level"
+  },
+  "Target": {
+    "ThisItem": "This Item"
+  },
+  "Type": {
+    "ActivityUses": {
+      "Label": "Activity Uses"
+    },
+    "Attribute": {
+      "Label": "Attribute"
+    },
+    "HitDice": {
+      "Label": "Hit Dice"
+    },
+    "ItemUses": {
+      "Label": "Item Uses"
+    },
+    "SpellSlots": {
+      "Label": "Spell Slots"
+    }
+  }
+},
 "DND5E.Consumed": "Consumed",
 "DND5E.Cover": "Cover",
 "DND5E.CoverHalf": "Half",
@@ -1908,6 +1972,7 @@
 "DND5E.TargetCube": "Cube",
 "DND5E.TargetCylinder": "Cylinder",
 "DND5E.TargetEnemy": "Enemy",
+"DND5E.TargetEvery": "Every",
 "DND5E.TargetLine": "Line",
 "DND5E.TargetObject": "Object",
 "DND5E.TargetRadius": "Radius",
@@ -2064,6 +2129,17 @@
         "label": "Spent Uses",
         "hint": "Number of uses that have been spent."
       }
+    }
+  },
+  "Recovery": {
+    "Action": {
+      "Add": "Add Recovery Profile",
+      "Delete": "Delete Recovery Profile"
+    },
+    "Type": {
+      "Formula": "Custom Formula",
+      "LoseAll": "Lose All Uses",
+      "RecoverAll": "Recover All Uses"
     }
   }
 },

--- a/lang/en.json
+++ b/lang/en.json
@@ -150,7 +150,8 @@
   "Category": {
     "Standard": "Standard",
     "Time": "Time",
-    "Monster": "Monster"
+    "Monster": "Monster",
+    "Vehicle": "Vehicle"
   }
 },
 

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -1,3 +1,4 @@
+export * as activity from "./activity/_module.mjs";
 export * as actor from "./actor/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";
 export * as api from "./api/_module.mjs";

--- a/module/applications/activity/_module.mjs
+++ b/module/applications/activity/_module.mjs
@@ -1,0 +1,1 @@
+export {default as ActivitySheet} from "./activity-sheet.mjs";

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -1,0 +1,494 @@
+import Application5e from "../api/application.mjs";
+
+/**
+ * Default sheet for activities.
+ */
+export default class ActivitySheet extends Application5e {
+  constructor(options={}) {
+    super(options);
+    this.#activityId = options.document.id;
+    this.#item = options.document.item;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static DEFAULT_OPTIONS = {
+    classes: ["activity", "sheet"],
+    tag: "form",
+    document: null,
+    viewPermission: CONST.DOCUMENT_OWNERSHIP_LEVELS.LIMITED,
+    editPermission: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+    window: {
+      icon: "fa-solid fa-gauge"
+    },
+    actions: {
+      addConsumption: ActivitySheet.#addConsumption,
+      addRecovery: ActivitySheet.#addRecovery,
+      deleteConsumption: ActivitySheet.#deleteConsumption,
+      deleteRecovery: ActivitySheet.#deleteRecovery
+    },
+    form: {
+      handler: ActivitySheet.#onSubmitForm,
+      submitOnChange: true
+    },
+    position: {
+      width: 540,
+      height: "auto"
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    tabs: {
+      template: "templates/generic/tab-navigation.hbs"
+    },
+    identity: {
+      template: "systems/dnd5e/templates/activity/identity.hbs"
+    },
+    activation: {
+      template: "systems/dnd5e/templates/activity/activation.hbs",
+      templates: [
+        "systems/dnd5e/templates/activity/parts/activity-time.hbs",
+        "systems/dnd5e/templates/activity/parts/activity-targeting.hbs",
+        "systems/dnd5e/templates/activity/parts/activity-consumption.hbs",
+        "systems/dnd5e/templates/shared/uses-recovery.hbs",
+        "systems/dnd5e/templates/shared/uses-values.hbs"
+      ]
+    },
+    effect: {
+      template: "systems/dnd5e/templates/activity/effect.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  tabGroups = {
+    sheet: "identity",
+    activation: "time"
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The Activity associated with this application.
+   * @type {Activity}
+   */
+  get activity() {
+    return this.item.system.activities.get(this.#activityId);
+  }
+
+  /**
+   * ID of this activity on the parent item.
+   * @type {string}
+   */
+  #activityId;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this Activity sheet visible to the current user?
+   * @type {boolean}
+   */
+  get isVisible() {
+    return this.item.testUserPermission(game.user, this.options.viewPermission);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this Document sheet editable by the current User?
+   * This is governed by the editPermission threshold configured for the class.
+   * @type {boolean}
+   */
+  get isEditable() {
+    if ( game.packs.get(this.item.pack)?.locked ) return false;
+    return this.item.testUserPermission(game.user, this.options.editPermission);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Parent item to which this activity belongs.
+   * @type {Item5e}
+   */
+  #item;
+
+  get item() {
+    return this.#item;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  get title() {
+    return this.activity.name;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    return {
+      ...await super._prepareContext(options),
+      activity: this.activity,
+      fields: this.activity.schema.fields,
+      source: this.activity.toObject(),
+      tabs: this._getTabs()
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _preparePartContext(partId, context) {
+    switch ( partId ) {
+      case "activation": return this._prepareActivationContext(context);
+      case "effect": return this._prepareEffectContext(context);
+      case "identity": return this._prepareIdentityContext(context);
+    }
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the activation tab.
+   * @param {object} context  Context being prepared.
+   * @returns {object}
+   */
+  async _prepareActivationContext(context) {
+    context.tab = context.tabs.activation;
+
+    context.activationTypes = Object.entries(CONFIG.DND5E.activityActivationTypes).map(([value, config]) => ({
+      value,
+      label: game.i18n.localize(config.label),
+      group: game.i18n.localize(config.group)
+    }));
+    context.affectsPlaceholder = game.i18n.localize(
+      `DND5E.Target${context.activity.target.template.type ? "Every" : "Any"}`
+    );
+    context.durationUnits = [
+      { value: "inst", label: game.i18n.localize("DND5E.TimeInst") },
+      ...Object.entries(CONFIG.DND5E.scalarTimePeriods).map(([value, label]) => ({
+        value, label, group: game.i18n.localize("DND5E.DurationTime")
+      })),
+      ...Object.entries(CONFIG.DND5E.permanentTimePeriods).map(([value, label]) => ({
+        value, label, group: game.i18n.localize("DND5E.DurationPermanent")
+      })),
+      { value: "spec", label: game.i18n.localize("DND5E.Special") }
+    ];
+    context.rangeUnits = [
+      ...Object.entries(CONFIG.DND5E.rangeTypes).map(([value, label]) => ({ value, label })),
+      ...Object.entries(CONFIG.DND5E.movementUnits).map(([value, label]) => ({
+        value, label, group: game.i18n.localize("DND5E.RangeDistance")
+      }))
+    ];
+    context.scalar = {
+      activation: CONFIG.DND5E.activityActivationTypes[context.activity.activation.type]?.scalar,
+      duration: context.activity.duration.units in CONFIG.DND5E.scalarTimePeriods,
+      range: context.activity.range.units in CONFIG.DND5E.movementUnits,
+      target: !["", "self", "any"].includes(context.activity.target.affects.type)
+    };
+
+    // Consumption targets
+    const canScale = this.activity.consumption.scaling.allowed
+      || (this.item.type === "spell" && this.item.system.level !== 0);
+    const consumptionTypeOptions = Array.from(this.activity.validConsumptionTypes).map(value => ({
+      value,
+      label: CONFIG.DND5E.activityConsumptionTypes[value].label
+    }));
+    context.consumptionTargets = context.activity.consumption.targets.map((data, index) => {
+      const typeConfig = CONFIG.DND5E.activityConsumptionTypes[data.type] ?? {};
+      const showTextTarget = typeConfig.targetRequiresEmbedded && !this.item.isEmbedded;
+      return {
+        data,
+        fields: this.activity.schema.fields.consumption.fields.targets.element.fields,
+        prefix: `consumption.targets.${index}.`,
+        source: context.source.consumption.targets[index] ?? data,
+        typeOptions: consumptionTypeOptions,
+        scalingModes: canScale ? [
+          { value: "", label: game.i18n.localize("DND5E.Consumption.Scaling.None") },
+          { value: "amount", label: game.i18n.localize("DND5E.Consumption.Scaling.Amount") },
+          ...(typeConfig.scalingModes ?? []).map(({ value, label }) => ({ value, label: game.i18n.localize(label) }))
+        ] : null,
+        showTargets: "validTargets" in typeConfig,
+        targetPlaceholder: data.type === "itemUses" ? game.i18n.localize("DND5E.Consumption.Target.ThisItem") : null,
+        validTargets: showTextTarget ? null : typeConfig.validTargets?.(this.activity)
+      };
+    });
+
+    // Uses recovery
+    const usesRecoveryPeriods = [
+      ...Object.entries(CONFIG.DND5E.limitedUsePeriods)
+        .filter(([, config]) => !config.deprecated)
+        .map(([value, config]) => ({
+          value, label: config.label, group: game.i18n.localize("DND5E.DurationTime")
+        }))
+    ];
+    const usesRecoveryTypes = [
+      { value: "recoverAll", label: game.i18n.localize("DND5E.USES.Recovery.Type.RecoverAll") },
+      { value: "loseAll", label: game.i18n.localize("DND5E.USES.Recovery.Type.LoseAll") },
+      { value: "formula", label: game.i18n.localize("DND5E.USES.Recovery.Type.Formula") }
+    ];
+    context.usesRecovery = context.activity.uses.recovery.map((data, index) => ({
+      data,
+      fields: this.activity.schema.fields.uses.fields.recovery.element.fields,
+      prefix: `uses.recovery.${index}.`,
+      source: context.source.uses.recovery[index] ?? data,
+      periods: usesRecoveryPeriods,
+      types: usesRecoveryTypes
+    }));
+
+    // Template dimensions
+    const sizes = CONFIG.DND5E.areaTargetTypes[context.activity.target.template.type]?.sizes;
+    if ( sizes ) {
+      context.dimensions = {
+        size: "DND5E.AreaOfEffect.Size.Label",
+        width: sizes.includes("width") && (sizes.includes("length") || sizes.includes("radius")),
+        height: sizes.includes("height")
+      };
+      if ( sizes.includes("radius") ) context.dimensions.size = "DND5E.AreaOfEffect.Size.Radius";
+      else if ( sizes.includes("length") ) context.dimensions.size = "DND5E.AreaOfEffect.Size.Length";
+      else if ( sizes.includes("width") ) context.dimensions.size = "DND5E.AreaOfEffect.Size.Width";
+      if ( sizes.includes("thickness") ) context.dimensions.width = "DND5E.AreaOfEffect.Size.Thickness";
+      else if ( context.dimensions.width ) context.dimensions.width = "DND5E.AreaOfEffect.Size.Width";
+      if ( context.dimensions.height ) context.dimensions.height = "DND5E.AreaOfEffect.Size.Height";
+    }
+
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the effect tab.
+   * @param {object} context  Context being prepared.
+   * @returns {object}
+   */
+  async _prepareEffectContext(context) {
+    context.tab = context.tabs.effect;
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the identity tab.
+   * @param {object} context  Context being prepared.
+   * @returns {object}
+   */
+  async _prepareIdentityContext(context) {
+    context.tab = context.tabs.identity;
+    context.placeholder = {
+      name: game.i18n.localize(this.activity.metadata.title),
+      img: this.activity.metadata.img
+    };
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the tab information for the sheet.
+   * @returns {Record<string, Partial<ApplicationTab>>}
+   * @protected
+   */
+  _getTabs() {
+    return this._markTabs({
+      identity: {
+        id: "identity", group: "sheet", icon: "fa-solid fa-tag",
+        label: "DND5E.ACTIVITY.SECTIONS.Identity"
+      },
+      activation: {
+        id: "activation", group: "sheet", icon: "fa-solid fa-clapperboard",
+        label: "DND5E.ACTIVITY.SECTIONS.Activation",
+        tabs: {
+          time: {
+            id: "time", group: "activation", icon: "fa-solid fa-clock",
+            label: "DND5E.ACTIVITY.SECTIONS.Time"
+          },
+          consumption: {
+            id: "consumption", group: "activation", icon: "fa-solid fa-boxes-stacked",
+            label: "DND5E.ACTIVITY.FIELDS.consumption.label"
+          },
+          targeting: {
+            id: "activation-targeting", group: "activation", icon: "fa-solid fa-bullseye",
+            label: "DND5E.ACTIVITY.FIELDS.target.label"
+          }
+        }
+      },
+      effect: {
+        id: "effect", group: "sheet", icon: "fa-solid fa-sun",
+        label: "DND5E.ACTIVITY.SECTIONS.Effect"
+      }
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Helper to mark the tabs data structure with the appropriate CSS class if it is active.
+   * @param {Record<string, Partial<ApplicationTab>>} tabs  Tabs definition to modify.
+   * @returns {Record<string, Partial<ApplicationTab>>}
+   * @internal
+   */
+  _markTabs(tabs) {
+    for ( const v of Object.values(tabs) ) {
+      v.active = this.tabGroups[v.group] === v.id;
+      v.cssClass = v.active ? "active" : "";
+      if ( "tabs" in v ) this._markTabs(v.tabs);
+    }
+    return tabs;
+  }
+
+  /* -------------------------------------------- */
+  /*  Life-Cycle Handlers                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _canRender(options) {
+    if ( !this.isVisible ) throw new Error(game.i18n.format("SHEETS.DocumentSheetPrivate", {
+      type: game.i18n.localize("DND5E.ACTIVITY.Label")
+    }));
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onFirstRender(context, options) {
+    super._onFirstRender(context, options);
+    this.activity.constructor._registerApp(this.activity, this);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onClose(_options) {
+    this.activity.constructor._unregisterApp(this.activity, this);
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle adding a new entry to the consumption list.
+   * @this {ActivityConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #addConsumption(event, target) {
+    const types = this.activity.validConsumptionTypes;
+    const existingTypes = new Set(this.activity.consumption.targets.map(t => t.type));
+    const filteredTypes = types.difference(existingTypes);
+    this.activity.update({
+      "consumption.targets": [
+        ...this.activity.toObject().consumption.targets,
+        { type: filteredTypes.first() ?? types.first() }
+      ]
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle adding a new entry to the uses recovery list.
+   * @this {ActivityConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #addRecovery(event, target) {
+    const periods = new Set(
+      Object.entries(CONFIG.DND5E.limitedUsePeriods).filter(([, config]) => !config.deprecated).map(([k]) => k)
+    );
+    const existingPeriods = new Set(this.activity.uses.recovery.map(t => t.period));
+    const filteredPeriods = periods.difference(existingPeriods);
+    this.activity.update({
+      "uses.recovery": [
+        ...this.activity.toObject().uses.recovery,
+        { period: filteredPeriods.first() ?? periods.first() }
+      ]
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle removing an entry from the consumption targets list.
+   * @this {ActivityConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #deleteConsumption(event, target) {
+    const consumption = this.activity.toObject().consumption.targets;
+    consumption.splice(target.closest("[data-index]").dataset.index, 1);
+    this.activity.update({ "consumption.targets": consumption });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle removing an entry from the uses recovery list.
+   * @this {ActivityConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #deleteRecovery(event, target) {
+    const recovery = this.activity.toObject().uses.recovery;
+    recovery.splice(target.closest("[data-index]").dataset.index, 1);
+    this.activity.update({ "uses.recovery": recovery });
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle form submission.
+   * @param {SubmitEvent} event          Triggering submit event.
+   * @param {HTMLFormElement} form       The form that was submitted.
+   * @param {FormDataExtended} formData  Data from the submitted form.
+   */
+  static async #onSubmitForm(event, form, formData) {
+    const submitData = this._prepareSubmitData(event, formData);
+    await this._processSubmitData(event, submitData);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Perform any pre-processing of the form data to prepare it for updating.
+   * @param {SubmitEvent} event          Triggering submit event.
+   * @param {FormDataExtended} formData  Data from the submitted form.
+   * @returns {object}
+   */
+  _prepareSubmitData(event, formData) {
+    const submitData = foundry.utils.expandObject(formData.object);
+    if ( foundry.utils.hasProperty(submitData, "consumption.targets") ) {
+      submitData.consumption.targets = Object.values(submitData.consumption.targets);
+    }
+    if ( foundry.utils.hasProperty(submitData, "uses.recovery") ) {
+      submitData.uses.recovery = Object.values(submitData.uses.recovery);
+    }
+    return submitData;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle updating the activity based on processed submit data.
+   * @param {SubmitEvent} event  Triggering submit event.
+   * @param {object} submitData  Prepared object for updating.
+   */
+  async _processSubmitData(event, submitData) {
+    await this.activity.update(submitData);
+  }
+}

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -221,7 +221,7 @@ export default class ActivitySheet extends Application5e {
         ] : null,
         showTargets: "validTargets" in typeConfig,
         targetPlaceholder: data.type === "itemUses" ? game.i18n.localize("DND5E.Consumption.Target.ThisItem") : null,
-        validTargets: showTextTarget ? null : typeConfig.validTargets?.(this.activity)
+        validTargets: showTextTarget ? null : typeConfig.validTargets?.call(this.activity)
       };
     });
 

--- a/module/applications/api/application.mjs
+++ b/module/applications/api/application.mjs
@@ -6,7 +6,7 @@ const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 export default class Application5e extends HandlebarsApplicationMixin(ApplicationV2) {
   /** @override */
   static DEFAULT_OPTIONS = {
-    classes: ["dnd5e"]
+    classes: ["dnd5e2"]
   };
 
   /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1,3 +1,4 @@
+import BaseActivityData from "./data/activity/base-activity.mjs";
 import MapLocationControlIcon from "./canvas/map-location-control-icon.mjs";
 import * as activities from "./documents/activity/_module.mjs";
 import * as advancement from "./documents/advancement/_module.mjs";
@@ -600,7 +601,7 @@ DND5E.activityActivationTypes = {
   },
   crew: {
     label: "DND5E.VehicleCrewAction",
-    group: "DND5E.Activation.Category.Monster",
+    group: "DND5E.Activation.Category.Vehicle",
     scalar: true
   },
   special: {
@@ -636,8 +637,8 @@ preLocalize("abilityConsumptionTypes", { sort: true });
 
 /**
  * @callback ConsumptionValidTargetsFunction
- * @param {Activity} activity  Activity to which the consumption belongs.
- * @returns {{value: string, label: string}[]}
+ * @this {Activity}
+ * @returns {FormSelectOption[]}
  */
 
 /**
@@ -651,33 +652,21 @@ DND5E.activityConsumptionTypes = {
   itemUses: {
     label: "DND5E.Consumption.Type.ItemUses.Label",
     targetRequiresEmbedded: true,
-    validTargets: activity => [
-      { value: "", label: game.i18n.localize("DND5E.Consumption.Type.ItemUses.ThisItem") },
-      ...(activity.actor?.items ?? [])
-        .filter(i => i.system.uses?.max && i !== activity.item)
-        .map(i => ({ value: i.id, label: i.name }))
-    ]
+    validTargets: BaseActivityData.validItemUsesTargets
   },
   hitDice: {
     label: "DND5E.Consumption.Type.HitDice.Label",
-    validTargets: activity => [
-      { value: "smallest", label: game.i18n.localize("DND5E.ConsumeHitDiceSmallest") },
-      ...DND5E.hitDieTypes.map(d => ({ value: d, label: d })),
-      { value: "largest", label: game.i18n.localize("DND5E.ConsumeHitDiceLargest") }
-    ]
+    validTargets: BaseActivityData.validHitDiceTargets
   },
   spellSlots: {
     label: "DND5E.Consumption.Type.SpellSlots.Label",
     scalingModes: [{ value: "level", label: "DND5E.Consumption.Scaling.SlotLevel" }],
-    validTargets: activity => Object.entries(CONFIG.DND5E.spellLevels).reduce((arr, [value, label]) => {
-      if ( value !== "0" ) arr.push({ value, label });
-      return arr;
-    }, [])
+    validTargets: BaseActivityData.validSpellSlotsTargets
   },
   attribute: {
     label: "DND5E.Consumption.Type.Attribute.Label",
-    targetRequiresEmbedded: true
-    // TODO: Fetch valid targets from actor data model
+    targetRequiresEmbedded: true,
+    validTargets: BaseActivityData.validAttributeTargets
   }
 };
 preLocalize("activityConsumptionTypes", { key: "label" });
@@ -1966,6 +1955,9 @@ preLocalize("individualTargetTypes");
  * @property {string} label        Localized label for this type.
  * @property {string} template     Type of `MeasuredTemplate` create for this target type.
  * @property {string} [reference]  Reference to a rule page describing this area of effect.
+ * @property {string[]} [sizes]    List of available sizes for this template. Options are chosen from the list:
+ *                                 "radius", "width", "height", "length", "thickness". No more than 3 dimensions may
+ *                                 be specified.
  */
 
 /**

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -546,6 +546,71 @@ preLocalize("abilityActivationTypes");
 /* -------------------------------------------- */
 
 /**
+ * @typedef {ActivityActivationTypeConfig}
+ * @property {string} label            Localized label for the activation type.
+ * @property {string} [group]          Localized label for the presentational group.
+ * @property {boolean} [scalar=false]  Does this activation type have a numeric value attached?
+ */
+
+/**
+ * Configuration data for activation types on activities.
+ * @enum {ActivityActivationTypeConfig}
+ */
+DND5E.activityActivationTypes = {
+  action: {
+    label: "DND5E.Action",
+    group: "DND5E.Activation.Category.Standard"
+  },
+  bonus: {
+    label: "DND5E.BonusAction",
+    group: "DND5E.Activation.Category.Standard"
+  },
+  reaction: {
+    label: "DND5E.Reaction",
+    group: "DND5E.Activation.Category.Standard"
+  },
+  minute: {
+    label: "DND5E.TimeMinute",
+    group: "DND5E.Activation.Category.Time",
+    scalar: true
+  },
+  hour: {
+    label: "DND5E.TimeHour",
+    group: "DND5E.Activation.Category.Time",
+    scalar: true
+  },
+  day: {
+    label: "DND5E.TimeDay",
+    group: "DND5E.Activation.Category.Time",
+    scalar: true
+  },
+  legendary: {
+    label: "DND5E.LegendaryActionLabel",
+    group: "DND5E.Activation.Category.Monster",
+    scalar: true
+  },
+  mythic: {
+    label: "DND5E.MythicActionLabel",
+    group: "DND5E.Activation.Category.Monster",
+    scalar: true
+  },
+  lair: {
+    label: "DND5E.LairActionLabel",
+    group: "DND5E.Activation.Category.Monster"
+  },
+  crew: {
+    label: "DND5E.VehicleCrewAction",
+    group: "DND5E.Activation.Category.Monster",
+    scalar: true
+  },
+  special: {
+    label: "DND5E.Special"
+  }
+};
+
+/* -------------------------------------------- */
+
+/**
  * Different things that an ability can consume upon use.
  * @enum {string}
  */
@@ -557,6 +622,65 @@ DND5E.abilityConsumptionTypes = {
   charges: "DND5E.ConsumeCharges"
 };
 preLocalize("abilityConsumptionTypes", { sort: true });
+
+/* -------------------------------------------- */
+
+/**
+ * @typedef {object} ActivityConsumptionTargetConfig
+ * @property {string} label                                     Localized label for the target type.
+ * @property {{value: string, label: string}[]} [scalingModes]  Additional scaling modes for this consumption type in
+ *                                                              addition to the default "amount" scaling.
+ * @property {boolean} [targetRequiresEmbedded]                 Use text input rather than select when not embedded.
+ * @property {ConsumptionValidTargetsFunction} [validTargets]   Method for creating an array of consumption targets.
+ */
+
+/**
+ * @callback ConsumptionValidTargetsFunction
+ * @param {Activity} activity  Activity to which the consumption belongs.
+ * @returns {{value: string, label: string}[]}
+ */
+
+/**
+ * Configuration information for different consumption targets.
+ * @enum {ActivityConsumptionTargetConfig}
+ */
+DND5E.activityConsumptionTypes = {
+  activityUses: {
+    label: "DND5E.Consumption.Type.ActivityUses.Label"
+  },
+  itemUses: {
+    label: "DND5E.Consumption.Type.ItemUses.Label",
+    targetRequiresEmbedded: true,
+    validTargets: activity => [
+      { value: "", label: game.i18n.localize("DND5E.Consumption.Type.ItemUses.ThisItem") },
+      ...(activity.actor?.items ?? [])
+        .filter(i => i.system.uses?.max && i !== activity.item)
+        .map(i => ({ value: i.id, label: i.name }))
+    ]
+  },
+  hitDice: {
+    label: "DND5E.Consumption.Type.HitDice.Label",
+    validTargets: activity => [
+      { value: "smallest", label: game.i18n.localize("DND5E.ConsumeHitDiceSmallest") },
+      ...DND5E.hitDieTypes.map(d => ({ value: d, label: d })),
+      { value: "largest", label: game.i18n.localize("DND5E.ConsumeHitDiceLargest") }
+    ]
+  },
+  spellSlots: {
+    label: "DND5E.Consumption.Type.SpellSlots.Label",
+    scalingModes: [{ value: "level", label: "DND5E.Consumption.Scaling.SlotLevel" }],
+    validTargets: activity => Object.entries(CONFIG.DND5E.spellLevels).reduce((arr, [value, label]) => {
+      if ( value !== "0" ) arr.push({ value, label });
+      return arr;
+    }, [])
+  },
+  attribute: {
+    label: "DND5E.Consumption.Type.Attribute.Label",
+    targetRequiresEmbedded: true
+    // TODO: Fetch valid targets from actor data model
+  }
+};
+preLocalize("activityConsumptionTypes", { key: "label" });
 
 /* -------------------------------------------- */
 
@@ -854,13 +978,13 @@ preLocalize("itemRarity");
  * @enum {LimitedUsePeriodConfiguration}
  */
 DND5E.limitedUsePeriods = {
-  sr: {
-    label: "DND5E.UsesPeriods.Sr",
-    abbreviation: "DND5E.UsesPeriods.SrAbbreviation"
-  },
   lr: {
     label: "DND5E.UsesPeriods.Lr",
     abbreviation: "DND5E.UsesPeriods.LrAbbreviation"
+  },
+  sr: {
+    label: "DND5E.UsesPeriods.Sr",
+    abbreviation: "DND5E.UsesPeriods.SrAbbreviation"
   },
   day: {
     label: "DND5E.UsesPeriods.Day",
@@ -869,7 +993,8 @@ DND5E.limitedUsePeriods = {
   charges: {
     label: "DND5E.UsesPeriods.Charges",
     abbreviation: "DND5E.UsesPeriods.ChargesAbbreviation",
-    formula: true
+    formula: true,
+    deprecated: true
   },
   dawn: {
     label: "DND5E.UsesPeriods.Dawn",
@@ -1850,40 +1975,48 @@ preLocalize("individualTargetTypes");
 DND5E.areaTargetTypes = {
   radius: {
     label: "DND5E.TargetRadius",
-    template: "circle"
+    template: "circle",
+    sizes: ["radius"]
   },
   sphere: {
     label: "DND5E.TargetSphere",
     template: "circle",
-    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.npdEWb2egUPnB5Fa"
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.npdEWb2egUPnB5Fa",
+    sizes: ["radius"]
   },
   cylinder: {
     label: "DND5E.TargetCylinder",
     template: "circle",
-    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.jZFp4R7tXsIqkiG3"
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.jZFp4R7tXsIqkiG3",
+    sizes: ["radius", "height"]
   },
   cone: {
     label: "DND5E.TargetCone",
     template: "cone",
-    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.DqqAOr5JnX71OCOw"
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.DqqAOr5JnX71OCOw",
+    sizes: ["length"]
   },
   square: {
     label: "DND5E.TargetSquare",
-    template: "rect"
+    template: "rect",
+    sizes: ["width"]
   },
   cube: {
     label: "DND5E.TargetCube",
     template: "rect",
-    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.dRfDIwuaHmUQ06uA"
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.dRfDIwuaHmUQ06uA",
+    sizes: ["width"]
   },
   line: {
     label: "DND5E.TargetLine",
     template: "ray",
-    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.6DOoBgg7okm9gBc6"
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.6DOoBgg7okm9gBc6",
+    sizes: ["length", "width"]
   },
   wall: {
     label: "DND5E.TargetWall",
-    template: "ray"
+    template: "ray",
+    sizes: ["length", "thickness", "height"]
   }
 };
 preLocalize("areaTargetTypes", { key: "label", sort: true });
@@ -3144,7 +3277,7 @@ DND5E.ruleTypes = {
     references: "enrichmentLookup.abilities"
   },
   areaOfEffect: {
-    label: "DND5E.AreaOfEffect",
+    label: "DND5E.AreaOfEffect.Label",
     references: "areaTargetTypes"
   },
   condition: {

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -90,11 +90,11 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
         required: true,
         readOnly: true
       }),
-      name: new StringField({initial: undefined}),
-      img: new FilePathField({initial: undefined, categories: ["IMAGE"]}),
+      name: new StringField({ initial: undefined }),
+      img: new FilePathField({ initial: undefined, categories: ["IMAGE"] }),
       activation: new SchemaField({
-        type: new StringField(),
-        value: new NumberField({min: 0, integer: true}),
+        type: new StringField({ initial: "action" }),
+        value: new NumberField({ min: 0, integer: true }),
         condition: new StringField()
       }),
       consumption: new SchemaField({
@@ -116,7 +116,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       }),
       duration: new SchemaField({
         value: new FormulaField({ deterministic: true }),
-        units: new StringField(),
+        units: new StringField({ initial: "inst" }),
         special: new StringField()
       }),
       range: new SchemaField({

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -168,4 +168,63 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * @protected
    */
   _preCreate(data) {}
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Generate a list of targets for the "Attribute" consumption type.
+   * @this {Activity}
+   * @returns {FormSelectOption[]}
+   */
+  static validAttributeTargets() {
+    // TODO: Fetch valid targets from actor data model
+    return [];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Generate a list of targets for the "Hit Dice" consumption type.
+   * @this {Activity}
+   * @returns {FormSelectOption[]}
+   */
+  static validHitDiceTargets() {
+    return [
+      { value: "smallest", label: game.i18n.localize("DND5E.ConsumeHitDiceSmallest") },
+      ...CONFIG.DND5E.hitDieTypes.map(d => ({ value: d, label: d })),
+      { value: "largest", label: game.i18n.localize("DND5E.ConsumeHitDiceLargest") }
+    ];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Generate a list of targets for the "Item Uses" consumption type.
+   * @this {Activity}
+   * @returns {FormSelectOption[]}
+   */
+  static validItemUsesTargets() {
+    return [
+      { value: "", label: game.i18n.localize("DND5E.Consumption.Type.ItemUses.ThisItem") },
+      ...(this.actor?.items ?? [])
+        .filter(i => i.system.uses?.max && i !== this.item)
+        .map(i => ({ value: i.id, label: i.name }))
+    ];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Generate a list of targets for the "Spell Slots" consumption type.
+   * @this {Activity}
+   * @returns {FormSelectOption[]}
+   */
+  static validSpellSlotsTargets() {
+    return Object.entries(CONFIG.DND5E.spellLevels).reduce((arr, [value, label]) => {
+      if ( value !== "0" ) arr.push({ value, label });
+      return arr;
+    }, []);
+  }
 }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -24,6 +24,30 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   });
 
   /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Is this activity on a spell?
+   * @type {boolean}
+   */
+  get isSpell() {
+    return this.item.type === "spell";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Consumption targets that can be use for this activity.
+   * @type {Set<string>}
+   */
+  get validConsumptionTypes() {
+    const types = new Set(Object.keys(CONFIG.DND5E.activityConsumptionTypes));
+    if ( this.isSpell ) types.delete("spellSlots");
+    return types;
+  }
+
+  /* -------------------------------------------- */
   /*  Helpers                                     */
   /* -------------------------------------------- */
 

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -1,12 +1,15 @@
+import ActivitySheet from "../../applications/activity/activity-sheet.mjs";
 import BaseActivityData from "../../data/activity/base-activity.mjs";
 import ActivityMixin from "./mixin.mjs";
 
 export default class UtilityActivity extends ActivityMixin(BaseActivityData) {
+  /** @inheritDoc */
   static metadata = Object.freeze(
     foundry.utils.mergeObject(super.metadata, {
       type: "utility",
       img: "systems/dnd5e/icons/svg/activity/utility.svg",
-      title: "DND5E.ACTIVITY.Utility.Title"
+      title: "DND5E.ACTIVITY.Utility.Title",
+      sheetClass: ActivitySheet
     }, { inplace: false })
   );
 }

--- a/templates/activity/activation.hbs
+++ b/templates/activity/activation.hbs
@@ -1,0 +1,6 @@
+<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
+    {{> "templates/generic/tab-navigation.hbs" tabs=tabs.activation.tabs }}
+    {{> "systems/dnd5e/templates/activity/parts/activity-time.hbs" tab=tabs.activation.tabs.time }}
+    {{> "systems/dnd5e/templates/activity/parts/activity-consumption.hbs" tab=tabs.activation.tabs.consumption }}
+    {{> "systems/dnd5e/templates/activity/parts/activity-targeting.hbs" tab=tabs.activation.tabs.targeting }}
+</section>

--- a/templates/activity/effect.hbs
+++ b/templates/activity/effect.hbs
@@ -1,0 +1,3 @@
+<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
+    TODO: Active effects to apply & effects from specific activity types
+</section>

--- a/templates/activity/identity.hbs
+++ b/templates/activity/identity.hbs
@@ -1,0 +1,4 @@
+<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
+    {{ formField fields.name value=source.name placeholder=placeholder.name }}
+    {{ formField fields.img value=source.img placeholder=placeholder.img }}
+</section>

--- a/templates/activity/parts/activity-consumption.hbs
+++ b/templates/activity/parts/activity-consumption.hbs
@@ -1,0 +1,44 @@
+<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
+    <fieldset>
+        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.consumption.label" }}</legend>
+        <ul class="unlist">
+            {{#each consumptionTargets}}
+            <li data-index="{{ @index }}">
+                {{ formField fields.type name=(concat prefix "type") value=data.type options=typeOptions }}
+                {{#if showTargets}}
+                {{ formField fields.target name=(concat prefix "target") value=data.target options=validTargets
+                   placeholder=targetPlaceholder }}
+                {{/if}}
+                {{ formField fields.value name=(concat prefix "amount") value=data.value }}
+                {{#if scalingModes}}
+                {{ formField fields.scaling.fields.mode name=(concat prefix "scaling.mode") value=data.scaling.mode
+                   options=scalingModes }}
+                {{#if data.scaling.mode}}
+                {{ formField fields.scaling.fields.formula name=(concat prefix "scaling.formula")
+                   value=data.scaling.formula placeholder=(localize "DND5E.Consumption.Scaling.Automatic") }}
+                {{/if}}
+                {{/if}}
+                <button type="button" class="unbutton" data-action="deleteConsumption">
+                    {{ localize "DND5E.Consumption.Action.Delete" }}
+                </button>
+            </li>
+            {{/each}}
+        </ul>
+        <button type="button" class="unbutton" data-action="addConsumption">
+            {{ localize "DND5E.Consumption.Action.Add" }}
+        </button>
+    </fieldset>
+
+    {{#with fields.consumption.fields.scaling.fields as |fields|}}
+    <fieldset>
+        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.consumption.scaling.label" }}</legend>
+        {{ formField fields.allowed value=../activity.consumption.scaling.allowed }}
+        {{#if ../activity.consumption.scaling.allowed}}
+        {{ formField fields.max value=../activity.consumption.scaling.max placeholder="∞" }}
+        {{/if}}
+    </fieldset>
+    {{/with}}
+
+    {{> "systems/dnd5e/templates/shared/uses-values.hbs" }}
+    {{> "systems/dnd5e/templates/shared/uses-recovery.hbs" }}
+</section>

--- a/templates/activity/parts/activity-targeting.hbs
+++ b/templates/activity/parts/activity-targeting.hbs
@@ -1,0 +1,48 @@
+<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
+    <!-- TODO: (override checkbox) -->
+    <fieldset>
+        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.range.label" }}</legend>
+        {{#if scalar.range}}{{ formField fields.range.fields.value value=source.range.value }}{{/if}}
+        {{ formField fields.range.fields.units value=source.range.units options=rangeUnits }}
+        {{#if activity.range.units}}{{ formField fields.range.fields.special value=source.range.special }}{{/if}}
+    </fieldset>
+
+    {{#with fields.target.fields.affects.fields as |fields|}}
+    <fieldset>
+        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.target.affects.label" }}</legend>
+        {{#if ../scalar.target}}
+        {{ formField fields.count value=../source.target.affects.count placeholder=../affectsPlaceholder }}
+        {{/if}}
+        {{ formField fields.type value=../source.target.affects.type choices=../CONFIG.individualTargetTypes }}
+        {{#if ../activity.target.affects.type}}
+        {{ formField fields.special value=../source.target.affects.special }}
+        {{#if ../activity.target.template.type}}
+        {{ formField fields.choice value=../source.target.affects.choice }}
+        {{/if}}
+        {{/if}}
+    </fieldset>
+    {{/with}}
+
+    {{#with fields.target.fields.template.fields as |fields|}}
+    <fieldset>
+        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.target.template.label" }}</legend>
+        {{#if ../activity.target.template.type}}
+        {{ formField fields.count value=../source.target.template.count }}
+        {{/if}}
+        {{ formField fields.type value=../source.target.template.type choices=../CONFIG.areaTargetTypes }}
+        {{#with ../dimensions}}
+        {{ formField fields.size value=@root.source.target.template.size label=(localize size) hint=false }}
+        {{#if width}}
+        {{ formField fields.width value=@root.source.target.template.width label=(localize width) hint=false }}
+        {{/if}}
+        {{#if height}}
+        {{ formField fields.height value=@root.source.target.template.height label=(localize height) hint=false }}
+        {{/if}}
+        {{ formField fields.units value=@root.source.target.template.units choices=@root.CONFIG.movementUnits }}
+        {{/with}}
+        {{#if (and ../activity.target.template.type (gt ../activity.target.template.count 1))}}
+        {{ formField fields.contiguous value=../source.target.template.contiguous }}
+        {{/if}}
+    </fieldset>
+    {{/with}}
+</section>

--- a/templates/activity/parts/activity-time.hbs
+++ b/templates/activity/parts/activity-time.hbs
@@ -1,0 +1,16 @@
+<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
+    <fieldset>
+        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.activation.label" }}</legend>
+        {{#if scalar.activation}}{{ formField fields.activation.fields.value value=source.activation.value }}{{/if}}
+        {{ formField fields.activation.fields.type value=source.activation.type options=activationTypes }}
+        {{ formField fields.activation.fields.condition value=source.activation.condition }}
+    </fieldset>
+
+    <fieldset>
+        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.duration.label" }}</legend>
+        <!-- TODO: (override checkbox) -->
+        {{#if scalar.duration}}{{ formField fields.duration.fields.value value=source.duration.value }}{{/if}}
+        {{ formField fields.duration.fields.units value=source.duration.units options=durationUnits }}
+        {{ formField fields.duration.fields.special value=source.duration.special }}
+    </fieldset>
+</section>

--- a/templates/shared/uses-recovery.hbs
+++ b/templates/shared/uses-recovery.hbs
@@ -1,0 +1,21 @@
+<fieldset class="uses-config">
+    <legend>{{ localize "DND5E.USES.FIELDS.uses.recovery.label" }}</legend>
+    <ul class="unlist">
+        {{#each usesRecovery}}
+        <li data-index="{{ @index }}">
+            {{ formField fields.period name=(concat prefix "period") value=data.period options=periods }}
+            <!-- TODO: Recharge formula -->
+            {{ formField fields.type name=(concat prefix "type") value=data.type options=types }}
+            {{#if (eq source.type "formula")}}
+            {{ formField fields.formula name=(concat prefix "formula") value=data.formula }}
+            {{/if}}
+            <button type="button" class="unbutton" data-action="deleteRecovery">
+                {{ localize "DND5E.USES.Recovery.Action.Delete" }}
+            </button>
+        </li>
+        {{/each}}
+    </ul>
+    <button type="button" class="unbutton" data-action="addRecovery">
+        {{ localize "DND5E.USES.Recovery.Action.Add" }}
+    </button>
+</fieldset>

--- a/templates/shared/uses-values.hbs
+++ b/templates/shared/uses-values.hbs
@@ -1,0 +1,5 @@
+<fieldset class="uses-config">
+    <legend>{{ localize "DND5E.USES.FIELDS.uses.label" }}</legend>
+    {{ formField fields.uses.fields.spent value=source.uses.spent }}
+    {{ formField fields.uses.fields.max value=source.uses.max }}
+</fieldset>


### PR DESCRIPTION
Adds a new ApplicationV2-based sheet for editing activities. This sheet is designed to work with the existing `UtilityActivity` and can be easily subclassed for other activty types.

Note: Due to the ongoing item sheet re-design, no work has been done to design this sheet to match the system design, only to get the underlying functionality and UX working.

The sheet consists of three primary tabs, the first of which is the Identity tab containing the activity name and icon. This tab will probably be eventually expanded to include a description and visibility settings once they are added.

<img width="549" alt="Activity Sheet v1 - Identity Tab" src="https://github.com/user-attachments/assets/6d8f1a2e-8b4b-4a71-b78e-cf7d5a580b93">

The Activation tab contains the bulk of the details with three sub-tabs. The Time tab contains activation time and condition and the duration of the activity.

<img width="551" alt="Activity Sheet v1 - Activation Time Tab" src="https://github.com/user-attachments/assets/f1c25160-b950-450b-9758-972f57509533">

The Consumption tab contains a list of consumption targets, allowing any number of consumption targets to be configured and supporting scaling of consumption. The scaling section indicates whether scaling is allowed (beyond default scaling from spells) and allows for setting a scaling cap. Uses indicates the spent uses and a formula for the maximum uses. Use recovery is another list of recovery profiles, allowing for complex recovery such as recovering one charge on a short rest and all on a long rest.

<img width="549" alt="Activity Sheet v1 - Activation Consumption Tab" src="https://github.com/user-attachments/assets/97880321-2794-4337-b3d2-9594307e639e">

Finally the Targeting tab contains details on the range, affected targets, and area of effect. For area of effect, the dimensions displayed and their labels will change depending on the selected area type so you only see the relevant sizes.

<img width="549" alt="Activity Sheet v1 - Activation Targeting Tab" src="https://github.com/user-attachments/assets/74e42ecc-eed0-4f39-b98d-557517424392">

The final primary tab, Effect, isn't currently implemented. For the base activity sheet this tab will contain controls for selecting what active effects can be applied by this activity. For other sheets this will display details on the type of saving throw the must be made, attack to hit modifiers, the damage to apply, creatures to summon, or enchantments to apply.

### ToDo
- [ ] Implement active effects controls on Effects tab
- [ ] Add "Recharge" recovery period & dropdown for selecting recharge roll target
- [ ] Add options for "Attribute" consumption type when on actor
- [ ] Handle displaying options that have been inferred from the containing item