### PR TITLE
[#1964] Properly scale items when activated

### DIFF
--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -130,7 +130,7 @@ export default class ActivityUsageDialog extends Application5e {
 
   /** @inheritDoc */
   async _prepareContext(options) {
-    // TODO: Adjust item scaling when scaling is changed
+    this.#item = this.#item.clone({ "flags.dnd5e.scaling": this.config.scaling ?? 0 });
     return {
       ...await super._prepareContext(options),
       activity: this.activity
@@ -296,7 +296,7 @@ export default class ActivityUsageDialog extends Application5e {
     context.hasScaling = true;
     context.notes = [];
 
-    if ( this.activity.requiresSpellSlot ) {
+    if ( this.activity.requiresSpellSlot && (this.config.scaling !== false) ) {
       const minimumLevel = this.item.system.level ?? 1;
       const maximumLevel = Object.values(this.actor.system.spells)
         .reduce((max, d) => d.max ? Math.max(max, d.level) : max, 0);
@@ -326,7 +326,7 @@ export default class ActivityUsageDialog extends Application5e {
       });
     }
 
-    else if ( this.activity.consumption.scaling.allowed ) {
+    else if ( this.activity.consumption.scaling.allowed && (this.config.scaling !== false) ) {
       const scale = this.activity.consumption.scaling;
       const max = scale.max ? simplifyBonus(scale.max, this.activity.getRollData({ deterministic: true })) : Infinity;
       context.scaling = {

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -441,6 +441,16 @@ export class ItemDataModel extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Scaling increase for this item type.
+   * @type {number|null}
+   */
+  get scalingIncrease() {
+    return null;
+  }
+
+  /* -------------------------------------------- */
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -563,7 +563,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * @protected
    */
   _processDamagePart(damage, rollConfig, rollData) {
-    const scaledFormula = damage.scaledFormula(rollConfig.scaling);
+    const scaledFormula = damage.scaledFormula(rollData.scaling);
     const parts = scaledFormula ? [scaledFormula] : [];
     const data = { ...rollData };
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -152,18 +152,6 @@ export default class CharacterData extends CreatureTemplate {
   }
 
   /* -------------------------------------------- */
-  /*  Properties                                  */
-  /* -------------------------------------------- */
-
-  /**
-   * Level used to determine cantrip scaling.
-   * @type {number}
-   */
-  get cantripLevel() {
-    return this.details.level;
-  }
-
-  /* -------------------------------------------- */
   /*  Data Migration                              */
   /* -------------------------------------------- */
 
@@ -253,6 +241,17 @@ export default class CharacterData extends CreatureTemplate {
 
   /* -------------------------------------------- */
   /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Level used to determine cantrip scaling.
+   * @param {Item5e} spell  Spell for which to fetch the cantrip level.
+   * @returns {number}
+   */
+  cantripLevel(spell) {
+    return this.details.level;
+  }
+
   /* -------------------------------------------- */
 
   /**

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -152,6 +152,18 @@ export default class CharacterData extends CreatureTemplate {
   }
 
   /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Level used to determine cantrip scaling.
+   * @type {number}
+   */
+  get cantripLevel() {
+    return this.details.level;
+  }
+
+  /* -------------------------------------------- */
   /*  Data Migration                              */
   /* -------------------------------------------- */
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -189,18 +189,6 @@ export default class NPCData extends CreatureTemplate {
   }
 
   /* -------------------------------------------- */
-  /*  Properties                                  */
-  /* -------------------------------------------- */
-
-  /**
-   * Level used to determine cantrip scaling.
-   * @type {number}
-   */
-  get cantripLevel() {
-    return Math.max(this.details.level, this.details.spellLevel, this.details.cr);
-  }
-
-  /* -------------------------------------------- */
   /*  Data Migration                              */
   /* -------------------------------------------- */
 
@@ -361,5 +349,19 @@ export default class NPCData extends CreatureTemplate {
       mod: this.abilities[CONFIG.DND5E.defaultAbilities.hitPoints ?? "con"]?.mod ?? 0
     };
     AttributesFields.prepareHitPoints.call(this, this.attributes.hp, hpOptions);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Level used to determine cantrip scaling.
+   * @param {Item5e} spell  Spell for which to fetch the cantrip level.
+   * @returns {number}
+   */
+  cantripLevel(spell) {
+    if ( spell.system.preparation.mode === "innate" ) return this.details.cr;
+    return this.details.level ? this.details.level : this.details.spellLevel;
   }
 }

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -189,6 +189,18 @@ export default class NPCData extends CreatureTemplate {
   }
 
   /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Level used to determine cantrip scaling.
+   * @type {number}
+   */
+  get cantripLevel() {
+    return Math.max(this.details.level, this.details.spellLevel, this.details.cr);
+  }
+
+  /* -------------------------------------------- */
   /*  Data Migration                              */
   /* -------------------------------------------- */
 

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -296,6 +296,31 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  get scalingIncrease() {
+    const actor = this.parent.actor;
+    if ( (this.level !== 0) || !actor ) return null;
+    let level = actor.system.details?.level;
+    if ( !level && (actor.type === "npc") ) {
+      if ( this.preparation.mode === "innate" ) level = Math.ceil(actor.system.details.cr);
+      else level = actor.system.details.spellLevel;
+    }
+    return Math.floor(((level ?? 0) + 1) / 6);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  getRollData(...options) {
+    const data = super.getRollData(...options);
+    data.item.level = data.item.level + (this.parent.getFlag("dnd5e", "scaling") ?? 0);
+    return data;
+  }
+
+  /* -------------------------------------------- */
   /*  Shims                                       */
   /* -------------------------------------------- */
 

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -300,7 +300,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   /** @inheritDoc */
   get scalingIncrease() {
     if ( this.level !== 0 ) return null;
-    return Math.floor(((this.parent.actor?.system.cantripLevel ?? 0) + 1) / 6);
+    return Math.floor(((this.parent.actor?.system.cantripLevel?.(this.parent) ?? 0) + 1) / 6);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -299,14 +299,8 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
 
   /** @inheritDoc */
   get scalingIncrease() {
-    const actor = this.parent.actor;
-    if ( (this.level !== 0) || !actor ) return null;
-    let level = actor.system.details?.level;
-    if ( !level && (actor.type === "npc") ) {
-      if ( this.preparation.mode === "innate" ) level = Math.ceil(actor.system.details.cr);
-      else level = actor.system.details.spellLevel;
-    }
-    return Math.floor(((level ?? 0) + 1) / 6);
+    if ( this.level !== 0 ) return null;
+    return Math.floor(((this.parent.actor?.system.cantripLevel ?? 0) + 1) / 6);
   }
 
   /* -------------------------------------------- */

--- a/module/data/shared/damage-field.mjs
+++ b/module/data/shared/damage-field.mjs
@@ -1,3 +1,4 @@
+import Scaling from "../../documents/scaling.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { BooleanField, EmbeddedDataField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
@@ -89,10 +90,12 @@ export class DamageData extends foundry.abstract.DataModel {
 
   /**
    * Scale the damage by a number of steps using its configured scaling configuration.
-   * @param {number} increase  Number of steps above base damage to scaling.
+   * @param {number|Scaling} increase  Number of steps above base damage to scaling.
    * @returns {string}
    */
   scaledFormula(increase) {
+    if ( increase instanceof Scaling ) increase = increase.increase;
+
     switch ( this.scaling.mode ) {
       case "whole": break;
       case "half": increase = Math.floor(increase * .5); break;

--- a/module/documents/_module.mjs
+++ b/module/documents/_module.mjs
@@ -17,3 +17,4 @@ export {default as SelectChoices} from "./actor/select-choices.mjs";
 export * as Trait from "./actor/trait.mjs";
 export * as mixins from "./mixins/_module.mjs";
 export * as macro from "./macro.mjs";
+export {default as Scaling} from "./scaling.mjs";

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -556,7 +556,6 @@ export default Base => class extends PseudoDocumentMixin(Base) {
     if ( usageConfig.scaling ) {
       foundry.utils.setProperty(messageConfig, "data.flags.dnd5e.scaling", usageConfig.scaling);
       item.updateSource({ "flags.dnd5e.scaling": usageConfig.scaling });
-      item.prepareData();
       item.prepareFinalAttributes();
     }
   }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -502,13 +502,23 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       config.consume.spellSlot ??= this.requiresSpellSlot;
     }
 
-    if ( this.canScale ) config.scaling ??= 0;
-    else config.scaling = false;
-
-    if ( this.isSpell ) {
-      const mode = this.item.system.preparation.mode;
+    const levelingFlag = this.item.getFlag("dnd5e", "spellLevel");
+    if ( levelingFlag ) {
+      // Handle fixed scaling from spell scrolls
+      config.scaling = false;
       config.spell ??= {};
-      config.spell.slot ??= (mode in this.actor.system.spells) ? mode : `spell${this.item.system.level}`;
+      config.spell.slot = levelingFlag.value;
+    }
+
+    else {
+      if ( this.canScale ) config.scaling ??= 0;
+      else config.scaling = false;
+
+      if ( this.isSpell ) {
+        const mode = this.item.system.preparation.mode;
+        config.spell ??= {};
+        config.spell.slot ??= (mode in this.actor.system.spells) ? mode : `spell${this.item.system.level}`;
+      }
     }
 
     if ( this.item.requiresConcentration && !game.settings.get("dnd5e", "disableConcentration") ) {
@@ -535,7 +545,20 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @protected
    */
   _prepareUsageScaling(usageConfig, messageConfig, item) {
-    // TODO: Implement scaling
+    const levelingFlag = this.item.getFlag("dnd5e", "spellLevel");
+    if ( levelingFlag ) {
+      usageConfig.scaling = Math.max(0, levelingFlag.value - levelingFlag.base);
+    } else if ( this.isSpell ) {
+      const level = this.actor.system.spells?.[usageConfig.spell?.slot]?.level;
+      if ( level ) usageConfig.scaling = level - item.system.level;
+    }
+
+    if ( usageConfig.scaling ) {
+      foundry.utils.setProperty(messageConfig, "data.flags.dnd5e.scaling", usageConfig.scaling);
+      item.updateSource({ "flags.dnd5e.scaling": usageConfig.scaling });
+      item.prepareData();
+      item.prepareFinalAttributes();
+    }
   }
 
   /* -------------------------------------------- */
@@ -848,12 +871,16 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @param {ChatMessage5e} message  Message associated with the activation.
    */
   async #onChatAction(event, target, message) {
+    const scaling = message.getFlag("dnd5e", "scaling") ?? 0;
+    const item = scaling ? this.item.clone({ "flags.dnd5e.scaling": scaling }, { keepId: true }) : this.item;
+    const activity = item.system.activities.get(this.id);
+
     const action = target.dataset.action;
     const handler = this.metadata.usage?.actions?.[action];
     target.disabled = true;
     try {
-      if ( handler ) await handler.call(this, event, target, message);
-      else await this._onChatAction(event, target);
+      if ( handler ) await handler.call(activity, event, target, message);
+      else await activity._onChatAction(event, target);
     } finally {
       target.disabled = false;
     }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1238,7 +1238,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     let item = this;
     if ( spellLevel && (this.type === "spell") ) {
-      item = item.clone({ "flags.dnd5e.scaling": Math.max(0, item.system.level - spellLevel) }, { keepId: true });
+      item = item.clone({ "flags.dnd5e.scaling": Math.max(0, spellLevel - item.system.level) }, { keepId: true });
     }
 
     const activity = item.system.activities?.getByType("attack")[0];
@@ -1290,7 +1290,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     let item = this;
     if ( spellLevel && (this.type === "spell") ) {
-      item = item.clone({ "flags.dnd5e.scaling": Math.max(0, item.system.level - spellLevel) }, { keepId: true });
+      item = item.clone({ "flags.dnd5e.scaling": Math.max(0, spellLevel - item.system.level) }, { keepId: true });
     }
 
     const activity = item.system.activities?.getByType("attack")[0] || item.system.activities?.getByType("damage")[0]
@@ -1320,7 +1320,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     let item = this;
     if ( spellLevel && (this.type === "spell") ) {
-      item = item.clone({ "flags.dnd5e.scaling": Math.max(0, item.system.level - spellLevel) }, { keepId: true });
+      item = item.clone({ "flags.dnd5e.scaling": Math.max(0, spellLevel - item.system.level) }, { keepId: true });
     }
 
     const activity = item.system.activities?.getByType("utility")[0];

--- a/module/documents/scaling.mjs
+++ b/module/documents/scaling.mjs
@@ -1,0 +1,41 @@
+/**
+ * Lightweight class containing scaling information for an item that is used in roll data to ensure it is available
+ * in the correct format in roll formulas: `@scaling` is the scaling value, and `@scaling.increase` as the scaling
+ * steps above baseline.
+ *
+ * @param {number} increase  Scaling steps above baseline.
+ */
+export default class Scaling {
+  constructor(increase) {
+    this.#increase = increase;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Scaling steps above baseline.
+   * @type {number}
+   */
+  #increase;
+
+  get increase() {
+    return this.#increase;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Value of the scaling starting 1.
+   * @type {string}
+   */
+  get value() {
+    return this.#increase + 1;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  toString() {
+    return this.value;
+  }
+}


### PR DESCRIPTION
Changes how scaling occurs to be able to handle scaling on all items, not just spells. It does this by adding the `dnd5e.scaling` flag which contains the number of steps an item was activated ahove its base level. So for a spell cast at its base level, this would be `0` and it would go up `1` for each level it is upcast.

This value is made available in roll data in two ways. For spells, their roll data is automatically updates to `@item.level` always coresponds to the proper spell level without having to update that value when cloning the item. There is also the `@scaling` value which is the scaling value and `@scaling.increase` which is the increase.

So for a spell that targets one creature at its base level and one additional creature for each slot above base level, you would just enter `@scaling` in the targets field. For a spell that starts at 30 foot range that increase by 10 feet per level you could enter `30 + (10 * @scaling.increase)` into the distance field. This should make scaled values easier to enter without having to subtract the base level from the upcast level like currently.

Cantrips behave a bit differently than normal spells. They override the `scalingIncrease` value provided by `ItemDataModel` setting their scaling increase to a fixed value based on character level. This allows cantrips to scale their damage properly without having to set a specific cantrip scaling mode.

There is some extra logic to handle the `spellLevel` flag provided by spell scrolls and tattoos, but the spell scroll creation code will have to be revisited to ensure it creates the proper activities.

### Todo
- [ ] Rewrite `createScrollFromSpell` to properly copy over activities & other data