### PR TITLE
[#1964] Add options to utility roll

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2628,6 +2628,14 @@
       "name": {
         "label": "Roll Label",
         "hint": "Display name for the rolling button."
+      },
+      "prompt": {
+        "label": "Utility Roll Prompt",
+        "hint": "Should the roll configuration dialog be displayed when rolling?"
+      },
+      "visible": {
+        "label": "Visible to All",
+        "hint": "Should the rolling button be visible to all players?"
       }
     }
   }

--- a/module/applications/activity/utility-sheet.mjs
+++ b/module/applications/activity/utility-sheet.mjs
@@ -15,6 +15,10 @@ export default class UtilitySheet extends ActivitySheet {
   /** @inheritDoc */
   static PARTS = {
     ...super.PARTS,
+    identity: {
+      template: "systems/dnd5e/templates/activity/utility-identity.hbs",
+      templates: super.PARTS.identity.templates
+    },
     effect: {
       template: "systems/dnd5e/templates/activity/utility-effect.hbs",
       templates: super.PARTS.effect.templates

--- a/module/data/activity/utility-data.mjs
+++ b/module/data/activity/utility-data.mjs
@@ -1,14 +1,16 @@
 import FormulaField from "../fields/formula-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
-const { SchemaField, StringField } = foundry.data.fields;
+const { BooleanField, SchemaField, StringField } = foundry.data.fields;
 
 /**
  * Data model for an utility activity.
  *
  * @property {object} roll
- * @property {string} roll.formula  Arbitrary formula that can be rolled.
- * @property {string} roll.name     Label for the rolling button.
+ * @property {string} roll.formula   Arbitrary formula that can be rolled.
+ * @property {string} roll.name      Label for the rolling button.
+ * @property {boolean} roll.prompt   Should the roll configuration dialog be displayed?
+ * @property {boolean} roll.visible  Should the rolling button be visible to all players?
  */
 export default class UtilityActivityData extends BaseActivityData {
   /** @inheritDoc */
@@ -17,7 +19,9 @@ export default class UtilityActivityData extends BaseActivityData {
       ...super.defineSchema(),
       roll: new SchemaField({
         formula: new FormulaField(),
-        name: new StringField()
+        name: new StringField(),
+        prompt: new BooleanField(),
+        visible: new BooleanField()
       })
     };
   }
@@ -31,7 +35,9 @@ export default class UtilityActivityData extends BaseActivityData {
     return foundry.utils.mergeObject(activityData, {
       roll: {
         formula: source.system.formula ?? "",
-        name: ""
+        name: "",
+        prompt: false,
+        visible: false
       }
     });
   }

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -41,7 +41,8 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
       label: this.roll.label || game.i18n.localize("DND5E.Roll"),
       icon: '<i class="fa-solid fa-dice" inert></i>',
       dataset: {
-        action: "rollFormula"
+        action: "rollFormula",
+        visibility: this.roll.visible ? "all" : "creator"
       }
     }];
   }
@@ -66,7 +67,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
     const rollConfig = foundry.utils.deepClone(config);
     rollConfig.rolls = [{ parts: [this.roll.formula], data: this.getRollData() }].concat(config.rolls ?? []);
 
-    const dialogConfig = foundry.utils.mergeObject({ configure: true }, dialog);
+    const dialogConfig = foundry.utils.mergeObject({ configure: this.roll.prompt }, dialog);
 
     const messageConfig = foundry.utils.mergeObject({
       create: true,

--- a/templates/activity/utility-effect.hbs
+++ b/templates/activity/utility-effect.hbs
@@ -4,5 +4,6 @@
         <legend>{{ localize "DND5E.UTILITY.FIELDS.roll.label" }}</legend>
         {{ formField fields.roll.fields.name value=source.roll.name }}
         {{ formField fields.roll.fields.formula value=source.roll.formula }}
+        {{ formField fields.roll.fields.visible value=source.roll.visible }}
     </fieldset>
 </section>

--- a/templates/activity/utility-identity.hbs
+++ b/templates/activity/utility-identity.hbs
@@ -1,0 +1,8 @@
+<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
+    {{> "systems/dnd5e/templates/activity/parts/activity-identity.hbs" }}
+    <fieldset>
+        <legend>{{ localize "DND5E.ACTIVITY.SECTIONS.Behavior" }}</legend>
+        {{ formField fields.target.fields.prompt value=source.target.prompt }}
+        {{ formField fields.roll.fields.prompt value=source.roll.prompt }}
+    </fieldset>
+</section>


### PR DESCRIPTION
Gives two options to the roll on `UtilityActivity` controlling whether the roll configuration dialog is displayed and whether the roll button is visible to all users or just the creator.