### PR TITLE
[#3910] Add attack mode selection, relay mode to damage rolls

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1430,6 +1430,14 @@
 "DND5E.FilterGroupAction": "Group by Action",
 "DND5E.FilterNoSpells": "No spells found for this set of filters.",
 "DND5E.NoSpellLevels": "This character has no spellcaster levels, but you may add spells manually.",
+
+"DND5E.FLAGS": {
+  "EnhancedDuelWielding": {
+    "Name": "Enhanced Duel Wielding",
+    "Hint": "Allow bonus action extra attacks using any melee weapon without the Two-Handed property."
+  }
+},
+
 "DND5E.FlagsInstructions": "Configure character features and traits which fine-tune behaviors of the DnD5e system.",
 "DND5E.FlagsSave": "Update Special Traits",
 "DND5E.FlagsTitle": "Configure Special Traits",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1432,8 +1432,8 @@
 "DND5E.NoSpellLevels": "This character has no spellcaster levels, but you may add spells manually.",
 
 "DND5E.FLAGS": {
-  "EnhancedDuelWielding": {
-    "Name": "Enhanced Duel Wielding",
+  "EnhancedDualWielding": {
+    "Name": "Enhanced Dual Wielding",
     "Hint": "Allow bonus action extra attacks using any melee weapon without the Two-Handed property."
   }
 },

--- a/lang/en.json
+++ b/lang/en.json
@@ -517,6 +517,13 @@
     "Unarmed": "Unarmed",
     "Weapon": "Weapon"
   },
+  "Mode": {
+    "Label": "Attack Mode",
+    "Offhand": "Offhand",
+    "OneHanded": "One-Handed",
+    "Thrown": "Thrown",
+    "TwoHanded": "Two-Handed"
+  },
   "Type": {
     "Melee": "Melee",
     "Ranged": "Ranged"

--- a/module/applications/components/enchantment-application.mjs
+++ b/module/applications/components/enchantment-application.mjs
@@ -104,7 +104,7 @@ export default class EnchantmentApplicationElement extends HTMLElement {
    * the card list.
    */
   async buildItemList() {
-    const enchantedItems = await dnd5e.registry.enchantment.applied(this.enchantmentActivity.uuid).map(enchantment => {
+    const enchantedItems = await dnd5e.registry.enchantments.applied(this.enchantmentActivity.uuid).map(enchantment => {
       const item = enchantment.parent;
       const div = document.createElement("div");
       div.classList.add("preview");

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3193,6 +3193,12 @@ DND5E.characterFlags = {
     section: "DND5E.Feats",
     type: Boolean
   },
+  enhancedDualWielding: {
+    name: "DND5E.FLAGS.EnhancedDuelWielding.Name",
+    hint: "DND5E.FLAGS.EnhancedDuelWielding.Hint",
+    section: "DND5E.Feats",
+    type: Boolean
+  },
   elvenAccuracy: {
     name: "DND5E.FlagsElvenAccuracy",
     hint: "DND5E.FlagsElvenAccuracyHint",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3194,8 +3194,8 @@ DND5E.characterFlags = {
     type: Boolean
   },
   enhancedDualWielding: {
-    name: "DND5E.FLAGS.EnhancedDuelWielding.Name",
-    hint: "DND5E.FLAGS.EnhancedDuelWielding.Hint",
+    name: "DND5E.FLAGS.EnhancedDualWielding.Name",
+    hint: "DND5E.FLAGS.EnhancedDualWielding.Hint",
     section: "DND5E.Feats",
     type: Boolean
   },

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -426,6 +426,16 @@ export class ItemDataModel extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
+   * Modes that can be used when making an attack with this item.
+   * @type {FormSelectOption[]}
+   */
+  get attackModes() {
+    return [];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Set of abilities that can automatically be associated with this item.
    * @type {Set<string>|null}
    */

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -290,7 +290,7 @@ export default class AttackActivityData extends BaseActivityData {
 
     if ( this.item.type === "weapon" ) {
       // Ensure `@mod` is present in damage unless it is positive and an off-hand attack
-      const includeMod = (rollConfig.mode !== "offHand") || (roll.data.mod < 0);
+      const includeMod = (rollConfig.mode !== "offhand") || (roll.data.mod < 0);
       if ( includeMod && !roll.parts.some(p => p.includes("@mod")) ) roll.parts.push("@mod");
 
       // Add magical bonus

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -231,7 +231,7 @@ export default class AttackActivityData extends BaseActivityData {
 
   /**
    * @typedef {AttackDamageRollProcessConfiguration} [config={}]
-   * @property {"oneHanded"|"twoHanded"|"offHand"|"thrown"} mode  Attack mode.
+   * @property {"oneHanded"|"twoHanded"|"offhand"|"thrown"} attackMode  Attack mode.
    */
 
   /**
@@ -276,7 +276,7 @@ export default class AttackActivityData extends BaseActivityData {
     if ( !damage.base ) super._processDamagePart(damage, rollConfig, rollData);
 
     // Swap base damage for versatile if two-handed attack is made on versatile weapon
-    if ( this.item.system.isVersatile && (rollConfig.mode === "twoHanded") ) {
+    if ( this.item.system.isVersatile && (rollConfig.attackMode === "twoHanded") ) {
       const versatile = this.item.system.damage.versatile.clone();
       versatile.base = true;
       versatile.denomination ||= damage.steppedDenomination();
@@ -290,7 +290,7 @@ export default class AttackActivityData extends BaseActivityData {
 
     if ( this.item.type === "weapon" ) {
       // Ensure `@mod` is present in damage unless it is positive and an off-hand attack
-      const includeMod = (rollConfig.mode !== "offhand") || (roll.data.mod < 0);
+      const includeMod = (rollConfig.attackMode !== "offhand") || (roll.data.mod < 0);
       if ( includeMod && !roll.parts.some(p => p.includes("@mod")) ) roll.parts.push("@mod");
 
       // Add magical bonus

--- a/module/data/activity/enchant-data.mjs
+++ b/module/data/activity/enchant-data.mjs
@@ -66,7 +66,7 @@ export default class EnchantActivityData extends BaseActivityData {
    * @type {ActiveEffect5e[]}
    */
   get appliedEnchantments() {
-    return dnd5e.registry.enchantment.applied(this.uuid);
+    return dnd5e.registry.enchantments.applied(this.uuid);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -51,7 +51,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
    * @type {ActiveEffect5e[]}
    */
   get appliedEnchantments() {
-    return dnd5e.registry.enchantment.applied(this.parent.uuid);
+    return dnd5e.registry.enchantments.applied(this.parent.uuid);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -264,7 +264,9 @@ export default class WeaponData extends ItemDataModel.mixin(
     }
 
     // Weapons with the "Light" property will have Offhand attack
-    if ( this.properties.has("lgt") ) modes.push({
+    // If player has the "Enhanced Duel Wielding" flag, then allow any melee weapon without the "Two-Handed" property
+    if ( this.properties.has("lgt") || (this.parent.actor?.getFlag("dnd5e", "enhancedDualWielding")
+      && ((this.attackType === "melee") && !this.properties.has("two"))) ) modes.push({
       value: "offhand", label: game.i18n.localize("DND5E.ATTACK.Mode.Offhand")
     });
 

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -246,6 +246,39 @@ export default class WeaponData extends ItemDataModel.mixin(
 
   /* -------------------------------------------- */
 
+  /** @override */
+  get attackModes() {
+    const modes = [];
+
+    // Thrown ranged weapons will just display the "Thrown" mode
+    if ( !(this.properties.has("thr") && (this.attackType === "ranged")) ) {
+      // Weapons without the "Two-Handed" property or with the "Versatile" property will have One-Handed attack
+      if ( this.isVersatile || !this.properties.has("two") ) modes.push({
+        value: "oneHanded", label: game.i18n.localize("DND5E.ATTACK.Mode.OneHanded")
+      });
+
+      // Weapons with the "Two-Handed" property or with the "Versatile" property will have Two-Handed attack
+      if ( this.isVersatile || this.properties.has("two") ) modes.push({
+        value: "twoHanded", label: game.i18n.localize("DND5E.ATTACK.Mode.TwoHanded")
+      });
+    }
+
+    // Weapons with the "Light" property will have Offhand attack
+    if ( this.properties.has("lgt") ) modes.push({
+      value: "offhand", label: game.i18n.localize("DND5E.ATTACK.Mode.Offhand")
+    });
+
+    // Weapons with the "Thrown" property will have Thrown attack
+    if ( this.properties.has("thr") ) {
+      if ( modes.length ) modes.push({ rule: true });
+      modes.push({ value: "thrown", label: game.i18n.localize("DND5E.ATTACK.Mode.Thrown") });
+    }
+
+    return modes;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Attack type offered by this weapon.
    * @type {"melee"|"ranged"|null}

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -26,12 +26,13 @@
  * @property {boolean} [reliableTalent]  Allow Reliable Talent to modify this roll?
  *
  * ## Roll Configuration Dialog
- * @property {boolean} [fastForward]           Should the roll configuration dialog be skipped?
- * @property {boolean} [chooseModifier=false]  If the configuration dialog is shown, should the ability modifier be
- *                                             configurable within that interface?
- * @property {string} [template]               The HTML template used to display the roll configuration dialog.
- * @property {string} [title]                  Title of the roll configuration dialog.
- * @property {object} [dialogOptions]          Additional options passed to the roll configuration dialog.
+ * @property {boolean} [fastForward]             Should the roll configuration dialog be skipped?
+ * @property {FormSelectOption[]} [attackModes]  Modes that can be used when making an attack.
+ * @property {boolean} [chooseModifier=false]    If the configuration dialog is shown, should the ability modifier be
+ *                                               configurable within that interface?
+ * @property {string} [template]                 The HTML template used to display the roll configuration dialog.
+ * @property {string} [title]                    Title of the roll configuration dialog.
+ * @property {object} [dialogOptions]            Additional options passed to the roll configuration dialog.
  *
  * ## Chat Message
  * @property {boolean} [chatMessage=true]  Should a chat message be created for this roll?
@@ -52,7 +53,7 @@ export async function d20Roll({
   parts=[], data={}, event,
   advantage, disadvantage, critical=20, fumble=1, targetValue,
   elvenAccuracy, halflingLucky, reliableTalent,
-  fastForward, chooseModifier=false, template, title, dialogOptions,
+  fastForward, attackModes, chooseModifier=false, template, title, dialogOptions,
   chatMessage=true, messageData={}, rollMode, flavor
 }={}) {
 
@@ -85,6 +86,7 @@ export async function d20Roll({
   if ( !isFF ) {
     const configured = await roll.configureDialog({
       title,
+      attackModes,
       chooseModifier,
       defaultRollMode,
       defaultAction: advantageMode,
@@ -101,6 +103,11 @@ export async function d20Roll({
   messageData = foundry.utils.expandObject(messageData);
   const messageId = event?.target.closest("[data-message-id]")?.dataset.messageId;
   if ( messageId ) foundry.utils.setProperty(messageData, "flags.dnd5e.originatingMessage", messageId);
+
+  // Set the attack mode
+  if ( roll.options.attackMode || attackModes?.length ) {
+    foundry.utils.setProperty(messageData, "flags.dnd5e.roll.mode", roll.options.attackMode ?? attackModes[0]);
+  }
 
   // Create a Chat Message
   if ( roll && chatMessage ) await roll.toMessage(messageData);

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -106,7 +106,7 @@ export async function d20Roll({
 
   // Set the attack mode
   if ( roll.options.attackMode || attackModes?.length ) {
-    foundry.utils.setProperty(messageData, "flags.dnd5e.roll.mode", roll.options.attackMode ?? attackModes[0]);
+    foundry.utils.setProperty(messageData, "flags.dnd5e.roll.attackMode", roll.options.attackMode ?? attackModes[0]);
   }
 
   // Create a Chat Message

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -340,7 +340,7 @@ export default class ActiveEffect5e extends ActiveEffect {
   prepareDerivedData() {
     super.prepareDerivedData();
     if ( this.id === this.constructor.ID.EXHAUSTION ) this._prepareExhaustionLevel();
-    if ( this.isAppliedEnchantment ) dnd5e.registry.enchantment.track(this.origin, this.uuid);
+    if ( this.isAppliedEnchantment ) dnd5e.registry.enchantments.track(this.origin, this.uuid);
   }
 
   /* -------------------------------------------- */
@@ -530,7 +530,7 @@ export default class ActiveEffect5e extends ActiveEffect {
   _onDelete(options, userId) {
     super._onDelete(options, userId);
     if ( game.user === game.users.activeGM ) this.getDependents().forEach(e => e.delete());
-    if ( this.isAppliedEnchantment ) dnd5e.registry.enchantment.untrack(this.origin, this.uuid);
+    if ( this.isAppliedEnchantment ) dnd5e.registry.enchantments.untrack(this.origin, this.uuid);
     document.body.querySelectorAll(`enchantment-application:has([data-enchantment-uuid="${this.uuid}"]`)
       .forEach(element => element.buildItemList());
   }

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -238,7 +238,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
    */
   static #rollDamage(event, target, message) {
     const lastAttack = message.getAssociatedRolls("attack").pop();
-    const mode = lastAttack?.getFlag("dnd5e", "roll.mode");
-    this.rollDamage({ event, mode });
+    const attackMode = lastAttack?.getFlag("dnd5e", "roll.attackMode");
+    this.rollDamage({ event, attackMode });
   }
 }

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -60,8 +60,13 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
   /* -------------------------------------------- */
 
   /**
+   * @typedef {D20RollProcessConfiguration} AttackRollProcessConfiguration
+   * @param {string} [attackMode]  Mode to use for making the attack and rolling damage.
+   */
+
+  /**
    * Perform an attack roll.
-   * @param {D20RollProcessConfiguration} config     Configuration information for the roll.
+   * @param {AttackRollProcessConfiguration} config  Configuration information for the roll.
    * @param {BasicRollDialogConfiguration} dialog    Configuration for the roll dialog.
    * @param {BasicRollMessageConfiguration} message  Configuration for the roll message.
    * @returns {Promise<D20Roll[]|void>}
@@ -106,7 +111,8 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
       options: {
         width: 400,
         top: config.event ? config.event.clientY - 80 : null,
-        left: window.innerWidth - 710
+        left: window.innerWidth - 710,
+        attackModes: this.item.system.attackModes
       }
     }, dialog);
 
@@ -130,7 +136,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
      * A hook event that fires before an attack is rolled.
      * @function dnd5e.preRollAttackV2
      * @memberof hookEvents
-     * @param {D20RollProcessConfiguration} config     Configuration data for the pending roll.
+     * @param {AttackRollProcessConfiguration} config  Configuration data for the pending roll.
      * @param {BasicRollDialogConfiguration} dialog    Presentation data for the roll configuration dialog.
      * @param {BasicRollMessageConfiguration} message  Configuration data for the roll's message.
      * @returns {boolean}                              Explicitly return `false` to prevent the roll.
@@ -151,6 +157,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
       halflingLucky: rollConfig.halflingLucky,
       reliableTalent: rollConfig.rolls[0].options.minimum === 10,
       fastForward: !dialogConfig.configure,
+      attackModes: dialogConfig.options.attackModes,
       title: dialogConfig.options.title,
       dialogOptions: dialogConfig.options,
       chatMessage: messageConfig.create,
@@ -230,6 +237,8 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
    * @param {ChatMessage5e} message  Message associated with the activation.
    */
   static #rollDamage(event, target, message) {
-    this.rollDamage({ event });
+    const lastAttack = message.getAssociatedRolls("attack").pop();
+    const mode = lastAttack?.getFlag("dnd5e", "roll.mode");
+    this.rollDamage({ event, mode });
   }
 }

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -88,6 +88,7 @@ export default class ChatMessage5e extends ChatMessage {
   prepareData() {
     super.prepareData();
     this._shimFlags();
+    dnd5e.registry.rollMessages.track(this);
   }
 
   /* -------------------------------------------- */
@@ -838,6 +839,16 @@ export default class ChatMessage5e extends ChatMessage {
   }
 
   /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    dnd5e.registry.rollMessages.untrack(this);
+  }
+
+  /* -------------------------------------------- */
   /*  Helpers                                     */
   /* -------------------------------------------- */
 
@@ -877,6 +888,17 @@ export default class ChatMessage5e extends ChatMessage {
     return storedData
       ? new Item.implementation(storedData, { parent: actor })
       : actor.items.get(this.getFlag("dnd5e", "item.id"));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get a list of all chat messages containing rolls that originated from this message.
+   * @param {string} [type]  Type of rolls to get. If empty, all roll types will be fetched.
+   * @returns {ChatMessage5e[]}
+   */
+  getAssociatedRolls(type) {
+    return dnd5e.registry.rollMessages.messages(this.id, type);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -88,7 +88,7 @@ export default class ChatMessage5e extends ChatMessage {
   prepareData() {
     super.prepareData();
     this._shimFlags();
-    dnd5e.registry.rollMessages.track(this);
+    dnd5e.registry.messages.track(this);
   }
 
   /* -------------------------------------------- */
@@ -845,7 +845,7 @@ export default class ChatMessage5e extends ChatMessage {
   /** @inheritDoc */
   _onDelete(options, userId) {
     super._onDelete(options, userId);
-    dnd5e.registry.rollMessages.untrack(this);
+    dnd5e.registry.messages.untrack(this);
   }
 
   /* -------------------------------------------- */
@@ -898,7 +898,7 @@ export default class ChatMessage5e extends ChatMessage {
    * @returns {ChatMessage5e[]}
    */
   getAssociatedRolls(type) {
-    return dnd5e.registry.rollMessages.messages(this.id, type);
+    return dnd5e.registry.messages.messages(this.id, type);
   }
 
   /* -------------------------------------------- */

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -65,10 +65,10 @@ class EnchantmentRegisty {
 /*  Message Rolls                               */
 /* -------------------------------------------- */
 
-class RollMessageRegistry {
+class MessageRegistry {
   /**
    * Registration of roll chat messages that originated at a specific message. The map is keyed by the ID of
-   * the originating message and contains sets or IDs for each roll type.
+   * the originating message and contains sets of IDs for each roll type.
    * @type {Map<string, Map<string, Set<string>>}
    */
   static #messages = new Map();
@@ -82,7 +82,7 @@ class RollMessageRegistry {
    * @returns {ChatMessage5e[]}
    */
   static messages(origin, type) {
-    const originMap = RollMessageRegistry.#messages.get(origin);
+    const originMap = MessageRegistry.#messages.get(origin);
     if ( !originMap ) return [];
     let ids;
     if ( type ) ids = Array.from(originMap.get(type)) ?? [];
@@ -103,8 +103,8 @@ class RollMessageRegistry {
     const origin = message.getFlag("dnd5e", "originatingMessage");
     const type = message.getFlag("dnd5e", "roll.type");
     if ( !origin || !type ) return;
-    if ( !RollMessageRegistry.#messages.has(origin) ) RollMessageRegistry.#messages.set(origin, new Map());
-    const originMap = RollMessageRegistry.#messages.get(origin);
+    if ( !MessageRegistry.#messages.has(origin) ) MessageRegistry.#messages.set(origin, new Map());
+    const originMap = MessageRegistry.#messages.get(origin);
     if ( !originMap.has(type) ) originMap.set(type, new Set());
     originMap.get(type).add(message.id);
   }
@@ -118,7 +118,7 @@ class RollMessageRegistry {
   static untrack(message) {
     const origin = message.getFlag("dnd5e", "originatingMessage");
     const type = message.getFlag("dnd5e", "roll.type");
-    RollMessageRegistry.#messages.get(origin)?.get(type)?.delete(message.id);
+    MessageRegistry.#messages.get(origin)?.get(type)?.delete(message.id);
   }
 }
 
@@ -175,6 +175,6 @@ class SummonRegistry {
 
 export default {
   enchantments: EnchantmentRegisty,
-  rollMessages: RollMessageRegistry,
+  messages: MessageRegistry,
   summons: SummonRegistry
 };

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -62,10 +62,71 @@ class EnchantmentRegisty {
 }
 
 /* -------------------------------------------- */
+/*  Message Rolls                               */
+/* -------------------------------------------- */
+
+class RollMessageRegistry {
+  /**
+   * Registration of roll chat messages that originated at a specific message. The map is keyed by the ID of
+   * the originating message and contains sets or IDs for each roll type.
+   * @type {Map<string, Map<string, Set<string>>}
+   */
+  static #messages = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Fetch roll messages for an origin message, in chronological order.
+   * @param {string} origin  ID of the origin message.
+   * @param {string} [type]  Type of roll messages to fetch.
+   * @returns {ChatMessage5e[]}
+   */
+  static messages(origin, type) {
+    const originMap = RollMessageRegistry.#messages.get(origin);
+    if ( !originMap ) return [];
+    let ids;
+    if ( type ) ids = Array.from(originMap.get(type)) ?? [];
+    else ids = Array.from(originMap.values()).map(v => Array.from(v)).flat();
+    return ids
+      .map(id => game.messages.get(id))
+      .filter(m => m)
+      .sort((lhs, rhs) => lhs.timestamp - rhs.timestamp);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add a new roll message to the registry.
+   * @param {ChatMessage5e} message  Message to add to the registry.
+   */
+  static track(message) {
+    const origin = message.getFlag("dnd5e", "originatingMessage");
+    const type = message.getFlag("dnd5e", "roll.type");
+    if ( !origin || !type ) return;
+    if ( !RollMessageRegistry.#messages.has(origin) ) RollMessageRegistry.#messages.set(origin, new Map());
+    const originMap = RollMessageRegistry.#messages.get(origin);
+    if ( !originMap.has(type) ) originMap.set(type, new Set());
+    originMap.get(type).add(message.id);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Remove a roll message to the registry.
+   * @param {ChatMessage5e} message  Message to remove from the registry.
+   */
+  static untrack(message) {
+    const origin = message.getFlag("dnd5e", "originatingMessage");
+    const type = message.getFlag("dnd5e", "roll.type");
+    RollMessageRegistry.#messages.get(origin)?.get(type)?.delete(message.id);
+  }
+}
+
+/* -------------------------------------------- */
 /*  Summons                                     */
 /* -------------------------------------------- */
 
-class SummonsRegistry {
+class SummonRegistry {
   /**
    * Registration of summoned creatures mapped to a specific summoner. The map is keyed by the UUID of
    * summoner while the set contains UUID of actors that have been summoned.
@@ -113,6 +174,7 @@ class SummonsRegistry {
 
 
 export default {
-  enchantment: EnchantmentRegisty,
-  summons: SummonsRegistry
+  enchantments: EnchantmentRegisty,
+  rollMessages: RollMessageRegistry,
+  summons: SummonRegistry
 };

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -5,6 +5,14 @@
         <input type="text" name="formula" value="{{formula}}" disabled>
     </div>
     {{/each}}
+    {{#if attackModes}}
+    <div class="form-group">
+        <label>{{ localize "DND5E.ATTACK.Mode.Label" }}</label>
+        <select name="attackMode">
+            {{ selectOptions attackModes }}
+        </select>
+    </div>
+    {{/if}}
     {{#if chooseModifier}}
     <div class="form-group">
         <label>{{ localize "DND5E.AbilityModifier" }}</label>


### PR DESCRIPTION
Adds attack modes that can be declared by item and are selectable within the attack roll dialog. When one of these modes is selected it is stored in the attack roll message flags.

When the damage button is clicked for an `AttackActivity`, it fetches the attack mode from the most recent attack roll performed from the same chat message and passes that to `rollDamage`. This is facilitated by a new `rollMessages` entry in the registry.

### Todo
- [ ] Remember previously selected attack mode for each weapon so user doesn't have to select it each time