### PR TITLE
[#1964] Re-implement uses recovery, adjust resting design

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1705,7 +1705,7 @@
 "DND5E.ItemRecoveryRoll": "{name} recovers {count} charges",
 "DND5E.ItemLossRoll": "{name} loses {count} charges",
 "DND5E.ItemRecoveryRollMax": "{name} recovers all charges",
-"DND5E.ItemRecoveryFormulaWarning": "Unable to recover charges for {name}. Invalid recovery formula '{formula}'.",
+"DND5E.ItemRecoveryFormulaWarning": "Unable to recover uses for {name}. Invalid recovery formula '{formula}' ({uuid}).",
 "DND5E.ItemRequiredStr": "Required Strength",
 "DND5E.ItemSiegeProperties": "Siege Properties",
 "DND5E.ItemSpeciesDetails": "Species Details",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2191,7 +2191,13 @@ DND5E.hitDieTypes = ["d4", "d6", "d8", "d10", "d12"];
  * Configuration data for rest types.
  *
  * @typedef {object} RestConfiguration
- * @property {Record<string, number>} duration  Duration of different rest variants in minutes.
+ * @property {Record<string, number>} duration    Duration of different rest variants in minutes.
+ * @property {boolean} recoverHitDice             Should hit dice be recovered during this rest?
+ * @property {boolean} recoverHitPoints           Should hit points be recovered during this rest?
+ * @property {string[]} recoverPeriods            What recovery periods should be applied when this rest is taken. The
+ *                                                ordering of the periods determines which is applied if more than one
+ *                                                recovery profile is found.
+ * @property {Set<string>} recoverSpellSlotTypes  Types of spellcasting slots to recover during this rest.
  */
 
 /**
@@ -2204,14 +2210,20 @@ DND5E.restTypes = {
       normal: 60,
       gritty: 480,
       epic: 1
-    }
+    },
+    recoverPeriods: ["sr"],
+    recoverSpellSlotTypes: new Set(["pact"])
   },
   long: {
     duration: {
       normal: 480,
       gritty: 10080,
       epic: 60
-    }
+    },
+    recoverHitDice: true,
+    recoverHitPoints: true,
+    recoverPeriods: ["lr", "sr"],
+    recoverSpellSlotTypes: new Set(["leveled", "pact"])
   }
 };
 

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -281,6 +281,35 @@ export default class ActivitiesTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Perform any item & activity uses recovery.
+   * @param {string[]} periods  Recovery periods to check.
+   * @param {object} rollData   Roll data to use when evaluating recover formulas.
+   * @returns {Promise<{ updates: object, rolls: BasicRoll[] }>}
+   */
+  async recoverUses(periods, rollData) {
+    const updates = {};
+    const rolls = [];
+
+    const result = await UsesField.recoverUses.call(this, periods, rollData);
+    if ( result ) {
+      foundry.utils.mergeObject(updates, { "system.uses": result.updates });
+      rolls.push(...result.rolls);
+    }
+
+    for ( const activity of this.activities ) {
+      const result = await UsesField.recoverUses.call(activity, periods, rollData);
+      if ( result ) {
+        foundry.utils.mergeObject(updates, { [`system.activities.${activity.id}.uses`]: result.updates });
+        rolls.push(...result.rolls);
+      }
+    }
+
+    return { updates, rolls };
+  }
+
+  /* -------------------------------------------- */
   /*  Shims                                       */
   /* -------------------------------------------- */
 

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -88,8 +88,15 @@ export default class UsesField extends SchemaField {
 
     // Search the recovery profiles in order to find the first matching period,
     // and then find the first profile that uses that recovery period
-    const matchingPeriod = periods.find(p => this.uses.recovery.find(r => r.period === p));
-    const profile = this.uses.recovery.find(r => r.period === matchingPeriod);
+    let profile;
+    for ( const period of periods ) {
+      for ( const recovery of this.uses.recovery ) {
+        if ( recovery.period === period ) {
+          profile = recovery;
+          break;
+        }
+      }
+    }
     if ( !profile ) return false;
 
     const updates = {};


### PR DESCRIPTION
Re-implements uses recovery to support uses on items and activities and multiple recovery profiles. Rest types now declare what type of periods they recover in prefered order.

This also introduces some other changes to the resting system to support better configuration of the process, allowing rest types to declare what types of spellcasting slots they recover and whether they recover hit points or hit dice. This should make it more feasible to implement custom rest types.