### PR TITLE
[#1039, #3268, #3314] Add ammo selection, consumption, & bonuses

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -267,13 +267,13 @@ export default class AttackActivityData extends BaseActivityData {
         // If mode is "replace" and base part is present, replace the base part
         if ( ammo.damage.replace & (basePartIndex !== -1) ) {
           damage.base = true;
-          rollConfig.rolls.splice(basePartIndex, 1, super._processDamagePart(damage, config, rollData));
+          rollConfig.rolls.splice(basePartIndex, 1, this._processDamagePart(damage, config, rollData));
         }
 
         // Otherwise stick the ammo damage after base part (or as first part)
         else {
           damage.ammo = true;
-          rollConfig.rolls.splice(basePartIndex + 1, 0, super._processDamagePart(damage, rollConfig, rollData));
+          rollConfig.rolls.splice(basePartIndex + 1, 0, this._processDamagePart(damage, rollConfig, rollData));
         }
       }
     }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -235,12 +235,12 @@ export default class WeaponData extends ItemDataModel.mixin(
     if ( this.parent.labels.damages?.length ) {
       const config = { ...CONFIG.DND5E.damageTypes, ...CONFIG.DND5E.healingTypes };
       context.info.push({ value: this.parent.labels.damages.reduce((str, { formula, damageType }) => {
-        const { label, icon } = config[damageType];
+        const type = config[damageType];
         return `${str}
           <span class="formula">${formula}</span>
-          <span class="damage-type" data-tooltip="${label}" aria-label="${label}">
-            <dnd5e-icon src="${icon}"></dnd5e-icon>
-          </span>
+          ${type ? `<span class="damage-type" data-tooltip="${type.label}" aria-label="${type.label}">
+            <dnd5e-icon src="${type.icon}"></dnd5e-icon>
+          </span>` : ""}
         `;
       }, ""), classes: "info-grid damage" });
     }

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -240,7 +240,8 @@ export default class D20Roll extends Roll {
    * @param {string} [data.title]             The title of the shown dialog window
    * @param {number} [data.defaultRollMode]   The roll mode that the roll mode select element should default to
    * @param {number} [data.defaultAction]     The button marked as default
-   * @param {FormSelectOption[]} [data.attackModes]  Selectable attack modes.
+   * @param {FormSelectOption[]} [data.ammunitionOptions]  Selectable ammunition options.
+   * @param {FormSelectOption[]} [data.attackModes]        Selectable attack modes.
    * @param {boolean} [data.chooseModifier]   Choose which ability modifier should be applied to the roll?
    * @param {string} [data.defaultAbility]    For tool rolls, the default ability modifier applied to the roll
    * @param {string} [data.template]          A custom path to an HTML template to use instead of the default
@@ -249,8 +250,8 @@ export default class D20Roll extends Roll {
    *                                          dialog was closed
    */
   async configureDialog({
-    title, defaultRollMode, defaultAction=D20Roll.ADV_MODE.NORMAL, attackModes,
-    chooseModifier=false, defaultAbility, template
+    title, defaultRollMode, defaultAction=D20Roll.ADV_MODE.NORMAL, ammunitionOptions,
+    attackModes, chooseModifier=false, defaultAbility, template
   }={}, options={}) {
 
     // Render the Dialog inner HTML
@@ -258,6 +259,7 @@ export default class D20Roll extends Roll {
       formulas: [{formula: `${this.formula} + @bonus`}],
       defaultRollMode,
       rollModes: CONFIG.Dice.rollModes,
+      ammunitionOptions,
       attackModes,
       chooseModifier,
       defaultAbility,
@@ -314,6 +316,9 @@ export default class D20Roll extends Roll {
       if ( !(bonus.terms[0] instanceof OperatorTerm) ) this.terms.push(new OperatorTerm({operator: "+"}));
       this.terms = this.terms.concat(bonus.terms);
     }
+
+    // Set the ammunition
+    if ( submitData.ammunition ) this.options.ammunition = submitData.ammunition;
 
     // Set the attack mode
     if ( submitData.attackMode ) this.options.attackMode = submitData.attackMode;

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -21,6 +21,14 @@
         </select>
     </div>
     {{/if}}
+    {{#if ammunitionOptions}}
+    <div class="form-group">
+        <label>{{ localize "DND5E.CONSUMABLE.Type.Ammunition.Label" }}</label>
+        <select name="ammunition">
+            {{ selectOptions ammunitionOptions blank="" }}
+        </select>
+    </div>
+    {{/if}}
     {{#if chooseModifier}}
     <div class="form-group">
         <label>{{ localize "DND5E.AbilityModifier" }}</label>


### PR DESCRIPTION
Adds a list of usable ammunition types to the attack dialog determined by the ammunition type on the weapon. When one of these is selected any magic bonus it has is added to the attack roll and a piece of ammunition is consumed. If the consumption destroys the ammunition then it is stored in the roll message to ensure it can be used for damage calculation.

When rolling damage the ammunition used on the last attack is sent to the `rollDamage` method. If the ammo has its own damage it either replaces the weapon's base damage or adds a new damage part. The ammo's magical bonus is added to the base damage.

Closes #1039
Closes #3268
Closes #3314

### Todo
- [ ] Remember previously-selected ammunition