### PR TITLE
[#3596] Remove multiplication constant from damage tooltips

### DIFF
--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -531,6 +531,7 @@ export default class ChatMessage5e extends ChatMessage {
    */
   _simplifyDamageRoll(roll) {
     const aggregate = { type: roll.options.type, total: roll.total, constant: 0, dice: [] };
+    let hasMultiplication = false;
     for ( let i = roll.terms.length - 1; i >= 0; ) {
       const term = roll.terms[i--];
       if ( !(term instanceof foundry.dice.terms.NumericTerm) && !(term instanceof foundry.dice.terms.DiceTerm) ) {
@@ -543,12 +544,13 @@ export default class ChatMessage5e extends ChatMessage {
       let multiplier = 1;
       let operator = roll.terms[i];
       while ( operator instanceof foundry.dice.terms.OperatorTerm ) {
+        if ( !["+", "-"].includes(operator.operator) ) hasMultiplication = true;
         if ( operator.operator === "-" ) multiplier *= -1;
         operator = roll.terms[--i];
       }
       if ( term instanceof foundry.dice.terms.NumericTerm ) aggregate.constant += value * multiplier;
     }
-
+    if ( hasMultiplication ) aggregate.constant = null;
     return aggregate;
   }
 


### PR DESCRIPTION
Since properly summarizing complex operators like multiplication is hard to do without just showing the whole roll formula, this simply removes the constant number portion of the damage roll tooltip if any operators other than addition or subtraction are found. This still allows the dice rolls to be seen and the total displays correctly, but removes any potentially confusion values.

Before:
<img width="298" alt="Screenshot 2024-07-30 at 11 18 49" src="https://github.com/user-attachments/assets/e6b0c8be-e36c-4c06-a735-6dcd01833eb9">

After:
<img width="299" alt="Screenshot 2024-07-30 at 11 18 34" src="https://github.com/user-attachments/assets/b941baaa-cc55-48cf-a0d1-777b44d7c899">


Closes #3596