### PR TITLE
[#1964] Migrate weapon base & versatile damage

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -66,6 +66,14 @@ export default class AttackActivityData extends BaseActivityData {
 
   /** @override */
   static transformTypeData(source, activityData) {
+    // For weapons, separate the first part from the rest to be used as the weapon's base damage and keep the rest
+    let damageParts = source.system.damage?.parts ?? [];
+    if ( (source.type === "weapon") && damageParts.length ) {
+      const [base, ...rest] = damageParts;
+      source.system.damage.parts = [base];
+      damageParts = rest;
+    }
+
     return foundry.utils.mergeObject(activityData, {
       ability: source.system.ability ?? "",
       attack: {
@@ -84,7 +92,7 @@ export default class AttackActivityData extends BaseActivityData {
           bonus: source.system.critical?.damage
         },
         includeBase: true,
-        parts: source.system.damage?.parts?.map(part => this.transformDamagePartData(source, part)) ?? []
+        parts: damageParts.map(part => this.transformDamagePartData(source, part)) ?? []
       }
     });
   }


### PR DESCRIPTION
Migrates the first damage part on a weapon to its base damage and the versatile formula if present into the versatile damage. If `@mod` is included it will be automatically stripped because that will be added automatically for weapon's base damage, and the type isn't stored in the versatile damage object because it will also match the type of the base damage.

Modifies the initial advancement creation for `AttackActivity` to separate out the first damage part from the rest. The first damage part is kept to be the item's base damage while the rest are added to the activity.