### PR TITLE
Add armor class minimum property

### DIFF
--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -113,7 +113,7 @@ export default class AttributesFields {
     const ac = this.attributes.ac;
     ac.armor = 10;
     ac.shield = ac.cover = 0;
-    ac.bonus = "";
+    ac.min = ac.bonus = "";
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -23,6 +23,7 @@ export default class ActiveEffect5e extends ActiveEffect {
    */
   static FORMULA_FIELDS = new Set([
     "system.attributes.ac.bonus",
+    "system.attributes.ac.min",
     "system.attributes.encumbrance.bonuses.encumbered",
     "system.attributes.encumbrance.bonuses.heavilyEncumbered",
     "system.attributes.encumbrance.bonuses.maximum",

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -568,8 +568,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     // Compute total AC and return
+    ac.min = simplifyBonus(ac.min, rollData);
     ac.bonus = simplifyBonus(ac.bonus, rollData);
-    ac.value = ac.base + ac.shield + ac.bonus + ac.cover;
+    ac.value = Math.max(ac.min, ac.base + ac.shield + ac.bonus + ac.cover);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Adds a new `attributes.ac.min` property. If this evaluates to something higher than what `ac.value` would evaluate to, it is used instead.

This allows spells like Barkskin to function (an AC that cannot be below 16 regardless of armor).

Unblocks #2258.