### PR TITLE
[#1964] Add back Place Template & Consume Resource buttons

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -768,7 +768,6 @@
 "DND5E.ConsumeMaterial": "Material",
 "DND5E.ConsumeCharges": "Item Uses",
 "DND5E.ConsumeResource": "Consume Resource?",
-"DND5E.ConsumeResourceAction": "Consume Resource",
 "DND5E.ConsumeRecharge": "Consume Recharge?",
 "DND5E.ConsumeScaling": "Resource Scaling",
 "DND5E.ConsumeScalingLabel": "Use Resources",
@@ -889,6 +888,7 @@
     }
   },
   "Action": {
+    "ConsumeResource": "Consume Resource",
     "Create": "Create Consumption Target",
     "Delete": "Delete Consumption Target"
   },
@@ -1886,8 +1886,6 @@
 "DND5E.PassivePerception": "Passive Perception",
 "DND5E.Period": "Period",
 "DND5E.PersonalityTraits": "Personality Traits",
-"DND5E.PlaceTemplate": "Place Measured Template",
-"DND5E.PlaceTemplateError": "Failed to place measured template",
 "DND5E.Polymorph": "Polymorph",
 "DND5E.PolymorphAcceptSettings": "Custom Settings",
 "DND5E.PolymorphCustomTransformation": "Custom Transformation",
@@ -2565,6 +2563,12 @@
         }
       }
     }
