### PR TITLE
[#1866, #4011] Update ammo types, add ammo damage & type to weapon

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -773,22 +773,69 @@
 "DND5E.ConsumeScaling": "Resource Scaling",
 "DND5E.ConsumeScalingLabel": "Use Resources",
 "DND5E.ConsumeScalingTooltip": "If checked, consuming additional resources will increase the level the spell is cast at.",
-"DND5E.ConsumableAmmo": "Ammunition",
-"DND5E.ConsumableAmmoArrow": "Arrow",
-"DND5E.ConsumableAmmoBlowgunNeedle": "Blowgun Needle",
-"DND5E.ConsumableAmmoCrossbowBolt": "Crossbow Bolt",
-"DND5E.ConsumableAmmoSlingBullet": "Sling Bullet",
-"DND5E.ConsumableFood": "Food",
-"DND5E.ConsumablePoison": "Poison",
-"DND5E.ConsumablePoisonContact": "Contact",
-"DND5E.ConsumablePoisonIngested": "Ingested",
-"DND5E.ConsumablePoisonInhaled": "Inhaled",
-"DND5E.ConsumablePoisonInjury": "Injury",
-"DND5E.ConsumablePotion": "Potion",
-"DND5E.ConsumableRod": "Rod",
-"DND5E.ConsumableScroll": "Scroll",
-"DND5E.ConsumableTrinket": "Trinket",
-"DND5E.ConsumableWand": "Wand",
+
+"DND5E.CONSUMABLE": {
+  "FIELDS": {
+    "damage": {
+      "label": "Ammunition Damage",
+      "replace": {
+        "label": "Replace Weapon Damage",
+        "hint": "Replace base weapon damage with this damage rather than augmenting it."
+      }
+    },
+    "magicalBonus": {
+      "label": "Magical Bonus"
+    },
+    "properties": {
+      "label": "Consumable Properties"
+    },
+    "uses": {
+      "autoDestroy": {
+        "label": "Destroy on Empty",
+        "hint": "Reduce the item's quantity by 1 whenever all of its limited uses are expended."
+      }
+    }
+  },
+  "Category": {
+    "Poison": "Poison"
+  },
+  "Type": {
+    "Ammunition": {
+      "Label": "Ammunition",
+      "Arrow": "Arrow",
+      "Bolt": "Bolt",
+      "BulletFirearm": "Bullet, Firearm",
+      "BulletSling": "Bullet, Sling",
+      "Needle": "Needle"
+    },
+    "Food": {
+      "Label": "Food"
+    },
+    "Poison": {
+      "Label": "Poison",
+      "Contact": "Contact",
+      "Ingested": "Ingested",
+      "Inhaled": "Inhaled",
+      "Injury": "Injury"
+    },
+    "Potion": {
+      "Label": "Potion"
+    },
+    "Rod": {
+      "Label": "Rod"
+    },
+    "Scroll": {
+      "Label": "Scroll"
+    },
+    "Trinket": {
+      "Label": "Trinket"
+    },
+    "Wand": {
+      "Label": "Wand"
+    }
+  }
+},
+
 "DND5E.ConsumableUseWarnStart": "This consumable has",
 "DND5E.ConsumableUseWarnEnd": "of the current unit",
 "DND5E.ConsumableUnitWarn": "units remaining",
@@ -1644,8 +1691,6 @@
 "DND5E.ItemCritThreshold": "Critical Hit Threshold",
 "DND5E.ItemCritExtraDamage": "Extra Critical Hit Damage",
 "DND5E.ItemDelete": "Delete Item",
-"DND5E.ItemDestroyEmpty": "Destroy on Empty",
-"DND5E.ItemDestroyEmptyTooltip": "Reduce the item's quantity by 1 whenever all of its limited uses are expended.",
 "DND5E.ItemEdit": "Edit Item",
 "DND5E.ItemEquipmentAction": "Equipment Action",
 "DND5E.ItemEquipmentBase": "Base Equipment",
@@ -2800,6 +2845,14 @@
 
 "DND5E.WEAPON": {
   "FIELDS": {
+    "ammunition": {
+      "type": {
+        "label": "Ammunition Type"
+      }
+    },
+    "damage": {
+      "hint": "Intrinsic damage dice from the weapon. Ability modifier and additional damage parts will be provided automatically when attacking."
+    },
     "mastery": {
       "label": "Mastery",
       "hint": "Special weapon ability unlocked for characters who have Weapon Mastery or a related feature."

--- a/module/applications/activity/attack-sheet.mjs
+++ b/module/applications/activity/attack-sheet.mjs
@@ -64,7 +64,7 @@ export default class AttackSheet extends ActivitySheet {
       }))
     ];
 
-    context.hasBaseDamage = safePropertyExists(this.item.system, "damage.base");
+    context.hasBaseDamage = this.item.system.offersBaseDamage;
 
     return context;
   }

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -37,7 +37,6 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
     const context = await super.getData(options);
     const { activities } = this.item.system;
     const target = this.item.type === "spell" ? this.item.system.target : null;
