### PR TITLE
[#3920, #3982] Add rules version setting, implement new exhaustion

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2989,6 +2989,12 @@
   "THEME": {
     "Name": "Theme",
     "Hint": "Theme that will apply to the UI and all sheets by default. Automatic will be determined by your browser or operating system settings."
+  },
+  "RULESVERSION": {
+    "Name": "Rules Version",
+    "Hint": "Change handling of various rules (including exhausion, Jack of All Trades, Remarkable Athlete, and hit dice recovery) between the 2024 and 2014 rule sets.",
+    "Legacy": "Legacy Rules (2014)",
+    "Modern": "Modern Rules (2024)"
   }
 },
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -2992,7 +2992,7 @@
   },
   "RULESVERSION": {
     "Name": "Rules Version",
-    "Hint": "Change handling of various rules (including exhausion, Jack of All Trades, Remarkable Athlete, and hit dice recovery) between the 2024 and 2014 rule sets.",
+    "Hint": "Change handling of various rules between the 2024 and 2014 rule sets.",
     "Legacy": "Legacy Rules (2014)",
     "Modern": "Modern Rules (2024)"
   }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2680,6 +2680,8 @@ DND5E.consumableResources = [
  * @property {boolean} [pseudo]    Is this a pseudo-condition, i.e. one that does not appear in the conditions appendix
  *                                 but acts as a status effect?
  * @property {number} [levels]     The number of levels of exhaustion an actor can obtain.
+ * @property {{ rolls: number, speed: number }} [reduction]  Amount D20 Tests & Speed are reduced per exhaustion level
+ *                                                           when using the modern rules.
  */
 
 /**
@@ -2728,7 +2730,8 @@ DND5E.conditionTypes = {
     label: "DND5E.ConExhaustion",
     icon: "systems/dnd5e/icons/svg/statuses/exhaustion.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.cspWveykstnu3Zcv",
-    levels: 6
+    levels: 6,
+    reduction: { rolls: 2, speed: 5 }
   },
   frightened: {
     label: "DND5E.ConFrightened",

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -196,8 +196,8 @@ export default class AttackActivityData extends BaseActivityData {
    * @returns {{ data: object, parts: string[] }}
    */
   getAttackData() {
-    const data = this.getRollData();
     const parts = [];
+    const data = this.getRollData();
     const item = this.item.system;
 
     if ( this.actor && !this.attack.flat ) {
@@ -213,6 +213,9 @@ export default class AttackActivityData extends BaseActivityData {
       if ( actorBonus?.attack ) parts.push(actorBonus.attack);
 
       // TODO: Ammunition
+
+      // Add exhaustion reduction
+      this.actor.addRollExhaustion(parts, data);
     }
 
     // Include the activity's attack bonus & item's magical bonus

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -269,8 +269,10 @@ export default class AttributesFields {
     const exceedingCarryingCapacity = statuses.has("exceedingCarryingCapacity");
     const crawl = this.parent.hasConditionEffect("crawl");
     const units = this.attributes.movement.units;
+    const reduction = game.settings.get("dnd5e", "rulesVersion") === "modern"
+      ? this.attributes.exhaustion * (CONFIG.DND5E.conditionTypes.exhaustion?.reduction?.speed ?? 0) : 0;
     for ( const type in CONFIG.DND5E.movementTypes ) {
-      let speed = this.attributes.movement[type];
+      let speed = Math.max(0, this.attributes.movement[type] - reduction);
       if ( noMovement || (crawl && (type !== "walk")) ) speed = 0;
       else {
         if ( halfMovement ) speed *= 0.5;

--- a/module/documents/actor/hit-dice.mjs
+++ b/module/documents/actor/hit-dice.mjs
@@ -169,11 +169,13 @@ export default class HitDice {
    * Create item updates for recovering hit dice during a rest.
    * @param {object} [options]
    * @param {number} [options.maxHitDice]                       Maximum number of hit dice to recover.
+   * @param {number} [options.fraction=0.5]                     Fraction of max hit dice to recover. Only used if
+   *                                                            `maxHitDice` isn't specified.
    * @param {boolean} [options.largest]                         Whether to restore the largest hit dice first.
    * @returns {{updates: object[], hitDiceRecovered: number}}   Array of item updates and number of hit dice recovered.
    */
-  createHitDiceUpdates({ maxHitDice, largest=true }={}) {
-    if ( !Number.isInteger(maxHitDice) ) maxHitDice = Math.max(Math.floor(this.max / 2), 1);
+  createHitDiceUpdates({ maxHitDice, fraction=0.5, largest=true }={}) {
+    if ( !Number.isInteger(maxHitDice) ) maxHitDice = Math.max(Math.floor(this.max * fraction), 1);
     const classes = Array.from(this.classes).sort((a, b) => {
       a = parseInt(a.system.hitDice.slice(1));
       b = parseInt(b.system.hitDice.slice(1));

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -71,6 +71,20 @@ export function registerSystemSettings() {
     }
   });
 
+  // Rules version
+  game.settings.register("dnd5e", "rulesVersion", {
+    name: "SETTINGS.DND5E.RULESVERSION.Name",
+    hint: "SETTINGS.DND5E.RULESVERSION.Hint",
+    scope: "world",
+    config: true,
+    default: "modern",
+    type: String,
+    choices: {
+      modern: "SETTINGS.DND5E.RULESVERSION.Modern",
+      legacy: "SETTINGS.DND5E.RULESVERSION.Legacy"
+    }
+  });
+
   // Rest Recovery Rules
   game.settings.register("dnd5e", "restVariant", {
     name: "SETTINGS.5eRestN",


### PR DESCRIPTION
Adds a setting to change between the Legacy (2014) and Modern (2024) rules and implements a few of those rules changes:

- Exhaustion now reduces D20 tests by 2 and speed by 5 for each level of exhaustion, without the other legacy effects.
- Jack of All Trades no longer adds to initiative bonus
- Remarkable athlete no longer adds half proficiency, but does give advantage on initiative rolls
- All hit dice are recovered on a long rest

Closes #3920
Closes #3982