### PR TITLE
[#1964] Migrate chat message flags to new structure, add shims

### DIFF
--- a/module/applications/item/ability-use-dialog.mjs
+++ b/module/applications/item/ability-use-dialog.mjs
@@ -127,7 +127,7 @@ export default class AbilityUseDialog extends Dialog {
   static _createConcentrationOptions(item) {
     const { effects } = item.actor.concentration;
     return effects.reduce((acc, effect) => {
-      const data = effect.getFlag("dnd5e", "itemData");
+      const data = effect.getFlag("dnd5e", "item.data");
       acc.push({
         name: effect.id,
         label: data?.name ?? item.actor.items.get(data)?.name ?? game.i18n.localize("DND5E.ConcentratingItemless")

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -533,7 +533,7 @@ export default class ActiveEffect5e extends ActiveEffect {
         type: game.i18n.localize(`TYPES.Item.${item.type}`)
       }),
       duration: ActiveEffect5e.getEffectDurationFromItem(item),
-      "flags.dnd5e.itemData": item.actor.items.has(item.id) ? item.id : item.toObject(),
+      "flags.dnd5e.item.data": item.actor.items.has(item.id) ? item.id : item.toObject(),
       origin: item.uuid,
       statuses: [statusEffect.id].concat(statusEffect.statuses ?? [])
     }, data, {inplace: false});
@@ -662,7 +662,7 @@ export default class ActiveEffect5e extends ActiveEffect {
       return;
     }
     const choices = effects.reduce((acc, effect) => {
-      const data = effect.getFlag("dnd5e", "itemData");
+      const data = effect.getFlag("dnd5e", "item.data");
       acc[effect.id] = data?.name ?? actor.items.get(data)?.name ?? game.i18n.localize("DND5E.ConcentratingItemless");
       return acc;
     }, {});

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -202,6 +202,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       data: {
         flags: {
           dnd5e: {
+            messageType: "usage",
             activity: { type: this.type, id: this.id, uuid: this.uuid },
             item: { type: this.item.type, id: this.item.id, uuid: this.item.uuid }
           }
@@ -509,7 +510,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       const { effects } = this.actor.concentration;
       const limit = this.actor.system.attributes?.concentration?.limit ?? 0;
       if ( limit && (limit <= effects.size) ) config.concentration.end = effects.find(e => {
-        const data = e.flags.dnd5e?.itemData ?? {};
+        const data = e.flags.dnd5e?.item?.data ?? {};
         return (data === this.id) || (data._id === this.id);
       })?.id ?? effects.first()?.id ?? null;
     }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -133,7 +133,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     for ( const effect of this.effects ) {
       if ( !effect.statuses.has(CONFIG.specialStatusEffects.CONCENTRATING) ) continue;
-      const data = effect.getFlag("dnd5e", "itemData");
+      const data = effect.getFlag("dnd5e", "item.data");
       concentration.effects.add(effect);
       if ( data ) {
         const item = typeof data === "string"
@@ -1214,7 +1214,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     else if ( target instanceof ActiveEffect5e ) effect = effects.has(target) ? target : null;
     else if ( target instanceof Item5e ) {
       effect = effects.find(e => {
-        const data = e.getFlag("dnd5e", "itemData") ?? {};
+        const data = e.getFlag("dnd5e", "item.data") ?? {};
         return (data === target._id) || (data._id === target._id);
       });
     }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1908,7 +1908,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       if ( !( isTargetted || game.user.isGM || actor.isOwner ) ) return;
 
       // Get the Item from stored flag data or by the item ID on the Actor
-      const storedData = message.getFlag("dnd5e", "itemData");
+      const storedData = message.getFlag("dnd5e", "item.data");
       let item = storedData ? new this(storedData, {parent: actor}) : actor.items.get(card.dataset.itemId);
       if ( !item ) {
         ui.notifications.error(game.i18n.format("DND5E.ActionWarningNoItem", {


### PR DESCRIPTION
Migrates the old chat usage chat flags (`itemData` and `use`) to a new data structure to better support activities and provide shims for accessing the data from the old locations.