### PR TITLE
[#1964] Copy inferred data from items to activity, add overrides

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -159,7 +159,7 @@
       },
       "override": {
         "label": "Override Activation",
-        "hint": "Override the activation information from the item with values for this activity."
+        "hint": "Use these activation values instead of the item's when using this activity."
       },
       "type": {
         "label": "Activation Type",
@@ -1057,7 +1057,7 @@
       "label": "Duration",
       "override": {
         "label": "Override Duration",
-        "hint": "Override the duration information from the item with values for this activity."
+        "hint": "Use these duration values instead of the item's when using this activity."
       },
       "special": {
         "label": "Special Duration",
@@ -1790,7 +1790,7 @@
       },
       "override": {
         "label": "Override Range",
-        "hint": "Override the range information from the item with values for this activity."
+        "hint": "Use these range values instead of the item's when using this activity."
       },
       "reach": {
         "label": "Reach"
@@ -2347,7 +2347,7 @@
       },
       "override": {
         "label": "Override Target",
-        "hint": "Override the target information from the item with values for this activity."
+        "hint": "Use these target values instead of the item's when using this activity."
       },
       "prompt": {
         "label": "Measured Template Prompt",

--- a/lang/en.json
+++ b/lang/en.json
@@ -157,6 +157,10 @@
         "label": "Activation Condition",
         "hint": "Condition required to activate this activity."
       },
+      "override": {
+        "label": "Override Activation",
+        "hint": "Override the activation information from the item with values for this activity."
+      },
       "type": {
         "label": "Activation Type",
         "hint": "Activation type (e.g. action, legendary action, minutes)."
@@ -1051,6 +1055,10 @@
   "FIELDS": {
     "duration": {
       "label": "Duration",
+      "override": {
+        "label": "Override Duration",
+        "hint": "Override the duration information from the item with values for this activity."
+      },
       "special": {
         "label": "Special Duration",
         "hint": "Description of any special duration details."
@@ -1776,12 +1784,16 @@
   "FIELDS": {
     "range": {
       "label": "Range",
-      "reach": {
-        "label": "Reach"
-      },
       "long": {
         "label": "Long Range",
         "hint": "Far attack range of the weapon, if present on the weapon."
+      },
+      "override": {
+        "label": "Override Range",
+        "hint": "Override the range information from the item with values for this activity."
+      },
+      "reach": {
+        "label": "Reach"
       },
       "special": {
         "label": "Special Range",
@@ -2332,6 +2344,10 @@
           "label": "Target Type",
           "hint": "Type of targets that can be affected (e.g. creatures, objects, spaces)."
         }
+      },
+      "override": {
+        "label": "Override Target",
+        "hint": "Override the target information from the item with values for this activity."
       },
       "prompt": {
         "label": "Measured Template Prompt",

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -459,7 +459,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
-   * Add an `canOverride` property to the provided object and, if `override` is `true`, replace the data on the
+   * Add an `canOverride` property to the provided object and, if `override` is `false`, replace the data on the
    * activity with data from the item.
    * @param {string} keyPath  Path of the property to set on the activity.
    * @internal

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -176,11 +176,11 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   prepareFinalData() {
     const rollData = this.parent.getRollData({ deterministic: true });
     const labels = this.parent.labels ?? {};
+    this.prepareFinalActivityData(rollData);
     ActivationField.prepareData.call(this, rollData, labels);
     DurationField.prepareData.call(this, rollData, labels);
     RangeField.prepareData.call(this, rollData, labels);
     TargetField.prepareData.call(this, rollData, labels);
-    this.prepareFinalActivityData(rollData);
   }
 
   /* -------------------------------------------- */

--- a/templates/activity/parts/activity-targeting.hbs
+++ b/templates/activity/parts/activity-targeting.hbs
@@ -1,47 +1,54 @@
 <section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
-    <!-- TODO: (override checkbox) -->
-    <fieldset>
+    {{#if activity.range.canOverride}}
+    {{ formField fields.range.fields.override value=source.range.override }}
+    {{/if}}
+
+    <fieldset {{ disabled disabled.range }}>
         <legend>{{ localize "DND5E.RANGE.FIELDS.range.label" }}</legend>
-        {{#if scalar.range}}{{ formField fields.range.fields.value value=source.range.value }}{{/if}}
-        {{ formField fields.range.fields.units value=source.range.units options=rangeUnits }}
-        {{#if activity.range.units}}{{ formField fields.range.fields.special value=source.range.special }}{{/if}}
+        {{#if activity.range.scalar}}{{ formField fields.range.fields.value value=data.range.value }}{{/if}}
+        {{ formField fields.range.fields.units value=data.range.units options=rangeUnits }}
+        {{#if activity.range.units}}{{ formField fields.range.fields.special value=data.range.special }}{{/if}}
     </fieldset>
 
+    {{#if activity.target.canOverride}}
+    {{ formField fields.target.fields.override value=source.target.override }}
+    {{/if}}
+
     {{#with fields.target.fields.affects.fields as |fields|}}
-    <fieldset>
+    <fieldset {{ disabled ../disabled.target }}>
         <legend>{{ localize "DND5E.TARGET.FIELDS.target.affects.label" }}</legend>
-        {{#if ../scalar.target}}
-        {{ formField fields.count value=../source.target.affects.count placeholder=../affectsPlaceholder }}
+        {{#if ../activity.target.affects.scalar}}
+        {{ formField fields.count value=../data.target.affects.count placeholder=../affectsPlaceholder }}
         {{/if}}
-        {{ formField fields.type value=../source.target.affects.type choices=../CONFIG.individualTargetTypes }}
+        {{ formField fields.type value=../data.target.affects.type choices=../CONFIG.individualTargetTypes }}
         {{#if ../activity.target.affects.type}}
-        {{ formField fields.special value=../source.target.affects.special }}
+        {{ formField fields.special value=../data.target.affects.special }}
         {{#if ../activity.target.template.type}}
-        {{ formField fields.choice value=../source.target.affects.choice }}
+        {{ formField fields.choice value=../data.target.affects.choice }}
         {{/if}}
         {{/if}}
     </fieldset>
     {{/with}}
 
     {{#with fields.target.fields.template.fields as |fields|}}
-    <fieldset>
+    <fieldset {{ disabled ../disabled.target }}>
         <legend>{{ localize "DND5E.TARGET.FIELDS.target.template.label" }}</legend>
         {{#if ../activity.target.template.type}}
-        {{ formField fields.count value=../source.target.template.count }}
+        {{ formField fields.count value=../data.target.template.count placeholder="1" }}
         {{/if}}
-        {{ formField fields.type value=../source.target.template.type choices=../CONFIG.areaTargetTypes }}
+        {{ formField fields.type value=../data.target.template.type choices=../CONFIG.areaTargetTypes }}
         {{#with ../dimensions}}
-        {{ formField fields.size value=@root.source.target.template.size label=(localize size) hint=false }}
+        {{ formField fields.size value=@root.data.target.template.size label=(localize size) hint=false }}
         {{#if width}}
-        {{ formField fields.width value=@root.source.target.template.width label=(localize width) hint=false }}
+        {{ formField fields.width value=@root.data.target.template.width label=(localize width) hint=false }}
         {{/if}}
         {{#if height}}
-        {{ formField fields.height value=@root.source.target.template.height label=(localize height) hint=false }}
+        {{ formField fields.height value=@root.data.target.template.height label=(localize height) hint=false }}
         {{/if}}
-        {{ formField fields.units value=@root.source.target.template.units choices=@root.CONFIG.movementUnits }}
+        {{ formField fields.units value=@root.data.target.template.units choices=@root.CONFIG.movementUnits }}
         {{/with}}
         {{#if (and ../activity.target.template.type (gt ../activity.target.template.count 1))}}
-        {{ formField fields.contiguous value=../source.target.template.contiguous }}
+        {{ formField fields.contiguous value=../data.target.template.contiguous }}
         {{/if}}
     </fieldset>
     {{/with}}

--- a/templates/activity/parts/activity-time.hbs
+++ b/templates/activity/parts/activity-time.hbs
@@ -1,16 +1,25 @@
 <section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
-    <fieldset>
+    {{#if activity.activation.canOverride}}
+    {{ formField fields.activation.fields.override value=source.activation.override }}
+    {{/if}}
+
+    <fieldset {{ disabled disabled.activation }}>
         <legend>{{ localize "DND5E.ACTIVATION.FIELDS.activation.label" }}</legend>
-        {{#if scalar.activation}}{{ formField fields.activation.fields.value value=source.activation.value }}{{/if}}
-        {{ formField fields.activation.fields.type value=source.activation.type options=activationTypes }}
-        {{ formField fields.activation.fields.condition value=source.activation.condition }}
+        {{#if activity.activation.scalar}}
+        {{ formField fields.activation.fields.value value=data.activation.value }}
+        {{/if}}
+        {{ formField fields.activation.fields.type value=data.activation.type options=activationTypes }}
+        {{ formField fields.activation.fields.condition value=data.activation.condition }}
     </fieldset>
 
-    <fieldset>
+    {{#if activity.duration.canOverride}}
+    {{ formField fields.duration.fields.override value=source.duration.override }}
+    {{/if}}
+
+    <fieldset {{ disabled disabled.duration }}>
         <legend>{{ localize "DND5E.DURATION.FIELDS.duration.label" }}</legend>
-        <!-- TODO: (override checkbox) -->
-        {{#if scalar.duration}}{{ formField fields.duration.fields.value value=source.duration.value }}{{/if}}
-        {{ formField fields.duration.fields.units value=source.duration.units options=durationUnits }}
-        {{ formField fields.duration.fields.special value=source.duration.special }}
+        {{#if activity.duration.scalar}}{{ formField fields.duration.fields.value value=data.duration.value }}{{/if}}
+        {{ formField fields.duration.fields.units value=data.duration.units options=durationUnits }}
+        {{ formField fields.duration.fields.special value=data.duration.special }}
     </fieldset>
 </section>


### PR DESCRIPTION
During activity preparation this copies data from the item over to the activity unless the `override` option is set. If the original data couldn't be found on the item, then the override checkbox won't appear and the activity values will be used.

After the copying occurs a copy of the activity data is saved in `_inferredSource` so that the activity sheet has a way to show inferred data before any final formula resolution occurs.

The sheet then selects the item data or activity data based on the override checkbox, and if override isn't set it will disable the whole `<fieldset>`.

### Todo
- [ ] Handle inferred data from weapon to `AttackActivity`