### PR TITLE
[#1964] Prepare final formulas and labels

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1776,6 +1776,13 @@
   "FIELDS": {
     "range": {
       "label": "Range",
+      "reach": {
+        "label": "Reach"
+      },
+      "long": {
+        "label": "Long Range",
+        "hint": "Far attack range of the weapon, if present on the weapon."
+      },
       "special": {
         "label": "Special Range",
         "hint": "Description of any special range details."

--- a/lang/en.json
+++ b/lang/en.json
@@ -149,20 +149,7 @@
 "DND5E.ActionWarningNoItem": "The requested item {item} no longer exists on Actor {name}",
 "DND5E.ActionWarningNoToken": "You must have one or more controlled Tokens in order to use this option.",
 
-"DND5E.Activation": {
-  "Category": {
-    "Standard": "Standard",
-    "Time": "Time",
-    "Monster": "Monster",
-    "Vehicle": "Vehicle"
-  }
-},
-
-"DND5E.ACTIVITY": {
-  "Title": {
-    "one": "Activity",
-    "other": "Activities"
-  },
+"DND5E.ACTIVATION": {
   "FIELDS": {
     "activation": {
       "label": "Activation",
@@ -178,70 +165,27 @@
         "label": "Activation Value",
         "hint": "Scalar value associated with the activation."
       }
-    },
-    "consumption": {
-      "label": "Consumption",
-      "scaling": {
-        "label": "Consumption Scaling",
-        "allowed": {
-          "label": "Allow Scaling",
-          "hint": "Can an activity not on a spell be activated at higher levels?"
-        },
-        "max": {
-          "label": "Max Scaling",
-          "hint": "Maximum number of scaling levels for this item, including the base level."
-        }
-      },
-      "targets": {
-        "label": "Consumption Targets",
-        "hint": "Targets of possible consumption when this activity is activated.",
-        "FIELDS": {
-          "type": {
-            "label": "Consumption Type",
-            "hint": "Type of consumption target."
-          },
-          "target": {
-            "label": "Consumption Target",
-            "hint": "Specific target to be consumed."
-          },
-          "value": {
-            "label": "Consumption Amount",
-            "hint": "Amount to consume of the target."
-          },
-          "scaling": {
-            "label": "Consumption Scaling",
-            "mode": {
-              "label": "Scaling Mode",
-              "hint": "How consumption should be scaled."
-            },
-            "formula": {
-              "label": "Scaling Formula",
-              "hint": "Custom scaling of consumption amount per level."
-            }
-          }
-        }
-      }
-    },
+    }
+  },
+  "Category": {
+    "Standard": "Standard",
+    "Time": "Time",
+    "Monster": "Monster",
+    "Vehicle": "Vehicle"
+  }
+},
+
+"DND5E.ACTIVITY": {
+  "Title": {
+    "one": "Activity",
+    "other": "Activities"
+  },
+  "FIELDS": {
     "description": {
       "label": "Description",
       "chatFlavor": {
         "label": "Chat Flavor",
         "hint": "Additional text displayed in the activation chat message."
-      }
-    },
-    "duration": {
-      "label": "Duration",
-      "special": {
-        "label": "Special Duration",
-        "hint": "Description of any special duration details."
-      },
-      "units": {
-        "label": "Duration Units",
-        "hint": "Units used to measure duration."
-      },
-      "value": {
-        "label": "Duration Value",
-        "hint": "Value of the duration in the specified units, if applicable."
       }
     },
     "effects": {
@@ -252,78 +196,6 @@
     },
     "name": {
       "label": "Name"
-    },
-    "range": {
-      "label": "Range",
-      "special": {
-        "label": "Special Range",
-        "hint": "Description of any special range details."
-      },
-      "units": {
-        "label": "Range Units",
-        "hint": "Units used to measure range."
-      },
-      "value": {
-        "label": "Range Value",
-        "hint": "Value of the range in the specified units, if applicable."
-      }
-    },
-    "target": {
-      "label": "Targeting",
-      "affects": {
-        "label": "Affected Targets",
-        "choice": {
-          "label": "Choose Targets",
-          "hint": "When targeting an area, can the user choose who it affects?"
-        },
-        "count": {
-          "label": "Target Count",
-          "hint": "Number of individual targets that can be affected."
-        },
-        "special": {
-          "label": "Special Targeting",
-          "hint": "Description of any special targeting details."
-        },
-        "type": {
-          "label": "Target Type",
-          "hint": "Type of targets that can be affected (e.g. creatures, objects, spaces)."
-        }
-      },
-      "prompt": {
-        "label": "Measured Template Prompt",
-        "hint": "Should the player be prompted to place a measured template? Players will still be able to place templates from the chat card if prompt is disabled."
-      },
-      "template": {
-        "label": "Area of Effect",
-        "contiguous": {
-          "label": "Contiguous Areas",
-          "hint": "Must all created areas be connected to one another?"
-        },
-        "count": {
-          "label": "Area Count",
-          "hint": "Number of distinct areas that can be targeted."
-        },
-        "height": {
-          "label": "Area Height",
-          "hint": "Height of a cylinder affected if applicable."
-        },
-        "size": {
-          "label": "Area Size",
-          "hint": "Size of the area of effect on its primary axis."
-        },
-        "type": {
-          "label": "Area Type",
-          "hint": "Type of area of effect targeted."
-        },
-        "units": {
-          "label": "Area Units",
-          "hint": "Units used to measure the area of effect sizes."
-        },
-        "width": {
-          "label": "Area Width",
-          "hint": "Width of a line affected if applicable."
-        }
-      }
     }
   },
   "SECTIONS": {
@@ -848,7 +720,53 @@
 "DND5E.ConsumableUnitWarn": "units remaining",
 "DND5E.ConsumableLastChargeWarn": "This is the last charge of this unit and consuming it will also reduce the item's quantity by 1",
 "DND5E.ConsumableWithoutCharges": "available units to use",
-"DND5E.Consumption": {
+
+"DND5E.CONSUMPTION": {
+  "FIELDS": {
+    "consumption": {
+      "label": "Consumption",
+      "scaling": {
+        "label": "Consumption Scaling",
+        "allowed": {
+          "label": "Allow Scaling",
+          "hint": "Can an activity not on a spell be activated at higher levels?"
+        },
+        "max": {
+          "label": "Max Scaling",
+          "hint": "Maximum number of scaling levels for this item, including the base level."
+        }
+      },
+      "targets": {
+        "label": "Consumption Targets",
+        "hint": "Targets of possible consumption when this activity is activated.",
+        "FIELDS": {
+          "type": {
+            "label": "Consumption Type",
+            "hint": "Type of consumption target."
+          },
+          "target": {
+            "label": "Consumption Target",
+            "hint": "Specific target to be consumed."
+          },
+          "value": {
+            "label": "Consumption Amount",
+            "hint": "Amount to consume of the target."
+          },
+          "scaling": {
+            "label": "Consumption Scaling",
+            "mode": {
+              "label": "Scaling Mode",
+              "hint": "How consumption should be scaled."
+            },
+            "formula": {
+              "label": "Scaling Formula",
+              "hint": "Custom scaling of consumption amount per level."
+            }
+          }
+        }
+      }
+    }
+  },
   "Action": {
     "Create": "Create Consumption Target",
     "Delete": "Delete Consumption Target"
@@ -881,8 +799,12 @@
     "SpellSlots": {
       "Label": "Spell Slots"
     }
+  },
+  "Warning": {
+    "MissingTarget": "Item configured to be consumed by {activity} activity on {item} could not be found."
   }
 },
+
 "DND5E.Consumed": "Consumed",
 "DND5E.Cover": "Cover",
 "DND5E.CoverHalf": "Half",
@@ -1124,6 +1046,27 @@
 "DND5E.DistTouch": "Touch",
 "DND5E.DocumentUseWarn": "You lack permission to use an item on this document.",
 "DND5E.DocumentViewWarn": "You lack permission to view this document.",
+
+"DND5E.DURATION": {
+  "FIELDS": {
+    "duration": {
+      "label": "Duration",
+      "special": {
+        "label": "Special Duration",
+        "hint": "Description of any special duration details."
+      },
+      "units": {
+        "label": "Duration Units",
+        "hint": "Units used to measure duration."
+      },
+      "value": {
+        "label": "Duration Value",
+        "hint": "Value of the duration in the specified units, if applicable."
+      }
+    }
+  }
+},
+
 "DND5E.Duration": "Duration",
 "DND5E.DurationPermanent": "Permanent",
 "DND5E.DurationTime": "Time",
@@ -1828,6 +1771,27 @@
 "DND5E.QuantityFormula": "Quantity Formula",
 "DND5E.QuantityRoll": "Roll Quantities",
 "DND5E.RacialTraits": "Racial Traits",
+
+"DND5E.RANGE": {
+  "FIELDS": {
+    "range": {
+      "label": "Range",
+      "special": {
+        "label": "Special Range",
+        "hint": "Description of any special range details."
+      },
+      "units": {
+        "label": "Range Units",
+        "hint": "Units used to measure range."
+      },
+      "value": {
+        "label": "Range Value",
+        "hint": "Value of the range in the specified units, if applicable."
+      }
+    }
+  }
+},
+
 "DND5E.Range": "Range",
 "DND5E.RangeDistance": "Distance",
 "DND5E.RangeLong": "Long Range",
@@ -2338,6 +2302,69 @@
 },
 "DND5E.Supply": "Supply",
 "DND5E.Suppressed": "Suppressed",
+
+"DND5E.TARGET": {
+  "FIELDS": {
+    "target": {
+      "label": "Targeting",
+      "affects": {
+        "label": "Affected Targets",
+        "choice": {
+          "label": "Choose Targets",
+          "hint": "When targeting an area, can the user choose who it affects?"
+        },
+        "count": {
+          "label": "Target Count",
+          "hint": "Number of individual targets that can be affected."
+        },
+        "special": {
+          "label": "Special Targeting",
+          "hint": "Description of any special targeting details."
+        },
+        "type": {
+          "label": "Target Type",
+          "hint": "Type of targets that can be affected (e.g. creatures, objects, spaces)."
+        }
+      },
+      "prompt": {
+        "label": "Measured Template Prompt",
+        "hint": "Should the player be prompted to place a measured template? Players will still be able to place templates from the chat card if prompt is disabled."
+      },
+      "template": {
+        "label": "Area of Effect",
+        "contiguous": {
+          "label": "Contiguous Areas",
+          "hint": "Must all created areas be connected to one another?"
+        },
+        "count": {
+          "label": "Area Count",
+          "hint": "Number of distinct areas that can be targeted."
+        },
+        "height": {
+          "label": "Area Height",
+          "hint": "Height of a cylinder affected if applicable."
+        },
+        "size": {
+          "label": "Area Size",
+          "hint": "Size of the area of effect on its primary axis."
+        },
+        "type": {
+          "label": "Area Type",
+          "hint": "Type of area of effect targeted."
+        },
+        "units": {
+          "label": "Area Units",
+          "hint": "Units used to measure the area of effect sizes."
+        },
+        "width": {
+          "label": "Area Width",
+          "hint": "Width of a line affected if applicable."
+        }
+      }
+    }
+  }
+},
+
 "DND5E.Target": "Target",
 "DND5E.TargetPl": "Targets",
 "DND5E.TargetAlly": "Ally",

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -227,10 +227,10 @@ export default class ActivitySheet extends Application5e {
       }))
     ];
     context.scalar = {
-      activation: CONFIG.DND5E.activityActivationTypes[context.activity.activation.type]?.scalar,
-      duration: context.activity.duration.units in CONFIG.DND5E.scalarTimePeriods,
-      range: context.activity.range.units in CONFIG.DND5E.movementUnits,
-      target: !["", "self", "any"].includes(context.activity.target.affects.type)
+      activation: context.activity.activation.scalar,
+      duration: context.activity.duration.scalar,
+      range: context.activity.range.scalar,
+      target: context.activity.target.affects.scalar
     };
 
     // Consumption targets
@@ -249,12 +249,12 @@ export default class ActivitySheet extends Application5e {
         source: context.source.consumption.targets[index] ?? data,
         typeOptions: consumptionTypeOptions,
         scalingModes: canScale ? [
-          { value: "", label: game.i18n.localize("DND5E.Consumption.Scaling.None") },
-          { value: "amount", label: game.i18n.localize("DND5E.Consumption.Scaling.Amount") },
+          { value: "", label: game.i18n.localize("DND5E.CONSUMPTION.Scaling.None") },
+          { value: "amount", label: game.i18n.localize("DND5E.CONSUMPTION.Scaling.Amount") },
           ...(typeConfig.scalingModes ?? []).map(({ value, label }) => ({ value, label: game.i18n.localize(label) }))
         ] : null,
         showTargets: "validTargets" in typeConfig,
-        targetPlaceholder: data.type === "itemUses" ? game.i18n.localize("DND5E.Consumption.Target.ThisItem") : null,
+        targetPlaceholder: data.type === "itemUses" ? game.i18n.localize("DND5E.CONSUMPTION.Target.ThisItem") : null,
         validTargets: showTextTarget ? null : typeConfig.validTargets?.call(this.activity)
       };
     });
