### PR TITLE
Resolve additional deprecated issues with V12

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -52,11 +52,6 @@ Hooks.once("init", function() {
 
   // TODO: Remove when v11 support is dropped.
   CONFIG.compatibility.excludePatterns.push(/filePicker|select/);
-  CONFIG.compatibility.excludePatterns.push(/foundry\.dice\.terms/);
-  CONFIG.compatibility.excludePatterns.push(
-    /aggregateDamageRoll|configureDamage|preprocessFormula|simplifyRollFormula/
-  );
-  CONFIG.compatibility.excludePatterns.push(/core\.sourceId/);
 
   // Record Configuration Values
   CONFIG.DND5E = DND5E;

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -51,7 +51,7 @@ Hooks.once("init", function() {
   console.log(`D&D 5e | Initializing the D&D Fifth Game System - Version ${dnd5e.version}\n${DND5E.ASCII}`);
 
   // TODO: Remove when v11 support is dropped.
-  CONFIG.compatibility.excludePatterns.push(/filePicker|select/);
+  CONFIG.compatibility.excludePatterns.push(/select/);
 
   // Record Configuration Values
   CONFIG.DND5E = DND5E;

--- a/less/v1/advancement.less
+++ b/less/v1/advancement.less
@@ -6,8 +6,8 @@
       box-shadow: none;
     }
   }
-  .form-group .form-fields button {
-    flex: 0;
+  .form-group .form-fields {
+    :not(file-picker) > button { flex: 0; }
   }
   .form-group .form-field-readonly {
     color: #999;
@@ -445,7 +445,7 @@
     }
     span.none { font-style: italic; }
   }
-  
+
   form[data-type="Trait"] {
     select {
       min-width: min(20em, 100%);

--- a/module/applications/actor/sheet-mixin.mjs
+++ b/module/applications/actor/sheet-mixin.mjs
@@ -30,7 +30,7 @@ export default Base => class extends Base {
     const droppedSourceId = itemData._stats?.compendiumSource ?? itemData.flags.core?.sourceId;
     if ( itemData.type !== "consumable" || !droppedSourceId ) return null;
     const similarItem = this.actor.items.find(i => {
-      const sourceId = i.getFlag("core", "sourceId");
+      const sourceId = i._stats?.compendiumSource;
       return sourceId && (sourceId === droppedSourceId) && (i.type === "consumable") && (i.name === itemData.name);
     });
     if ( !similarItem ) return null;

--- a/module/canvas/token-placement.mjs
+++ b/module/canvas/token-placement.mjs
@@ -232,10 +232,10 @@ export default class TokenPlacement {
     const preview = this.#previews[idx];
     const adjustment = this.#getSnapAdjustment(preview);
     const point = event.data.getLocalPosition(canvas.tokens);
-    const center = canvas.grid.getCenter(point.x - adjustment.x, point.y - adjustment.y);
+    const center = canvas.grid.getCenterPoint({ x: point.x - adjustment.x, y: point.y - adjustment.y });
     preview.updateSource({
-      x: center[0] + adjustment.x - Math.round((this.config.tokens[idx].width * canvas.dimensions.size) / 2),
-      y: center[1] + adjustment.y - Math.round((this.config.tokens[idx].height * canvas.dimensions.size) / 2)
+      x: center.x + adjustment.x - Math.round((this.config.tokens[idx].width * canvas.dimensions.size) / 2),
+      y: center.y + adjustment.y - Math.round((this.config.tokens[idx].height * canvas.dimensions.size) / 2)
     });
     this.#placements[idx].x = preview.x;
     this.#placements[idx].y = preview.y;

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -317,7 +317,6 @@ export class SummonsData extends foundry.abstract.DataModel {
       // Template actor (linked) found in world, create a copy for this user's item.
       return actor.clone({
         "flags.dnd5e.summonedCopy": true,
-        "flags.core.sourceId": actor.uuid,
         "_stats.compendiumSource": actor.uuid
       }, {save: true});
     }

--- a/module/data/item/fields/summons-field.mjs
+++ b/module/data/item/fields/summons-field.mjs
@@ -298,7 +298,7 @@ export class SummonsData extends foundry.abstract.DataModel {
       // Has been cloned for summoning use
       a.getFlag("dnd5e", "summonedCopy")
       // Sourced from the desired actor UUID
-      && (a.getFlag("core", "sourceId") === uuid)
+      && (a._stats?.compendiumSource === uuid)
       // Unlinked or created from this item specifically
       && ((a.getFlag("dnd5e", "summon.origin") === this.item.uuid) || !a.prototypeToken.actorLink)
     );

--- a/module/dice/aggregate-damage-rolls.mjs
+++ b/module/dice/aggregate-damage-rolls.mjs
@@ -1,3 +1,5 @@
+const { OperatorTerm, RollTerm } = foundry.dice.terms;
+
 /**
  * Parse the provided rolls, splitting parts based on damage types & properties, taking flavor into account.
  * @param {DamageRoll[]} rolls                   Evaluated damage rolls to aggregate.
@@ -60,14 +62,14 @@ function chunkTerms(terms, type) {
 
   for ( let term of terms ) {
     // Plus or minus operators split chunks
-    if ( (term instanceof foundry.dice.terms.OperatorTerm) && ["+", "-"].includes(term.operator) ) {
+    if ( (term instanceof OperatorTerm) && ["+", "-"].includes(term.operator) ) {
       if ( currentChunk ) pushChunk();
       if ( term.operator === "-" ) negative = !negative;
       continue;
     }
 
     // All other terms get added to the current chunk
-    term = foundry.dice.terms.RollTerm.fromData(foundry.utils.deepClone(term.toJSON()));
+    term = RollTerm.fromData(foundry.utils.deepClone(term.toJSON()));
     currentChunk ??= { terms: [], negative, type: null };
     currentChunk.terms.push(term);
     const flavor = term.flavor?.toLowerCase().trim();

--- a/module/dice/aggregate-damage-rolls.mjs
+++ b/module/dice/aggregate-damage-rolls.mjs
@@ -60,14 +60,14 @@ function chunkTerms(terms, type) {
 
   for ( let term of terms ) {
     // Plus or minus operators split chunks
-    if ( (term instanceof OperatorTerm) && ["+", "-"].includes(term.operator) ) {
+    if ( (term instanceof foundry.dice.terms.OperatorTerm) && ["+", "-"].includes(term.operator) ) {
       if ( currentChunk ) pushChunk();
       if ( term.operator === "-" ) negative = !negative;
       continue;
     }
 
     // All other terms get added to the current chunk
-    term = RollTerm.fromData(foundry.utils.deepClone(term.toJSON()));
+    term = foundry.dice.terms.RollTerm.fromData(foundry.utils.deepClone(term.toJSON()));
     currentChunk ??= { terms: [], negative, type: null };
     currentChunk.terms.push(term);
     const flavor = term.flavor?.toLowerCase().trim();

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -1,3 +1,5 @@
+const { Die, NumericTerm, OperatorTerm } = foundry.dice.terms;
+
 /**
  * A type of Roll specific to a d20-based check, save, or attack roll in the 5e system.
  * @param {string} formula                       The string formula to parse

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -1,4 +1,4 @@
-const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm } = foundry.dice.terms;
+const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, StringTerm } = foundry.dice.terms;
 
 /**
  * A type of Roll specific to a damage (or healing) roll in the 5e system.

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -1,3 +1,5 @@
+const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm } = foundry.dice.terms;
+
 /**
  * A type of Roll specific to a damage (or healing) roll in the 5e system.
  * @param {string} formula                       The string formula to parse
@@ -89,7 +91,7 @@ export default class DamageRoll extends Roll {
       }
 
       // Merge any parenthetical terms followed by string terms
-      else if ( (term instanceof ParentheticalTerm || term instanceof MathTerm) && (nextTerm instanceof StringTerm)
+      else if ( (term instanceof ParentheticalTerm || term instanceof FunctionTerm) && (nextTerm instanceof StringTerm)
         && nextTerm.term.match(/^d[0-9]*$/)) {
         if ( term.isDeterministic ) {
           const newFormula = `${term.evaluate().total}${nextTerm.term}`;

--- a/module/dice/simplify-roll-formula.mjs
+++ b/module/dice/simplify-roll-formula.mjs
@@ -1,3 +1,7 @@
+const {
+  Coin, DiceTerm, Die, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, RollTerm
+} = foundry.dice.terms;
+
 /**
  * A standardized helper function for simplifying the constant parts of a multipart roll formula.
  *
@@ -196,8 +200,8 @@ function _expandParentheticalTerms(terms) {
 /* -------------------------------------------- */
 
 /**
- * A helper function to group terms into PoolTerms, DiceTerms, MathTerms, and NumericTerms.
- * MathTerms are included as NumericTerms if they are deterministic.
+ * A helper function to group terms into PoolTerms, DiceTerms, FunctionTerms, and NumericTerms.
+ * FunctionTerms are included as NumericTerms if they are deterministic.
  * @param {RollTerm[]} terms  An array of roll terms.
  * @returns {object}          An object mapping term types to arrays containing roll terms of that type.
  */
@@ -208,7 +212,7 @@ function _groupTermsByType(terms) {
   return terms.reduce((obj, term, i) => {
     let type;
     if ( term instanceof DiceTerm ) type = DiceTerm;
-    else if ( (term instanceof MathTerm) && (term.isDeterministic) ) type = NumericTerm;
+    else if ( (term instanceof FunctionTerm) && (term.isDeterministic) ) type = NumericTerm;
     else type = term.constructor;
     const key = `${type.name.charAt(0).toLowerCase()}${type.name.substring(1)}s`;
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -826,7 +826,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   async _preCreate(data, options, user) {
     if ( (await super._preCreate(data, options, user)) === false ) return false;
 
-    const sourceId = this.getFlag("core", "sourceId");
+    const sourceId = this._stats?.compendiumSource;
     if ( sourceId?.startsWith("Compendium.") ) return;
 
     // Configure prototype token settings

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -481,9 +481,11 @@ export default class ChatMessage5e extends ChatMessage {
     const aggregate = { type: roll.options.type, total: roll.total, constant: 0, dice: [] };
     for ( let i = roll.terms.length - 1; i >= 0; ) {
       const term = roll.terms[i--];
-      if ( !(term instanceof NumericTerm) && !(term instanceof DiceTerm) ) continue;
+      if ( !(term instanceof foundry.dice.terms.NumericTerm) && !(term instanceof foundry.dice.terms.DiceTerm) ) {
+        continue;
+      }
       const value = term.total;
-      if ( term instanceof DiceTerm ) aggregate.dice.push(...term.results.map(r => ({
+      if ( term instanceof foundry.dice.terms.DiceTerm ) aggregate.dice.push(...term.results.map(r => ({
         result: term.getResultLabel(r), classes: term.getResultCSS(r).filterJoin(" ")
       })));
       let multiplier = 1;
@@ -492,7 +494,7 @@ export default class ChatMessage5e extends ChatMessage {
         if ( operator.operator === "-" ) multiplier *= -1;
         operator = roll.terms[--i];
       }
-      if ( term instanceof NumericTerm ) aggregate.constant += value * multiplier;
+      if ( term instanceof foundry.dice.terms.NumericTerm ) aggregate.constant += value * multiplier;
     }
 
     return aggregate;

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -490,7 +490,7 @@ export default class ChatMessage5e extends ChatMessage {
       })));
       let multiplier = 1;
       let operator = roll.terms[i];
-      while ( operator instanceof OperatorTerm ) {
+      while ( operator instanceof foundry.dice.terms.OperatorTerm ) {
         if ( operator.operator === "-" ) multiplier *= -1;
         operator = roll.terms[--i];
       }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1682,10 +1682,10 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     // Attempt to simplify by combining like dice terms
     let simplified = false;
-    if ( (s.terms[0] instanceof Die) && (s.terms.length === 1) ) {
+    if ( (s.terms[0] instanceof foundry.dice.terms.Die) && (s.terms.length === 1) ) {
       const d0 = p0.terms[0];
       const s0 = s.terms[0];
-      if ( (d0 instanceof Die) && (d0.faces === s0.faces) && d0.modifiers.equals(s0.modifiers) ) {
+      if ( (d0 instanceof foundry.dice.terms.Die) && (d0.faces === s0.faces) && d0.modifiers.equals(s0.modifiers) ) {
         d0.number += s0.number;
         parts[0] = p0.formula;
         simplified = true;

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -752,7 +752,6 @@ function _synchronizeActorSpells(actor, spellsMap) {
     Object.assign(spellData.system, {preparation, uses});
     spellData.system.save.dc = save.dc;
     foundry.utils.setProperty(spellData, "_stats.compendiumSource", source.uuid);
-    foundry.utils.setProperty(spellData, "flags.core.sourceId", source.uuid);
 
     // Record spells to be deleted and created
     toDelete.push(spell.id);

--- a/templates/advancement/parts/advancement-controls.hbs
+++ b/templates/advancement/parts/advancement-controls.hbs
@@ -8,8 +8,7 @@
 <div class="form-group">
     <label>{{ localize "DND5E.AdvancementCustomIcon" }}</label>
     <div class="form-fields">
-        {{ filePicker type="image" target="icon" }}
-        <input type="text" name="icon" value="{{ src.icon }}" placeholder="{{ default.icon }}">
+        <file-picker type="image" name="icon" value="{{ src.icon }}" placeholder="{{ default.icon }}"></file-picker>
     </div>
 </div>
 


### PR DESCRIPTION
- Remove the silences warning on `foundry.dice.terms` and change references to avoid the globally namespaced terms
- Swam `{{filepicker}}` with `<file-picker>` in advancement config
- Change access of `flags.core.sourceId` with `_stats.compendiumSource`
- Swap from `getCenter` to `getCenterPoint` in `TokenPlacement`