### PR TITLE
[#1964] Add arbitrary roll to `UtilityActivity`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2323,7 +2323,20 @@
 },
 
 "DND5E.UTILITY": {
-  "Title": "Utility"
+  "Title": "Utility",
+  "FIELDS": {
+    "roll": {
+      "label": "Utility Roll",
+      "formula": {
+        "label": "Roll Formula",
+        "hint": "Formula for an arbitrary roll."
+      },
+      "name": {
+        "label": "Roll Label",
+        "hint": "Display name for the rolling button."
+      }
+    }
+  }
 },
 
 "DND5E.Vehicle": "Vehicle",

--- a/module/applications/activity/_module.mjs
+++ b/module/applications/activity/_module.mjs
@@ -1,5 +1,6 @@
 export {default as ActivitySheet} from "./activity-sheet.mjs";
 export {default as AttackSheet} from "./attack-sheet.mjs";
 export {default as SummonSheet} from "./summon-sheet.mjs";
+export {default as UtilitySheet} from "./utility-sheet.mjs";
 
 export {default as ActivityUsageDialog} from "./activity-usage-dialog.mjs";

--- a/module/applications/activity/utility-sheet.mjs
+++ b/module/applications/activity/utility-sheet.mjs
@@ -1,0 +1,23 @@
+import ActivitySheet from "./activity-sheet.mjs";
+
+/**
+ * Sheet for the utility activity.
+ */
+export default class UtilitySheet extends ActivitySheet {
+
+  /** @inheritDoc */
+  static DEFAULT_OPTIONS = {
+    classes: ["utility-activity"]
+  };
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static PARTS = {
+    ...super.PARTS,
+    effect: {
+      template: "systems/dnd5e/templates/activity/utility-effect.hbs",
+      templates: super.PARTS.effect.templates
+    }
+  };
+}

--- a/module/data/activity/_module.mjs
+++ b/module/data/activity/_module.mjs
@@ -2,3 +2,4 @@ export {default as BaseActivityData} from "./base-activity.mjs";
 
 export {default as AttackActivityData} from "./attack-data.mjs";
 export {default as SummonActivityData} from "./summon-data.mjs";
+export {default as UtilityActivityData} from "./utility-data.mjs";

--- a/module/data/activity/utility-data.mjs
+++ b/module/data/activity/utility-data.mjs
@@ -1,0 +1,24 @@
+import FormulaField from "../fields/formula-field.mjs";
+import BaseActivityData from "./base-activity.mjs";
+
+const { SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * Data model for an utility activity.
+ *
+ * @property {object} roll
+ * @property {string} roll.formula  Arbitrary formula that can be rolled.
+ * @property {string} roll.name     Label for the rolling button.
+ */
+export default class UtilityActivityData extends BaseActivityData {
+  /** @inheritDoc */
+  static defineSchema() {
+    return {
+      ...super.defineSchema(),
+      roll: new SchemaField({
+        formula: new FormulaField(),
+        name: new StringField()
+      })
+    };
+  }
+}

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -1,11 +1,11 @@
-import ActivitySheet from "../../applications/activity/activity-sheet.mjs";
-import BaseActivityData from "../../data/activity/base-activity.mjs";
+import UtilitySheet from "../../applications/activity/utility-sheet.mjs";
+import UtilityActivityData from "../../data/activity/utility-data.mjs";
 import ActivityMixin from "./mixin.mjs";
 
 /**
  * Generic activity for applying effects and rolling an arbitrary die.
  */
-export default class UtilityActivity extends ActivityMixin(BaseActivityData) {
+export default class UtilityActivity extends ActivityMixin(UtilityActivityData) {
   /* -------------------------------------------- */
   /*  Model Configuration                         */
   /* -------------------------------------------- */
@@ -21,7 +21,7 @@ export default class UtilityActivity extends ActivityMixin(BaseActivityData) {
       type: "utility",
       img: "systems/dnd5e/icons/svg/activity/utility.svg",
       title: "DND5E.UTILITY.Title",
-      sheetClass: ActivitySheet
+      sheetClass: UtilitySheet
     }, { inplace: false })
   );
 }

--- a/templates/activity/utility-effect.hbs
+++ b/templates/activity/utility-effect.hbs
@@ -1,0 +1,8 @@
+<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
+    {{> "systems/dnd5e/templates/activity/parts/activity-effects.hbs" }}
+    <fieldset>
+        <legend>{{ localize "DND5E.UTILITY.FIELDS.roll.label" }}</legend>
+        {{ formField fields.roll.fields.name value=source.roll.name }}
+        {{ formField fields.roll.fields.formula value=source.roll.formula }}
+    </fieldset>
+</section>


### PR DESCRIPTION
Adds a rolling formula and name that can be rolled when a `UtilityActivity` is used, similar to the "Other Formula" field on items currently.

Closes #941 