### PR TITLE
[#1964] Remove Action & Activated Effect data & add shims

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -222,6 +222,13 @@
         }
       }
     },
+    "description": {
+      "label": "Description",
+      "chatFlavor": {
+        "label": "Chat Flavor",
+        "hint": "Additional text displayed in the activation chat message."
+      }
+    },
     "duration": {
       "label": "Duration",
       "special": {
@@ -553,6 +560,12 @@
         "label": "To Hit Bonus",
         "hint": "Bonus added to the to hit roll for the attack."
       },
+      "critical": {
+        "threshold": {
+          "label": "Critical Threshold",
+          "hint": "Minimum value on the D20 needed to rolling a critical hit."
+        }
+      },
       "flat": {
         "label": "Flat To Hit",
         "hint": "Ignore the ability modifier, proficiency, and any other bonuses from the actor and only use the bonus defined by the activity when calculating to hit."
@@ -571,6 +584,12 @@
     },
     "damage": {
       "label": "Attack Damage",
+      "critical": {
+        "bonus": {
+          "label": "Extra Critical Damage",
+          "hint": "Extra damage applied when a critical is rolled. Will be added to the base damage or first damage part."
+        }
+      },
       "includeBase": {
         "label": "Include Base Damage",
         "hint": "Include the item's base damage with any additional damage parts."
@@ -942,9 +961,15 @@
   "FIELDS": {
     "damage": {
       "label": "Damage",
-      "allowCritical": {
-        "label": "Allow Critical",
-        "hint": "Should the use be able to roll critical damage?"
+      "critical": {
+        "allow": {
+          "label": "Allow Critical",
+          "hint": "Should the use be able to roll critical damage?"
+        },
+        "bonus": {
+          "label": "Extra Critical Damage",
+          "hint": "Extra damage applied when a critical is rolled. Will be added to the first damage part."
+        }
       },
       "parts": {
         "label": "Damage Parts",

--- a/lang/en.json
+++ b/lang/en.json
@@ -563,7 +563,7 @@
       "critical": {
         "threshold": {
           "label": "Critical Threshold",
-          "hint": "Minimum value on the D20 needed to rolling a critical hit."
+          "hint": "Minimum value on the D20 needed to roll a critical hit."
         }
       },
       "flat": {
@@ -587,7 +587,7 @@
       "critical": {
         "bonus": {
           "label": "Extra Critical Damage",
-          "hint": "Extra damage applied when a critical is rolled. Will be added to the base damage or first damage part."
+          "hint": "Extra damage applied when a critical is rolled. Added to the base damage or first damage part."
         }
       },
       "includeBase": {
@@ -968,7 +968,7 @@
         },
         "bonus": {
           "label": "Extra Critical Damage",
-          "hint": "Extra damage applied when a critical is rolled. Will be added to the first damage part."
+          "hint": "Extra damage applied when a critical is rolled. Added to the first damage part."
         }
       },
       "parts": {

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -11,15 +11,15 @@ const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foun
  * @property {object} attack
  * @property {string} attack.bonus                Arbitrary bonus added to the attack.
  * @property {object} attack.critical
- * @property {number} attack.critical.threshold   Minimum value on the D20 needed to rolling a critical hit.
+ * @property {number} attack.critical.threshold   Minimum value on the D20 needed to roll a critical hit.
  * @property {boolean} attack.flat                Should the bonus be used in place of proficiency & ability modifier?
  * @property {object} attack.type
  * @property {string} attack.type.value           Is this a melee or ranged attack?
  * @property {string} attack.type.classification  Is this a unarmed, weapon, or spell attack?
  * @property {object} damage
  * @property {object} damage.critical
- * @property {string} damage.critical.bonus       Extra damage applied when a critical is rolled. Will be added to the
- *                                                base damage or first damage part.
+ * @property {string} damage.critical.bonus       Extra damage applied when a critical is rolled. Added to the base
+ *                                                damage or first damage part.
  * @property {boolean} damage.includeBase         Should damage defined by the item be included with other damage parts?
  * @property {DamageData[]} damage.parts          Parts of damage to inflict.
  */

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -2,7 +2,7 @@ import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
-const { ArrayField, BooleanField, SchemaField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
  * Data model for an attack activity.
@@ -10,11 +10,16 @@ const { ArrayField, BooleanField, SchemaField, StringField } = foundry.data.fiel
  * @property {string} ability                     Ability used to make the attack and determine damage.
  * @property {object} attack
  * @property {string} attack.bonus                Arbitrary bonus added to the attack.
+ * @property {object} attack.critical
+ * @property {number} attack.critical.threshold   Minimum value on the D20 needed to rolling a critical hit.
  * @property {boolean} attack.flat                Should the bonus be used in place of proficiency & ability modifier?
  * @property {object} attack.type
  * @property {string} attack.type.value           Is this a melee or ranged attack?
  * @property {string} attack.type.classification  Is this a unarmed, weapon, or spell attack?
  * @property {object} damage
+ * @property {object} damage.critical
+ * @property {string} damage.critical.bonus       Extra damage applied when a critical is rolled. Will be added to the
+ *                                                base damage or first damage part.
  * @property {boolean} damage.includeBase         Should damage defined by the item be included with other damage parts?
  * @property {DamageData[]} damage.parts          Parts of damage to inflict.
  */
@@ -26,6 +31,9 @@ export default class AttackActivityData extends BaseActivityData {
       ability: new StringField(),
       attack: new SchemaField({
         bonus: new FormulaField(),
+        critical: new SchemaField({
+          threshold: new NumberField({ integer: true, positive: true })
+        }),
         flat: new BooleanField(),
         type: new SchemaField({
           value: new StringField(),
@@ -33,10 +41,23 @@ export default class AttackActivityData extends BaseActivityData {
         })
       }),
       damage: new SchemaField({
+        critical: new SchemaField({
+          bonus: new FormulaField()
+        }),
         includeBase: new BooleanField({ initial: true }),
         parts: new ArrayField(new DamageField())
       })
     };
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get actionType() {
+    const type = this.attack.type;
+    return `${type.value === "ranged" ? "r" : "m"}${type.classification === "spell" ? "sak" : "wak"}`;
   }
 
   /* -------------------------------------------- */
@@ -49,6 +70,9 @@ export default class AttackActivityData extends BaseActivityData {
       ability: source.system.ability ?? "",
       attack: {
         bonus: source.system.attack?.bonus ?? "",
+        critical: {
+          threshold: source.system.critical?.threshold
+        },
         flat: source.system.attack?.flat ?? false,
         type: {
           value: source.system.actionType.startsWith("m") ? "melee" : "ranged",
@@ -56,6 +80,9 @@ export default class AttackActivityData extends BaseActivityData {
         }
       },
       damage: {
+        critical: {
+          bonus: source.system.critical?.damage
+        },
         includeBase: true,
         parts: source.system.damage?.parts?.map(part => this.transformDamagePartData(source, part)) ?? []
       }

--- a/module/data/activity/damage-data.mjs
+++ b/module/data/activity/damage-data.mjs
@@ -9,7 +9,7 @@ const { ArrayField, BooleanField, SchemaField } = foundry.data.fields;
  *
  * @property {object} damage
  * @property {boolean} damage.critical.allow  Can this damage be critical?
- * @property {boolean} damage.critical.bonus  Extra damage applied when a critical is rolled. Will be added to the first
+ * @property {boolean} damage.critical.bonus  Extra damage applied when a critical is rolled. Added to the first
  *                                            damage part.
  * @property {DamageData[]} damage.parts      Parts of damage to inflict.
  */

--- a/module/data/activity/damage-data.mjs
+++ b/module/data/activity/damage-data.mjs
@@ -1,3 +1,4 @@
+import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
@@ -7,8 +8,10 @@ const { ArrayField, BooleanField, SchemaField } = foundry.data.fields;
  * Data model for an damage activity.
  *
  * @property {object} damage
- * @property {boolean} damage.allowCritical  Can this damage be critical?
- * @property {DamageData[]} damage.parts     Parts of damage to inflict.
+ * @property {boolean} damage.critical.allow  Can this damage be critical?
+ * @property {boolean} damage.critical.bonus  Extra damage applied when a critical is rolled. Will be added to the first
+ *                                            damage part.
+ * @property {DamageData[]} damage.parts      Parts of damage to inflict.
  */
 export default class DamageActivityData extends BaseActivityData {
   /** @inheritDoc */
@@ -16,7 +19,10 @@ export default class DamageActivityData extends BaseActivityData {
     return {
       ...super.defineSchema(),
       damage: new SchemaField({
-        allowCritical: new BooleanField(),
+        critical: new SchemaField({
+          allow: new BooleanField(),
+          bonus: new FormulaField()
+        }),
         parts: new ArrayField(new DamageField())
       })
     };
@@ -30,7 +36,10 @@ export default class DamageActivityData extends BaseActivityData {
   static transformTypeData(source, activityData) {
     return foundry.utils.mergeObject(activityData, {
       damage: {
-        allowCritical: false,
+        critical: {
+          allow: false,
+          bonus: source.system.critical?.damage ?? ""
+        },
         parts: source.system.damage?.parts?.map(part => this.transformDamagePartData(source, part)) ?? []
       }
     });

--- a/module/data/activity/enchant-data.mjs
+++ b/module/data/activity/enchant-data.mjs
@@ -51,6 +51,15 @@ export default class EnchantActivityData extends BaseActivityData {
   }
 
   /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get actionType() {
+    return "ench";
+  }
+
+  /* -------------------------------------------- */
   /*  Data Migrations                             */
   /* -------------------------------------------- */
 

--- a/module/data/activity/summon-data.mjs
+++ b/module/data/activity/summon-data.mjs
@@ -86,6 +86,15 @@ export default class SummonActivityData extends BaseActivityData {
   }
 
   /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get actionType() {
+    return "summ";
+  }
+
+  /* -------------------------------------------- */
   /*  Data Migrations                             */
   /* -------------------------------------------- */
 

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -1,8 +1,6 @@
 import { filteredKeys } from "../../utils.mjs";
 import { ItemDataModel } from "../abstract.mjs";
 import UsesField from "../shared/uses-field.mjs";
-import ActionTemplate from "./templates/action.mjs";
-import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
 import ActivitiesTemplate from "./templates/activities.mjs";
 import EquippableItemTemplate from "./templates/equippable-item.mjs";
 import IdentifiableTemplate from "./templates/identifiable.mjs";
@@ -15,14 +13,12 @@ const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields
 
 /**
  * Data definition for Consumable items.
+ * @mixes ActivitiesTemplate
  * @mixes ItemDescriptionTemplate
  * @mixes ItemTypeTemplate
  * @mixes IdentifiableTemplate
  * @mixes PhysicalItemTemplate
  * @mixes EquippableItemTemplate
- * @mixes ActivatedEffectTemplate
- * @mixes ActionTemplate
- * @mixes ActivitiesTemplate
  *
  * @property {number} magicalBonus       Magical bonus added to attack & damage rolls by ammunition.
  * @property {Set<string>} properties    Ammunition properties.
@@ -30,8 +26,8 @@ const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields
  * @property {boolean} uses.autoDestroy  Should this item be destroyed when it runs out of uses.
  */
 export default class ConsumableData extends ItemDataModel.mixin(
-  ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate, PhysicalItemTemplate, EquippableItemTemplate,
-  ActivatedEffectTemplate, ActionTemplate, ActivitiesTemplate
+  ActivitiesTemplate, ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate,
+  PhysicalItemTemplate, EquippableItemTemplate
 ) {
   /** @inheritdoc */
   static defineSchema() {
@@ -101,6 +97,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareDerivedData() {
+    ActivitiesTemplate._applyActivityShims.call(this);
     super.prepareDerivedData();
     if ( !this.type.value ) return;
     const config = CONFIG.DND5E.consumableTypes[this.type.value];
@@ -115,7 +112,6 @@ export default class ConsumableData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareFinalData() {
-    this.prepareFinalActivatedEffectData();
     this.prepareFinalActivityData(this.parent.getRollData({ deterministic: true }));
     this.prepareFinalEquippableData();
   }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -1,6 +1,4 @@
 import { ItemDataModel } from "../abstract.mjs";
-import ActionTemplate from "./templates/action.mjs";
-import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
 import ActivitiesTemplate from "./templates/activities.mjs";
 import EquippableItemTemplate from "./templates/equippable-item.mjs";
 import IdentifiableTemplate from "./templates/identifiable.mjs";
@@ -14,15 +12,13 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * Data definition for Equipment items.
+ * @mixes ActivitiesTemplate
  * @mixes ItemDescriptionTemplate
  * @mixes ItemTypeTemplate
  * @mixes IdentifiableTemplate
  * @mixes PhysicalItemTemplate
  * @mixes EquippableItemTemplate
- * @mixes ActivatedEffectTemplate
- * @mixes ActionTemplate
  * @mixes MountableTemplate
- * @mixes ActivitiesTemplate
  *
  * @property {object} armor               Armor details and equipment type information.
  * @property {number} armor.value         Base armor class or shield bonus.
@@ -36,8 +32,8 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
  * @property {number} proficient          Does the owner have proficiency in this piece of equipment?
  */
 export default class EquipmentData extends ItemDataModel.mixin(
-  ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate, PhysicalItemTemplate, EquippableItemTemplate,
-  ActivatedEffectTemplate, ActionTemplate, MountableTemplate, ActivitiesTemplate
+  ActivitiesTemplate, ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate,
+  PhysicalItemTemplate, EquippableItemTemplate, MountableTemplate
 ) {
   /** @inheritdoc */
   static defineSchema() {
@@ -173,6 +169,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareDerivedData() {
+    ActivitiesTemplate._applyActivityShims.call(this);
     super.prepareDerivedData();
     this.armor.value = (this._source.armor.value ?? 0) + (this.magicAvailable ? (this.armor.magicalBonus ?? 0) : 0);
     this.type.label = CONFIG.DND5E.equipmentTypes[this.type.value]
@@ -183,7 +180,6 @@ export default class EquipmentData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareFinalData() {
-    this.prepareFinalActivatedEffectData();
     this.prepareFinalActivityData(this.parent.getRollData({ deterministic: true }));
     this.prepareFinalEquippableData();
   }

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -1,6 +1,4 @@
 import { ItemDataModel } from "../abstract.mjs";
-import ActionTemplate from "./templates/action.mjs";
-import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
 import ActivitiesTemplate from "./templates/activities.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ItemTypeTemplate from "./templates/item-type.mjs";
@@ -11,11 +9,9 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * Data definition for Feature items.
+ * @mixes ActivitiesTemplate
  * @mixes ItemDescriptionTemplate
  * @mixes ItemTypeTemplate
- * @mixes ActivatedEffectTemplate
- * @mixes ActionTemplate
- * @mixes ActivitiesTemplate
  *
  * @property {object} prerequisites
  * @property {number} prerequisites.level           Character or class level required to choose this feature.
@@ -26,7 +22,7 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
  * @property {boolean} recharge.charged             Does this feature have a charge remaining?
  */
 export default class FeatData extends ItemDataModel.mixin(
-  ItemDescriptionTemplate, ItemTypeTemplate, ActivatedEffectTemplate, ActionTemplate, ActivitiesTemplate
+  ActivitiesTemplate, ItemDescriptionTemplate, ItemTypeTemplate
 ) {
 
   /** @override */
@@ -80,6 +76,7 @@ export default class FeatData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareDerivedData() {
+    ActivitiesTemplate._applyActivityShims.call(this);
     super.prepareDerivedData();
 
     if ( this.type.value ) {
@@ -93,7 +90,6 @@ export default class FeatData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareFinalData() {
-    this.prepareFinalActivatedEffectData();
     this.prepareFinalActivityData(this.parent.getRollData({ deterministic: true }));
 
     const uses = this.uses;

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -6,32 +6,16 @@ import SummonsField from "../fields/summons-field.mjs";
 const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
- * Data model template for item actions.
- *
- * @property {string} ability               Ability score to use when determining modifier.
- * @property {string} actionType            Action type as defined in `DND5E.itemActionTypes`.
- * @property {object} attack                Information how attacks are handled.
- * @property {string} attack.bonus          Numeric or dice bonus to attack rolls.
- * @property {boolean} attack.flat          Is the attack bonus the only bonus to attack rolls?
- * @property {string} chatFlavor            Extra text displayed in chat.
- * @property {object} critical              Information on how critical hits are handled.
- * @property {number} critical.threshold    Minimum number on the dice to roll a critical hit.
- * @property {string} critical.damage       Extra damage on critical hit.
- * @property {object} damage                Item damage formulas.
- * @property {string[][]} damage.parts      Array of damage formula and types.
- * @property {string} damage.versatile      Special versatile damage formula.
- * @property {EnchantmentData} enchantment  Enchantment configuration associated with this type.
- * @property {string} formula               Other roll formula.
- * @property {object} save                  Item saving throw data.
- * @property {string} save.ability          Ability required for the save.
- * @property {number} save.dc               Custom saving throw value.
- * @property {string} save.scaling          Method for automatically determining saving throw DC.
- * @property {SummonsData} summons
+ * @deprecated since 4.0, targeted for removal in 4.4
  * @mixin
  */
 export default class ActionTemplate extends ItemDataModel {
   /** @inheritdoc */
   static defineSchema() {
+    foundry.utils.logCompatibilityWarning(
+      "The `ActionTemplate` data model has been deprecated in favor of `ActivitiesTemplate`.",
+      { since: "DnD5e 4.0", until: "DnD5e 4.4", once: true }
+    );
     return {
       ability: new StringField({required: true, nullable: true, initial: null, label: "DND5E.AbilityModifier"}),
       actionType: new StringField({required: true, nullable: true, initial: null, label: "DND5E.ItemActionType"}),

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -5,35 +5,16 @@ import { FormulaField } from "../../fields.mjs";
 const { BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
- * Data model template for items that can be used as some sort of action.
- *
- * @property {object} activation            Effect's activation conditions.
- * @property {string} activation.type       Activation type as defined in `DND5E.abilityActivationTypes`.
- * @property {number} activation.cost       How much of the activation type is needed to use this item's effect.
- * @property {string} activation.condition  Special conditions required to activate the item.
- * @property {object} duration              Effect's duration.
- * @property {number} duration.value        How long the effect lasts.
- * @property {string} duration.units        Time duration period as defined in `DND5E.timePeriods`.
- * @property {number} cover                 Amount of cover does this item affords to its crew on a vehicle.
- * @property {object} target                Effect's valid targets.
- * @property {string} target.value          Length or radius of target depending on targeting mode selected.
- * @property {number} target.width          Width of line when line type is selected.
- * @property {string} target.units          Units used for value and width as defined in `DND5E.distanceUnits`.
- * @property {string} target.type           Targeting mode as defined in `DND5E.targetTypes`.
- * @property {boolean} target.prompt        Should the player be prompted to place the template?
- * @property {object} range                 Effect's range.
- * @property {number} range.value           Regular targeting distance for item's effect.
- * @property {number} range.long            Maximum targeting distance for features that have a separate long range.
- * @property {string} range.units           Units used for value and long as defined in `DND5E.distanceUnits`.
- * @property {object} consume               Effect's resource consumption.
- * @property {string} consume.type          Type of resource to consume as defined in `DND5E.abilityConsumptionTypes`.
- * @property {string} consume.target        Item ID or resource key path of resource to consume.
- * @property {number} consume.amount        Quantity of the resource to consume per use.
+ * @deprecated since 4.0, targeted for removal in 4.4
  * @mixin
  */
 export default class ActivatedEffectTemplate extends SystemDataModel {
   /** @inheritdoc */
   static defineSchema() {
+    foundry.utils.logCompatibilityWarning(
+      "The `ActivtedEffectTemplate` data model has been deprecated in favor of `ActivitiesTemplate`.",
+      { since: "DnD5e 4.0", until: "DnD5e 4.4", once: true }
+    );
     return {
       activation: new SchemaField({
         type: new StringField({required: true, blank: true, label: "DND5E.ItemActivationType"}),
@@ -44,10 +25,6 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
         value: new FormulaField({required: true, deterministic: true, label: "DND5E.Duration"}),
         units: new StringField({required: true, blank: true, label: "DND5E.DurationType"})
       }, {label: "DND5E.Duration"}),
-      cover: new NumberField({
-        required: true, nullable: true, min: 0, max: 1, label: "DND5E.Cover"
-      }),
-      crewed: new BooleanField({label: "DND5E.Crewed"}),
       target: new SchemaField({
         value: new FormulaField({required: true, deterministic: true, label: "DND5E.TargetValue"}),
         width: new NumberField({required: true, min: 0, label: "DND5E.TargetWidth"}),

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -76,6 +76,16 @@ export default class ActivitiesTemplate extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
+   * Does the Item implement an attack roll as part of its usage?
+   * @type {boolean}
+   */
+  get hasAttack() {
+    return !!this.activities.getByType("attack").size;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Is this Item limited in its ability to be used by charges or by recharge?
    * @type {boolean}
    */
@@ -86,11 +96,52 @@ export default class ActivitiesTemplate extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
+   * Does the Item implement a saving throw as part of its usage?
+   * @type {boolean}
+   */
+  get hasSave() {
+    return !!this.activities.getByType("save").size;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does this Item implement summoning as part of its usage?
+   * @type {boolean}
+   */
+  get hasSummoning() {
+    const activity = this.activities.getByType("summon")[0];
+    return activity && activity.profiles.length > 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Is this Item an activatable item?
    * @type {boolean}
    */
   get isActive() {
     return this.activities.size > 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Can this item enchant other items?
+   * @type {boolean}
+   */
+  get isEnchantment() {
+    return !!this.activities.getByType("enchant").size;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item provide an amount of healing instead of conventional damage?
+   * @type {boolean}
+   */
+  get isHealing() {
+    return !!this.activities.getByType("heal").size;
   }
 
   /* -------------------------------------------- */
@@ -261,17 +312,19 @@ export default class ActivitiesTemplate extends SystemDataModel {
           damage: activity?.damage?.critical?.bonus ?? ""
         };
       },
-      dammage: () => ({ parts: [], versatile: "" }),
+      damage: () => {
+        const activity = this.activities.getByType("attack")[0] || this.activities.getByType("damage")[0]
+          || this.activities.getByType("save")[0];
+        return {
+          parts: activity?.damage.parts.map(d => ([d.formula, d.types.first() ?? ""])) ?? [],
+          versatile: ""
+        };
+      },
       enchantment: () => this.activities.getByType("enchant")[0],
       formula: () => this.activities.getByType("utility")[0]?.roll?.formula ?? "",
       hasAbilityCheck: () => false,
-      hasAttack: () => !!this.activities.getByType("attack").size,
       hasDamage: () => !!this.activities.find(a => a.damage?.parts?.length),
-      hasSave: () => !!this.activities.getByType("save").size,
-      hasSummoning: () => !!this.activities.getByType("summon").size,
-      isEnchantment: () => !!this.activities.getByType("enchant").size,
-      isHealing: () => !!this.activities.getByType("heal").size,
-      isVersatile: () => this.actionType && this.properties?.has("ver"),
+      isVersatile: () => this.properties?.has("ver"),
       save: () => {
         const activity = this.activities.getByType("save")[0] ?? {};
         return {

--- a/module/data/item/templates/mountable.mjs
+++ b/module/data/item/templates/mountable.mjs
@@ -1,10 +1,14 @@
 import SystemDataModel from "../../abstract.mjs";
 
+const { BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
+
 /**
  * Data model template for equipment that can be mounted on a vehicle.
  *
  * @property {object} armor          Equipment's armor class.
  * @property {number} armor.value    Armor class value for equipment.
+ * @property {number} cover          Amount of cover does this item affords to its crew on a vehicle.
+ * @property {boolean} crewed        Is this equipment currently crewed?
  * @property {object} hp             Equipment's hit points.
  * @property {number} hp.value       Current hit point value.
  * @property {number} hp.max         Max hit points.
@@ -13,25 +17,19 @@ import SystemDataModel from "../../abstract.mjs";
  * @mixin
  */
 export default class MountableTemplate extends SystemDataModel {
-  /** @inheritdoc */
+  /** @inheritDoc */
   static defineSchema() {
     return {
-      armor: new foundry.data.fields.SchemaField({
-        value: new foundry.data.fields.NumberField({
-          required: true, integer: true, min: 0, label: "DND5E.ArmorClass"
-        })
+      armor: new SchemaField({
+        value: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.ArmorClass" })
       }, {label: "DND5E.ArmorClass"}),
-      hp: new foundry.data.fields.SchemaField({
-        value: new foundry.data.fields.NumberField({
-          required: true, integer: true, min: 0, label: "DND5E.HitPointsCurrent"
-        }),
-        max: new foundry.data.fields.NumberField({
-          required: true, integer: true, min: 0, label: "DND5E.HitPointsMax"
-        }),
-        dt: new foundry.data.fields.NumberField({
-          required: true, integer: true, min: 0, label: "DND5E.DamageThreshold"
-        }),
-        conditions: new foundry.data.fields.StringField({required: true, label: "DND5E.HealthConditions"})
+      cover: new NumberField({ min: 0, max: 1, label: "DND5E.Cover" }),
+      crewed: new BooleanField({ label: "DND5E.Crewed" }),
+      hp: new SchemaField({
+        value: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.HitPointsCurrent" }),
+        max: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.HitPointsMax" }),
+        dt: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.DamageThreshold" }),
+        conditions: new StringField({required: true, label: "DND5E.HealthConditions"})
       }, {label: "DND5E.HitPoints"})
     };
   }

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -1,23 +1,21 @@
 import { ItemDataModel } from "../abstract.mjs";
 import { FormulaField } from "../fields.mjs";
+import ItemTypeField from "./fields/item-type-field.mjs";
 import ActivitiesTemplate from "./templates/activities.mjs";
 import EquippableItemTemplate from "./templates/equippable-item.mjs";
 import IdentifiableTemplate from "./templates/identifiable.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ItemTypeTemplate from "./templates/item-type.mjs";
 import PhysicalItemTemplate from "./templates/physical-item.mjs";
-import ItemTypeField from "./fields/item-type-field.mjs";
-import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
 
 /**
  * Data definition for Tool items.
+ * @mixes ActivitiesTemplate
  * @mixes ItemDescriptionTemplate
  * @mixes ItemTypeTemplate
  * @mixes IdentifiableTemplate
  * @mixes PhysicalItemTemplate
  * @mixes EquippableItemTemplate
- * @mixes ActivatedEffectTemplate
- * @mixes ActivitiesTemplate
  *
  * @property {string} ability     Default ability when this tool is being used.
  * @property {string} chatFlavor  Additional text added to chat when this tool is used.
@@ -25,8 +23,8 @@ import ActivatedEffectTemplate from "./templates/activated-effect.mjs";
  * @property {string} bonus       Bonus formula added to tool rolls.
  */
 export default class ToolData extends ItemDataModel.mixin(
-  ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate,
-  PhysicalItemTemplate, EquippableItemTemplate, ActivatedEffectTemplate, ActivitiesTemplate
+  ActivitiesTemplate, ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate,
+  PhysicalItemTemplate, EquippableItemTemplate
 ) {
   /** @inheritdoc */
   static defineSchema() {
@@ -101,6 +99,7 @@ export default class ToolData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareDerivedData() {
+    ActivitiesTemplate._applyActivityShims.call(this);
     super.prepareDerivedData();
     this.type.label = CONFIG.DND5E.toolTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.tool);
   }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -230,6 +230,16 @@ export default class WeaponData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /**
+   * Does the Weapon implement a versatile damage roll as part of its usage?
+   * @type {boolean}
+   */
+  get isVersatile() {
+    return this.properties.has("ver");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * The proficiency multiplier for this item.
    * @returns {number}
    */

--- a/module/data/shared/activation-field.mjs
+++ b/module/data/shared/activation-field.mjs
@@ -1,0 +1,20 @@
+const { NumberField, SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * Field for storing activation data.
+ *
+ * @property {string} type            Activation type (e.g. action, legendary action, minutes).
+ * @property {number} value           Scalar value associated with the activation.
+ * @property {string} condition       Condition required to activate this activity.
+ */
+export default class ActivationField extends SchemaField {
+  constructor(fields={}, options={}) {
+    fields = {
+      type: new StringField({ initial: "action" }),
+      value: new NumberField({ min: 0, integer: true }),
+      condition: new StringField(),
+      ...fields
+    };
+    super(fields, options);
+  }
+}

--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -1,0 +1,22 @@
+import FormulaField from "../fields/formula-field.mjs";
+
+const { SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * Field for storing duration data.
+ *
+ * @property {string} value             Scalar value for the activity's duration.
+ * @property {string} units             Units that are used for the duration.
+ * @property {string} special           Description of any special duration details.
+ */
+export default class DurationField extends SchemaField {
+  constructor(fields={}, options={}) {
+    fields = {
+      value: new FormulaField({ deterministic: true }),
+      units: new StringField({ initial: "inst" }),
+      special: new StringField(),
+      ...fields
+    };
+    super(fields, options);
+  }
+}

--- a/module/data/shared/range-field.mjs
+++ b/module/data/shared/range-field.mjs
@@ -1,0 +1,22 @@
+import FormulaField from "../fields/formula-field.mjs";
+
+const { SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * Field for storing range data.
+ *
+ * @property {string} value                Scalar value for the activity's range.
+ * @property {string} units                Units that are used for the range.
+ * @property {string} special              Description of any special range details.
+ */
+export default class RangeField extends SchemaField {
+  constructor(fields={}, options={}) {
+    fields = {
+      value: new FormulaField({ deterministic: true }),
+      units: new StringField(),
+      special: new StringField(),
+      ...fields
+    };
+    super(fields, options);
+  }
+}

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -1,0 +1,44 @@
+import FormulaField from "../fields/formula-field.mjs";
+
+const { BooleanField, SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * Field for storing target data.
+ *
+ * @property {object} template
+ * @property {string} template.count        Number of templates created.
+ * @property {boolean} template.contiguous  Must all created areas be connected to one another?
+ * @property {string} template.type         Type of area of effect caused by this activity.
+ * @property {string} template.size         Size of the activity's area of effect on its primary axis.
+ * @property {string} template.width        Width of line area of effect.
+ * @property {string} template.height       Height of cylinder area of effect.
+ * @property {string} template.units        Units used to measure the area of effect sizes.
+ * @property {object} affects
+ * @property {string} affects.count         Number of individual targets that can be affected.
+ * @property {string} affects.type          Type of targets that can be affected (e.g. creatures, objects, spaces).
+ * @property {boolean} affects.choice       When targeting an area, can the user choose who it affects?
+ * @property {string} affects.special       Description of special targeting.
+ */
+export default class TargetField extends SchemaField {
+  constructor(fields={}, options={}) {
+    fields = {
+      template: new SchemaField({
+        count: new FormulaField({ deterministic: true }),
+        contiguous: new BooleanField(),
+        type: new StringField(),
+        size: new FormulaField({ deterministic: true }),
+        width: new FormulaField({ deterministic: true }),
+        height: new FormulaField({ deterministic: true }),
+        units: new StringField({ initial: "ft" })
+      }),
+      affects: new SchemaField({
+        count: new FormulaField({ deterministic: true }),
+        type: new StringField(),
+        choice: new BooleanField(),
+        special: new StringField()
+      }),
+      ...fields
+    };
+    super(fields, options);
+  }
+}

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -178,6 +178,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @returns {Promise<ActivityUsageResults|void>}  Details on the usage process if not canceled.
    */
   async use(usage={}, dialog={}, message={}) {
+    if ( !this.item.isEmbedded ) return;
     if ( !this.item.isOwner ) {
       ui.notifications.error("DND5E.DocumentUseWarn", { localize: true });
       return;
@@ -596,7 +597,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       buttons: null,
       description: data.description.chat,
       properties: properties.length ? properties : null,
-      subtitle: data.subtitle ?? this.item.system.chatFlavor,
+      subtitle: this.description.chatFlavor ?? data.subtitle,
       supplements
     };
   }

--- a/templates/activity/parts/activity-identity.hbs
+++ b/templates/activity/parts/activity-identity.hbs
@@ -2,4 +2,5 @@
     <legend>{{ localize "DND5E.ACTIVITY.Title.one" }}</legend>
     {{ formField fields.name value=source.name placeholder=placeholder.name }}
     {{ formField fields.img value=source.img placeholder=placeholder.img }}
+    {{ formField fields.description.fields.chatFlavor value=source.description.chatFlavor }}
 </fieldset>

--- a/templates/activity/parts/attack-damage.hbs
+++ b/templates/activity/parts/attack-damage.hbs
@@ -3,5 +3,6 @@
     {{#if hasBaseDamage}}
     {{ formField fields.damage.fields.includeBase value=source.damage.includeBase }}
     {{/if}}
+    {{ formField fields.damage.fields.critical.fields.bonus value=source.damage.critical.bonus }}
     {{> "systems/dnd5e/templates/activity/parts/damage-parts.hbs" }}
 </fieldset>

--- a/templates/activity/parts/attack-details.hbs
+++ b/templates/activity/parts/attack-details.hbs
@@ -4,5 +4,6 @@
     {{#with fields.attack.fields as |fields|}}
     {{ formField fields.bonus value=../source.attack.bonus }}
     {{ formField fields.flat value=../source.attack.flat }}
+    {{ formField fields.critical.fields.threshold value=../source.attack.critical.threshold }}
     {{/with}}
 </fieldset>

--- a/templates/activity/parts/damage-damage.hbs
+++ b/templates/activity/parts/damage-damage.hbs
@@ -1,5 +1,10 @@
 <fieldset>
     <legend>{{ localize "DND5E.DAMAGE.FIELDS.damage.label" }}</legend>
-    {{ formField fields.damage.fields.allowCritical value=source.damage.allowCritical }}
+    {{#with fields.damage.fields.critical.fields as |fields|}}
+    {{ formField fields.allow value=../source.damage.critical.allow }}
+    {{#if ../source.damage.critical.allow}}
+    {{ formField fields.bonus value=../source.damage.critical.bonus }}
+    {{/if}}
+    {{/with}}
     {{> "systems/dnd5e/templates/activity/parts/damage-parts.hbs" }}
 </fieldset>


### PR DESCRIPTION
All of the item types in the system that mix in `ActivityTemplate` no longer use `ActionTemplate` or `ActivatedEffectTemplate`. To avoid breakages they now call `_applyActivityShims` which adds shims to all of the old properties from those templates where possible.

This PR also includes changes to `WeaponData` that includes base damage & versatile damage as well as changes to `SpellData` that includes activation, duration, range, and target objects.

A few additional data changes had to be made to due to gaps:
- `cover` and `crewed` have moved from `ActivatedEffectTemplate` to `MountableTemplate`
- `chatFlavor` has been added to all activities and is now used in the created chat messages
- Critical bonus formula has been added to attack & damage activities, and critical threshold has been added to attack activity

Currently the preparation that was performed in
`prepareFinalActivatedEffectData` hasn't been re-implemented, but most of that will be handled by `BaseActivityData`. This means that a few labels won't display on legacy item sheets.

### Todo
- [ ] Implement data preparation from `prepareFinalActivatedEffectData` in `BaseActivityData`
- [ ] Migrate weapon damage & range
- [ ] Migrate spell activation, duration, range, and target