### PR TITLE
[#3910] Add damage rolls for `AttackActivity`

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -286,8 +286,9 @@ export default class AttackActivityData extends BaseActivityData {
     roll.base = true;
 
     if ( this.item.type === "weapon" ) {
-      // Ensure `@mod` is present in damage unless it is a off hand attack
-      if ( (rollConfig.mode !== "offHand") && !roll.parts.some(p => p.includes("@mod")) ) roll.parts.push("@mod");
+      // Ensure `@mod` is present in damage unless it is positive and an off-hand attack
+      const includeMod = (rollConfig.mode !== "offHand") || (roll.data.mod < 0);
+      if ( includeMod && !roll.parts.some(p => p.includes("@mod")) ) roll.parts.push("@mod");
 
       // Add magical bonus
       if ( this.item.system.magicalBonus && this.item.system.magicAvailable ) {

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -223,4 +223,84 @@ export default class AttackActivityData extends BaseActivityData {
 
     return { data, parts };
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * @typedef {AttackDamageRollProcessConfiguration} [config={}]
+   * @property {"oneHanded"|"twoHanded"|"offHand"|"thrown"} mode  Attack mode.
+   */
+
+  /**
+   * Get the roll parts used to create the damage rolls.
+   * @param {Partial<AttackDamageRollProcessConfiguration>} [config={}]
+   * @returns {AttackDamageRollProcessConfiguration}
+   */
+  getDamageConfig(config={}) {
+    const rollConfig = super.getDamageConfig(config);
+
+    // TODO: Handle ammunition
+    // If base part is present, add ammunition physical properties to it
+    // If ammo has its own damage, create a new damage part of it
+
+    // const ammo = this.hasAmmo ? this.actor.items.get(this.system.consume.target) : null;
+    // if ( ammo ) {
+    //   const properties = Array.from(ammo.system.properties).filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical);
+    //   if ( this.system.properties.has("mgc") && !properties.includes("mgc") ) properties.push("mgc");
+    //   const ammoConfigs = ammo.system.damage.parts.map((([formula, type]) => ({ parts: [formula], type, properties })));
+    //   if ( ammo.system.magicalBonus && ammo.system.magicAvailable ) {
+    //     rollConfigs[0].parts.push("@ammo");
+    //     properties.forEach(p => {
+    //       if ( !rollConfigs[0].properties.includes(p) ) rollConfigs[0].properties.push(p);
+    //     });
+    //     rollData.ammo = ammo.system.magicalBonus;
+    //   }
+    //   rollConfigs.push(...ammoConfigs);
+    // }
+
+    if ( this.damage.critical.bonus ) {
+      rollConfig.critical ??= {};
+      rollConfig.critical.bonusDamage ??= this.damage.critical.bonus;
+    }
+
+    return rollConfig;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _processDamagePart(damage, rollConfig, rollData) {
+    if ( !damage.base ) super._processDamagePart(damage, rollConfig, rollData);
+
+    // Swap base damage for versatile if two-handed attack is made on versatile weapon
+    if ( this.item.system.isVersatile && (rollConfig.mode === "twoHanded") ) {
+      const versatile = this.item.system.damage.versatile.clone();
+      versatile.base = true;
+      versatile.denomination ||= damage.steppedDenomination();
+      versatile.number ||= damage.number;
+      versatile.types = damage.types;
+      damage = versatile;
+    }
+
+    const roll = super._processDamagePart(damage, rollConfig, rollData);
+    roll.base = true;
+
+    if ( this.item.type === "weapon" ) {
+      // Ensure `@mod` is present in damage unless it is a off hand attack
+      if ( (rollConfig.mode !== "offHand") && !roll.parts.some(p => p.includes("@mod")) ) roll.parts.push("@mod");
+
+      // Add magical bonus
+      if ( this.item.system.magicalBonus && this.item.system.magicAvailable ) {
+        roll.parts.push("@magicalBonus");
+        roll.data.magicalBonus = this.item.system.magicalBonus;
+      }
+    }
+
+    const criticalBonusDice = this.actor?.getFlag("dnd5e", "meleeCriticalDamageDice") ?? 0;
+    if ( (this.actionType === "mwak") && (parseInt(criticalBonusDice) !== 0) ) {
+      foundry.utils.setProperty(roll, "options.critical.bonusDice", criticalBonusDice);
+    }
+
+    return roll;
+  }
 }

--- a/module/data/shared/damage-field.mjs
+++ b/module/data/shared/damage-field.mjs
@@ -119,4 +119,19 @@ export class DamageData extends foundry.abstract.DataModel {
 
     return formula;
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Step the die denomination up or down by a number of steps, sticking to proper die sizes. Will return `null` if
+   * stepping reduced the denomination below minimum die size.
+   * @param {number} [steps=1]  Number of steps to increase or decrease the denomination.
+   * @returns {number|null}
+   */
+  steppedDenomination(steps=1) {
+    return CONFIG.DND5E.dieSteps[Math.min(
+      CONFIG.DND5E.dieSteps.indexOf(this.denomination) + steps,
+      CONFIG.DND5E.dieSteps.length - 1
+    )] ?? null;
+  }
 }

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -25,7 +25,8 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
       sheetClass: AttackSheet,
       usage: {
         actions: {
-          rollAttack: AttackActivity.#rollAttack
+          rollAttack: AttackActivity.#rollAttack,
+          rollDamage: AttackActivity.#rollDamage
         }
       }
     }, { inplace: false })
@@ -37,13 +38,21 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
 
   /** @override */
   _usageChatButtons() {
-    return [{
+    const buttons = [{
       label: game.i18n.localize("DND5E.Attack"),
       icon: '<i class="dnd5e-icon" data-src="systems/dnd5e/icons/svg/trait-weapon-proficiencies.svg" inert></i>',
       dataset: {
         action: "rollAttack"
       }
     }];
+    if ( this.damage.parts.length ) buttons.push({
+      label: game.i18n.localize("DND5E.Damage"),
+      icon: '<i class="fa-solid fa-burst" inert></i>',
+      dataset: {
+        action: "rollDamage"
+      }
+    });
+    return buttons;
   }
 
   /* -------------------------------------------- */
@@ -209,5 +218,18 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
    */
   static #rollAttack(event, target, message) {
     this.rollAttack({ event });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle performing a damage roll.
+   * @this {AttackActivity}
+   * @param {PointerEvent} event     Triggering click event.
+   * @param {HTMLElement} target     The capturing HTML element which defined a [data-action].
+   * @param {ChatMessage5e} message  Message associated with the activation.
+   */
+  static #rollDamage(event, target, message) {
+    this.rollDamage({ event });
   }
 }

--- a/module/documents/activity/damage.mjs
+++ b/module/documents/activity/damage.mjs
@@ -39,7 +39,7 @@ export default class DamageActivity extends ActivityMixin(DamageActivityData) {
     if ( !this.damage.parts.length ) return null;
     return [{
       label: game.i18n.localize("DND5E.Damage"),
-      icon: '<i class="fas fa-burst" inert></i>',
+      icon: '<i class="fa-solid fa-burst" inert></i>',
       dataset: {
         action: "rollDamage"
       }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1284,7 +1284,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const rolls = await activity.rollDamage(options);
     return returnMultiple ? rolls : rolls?.[0];
 
-    // TODO: Remove this reference code once rollDamage is implemented for attacks & scaling is implemented
+    // TODO: Remove this reference code once scaling is implemented
 
     // Fetch level from tags if not specified
     let originalLevel = this.system.level;
@@ -1294,17 +1294,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       spellLevel = levelingFlag.value;
       originalLevel = levelingFlag.base;
       scaling = levelingFlag.scaling;
-    }
-
-    // Adjust damage from versatile usage
-    if ( versatile && dmg.versatile ) {
-      rollConfigs[0].parts[0] = dmg.versatile;
-      rollConfig.messageData["flags.dnd5e"].roll.versatile = true;
-    }
-
-    // Add magical damage if available
-    if ( this.system.magicalBonus && this.system.magicAvailable ) {
-      rollConfigs[0].parts.push(this.system.magicalBonus);
     }
 
     // Scale damage from up-casting spells
@@ -1322,30 +1311,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
         }
       });
     }
-
-    // Only add the ammunition damage if the ammunition is a consumable with type 'ammo'
-    const ammo = this.hasAmmo ? this.actor.items.get(this.system.consume.target) : null;
-    if ( ammo ) {
-      const properties = Array.from(ammo.system.properties).filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical);
-      if ( this.system.properties.has("mgc") && !properties.includes("mgc") ) properties.push("mgc");
-      const ammoConfigs = ammo.system.damage.parts.map((([formula, type]) => ({ parts: [formula], type, properties })));
-      if ( ammo.system.magicalBonus && ammo.system.magicAvailable ) {
-        rollConfigs[0].parts.push("@ammo");
-        properties.forEach(p => {
-          if ( !rollConfigs[0].properties.includes(p) ) rollConfigs[0].properties.push(p);
-        });
-        rollData.ammo = ammo.system.magicalBonus;
-      }
-      rollConfigs.push(...ammoConfigs);
-    }
-
-    // Factor in extra critical damage dice from the Barbarian's "Brutal Critical"
-    if ( this.system.actionType === "mwak" ) {
-      rollConfig.criticalBonusDice = this.actor.getFlag("dnd5e", "meleeCriticalDamageDice") ?? 0;
-    }
-
-    // Factor in extra weapon-specific critical damage
-    if ( this.system.critical?.damage ) rollConfig.criticalBonusDamage = this.system.critical.damage;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Adds the damage button for the attack activity and handles all of the attack-specific bonuses.

This adds a new option to the configuration for `mode`, which will be determined by the attack roll and modifies damage based on whether it is a one-handed, two-handed, off-hand, or thrown attack.

### Todo
- [ ] Handle ammunition bonuses
- [ ] Set attack mode in attack dialog and propagate to next damage roll