+  },
+  "Action": {
+    "PlaceTemplate": "Place Measured Template"
+  },
+  "Warning": {
+    "PlaceTemplate": "Failed to place measured template."
   }
 },
 

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -170,10 +170,10 @@ export default class ActivityUsageDialog extends Application5e {
    * @protected
    */
   async _prepareConcentrationContext(context, options) {
-    context.hasConcentration = this.activity.requiresConcentration
-      && !game.settings.get("dnd5e", "disableConcentration");
+    if ( !this.activity.requiresConcentration || game.settings.get("dnd5e", "disableConcentration")
+      || !this._shouldDisplay("concentration") ) return context;
+    context.hasConcentration = true;
     context.notes = [];
-    if ( !context.hasConcentration || !this._shouldDisplay("concentration") ) return context;
 
     context.fields = [{
       field: new BooleanField({ label: game.i18n.localize("DND5E.Concentration") }),
@@ -264,10 +264,10 @@ export default class ActivityUsageDialog extends Application5e {
    */
   async _prepareCreationContext(context, options) {
     context.hasCreation = false;
-    if ( this.activity.target.template.type && this._shouldDisplay("create.measuredTemplate") ) {
+    if ( this.activity.target?.template?.type && this._shouldDisplay("create.measuredTemplate") ) {
       context.hasCreation = true;
       context.template = {
-        field: new BooleanField({ label: game.i18n.localize("DND5E.PlaceTemplate") }),
+        field: new BooleanField({ label: game.i18n.localize("DND5E.TARGET.Action.PlaceTemplate") }),
         name: "create.measuredTemplate",
         value: this.config.create?.measuredTemplate
       };

--- a/module/applications/components/enchantment-application.mjs
+++ b/module/applications/components/enchantment-application.mjs
@@ -72,11 +72,7 @@ export default class EnchantmentApplicationElement extends HTMLElement {
     // Calculate the maximum targets
     let item = this.enchantmentItem;
     const scaling = this.chatMessage.getFlag("dnd5e", "scaling");
-    if ( scaling ) {
-      item = item.clone({ "flags.dnd5e.scaling": scaling });
-      item.prepareData();
-      item.prepareFinalAttributes();
-    }
+    if ( scaling ) item = item.clone({ "flags.dnd5e.scaling": scaling });
     const activity = item.system.activities.get(this.enchantmentActivity.id);
     const maxTargets = activity.target?.affects?.count;
     if ( maxTargets ) {

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -52,7 +52,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
         action: "rollDamage"
       }
     });
-    return buttons;
+    return buttons.concat(super._usageChatButtons());
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/damage.mjs
+++ b/module/documents/activity/damage.mjs
@@ -36,14 +36,14 @@ export default class DamageActivity extends ActivityMixin(DamageActivityData) {
 
   /** @override */
   _usageChatButtons() {
-    if ( !this.damage.parts.length ) return null;
+    if ( !this.damage.parts.length ) return super._usageChatButtons();
     return [{
       label: game.i18n.localize("DND5E.Damage"),
       icon: '<i class="fa-solid fa-burst" inert></i>',
       dataset: {
         action: "rollDamage"
       }
-    }];
+    }].concat(super._usageChatButtons());
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/heal.mjs
+++ b/module/documents/activity/heal.mjs
@@ -45,14 +45,14 @@ export default class HealActivity extends ActivityMixin(HealActivityData) {
 
   /** @override */
   _usageChatButtons() {
-    if ( !this.healing.formula ) return null;
+    if ( !this.healing.formula ) return super._usageChatButtons();
     return [{
       label: game.i18n.localize("DND5E.Healing"),
       icon: '<i class="dnd5e-icon" data-src="systems/dnd5e/icons/svg/damage/healing.svg"></i>',
       dataset: {
         action: "rollHealing"
       }
-    }];
+    }].concat(super._usageChatButtons());
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -650,7 +650,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       actor: this.item.actor,
       item: this.item,
       token: this.item.actor?.token,
-      buttons: buttons.length ? this._usageChatButtons() : null,
+      buttons: buttons.length ? buttons : null,
       description: data.description.chat,
       properties: properties.length ? properties : null,
       subtitle: this.description.chatFlavor ?? data.subtitle,

--- a/module/documents/activity/save.mjs
+++ b/module/documents/activity/save.mjs
@@ -59,7 +59,7 @@ export default class SaveActivity extends ActivityMixin(SaveActivityData) {
         action: "rollDamage"
       }
     });
-    return buttons;
+    return buttons.concat(super._usageChatButtons());
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -126,14 +126,22 @@ export default class SummonActivity extends ActivityMixin(SummonActivityData) {
 
   /** @override */
   _usageChatButtons() {
-    if ( !this.availableProfiles.length ) return null;
+    if ( !this.availableProfiles.length ) return super._usageChatButtons();
     return [{
       label: game.i18n.localize("DND5E.SUMMON.Action.Summon"),
       icon: '<i class="fa-solid fa-spaghetti-monster-flying" inert></i>',
       dataset: {
         action: "placeSummons"
       }
-    }];
+    }].concat(super._usageChatButtons());
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  shouldHideChatButton(button, message) {
+    if ( button.dataset.action === "placeSummons" ) return !this.canSummon;
+    return super.shouldHideChatButton(button, message);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -36,7 +36,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
 
   /** @override */
   _usageChatButtons() {
-    if ( !this.roll.formula ) return null;
+    if ( !this.roll.formula ) return super._usageChatButtons();
     return [{
       label: this.roll.name || game.i18n.localize("DND5E.Roll"),
       icon: '<i class="fa-solid fa-dice" inert></i>',
@@ -44,7 +44,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
         action: "rollFormula",
         visibility: this.roll.visible ? "all" : undefined
       }
-    }];
+    }].concat(super._usageChatButtons());
   }
 
   /* -------------------------------------------- */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -172,29 +172,8 @@ export default class ChatMessage5e extends ChatMessage {
 
         // GM buttons should only be visible to GMs, otherwise button should only be visible to message's creator
         if ( ((button.dataset.visibility === "gm") && !game.user.isGM) || !isCreator
-          || this.getAssociatedActivity()?.shouldHideChatButton(button) ) button.hidden = true;
+          || this.getAssociatedActivity()?.shouldHideChatButton(button, this) ) button.hidden = true;
       }
-
-      // TODO: Refer some of this more complex hiding behavior to activity when these buttons are re-implemented
-      // // If the user is the message author or the actor owner, proceed
-      // if ( game.user.isGM || actor?.isOwner || (this.author.id === game.user.id) ) {
-      //   const optionallyHide = (selector, hide) => {
-      //     const element = chatCard[0].querySelector(selector);
-      //     if ( element && hide ) element.style.display = "none";
-      //   };
-      //   optionallyHide('button[data-action="summon"]', !SummonsData.canSummon);
-      //   optionallyHide('button[data-action="placeTemplate"]', !game.user.can("TEMPLATE_CREATE"));
-      //   optionallyHide('button[data-action="consumeUsage"]', this.getFlag("dnd5e", "use.consumedUsage"));
-      //   optionallyHide('button[data-action="consumeResource"]', this.getFlag("dnd5e", "use.consumedResource"));
-      //   return;
-      // }
-
-      // // Otherwise conceal action buttons except for saving throw
-      // const buttons = chatCard.find("button[data-action]:not(.apply-effect)");
-      // buttons.each((i, btn) => {
-      //   if ( ["save", "rollRequest", "concentration"].includes(btn.dataset.action) ) return;
-      //   btn.style.display = "none";
-      // });
     }
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -537,9 +537,10 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  clone(...args) {
-    const item = super.clone(...args);
-    if ( !item.parent ) item.prepareFinalAttributes();
+  clone(data={}, options={}) {
+    if ( options.save ) return super.clone(data, options);
+    const item = super.clone(data, options);
+    if ( item.parent ) item.prepareFinalAttributes();
     return item;
   }
 


### PR DESCRIPTION
Add the "Place Template" and "Consume Resource" buttons back to the chat card if necessary.

Also modified the `clone` data on items to automatically call `prepareFinalAttributes` to prevent bugs caused by cloned items not being fully prepared.