### PR TITLE
[#1964] Move concentration into activity duration

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1201,7 +1201,7 @@
       "label": "Duration",
       "concentration": {
         "label": "Concentration",
-        "hint": "User must maintain concentration while active."
+        "hint": "Creature must maintain concentration while active."
       },
       "override": {
         "label": "Override Duration",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1199,6 +1199,10 @@
   "FIELDS": {
     "duration": {
       "label": "Duration",
+      "concentration": {
+        "label": "Concentration",
+        "hint": "User must maintain concentration while active."
+      },
       "override": {
         "label": "Override Duration",
         "hint": "Use these duration values instead of the item's when using this activity."

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1612,12 +1612,10 @@ DND5E.validProperties = {
     "weightlessContents"
   ]),
   equipment: new Set([
-    "concentration",
     "mgc",
     "stealthDisadvantage"
   ]),
   feat: new Set([
-    "concentration",
     "mgc"
   ]),
   loot: new Set([
@@ -1650,7 +1648,6 @@ DND5E.validProperties = {
     "ritual"
   ]),
   tool: new Set([
-    "concentration",
     "mgc"
   ])
 };

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -28,6 +28,7 @@ const {
  * @property {string} name                       Name for this activity.
  * @property {string} img                        Image that represents this activity.
  * @property {ActivationField} activation        Activation time & conditions.
+ * @property {boolean} activation.override       Override activation values inferred from item.
  * @property {object} consumption
  * @property {ConsumptionTargetData[]} consumption.targets  Collection of consumption targets.
  * @property {object} consumption.scaling
@@ -36,9 +37,13 @@ const {
  * @property {object} description
  * @property {string} description.chatFlavor     Extra text displayed in the activation chat message.
  * @property {DurationField} duration            Duration of the effect.
+ * @property {boolean} duration.concentration    Does this effect require concentration?
+ * @property {boolean} duration.override         Override duration values inferred from item.
  * @property {EffectApplicationData[]} effects   Linked effects that can be applied.
  * @property {object} range
+ * @property {boolean} range.override            Override range values inferred from item.
  * @property {TargetField} target
+ * @property {boolean} target.override           Override target values inferred from item.
  * @property {boolean} target.prompt             Should the player be prompted to place the template?
  * @property {UsesField} uses                    Uses available to this activity.
  */
@@ -81,6 +86,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
         chatFlavor: new StringField()
       }),
       duration: new DurationField({
+        concentration: new BooleanField(),
         override: new BooleanField()
       }),
       effects: new ArrayField(new AppliedEffectField()),
@@ -160,7 +166,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * @type {boolean}
    */
   get requiresConcentration() {
-    return this.item.requiresConcentration;
+    return this.duration.concentration;
   }
 
   /* -------------------------------------------- */
@@ -342,7 +348,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    */
   static transformDurationData(source, options) {
     if ( source.type === "spell" ) return {};
+    const concentration = !!source.sytem.properties?.findSplice(p => p === "concentration");
     return {
+      concentration,
       value: source.system.duration?.value ?? null,
       units: source.system.duration?.units ?? "inst",
       special: ""

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -348,7 +348,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    */
   static transformDurationData(source, options) {
     if ( source.type === "spell" ) return {};
-    const concentration = !!source.sytem.properties?.findSplice(p => p === "concentration");
+    const concentration = !!source.system.properties?.findSplice(p => p === "concentration");
     return {
       concentration,
       value: source.system.duration?.value ?? null,

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -169,6 +169,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     super.prepareDerivedData();
     this.preparation.mode ||= "prepared";
     this.properties.add("mgc");
+    this.duration.concentration = this.properties.has("concentration");
 
     const labels = this.parent.labels ??= {};
     labels.level = CONFIG.DND5E.spellLevels[this.level];

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -362,9 +362,8 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @type {boolean}
    */
   get requiresConcentration() {
-    // TODO: Add to activity
-    const isValid = this.system.validProperties.has("concentration") && this.system.properties.has("concentration");
-    return isValid && this.isActive;
+    if ( this.system.validProperties.has("concentration") && this.system.properties.has("concentration") ) return true;
+    return this.system.activities?.contents[0]?.duration.concentration ?? false;
   }
 
   /* -------------------------------------------- */

--- a/templates/activity/parts/activity-time.hbs
+++ b/templates/activity/parts/activity-time.hbs
@@ -29,5 +29,7 @@
         </legend>
         {{> "dnd5e.field-duration" duration=activity.duration fields=fields.duration.fields data=data.duration
             durationUnits=durationUnits inputs=inputs }}
+        {{ formField fields.duration.fields.concentration value=data.duration.concentration
+           input=inputs.createCheckboxInput }}
     </fieldset>
 </section>


### PR DESCRIPTION
Adds `concentration` into the duration data on activities and removed it as a property on all items except spells. This allows concentration to be handled on a per-activity basis rather than for an item as a whole.

For spells, they get the derived `duration.concentration` value based on their properties and that will be inferred on the activity unless the duration is overridden.