### PR TITLE
[#1964] Migrate reach & versatile damage for non-weapons

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -122,7 +122,7 @@ export default class AttackActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @override */
-  static transformTypeData(source, activityData) {
+  static transformTypeData(source, activityData, options) {
     // For weapons and ammunition, separate the first part from the rest to be used as the base damage and keep the rest
     let damageParts = source.system.damage?.parts ?? [];
     const hasBase = (source.type === "weapon")

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -188,21 +188,22 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Migrate data from the item to a newly created activity.
-   * @param {object} source  Item's candidate source data.
-   * @param {number} offset  Adjust the default ID using this number when creating multiple activities.
+   * @param {object} source              Item's candidate source data.
+   * @param {object} [options={}]
+   * @param {number} [options.offset=0]  Adjust the default ID using this number when creating multiple activities.
    */
-  static createInitialActivity(source, offset=0) {
+  static createInitialActivity(source, { offset=0, ...options }={}) {
     const activityData = this.transformTypeData(source, {
       _id: this.INITIAL_ID.replace("0", offset),
       type: this.metadata.type,
-      activation: this.transformActivationData(source),
-      consumption: this.transformConsumptionData(source),
-      description: this.transformDescriptionData(source),
-      duration: this.transformDurationData(source),
-      effects: this.transformEffectsData(source),
-      range: this.transformRangeData(source),
-      target: this.transformTargetData(source)
-    });
+      activation: this.transformActivationData(source, options),
+      consumption: this.transformConsumptionData(source, options),
+      description: this.transformDescriptionData(source, options),
+      duration: this.transformDurationData(source, options),
+      effects: this.transformEffectsData(source, options),
+      range: this.transformRangeData(source, options),
+      target: this.transformTargetData(source, options)
+    }, options);
     foundry.utils.setProperty(source, `system.activities.${activityData._id}`, activityData);
     foundry.utils.setProperty(source, "flags.dnd5e.persistSourceMigration", true);
   }
@@ -212,9 +213,10 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /**
    * Fetch data from the item source and transform it into an activity's activation object.
    * @param {object} source  Item's candidate source data to transform.
+   * @param {object} options       Additional options passed to the creation process.
    * @returns {object}       Creation data for new activity.
    */
-  static transformActivationData(source) {
+  static transformActivationData(source, options) {
     if ( source.type === "spell" ) return {};
     return {
       type: source.system.activation?.type === "none" ? "" : (source.system.activation?.type ?? ""),
@@ -228,9 +230,10 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /**
    * Fetch data from the item source and transform it into an activity's consumption object.
    * @param {object} source  Item's candidate source data to transform.
+   * @param {object} options       Additional options passed to the creation process.
    * @returns {object}       Creation data for new activity.
    */
-  static transformConsumptionData(source) {
+  static transformConsumptionData(source, options) {
     const targets = [];
 
     const type = {
@@ -320,9 +323,10 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /**
    * Fetch data from the item source and transform it into an activity's description object.
    * @param {object} source  Item's candidate source data to transform.
+   * @param {object} options       Additional options passed to the creation process.
    * @returns {object}       Creation data for new activity.
    */
-  static transformDescriptionData(source) {
+  static transformDescriptionData(source, options) {
     return {
       chatFlavor: source.system.chatFlavor ?? ""
     };
@@ -333,9 +337,10 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /**
    * Fetch data from the item source and transform it into an activity's duration object.
    * @param {object} source  Item's candidate source data to transform.
+   * @param {object} options       Additional options passed to the creation process.
    * @returns {object}       Creation data for new activity.
    */
-  static transformDurationData(source) {
+  static transformDurationData(source, options) {
     if ( source.type === "spell" ) return {};
     return {
       value: source.system.duration?.value ?? null,
@@ -349,9 +354,10 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /**
    * Fetch data from the item source and transform it into an activity's effects array.
    * @param {object} source  Item's candidate source data to transform.
+   * @param {object} options       Additional options passed to the creation process.
    * @returns {object[]}     Creation data for new activity.
    */
-  static transformEffectsData(source) {
+  static transformEffectsData(source, options) {
     return source.effects
       .filter(e => !e.transfer && (e.type !== "enchantment") && (e.flags?.dnd5e?.type !== "enchantment"))
       .map(e => ({ _id: e._id }));
@@ -362,9 +368,10 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /**
    * Fetch data from the item source and transform it into an activity's range object.
    * @param {object} source  Item's candidate source data to transform.
+   * @param {object} options       Additional options passed to the creation process.
    * @returns {object}       Creation data for new activity.
    */
-  static transformRangeData(source) {
+  static transformRangeData(source, options) {
     if ( source.type === "spell" ) return {};
     return {
       value: source.system.range?.value ?? null,
@@ -378,9 +385,10 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /**
    * Fetch data from the item source and transform it into an activity's target object.
    * @param {object} source  Item's candidate source data to transform.
+   * @param {object} options       Additional options passed to the creation process.
    * @returns {object}       Creation data for new activity.
    */
-  static transformTargetData(source) {
+  static transformTargetData(source, options) {
     if ( source.type === "spell" ) return {
       prompt: source.system.target?.prompt ?? true
     };
@@ -428,9 +436,10 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * Perform any type-specific data transformations.
    * @param {object} source        Item's candidate source data to transform.
    * @param {object} activityData  In progress creation data.
+   * @param {object} options       Additional options passed to the creation process.
    * @returns {object}             Creation data for new activity.
    */
-  static transformTypeData(source, activityData) {
+  static transformTypeData(source, activityData, options) {
     return activityData;
   }
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -212,9 +212,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Fetch data from the item source and transform it into an activity's activation object.
-   * @param {object} source  Item's candidate source data to transform.
-   * @param {object} options       Additional options passed to the creation process.
-   * @returns {object}       Creation data for new activity.
+   * @param {object} source   Item's candidate source data to transform.
+   * @param {object} options  Additional options passed to the creation process.
+   * @returns {object}        Creation data for new activity.
    */
   static transformActivationData(source, options) {
     if ( source.type === "spell" ) return {};
@@ -229,9 +229,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Fetch data from the item source and transform it into an activity's consumption object.
-   * @param {object} source  Item's candidate source data to transform.
-   * @param {object} options       Additional options passed to the creation process.
-   * @returns {object}       Creation data for new activity.
+   * @param {object} source   Item's candidate source data to transform.
+   * @param {object} options  Additional options passed to the creation process.
+   * @returns {object}        Creation data for new activity.
    */
   static transformConsumptionData(source, options) {
     const targets = [];
@@ -322,9 +322,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Fetch data from the item source and transform it into an activity's description object.
-   * @param {object} source  Item's candidate source data to transform.
-   * @param {object} options       Additional options passed to the creation process.
-   * @returns {object}       Creation data for new activity.
+   * @param {object} source   Item's candidate source data to transform.
+   * @param {object} options  Additional options passed to the creation process.
+   * @returns {object}        Creation data for new activity.
    */
   static transformDescriptionData(source, options) {
     return {
@@ -336,9 +336,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Fetch data from the item source and transform it into an activity's duration object.
-   * @param {object} source  Item's candidate source data to transform.
-   * @param {object} options       Additional options passed to the creation process.
-   * @returns {object}       Creation data for new activity.
+   * @param {object} source   Item's candidate source data to transform.
+   * @param {object} options  Additional options passed to the creation process.
+   * @returns {object}        Creation data for new activity.
    */
   static transformDurationData(source, options) {
     if ( source.type === "spell" ) return {};
@@ -353,9 +353,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Fetch data from the item source and transform it into an activity's effects array.
-   * @param {object} source  Item's candidate source data to transform.
-   * @param {object} options       Additional options passed to the creation process.
-   * @returns {object[]}     Creation data for new activity.
+   * @param {object} source   Item's candidate source data to transform.
+   * @param {object} options  Additional options passed to the creation process.
+   * @returns {object[]}      Creation data for new activity.
    */
   static transformEffectsData(source, options) {
     return source.effects
@@ -367,9 +367,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Fetch data from the item source and transform it into an activity's range object.
-   * @param {object} source  Item's candidate source data to transform.
-   * @param {object} options       Additional options passed to the creation process.
-   * @returns {object}       Creation data for new activity.
+   * @param {object} source   Item's candidate source data to transform.
+   * @param {object} options  Additional options passed to the creation process.
+   * @returns {object}        Creation data for new activity.
    */
   static transformRangeData(source, options) {
     if ( source.type === "spell" ) return {};
@@ -384,9 +384,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Fetch data from the item source and transform it into an activity's target object.
-   * @param {object} source  Item's candidate source data to transform.
-   * @param {object} options       Additional options passed to the creation process.
-   * @returns {object}       Creation data for new activity.
+   * @param {object} source   Item's candidate source data to transform.
+   * @param {object} options  Additional options passed to the creation process.
+   * @returns {object}        Creation data for new activity.
    */
   static transformTargetData(source, options) {
     if ( source.type === "spell" ) return {

--- a/module/data/activity/damage-data.mjs
+++ b/module/data/activity/damage-data.mjs
@@ -33,14 +33,16 @@ export default class DamageActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @override */
-  static transformTypeData(source, activityData) {
+  static transformTypeData(source, activityData, options) {
     return foundry.utils.mergeObject(activityData, {
       damage: {
         critical: {
           allow: false,
           bonus: source.system.critical?.damage ?? ""
         },
-        parts: source.system.damage?.parts?.map(part => this.transformDamagePartData(source, part)) ?? []
+        parts: options.versatile
+          ? [this.transformDamagePartData(source, [source.system.damage?.versatile, ""])]
+          : (source.system.damage?.parts?.map(part => this.transformDamagePartData(source, part)) ?? [])
       }
     });
   }

--- a/module/data/activity/enchant-data.mjs
+++ b/module/data/activity/enchant-data.mjs
@@ -104,7 +104,7 @@ export default class EnchantActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @override */
-  static transformEffectsData(source) {
+  static transformEffectsData(source, options) {
     const effects = [];
     for ( const effect of source.effects ) {
       if ( (effect.type !== "enchantment") && (effect.flags?.dnd5e?.type !== "enchantment") ) continue;

--- a/module/data/activity/heal-data.mjs
+++ b/module/data/activity/heal-data.mjs
@@ -20,7 +20,7 @@ export default class HealActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @override */
-  static transformTypeData(source, activityData) {
+  static transformTypeData(source, activityData, options) {
     return foundry.utils.mergeObject(activityData, {
       healing: this.transformDamagePartData(source, source.system.damage?.parts?.[0] ?? ["", ""])
     });

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -66,7 +66,7 @@ export default class SaveActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @override */
-  static transformTypeData(source, activityData) {
+  static transformTypeData(source, activityData, options) {
     let calculation = source.system.save?.scaling;
     if ( calculation === "flat" ) calculation = "custom";
     else if ( calculation === "spell" ) calculation = "spellcasting";

--- a/module/data/activity/summon-data.mjs
+++ b/module/data/activity/summon-data.mjs
@@ -135,7 +135,7 @@ export default class SummonActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @override */
-  static transformTypeData(source, activityData) {
+  static transformTypeData(source, activityData, options) {
     return foundry.utils.mergeObject(activityData, {
       bonuses: source.system.summons?.bonuses ?? {},
       creatureSizes: source.system.summons?.creatureSizes ?? [],

--- a/module/data/activity/utility-data.mjs
+++ b/module/data/activity/utility-data.mjs
@@ -31,7 +31,7 @@ export default class UtilityActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @override */
-  static transformTypeData(source, activityData) {
+  static transformTypeData(source, activityData, options) {
     return foundry.utils.mergeObject(activityData, {
       roll: {
         formula: source.system.formula ?? "",

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -254,10 +254,13 @@ export default class ActivitiesTemplate extends SystemDataModel {
     cls.createInitialActivity(source);
 
     if ( (type !== "save") && source.system.save.ability ) {
-      CONFIG.DND5E.activityTypes.save.documentClass.createInitialActivity(source, 1);
+      CONFIG.DND5E.activityTypes.save.documentClass.createInitialActivity(source, { offset: 1 });
+    }
+    if ( (source.type !== "weapon") && source.system.damage?.versatile ) {
+      CONFIG.DND5E.activityTypes.damage.documentClass.createInitialActivity(source, { offset: 2, versatile: true });
     }
     if ( (type !== "utility") && source.system.formula ) {
-      CONFIG.DND5E.activityTypes.utility.documentClass.createInitialActivity(source, 2);
+      CONFIG.DND5E.activityTypes.utility.documentClass.createInitialActivity(source, { offset: 3 });
     }
   }
 

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -176,7 +176,7 @@ export default class WeaponData extends ItemDataModel.mixin(
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateReach(source) {
-    if ( !source.properties || !source.range?.value || !source.type?.value ) return;
+    if ( !source.properties || !source.range?.value || !source.type?.value || source.range?.reach ) return;
     if ( (CONFIG.DND5E.weaponTypeMap[source.type.value] !== "melee") || source.properties.includes("thr") ) return;
     // Range of `0` or greater than `10` is always included, and so is range longer than `5` without reach property
     if ( (source.range.value === 0) || (source.range.value > 10)

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -125,6 +125,7 @@ export default class WeaponData extends ItemDataModel.mixin(
     WeaponData.#migrateDamage(source);
     WeaponData.#migratePropertiesData(source);
     WeaponData.#migrateProficient(source);
+    WeaponData.#migrateReach(source);
   }
 
   /* -------------------------------------------- */
@@ -166,6 +167,23 @@ export default class WeaponData extends ItemDataModel.mixin(
    */
   static #migrateProficient(source) {
     if ( typeof source.proficient === "boolean" ) source.proficient = Number(source.proficient);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Migrate the range value to the reach field for melee weapons without the thrown property.
+   * @param {object} source  The candidate source data from which the model will be constructed.
+   */
+  static #migrateReach(source) {
+    if ( !source.properties || !source.range?.value || !source.type?.value ) return;
+    if ( (CONFIG.DND5E.weaponTypeMap[source.type.value] !== "melee") || source.properties.includes("thr") ) return;
+    // Range of `0` or greater than `10` is always included, and so is range longer than `5` without reach property
+    if ( (source.range.value === 0) || (source.range.value > 10)
+      || (!source.properties.includes("rch") && (source.range.value > 5)) ) {
+      source.range.reach = source.range.value;
+    }
+    source.range.value = null;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
- Creates additional `DamageActivity` for items that aren't weapons but have versatile damage
- Migrates `range.value` to `range.reach` for melee waepons without the thrown property
- Adjust the API of `refreshCompendium` to call `migrateCompendium` first with proper error handling if the migration fails