@@ -429,11 +429,11 @@ export default class ActivitySheet extends Application5e {
           },
           consumption: {
             id: "consumption", group: "activation", icon: "fa-solid fa-boxes-stacked",
-            label: "DND5E.ACTIVITY.FIELDS.consumption.label"
+            label: "DND5E.CONSUMPTION.FIELDS.consumption.label"
           },
           targeting: {
             id: "activation-targeting", group: "activation", icon: "fa-solid fa-bullseye",
-            label: "DND5E.ACTIVITY.FIELDS.target.label"
+            label: "DND5E.TARGET.FIELDS.target.label"
           }
         }
       },

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -333,6 +333,17 @@ DND5E.weaponProficienciesMap = {
 };
 
 /**
+ * A mapping between `DND5E.weaponTypes` and `DND5E.attackTypes`.
+ * @enum {string}
+ */
+DND5E.weaponTypeMap = {
+  simpleM: "melee",
+  simpleR: "ranged",
+  martialM: "melee",
+  martialR: "ranged"
+};
+
+/**
  * The basic weapon types in 5e. This enables specific weapon proficiencies or
  * starting equipment provided by classes and backgrounds.
  * @enum {string}
@@ -560,54 +571,55 @@ preLocalize("abilityActivationTypes");
 DND5E.activityActivationTypes = {
   action: {
     label: "DND5E.Action",
-    group: "DND5E.Activation.Category.Standard"
+    group: "DND5E.ACTIVATION.Category.Standard"
   },
   bonus: {
     label: "DND5E.BonusAction",
-    group: "DND5E.Activation.Category.Standard"
+    group: "DND5E.ACTIVATION.Category.Standard"
   },
   reaction: {
     label: "DND5E.Reaction",
-    group: "DND5E.Activation.Category.Standard"
+    group: "DND5E.ACTIVATION.Category.Standard"
   },
   minute: {
     label: "DND5E.TimeMinute",
-    group: "DND5E.Activation.Category.Time",
+    group: "DND5E.ACTIVATION.Category.Time",
     scalar: true
   },
   hour: {
     label: "DND5E.TimeHour",
-    group: "DND5E.Activation.Category.Time",
+    group: "DND5E.ACTIVATION.Category.Time",
     scalar: true
   },
   day: {
     label: "DND5E.TimeDay",
-    group: "DND5E.Activation.Category.Time",
+    group: "DND5E.ACTIVATION.Category.Time",
     scalar: true
   },
   legendary: {
     label: "DND5E.LegendaryActionLabel",
-    group: "DND5E.Activation.Category.Monster",
+    group: "DND5E.ACTIVATION.Category.Monster",
     scalar: true
   },
   mythic: {
     label: "DND5E.MythicActionLabel",
-    group: "DND5E.Activation.Category.Monster",
+    group: "DND5E.ACTIVATION.Category.Monster",
     scalar: true
   },
   lair: {
     label: "DND5E.LairActionLabel",
-    group: "DND5E.Activation.Category.Monster"
+    group: "DND5E.ACTIVATION.Category.Monster"
   },
   crew: {
     label: "DND5E.VehicleCrewAction",
-    group: "DND5E.Activation.Category.Vehicle",
+    group: "DND5E.ACTIVATION.Category.Vehicle",
     scalar: true
   },
   special: {
     label: "DND5E.Special"
   }
 };
+preLocalize("activityActivationTypes", { key: "label" });
 
 /* -------------------------------------------- */
 
