### PR TITLE
[#1964] Add applied effects data to activities & sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -156,8 +156,10 @@
 },
 
 "DND5E.ACTIVITY": {
-  "Label": "Activity",
-  "LabelPl": "Activities",
+  "Title": {
+    "one": "Activity",
+    "other": "Activities"
+  },
   "FIELDS": {
     "activation": {
       "label": "Activation",
@@ -206,6 +208,9 @@
         "label": "Duration Value",
         "hint": "Value of the duration in the specified units, if applicable."
       }
+    },
+    "effects": {
+      "label": "Applied Effects"
     },
     "img": {
       "label": "Icon"
@@ -740,7 +745,7 @@
 "DND5E.ConsumableWithoutCharges": "available units to use",
 "DND5E.Consumption": {
   "Action": {
-    "Add": "Add Consumption Target",
+    "Create": "Create Consumption Target",
     "Delete": "Delete Consumption Target"
   },
   "Scaling": {
@@ -943,6 +948,12 @@
 "DND5E.Dusk": "Dusk",
 "DND5E.Effect": "Effect",
 "DND5E.Effects": "Effects",
+"DND5E.EFFECT": {
+  "Action": {
+    "Create": "Create Effect",
+    "Delete": "Delete Effect"
+  }
+},
 "DND5E.EffectsApplyTokens": "Apply to selected tokens",
 "DND5E.EffectApplyWarningConcentration": "Applying an effect that is being concentrated on by another character requires GM permissions.",
 "DND5E.EffectApplyWarningOwnership": "Effects cannot be applied to tokens you are not the owner of.",
@@ -2137,7 +2148,7 @@
   },
   "Recovery": {
     "Action": {
-      "Add": "Add Recovery Profile",
+      "Create": "Create Recovery Profile",
       "Delete": "Delete Recovery Profile"
     },
     "Recharge": {

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -430,7 +430,7 @@ export default class ActivitySheet extends Application5e {
   static async #addEffect(event, target) {
     const effectData = {
       name: this.item.name,
-      icon: this.item.img,
+      img: this.item.img,
       origin: this.item.uuid,
       transfer: false
     };
@@ -485,7 +485,7 @@ export default class ActivitySheet extends Application5e {
   static async #deleteEffect(event, target) {
     const effectId = target.closest("[data-effect-id]")?.dataset.effectId;
     const result = await this.item.effects.get(effectId)?.deleteDialog();
-    if ( result !== false ) {
+    if ( result instanceof ActiveEffect ) {
       const effects = this.activity.toObject().effects.filter(e => e.id !== effectId);
       this.activity.update({ effects });
     }

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -20,6 +20,13 @@ const {
  */
 
 /**
+ * Data for effects that can be applied.
+ *
+ * @typedef {object} EffectApplicationData
+ * @property {string} effect  ID of the effect to apply.
+ */
+
+/**
  * Data for a recovery profile for an activity's uses.
  *
  * @typedef {object} UsesRecoveryData
@@ -48,6 +55,7 @@ const {
  * @property {string} duration.value             Scalar value for the activity's duration.
  * @property {string} duration.units             Units that are used for the duration.
  * @property {string} duration.special           Description of any special duration details.
+ * @property {EffectApplicationData[]} effects   Linked effects that can be applied.
  * @property {object} range
  * @property {string} range.value                Scalar value for the activity's range.
  * @property {string} range.units                Units that are used for the range.
@@ -120,6 +128,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
         units: new StringField({ initial: "inst" }),
         special: new StringField()
       }),
+      effects: new ArrayField(new SchemaField({
+        id: new DocumentIdField()
+      })),
       range: new SchemaField({
         value: new FormulaField({ deterministic: true }),
         units: new StringField(),
@@ -156,6 +167,11 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   prepareData() {
     this.name = this.name || game.i18n.localize(this.metadata?.title);
     this.img = this.img || this.metadata?.img;
+    const item = this.item;
+    this.effects.forEach(e => Object.defineProperty(e, "effect", {
+      get() { return item.effects.get(e.id); },
+      configurable: true
+    }));
     UsesField.prepareData.call(this, this.getRollData({ deterministic: true }));
   }
 

--- a/module/documents/mixins/pseudo-document.mjs
+++ b/module/documents/mixins/pseudo-document.mjs
@@ -159,7 +159,9 @@ export default Base => class extends Base {
    * @param {RenderOptions} [options]  Rendering options.
    */
   render(options) {
-    for ( const app of this.constructor._apps.get(this.uuid) ?? [] ) app.render(options);
+    for ( const app of this.constructor._apps.get(this.uuid) ?? [] ) {
+      app.render({ window: { title: app.title }, ...options });
+    }
   }
 
   /* -------------------------------------------- */

--- a/templates/activity/effect.hbs
+++ b/templates/activity/effect.hbs
@@ -1,3 +1,3 @@
 <section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
-    TODO: Active effects to apply & effects from specific activity types
+    {{> "systems/dnd5e/templates/activity/parts/activity-effects.hbs" }}
 </section>

--- a/templates/activity/parts/activity-consumption.hbs
+++ b/templates/activity/parts/activity-consumption.hbs
@@ -25,7 +25,7 @@
             {{/each}}
         </ul>
         <button type="button" class="unbutton" data-action="addConsumption">
-            {{ localize "DND5E.Consumption.Action.Add" }}
+            {{ localize "DND5E.Consumption.Action.Create" }}
         </button>
     </fieldset>
 

--- a/templates/activity/parts/activity-effects.hbs
+++ b/templates/activity/parts/activity-effects.hbs
@@ -1,0 +1,20 @@
+<fieldset>
+    <legend>{{ localize "DND5E.ACTIVITY.FIELDS.effects.label" }}</legend>
+    <multi-select name="appliedEffects">
+        {{ selectOptions allEffects }}
+    </multi-select>
+    <ul class="unlist">
+        {{#each activity.effects}}
+        <li data-index="{{ @index }}" data-effect-id="{{ id }}" class="flexrow">
+            <img class="gold-icon" src="{{ effect.img }}" alt="{{ effect.name }}">
+            <span class="name">{{{ dnd5e-linkForUuid effect.uuid }}}</span>
+            <button type="button" class="unbutton" data-action="deleteEffect">
+                {{ localize "DND5E.EFFECT.Action.Delete" }}
+            </button>
+        </li>
+        {{/each}}
+    </ul>
+    <button type="button" class="unbutton" data-action="addEffect">
+        {{ localize "DND5E.EFFECT.Action.Create" }}
+    </button>
+</fieldset>

--- a/templates/shared/uses-recovery.hbs
+++ b/templates/shared/uses-recovery.hbs
@@ -17,6 +17,6 @@
         {{/each}}
     </ul>
     <button type="button" class="unbutton" data-action="addRecovery">
-        {{ localize "DND5E.USES.Recovery.Action.Add" }}
+        {{ localize "DND5E.USES.Recovery.Action.Create" }}
     </button>
 </fieldset>


### PR DESCRIPTION
Adds list of effects for an activity to apply. These effects are stored as an array of objects with IDs in case the system needs something like level restrictions in the future (like with enchantments).

Configuring these applied effects is handled through the Effect tab of the activity sheet. There is a list of currently applied effects (unstyled currently) with controls for opening and deleting effects. There is a button for adding new effects directly rather than returning to the item sheet, and a `<multi-select>` allowing for effects that are already on the item to be selected.