### PR TITLE
[#1964] Add attribute & material consumption & recharge recovery

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -765,6 +765,9 @@
     "ItemUses": {
       "Label": "Item Uses"
     },
+    "Material": {
+      "Label": "Material"
+    },
     "SpellSlots": {
       "Label": "Spell Slots"
     }
@@ -2136,6 +2139,10 @@
     "Action": {
       "Add": "Add Recovery Profile",
       "Delete": "Delete Recovery Profile"
+    },
+    "Recharge": {
+      "Label": "Recharge",
+      "Range": "Recharge {range}"
     },
     "Type": {
       "Formula": "Custom Formula",

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -231,7 +231,8 @@ export default class ActivitySheet extends Application5e {
         .filter(([, config]) => !config.deprecated)
         .map(([value, config]) => ({
           value, label: config.label, group: game.i18n.localize("DND5E.DurationTime")
-        }))
+        })),
+      { value: "recharge", label: game.i18n.localize("DND5E.USES.Recovery.Recharge.Label") }
     ];
     const usesRecoveryTypes = [
       { value: "recoverAll", label: game.i18n.localize("DND5E.USES.Recovery.Type.RecoverAll") },
@@ -244,7 +245,8 @@ export default class ActivitySheet extends Application5e {
       prefix: `uses.recovery.${index}.`,
       source: context.source.uses.recovery[index] ?? data,
       periods: usesRecoveryPeriods,
-      types: usesRecoveryTypes
+      types: usesRecoveryTypes,
+      formulaOptions: data.period === "recharge" ? data.recharge?.options : null
     }));
 
     // Template dimensions

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -654,6 +654,11 @@ DND5E.activityConsumptionTypes = {
     targetRequiresEmbedded: true,
     validTargets: BaseActivityData.validItemUsesTargets
   },
+  material: {
+    label: "DND5E.Consumption.Type.Material.Label",
+    targetRequiresEmbedded: true,
+    validTargets: BaseActivityData.validMaterialTargets
+  },
   hitDice: {
     label: "DND5E.Consumption.Type.HitDice.Label",
     validTargets: BaseActivityData.validHitDiceTargets

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -156,7 +156,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   prepareData() {
     this.name = this.name || game.i18n.localize(this.metadata?.title);
     this.img = this.img || this.metadata?.img;
-    UsesField.prepareData.call(this, this.getRollData({ determinstic: true }));
+    UsesField.prepareData.call(this, this.getRollData({ deterministic: true }));
   }
 
   /* -------------------------------------------- */
@@ -217,8 +217,8 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
         const per = CONFIG.DND5E.limitedUsePeriods[uses.recovery[0].period]?.abbreviation;
         label = game.i18n.format("DND5E.AbilityUseConsumableLabel", { max: uses.max, per });
       }
-      else if ( uses.value ) label = game.i18n.format("DND5E.AbilityUseChargesLabel", { value: uses.value });
-      return label ? `${name} (${label})` : name;
+      else label = game.i18n.format("DND5E.AbilityUseChargesLabel", { value: uses.value });
+      return `${name} (${label})`;
     };
     return [
       { value: "", label: makeLabel(game.i18n.localize("DND5E.Consumption.Target.ThisItem"), this.item) },

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -33,7 +33,6 @@ export default class UsesField extends SchemaField {
    * @param {object} rollData
    */
   static prepareData(rollData) {
-    console.log("UsesField#prepareData");
     // TODO: Move maximum uses preparation from `ActivatedEffectTemplate`
     this.uses.value = Math.clamp(this.uses.max - this.uses.spent, 0, this.uses.max);
 

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -1,3 +1,4 @@
+import { formatNumber, formatRange } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
@@ -32,7 +33,22 @@ export default class UsesField extends SchemaField {
    * @param {object} rollData
    */
   static prepareData(rollData) {
+    console.log("UsesField#prepareData");
     // TODO: Move maximum uses preparation from `ActivatedEffectTemplate`
     this.uses.value = Math.clamp(this.uses.max - this.uses.spent, 0, this.uses.max);
+
+    for ( const recovery of this.uses.recovery ) {
+      if ( recovery.period === "recharge" ) {
+        recovery.type = "recoverAll";
+        recovery.recharge = {
+          options: Array.fromRange(5, 2).reverse().map(min => ({
+            value: min,
+            label: game.i18n.format("DND5E.USES.Recovery.Recharge.Range", {
+              range: min === 6 ? formatNumber(6) : formatRange(min, 6)
+            })
+          }))
+        };
+      }
+    }
   }
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -513,6 +513,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /** @inheritDoc */
   prepareEmbeddedDocuments() {
     super.prepareEmbeddedDocuments();
+    for ( const activity of this.system.activities ?? [] ) activity.prepareData();
     if ( !this.actor || this.actor._embeddedPreparation ) this.applyActiveEffects();
   }
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -39,6 +39,20 @@ export function formatNumber(value, options) {
 /* -------------------------------------------- */
 
 /**
+ * A helper for using Intl.NumberFormat within handlebars for format a range.
+ * @param {number} min      The lower end of the range.
+ * @param {number} max      The upper end of the range.
+ * @param {object} options  Options forwarded to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat}
+ * @returns {string}
+ */
+export function formatRange(min, max, options) {
+  const formatter = new Intl.NumberFormat(game.i18n.lang, options);
+  return formatter.formatRange(min, max);
+}
+
+/* -------------------------------------------- */
+
+/**
  * A helper function to format textarea text to HTML with linebreaks.
  * @param {string} value  The text to format.
  * @returns {Handlebars.SafeString}

--- a/templates/shared/uses-recovery.hbs
+++ b/templates/shared/uses-recovery.hbs
@@ -4,10 +4,11 @@
         {{#each usesRecovery}}
         <li data-index="{{ @index }}">
             {{ formField fields.period name=(concat prefix "period") value=data.period options=periods }}
-            <!-- TODO: Recharge formula -->
+            {{#unless (eq source.period "recharge")}}
             {{ formField fields.type name=(concat prefix "type") value=data.type options=types }}
-            {{#if (eq source.type "formula")}}
-            {{ formField fields.formula name=(concat prefix "formula") value=data.formula }}
+            {{/unless}}
+            {{#if (or (eq source.type "formula") formulaOptions)}}
+            {{ formField fields.formula name=(concat prefix "formula") value=data.formula options=formulaOptions }}
             {{/if}}
             <button type="button" class="unbutton" data-action="deleteRecovery">
                 {{ localize "DND5E.USES.Recovery.Action.Delete" }}


### PR DESCRIPTION
Adds full support for configuring attribute & material consumption including a list of targets when embedded. Also adjusts how item uses targest are displayed to list charges remaining or for a period in the same way as they are presented on the current item sheet.

Adds the recharge recovery period that displays a fixed list of recharge rolls (e.g. "Recharge 4–6") to select.