### PR TITLE
[#1964] Implement initial activity usage dialog

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -822,22 +822,28 @@
   },
   "Type": {
     "ActivityUses": {
-      "Label": "Activity Uses"
+      "Label": "Activity Uses",
+      "Prompt": "Consume Activity Use?"
     },
     "Attribute": {
-      "Label": "Attribute"
+      "Label": "Attribute",
+      "Prompt": "Consume Attribute?"
     },
     "HitDice": {
-      "Label": "Hit Dice"
+      "Label": "Hit Dice",
+      "Prompt": "Consume Hit Die?"
     },
     "ItemUses": {
-      "Label": "Item Uses"
+      "Label": "Item Uses",
+      "Prompt": "Consume Item Use?"
     },
     "Material": {
-      "Label": "Material"
+      "Label": "Material",
+      "Prompt": "Consume Material?"
     },
     "SpellSlots": {
-      "Label": "Spell Slots"
+      "Label": "Spell Slots",
+      "Prompt": "Consume Spell Slot?"
     }
   },
   "Warning": {
@@ -2016,6 +2022,7 @@
 "DND5E.SavePromptTitle": "{ability} Saving Throw",
 "DND5E.ScalingFormula": "Scaling Formula",
 "DND5E.ScalingMode": "Scaling Mode",
+"DND5E.ScalingValue": "Scaling Value",
 "DND5E.School": "School",
 "DND5E.SchoolAbj": "Abjuration",
 "DND5E.SchoolCon": "Conjuration",
@@ -2573,6 +2580,15 @@
 "DND5E.Unidentified.Value": "???",
 "DND5E.Unknown": "Unknown",
 "DND5E.Unlimited": "Unlimited",
+
+"DND5E.USAGE": {
+  "SECTION": {
+    "Consumption": "Consumption",
+    "Creation": "Creation",
+    "Scaling": "Scaling"
+  }
+},
+
 "DND5E.Usage": "Usage",
 "DND5E.Use": "Use",
 "DND5E.UseItem": "Use {item}",

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -296,20 +296,20 @@ export default class ActivityUsageDialog extends Application5e {
     context.hasScaling = true;
     context.notes = [];
 
-    if ( this.actor.system.spells && this.activity.isSpell && (this.item.system.level > 0) ) {
+    if ( this.activity.requiresSpellSlot ) {
       const minimumLevel = this.item.system.level ?? 1;
       const maximumLevel = Object.values(this.actor.system.spells)
         .reduce((max, d) => d.max ? Math.max(max, d.level) : max, 0);
 
       const spellSlotOptions = Object.entries(this.actor.system.spells).map(([value, slot]) => {
         if ( (slot.level < minimumLevel) || (slot.level > maximumLevel) ) return null;
-        let label = slot.label;
-        if ( slot.type === "pact" ) label = `${label} [${CONFIG.DND5E.spellLevels[slot.level]}]`;
-        return {
-          value,
-          label: game.i18n.format("DND5E.SpellLevelSlot", { level: label, n: slot.value }),
-          disabled: (slot.value === 0) && this.config.consume?.spellSlot
-        };
+        let label;
+        if ( slot.type === "leveled" ) {
+          label = game.i18n.format("DND5E.SpellLevelSlot", { level: slot.label, n: slot.value });
+        } else {
+          label = game.i18n.format(`DND5E.SpellLevel${slot.type.capitalize()}`, { level: slot.level, n: slot.value });
+        }
+        return { value, label, disabled: (slot.value === 0) && this.config.consume?.spellSlot };
       }).filter(o => o);
 
       if ( spellSlotOptions ) context.spellSlots = {

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -255,7 +255,7 @@ export default class RollConfigurationDialog extends Application5e {
   }
 
   /* -------------------------------------------- */
-  /*  Event Handling                              */
+  /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 
   /**
@@ -285,12 +285,12 @@ export default class RollConfigurationDialog extends Application5e {
   /* -------------------------------------------- */
 
   /** @override */
-  _onClose(options = {}) {
+  _onClose(options={}) {
     if ( !options.dnd5e?.submitted ) this.#rolls = [];
   }
 
   /* -------------------------------------------- */
-  /*  Constructor                                 */
+  /*  Factory Methods                             */
   /* -------------------------------------------- */
 
   /**

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -668,34 +668,40 @@ preLocalize("abilityConsumptionTypes", { sort: true });
  */
 DND5E.activityConsumptionTypes = {
   activityUses: {
-    label: "DND5E.CONSUMPTION.Type.ActivityUses.Label"
+    label: "DND5E.CONSUMPTION.Type.ActivityUses.Label",
+    prompt: "DND5E.CONSUMPTION.Type.ActivityUses.Prompt"
   },
   itemUses: {
     label: "DND5E.CONSUMPTION.Type.ItemUses.Label",
+    prompt: "DND5E.CONSUMPTION.Type.ItemUses.Prompt",
     targetRequiresEmbedded: true,
     validTargets: BaseActivityData.validItemUsesTargets
   },
   material: {
     label: "DND5E.CONSUMPTION.Type.Material.Label",
+    prompt: "DND5E.CONSUMPTION.Type.Material.Prompt",
     targetRequiresEmbedded: true,
     validTargets: BaseActivityData.validMaterialTargets
   },
   hitDice: {
     label: "DND5E.CONSUMPTION.Type.HitDice.Label",
+    prompt: "DND5E.CONSUMPTION.Type.HitDice.Prompt",
     validTargets: BaseActivityData.validHitDiceTargets
   },
   spellSlots: {
     label: "DND5E.CONSUMPTION.Type.SpellSlots.Label",
+    prompt: "DND5E.CONSUMPTION.Type.SpellSlots.Prompt",
     scalingModes: [{ value: "level", label: "DND5E.CONSUMPTION.Scaling.SlotLevel" }],
     validTargets: BaseActivityData.validSpellSlotsTargets
   },
   attribute: {
     label: "DND5E.CONSUMPTION.Type.Attribute.Label",
+    prompt: "DND5E.CONSUMPTION.Type.Attribute.Prompt",
     targetRequiresEmbedded: true,
     validTargets: BaseActivityData.validAttributeTargets
   }
 };
-preLocalize("activityConsumptionTypes", { key: "label" });
+preLocalize("activityConsumptionTypes", { keys: ["label", "prompt"] });
 
 /* -------------------------------------------- */
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -142,6 +142,28 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Does this activity or its item require concentration?
+   * @type {boolean}
+   */
+  get requiresConcentration() {
+    return this.item.requiresConcentration;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does activating this activity consume a spell slot?
+   * @type {boolean}
+   */
+  get requiresSpellSlot() {
+    if ( !this.isSpell || !this.actor?.system.spells ) return false;
+    // TODO: Check against specific preparation modes here
+    return this.item.system.level > 0;
+  }
+
+  /* -------------------------------------------- */
   /*  Data Migrations                             */
   /* -------------------------------------------- */
 

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -48,7 +48,7 @@ export default class UsesField extends SchemaField {
    */
   static prepareData(rollData, labels) {
     prepareFormulaValue(this, "uses.max", "DND5E.USES.FIELDS.uses.max.label", rollData);
-    this.uses.value = Math.clamp(this.uses.max - this.uses.spent, 0, this.uses.max);
+    this.uses.value = this.uses.max ? Math.clamp(this.uses.max - this.uses.spent, 0, this.uses.max) : 0;
 
     const periods = [];
     for ( const recovery of this.uses.recovery ) {

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -38,7 +38,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
   _usageChatButtons() {
     if ( !this.roll.formula ) return null;
     return [{
-      label: this.roll.label || game.i18n.localize("DND5E.Roll"),
+      label: this.roll.name || game.i18n.localize("DND5E.Roll"),
       icon: '<i class="fa-solid fa-dice" inert></i>',
       dataset: {
         action: "rollFormula",

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -761,8 +761,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const slots = CONFIG.DND5E.SPELL_SLOT_TABLE[Math.min(levels, CONFIG.DND5E.SPELL_SLOT_TABLE.length) - 1] ?? [];
     for ( const level of Array.fromRange(Object.keys(CONFIG.DND5E.spellLevels).length - 1, 1) ) {
       const slot = spells[`spell${level}`] ??= { value: 0 };
+      slot.label = CONFIG.DND5E.spellLevels[level];
       slot.level = level;
       slot.max = Number.isNumeric(slot.override) ? Math.max(parseInt(slot.override), 0) : slots[level - 1] ?? 0;
+      slot.type = "leveled";
     }
   }
 
@@ -785,6 +787,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     let keyLevel = Math.clamp(progression[key], 0, CONFIG.DND5E.maxLevel);
     spells[key] ??= {};
+    spells[key].type = key;
     const override = Number.isNumeric(spells[key].override) ? parseInt(spells[key].override) : null;
 
     // Slot override
@@ -816,6 +819,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   static preparePactSlots(spells, actor, progression) {
     this.prepareAltSlots(spells, actor, progression, "pact", CONFIG.DND5E.pactCastingProgression);
+    spells.pact.label = game.i18n.localize("DND5E.PactMagic");
   }
 
   /* -------------------------------------------- */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -847,7 +847,7 @@ export default class ChatMessage5e extends ChatMessage {
     const storedData = this.getFlag("dnd5e", "item.data");
     return storedData
       ? new Item.implementation(storedData, { parent: actor })
-      : actor.items.get(this.getFlag("dnd5e", "item.id")) ?? actor.items.get(this.getFlag("dnd5e", "use.itemId"));
+      : actor.items.get(this.getFlag("dnd5e", "item.id"));
   }
 
   /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -433,6 +433,9 @@ export async function preloadHandlebarsTemplates() {
     // Journal Partials
     "systems/dnd5e/templates/journal/parts/journal-table.hbs",
 
+    // Activity Partials
+    "systems/dnd5e/templates/activity/activity-usage-notes.hbs",
+
     // Advancement Partials
     "systems/dnd5e/templates/advancement/parts/advancement-ability-score-control.hbs",
     "systems/dnd5e/templates/advancement/parts/advancement-controls.hbs",
@@ -567,7 +570,8 @@ function concealSection(conceal, options) {
 
 /**
  * Construct an object from the provided arguments.
- * @param {object} options  Handlebars options.
+ * @param {object} options       Handlebars options.
+ * @param {object} options.hash
  * @returns {object}
  */
 function makeObject({ hash }) {

--- a/templates/activity/activity-usage-concentration.hbs
+++ b/templates/activity/activity-usage-concentration.hbs
@@ -1,0 +1,11 @@
+<section>
+    {{> "dnd5e.activity-usage-notes" }}
+    {{#if hasConcentration}}
+    <fieldset>
+        <legend>{{ localize "DND5E.Concentration" }}</legend>
+        {{#each fields}}
+            {{ formField field name=name value=value options=options }}
+        {{/each}}
+    </fieldset>
+    {{/if}}
+</section>

--- a/templates/activity/activity-usage-consumption.hbs
+++ b/templates/activity/activity-usage-consumption.hbs
@@ -1,0 +1,15 @@
+<section>
+    {{> "dnd5e.activity-usage-notes" }}
+    {{#if hasConsumption}}
+    <fieldset>
+        <legend>{{ localize "DND5E.USAGE.SECTION.Consumption" }}</legend>
+        {{#if spellSlot}}
+            {{ formField spellSlot.field name=spellSlot.name value=spellSlot.value }}
+        {{/if}}
+        {{#if resources}}
+            {{ formInput resources.field name=resources.name options=resources.options type="checkboxes"
+               dataset=resources.dataset }}
+        {{/if}}
+    </fieldset>
+    {{/if}}
+</section>

--- a/templates/activity/activity-usage-creation.hbs
+++ b/templates/activity/activity-usage-creation.hbs
@@ -1,0 +1,11 @@
+<section>
+    {{> "dnd5e.activity-usage-notes" }}
+    {{#if hasCreation}}
+    <fieldset>
+        <legend>{{ localize "DND5E.USAGE.SECTION.Creation" }}</legend>
+        {{#if template}}
+            {{ formField template.field name=template.name value=template.value }}
+        {{/if}}
+    </fieldset>
+    {{/if}}
+</section>

--- a/templates/activity/activity-usage-notes.hbs
+++ b/templates/activity/activity-usage-notes.hbs
@@ -1,0 +1,3 @@
+{{#each notes}}
+    <p class="note {{ type }}">{{ message }}</p>
+{{/each}}

--- a/templates/activity/activity-usage-scaling.hbs
+++ b/templates/activity/activity-usage-scaling.hbs
@@ -1,0 +1,30 @@
+<section>
+    {{> "dnd5e.activity-usage-notes" }}
+    {{#if hasScaling}}
+    <fieldset>
+        <legend>{{ localize "DND5E.USAGE.SECTION.Scaling" }}</legend>
+        {{#if spellSlots}}
+        {{ formField spellSlots.field name=spellSlots.name value=spellSlots.value options=spellSlots.options }}
+        {{/if}}
+        {{#if scaling}}
+        <div class="form-group">
+            <label>{{ localize "DND5E.ScalingValue" }}</label>
+            <div class="form-fields">
+                {{#if scaling.showRange}}
+                <range-picker name="{{ scaling.name }}" value="{{ scaling.value }}" min="1" max="{{ scaling.max }}"
+                              step="1"></range-picker>
+                {{else}}
+                {{ formInput scaling.field name=scaling.name value=scaling.value }}
+                {{/if}}
+            </div>
+        </div>
+        <div class="form-group">
+            <label>{{ localize "DND5E.CONSUMPTION.FIELDS.consumption.scaling.max.label" }}</label>
+            <div class="form-fields">
+                <span>{{ dnd5e-numberFormat scaling.max }}</span>
+            </div>
+        </div>
+        {{/if}}
+    </fieldset>
+    {{/if}}
+</section>

--- a/templates/activity/parts/activity-consumption.hbs
+++ b/templates/activity/parts/activity-consumption.hbs
@@ -9,7 +9,7 @@
                 {{ formField fields.target name=(concat prefix "target") value=data.target options=validTargets
                    placeholder=targetPlaceholder }}
                 {{/if}}
-                {{ formField fields.value name=(concat prefix "amount") value=data.value }}
+                {{ formField fields.value name=(concat prefix "value") value=data.value }}
                 {{#if scalingModes}}
                 {{ formField fields.scaling.fields.mode name=(concat prefix "scaling.mode") value=data.scaling.mode
                    options=scalingModes }}


### PR DESCRIPTION
Adds the initial activity usage dialog which re-implements the item usage dialog in ApplicationV2. The new setup should be more flexible to allow for specific activity types like Enchant and Summon to add their own controls. It also now re-renders when changes are made allowing for dynamic inputs and messages.

The dialog currently doesn't implement the consumption warnings from the original dialog pending the implementation of the consumption system, nor does it re-scale the item when changes to scaling are made.

<img width="861" alt="Usage Dialog V1" src="https://github.com/user-attachments/assets/85063bbf-c8be-4346-a7a5-be5246cd9bc6">

### Todo
- [ ] Dynamically re-scale item when changes are made to scaling
- [ ] Display more detailed information on each consumption target (target name, scaled amount consumed)
- [ ] Display proper consumption warnings (will consume last quantity and destroy item, not enough uses left, etc.)