### PR TITLE
[#1964] Add inferred attack data, fix bug in save sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1025,6 +1025,7 @@
 "DND5E.DeathSavingThrow": "Death Saving Throw",
 "DND5E.DeathSaveUnnecessary": "You do not need to roll death saves because you have a positive number of hit points or have already reached 3 successes or failures.",
 "DND5E.Default": "Default",
+"DND5E.DefaultSpecific": "Default ({default})",
 "DND5E.DefaultAbilityCheck": "Default Ability Check",
 "DND5E.Description": "Description",
 "DND5E.DescriptionChat": "Chat Description",

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -28,6 +28,10 @@
     > i { margin: 0; }
   }
 
+  fieldset.unfieldset {
+    display: contents;
+  }
+
   /* Inputs & Buttons */
   input, button {
     transition: all 250ms ease;

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -371,12 +371,14 @@ export default class ActivitySheet extends Application5e {
         { value: "", label: game.i18n.localize("DND5E.DAMAGE.Scaling.None") },
         ...Object.entries(CONFIG.DND5E.damageScalingModes).map(([value, config]) => ({ value, label: config.label }))
       ];
+      let indexOffset = 0;
       context.damageParts = context.activity.damage.parts.map((data, index) => {
+        if ( data.base ) indexOffset--;
         const part = {
           data,
           fields: this.activity.schema.fields.damage.fields.parts.element.fields,
-          prefix: `damage.parts.${index}.`,
-          source: context.source.damage.parts[index] ?? data,
+          prefix: `damage.parts.${index + indexOffset}.`,
+          source: context.source.damage.parts[index + indexOffset] ?? data,
           canScale: this.activity.canScaleDamage,
           denominationOptions,
           scalingOptions,
@@ -497,7 +499,7 @@ export default class ActivitySheet extends Application5e {
 
   /** @override */
   _onClose(_options) {
-    this.activity.constructor._unregisterApp(this.activity, this);
+    this.activity?.constructor._unregisterApp(this.activity, this);
   }
 
   /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -114,6 +114,8 @@ preLocalize("abilities", { keys: ["label", "abbreviation"] });
  * @enum {string}
  */
 DND5E.defaultAbilities = {
+  meleeAttack: "str",
+  rangedAttack: "dex",
   initiative: "dex",
   hitPoints: "con",
   concentration: "con"
@@ -330,6 +332,15 @@ DND5E.weaponProficienciesMap = {
   simpleR: "sim",
   martialM: "mar",
   martialR: "mar"
+};
+
+/**
+ * A mapping between `DND5E.weaponTypes` and `DND5E.attackClassifications`. Unlisted types are assumed to be
+ * of the "weapon" classification.
+ * @enum {string}
+ */
+DND5E.weaponClassificationMap = {
+  natural: "unarmed"
 };
 
 /**

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -339,9 +339,7 @@ DND5E.weaponProficienciesMap = {
  * of the "weapon" classification.
  * @enum {string}
  */
-DND5E.weaponClassificationMap = {
-  natural: "unarmed"
-};
+DND5E.weaponClassificationMap = {};
 
 /**
  * A mapping between `DND5E.weaponTypes` and `DND5E.attackTypes`.

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -427,10 +427,10 @@ export class ItemDataModel extends SystemDataModel {
 
   /**
    * Set of abilities that can automatically be associated with this item.
-   * @type {Set<string>}
+   * @type {Set<string>|null}
    */
   get availableAbilities() {
-    return new Set();
+    return null;
   }
 
   /* -------------------------------------------- */

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -425,6 +425,16 @@ export class ItemDataModel extends SystemDataModel {
   /*  Properties                                  */
   /* -------------------------------------------- */
 
+  /**
+   * Set of abilities that can automatically be associated with this item.
+   * @type {Set<string>}
+   */
+  get availableAbilities() {
+    return new Set();
+  }
+
+  /* -------------------------------------------- */
+
   /** @override */
   get embeddedDescriptionKeyPath() {
     return game.user.isGM || (this.identified !== false) ? "description.value" : "unidentified.description";

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -72,10 +72,11 @@ export default class AttackActivityData extends BaseActivityData {
     if ( this.item.system.availableAbilities ) return this.item.system.availableAbilities;
 
     // Spell attack not associated with a single class, use highest spellcasting ability on actor
-    if ( this.attack.type.classification === "spell" ) return new Set([
-      this.parent?.actor?.system.attributes?.spellcasting,
-      ...Object.values(this.parent?.actor?.spellcastingClasses ?? {}).map(c => c.spellcasting.ability)
-    ].filter(a => a));
+    if ( this.attack.type.classification === "spell" ) return new Set(
+      this.actor?.system.attributes?.spellcasting
+        ? [this.actor.system.attributes.spellcasting]
+        : Object.values(this.actor?.spellcastingClasses ?? {}).map(c => c.spellcasting.ability)
+    );
 
     // Weapon & unarmed attacks uses melee or ranged ability depending on type, or both if actor is an NPC
     const melee = CONFIG.DND5E.defaultAbilities.meleeAttack;

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -219,7 +219,26 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   }
 
   /* -------------------------------------------- */
-  /*  Getters                                     */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Attack classification of this spell.
+   * @type {"spell"}
+   */
+  get attackClassification() {
+    return "spell";
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  get availableAbilities() {
+    const spellcasting = this.parent?.actor?.spellcastingClasses[this.sourceClass]?.spellcasting.ability
+      ?? this.parent?.actor?.system.attributes?.spellcasting;
+    return new Set(spellcasting ? [spellcasting] : []);
+  }
+
   /* -------------------------------------------- */
 
   /**
@@ -238,9 +257,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
 
   /** @inheritdoc */
   get _typeAbilityMod() {
-    return this.parent?.actor?.spellcastingClasses[this.sourceClass]?.spellcasting.ability
-      ?? this.parent?.actor?.system.attributes?.spellcasting
-      ?? "int";
+    return availableAbilities.first() ?? "int";
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2200,7 +2200,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @returns {Promise<Item5e>}  This item with the changes applied.
    */
   deleteActivity(id) {
-    if ( !this.system.activities ) return this;
+    const activity = this.system.activities?.get(id);
+    if ( !activity ) return this;
+    activity.constructor._apps.get(activity.uuid)?.forEach(a => a.close());
     return this.update({ [`system.activities.-=${id}`]: null });
   }
 

--- a/templates/activity/parts/damage-part.hbs
+++ b/templates/activity/parts/damage-part.hbs
@@ -20,7 +20,7 @@
     <input type="hidden" name="{{ prefix }}bonus" value="{{ data.bonus }}">
 
     {{/unless}}
-    {{#unless singleton}}
+    {{#unless (or singleton data.base)}}
     <div class="list-controls">
         <button type="button" class="unbutton" data-action="deleteDamagePart"
                 data-tooltip="DND5E.DAMAGE.Part.Action.Delete"
@@ -31,7 +31,9 @@
     {{/unless}}
 </div>
 
-{{ formField fields.types name=(concat prefix "types") value=data.types options=typeOptions hint=false }}
+{{ formField fields.types name=(concat prefix "types") value=data.types options=typeOptions hint=false
+   disabled=data.base }}
+<!-- TODO: This disabled is only necessary because of https://github.com/foundryvtt/foundryvtt/issues/11564 -->
 
 {{#if canScale}}
 {{#with fields.scaling.fields as |fields|}}

--- a/templates/activity/parts/damage-parts.hbs
+++ b/templates/activity/parts/damage-parts.hbs
@@ -1,7 +1,9 @@
 <ul class="separated-list damage-list">
     {{#each damageParts}}
-    <li data-index="{{ @index }}">
-        {{> "systems/dnd5e/templates/activity/parts/damage-part.hbs" }}
+    <li {{~#if data.base}} class="base-part"{{/if}} data-index="{{ index }}">
+        <fieldset class="unfieldset" {{~#if data.base}} disabled{{/if}}>
+            {{> "systems/dnd5e/templates/activity/parts/damage-part.hbs" }}
+        </fieldset>
     </li>
     {{/each}}
 </ul>

--- a/templates/activity/parts/save-damage.hbs
+++ b/templates/activity/parts/save-damage.hbs
@@ -1,5 +1,5 @@
 <fieldset>
     <legend>{{ localize "DND5E.SAVE.FIELDS.damage.label" }}</legend>
-    {{ formField fields.damage.fields.onSave value=source.damage.onSave options=onSaveOptions }}
+    {{ formField fields.damage.fields.onSave value=activity.damage.onSave options=onSaveOptions }}
     {{> "systems/dnd5e/templates/activity/parts/damage-parts.hbs" }}
 </fieldset>

--- a/templates/activity/parts/save-details.hbs
+++ b/templates/activity/parts/save-details.hbs
@@ -2,7 +2,7 @@
     <legend>{{ localize "DND5E.SAVE.FIELDS.save.label" }}</legend>
     {{ formField fields.ability value=source.ability options=abilityOptions }}
     {{#with fields.save.fields.dc.fields as |fields|}}
-    {{ formField fields.calculation value=../source.save.dc.calculation options=../calculationOptions }}
+    {{ formField fields.calculation value=../activity.save.dc.calculation options=../calculationOptions }}
     {{#if (eq ../source.save.dc.calculation "custom")}}
     {{ formField fields.formula value=../source.save.dc.formula }}
     {{else}}


### PR DESCRIPTION
Infers attack type & classification from the containing item and displays a label indicating the inferred value if no overriding value is specific on the `AttackActivity`. Also displays the potential ability options that might be used for the attack.

When base damage is included, this adds the weapon's base damage to the list of parts but disables its form elements, so users can view the weapon's damage on the activity sheet.

Also fixed a bug on the `SaveSheet` causing the incorrect DC calculation value to be displayed.