### PR TITLE
[#1964] Add buttons to activity messages, rollFormula for Utility

### DIFF
--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -707,7 +707,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    */
   activateChatListeners(message, html) {
     html.addEventListener("click", event => {
-      const target = event.target.closest("[data-action");
+      const target = event.target.closest("[data-action]");
       if ( target ) this.#onChatAction(event, target, message);
     });
   }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -14,7 +14,9 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @property {string} type                              Type name of this activity.
    * @property {string} img                               Default icon.
    * @property {string} title                             Default title.
+   * @property {typeof ActivitySheet} sheetClass          Sheet class used to configure this activity.
    * @property {object} usage
+   * @property {Record<string, Function>} usage.actions   Actions that can be triggered from the chat card.
    * @property {string} usage.chatCard                    Template used to render the chat card.
    * @property {typeof ActivityUsageDialog} usage.dialog  Default usage prompt.
    */
@@ -26,6 +28,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   static metadata = Object.freeze({
     name: "Activity",
     usage: {
+      actions: {},
       chatCard: "systems/dnd5e/templates/chat/activity-card.hbs",
       dialog: ActivityUsageDialog
     }
@@ -202,6 +205,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       data: {
         flags: {
           dnd5e: {
+            messageType: "usage",
             activity: { type: this.type, id: this.id, uuid: this.uuid },
             item: { type: this.item.type, id: this.item.id, uuid: this.item.uuid }
           }
@@ -594,12 +598,31 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       actor: this.item.actor,
       item: this.item,
       token: this.item.actor?.token,
-      buttons: null,
+      buttons: this._usageChatButtons(),
       description: data.description.chat,
       properties: properties.length ? properties : null,
       subtitle: this.description.chatFlavor ?? data.subtitle,
       supplements
     };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * @typedef {object} ActivityUsageChatButton
+   * @property {string} label    Label to display on the button.
+   * @property {string} icon     Icon to display on the button.
+   * @property {string} classes  Classes for the button.
+   * @property {object} dataset  Data attributes attached to the button.
+   */
+
+  /**
+   * Create the buttons that will be displayed in chat.
+   * @returns {ActivityUsageChatButton[]|null}
+   * @protected
+   */
+  _usageChatButtons() {
+    return null;
   }
 
   /* -------------------------------------------- */
@@ -672,6 +695,49 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       }
     }
   }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Activate listeners on a chat message.
+   * @param {ChatMessage} message  Associated chat message.
+   * @param {HTMLElement} html     Element in the chat log.
+   */
+  activateChatListeners(message, html) {
+    html.addEventListener("click", event => {
+      const target = event.target.closest("[data-action");
+      if ( target ) this.#onChatAction(event, target, message);
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle an action activated from an activity's chat message.
+   * @param {PointerEvent} event     Triggering click event.
+   * @param {HTMLElement} target     The capturing HTML element which defined a [data-action].
+   * @param {ChatMessage5e} message  Message associated with the activation.
+   */
+  async #onChatAction(event, target, message) {
+    const action = target.dataset.action;
+    const handler = this.metadata.usage?.actions?.[action];
+    if ( handler ) handler.call(this, event, target, message);
+    else this._onChatAction(event, target);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle an action activated from an activity's chat message. Action handlers in metadata are called first.
+   * This method is only called for actions which have no defined handler.
+   * @param {PointerEvent} event     Triggering click event.
+   * @param {HTMLElement} target     The capturing HTML element which defined a [data-action].
+   * @param {ChatMessage5e} message  Message associated with the activation.
+   * @protected
+   */
+  async _onChatAction(event, target, message) {}
 
   /* -------------------------------------------- */
   /*  Helpers                                     */

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -21,7 +21,129 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
       type: "utility",
       img: "systems/dnd5e/icons/svg/activity/utility.svg",
       title: "DND5E.UTILITY.Title",
-      sheetClass: UtilitySheet
+      sheetClass: UtilitySheet,
+      usage: {
+        actions: {
+          rollFormula: UtilityActivity.#rollFormula
+        }
+      }
     }, { inplace: false })
   );
+
+  /* -------------------------------------------- */
+  /*  Activation                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _usageChatButtons() {
+    if ( !this.roll.formula ) return null;
+    return [{
+      label: this.roll.label || game.i18n.localize("DND5E.Roll"),
+      icon: '<i class="fa-solid fa-dice" inert></i>',
+      dataset: {
+        action: "rollFormula"
+      }
+    }];
+  }
+
+  /* -------------------------------------------- */
+  /*  Rolling                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Roll the formula attached to this utility.
+   * @param {BasicRollProcessConfiguration} [config]   Configuration information for the roll.
+   * @param {BasicRollDialogConfiguration} [dialog]    Configuration for the roll dialog.
+   * @param {BasicRollMessageConfiguration} [message]  Configuration for the roll message.
+   * @returns {Promise<BasicRoll[]|void>}              The created Roll instances.
+   */
+  async rollFormula(config={}, dialog={}, message={}) {
+    if ( !this.roll.formula ) {
+      console.warn(`No formula defined for the activity ${this.name} on ${this.item.name} (${this.uuid}).`);
+      return;
+    }
+
+    const rollConfig = foundry.utils.deepClone(config);
+    rollConfig.rolls = [{ parts: [this.roll.formula], data: this.getRollData() }].concat(config.rolls ?? []);
+
+    const dialogConfig = foundry.utils.mergeObject({
+      configure: true
+    }, dialog);
+
+    const messageConfig = foundry.utils.mergeObject({
+      create: true,
+      data: {
+        flavor: `${this.item.name} - ${this.roll.label || game.i18n.localize("DND5E.OtherFormula")}`,
+        flags: {
+          dnd5e: {
+            messageType: "roll",
+            activity: { type: this.type, id: this.id, uuid: this.uuid },
+            item: { type: this.item.type, id: this.item.id, uuid: this.item.uuid }
+          }
+        }
+      }
+    });
+
+    /**
+     * A hook event that fires before a formula is rolled for an Utility activity.
+     * @function dnd5e.preRollFormulaV2
+     * @memberof hookEvents
+     * @param {UtilityActivity} activity               The activity performing the roll.
+     * @param {BasicRollProcessConfiguration} config   Configuration information for the roll.
+     * @param {BasicRollDialogConfiguration} dialog    Configuration for the roll dialog.
+     * @param {BasicRollMessageConfiguration} message  Configuration for the roll message.
+     * @returns {boolean}                   Explicitly return `false` to prevent the roll from being performed.
+     */
+    if ( Hooks.call("dnd5e.preRollFormulaV2", this, rollConfig, dialogConfig, messageConfig) === false ) return;
+
+    if ( "dnd5e.preRollFormula" in Hooks.events ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `dnd5e.preRollFormula` hook has been deprecated and replaced with `dnd5e.preRollFormulaV2`.",
+        { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+      );
+      const hookData = {
+        formula: rollConfig.rolls[0].parts[0], data: rollConfig.rolls[0].data, chatMessage: messageConfig.create
+      };
+      if ( Hooks.call("dnd5e.preRollFormula", this.item, hookData) === false ) return;
+      rollConfig.rolls[0].parts[0] = hookData.formula;
+      rollConfig.rolls[0].data = hookData.data;
+      messageConfig.create = hookData.chatMessage;
+    }
+
+    const rolls = await CONFIG.Dice.BasicRoll.build(rollConfig, dialogConfig, messageConfig);
+
+    /**
+     * A hook event that fires after a hit die has been rolled for an Actor, but before updates have been performed.
+     * @function dnd5e.rollFormulaV2
+     * @memberof hookEvents
+     * @param {UtilityActivity} activity  The activity that performed the roll.
+     * @param {BasicRoll[]} rolls         The resulting rolls.
+     */
+    Hooks.callAll("dnd5e.rollFormulaV2", this, rolls);
+
+    if ( "dnd5e.rollFormula" in Hooks.events ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `dnd5e.rollFormula` hook has been deprecated and replaced with `dnd5e.rollFormulaV2`.",
+        { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+      );
+      Hooks.callAll("dnd5e.rollFormula", this.item, rolls[0]);
+    }
+
+    return rolls;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle rolling the formula attached to this utility.
+   * @this {UtilityActivity}
+   * @param {PointerEvent} event     Triggering click event.
+   * @param {HTMLElement} target     The capturing HTML element which defined a [data-action].
+   * @param {ChatMessage5e} message  Message associated with the activation.
+   */
+  static #rollFormula(event, target, message) {
+    this.rollFormula({ event });
+  }
 }

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -66,9 +66,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
     const rollConfig = foundry.utils.deepClone(config);
     rollConfig.rolls = [{ parts: [this.roll.formula], data: this.getRollData() }].concat(config.rolls ?? []);
 
