### PR TITLE
Don't assume _stats is present in activities migration

### DIFF
--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -201,7 +201,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
     if ( !source.system.actionType && !source.system.activation?.type ) return false;
 
     // If item was updated after `4.0.0`, it shouldn't need the migration
-    if ( !foundry.utils.isNewerVersion("4.0.0", source._stats.systemVersion ?? "0.0.0") ) return false;
+    if ( !foundry.utils.isNewerVersion("4.0.0", source._stats?.systemVersion ?? "0.0.0") ) return false;
 
     // If the initial activity has already been created, no reason to create it again
     if ( !foundry.utils.isEmpty(source.system.activities) ) return false;


### PR DESCRIPTION
Other places where similar checks happend in the system don't assume `_stats` is present, this can cause issues when creating documents from data.