### PR TITLE
[#1964] Tweak how activity migrations are performed

### DIFF
--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -189,10 +189,11 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /**
    * Migrate data from the item to a newly created activity.
    * @param {object} source  Item's candidate source data.
+   * @param {number} offset  Adjust the default ID using this number when creating multiple activities.
    */
-  static createInitialActivity(source) {
+  static createInitialActivity(source, offset=0) {
     const activityData = this.transformTypeData(source, {
-      _id: this.INITIAL_ID,
+      _id: this.INITIAL_ID.replace("0", offset),
       type: this.metadata.type,
       activation: this.transformActivationData(source),
       consumption: this.transformConsumptionData(source),
@@ -202,7 +203,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       range: this.transformRangeData(source),
       target: this.transformTargetData(source)
     });
-    foundry.utils.setProperty(source, `system.activities.${this.INITIAL_ID}`, activityData);
+    foundry.utils.setProperty(source, `system.activities.${activityData._id}`, activityData);
     foundry.utils.setProperty(source, "flags.dnd5e.persistSourceMigration", true);
   }
 

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -168,7 +168,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
     if ( Array.isArray(source.uses?.recovery) ) return;
 
     const charged = source.recharge?.charged;
-    if ( charged !== undefined ) {
+    if ( (source.recharge?.value !== null) && (charged !== undefined) ) {
       source.uses ??= {};
       source.uses.spent = charged ? 0 : 1;
     }
@@ -252,6 +252,13 @@ export default class ActivitiesTemplate extends SystemDataModel {
 
     const cls = CONFIG.DND5E.activityTypes[type].documentClass;
     cls.createInitialActivity(source);
+
+    if ( (type !== "save") && source.system.save.ability ) {
+      CONFIG.DND5E.activityTypes.save.documentClass.createInitialActivity(source, 1);
+    }
+    if ( (type !== "utility") && source.system.formula ) {
+      CONFIG.DND5E.activityTypes.utility.documentClass.createInitialActivity(source, 2);
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,6 +1,5 @@
 import AdvancementManager from "../applications/advancement/advancement-manager.mjs";
 import AdvancementConfirmationDialog from "../applications/advancement/advancement-confirmation-dialog.mjs";
-import AbilityUseDialog from "../applications/item/ability-use-dialog.mjs";
 import ClassData from "../data/item/class.mjs";
 import ContainerData from "../data/item/container.mjs";
 import EquipmentData from "../data/item/equipment.mjs";
@@ -2103,12 +2102,12 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
   /** @inheritdoc */
   static migrateData(source) {
+    ActivitiesTemplate.initializeActivities(source);
     source = super.migrateData(source);
     if ( source.type === "class" ) ClassData._migrateTraitAdvancement(source);
     else if ( source.type === "container" ) ContainerData._migrateWeightlessData(source);
     else if ( source.type === "equipment" ) EquipmentData._migrateStealth(source);
     else if ( source.type === "spell" ) SpellData._migrateComponentData(source);
-    ActivitiesTemplate.initializeActivities(source);
     return source;
   }
 }

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -183,7 +183,6 @@ export const migrateCompendium = async function(pack) {
   dnd5e.moduleArt.suppressArt = true;
 
   // Begin by requesting server-side data model migration and get the migrated content
-  await pack.migrate();
   const documents = await pack.getDocuments();
 
   // Iterate over compendium entries - applying fine-tuned migration functions
@@ -293,7 +292,6 @@ export async function refreshCompendium(pack) {
   const DocumentClass = CONFIG[pack.documentName].documentClass;
   const wasLocked = pack.locked;
   await pack.configure({locked: false});
-  await pack.migrate();
 
   ui.notifications.info(`Beginning to refresh Compendium ${pack.collection}`);
   const documents = await pack.getDocuments();


### PR DESCRIPTION
- Remove call to `pack.migrate` to fix core bug with missing `template.json`
- Doesn't migrate charged state if charged formula is `null`
- Create activities before item migration
- Creates separate `SaveActivity` if a save ability is set and the main activity isn't `SaveActivity`
- Creates separate `UtilityActivity` if formula is set and the main activity isn't `UtilityActivity`