@@ -647,29 +659,29 @@ preLocalize("abilityConsumptionTypes", { sort: true });
  */
 DND5E.activityConsumptionTypes = {
   activityUses: {
-    label: "DND5E.Consumption.Type.ActivityUses.Label"
+    label: "DND5E.CONSUMPTION.Type.ActivityUses.Label"
   },
   itemUses: {
-    label: "DND5E.Consumption.Type.ItemUses.Label",
+    label: "DND5E.CONSUMPTION.Type.ItemUses.Label",
     targetRequiresEmbedded: true,
     validTargets: BaseActivityData.validItemUsesTargets
   },
   material: {
-    label: "DND5E.Consumption.Type.Material.Label",
+    label: "DND5E.CONSUMPTION.Type.Material.Label",
     targetRequiresEmbedded: true,
     validTargets: BaseActivityData.validMaterialTargets
   },
   hitDice: {
-    label: "DND5E.Consumption.Type.HitDice.Label",
+    label: "DND5E.CONSUMPTION.Type.HitDice.Label",
     validTargets: BaseActivityData.validHitDiceTargets
   },
   spellSlots: {
-    label: "DND5E.Consumption.Type.SpellSlots.Label",
-    scalingModes: [{ value: "level", label: "DND5E.Consumption.Scaling.SlotLevel" }],
+    label: "DND5E.CONSUMPTION.Type.SpellSlots.Label",
+    scalingModes: [{ value: "level", label: "DND5E.CONSUMPTION.Scaling.SlotLevel" }],
     validTargets: BaseActivityData.validSpellSlotsTargets
   },
   attribute: {
-    label: "DND5E.Consumption.Type.Attribute.Label",
+    label: "DND5E.CONSUMPTION.Type.Attribute.Label",
     targetRequiresEmbedded: true,
     validTargets: BaseActivityData.validAttributeTargets
   }

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -185,6 +185,11 @@ export default class ActivitiesTemplate extends SystemDataModel {
     else if ( source.recharge?.value ) {
       source.uses.recovery = [{ period: "recharge", formula: source.recharge.value }];
     }
+
+    // Prevent a string value for uses recovery from being cleaned into an default recovery entry
+    else if ( source.uses?.recovery === "" ) {
+      delete source.uses.recovery;
+    }
   }
 
   /* -------------------------------------------- */
@@ -194,8 +199,6 @@ export default class ActivitiesTemplate extends SystemDataModel {
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static initializeActivities(source) {
-    // TODO: Handle migration of data kept on spells and inferred by activities
-    // TODO: Handle migration of base damage, range, & ammunition on weapons
     if ( this.#shouldCreateInitialActivity(source) ) this.#createInitialActivity(source);
   }
 
@@ -253,7 +256,9 @@ export default class ActivitiesTemplate extends SystemDataModel {
    * @param {object} rollData
    */
   prepareFinalActivityData(rollData) {
-    UsesField.prepareData.call(this, rollData);
+    const labels = this.parent.labels ?? {};
+    UsesField.prepareData.call(this, rollData, labels);
+    for ( const activity of this.activities ) activity.prepareFinalData(rollData);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -32,12 +32,23 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
  * @property {object} range
  * @property {number} range.value           Short range of the weapon.
  * @property {number} range.long            Long range of the weapon.
- * @property {string} range.units           Units used to measure the weapon's range.
+ * @property {number} range.reach           Reach of the weapon.
+ * @property {string} range.units           Units used to measure the weapon's range and reach.
  */
 export default class WeaponData extends ItemDataModel.mixin(
   ActivitiesTemplate, ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate,
   PhysicalItemTemplate, EquippableItemTemplate, MountableTemplate
 ) {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.RANGE"];
+
+  /* -------------------------------------------- */
+
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
@@ -52,9 +63,10 @@ export default class WeaponData extends ItemDataModel.mixin(
         required: true, min: 0, max: 1, integer: true, initial: null, label: "DND5E.ProficiencyLevel"
       }),
       range: new SchemaField({
-        value: new NumberField({ min: 0, label: "DND5E.RangeNormal" }),
-        long: new NumberField({ min: 0, label: "DND5E.RangeLong" }),
-        units: new StringField({ label: "DND5E.RangeUnits" })
+        value: new NumberField({ min: 0 }),
+        long: new NumberField({ min: 0 }),
+        reach: new NumberField({ min: 0 }),
+        units: new StringField()
       })
     });
   }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -157,6 +157,16 @@ export default class WeaponData extends ItemDataModel.mixin(
   prepareFinalData() {
     this.prepareFinalActivityData(this.parent.getRollData({ deterministic: true }));
     this.prepareFinalEquippableData();
+
+    const labels = this.parent.labels ??= {};
+    if ( this.hasRange ) {
+      const parts = [
+        this.range.value,
+        this.range.long ? `/ ${this.range.long}` : null,
+        game.i18n.localize(`DND5E.Dist${this.range.units.capitalize()}Abbr`)
+      ];
+      labels.range = parts.filterJoin(" ");
+    } else labels.range = game.i18n.localize("DND5E.None");
   }
 
   /* -------------------------------------------- */
@@ -199,6 +209,16 @@ export default class WeaponData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /**
+   * Attack type offered by this weapon.
+   * @type {"melee"|"ranged"|null}
+   */
+  get attackType() {
+    return CONFIG.DND5E.weaponTypeMap[this.type.value] ?? null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Properties displayed in chat.
    * @type {string[]}
    */
@@ -235,6 +255,16 @@ export default class WeaponData extends ItemDataModel.mixin(
   /** @inheritdoc */
   get _typeCriticalThreshold() {
     return this.parent?.actor?.flags.dnd5e?.weaponCriticalThreshold ?? Infinity;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is the range value relevant to this weapon?
+   * @type {boolean}
+   */
+  get hasRange() {
+    return (this.attackType === "ranged") || this.properties.has("thr");
   }
 
   /* -------------------------------------------- */

--- a/module/data/shared/activation-field.mjs
+++ b/module/data/shared/activation-field.mjs
@@ -17,4 +17,29 @@ export default class ActivationField extends SchemaField {
     };
     super(fields, options);
   }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare data for this field. Should be called during the `prepareFinalData` stage.
+   * @this {ItemDataModel|BaseActivityData}
+   * @param {object} rollData  Roll data used for formula replacements.
+   * @param {object} [labels]  Object in which to insert generated labels.
+   */
+  static prepareData(rollData, labels) {
+    Object.defineProperty(this.activation, "scalar", {
+      get() { return CONFIG.DND5E.activityActivationTypes[this.type]?.scalar ?? false; },
+      configurable: true
+    });
+
+    if ( !this.activation.scalar ) this.activation.value = null;
+
+    if ( labels && this.activation.type ) {
+      labels.activation = [
+        this.activation.value, CONFIG.DND5E.activityActivationTypes[this.activation.type]?.label
+      ].filterJoin(" ");
+    }
+  }
 }

--- a/module/data/shared/activation-field.mjs
+++ b/module/data/shared/activation-field.mjs
@@ -29,11 +29,7 @@ export default class ActivationField extends SchemaField {
    * @param {object} [labels]  Object in which to insert generated labels.
    */
   static prepareData(rollData, labels) {
-    Object.defineProperty(this.activation, "scalar", {
-      get() { return CONFIG.DND5E.activityActivationTypes[this.type]?.scalar ?? false; },
-      configurable: true
-    });
-
+    this.activation.scalar = CONFIG.DND5E.activityActivationTypes[this.type]?.scalar ?? false;
     if ( !this.activation.scalar ) this.activation.value = null;
 
     if ( labels && this.activation.type ) {

--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -32,11 +32,7 @@ export default class DurationField extends SchemaField {
    * @param {object} [labels]  Object in which to insert generated labels.
    */
   static prepareData(rollData, labels) {
-    Object.defineProperty(this.duration, "scalar", {
-      get() { return this.units in CONFIG.DND5E.scalarTimePeriods; },
-      configurable: true
-    });
-
+    this.duration.scalar = this.units in CONFIG.DND5E.scalarTimePeriods;
     if ( this.duration.scalar ) {
       prepareFormulaValue(this, "duration.value", "DND5E.DURATION.FIELDS.duration.value.label", rollData);
     } else this.duration.value = null;

--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -1,3 +1,4 @@
+import { prepareFormulaValue } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { SchemaField, StringField } = foundry.data.fields;
@@ -18,5 +19,34 @@ export default class DurationField extends SchemaField {
       ...fields
     };
     super(fields, options);
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare data for this field. Should be called during the `prepareFinalData` stage.
+   * @this {ItemDataModel|BaseActivityData}
+   * @param {object} rollData  Roll data used for formula replacements.
+   * @param {object} [labels]  Object in which to insert generated labels.
+   */
+  static prepareData(rollData, labels) {
+    Object.defineProperty(this.duration, "scalar", {
+      get() { return this.units in CONFIG.DND5E.scalarTimePeriods; },
+      configurable: true
+    });
+
+    if ( this.duration.scalar ) {
+      prepareFormulaValue(this, "duration.value", "DND5E.DURATION.FIELDS.duration.value.label", rollData);
+    } else this.duration.value = null;
+
+    if ( labels && this.duration.units ) {
+      let duration = CONFIG.DND5E.timePeriods[this.duration.units] ?? "";
+      if ( this.duration.value ) duration = `${this.duration.value} ${duration.toLowerCase()}`;
+      labels.duration = duration;
+      labels.concentrationDuration = this.properties?.has("concentration")
+        ? game.i18n.format("DND5E.ConcentrationDuration", { duration }) : duration;
+    }
   }
 }

--- a/module/data/shared/range-field.mjs
+++ b/module/data/shared/range-field.mjs
@@ -32,11 +32,7 @@ export default class RangeField extends SchemaField {
    * @param {object} [labels]  Object in which to insert generated labels.
    */
   static prepareData(rollData, labels) {
-    Object.defineProperty(this.range, "scalar", {
-      get() { return this.units in CONFIG.DND5E.movementUnits; },
-      configurable: true
-    });
-
+    this.range.scalar = this.units in CONFIG.DND5E.movementUnits;
     if ( this.range.scalar ) {
       prepareFormulaValue(this, "range.value", "DND5E.RANGE.FIELDS.range.value.label", rollData);
     } else this.range.value = null;

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -54,11 +54,7 @@ export default class TargetField extends SchemaField {
    * @param {object} [labels]  Object in which to insert generated labels.
    */
   static prepareData(rollData, labels) {
-    Object.defineProperty(this.target.affects, "scalar", {
-      get() { return !["", "self", "any"].includes(this.type); },
-      configurable: true
-    });
-
+    this.target.affects.scalar = !["", "self", "any"].includes(this.type);
     if ( this.target.affects.scalar ) {
       prepareFormulaValue(this, "target.affects.count", "DND5E.TARGET.FIELDS.target.affects.count.label", rollData);
     } else this.target.affects.count = null;

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -1,3 +1,4 @@
+import { prepareFormulaValue } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { BooleanField, SchemaField, StringField } = foundry.data.fields;
@@ -40,5 +41,57 @@ export default class TargetField extends SchemaField {
       ...fields
     };
     super(fields, options);
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare data for this field. Should be called during the `prepareFinalData` stage.
+   * @this {ItemDataModel|BaseActivityData}
+   * @param {object} rollData  Roll data used for formula replacements.
+   * @param {object} [labels]  Object in which to insert generated labels.
+   */
+  static prepareData(rollData, labels) {
+    Object.defineProperty(this.target.affects, "scalar", {
+      get() { return !["", "self", "any"].includes(this.type); },
+      configurable: true
+    });
+
+    if ( this.target.affects.scalar ) {
+      prepareFormulaValue(this, "target.affects.count", "DND5E.TARGET.FIELDS.target.affects.count.label", rollData);
+    } else this.target.affects.count = null;
+
+    if ( this.target.template.type ) {
+      this.target.template.count ||= "1";
+      prepareFormulaValue(this, "target.template.count", "DND5E.TARGET.FIELDS.target.template.count.label", rollData);
+      prepareFormulaValue(this, "target.template.size", "DND5E.TARGET.FIELDS.target.template.size.label", rollData);
+      prepareFormulaValue(this, "target.template.width", "DND5E.TARGET.FIELDS.target.template.width.label", rollData);
+      prepareFormulaValue(this, "target.template.height", "DND5E.TARGET.FIELDS.target.template.height.label", rollData);
+    } else {
+      this.target.template.count = null;
+      this.target.template.size = null;
+      this.target.template.width = null;
+      this.target.template.height = null;
+    }
+
+    if ( labels ) {
+      const parts = [];
+
+      if ( this.target.template.type ) {
+        if ( this.target.template.count > 1 ) parts.push(`${this.target.template.count} ×`);
+        parts.push(this.target.template.size);
+        parts.push(game.i18n.localize(`DND5E.Dist${this.target.template.units.capitalize()}Abbr`));
+        parts.push(CONFIG.DND5E.areaTargetTypes[this.target.template.type]?.label);
+      }
+
+      else if ( this.target.affects.type ) {
+        if ( this.target.affects.scalar ) parts.push(this.target.affects.count);
+        parts.push(CONFIG.DND5E.individualTargetTypes[this.target.affects.type]);
+      }
+
+      labels.target = parts.filterJoin(" ");
+    }
   }
 }

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -1,4 +1,4 @@
-import { formatNumber, formatRange } from "../../utils.mjs";
+import { formatNumber, formatRange, prepareFormulaValue } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
@@ -41,12 +41,13 @@ export default class UsesField extends SchemaField {
   /* -------------------------------------------- */
 
   /**
-   * Prepare data for the uses field. Should be called during the `prepareFinalData` stage.
+   * Prepare data for this field. Should be called during the `prepareFinalData` stage.
    * @this {ItemDataModel|BaseActivityData}
-   * @param {object} rollData
+   * @param {object} rollData  Roll data used for formula replacements.
+   * @param {object} [labels]  Object in which to insert generated labels.
    */
-  static prepareData(rollData) {
-    // TODO: Move maximum uses preparation from `ActivatedEffectTemplate`
+  static prepareData(rollData, labels) {
+    prepareFormulaValue(this, "uses.max", "DND5E.USES.FIELDS.uses.max.label", rollData);
     this.uses.value = Math.clamp(this.uses.max - this.uses.spent, 0, this.uses.max);
 
     for ( const recovery of this.uses.recovery ) {
@@ -60,6 +61,8 @@ export default class UsesField extends SchemaField {
             })
           }))
         };
+        if ( labels ) labels.recharge ??= `${game.i18n.localize("DND5E.Recharge")} [${
+          recovery.formula}${parseInt(recovery.formula) < 6 ? "+" : ""}]`;
       }
     }
   }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -42,7 +42,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
     if ( fields.damage?.fields.parts ) {
       this._localizeSchema(fields.damage.fields.parts.element, ["DND5E.DAMAGE.FIELDS.damage.parts"]);
     }
-    this._localizeSchema(fields.consumption.fields.targets.element, ["DND5E.ACTIVITY.FIELDS.consumption.targets"]);
+    this._localizeSchema(fields.consumption.fields.targets.element, ["DND5E.CONSUMPTION.FIELDS.consumption.targets"]);
     this._localizeSchema(fields.uses.fields.recovery.element, ["DND5E.USES.FIELDS.uses.recovery"]);
   }
 

--- a/templates/activity/parts/activity-consumption.hbs
+++ b/templates/activity/parts/activity-consumption.hbs
@@ -1,6 +1,6 @@
 <section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
     <fieldset>
-        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.consumption.label" }}</legend>
+        <legend>{{ localize "DND5E.CONSUMPTION.FIELDS.consumption.label" }}</legend>
         <ul class="unlist">
             {{#each consumptionTargets}}
             <li data-index="{{ @index }}">
@@ -15,24 +15,24 @@
                    options=scalingModes }}
                 {{#if data.scaling.mode}}
                 {{ formField fields.scaling.fields.formula name=(concat prefix "scaling.formula")
-                   value=data.scaling.formula placeholder=(localize "DND5E.Consumption.Scaling.Automatic") }}
+                   value=data.scaling.formula placeholder=(localize "DND5E.CONSUMPTION.Scaling.Automatic") }}
                 {{/if}}
                 {{/if}}
                 <button type="button" class="unbutton" data-action="deleteConsumption">
-                    {{ localize "DND5E.Consumption.Action.Delete" }}
+                    {{ localize "DND5E.CONSUMPTION.Action.Delete" }}
                 </button>
             </li>
             {{/each}}
         </ul>
         <button type="button" class="unbutton" data-action="addConsumption">
-            {{ localize "DND5E.Consumption.Action.Create" }}
+            {{ localize "DND5E.CONSUMPTION.Action.Create" }}
         </button>
     </fieldset>
 
     {{#unless activity.isSpell}}
     {{#with fields.consumption.fields.scaling.fields as |fields|}}
     <fieldset>
-        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.consumption.scaling.label" }}</legend>
+        <legend>{{ localize "DND5E.CONSUMPTION.FIELDS.consumption.scaling.label" }}</legend>
         {{ formField fields.allowed value=../activity.consumption.scaling.allowed }}
         {{#if ../activity.consumption.scaling.allowed}}
         {{ formField fields.max value=../activity.consumption.scaling.max placeholder="∞" }}

--- a/templates/activity/parts/activity-targeting.hbs
+++ b/templates/activity/parts/activity-targeting.hbs
@@ -1,7 +1,7 @@
 <section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
     <!-- TODO: (override checkbox) -->
     <fieldset>
-        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.range.label" }}</legend>
+        <legend>{{ localize "DND5E.RANGE.FIELDS.range.label" }}</legend>
         {{#if scalar.range}}{{ formField fields.range.fields.value value=source.range.value }}{{/if}}
         {{ formField fields.range.fields.units value=source.range.units options=rangeUnits }}
         {{#if activity.range.units}}{{ formField fields.range.fields.special value=source.range.special }}{{/if}}
@@ -9,7 +9,7 @@
 
     {{#with fields.target.fields.affects.fields as |fields|}}
     <fieldset>
-        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.target.affects.label" }}</legend>
+        <legend>{{ localize "DND5E.TARGET.FIELDS.target.affects.label" }}</legend>
         {{#if ../scalar.target}}
         {{ formField fields.count value=../source.target.affects.count placeholder=../affectsPlaceholder }}
         {{/if}}
@@ -25,7 +25,7 @@
 
     {{#with fields.target.fields.template.fields as |fields|}}
     <fieldset>
-        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.target.template.label" }}</legend>
+        <legend>{{ localize "DND5E.TARGET.FIELDS.target.template.label" }}</legend>
         {{#if ../activity.target.template.type}}
         {{ formField fields.count value=../source.target.template.count }}
         {{/if}}

--- a/templates/activity/parts/activity-time.hbs
+++ b/templates/activity/parts/activity-time.hbs
@@ -1,13 +1,13 @@
 <section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
     <fieldset>
-        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.activation.label" }}</legend>
+        <legend>{{ localize "DND5E.ACTIVATION.FIELDS.activation.label" }}</legend>
         {{#if scalar.activation}}{{ formField fields.activation.fields.value value=source.activation.value }}{{/if}}
         {{ formField fields.activation.fields.type value=source.activation.type options=activationTypes }}
         {{ formField fields.activation.fields.condition value=source.activation.condition }}
     </fieldset>
 
     <fieldset>
-        <legend>{{ localize "DND5E.ACTIVITY.FIELDS.duration.label" }}</legend>
+        <legend>{{ localize "DND5E.DURATION.FIELDS.duration.label" }}</legend>
         <!-- TODO: (override checkbox) -->
         {{#if scalar.duration}}{{ formField fields.duration.fields.value value=source.duration.value }}{{/if}}
         {{ formField fields.duration.fields.units value=source.duration.units options=durationUnits }}


### PR DESCRIPTION
Implements that final formula resolution and other preparation for duration, range, and target fields on spells and activities, and in the uses field everywhere. Some behavior previously implemented in `ActivatedEffectTemplate` to resolve formulas is now in the new `prepareFormulaValue` utility function.

This also re-implements the label generation previously handled in `ActivatedEffectTemplate` for spells and weapons.