### PR TITLE
[#3910, #3911, #3912] Add damage type selection to roll dialog

### DIFF
--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -587,7 +587,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     return {
       data, parts,
       options: {
-        types: damage.types,
+        types: Array.from(damage.types),
         properties: Array.from(this.item.system.properties ?? [])
           .filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical)
       }

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -301,7 +301,7 @@ export default class DamageRoll extends Roll {
   /* -------------------------------------------- */
 
   /**
-   * Create a Dialog prompt used to configure evaluation of one or more daamge rolls.
+   * Create a Dialog prompt used to configure evaluation of one or more damage rolls.
    * @param {DamageRoll[]} rolls                Damage rolls to configure.
    * @param {object} [data={}]                  Dialog configuration data
    * @param {string} [data.title]               The title of the shown dialog window
@@ -322,8 +322,10 @@ export default class DamageRoll extends Roll {
     const content = await renderTemplate(template ?? this.EVALUATION_TEMPLATE, {
       formulas: rolls.map((roll, index) => ({
         formula: `${roll.formula}${index === 0 ? " + @bonus" : ""}`,
-        type: roll.options.types?.length ? null : damageTypeLabel(roll.options.type) ?? null,
-        types: roll.options.types?.map(value => ({ value, label: damageTypeLabel(value) }))
+        type: roll.options.types?.length > 1 ? null
+          : damageTypeLabel(roll.options.types?.[0] ?? roll.options.type) ?? null,
+        types: roll.options.types?.length > 1
+          ? roll.options.types?.map(value => ({ value, label: damageTypeLabel(value) })) : null
       })),
       defaultRollMode,
       rollModes: CONFIG.Dice.rollModes

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -150,6 +150,8 @@ export async function d20Roll({
  * @typedef {object} SingleDamageRollConfiguration
  * @property {string[]} parts         The dice roll component parts.
  * @property {string} [type]          Damage type represented by the roll.
+ * @property {string[]} [types]       List of damage types selectable in the configuration app. If no
+ *                                    type is provided, then the first of these types will be used.
  * @property {string[]} [properties]  Physical properties of the damage source (e.g. magical, silvered).
  */
 
@@ -181,10 +183,10 @@ export async function damageRoll({
   multiplyNumeric ??= game.settings.get("dnd5e", "criticalDamageModifiers");
   powerfulCritical ??= game.settings.get("dnd5e", "criticalDamageMaxDice");
   critical = isFF ? isCritical : false;
-  for ( const [index, { parts, type, properties }] of rollConfigs.entries() ) {
+  for ( const [index, { parts, type, types, properties }] of rollConfigs.entries() ) {
     const formula = parts.join(" + ");
     const rollOptions = {
-      flavor, rollMode, critical, criticalMultiplier, multiplyNumeric, powerfulCritical, type, properties
+      flavor, rollMode, critical, criticalMultiplier, multiplyNumeric, powerfulCritical, type, types, properties
     };
     if ( index === 0 ) {
       rollOptions.criticalBonusDice = criticalBonusDice;
@@ -208,6 +210,7 @@ export async function damageRoll({
   // Evaluate the configured roll
   for ( const roll of rolls ) {
     const rollMode = rolls.at(-1).options.rollMode ?? defaultRollMode;
+    if ( !roll.options.type ) roll.options.type = roll.options.types?.[0];
     await roll.evaluate({ allowInteractive: rollMode !== CONST.DICE_ROLL_MODES.BLIND });
   }
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -814,7 +814,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       actor: this.actor,
       rollConfigs: rollConfig.rolls.map(r => ({
         parts: r.parts,
-        type: r.options?.types?.first(),
+        types: r.options?.types,
         properties: r.options?.properties
       })),
       data: rollConfig.rolls[0]?.data ?? {},

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -4,6 +4,14 @@
         <label>{{ localize "DND5E.Formula" }} {{#if type}}({{type}}){{/if}}</label>
         <input type="text" name="formula" value="{{formula}}" disabled>
     </div>
+    {{#if types}}
+    <div class="form-group">
+        <label>{{ localize "DND5E.DamageType" }}</label>
+        <select name="roll.{{ @index }}.type">
+            {{ selectOptions types }}
+        </select>
+    </div>
+    {{/if}}
     {{/each}}
     {{#if chooseModifier}}
     <div class="form-group">


### PR DESCRIPTION
Adds the damage type selection to the damage roll dialog, falling back to the first damage type specified if the dialog is skipped.

Closes #3911
Closes #3912