-    const dialogConfig = foundry.utils.mergeObject({
-      configure: true
-    }, dialog);
+    const dialogConfig = foundry.utils.mergeObject({ configure: true }, dialog);
 
     const messageConfig = foundry.utils.mergeObject({
       create: true,

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2078,7 +2078,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     /**
      * A hook event that fires before a hit die is rolled for an Actor.
-     * @function dnd5e.preRollHitDie
+     * @function dnd5e.preRollHitDieV2
      * @memberof hookEvents
      * @param {Actor5e} actor                          Actor performing the roll.
      * @param {HitDieRollProcessConfiguration} config  Configuration information for the roll.
@@ -2120,7 +2120,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     /**
      * A hook event that fires after a hit die has been rolled for an Actor, but before updates have been performed.
-     * @function dnd5e.rollHitDie
+     * @function dnd5e.rollHitDieV2
      * @memberof hookEvents
      * @param {Actor5e} actor           Actor for which the hit die has been rolled.
      * @param {BasicRoll[]} rolls       The resulting rolls.

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -76,6 +76,7 @@ export default class ChatMessage5e extends ChatMessage {
 
     this._enrichChatCard(html[0]);
     this._collapseTrays(html[0]);
+    this._activateActivityListeners(html[0]);
 
     /**
      * A hook event that fires after dnd5e-specific chat message modifications have completed.
@@ -595,6 +596,18 @@ export default class ChatMessage5e extends ChatMessage {
   /* -------------------------------------------- */
 
   /**
+   * Add event listeners for chat messages created from activities.
+   * @param {HTMLElement} html  The chat message HTML.
+   */
+  _activateActivityListeners(html) {
+    if ( !this.getFlag("dnd5e", "activity") ) return;
+    const activity = this.getAssociatedActivity();
+    activity?.activateChatListeners(this, html);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Handle target selection and panning.
    * @param {Event} event   The triggering event.
    * @returns {Promise}     A promise that resolves once the canvas pan has completed.
@@ -748,6 +761,16 @@ export default class ChatMessage5e extends ChatMessage {
 
   /* -------------------------------------------- */
   /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Get the Activity that created this chat card.
+   * @returns {Activity|void}
+   */
+  getAssociatedActivity() {
+    return fromUuidSync(this.getFlag("dnd5e", "activity.uuid"));
+  }
+
   /* -------------------------------------------- */
 
   /**

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -600,9 +600,7 @@ export default class ChatMessage5e extends ChatMessage {
    * @param {HTMLElement} html  The chat message HTML.
    */
   _activateActivityListeners(html) {
-    if ( !this.getFlag("dnd5e", "activity") ) return;
-    const activity = this.getAssociatedActivity();
-    activity?.activateChatListeners(this, html);
+    this.getAssociatedActivity()?.activateChatListeners(this, html);
   }
 
   /* -------------------------------------------- */

--- a/templates/chat/activity-card.hbs
+++ b/templates/chat/activity-card.hbs
@@ -18,7 +18,9 @@
     {{#if buttons}}
     <div class="card-buttons">
         {{#each buttons}}
-        <button type="button" name="{{ @key }}" {{ dnd5e-dataset dataset }}>{{{ label }}}</button>
+        <button type="button" name="{{ @key }}" {{ dnd5e-dataset dataset }}>
+            {{{ icon }}} {{{ label }}}
+        </button>
         {{/each}}
     </div>
     {{/if}}

--- a/templates/chat/activity-card.hbs
+++ b/templates/chat/activity-card.hbs
@@ -19,7 +19,7 @@
     <div class="card-buttons">
         {{#each buttons}}
         <button type="button" name="{{ @key }}" {{ dnd5e-dataset dataset }}>
-            {{{ icon }}} {{{ label }}}
+            {{{ icon }}} <span>{{{ label }}}</span>
         </button>
         {{/each}}
     </div>


### PR DESCRIPTION
Buttons created in chat messages through activities can now take `[data-action]` parameters which will automatically call handlers defined in the activity's metadata.

The `UtilityActivity` now has a rolling button which calls the `rollFormula` method, duplicating the functionality of the old method from `Item5e` using the new rolling API.

The old `rollFormula` method has been deprecated and will call the new method provided a `UtilityActivity` is present on the item.