### PR TITLE
Item Sheet V2: Add equipped/identified toggles

### DIFF
--- a/less/v2/actors.less
+++ b/less/v2/actors.less
@@ -294,7 +294,7 @@
 
     > header {
       align-items: center;
-      .header-button, .document-id-link { margin-top: 0; }
+      .header-button, .pseudo-header-button { margin-top: 0; }
       .window-title { visibility: visible; }
     }
 

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -27,9 +27,17 @@
     }
   }
 
-  &.window-app.minimized .window-header .document-id-link {
-    display: grid;
-    margin-top: 0;
+  &.window-app.minimized .window-header {
+    .window-title {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    .document-id-link {
+      display: grid;
+      margin-top: 0;
+    }
   }
 
   .window-content {

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -12,7 +12,7 @@
     border: none;
     align-items: center;
 
-    .header-button {
+    .header-button, .pseudo-header-button {
       border-radius: 100%;
       background: var(--dnd5e-background-25);
       width: 18px;
@@ -20,12 +20,11 @@
       aspect-ratio: 1;
       line-height: unset;
       place-content: center;
+      margin-top: 4px;
 
       &:not([hidden]) { display: grid; }
       > i { margin: 0 }
     }
-
-    .header-button, .document-id-link { margin-top: .25rem; }
   }
 
   &.window-app.minimized .window-header .document-id-link {

--- a/less/v2/items.less
+++ b/less/v2/items.less
@@ -39,6 +39,8 @@
     }
   }
 
+  .window-header .state-toggle.active { color: var(--color-text-dark-primary); }
+
   .window-content {
     background: url("ui/texture-gray1.webp") no-repeat top left,
       url("ui/texture-gray2.webp") no-repeat bottom right,
@@ -61,7 +63,7 @@
 
     > header {
       align-items: center;
-      .header-button, .document-id-link { margin-top: 0; }
+      .header-button, .pseudo-header-button { margin-top: 0; }
       .window-title { visibility: visible; }
     }
   }

--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -34,16 +34,15 @@ export default function ActorSheetV2Mixin(Base) {
       const html = await super._renderOuter();
       if ( !game.user.isGM && this.actor.limited ) return html;
       const header = html[0].querySelector(".window-header");
-      const firstButton = header.querySelector(".header-button");
 
       // Preparation warnings.
       const warnings = document.createElement("a");
-      warnings.classList.add("header-button", "preparation-warnings");
+      warnings.classList.add("pseudo-header-button", "preparation-warnings");
       warnings.dataset.tooltip = "Warnings";
       warnings.setAttribute("aria-label", game.i18n.localize("Warnings"));
       warnings.innerHTML = '<i class="fas fa-triangle-exclamation"></i>';
       warnings.addEventListener("click", this._onOpenWarnings.bind(this));
-      firstButton?.insertAdjacentElement("beforebegin", warnings);
+      header.querySelector(".window-title").insertAdjacentElement("afterend", warnings);
 
       // Render tabs.
       const nav = document.createElement("nav");
@@ -75,7 +74,7 @@ export default function ActorSheetV2Mixin(Base) {
     /** @inheritDoc */
     async _render(force=false, options={}) {
       await super._render(force, options);
-      const [warnings] = this.element.find(".header-button.preparation-warnings");
+      const [warnings] = this.element.find(".pseudo-header-button.preparation-warnings");
       warnings?.toggleAttribute("hidden", !this.actor._preparationWarnings?.length);
     }
 

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -81,7 +81,7 @@ export default function DocumentSheetV2Mixin(Base) {
       const idLink = header.querySelector(".document-id-link");
       if ( idLink ) {
         firstButton?.insertAdjacentElement("beforebegin", idLink);
-        idLink.classList.add("header-button");
+        idLink.classList.add("pseudo-header-button");
         idLink.dataset.tooltipDirection = "DOWN";
       }
 


### PR DESCRIPTION
- Closes #3893 

This also fixes the error thrown when clicking certain header buttons sometimes, by shifting to the `.pseudo-header-button` class for header buttons that are added but don't exist in the `_getHeaderButtons` data.