### PR TITLE
Corrected roll formula simplification for display purposes.

### DIFF
--- a/module/dice/simplify-roll-formula.mjs
+++ b/module/dice/simplify-roll-formula.mjs
@@ -154,7 +154,7 @@ function _simplifyDiceTerms(terms) {
     const modifiers = isCoin ? "" : curr.modifiers.filterJoin("");
     const key = `${unannotated[i - 1].operator}${face}${modifiers}`;
     obj[key] ??= {};
-    if ( (curr._number instanceof Roll) && (curr._number.isDeterministic)) curr._number.evaluateSync();
+    if ( (curr._number instanceof Roll) && (curr._number.isDeterministic) ) curr._number.evaluateSync();
     obj[key].number = (obj[key].number ?? 0) + curr.number;
     if ( !isCoin ) obj[key].modifiers = (obj[key].modifiers ?? []).concat(curr.modifiers);
     return obj;

--- a/module/dice/simplify-roll-formula.mjs
+++ b/module/dice/simplify-roll-formula.mjs
@@ -154,6 +154,7 @@ function _simplifyDiceTerms(terms) {
     const modifiers = isCoin ? "" : curr.modifiers.filterJoin("");
     const key = `${unannotated[i - 1].operator}${face}${modifiers}`;
     obj[key] ??= {};
+    if ( (curr._number instanceof Roll) && (curr._number.isDeterministic)) curr._number.evaluateSync();
     obj[key].number = (obj[key].number ?? 0) + curr.number;
     if ( !isCoin ) obj[key].modifiers = (obj[key].modifiers ?? []).concat(curr.modifiers);
     return obj;


### PR DESCRIPTION
Occurs when a parenthetical term containing deterministic terms is used for a die quantity. Now detects a deterministic, but non-numerical number of die and further simplifies the expression for cleaner display.

Note: The actual roll and display of the roll in the chat log behaved as expected. This change affects the display of non-trivial roll formulas in sheet and other "display-only" summaries.

### Original
![image](https://github.com/user-attachments/assets/c6e0ea07-084b-4884-ba35-cad1a7accb47)

### Corrected
![image](https://github.com/user-attachments/assets/139ce4a4-0d8f-44db-bfd3-3dc1493f9067)
