### PR TITLE
[#3910] Move rollAttack to AttackActivity

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -101,6 +101,23 @@ export default class AttackActivityData extends BaseActivityData {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Critical threshold for attacks with this activity.
+   * @type {number}
+   */
+  get criticalThreshold() {
+    let ammoThreshold;
+    // TODO: Fetch threshold from ammo
+    const threshold = Math.min(
+      this.attack.critical.threshold ?? Infinity,
+      this.item.system.criticalThreshold ?? Infinity,
+      ammoThreshold ?? Infinity
+    );
+    return threshold < Infinity ? threshold : 20;
+  }
+
+  /* -------------------------------------------- */
   /*  Data Migrations                             */
   /* -------------------------------------------- */
 

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -279,8 +279,8 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
 
   /* -------------------------------------------- */
 
-  /** @inheritdoc */
-  get _typeCriticalThreshold() {
+  /** @override */
+  get criticalThreshold() {
     return this.parent?.actor?.flags.dnd5e?.spellCriticalThreshold ?? Infinity;
   }
 

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -47,30 +47,11 @@ export default class ActivitiesTemplate extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
-   * What is the critical hit threshold for this item? Uses the smallest value from among the following sources:
-   *  - `critical.threshold` defined on the item
-   *  - `critical.threshold` defined on ammunition, if consumption mode is set to ammo
-   *  - Type-specific critical threshold
+   * Value on a d20 die needed to roll a critical hit with an attack from this item.
    * @type {number|null}
    */
   get criticalThreshold() {
-    // TODO: Re-write this when `rollAttack` is moved into attack activity
-    if ( !this.hasAttack ) return null;
-    let ammoThreshold = Infinity;
-    if ( this.hasAmmo ) {
-      ammoThreshold = this.parent?.actor?.items.get(this.consume.target)?.system.critical.threshold ?? Infinity;
-    }
-    const threshold = Math.min(this.critical.threshold ?? Infinity, this._typeCriticalThreshold, ammoThreshold);
-    return threshold < Infinity ? threshold : 20;
-  }
-
-  /**
-   * Default critical threshold for this type.
-   * @type {number}
-   * @internal
-   */
-  get _typeCriticalThreshold() {
-    return Infinity;
+    return this._typeCriticalThreshold ?? null;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -294,8 +294,8 @@ export default class WeaponData extends ItemDataModel.mixin(
 
   /* -------------------------------------------- */
 
-  /** @inheritdoc */
-  get _typeCriticalThreshold() {
+  /** @override */
+  get criticalThreshold() {
     return this.parent?.actor?.flags.dnd5e?.weaponCriticalThreshold ?? Infinity;
   }
 

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -1,6 +1,35 @@
 const { Die, NumericTerm, OperatorTerm } = foundry.dice.terms;
 
 /**
+ * Configuration data for the process of rolling d20 rolls.
+ *
+ * @typedef {BasicRollProcessConfiguration} D20RollProcessConfiguration
+ * @property {boolean} elvenAccuracy         Use three dice when rolling with advantage.
+ * @property {boolean} halflingLucky         Add a re-roll once modifier to the d20 die.
+ * @property {D20RollConfiguration[]} rolls  Configuration data for individual rolls.
+ */
+
+/**
+ * D20 roll configuration data.
+ *
+ * @typedef {BasicRollConfiguration} D20RollConfiguration
+ * @property {string[]} parts          Parts used to construct the roll formula, not including the d20 die.
+ * @property {D20RollOptions} options  Options passed through to the roll.
+ */
+
+/**
+ * Options that describe a d20 roll.
+ *
+ * @typedef {BasicRollOptions} D20RollOptions
+ * @property {boolean} advantage       Is the roll granted advantage?
+ * @property {boolean} disadvantage    Is the roll granted disadvantage?
+ * @property {number} criticalSuccess  The value of the d20 die to be considered a critical success.
+ * @property {number} criticalFailure  The value of the d20 die to be considered a critical failure.
+ * @property {number} maximum          Maximum number the d20 die can roll.
+ * @property {number} minimum          Minimum number the d20 die can roll.
+ */
+
+/**
  * A type of Roll specific to a d20-based check, save, or attack roll in the 5e system.
  * @param {string} formula                       The string formula to parse
  * @param {object} data                          The data object against which to parse attributes within the formula

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -1,5 +1,6 @@
 import AttackSheet from "../../applications/activity/attack-sheet.mjs";
 import AttackActivityData from "../../data/activity/attack-data.mjs";
+import { d20Roll } from "../../dice/dice.mjs";
 import ActivityMixin from "./mixin.mjs";
 
 /**
@@ -21,7 +22,192 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
       type: "attack",
       img: "systems/dnd5e/icons/svg/activity/attack.svg",
       title: "DND5E.ATTACK.Title.one",
-      sheetClass: AttackSheet
+      sheetClass: AttackSheet,
+      usage: {
+        actions: {
+          rollAttack: AttackActivity.#rollAttack
+        }
+      }
     }, { inplace: false })
   );
+
+  /* -------------------------------------------- */
+  /*  Activation                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _usageChatButtons() {
+    return [{
+      label: game.i18n.localize("DND5E.Attack"),
+      icon: '<i class="dnd5e-icon" data-src="systems/dnd5e/icons/svg/trait-weapon-proficiencies.svg" inert></i>',
+      dataset: {
+        action: "rollAttack"
+      }
+    }];
+  }
+
+  /* -------------------------------------------- */
+  /*  Rolling                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Perform an attack roll.
+   * @param {D20RollProcessConfiguration} config     Configuration information for the roll.
+   * @param {BasicRollDialogConfiguration} dialog    Configuration for the roll dialog.
+   * @param {BasicRollMessageConfiguration} message  Configuration for the roll message.
+   * @returns {Promise<D20Roll[]|void>}
+   */
+  async rollAttack(config={}, dialog={}, message={}) {
+    const { parts, data } = this.getAttackData();
+    const targets = this.constructor.getTargetDescriptors();
+
+    let ammoUpdate = [];
+    // TODO: Handle ammunition consumption
+    // const consume = this.system.consume;
+    // const ammo = this.hasAmmo ? this.actor.items.get(consume.target) : null;
+    // if ( ammo ) {
+    //   const q = ammo.system.quantity;
+    //   const consumeAmount = consume.amount ?? 0;
+    //   if ( q && (q - consumeAmount >= 0) ) {
+    //     title += ` [${ammo.name}]`;
+    //   }
+    //
+    //   // Get pending ammunition update
+    //   const usage = this._getUsageUpdates({consumeResource: true});
+    //   if ( usage === false ) return null;
+    //   ammoUpdate = usage.resourceUpdates ?? [];
+    // }
+
+    const rollConfig = foundry.utils.mergeObject({
+      elvenAccuracy: this.actor?.getFlag("dnd5e", "elvenAccuracy")
+        && CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(this.ability),
+      halflingLucky: this.actor?.getFlag("dnd5e", "halflingLucky")
+    }, config);
+    rollConfig.origin = this;
+    rollConfig.rolls = [{
+      parts, data,
+      options: {
+        criticalSuccess: this.criticalThreshold,
+        target: targets.length === 1 ? targets[0].ac : undefined
+      }
+    }].concat(config.rolls ?? []);
+
+    const dialogConfig = foundry.utils.mergeObject({
+      configure: true,
+      options: {
+        width: 400,
+        top: config.event ? config.event.clientY - 80 : null,
+        left: window.innerWidth - 710
+      }
+    }, dialog);
+
+    const messageConfig = foundry.utils.mergeObject({
+      create: true,
+      data: {
+        flavor: `${this.item.name} - ${game.i18n.localize("DND5E.AttackRoll")}`,
+        flags: {
+          dnd5e: {
+            ...this.messageFlags,
+            messageType: "roll",
+            roll: { type: "attack" },
+            targets
+          }
+        },
+        speaker: ChatMessage.getSpeaker({ actor: this.actor })
+      }
+    }, message);
+
+    /**
+     * A hook event that fires before an attack is rolled.
+     * @function dnd5e.preRollAttackV2
+     * @memberof hookEvents
+     * @param {D20RollProcessConfiguration} config     Configuration data for the pending roll.
+     * @param {BasicRollDialogConfiguration} dialog    Presentation data for the roll configuration dialog.
+     * @param {BasicRollMessageConfiguration} message  Configuration data for the roll's message.
+     * @returns {boolean}                              Explicitly return `false` to prevent the roll.
+     */
+    if ( Hooks.call("dnd5e.preRollAttackV2", rollConfig, dialogConfig, messageConfig) === false ) return;
+
+    const oldRollConfig = {
+      actor: this.actor,
+      parts: rollConfig.rolls[0].parts,
+      data: rollConfig.rolls[0].data,
+      event: rollConfig.event,
+      advantage: rollConfig.rolls[0].options.advantage,
+      disadvantage: rollConfig.rolls[0].options.disadvantage,
+      critical: rollConfig.rolls[0].options.criticalSuccess,
+      fumble: rollConfig.rolls[0].options.criticalFailure,
+      targetValue: rollConfig.rolls[0].options.target,
+      elvenAccuracy: rollConfig.elvenAccuracy,
+      halflingLucky: rollConfig.halflingLucky,
+      reliableTalent: rollConfig.rolls[0].options.minimum === 10,
+      fastForward: !dialogConfig.configure,
+      title: dialogConfig.options.title,
+      dialogOptions: dialogConfig.options,
+      chatMessage: messageConfig.create,
+      messageData: messageConfig.data,
+      rollMode: messageConfig.rollMode,
+      flavor: messageConfig.data.flavor
+    };
+
+    if ( "dnd5e.preRollAttack" in Hooks.events ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `dnd5e.preRollAttack` hook has been deprecated and replaced with `dnd5e.preRollAttackV2`.",
+        { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+      );
+      if ( Hooks.call("dnd5e.preRollAttack", this.item, oldRollConfig) === false ) return;
+    }
+
+    const roll = await d20Roll(oldRollConfig);
+    if ( roll === null ) return;
+
+    /**
+     * A hook event that fires after an attack has been rolled but before any ammunition is consumed.
+     * @function dnd5e.rollAttackV2
+     * @memberof hookEvents
+     * @param {D20Roll[]} rolls               The resulting rolls.
+     * @param {object} data
+     * @param {AttackActivity} data.activity  The activity that performed the attack.
+     * @param {object[]} data.ammoUpdate      Any updates related to ammo consumption for this attack.
+     */
+    Hooks.callAll("dnd5e.rollAttackV2", [roll], { activity: this, ammoUpdate });
+
+    if ( "dnd5e.rollAttack" in Hooks.events ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `dnd5e.rollAttack` hook has been deprecated and replaced with `dnd5e.rollAttackV2`.",
+        { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+      );
+      Hooks.callAll("dnd5e.rollAttack", this.item, roll, ammoUpdate);
+    }
+
+    // Commit ammunition consumption on attack rolls resource consumption if the attack roll was made
+    if ( ammoUpdate.length ) await this.actor?.updateEmbeddedDocuments("Item", ammoUpdate);
+
+    /**
+     * A hook event that fires after an attack has been rolled and ammunition has been consumed.
+     * @function dnd5e.postRollAttack
+     * @memberof hookEvents
+     * @param {D20Roll[]} rolls               The resulting rolls.
+     * @param {object} data
+     * @param {AttackActivity} data.activity  The activity that performed the attack.
+     */
+    Hooks.callAll("dnd5e.postRollAttack", [roll], { activity: this });
+
+    return [roll];
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle performing an attack roll.
+   * @this {AttackActivity}
+   * @param {PointerEvent} event     Triggering click event.
+   * @param {HTMLElement} target     The capturing HTML element which defined a [data-action].
+   * @param {ChatMessage5e} message  Message associated with the activation.
+   */
+  static #rollAttack(event, target, message) {
+    this.rollAttack({ event });
+  }
 }

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -64,6 +64,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
     }
 
     const rollConfig = foundry.utils.deepClone(config);
+    rollConfig.origin = this;
     rollConfig.rolls = [{ parts: [this.roll.formula], data: this.getRollData() }].concat(config.rolls ?? []);
 
     const dialogConfig = foundry.utils.mergeObject({ configure: true }, dialog);
@@ -74,9 +75,9 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
         flavor: `${this.item.name} - ${this.roll.label || game.i18n.localize("DND5E.OtherFormula")}`,
         flags: {
           dnd5e: {
+            ...this.messageFlags,
             messageType: "roll",
-            activity: { type: this.type, id: this.id, uuid: this.uuid },
-            item: { type: this.item.type, id: this.item.id, uuid: this.item.uuid }
+            roll: { type: "generic" }
           }
         }
       }
@@ -86,13 +87,12 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
      * A hook event that fires before a formula is rolled for an Utility activity.
      * @function dnd5e.preRollFormulaV2
      * @memberof hookEvents
-     * @param {UtilityActivity} activity               The activity performing the roll.
      * @param {BasicRollProcessConfiguration} config   Configuration information for the roll.
      * @param {BasicRollDialogConfiguration} dialog    Configuration for the roll dialog.
      * @param {BasicRollMessageConfiguration} message  Configuration for the roll message.
      * @returns {boolean}                   Explicitly return `false` to prevent the roll from being performed.
      */
-    if ( Hooks.call("dnd5e.preRollFormulaV2", this, rollConfig, dialogConfig, messageConfig) === false ) return;
+    if ( Hooks.call("dnd5e.preRollFormulaV2", rollConfig, dialogConfig, messageConfig) === false ) return;
 
     if ( "dnd5e.preRollFormula" in Hooks.events ) {
       foundry.utils.logCompatibilityWarning(
@@ -114,10 +114,11 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
      * A hook event that fires after a hit die has been rolled for an Actor, but before updates have been performed.
      * @function dnd5e.rollFormulaV2
      * @memberof hookEvents
-     * @param {UtilityActivity} activity  The activity that performed the roll.
-     * @param {BasicRoll[]} rolls         The resulting rolls.
+     * @param {BasicRoll[]} rolls              The resulting rolls.
+     * @param {object} data
+     * @param {UtilityActivity} data.activity  The activity that performed the roll.
      */
-    Hooks.callAll("dnd5e.rollFormulaV2", this, rolls);
+    Hooks.callAll("dnd5e.rollFormulaV2", rolls, { activity: this });
 
     if ( "dnd5e.rollFormula" in Hooks.events ) {
       foundry.utils.logCompatibilityWarning(

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2080,13 +2080,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * A hook event that fires before a hit die is rolled for an Actor.
      * @function dnd5e.preRollHitDieV2
      * @memberof hookEvents
-     * @param {Actor5e} actor                          Actor performing the roll.
      * @param {HitDieRollProcessConfiguration} config  Configuration information for the roll.
      * @param {BasicRollDialogConfiguration} dialog    Configuration for the roll dialog.
      * @param {BasicRollMessageConfiguration} message  Configuration for the roll message.
      * @returns {boolean}                              Explicitly return `false` to prevent hit die from being rolled.
      */
-    if ( Hooks.call("dnd5e.preRollHitDieV2", this, rollConfig, dialogConfig, messageConfig) === false ) return;
+    if ( Hooks.call("dnd5e.preRollHitDieV2", rollConfig, dialogConfig, messageConfig) === false ) return;
 
     if ( "dnd5e.preRollHitDie" in Hooks.events ) {
       foundry.utils.logCompatibilityWarning(
@@ -2122,14 +2121,15 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * A hook event that fires after a hit die has been rolled for an Actor, but before updates have been performed.
      * @function dnd5e.rollHitDieV2
      * @memberof hookEvents
-     * @param {Actor5e} actor           Actor for which the hit die has been rolled.
-     * @param {BasicRoll[]} rolls       The resulting rolls.
-     * @param {object} updates
-     * @param {object} updates.actor    Updates that will be applied to the actor.
-     * @param {object} [updates.class]  Updates that will be applied to the class.
-     * @returns {boolean}               Explicitly return `false` to prevent updates from being performed.
+     * @param {BasicRoll[]} rolls          The resulting rolls.
+     * @param {object} data
+     * @param {Actor5e} data.actor         Actor for which the hit die has been rolled.
+     * @param {object} data.updates
+     * @param {object} data.updates.actor  Updates that will be applied to the actor.
+     * @param {object} data.updates.class  Updates that will be applied to the class.
+     * @returns {boolean}                  Explicitly return `false` to prevent updates from being performed.
      */
-    if ( Hooks.call("dnd5e.rollHitDieV2", this, rolls, updates) === false ) return returnValue;
+    if ( Hooks.call("dnd5e.rollHitDieV2", rolls, { actor: this, updates }) === false ) return returnValue;
 
     if ( "dnd5e.rollHitDie" in Hooks.events ) {
       foundry.utils.logCompatibilityWarning(


### PR DESCRIPTION
Adds the Attack button to attack activities and the `rollAttack` method, which replicates the behavior of that method from `Item5e` but uses the new rolling API. Internally this constructs config objects according to the new API to call the `preRollAttackV2` hook, and then translates that back into the old configuration format for calling the deprecated hooks and the roll constructor.

A new `criticalThreshold` getter on `AttackActivity` now handles most of the functionality of the old getter on `ActionTemplate`. The `criticalThreshold` getter on `ItemDataModel` replaces `_typeCriticalThreshold` which is no longer required (but is still checked for backwards compatibility).

A few of the signatures of the new rolling hooks have changed. The pre hooks no longer pass the activity as the first parameter because that is included as part of `rollConfig`. The post hooks now include the activity as part of the second data object, not the first value. These changes should help in situations like enrichers where you might be rolling attacks or damage without an associated activity.

### Todo
- [ ] Handle ammunition for weapons
- [ ] Refactor configuration positioning into `RollConfigurationDialog`