### PR TITLE
[#1964] Remove activation-based preparation from items

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -430,12 +430,12 @@
     "other": "Attacks"
   },
   "FIELDS": {
-    "ability": {
-      "label": "Attack Ability",
-      "hint": "Ability used for make the attack and determine damage. Available using @mod in formulas."
-    },
     "attack": {
       "label": "Attack Details",
+      "ability": {
+        "label": "Attack Ability",
+        "hint": "Ability used for make the attack and determine damage. Available using @mod in formulas."
+      },
       "bonus": {
         "label": "To Hit Bonus",
         "hint": "Bonus added to the to hit roll for the attack."
@@ -1883,10 +1883,6 @@
     "other": "Saves"
   },
   "FIELDS": {
-    "ability": {
-      "label": "Challenge Ability",
-      "hint": "Ability that must be rolled to attempt to save."
-    },
     "damage": {
       "label": "Save Damage",
       "onSave": {
@@ -1903,6 +1899,10 @@
     },
     "save": {
       "label": "Save Details",
+      "ability": {
+        "label": "Challenge Ability",
+        "hint": "Ability that must be rolled to attempt to save."
+      },
       "dc": {
         "label": "Difficulty Class",
         "calculation": {

--- a/module/applications/activity/attack-sheet.mjs
+++ b/module/applications/activity/attack-sheet.mjs
@@ -46,7 +46,7 @@ export default class AttackSheet extends ActivitySheet {
     context.abilityOptions = [
       {
         value: "", label: game.i18n.format("DND5E.DefaultSpecific", {
-          default: this.activity.type.classification === "spell"
+          default: this.activity.attack.type.classification === "spell"
             ? game.i18n.localize("DND5E.Spellcasting").toLowerCase()
             : availableAbilities.size
               ? game.i18n.getListFormatter({ style: "short", type: "disjunction" }).format(
@@ -63,7 +63,7 @@ export default class AttackSheet extends ActivitySheet {
       }))
     ];
 
-    context.hasBaseDamage = this.item.system.damage?.base;
+    context.hasBaseDamage = this.activity._safePropertyExists(this.item.system, "damage.base");
 
     return context;
   }

--- a/module/applications/activity/attack-sheet.mjs
+++ b/module/applications/activity/attack-sheet.mjs
@@ -1,3 +1,4 @@
+import { safePropertyExists } from "../../utils.mjs";
 import ActivitySheet from "./activity-sheet.mjs";
 
 /**
@@ -63,7 +64,7 @@ export default class AttackSheet extends ActivitySheet {
       }))
     ];
 
-    context.hasBaseDamage = this.activity._safePropertyExists(this.item.system, "damage.base");
+    context.hasBaseDamage = safePropertyExists(this.item.system, "damage.base");
 
     return context;
   }

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -1,3 +1,4 @@
+import simplifyRollFormula from "../../dice/simplify-roll-formula.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
@@ -7,8 +8,8 @@ const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foun
 /**
  * Data model for an attack activity.
  *
- * @property {string} ability                     Ability used to make the attack and determine damage.
  * @property {object} attack
+ * @property {string} attack.ability              Ability used to make the attack and determine damage.
  * @property {string} attack.bonus                Arbitrary bonus added to the attack.
  * @property {object} attack.critical
  * @property {number} attack.critical.threshold   Minimum value on the D20 needed to roll a critical hit.
@@ -28,8 +29,8 @@ export default class AttackActivityData extends BaseActivityData {
   static defineSchema() {
     return {
       ...super.defineSchema(),
-      ability: new StringField(),
       attack: new SchemaField({
+        ability: new StringField(),
         bonus: new FormulaField(),
         critical: new SchemaField({
           threshold: new NumberField({ integer: true, positive: true })
@@ -52,6 +53,19 @@ export default class AttackActivityData extends BaseActivityData {
 
   /* -------------------------------------------- */
   /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get ability() {
+    const availableAbilities = this.availableAbilities;
+    if ( !availableAbilities?.size ) return null;
+    if ( availableAbilities?.size === 1 ) return availableAbilities.first();
+    const abilities = this.actor?.system.abilities ?? {};
+    return availableAbilities.reduce((largest, ability) =>
+      (abilities[ability]?.mod ?? -Infinity) > (abilities[largest]?.mod ?? -Infinity) ? ability : largest
+    , availableAbilities.first());
+  }
+
   /* -------------------------------------------- */
 
   /** @override */
@@ -100,8 +114,8 @@ export default class AttackActivityData extends BaseActivityData {
     }
 
     return foundry.utils.mergeObject(activityData, {
-      ability: source.system.ability ?? "",
       attack: {
+        ability: source.system.ability ?? "",
         bonus: source.system.attack?.bonus ?? "",
         critical: {
           threshold: source.system.critical?.threshold
@@ -126,17 +140,69 @@ export default class AttackActivityData extends BaseActivityData {
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 
-  /**
-   * Prepare data related to this activity.
-   */
+  /** @inheritDoc */
   prepareData() {
     super.prepareData();
     this.attack.type.value ||= this.item.system.attackType ?? "";
     this.attack.type.classification ||= this.item.system.attackClassification ?? "";
-    if ( this.damage.includeBase && this.item.system.damage?.base?.formula ) {
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareFinalData(rollData) {
+    if ( this.damage.includeBase && this._safePropertyExists(this.item.system, "damage.base")
+      && this.item.system.damage.base.formula ) {
       const basePart = this.item.system.damage.base.clone();
       basePart.base = true;
       this.damage.parts.unshift(basePart);
     }
+
+    rollData ??= this.getRollData({ deterministic: true });
+    super.prepareFinalData(rollData);
+    this.prepareDamageLabel(this.damage.parts, rollData);
+
+    const { data, parts } = this.getAttackData();
+    const roll = new Roll(parts.join("+"), data);
+    this.labels.modifier = simplifyRollFormula(roll.formula, { deterministic: true }) || "0";
+    const formula = simplifyRollFormula(roll.formula) || "0";
+    this.labels.toHit = !/^[+-]/.test(formula) ? `+ ${formula}` : formula;
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Get the roll parts used to create to the attack roll.
+   * @returns {{ data: object, parts: string[] }}
+   */
+  getAttackData() {
+    const data = this.getRollData();
+    const parts = [];
+    const item = this.item.system;
+
+    if ( this.actor && !this.attack.flat ) {
+      // Ability modifier & proficiency bonus
+      if ( this.attack.ability !== "none" ) parts.push("@mod");
+      if ( item.prof?.hasProficiency ) {
+        parts.push("@prof");
+        data.prof = item.prof.term;
+      }
+
+      // Actor-level global bonus to attack rolls
+      const actorBonus = this.actor.system.bonuses?.[this.actionType];
+      if ( actorBonus?.attack ) parts.push(actorBonus.attack);
+
+      // TODO: Ammunition
+    }
+
+    // Include the activity's attack bonus & item's magical bonus
+    if ( this.attack.bonus ) parts.push(this.attack.bonus);
+    if ( item.magicalBonus && item.magicAvailable && !this.attack.flat ) parts.push(item.magicalBonus);
+
+    // TODO: One-time ammunition bonus
+
+    return { data, parts };
   }
 }

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -1,4 +1,5 @@
 import simplifyRollFormula from "../../dice/simplify-roll-formula.mjs";
+import { safePropertyExists } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
@@ -151,7 +152,7 @@ export default class AttackActivityData extends BaseActivityData {
 
   /** @inheritDoc */
   prepareFinalData(rollData) {
-    if ( this.damage.includeBase && this._safePropertyExists(this.item.system, "damage.base")
+    if ( this.damage.includeBase && safePropertyExists(this.item.system, "damage.base")
       && this.item.system.damage.base.formula ) {
       const basePart = this.item.system.damage.base.clone();
       basePart.base = true;

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -1,3 +1,4 @@
+import simplifyRollFormula from "../../dice/simplify-roll-formula.mjs";
 import { formatNumber, staticID } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import ActivationField from "../shared/activation-field.mjs";
@@ -116,6 +117,16 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /* -------------------------------------------- */
   /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The primary ability for this activity that will be available as `@mod` in roll data.
+   * @type {string|null}
+   */
+  get ability() {
+    return null;
+  }
+
   /* -------------------------------------------- */
 
   /**
@@ -396,15 +407,18 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   prepareData() {
     this.name = this.name || game.i18n.localize(this.metadata?.title);
     this.img = this.img || this.metadata?.img;
+    this.labels ??= {};
   }
 
   /* -------------------------------------------- */
 
   /**
    * Perform final preparation after containing item is prepared.
-   * @param {object} rollData  Deterministic roll data from the item.
+   * @param {object} [rollData]  Deterministic roll data from the activity.
    */
   prepareFinalData(rollData) {
+    rollData ??= this.getRollData({ deterministic: true });
+
     this._setOverride("activation");
     this._setOverride("duration");
     this._setOverride("range");
@@ -417,11 +431,11 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       writable: false
     });
 
-    ActivationField.prepareData.call(this, rollData);
-    DurationField.prepareData.call(this, rollData);
-    RangeField.prepareData.call(this, rollData);
-    TargetField.prepareData.call(this, rollData);
-    UsesField.prepareData.call(this, rollData);
+    ActivationField.prepareData.call(this, rollData, this.labels);
+    DurationField.prepareData.call(this, rollData, this.labels);
+    RangeField.prepareData.call(this, rollData, this.labels);
+    TargetField.prepareData.call(this, rollData, this.labels);
+    UsesField.prepareData.call(this, rollData, this.labels);
 
     const actor = this.item.actor;
     if ( !actor ) return;
@@ -440,6 +454,42 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
         actor._preparationWarnings.push({ message, link: this.uuid, type: "warning" });
       }
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the label for a compiled and simplified damage formula.
+   * @param {DamageData[]} parts  Damage parts to create labels for.
+   * @param {object} rollData     Deterministic roll data from the item.
+   */
+  prepareDamageLabel(parts, rollData) {
+    this.labels.damage = parts.map(part => {
+      let formula;
+      try {
+        formula = part.formula;
+        if ( part.base && this.item.system.magicAvailable ) {
+          formula = `${formula} + ${this.item.system.magicalBonus ?? 0}`;
+        }
+        const roll = new Roll(formula, rollData);
+        formula = simplifyRollFormula(roll.formula, { preserveFlavor: true });
+      } catch(err) {
+        console.warn(`Unable to simplify formula for ${this.name} in item ${this.item.name}${
+          this.actor ? ` on ${this.actor.name} (${this.actor.id})` : ""
+        } (${this.uuid})`, err);
+      }
+
+      let label = formula;
+      if ( part.types.size ) {
+        label = `${formula} ${game.i18n.getListFormatter({ type: "conjunction" }).format(
+          Array.from(part.types)
+            .map(p => CONFIG.DND5E.damageTypes[p]?.label ?? CONFIG.DND5E.healingTypes[p]?.label)
+            .filter(t => t)
+        )}`;
+      }
+
+      return { formula, damageType: part.types.size === 1 ? part.types.first() : null, label };
+    });
   }
 
   /* -------------------------------------------- */
@@ -467,13 +517,33 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   _setOverride(keyPath) {
     const obj = foundry.utils.getProperty(this, keyPath);
     Object.defineProperty(obj, "canOverride", {
-      value: foundry.utils.hasProperty(this.item.system, keyPath),
+      value: this._safePropertyExists(this.item.system, keyPath),
       configurable: true,
       enumerable: false
     });
     if ( obj.canOverride && !obj.override ) {
       foundry.utils.mergeObject(obj, foundry.utils.getProperty(this.item.system, keyPath));
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Check whether an object exists without triggering potential deprecation warnings.
+   * This can be removed in DnD5e 4.4 when the data shims are removed.
+   * @param {object} object
+   * @param {string} keyPath
+   * @returns {boolean}
+   * @internal
+   */
+  _safePropertyExists(object, keyPath) {
+    const parts = keyPath.split(".");
+    for ( const part of parts ) {
+      const descriptor = Object.getOwnPropertyDescriptor(object, part);
+      if ( !descriptor || !("value" in descriptor) ) return false;
+      object = object[part];
+    }
+    return true;
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -1,5 +1,5 @@
 import simplifyRollFormula from "../../dice/simplify-roll-formula.mjs";
-import { formatNumber, staticID } from "../../utils.mjs";
+import { formatNumber, safePropertyExists, staticID } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import ActivationField from "../shared/activation-field.mjs";
 import DurationField from "../shared/duration-field.mjs";
@@ -517,33 +517,13 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   _setOverride(keyPath) {
     const obj = foundry.utils.getProperty(this, keyPath);
     Object.defineProperty(obj, "canOverride", {
-      value: this._safePropertyExists(this.item.system, keyPath),
+      value: safePropertyExists(this.item.system, keyPath),
       configurable: true,
       enumerable: false
     });
     if ( obj.canOverride && !obj.override ) {
       foundry.utils.mergeObject(obj, foundry.utils.getProperty(this.item.system, keyPath));
     }
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Check whether an object exists without triggering potential deprecation warnings.
-   * This can be removed in DnD5e 4.4 when the data shims are removed.
-   * @param {object} object
-   * @param {string} keyPath
-   * @returns {boolean}
-   * @internal
-   */
-  _safePropertyExists(object, keyPath) {
-    const parts = keyPath.split(".");
-    for ( const part of parts ) {
-      const descriptor = Object.getOwnPropertyDescriptor(object, part);
-      if ( !descriptor || !("value" in descriptor) ) return false;
-      object = object[part];
-    }
-    return true;
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/damage-data.mjs
+++ b/module/data/activity/damage-data.mjs
@@ -44,4 +44,15 @@ export default class DamageActivityData extends BaseActivityData {
       }
     });
   }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareFinalData(rollData) {
+    rollData ??= this.getRollData({ deterministic: true });
+    super.prepareFinalData(rollData);
+    this.prepareDamageLabel(this.damage.parts, rollData);
+  }
 }

--- a/module/data/activity/heal-data.mjs
+++ b/module/data/activity/heal-data.mjs
@@ -25,4 +25,15 @@ export default class HealActivityData extends BaseActivityData {
       healing: this.transformDamagePartData(source, source.system.damage?.parts?.[0] ?? ["", ""])
     });
   }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareFinalData(rollData) {
+    rollData ??= this.getRollData({ deterministic: true });
+    super.prepareFinalData(rollData);
+    this.prepareDamageLabel([this.healing], rollData);
+  }
 }

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -108,18 +108,8 @@ export default class SaveActivityData extends BaseActivityData {
     this.prepareDamageLabel(this.damage.parts, rollData);
 
     let ability;
-    switch ( this.save.dc.calculation ) {
-      case "custom":
-        this.save.dc.value = simplifyBonus(this.save.dc.formula, rollData);
-        break;
-      case "spellcasting":
-        ability = this.isSpell ? this.item.system.availableAbilities?.first() : null;
-        ability ??= this.actor?.system.attributes?.spellcasting;
-        break;
-      default:
-        ability = this.save.dc.calculation;
-        break;
-    }
+    if ( this.save.dc.calculation === "custom" ) this.save.dc.value = simplifyBonus(this.save.dc.formula, rollData);
+    else ability = this.ability;
     if ( ability ) this.save.dc.value = this.actor?.system.abilities?.[ability]?.dc
       ?? 8 + (this.actor?.system.attributes?.prof ?? 0);
 

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -70,6 +70,13 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  prepareFinalData() {
+    this.isOriginalClass = this.parent.isOriginalClass;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   async getFavoriteData() {
     const context = await super.getFavoriteData();
     if ( this.parent.subclass ) context.subtitle = this.parent.subclass.name;

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -174,6 +174,9 @@ export default class EquipmentData extends ItemDataModel.mixin(
     this.armor.value = (this._source.armor.value ?? 0) + (this.magicAvailable ? (this.armor.magicalBonus ?? 0) : 0);
     this.type.label = CONFIG.DND5E.equipmentTypes[this.type.value]
       ?? game.i18n.localize(CONFIG.Item.typeLabels.equipment);
+
+    const labels = this.parent.labels ??= {};
+    labels.armor = this.armor.value ? `${this.armor.value} ${game.i18n.localize("DND5E.AC")}` : "";
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -84,6 +84,16 @@ export default class FeatData extends ItemDataModel.mixin(
       if ( config ) this.type.label = config.subtypes?.[this.type.subtype] ?? null;
       else this.type.label = game.i18n.localize(CONFIG.Item.typeLabels.feat);
     }
+
+    let label;
+    const activation = this.activities.contents[0]?.activation.type;
+    if ( activation === "legendary" ) label = game.i18n.localize("DND5E.LegendaryActionLabel");
+    else if ( activation === "lair" ) label = game.i18n.localize("DND5E.LairActionLabel");
+    else if ( activation === "action" && this.hasAttack ) label = game.i18n.localize("DND5E.Attack");
+    else if ( activation ) label = game.i18n.localize("DND5E.Action");
+    else label = game.i18n.localize("DND5E.Passive");
+    this.parent.labels ??= {};
+    this.parent.labels.featType = label;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -256,9 +256,9 @@ export default class ActivitiesTemplate extends SystemDataModel {
    * @param {object} rollData
    */
   prepareFinalActivityData(rollData) {
-    const labels = this.parent.labels ?? {};
+    const labels = this.parent.labels ??= {};
     UsesField.prepareData.call(this, rollData, labels);
-    for ( const activity of this.activities ) activity.prepareFinalData(rollData);
+    for ( const activity of this.activities ) activity.prepareFinalData();
   }
 
   /* -------------------------------------------- */
@@ -373,7 +373,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
       },
       hasAreaTarget: () => this.isActive && this.target.template?.type,
       hasIndividualTarget: () => this.isActive && this.target.affects?.type,
-      hasResource: () => this.isActive && !!consume.target && !!consume.type && !this.hasAttack,
+      hasResource: () => this.isActive && !!this.consume.target && !!this.consume.type && !this.hasAttack,
       hasScalarDuration: () => this.duration.units in CONFIG.DND5E.scalarTimePeriods,
       hasScalarRange: () => this.range.units in CONFIG.DND5E.movementUnits,
       hasScalarTarget: () => this.target.template?.type || ![null, "", "self"].includes(this.target.affects?.type),

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -161,6 +161,13 @@ export default class WeaponData extends ItemDataModel.mixin(
     ActivitiesTemplate._applyActivityShims.call(this);
     super.prepareDerivedData();
     this.type.label = CONFIG.DND5E.weaponTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.weapon);
+
+    const labels = this.parent.labels ??= {};
+    labels.armor = this.armor.value ? `${this.armor.value} ${game.i18n.localize("DND5E.AC")}` : "";
+    labels.damage = this.damage.base.formula;
+    labels.damageTypes = game.i18n.getListFormatter({ style: "narrow" }).format(
+      Array.from(this.damage.base.types).map(t => CONFIG.DND5E.damageTypes[t]?.label).filter(t => t)
+    );
   }
 
   /* -------------------------------------------- */

--- a/module/data/shared/activation-field.mjs
+++ b/module/data/shared/activation-field.mjs
@@ -29,7 +29,7 @@ export default class ActivationField extends SchemaField {
    * @param {object} [labels]  Object in which to insert generated labels.
    */
   static prepareData(rollData, labels) {
-    this.activation.scalar = CONFIG.DND5E.activityActivationTypes[this.type]?.scalar ?? false;
+    this.activation.scalar = CONFIG.DND5E.activityActivationTypes[this.activation.type]?.scalar ?? false;
     if ( !this.activation.scalar ) this.activation.value = null;
 
     if ( labels && this.activation.type ) {

--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -32,7 +32,7 @@ export default class DurationField extends SchemaField {
    * @param {object} [labels]  Object in which to insert generated labels.
    */
   static prepareData(rollData, labels) {
-    this.duration.scalar = this.units in CONFIG.DND5E.scalarTimePeriods;
+    this.duration.scalar = this.duration.units in CONFIG.DND5E.scalarTimePeriods;
     if ( this.duration.scalar ) {
       prepareFormulaValue(this, "duration.value", "DND5E.DURATION.FIELDS.duration.value.label", rollData);
     } else this.duration.value = null;
@@ -41,6 +41,7 @@ export default class DurationField extends SchemaField {
       let duration = CONFIG.DND5E.timePeriods[this.duration.units] ?? "";
       if ( this.duration.value ) duration = `${this.duration.value} ${duration.toLowerCase()}`;
       labels.duration = duration;
+      // TODO: Allow activities to indicate they require concentration regardless of the base item
       labels.concentrationDuration = this.properties?.has("concentration")
         ? game.i18n.format("DND5E.ConcentrationDuration", { duration }) : duration;
     }

--- a/module/data/shared/range-field.mjs
+++ b/module/data/shared/range-field.mjs
@@ -32,7 +32,7 @@ export default class RangeField extends SchemaField {
    * @param {object} [labels]  Object in which to insert generated labels.
    */
   static prepareData(rollData, labels) {
-    this.range.scalar = this.units in CONFIG.DND5E.movementUnits;
+    this.range.scalar = this.range.units in CONFIG.DND5E.movementUnits;
     if ( this.range.scalar ) {
       prepareFormulaValue(this, "range.value", "DND5E.RANGE.FIELDS.range.value.label", rollData);
     } else this.range.value = null;

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -54,7 +54,7 @@ export default class TargetField extends SchemaField {
    * @param {object} [labels]  Object in which to insert generated labels.
    */
   static prepareData(rollData, labels) {
-    this.target.affects.scalar = !["", "self", "any"].includes(this.type);
+    this.target.affects.scalar = !["", "self", "any"].includes(this.target.affects.type);
     if ( this.target.affects.scalar ) {
       prepareFormulaValue(this, "target.affects.count", "DND5E.TARGET.FIELDS.target.affects.count.label", rollData);
     } else this.target.affects.count = null;

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -50,6 +50,7 @@ export default class UsesField extends SchemaField {
     prepareFormulaValue(this, "uses.max", "DND5E.USES.FIELDS.uses.max.label", rollData);
     this.uses.value = Math.clamp(this.uses.max - this.uses.spent, 0, this.uses.max);
 
+    const periods = [];
     for ( const recovery of this.uses.recovery ) {
       if ( recovery.period === "recharge" ) {
         recovery.type = "recoverAll";
@@ -63,7 +64,11 @@ export default class UsesField extends SchemaField {
         };
         if ( labels ) labels.recharge ??= `${game.i18n.localize("DND5E.Recharge")} [${
           recovery.formula}${parseInt(recovery.formula) < 6 ? "+" : ""}]`;
+      } else if ( recovery.period in CONFIG.DND5E.limitedUsePeriods ) {
+        const config = CONFIG.DND5E.limitedUsePeriods[recovery.period];
+        periods.push(config.abbreviation ?? config.label);
       }
     }
+    if ( labels ) labels.recovery = game.i18n.getListFormatter({ style: "narrow" }).format(periods);
   }
 }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -685,6 +685,8 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @returns {object}
    */
   getRollData(options) {
-    return this.item.getRollData(options);
+    const rollData = this.item.getRollData(options);
+    rollData.mod = this.actor?.system.abilities?.[this.ability]?.mod ?? 0;
+    return rollData;
   }
 };

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -218,6 +218,24 @@ export function filteredKeys(obj, filter) {
 /* -------------------------------------------- */
 
 /**
+ * Check whether an object exists without transversing any getters, preventing any deprecation warnings from triggering.
+ * @param {object} object
+ * @param {string} keyPath
+ * @returns {boolean}
+ */
+export function safePropertyExists(object, keyPath) {
+  const parts = keyPath.split(".");
+  for ( const part of parts ) {
+    const descriptor = Object.getOwnPropertyDescriptor(object, part);
+    if ( !descriptor || !("value" in descriptor) ) return false;
+    object = object[part];
+  }
+  return true;
+}
+
+/* -------------------------------------------- */
+
+/**
  * Sort the provided object by its values or by an inner sortKey.
  * @param {object} obj                 The object to sort.
  * @param {string|Function} [sortKey]  An inner key upon which to sort or sorting function.

--- a/templates/activity/parts/attack-details.hbs
+++ b/templates/activity/parts/attack-details.hbs
@@ -1,7 +1,7 @@
 <fieldset>
     <legend>{{ localize "DND5E.ATTACK.FIELDS.attack.label" }}</legend>
-    {{ formField fields.ability value=source.ability options=abilityOptions }}
     {{#with fields.attack.fields as |fields|}}
+    {{ formField fields.ability value=../source.attack.ability options=../abilityOptions }}
     {{ formField fields.bonus value=../source.attack.bonus }}
     {{ formField fields.flat value=../source.attack.flat }}
     {{ formField fields.critical.fields.threshold value=../source.attack.critical.threshold }}

--- a/templates/activity/parts/save-details.hbs
+++ b/templates/activity/parts/save-details.hbs
@@ -1,6 +1,6 @@
 <fieldset>
     <legend>{{ localize "DND5E.SAVE.FIELDS.save.label" }}</legend>
-    {{ formField fields.ability value=source.ability options=abilityOptions }}
+    {{ formField fields.save.fields.ability value=source.save.ability options=abilityOptions }}
     {{#with fields.save.fields.dc.fields as |fields|}}
     {{ formField fields.calculation value=../activity.save.dc.calculation options=../calculationOptions }}
     {{#if (eq ../source.save.dc.calculation "custom")}}


### PR DESCRIPTION
This should resolve any data preparation warnings caused by data that has been moved into activities. This means that most labels are now generated on an activity's `label` object rather than on the item, unless it is something like a spell or weapon that has certain intrinsic data.

The handfull of type-specific label generation that is left on items has been moved into data models to clean up `Item5e`.

The `ability` data for `AttackActivity` and `SaveActivity` has been moved into the `attack` and `save` objects respectively to make room at the top level for an `ability` getter which is used to set `@mod` in roll data.

A number of the getters on `Item5e` have been marked as deprecated if they call into deprecated getters on the data model.