-    const damage = this.item.type === "weapon" ? this.item.system.damage : null;
 
     // Effects
     for ( const category of Object.values(context.effects) ) {
@@ -135,18 +134,6 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
       source: context.source.uses.recovery[index] ?? data,
       formulaOptions: data.period === "recharge" ? data.recharge?.options : null
     }));
-
-    // Damage
-    context.denominationOptions = [
-      { value: "", label: "" },
-      ...CONFIG.DND5E.dieSteps.map(value => ({ value, label: `d${value}` }))
-    ];
-    context.damageTypes = ["base", "versatile"].reduce((obj, k) => {
-      obj[k] = Object.entries(CONFIG.DND5E.damageTypes).map(([value, { label }]) => {
-        return { value, label, selected: damage?.[k]?.types?.has(value) };
-      });
-      return obj;
-    }, {});
 
     // Activities
     context.activities = (activities ?? []).map(({ _id: id, name, img, sort }) => ({
@@ -306,7 +293,7 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
    * @protected
    */
   _onOpenActivityContext(target) {
-    const { id } = target.closest(".activity[data-id]")?.dataset;
+    const { id } = target.closest(".activity[data-id]")?.dataset ?? {};
     const activity = this.item.system.activities.get(id);
     if ( !activity ) return;
     const menuItems = this._getActivityContextMenuOptions(activity);
@@ -314,7 +301,7 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
     /**
      * A hook even that fires when the context menu for an Activity is opened.
      * @function dnd5e.getItemActivityContext
-     * @memberOf hookEvents
+     * @memberof hookEvents
      * @param {Activity} activity             The Activity.
      * @param {HTMLElement} target            The element that menu was triggered for.
      * @param {ContextMenuEntry[]} menuItems  The context menu entries.

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1303,40 +1303,41 @@ preLocalize("armorClasses", { key: "label" });
  */
 DND5E.consumableTypes = {
   ammo: {
-    label: "DND5E.ConsumableAmmo",
+    label: "DND5E.CONSUMABLE.Type.Ammunition.Label",
     subtypes: {
-      arrow: "DND5E.ConsumableAmmoArrow",
-      blowgunNeedle: "DND5E.ConsumableAmmoBlowgunNeedle",
-      crossbowBolt: "DND5E.ConsumableAmmoCrossbowBolt",
-      slingBullet: "DND5E.ConsumableAmmoSlingBullet"
+      arrow: "DND5E.CONSUMABLE.Type.Ammunition.Arrow",
+      crossbowBolt: "DND5E.CONSUMABLE.Type.Ammunition.Bolt",
+      firearmBullet: "DND5E.CONSUMABLE.Type.Ammunition.BulletFirearm",
+      slingBullet: "DND5E.CONSUMABLE.Type.Ammunition.BulletSling",
+      blowgunNeedle: "DND5E.CONSUMABLE.Type.Ammunition.Needle"
     }
   },
   potion: {
-    label: "DND5E.ConsumablePotion"
+    label: "DND5E.CONSUMABLE.Type.Potion.Label"
   },
   poison: {
-    label: "DND5E.ConsumablePoison",
+    label: "DND5E.CONSUMABLE.Type.Poison.Label",
     subtypes: {
-      contact: "DND5E.ConsumablePoisonContact",
-      ingested: "DND5E.ConsumablePoisonIngested",
-      inhaled: "DND5E.ConsumablePoisonInhaled",
-      injury: "DND5E.ConsumablePoisonInjury"
+      contact: "DND5E.CONSUMABLE.Type.Poison.Contact",
+      ingested: "DND5E.CONSUMABLE.Type.Poison.Ingested",
+      inhaled: "DND5E.CONSUMABLE.Type.Poison.Inhaled",
+      injury: "DND5E.CONSUMABLE.Type.Poison.Injury"
     }
   },
   food: {
-    label: "DND5E.ConsumableFood"
+    label: "DND5E.CONSUMABLE.Type.Food.Label"
   },
   scroll: {
-    label: "DND5E.ConsumableScroll"
+    label: "DND5E.CONSUMABLE.Type.Scroll.Label"
   },
   wand: {
-    label: "DND5E.ConsumableWand"
+    label: "DND5E.CONSUMABLE.Type.Wand.Label"
   },
   rod: {
-    label: "DND5E.ConsumableRod"
+    label: "DND5E.CONSUMABLE.Type.Rod.Label"
   },
   trinket: {
-    label: "DND5E.ConsumableTrinket"
+    label: "DND5E.CONSUMABLE.Type.Trinket.Label"
   }
 };
 preLocalize("consumableTypes", { key: "label", sort: true });

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -123,9 +123,11 @@ export default class AttackActivityData extends BaseActivityData {
 
   /** @override */
   static transformTypeData(source, activityData) {
-    // For weapons, separate the first part from the rest to be used as the weapon's base damage and keep the rest
+    // For weapons and ammunition, separate the first part from the rest to be used as the base damage and keep the rest
     let damageParts = source.system.damage?.parts ?? [];
-    if ( (source.type === "weapon") && damageParts.length ) {
+    const hasBase = (source.type === "weapon")
+      || ((source.type === "consumable") && (source.system?.type?.value === "ammo"));
+    if ( hasBase && damageParts.length ) {
       const [base, ...rest] = damageParts;
       source.system.damage.parts = [base];
       damageParts = rest;
@@ -169,7 +171,7 @@ export default class AttackActivityData extends BaseActivityData {
 
   /** @inheritDoc */
   prepareFinalData(rollData) {
-    if ( this.damage.includeBase && safePropertyExists(this.item.system, "damage.base")
+    if ( this.damage.includeBase && this.item.system.offersBaseDamage
       && this.item.system.damage.base.formula ) {
       const basePart = this.item.system.damage.base.clone();
       basePart.base = true;

--- a/templates/items/details/details-consumable.hbs
+++ b/templates/items/details/details-consumable.hbs
@@ -48,3 +48,12 @@
     </div>
     {{/if}}
 </fieldset>
+
+{{#if (eq source.type.value "ammo")}}
+<fieldset>
+    <legend>{{ localize "DND5E.CONSUMABLE.FIELDS.damage.label" }}</legend>
+    {{ formField fields.damage.fields.replace value=source.damage.replace input=inputs.createCheckboxInput }}
+    {{> "dnd5e.details-damage" fields=fields.damage.fields.base.fields source=source.damage.base
+        types=damageTypes prefix="system.damage.base." }}
+</fieldset>
+{{/if}}

--- a/templates/items/details/details-damage.hbs
+++ b/templates/items/details/details-damage.hbs
@@ -1,5 +1,4 @@
 {{!-- TODO: Unify this with activity damage part --}}
-{{#*inline ".damage"}}
 
 {{!-- Custom Formula --}}
 <div class="form-group split-group">
@@ -28,7 +27,7 @@
 
         {{!-- Number --}}
         {{ formField fields.number name=(concat prefix "number") value=source.number label="DND5E.Number" localize=true
-                     classes="label-top" }}
+                     classes="label-top" placeholder=numberPlaceholder }}
 
         {{!-- Die --}}
         {{ formField fields.denomination name=(concat prefix "denomination") value=source.denomination label="DND5E.Die"
@@ -41,22 +40,8 @@
 </div>
 {{/unless}}
 
-{{!-- Type --}}
+{{!-- Types --}}
+{{#if types}}
 {{ formField fields.types name=(concat prefix "types") value=source.types options=types label="DND5E.Type"
              localize=true }}
-
-{{/inline}}
-
-<fieldset>
-    <legend>{{ localize "DND5E.DAMAGE.Title" }}</legend>
-    {{> ".damage" fields=fields.damage.fields.base.fields source=source.damage.base types=damageTypes.base
-        prefix="system.damage.base." }}
-</fieldset>
-
-{{#if properties.object.ver}}
-<fieldset>
-    <legend>{{ localize "DND5E.Versatile" }}</legend>
-    {{> ".damage" fields=fields.damage.fields.versatile.fields source=source.damage.versatile
-        types=damageTypes.versatile prefix="system.damage.versatile." }}
-</fieldset>
 {{/if}}

--- a/templates/items/details/details-weapon.hbs
+++ b/templates/items/details/details-weapon.hbs
@@ -53,6 +53,11 @@
         </div>
     </div>
     {{/if}}
+
+    {{!-- Ammunition Type --}}
+    {{#if properties.object.amm}}
+    {{ formField fields.ammunition.fields.type value=source.ammunition.type choices=config.consumableTypes.ammo.subtypes }}
+    {{/if}}
 </fieldset>
 
 <fieldset>
@@ -109,4 +114,22 @@
 
 {{#if system.isMountable}}
     {{> "dnd5e.details-mountable" }}
+{{/if}}
+
+<fieldset>
+    <legend>{{ localize "DND5E.DAMAGE.Title" }}</legend>
+    <div class="form-fields">
+        <p class="hint">{{ localize "DND5E.WEAPON.FIELDS.damage.hint" }}</p>
+    </div>
+    {{> "dnd5e.details-damage" fields=fields.damage.fields.base.fields source=source.damage.base types=damageTypes
+        prefix="system.damage.base." denominationOptions=denominationOptions.base }}
+</fieldset>
+
+{{#if properties.object.ver}}
+<fieldset>
+    <legend>{{ localize "DND5E.Versatile" }}</legend>
+    {{> "dnd5e.details-damage" fields=fields.damage.fields.versatile.fields source=source.damage.versatile
+        prefix="system.damage.versatile." bonus=false numberPlaceholder=source.damage.base.number
+        denominationOptions=denominationOptions.versatile }}
+</fieldset>
 {{/if}}

--- a/templates/items/parts/item-activation.hbs
+++ b/templates/items/parts/item-activation.hbs
@@ -168,23 +168,27 @@
 {{!-- Prompt Configuration --}}
 <div class="form-group">
     {{#if (eq item.type "consumable")}}
-    <label class="checkbox" data-tooltip="DND5E.ItemDestroyEmptyTooltip">
-        <input type="checkbox" name="system.uses.autoDestroy" {{checked system.uses.autoDestroy}}> {{ localize "DND5E.ItemDestroyEmpty" }}
+    <label class="checkbox" data-tooltip="DND5E.CONSUMABLE.FIELDS.uses.autoDestroy.hint">
+        <input type="checkbox" name="system.uses.autoDestroy" {{checked system.uses.autoDestroy}}>
+        {{ localize "DND5E.CONSUMABLE.FIELDS.uses.autoDestroy.label" }}
     </label>
     {{/if}}
     {{#if item.hasAreaTarget}}
     <label class="checkbox" data-tooltip="DND5E.TemplatePromptTooltip">
-        <input type="checkbox" name="system.target.prompt" {{checked system.target.prompt}}> {{ localize "DND5E.TemplatePrompt" }}
+        <input type="checkbox" name="system.target.prompt" {{checked system.target.prompt}}>
+        {{ localize "DND5E.TemplatePrompt" }}
     </label>
     {{/if}}
     {{#if system.uses.per}}
     <label class="checkbox" data-tooltip="DND5E.LimitedUsesPromptTooltip">
-        <input type="checkbox" name="system.uses.prompt" {{checked system.uses.prompt}}> {{ localize "DND5E.LimitedUsesPrompt" }}
+        <input type="checkbox" name="system.uses.prompt" {{checked system.uses.prompt}}>
+        {{ localize "DND5E.LimitedUsesPrompt" }}
     </label>
     {{/if}}
     {{#if (and (eq item.type "spell") system.consume.type)}}
     <label class="checkbox" data-tooltip="DND5E.ConsumeScalingTooltip">
-        <input type="checkbox" name="system.consume.scale" {{checked system.consume.scale}}> {{ localize "DND5E.ConsumeScaling" }}
+        <input type="checkbox" name="system.consume.scale" {{checked system.consume.scale}}>
+        {{ localize "DND5E.ConsumeScaling" }}
     </label>
     {{/if}}
 </div>


### PR DESCRIPTION
Updates the names for ammunition types and add "Firearm Bullet" type to bring everything up to date with the 2024 rules.

Adds damage data to consumable items that is only visible for ammunition. This damage has an additional option defining whether it supplements the weapon damage or replaces it.

Adds a "Ammunition Type" field to weapons defining what type of ammo they use. This data will be used in a followup PR to add a ammo selection UI to the attack roll dialog that only lists ammo that can be used with the weapon.

Also modified the damage section on weapons to add a hint about how the weapon damage is used and how `@mod` isn't necessary. Plus hide damage types for versatile damage since the system just fetches those from the base damage. Finally it displays a placeholder for the number and die fields in versatile damage to indicate that those fields can be inferred automatically.

Closes #1866
Closes #4011

### Todo
- [x] Display ammo selection in attack dialog
- [x] Handle ammo bonuses in attack & damage rolls