### PR TITLE
[#3911] Add damage rolls for `SaveActivity`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1905,7 +1905,7 @@
       "onSave": {
         "label": "Damage on Save",
         "hint": "How much damage should be applied on a successful save?",
-        "Flavor": "{amount} on Save",
+        "Flavor": "<strong>On Save</strong> {amount}",
         "Full": "Full Damage",
         "Half": "Half Damage",
         "None": "No Damage"

--- a/lang/en.json
+++ b/lang/en.json
@@ -1905,6 +1905,7 @@
       "onSave": {
         "label": "Damage on Save",
         "hint": "How much damage should be applied on a successful save?",
+        "Flavor": "{amount} on Save",
         "Full": "Full Damage",
         "Half": "Half Damage",
         "None": "No Damage"

--- a/module/data/activity/damage-data.mjs
+++ b/module/data/activity/damage-data.mjs
@@ -60,7 +60,7 @@ export default class DamageActivityData extends BaseActivityData {
   /*  Helpers                                     */
   /* -------------------------------------------- */
 
-  /** @override */
+  /** @inheritDoc */
   getDamageConfig(config={}) {
     const rollConfig = super.getDamageConfig(config);
 

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -118,4 +118,18 @@ export default class SaveActivityData extends BaseActivityData {
       ability: CONFIG.DND5E.abilities[ability]?.label ?? ""
     });
   }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  getDamageConfig(config={}) {
+    const rollConfig = super.getDamageConfig(config);
+
+    rollConfig.critical ??= {};
+    rollConfig.critical.allow ??= false;
+
+    return rollConfig;
+  }
 }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -768,7 +768,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
         },
         speaker: ChatMessage.getSpeaker({ actor: this.actor })
       }
-    });
+    }, message);
 
     /**
      * A hook event that fires before damage is rolled.

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -82,7 +82,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
           }
         }
       }
-    });
+    }, message);
 
     /**
      * A hook event that fires before a formula is rolled for an Utility activity.

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -1,4 +1,3 @@
-import { SummonsData } from "../data/item/fields/summons-field.mjs";
 import aggregateDamageRolls from "../dice/aggregate-damage-rolls.mjs";
 import DamageRoll from "../dice/damage-roll.mjs";
 import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
@@ -324,19 +323,11 @@ export default class ChatMessage5e extends ChatMessage {
     const item = this.getAssociatedItem();
     if ( this.isContentVisible && item ) {
       const isCritical = (roll.type === "damage") && this.rolls[0]?.options?.critical;
-      let subtitle;
-      if ( roll.type === "damage" ) {
-        subtitle = isCritical ? game.i18n.localize("DND5E.CriticalHit") : game.i18n.localize("DND5E.DamageRoll");
-        if ( roll.damageOnSave ) subtitle = `${subtitle} (${
-          game.i18n.format("DND5E.SAVE.FIELDS.damage.onSave.Flavor", {
-            amount: game.i18n.localize(`DND5E.SAVE.FIELDS.damage.onSave.${roll.damageOnSave.capitalize()}`)
-          }).toLowerCase()
-        })`;
-      } else if ( roll.type === "attack" ) {
-        subtitle = game.i18n.localize(`DND5E.Action${item.system.actionType.toUpperCase()}`);
-      } else {
-        subtitle = item.system.type?.label ?? game.i18n.localize(CONFIG.Item.typeLabels[item.type]);
-      }
+      const subtitle = roll.type === "damage"
+        ? isCritical ? game.i18n.localize("DND5E.CriticalHit") : game.i18n.localize("DND5E.DamageRoll")
+        : roll.type === "attack"
+          ? game.i18n.localize(`DND5E.Action${item.system.actionType.toUpperCase()}`)
+          : item.system.type?.label ?? game.i18n.localize(CONFIG.Item.typeLabels[item.type]);
       const flavor = document.createElement("div");
       flavor.classList.add("dnd5e2", "chat-card");
       flavor.innerHTML = `
@@ -507,6 +498,16 @@ export default class ChatMessage5e extends ChatMessage {
       </div>
     `;
     html.querySelector(".message-content").appendChild(roll);
+
+    const damageOnSave = this.getFlag("dnd5e", "roll.damageOnSave");
+    if ( damageOnSave ) {
+      const p = document.createElement("p");
+      p.classList.add("supplement");
+      p.innerHTML = game.i18n.format("DND5E.SAVE.FIELDS.damage.onSave.Flavor", {
+        amount: game.i18n.localize(`DND5E.SAVE.FIELDS.damage.onSave.${damageOnSave.capitalize()}`)
+      });
+      html.querySelector(".chat-card").appendChild(p);
+    }
 
     if ( game.user.isGM ) {
       const damageApplication = document.createElement("damage-application");

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -324,11 +324,19 @@ export default class ChatMessage5e extends ChatMessage {
     const item = this.getAssociatedItem();
     if ( this.isContentVisible && item ) {
       const isCritical = (roll.type === "damage") && this.rolls[0]?.options?.critical;
-      const subtitle = roll.type === "damage"
-        ? isCritical ? game.i18n.localize("DND5E.CriticalHit") : game.i18n.localize("DND5E.DamageRoll")
-        : roll.type === "attack"
-          ? game.i18n.localize(`DND5E.Action${item.system.actionType.toUpperCase()}`)
-          : item.system.type?.label ?? game.i18n.localize(CONFIG.Item.typeLabels[item.type]);
+      let subtitle;
+      if ( roll.type === "damage" ) {
+        subtitle = isCritical ? game.i18n.localize("DND5E.CriticalHit") : game.i18n.localize("DND5E.DamageRoll");
+        if ( roll.damageOnSave ) subtitle = `${subtitle} (${
+          game.i18n.format("DND5E.SAVE.FIELDS.damage.onSave.Flavor", {
+            amount: game.i18n.localize(`DND5E.SAVE.FIELDS.damage.onSave.${roll.damageOnSave.capitalize()}`)
+          }).toLowerCase()
+        })`;
+      } else if ( roll.type === "attack" ) {
+        subtitle = game.i18n.localize(`DND5E.Action${item.system.actionType.toUpperCase()}`);
+      } else {
+        subtitle = item.system.type?.label ?? game.i18n.localize(CONFIG.Item.typeLabels[item.type]);
+      }
       const flavor = document.createElement("div");
       flavor.classList.add("dnd5e2", "chat-card");
       flavor.innerHTML = `


### PR DESCRIPTION
Adds the damage button for the save activity. Saves are set to not allow critical damage.

Also adds a flag to the chat message indicating how much damage is done on a save, which is displayed in the chat message.

<img width="299" alt="Screenshot 2024-08-13 at 14 43 44" src="https://github.com/user-attachments/assets/56ee37d1-3424-4e92-b1c9-03c60f82e4f6">