### PR TITLE
[#3912] Implement damage rolls for Damage & Heal activities

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -192,7 +192,7 @@ export default class AttackActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /**
-   * Get the roll parts used to create to the attack roll.
+   * Get the roll parts used to create the attack roll.
    * @returns {{ data: object, parts: string[] }}
    */
   getAttackData() {

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -521,8 +521,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
     const scaling = config.scaling ?? 0; // TODO: Set properly once scaling is handled during activation
     const rollConfig = foundry.utils.mergeObject({ scaling }, config);
+    const rollData = this.getRollData();
     rollConfig.rolls = this.damage.parts
-      .map(d => this.processDamagePart(d, rollConfig))
+      .map(d => this._processDamagePart(d, rollConfig, rollData))
       .filter(d => d.parts.length)
       .concat(config.rolls ?? []);
 
@@ -533,14 +534,16 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Process a single damage part into a roll configuration.
-   * @param {DamageData} damage                          Damage to prepare for the roll.
-   * @param {DamageRollProcessConfiguration} rollConfig  Roll configuration being built.
+   * @param {DamageData} damage                                   Damage to prepare for the roll.
+   * @param {Partial<DamageRollProcessConfiguration>} rollConfig  Roll configuration being built.
+   * @param {object} rollData                                     Roll data to populate with damage data.
    * @returns {DamageRollConfiguration}
+   * @protected
    */
-  processDamagePart(damage, rollConfig) {
+  _processDamagePart(damage, rollConfig, rollData) {
     const scaledFormula = damage.scaledFormula(rollConfig.scaling);
     const parts = scaledFormula ? [scaledFormula] : [];
-    const data = this.getRollData();
+    const data = { ...rollData };
 
     const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.bonuses.${this.actionType}.damage`);
     if ( bonus && (parseInt(bonus) !== 0) ) {

--- a/module/data/activity/damage-data.mjs
+++ b/module/data/activity/damage-data.mjs
@@ -64,12 +64,9 @@ export default class DamageActivityData extends BaseActivityData {
   getDamageConfig(config={}) {
     const rollConfig = super.getDamageConfig(config);
 
-    rollConfig.allowCritical ??= this.damage.critical.allow;
-    if ( this.damage.critical.bonus ) {
-      rollConfig.critical ??= {};
-      rollConfig.critical.bonusDamage = this.damage.critical.bonus;
-    }
     rollConfig.critical ??= {};
+    rollConfig.critical.allow ??= this.damage.critical.allow;
+    rollConfig.critical.bonusDamage ??= this.damage.critical.bonus;
 
     return rollConfig;
   }

--- a/module/data/activity/damage-data.mjs
+++ b/module/data/activity/damage-data.mjs
@@ -55,4 +55,22 @@ export default class DamageActivityData extends BaseActivityData {
     super.prepareFinalData(rollData);
     this.prepareDamageLabel(this.damage.parts, rollData);
   }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /** @override */
+  getDamageConfig(config={}) {
+    const rollConfig = super.getDamageConfig(config);
+
+    rollConfig.allowCritical ??= this.damage.critical.allow;
+    if ( this.damage.critical.bonus ) {
+      rollConfig.critical ??= {};
+      rollConfig.critical.bonusDamage = this.damage.critical.bonus;
+    }
+    rollConfig.critical ??= {};
+
+    return rollConfig;
+  }
 }

--- a/module/data/activity/heal-data.mjs
+++ b/module/data/activity/heal-data.mjs
@@ -36,4 +36,19 @@ export default class HealActivityData extends BaseActivityData {
     super.prepareFinalData(rollData);
     this.prepareDamageLabel([this.healing], rollData);
   }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /** @override */
+  getDamageConfig(config={}) {
+    if ( !this.healing.formula ) return foundry.utils.mergeObject({ rolls: [] }, config);
+
+    const scaling = config.scaling ?? 0; // TODO: Set properly once scaling is handled during activation
+    const rollConfig = foundry.utils.mergeObject({ allowCritical: false, scaling }, config);
+    rollConfig.rolls = [this.processDamagePart(this.healing, rollConfig)].concat(config.rolls ?? []);
+
+    return rollConfig;
+  }
 }

--- a/module/data/activity/heal-data.mjs
+++ b/module/data/activity/heal-data.mjs
@@ -46,8 +46,9 @@ export default class HealActivityData extends BaseActivityData {
     if ( !this.healing.formula ) return foundry.utils.mergeObject({ rolls: [] }, config);
 
     const scaling = config.scaling ?? 0; // TODO: Set properly once scaling is handled during activation
-    const rollConfig = foundry.utils.mergeObject({ allowCritical: false, scaling }, config);
-    rollConfig.rolls = [this.processDamagePart(this.healing, rollConfig)].concat(config.rolls ?? []);
+    const rollConfig = foundry.utils.mergeObject({ critical: { allow: false }, scaling }, config);
+    const rollData = this.getRollData();
+    rollConfig.rolls = [this._processDamagePart(this.healing, rollConfig, rollData)].concat(config.rolls ?? []);
 
     return rollConfig;
   }

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -1,6 +1,47 @@
 const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, StringTerm } = foundry.dice.terms;
 
 /**
+ * Configuration data for the process of rolling a damage roll.
+ *
+ * @typedef {BasicRollProcessConfiguration} DamageRollProcessConfiguration
+ * @property {DamageRollConfiguration[]} rolls         Configuration data for individual rolls.
+ * @property {boolean} [allowCritical=true]            Should critical damage be allowed for any rolls?
+ * @property {CriticalDamageConfiguration} [critical]  Critical configuration for all rolls.
+ * @property {number} [scaling=0]                      Scale increase above base damage.
+ */
+
+/**
+ * Damage roll configuration data.
+ *
+ * @typedef {BasicRollConfiguration} DamageRollConfiguration
+ * @property {DamageRollOptions} [options] - Options passed through to the roll.
+ */
+
+/**
+ * Options that describe a damage roll.
+ *
+ * @typedef {BasicRollOptions} DamageRollOptions
+ * @property {boolean} [isCritical]                    Should critical damage by calculated for this roll?
+ * @property {CriticalDamageConfiguration} [critical]  Critical configuration for this roll.
+ * @property {string[]} [properties]                   Physical properties of the source (e.g. magical, silvered).
+ * @property {string} [type]                           Type of damage represented.
+ * @property {string[]} [types]                        List of damage types selectable in the configuration app. If no
+ *                                                     type is provided, then the first of these types will be used.
+ */
+
+/**
+ * Critical effects configuration data.
+ *
+ * @typedef {object} CriticalDamageConfiguration
+ * @property {number} [multiplier=2]      Amount by which to multiply critical damage.
+ * @property {number} [bonusDice=0]       Additional dice added to first term when calculating critical damage.
+ * @property {string} [bonusDamage]       Additional, unmodified, damage formula added when calculating a critical.
+ * @property {boolean} [multiplyDice]     Should dice result be multiplied rather than number of dice rolled increased?
+ * @property {boolean} [multiplyNumeric]  Should numeric terms be multiplied along side dice during criticals?
+ * @property {string} [powerfulCritical]  Maximize result of extra dice added by critical, rather than rolling.
+ */
+
+/**
  * A type of Roll specific to a damage (or healing) roll in the 5e system.
  * @param {string} formula                       The string formula to parse
  * @param {object} data                          The data object against which to parse attributes within the formula

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -5,7 +5,6 @@ const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, St
  *
  * @typedef {BasicRollProcessConfiguration} DamageRollProcessConfiguration
  * @property {DamageRollConfiguration[]} rolls         Configuration data for individual rolls.
- * @property {boolean} [allowCritical=true]            Should critical damage be allowed for any rolls?
  * @property {CriticalDamageConfiguration} [critical]  Critical configuration for all rolls.
  * @property {number} [scaling=0]                      Scale increase above base damage.
  */
@@ -21,7 +20,7 @@ const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, St
  * Options that describe a damage roll.
  *
  * @typedef {BasicRollOptions} DamageRollOptions
- * @property {boolean} [isCritical]                    Should critical damage by calculated for this roll?
+ * @property {boolean} [isCritical]                    Should critical damage be calculated for this roll?
  * @property {CriticalDamageConfiguration} [critical]  Critical configuration for this roll.
  * @property {string[]} [properties]                   Physical properties of the source (e.g. magical, silvered).
  * @property {string} [type]                           Type of damage represented.
@@ -33,6 +32,7 @@ const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, St
  * Critical effects configuration data.
  *
  * @typedef {object} CriticalDamageConfiguration
+ * @property {boolean} [allow=true]       Should critical damage be allowed?
  * @property {number} [multiplier=2]      Amount by which to multiply critical damage.
  * @property {number} [bonusDice=0]       Additional dice added to first term when calculating critical damage.
  * @property {string} [bonusDamage]       Additional, unmodified, damage formula added when calculating a critical.

--- a/module/documents/activity/damage.mjs
+++ b/module/documents/activity/damage.mjs
@@ -21,7 +21,43 @@ export default class DamageActivity extends ActivityMixin(DamageActivityData) {
       type: "damage",
       img: "systems/dnd5e/icons/svg/activity/damage.svg",
       title: "DND5E.DAMAGE.Title",
-      sheetClass: DamageSheet
+      sheetClass: DamageSheet,
+      usage: {
+        actions: {
+          rollDamage: DamageActivity.#rollDamage
+        }
+      }
     }, { inplace: false })
   );
+
+  /* -------------------------------------------- */
+  /*  Activation                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _usageChatButtons() {
+    if ( !this.damage.parts.length ) return null;
+    return [{
+      label: game.i18n.localize("DND5E.Damage"),
+      icon: '<i class="fas fa-burst" inert></i>',
+      dataset: {
+        action: "rollDamage"
+      }
+    }];
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle performing a damage roll.
+   * @this {DamageActivity}
+   * @param {PointerEvent} event     Triggering click event.
+   * @param {HTMLElement} target     The capturing HTML element which defined a [data-action].
+   * @param {ChatMessage5e} message  Message associated with the activation.
+   */
+  static #rollDamage(event, target, message) {
+    this.rollDamage({ event });
+  }
 }

--- a/module/documents/activity/heal.mjs
+++ b/module/documents/activity/heal.mjs
@@ -21,7 +21,52 @@ export default class HealActivity extends ActivityMixin(HealActivityData) {
       type: "heal",
       img: "systems/dnd5e/icons/svg/activity/heal.svg",
       title: "DND5E.HEAL.Title",
-      sheetClass: HealSheet
+      sheetClass: HealSheet,
+      usage: {
+        actions: {
+          rollHealing: HealActivity.#rollHealing
+        }
+      }
     }, { inplace: false })
   );
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get damageFlavor() {
+    return game.i18n.localize("DND5E.Healing");
+  }
+
+  /* -------------------------------------------- */
+  /*  Activation                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _usageChatButtons() {
+    if ( !this.healing.formula ) return null;
+    return [{
+      label: game.i18n.localize("DND5E.Healing"),
+      icon: '<i class="dnd5e-icon" data-src="systems/dnd5e/icons/svg/damage/healing.svg"></i>',
+      dataset: {
+        action: "rollHealing"
+      }
+    }];
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle performing a healing roll.
+   * @this {HealActivity}
+   * @param {PointerEvent} event     Triggering click event.
+   * @param {HTMLElement} target     The capturing HTML element which defined a [data-action].
+   * @param {ChatMessage5e} message  Message associated with the activation.
+   */
+  static #rollHealing(event, target, message) {
+    this.rollDamage({ event });
+  }
 }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -791,7 +791,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       data: rollConfig.rolls[0]?.data ?? {},
       event: rollConfig.event,
       returnMultiple: rollConfig.returnMultiple,
-      allowCritical: rollConfig.allowCritical,
+      allowCritical: rollConfig.rolls[0]?.critical?.allow ?? rollConfig.critical?.allow ?? true,
       critical: rollConfig.rolls[0]?.isCritical,
       criticalBonusDice: rollConfig.rolls[0]?.critical?.bonusDice ?? rollConfig.critical?.bonusDice,
       criticalMultiplier: rollConfig.rolls[0]?.critical?.multiplier ?? rollConfig.critical?.multiplier,

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1,4 +1,5 @@
 import ActivityUsageDialog from "../../applications/activity/activity-usage-dialog.mjs";
+import { damageRoll } from "../../dice/dice.mjs";
 import PseudoDocumentMixin from "../mixins/pseudo-document.mjs";
 
 /**
@@ -82,6 +83,16 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    */
   get canScaleDamage() {
     return this.consumption.scaling.allowed || this.isSpell;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Description used in chat message flavor for messages created with `rollDamage`.
+   * @type {string}
+   */
+  get damageFlavor() {
+    return game.i18n.localize("DND5E.DamageRoll");
   }
 
   /* -------------------------------------------- */
@@ -717,6 +728,118 @@ export default Base => class extends PseudoDocumentMixin(Base) {
         });
       }
     }
+  }
+
+  /* -------------------------------------------- */
+  /*  Rolling                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Perform a damage roll.
+   * @param {Partial<DamageRollProcessConfiguration>} config  Configuration information for the roll.
+   * @param {Partial<BasicRollDialogConfiguration>} dialog    Configuration for the roll dialog.
+   * @param {Partial<BasicRollMessageConfiguration>} message  Configuration for the roll message.
+   * @returns {Promise<DamageRoll[]|void>}
+   */
+  async rollDamage(config={}, dialog={}, message={}) {
+    const rollConfig = this.getDamageConfig(config);
+    rollConfig.origin = this;
+
+    const dialogConfig = foundry.utils.mergeObject({
+      configure: true,
+      options: {
+        width: 400,
+        top: config.event ? config.event.clientY - 80 : null,
+        left: window.innerWidth - 710
+      }
+    }, dialog);
+
+    const messageConfig = foundry.utils.mergeObject({
+      create: true,
+      data: {
+        flavor: `${this.item.name} - ${this.damageFlavor}`,
+        flags: {
+          dnd5e: {
+            ...this.messageFlags,
+            messageType: "roll",
+            roll: { type: "damage" },
+            targets: this.constructor.getTargetDescriptors()
+          }
+        },
+        speaker: ChatMessage.getSpeaker({ actor: this.actor })
+      }
+    });
+
+    /**
+     * A hook event that fires before damage is rolled.
+     * @function dnd5e.preRollDamageV2
+     * @memberof hookEvents
+     * @param {DamageRollProcessConfiguration} config  Configuration data for the pending roll.
+     * @param {BasicRollDialogConfiguration} dialog    Presentation data for the roll configuration dialog.
+     * @param {BasicRollMessageConfiguration} message  Configuration data for the roll's message.
+     * @returns {boolean}                              Explicitly return `false` to prevent the roll.
+     */
+    if ( Hooks.call("dnd5e.preRollDamageV2", rollConfig, dialogConfig, messageConfig) === false ) return;
+
+    const oldRollConfig = {
+      actor: this.actor,
+      rollConfigs: rollConfig.rolls.map(r => ({
+        parts: r.parts,
+        type: r.options?.types?.first(),
+        properties: r.options?.properties
+      })),
+      data: rollConfig.rolls[0]?.data ?? {},
+      event: rollConfig.event,
+      returnMultiple: rollConfig.returnMultiple,
+      allowCritical: rollConfig.allowCritical,
+      critical: rollConfig.rolls[0]?.isCritical,
+      criticalBonusDice: rollConfig.rolls[0]?.critical?.bonusDice ?? rollConfig.critical?.bonusDice,
+      criticalMultiplier: rollConfig.rolls[0]?.critical?.multiplier ?? rollConfig.critical?.multiplier,
+      multiplyNumeric: rollConfig.rolls[0]?.critical?.multiplyNumeric ?? rollConfig.critical?.multiplyNumeric,
+      powerfulCritical: rollConfig.rolls[0]?.critical?.powerfulCritical ?? rollConfig.critical?.powerfulCritical,
+      criticalBonusDamage: rollConfig.rolls[0]?.critical?.bonusDamage ?? rollConfig.critical?.bonusDamage,
+      fastForward: !dialogConfig.configure,
+      title: dialogConfig.options.title,
+      dialogOptions: dialogConfig.options,
+      chatMessage: messageConfig.create,
+      messageData: messageConfig.data,
+      rollMode: messageConfig.rollMode,
+      flavor: messageConfig.data.flavor
+    };
+
+    if ( "dnd5e.preRollDamage" in Hooks.events ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `dnd5e.preRollDamage` hook has been deprecated and replaced with `dnd5e.preRollDamageV2`.",
+        { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+      );
+      if ( Hooks.call("dnd5e.preRollDamage", this.item, oldRollConfig) === false ) return;
+    }
+
+    const returnMultiple = oldRollConfig.returnMultiple;
+    oldRollConfig.returnMultiple = true;
+
+    const rolls = await damageRoll(oldRollConfig);
+    if ( !rolls?.length ) return;
+
+    /**
+     * A hook event that fires after damage has been rolled.
+     * @function dnd5e.rollDamageV2
+     * @memberof hookEvents
+     * @param {DamageRoll[]} rolls        The resulting rolls.
+     * @param {object} [data]
+     * @param {Activity} [data.activity]  The activity that performed the roll.
+     */
+    Hooks.callAll("dnd5e.rollDamageV2", rolls, { activity: this });
+
+    if ( "dnd5e.rollDamage" in Hooks.events ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `dnd5e.rollDamage` hook has been deprecated and replaced with `dnd5e.rollDamageV2`.",
+        { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+      );
+      Hooks.callAll("dnd5e.rollDamage", this.item, returnMultiple ? rolls : rolls[0], ammoUpdate);
+    }
+
+    return rolls;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1272,7 +1272,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     let item = this;
     if ( spellLevel ) {
-      if ( this.type === "spell" ) item = item.clone({ "system.item.level": spellLevel });
+      if ( this.type === "spell" ) item = item.clone({ "system.level": spellLevel });
       options.scaling = spellLevel;
     }
 
@@ -1433,7 +1433,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     );
 
     let item = this;
-    if ( spellLevel && (this.type === "spell") ) item = item.clone({ "system.item.level": spellLevel });
+    if ( spellLevel && (this.type === "spell") ) item = item.clone({ "system.level": spellLevel });
 
     const activity = item.system.activities?.getByType("utility")[0];
     if ( !activity ) throw new Error("This Item does not have a Utility activity to roll!");

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -8,7 +8,6 @@ import SpellData from "../data/item/spell.mjs";
 import { EnchantmentData } from "../data/item/fields/enchantment-field.mjs";
 import ActivitiesTemplate from "../data/item/templates/activities.mjs";
 import PhysicalItemTemplate from "../data/item/templates/physical-item.mjs";
-import { damageRoll } from "../dice/dice.mjs";
 import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
 import { getSceneTargets } from "../utils.mjs";
 import Proficiency from "./actor/proficiency.mjs";
@@ -1263,9 +1262,29 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @param {DamageRollConfiguration} [config.options]  Additional options passed to the damageRoll function
    * @returns {Promise<DamageRoll[]>}      A Promise which resolves to the created Roll instances, or null if the action
    *                                       cannot be performed.
+   * @deprecated since DnD5e 4.0, targeted for removal in DnD5e 4.4
    */
-  async rollDamage({critical, event=null, spellLevel=null, versatile=false, options={}}={}) {
-    if ( !this.hasDamage ) throw new Error("You may not make a Damage Roll with this Item.");
+  async rollDamage({ spellLevel, ...options }={}) {
+    foundry.utils.logCompatibilityWarning(
+      "The Item5e#rollDamage method has been deprecated and should now be called directly on an activity.",
+      { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+    );
+
+    let item = this;
+    if ( spellLevel ) {
+      if ( this.type === "spell" ) item = item.clone({ "system.item.level": spellLevel });
+      options.scaling = spellLevel;
+    }
+
+    const activity = item.system.activities?.getByType("attack")[0] || item.system.activities?.getByType("damage")[0]
+      || item.system.activities?.getByType("save")[0] || item.system.activities?.getByType("heal")[0];
+    if ( !activity ) throw new Error("This Item does not have a damaging activity to roll!");
+
+    const returnMultiple = options.returnMultiple;
+    const rolls = await activity.rollDamage(options);
+    return returnMultiple ? rolls : rolls?.[0];
+
+    // TODO: Remove this reference code once rollDamage is implemented for attacks & scaling is implemented
 
     // Fetch level from tags if not specified
     let originalLevel = this.system.level;
@@ -1276,37 +1295,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       originalLevel = levelingFlag.base;
       scaling = levelingFlag.scaling;
     }
-
-    // Get roll data
-    const dmg = this.system.damage;
-    const properties = Array.from(this.system.properties).filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical);
-    const rollConfigs = dmg.parts.map(([formula, type]) => ({ parts: [formula], type, properties }));
-    const rollData = this.getRollData();
-    if ( spellLevel ) rollData.item.level = spellLevel;
-
-    // Configure the damage roll
-    const actionFlavor = game.i18n.localize(this.system.actionType === "heal" ? "DND5E.Healing" : "DND5E.DamageRoll");
-    const title = `${this.name} - ${actionFlavor}`;
-    const rollConfig = {
-      actor: this.actor,
-      critical,
-      data: rollData,
-      event,
-      title: title,
-      flavor: this.labels.damageTypes.length ? `${title} (${this.labels.damageTypes})` : title,
-      dialogOptions: {
-        width: 400,
-        top: event ? event.clientY - 80 : null,
-        left: window.innerWidth - 710
-      },
-      messageData: {
-        "flags.dnd5e": {
-          targets: this.constructor._formatAttackTargets(),
-          roll: {type: "damage", itemId: this.id, itemUuid: this.uuid}
-        },
-        speaker: ChatMessage.getSpeaker({actor: this.actor})
-      }
-    };
 
     // Adjust damage from versatile usage
     if ( versatile && dmg.versatile ) {
@@ -1335,12 +1323,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       });
     }
 
-    // Add damage bonus formula
-    const actorBonus = foundry.utils.getProperty(this.actor.system, `bonuses.${this.system.actionType}`) || {};
-    if ( actorBonus.damage && (parseInt(actorBonus.damage) !== 0) ) {
-      rollConfigs[0].parts.push(actorBonus.damage);
-    }
-
     // Only add the ammunition damage if the ammunition is a consumable with type 'ammo'
     const ammo = this.hasAmmo ? this.actor.items.get(this.system.consume.target) : null;
     if ( ammo ) {
@@ -1364,32 +1346,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     // Factor in extra weapon-specific critical damage
     if ( this.system.critical?.damage ) rollConfig.criticalBonusDamage = this.system.critical.damage;
-
-    foundry.utils.mergeObject(rollConfig, options);
-    rollConfig.rollConfigs = rollConfigs.concat(options.rollConfigs ?? []);
-
-    /**
-     * A hook event that fires before a damage is rolled for an Item.
-     * @function dnd5e.preRollDamage
-     * @memberof hookEvents
-     * @param {Item5e} item                     Item for which the roll is being performed.
-     * @param {DamageRollConfiguration} config  Configuration data for the pending roll.
-     * @returns {boolean}                       Explicitly return false to prevent the roll from being performed.
-     */
-    if ( Hooks.call("dnd5e.preRollDamage", this, rollConfig) === false ) return;
-
-    const rolls = await damageRoll(rollConfig);
-
-    /**
-     * A hook event that fires after a damage has been rolled for an Item.
-     * @function dnd5e.rollDamage
-     * @memberof hookEvents
-     * @param {Item5e} item                    Item for which the roll was performed.
-     * @param {DamageRoll|DamageRoll[]} rolls  The resulting rolls (or single roll if `returnMultiple` is `false`).
-     */
-    if ( rolls || (rollConfig.returnMultiple && rolls?.length) ) Hooks.callAll("dnd5e.rollDamage", this, rolls);
-
-    return rolls;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Adds the `rollDamage` method to the activity mixin which provides a shared method for all activity types that roll damage. This calls into `getDamageConfig` and `processDamagePart` which provide places for individual activity types a place to configure the data provided to damage rolls.

This PR implements rolling damage for `DamageActivity` and `HealActivity`, and leaves out some parts of the damage data preparation that are only relevant to attack damage rolls.

Note: Currently just falls back to using the first of the provided damage types.

## Todo
- [ ] Implement damage rolls for `AttackActivity` and `SaveActivity`
- [ ] Handle attack-specific damage bonuses
- [ ] Handle ammunition damage bonuses
- [ ] Add damage type selection to the damage configuration interface