### PR TITLE
[#3911] Add Saving Throw button for `SaveActivity`

### DIFF
--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -421,6 +421,7 @@
     display: flex;
     flex-direction: column;
     gap: .375rem;
+    [hidden] { display: none; }
   }
 
   .pills .pill {

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -179,7 +179,7 @@ export default class FeatData extends ItemDataModel.mixin(
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateEnchantment(source) {
-    if ( foundry.utils.getType(source.enchantment) !== "Object" ) return;
+    if ( foundry.utils.getType(source.enchantment?.items) !== "Object" ) return;
     const { items } = source.enchantment;
     source.enchant ??= {};
     if ( "max" in items ) source.enchant.max = items.max;

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -179,7 +179,7 @@ export default class FeatData extends ItemDataModel.mixin(
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateEnchantment(source) {
-    if ( !("enchantment" in source) || !("items" in source.enchantment) ) return;
+    if ( foundry.utils.getType(source.enchantment) !== "Object" ) return;
     const { items } = source.enchantment;
     source.enchant ??= {};
     if ( "max" in items ) source.enchant.max = items.max;

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -640,6 +640,17 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   /* -------------------------------------------- */
 
   /**
+   * Determine whether the provided button in a chat message should be visible.
+   * @param {HTMLButtonElement} button
+   * @returns {boolean}
+   */
+  shouldHideChatButton(button) {
+    return false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Display a chat message for this usage.
    * @param {ActivityMessageConfiguration} message  Configuration info for the created message.
    * @returns {Promise<ChatMessage5e|object>}
@@ -735,8 +746,13 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   async #onChatAction(event, target, message) {
     const action = target.dataset.action;
     const handler = this.metadata.usage?.actions?.[action];
-    if ( handler ) handler.call(this, event, target, message);
-    else this._onChatAction(event, target);
+    target.disabled = true;
+    try {
+      if ( handler ) await handler.call(this, event, target, message);
+      else await this._onChatAction(event, target);
+    } finally {
+      target.disabled = false;
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -42,7 +42,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
       icon: '<i class="fa-solid fa-dice" inert></i>',
       dataset: {
         action: "rollFormula",
-        visibility: this.roll.visible ? "all" : "creator"
+        visibility: this.roll.visible ? "all" : undefined
       }
     }];
   }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1271,7 +1271,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     return ChatMessage.implementation.create({
       content: await renderTemplate("systems/dnd5e/templates/chat/request-card.hbs", {
-        dataset: { ...dataset, type: "concentration" },
+        dataset: { ...dataset, type: "concentration", visbility: "all" },
         buttonLabel: createRollLabel({ ...dataset, ...config }),
         hiddenLabel: createRollLabel({ ...dataset, ...config, hideDC: true })
       }),

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -166,26 +166,36 @@ export default class ChatMessage5e extends ChatMessage {
         }
       });
 
-      // If the user is the message author or the actor owner, proceed
       let actor = game.actors.get(this.speaker.actor);
-      if ( game.user.isGM || actor?.isOwner || (this.author.id === game.user.id) ) {
-        const optionallyHide = (selector, hide) => {
-          const element = chatCard[0].querySelector(selector);
-          if ( element && hide ) element.style.display = "none";
-        };
-        optionallyHide('button[data-action="summon"]', !SummonsData.canSummon);
-        optionallyHide('button[data-action="placeTemplate"]', !game.user.can("TEMPLATE_CREATE"));
-        optionallyHide('button[data-action="consumeUsage"]', this.getFlag("dnd5e", "use.consumedUsage"));
-        optionallyHide('button[data-action="consumeResource"]', this.getFlag("dnd5e", "use.consumedResource"));
-        return;
+      const isCreator = actor?.isOwner || (this.author.id === game.user.id);
+      for ( const button of html[0].querySelectorAll(".card-buttons button") ) {
+        if ( button.dataset.visibility === "all" ) continue;
+
+        // GM buttons should only be visible to GMs, otherwise button should only be visible to message's creator
+        if ( ((button.dataset.visibility === "gm") && !game.user.isGM) || !isCreator
+          || this.getAssociatedActivity()?.shouldHideChatButton(button) ) button.hidden = true;
       }
 
-      // Otherwise conceal action buttons except for saving throw
-      const buttons = chatCard.find("button[data-action]:not(.apply-effect)");
-      buttons.each((i, btn) => {
-        if ( ["save", "rollRequest", "concentration"].includes(btn.dataset.action) ) return;
-        btn.style.display = "none";
-      });
+      // TODO: Refer some of this more complex hiding behavior to activity when these buttons are re-implemented
+      // // If the user is the message author or the actor owner, proceed
+      // if ( game.user.isGM || actor?.isOwner || (this.author.id === game.user.id) ) {
+      //   const optionallyHide = (selector, hide) => {
+      //     const element = chatCard[0].querySelector(selector);
+      //     if ( element && hide ) element.style.display = "none";
+      //   };
+      //   optionallyHide('button[data-action="summon"]', !SummonsData.canSummon);
+      //   optionallyHide('button[data-action="placeTemplate"]', !game.user.can("TEMPLATE_CREATE"));
+      //   optionallyHide('button[data-action="consumeUsage"]', this.getFlag("dnd5e", "use.consumedUsage"));
+      //   optionallyHide('button[data-action="consumeResource"]', this.getFlag("dnd5e", "use.consumedResource"));
+      //   return;
+      // }
+
+      // // Otherwise conceal action buttons except for saving throw
+      // const buttons = chatCard.find("button[data-action]:not(.apply-effect)");
+      // buttons.each((i, btn) => {
+      //   if ( ["save", "rollRequest", "concentration"].includes(btn.dataset.action) ) return;
+      //   btn.style.display = "none";
+      // });
     }
   }
 
@@ -875,7 +885,7 @@ export default class ChatMessage5e extends ChatMessage {
       });
     }
 
-    if ( flags.item?.data ) Object.defineProperty(flags, "itemData", {
+    if ( flags?.item?.data ) Object.defineProperty(flags, "itemData", {
       get() {
         foundry.utils.logCompatibilityWarning(
           "The `dnd5e.itemData` flag on `ChatMessage` is now `dnd5e.item.data`.",

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -166,8 +166,8 @@ export default class ChatMessage5e extends ChatMessage {
         }
       });
 
-      let actor = game.actors.get(this.speaker.actor);
-      const isCreator = actor?.isOwner || (this.author.id === game.user.id);
+      const actor = game.actors.get(this.speaker.actor);
+      const isCreator = game.user.isGM || actor?.isOwner || (this.author.id === game.user.id);
       for ( const button of html[0].querySelectorAll(".card-buttons button") ) {
         if ( button.dataset.visibility === "all" ) continue;
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1690,9 +1690,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
             versatile: action === "versatile"
           });
           break;
-        case "formula":
-          await item.rollFormula({event, spellLevel});
-          break;
         case "placeTemplate":
           try {
             await dnd5e.canvas.AbilityTemplate.fromItem(item, {"flags.dnd5e.spellLevel": spellLevel})?.drawPreview();
@@ -1701,16 +1698,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
               msg: game.i18n.localize("DND5E.PlaceTemplateError"),
               log: "error",
               notify: "error"
-            });
-          }
-          break;
-        case "save":
-          targets = this._getChatCardTargets(card);
-          for ( let token of targets ) {
-            const dc = parseInt(button.dataset.dc);
-            const speaker = ChatMessage.getSpeaker({scene: canvas.scene, token: token.document});
-            await token.actor.rollAbilitySave(button.dataset.ability, {
-              event, speaker, targetValue: Number.isFinite(dc) ? dc : undefined
             });
           }
           break;

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -815,7 +815,7 @@ async function rollAction(event) {
       content: await renderTemplate("systems/dnd5e/templates/chat/request-card.hbs", {
         buttonLabel: createRollLabel({ ...target.dataset, format: "short", icon: true }),
         hiddenLabel: createRollLabel({ ...target.dataset, format: "short", icon: true, hideDC: true }),
-        dataset: { ...target.dataset, action: "rollRequest" }
+        dataset: { ...target.dataset, action: "rollRequest", visibility: "all" }
       }),
       flavor: game.i18n.localize("EDITOR.DND5E.Inline.RollRequest"),
       speaker: MessageClass.getSpeaker({user: game.user})

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -459,6 +459,7 @@ export async function preloadHandlebarsTemplates() {
 function dataset(object, options) {
   const entries = [];
   for ( let [key, value] of Object.entries(object ?? {}) ) {
+    if ( value === undefined ) continue;
     key = key.replace(/[A-Z]+(?![a-z])|[A-Z]/g, (a, b) => (b ? "-" : "") + a.toLowerCase());
     entries.push(`data-${key}="${value}"`);
   }

--- a/templates/chat/activity-card.hbs
+++ b/templates/chat/activity-card.hbs
@@ -18,7 +18,7 @@
     {{#if buttons}}
     <div class="card-buttons">
         {{#each buttons}}
-        <button type="button" name="{{ @key }}" {{ dnd5e-dataset dataset }}>
+        <button type="button" {{ dnd5e-dataset dataset }}>
             {{{ icon }}} <span>{{{ label }}}</span>
         </button>
         {{/each}}


### PR DESCRIPTION
Adds a saving throw button to the card generated by the `SaveActivity` and transfer the logic from `_onChatCardAction`.

Modifies the logic in `ChatMessage5e` for hiding buttons to give activites more control over what buttons are visible. Right now they can use `data-visibility` to specify whether a button is available only go GMs (`gm`), to the message creator (blank value), or everyone (`all`). It then asks the activity using the `shouldHideChatButton` method to implement more complex logic if necessary.