### PR TITLE
[#1964] Adjust styling of usage, switch to <dialog> element

### DIFF
--- a/less/v2/activities.less
+++ b/less/v2/activities.less
@@ -124,6 +124,7 @@
     .separator, .max {
       flex: 0;
       padding-inline: 3px;
+      font-weight: bold;
     }
     .separator { color: var(--dnd5e-color-gold); }
   }

--- a/less/v2/activities.less
+++ b/less/v2/activities.less
@@ -114,3 +114,17 @@
     border-radius: 4px;
   }
 }
+
+/* ----------------------------------------- */
+/*  Usage Dialog                             */
+/* ----------------------------------------- */
+
+.activity-usage {
+  .scaling-fields {
+    .separator, .max {
+      flex: 0;
+      padding-inline: 3px;
+    }
+    .separator { color: var(--dnd5e-color-gold); }
+  }
+}

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -788,13 +788,22 @@
     .header-control { background: var(--dnd5e-background-25); }
 
     .window-icon {
+      --icon-size: var(--button-size);
+      block-size: var(--button-size);
+      inline-size: var(--button-size);
       margin-right: auto;
+
+      --icon-fill: var(--color-text-dark-5);
       color: var(--color-text-dark-5);
     }
+    dnd5e-icon.window-icon { margin-block-start: 2px; }
+    img.window-icon {
+      border: var(--dnd5e-border-gold);
+      border-radius: 4px;
+    }
   }
-  &.minimized .window-header {
-    h2 { display: none; }
-  }
+  &.minimized .window-header h2 { display: none; }
+  .window-header dnd5e-icon.window-icon { display: block; }
 
   .window-content {
     background: transparent;

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -763,16 +763,26 @@
     margin-block-end: calc(var(--font-size-24) + 6px);
     background: none;
 
-    h1 {
+    &:has(h2:not(:empty)) { margin-block-end: calc(var(--font-size-24) + 12px); }
+
+    h1, h2 {
       position: absolute;
-      inset-block-start: calc(var(--header-height) - 20px);
       inset-inline: 0;
       color: var(--color-text-dark-primary);
       font-family: var(--dnd5e-font-roboto-slab);
       font-weight: bold;
-      font-size: var(--font-size-24);
       text-align: center;
       z-index: -1;
+    }
+    h1 {
+      inset-block-start: calc(var(--header-height) - 20px);
+      font-size: var(--font-size-24);
+    }
+    h2 {
+      inset-block-start: calc(var(--header-height) + var(--font-size-16));
+      margin: 0;
+      font-size: var(--font-size-16);
+      text-shadow: none;
     }
 
     .header-control { background: var(--dnd5e-background-25); }
@@ -782,6 +792,9 @@
       color: var(--color-text-dark-5);
     }
   }
+  &.minimized .window-header {
+    h2 { display: none; }
+  }
 
   .window-content {
     background: transparent;
@@ -790,6 +803,8 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+
+    > section:empty { display: none; }
   }
 
   /* Tabs */
@@ -835,6 +850,11 @@
     flex-direction: column;
     gap: 8px;
   }
+}
+
+dialog.dnd5e2.application {
+  margin: 0;
+  padding: 0;
 }
 
 /* ---------------------------------- */

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -788,16 +788,16 @@
     .header-control { background: var(--dnd5e-background-25); }
 
     .window-icon {
-      --icon-size: var(--button-size);
-      block-size: var(--button-size);
-      inline-size: var(--button-size);
-      margin-right: auto;
-
+      --icon-size: 20px;
       --icon-fill: var(--color-text-dark-5);
-      color: var(--color-text-dark-5);
+      margin-right: auto;
+      color: var(--icon-fill);
+      font-size: calc(var(--icon-size) * .75);
     }
     dnd5e-icon.window-icon { margin-block-start: 2px; }
     img.window-icon {
+      block-size: calc(var(--icon-size) + 2px);
+      inline-size: calc(var(--icon-size) + 2px);
       border: var(--dnd5e-border-gold);
       border-radius: 4px;
     }

--- a/less/v2/compendium-browser.less
+++ b/less/v2/compendium-browser.less
@@ -242,11 +242,6 @@
       &:not(.invalid) .value { color: var(--dnd5e-color-green); }
       &.invalid .value { color: var(--dnd5e-color-maroon); }
     }
-
-    button:hover {
-      background: var(--dnd5e-background-card);
-      color: var(--color-text-dark-primary);
-    }
   }
 
   &.minimized {

--- a/less/v2/dark/apps.less
+++ b/less/v2/dark/apps.less
@@ -1,6 +1,6 @@
 :is(.dnd5e-theme-dark, .theme-dark) .dnd5e2,
 .dnd5e2.dnd5e-theme-dark {
-  &.sheet, &.compendium-browser {
+  &.sheet, &.application {
     /* TODO: Move these out once dark themes have been ported to all apps, not just the character sheet. */
     --color-text-dark-primary: var(--dnd5e-color-blue-white);
     --color-text-dark-secondary: var(--color-text-light-6);

--- a/less/v2/dark/forms.less
+++ b/less/v2/dark/forms.less
@@ -13,12 +13,12 @@
     &.card { background: var(--dnd5e-background-10); }
   }
 
-  :is(.form-group, fieldset) :is(select, input) {
+  :is(.form-group, fieldset) :is(select, input):not([type="range"]) {
     border: var(--dnd5e-border-gold);
     background: var(--dnd5e-background-parchment);
   }
 
-  :is(input, select):disabled {
+  :is(input, select):not([type="range"]):disabled {
     background: var(--dnd5e-color-dark-gray);
   }
 

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -58,7 +58,11 @@
       cursor: default;
       color: var(--color-text-dark-inactive);
     }
-    &:hover:not(:disabled), &:focus { box-shadow: 0 0 5px var(--color-shadow-primary); }
+    &:hover:not(:disabled), &:focus {
+      background: var(--dnd5e-background-card);
+      box-shadow: 0 0 5px var(--color-shadow-primary);
+      color: var(--color-text-dark-primary);
+    }
   }
 
   button.radio-button {
@@ -358,7 +362,7 @@
     }
   }
 
-  :is(.form-group, fieldset) :is(select, input) {
+  :is(.form-group, fieldset) :is(select, input):not([type="range"]) {
     color: var(--color-text-dark-primary);
     border: 1px solid var(--input-border-color);
     font-size: var(--font-size-11);

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -421,22 +421,29 @@
 
       &:hover, &:focus-visible {
         --range-track-border-color: var(--dnd5e-color-gold);
-        &::-moz-range-track, &::-webkit-slider-runnable-track {
-          box-shadow: 0 0 6px var(--dnd5e-color-gold);
-        }
+        &::-moz-range-track { box-shadow: 0 0 6px var(--dnd5e-color-gold); }
+        &::-webkit-slider-runnable-track { box-shadow: 0 0 6px var(--dnd5e-color-gold); }
       }
 
-      &::-moz-range-thumb, &::-moz-range-track, &::-webkit-slider-thumb, &::-webkit-slider-runnable-track {
-        transition: all 250ms ease;
-      }
-      &::-moz-range-thumb, &::-webkit-slider-thumb {
+      &::-moz-range-thumb { transition: all 250ms ease; }
+      &::-moz-range-track { transition: all 250ms ease; }
+      &::-webkit-slider-thumb { transition: all 250ms ease; }
+      &::-webkit-slider-runnable-track { transition: all 250ms ease; }
+
+      .range-thumb() {
         border-radius: 100%;
         box-shadow: 0 0 3px var(--dnd5e-shadow-45);
       }
-      &::-moz-range-track, &::-webkit-slider-runnable-track {
+
+      .range-track() {
         border: 1px solid var(--range-track-border-color);
         box-shadow: none;
       }
+
+      &::-moz-range-thumb { .range-thumb(); }
+      &::-webkit-slider-thumb { .range-thumb(); }
+      &::-moz-range-track { .range-track(); }
+      &::-webkit-slider-runnable-track { .range-track(); }
     }
   }
 

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -412,6 +412,34 @@
     }
   }
 
+  range-picker {
+    input[type="range"] {
+      --range-thumb-background-color: var(--dnd5e-color-card);
+      --range-thumb-border-color: var(--dnd5e-color-gold);
+      --range-track-border-color: transparent;
+      border: none;
+
+      &:hover, &:focus-visible {
+        --range-track-border-color: var(--dnd5e-color-gold);
+        &::-moz-range-track, &::-webkit-slider-runnable-track {
+          box-shadow: 0 0 6px var(--dnd5e-color-gold);
+        }
+      }
+
+      &::-moz-range-thumb, &::-moz-range-track, &::-webkit-slider-thumb, &::-webkit-slider-runnable-track {
+        transition: all 250ms ease;
+      }
+      &::-moz-range-thumb, &::-webkit-slider-thumb {
+        border-radius: 100%;
+        box-shadow: 0 0 3px var(--dnd5e-shadow-45);
+      }
+      &::-moz-range-track, &::-webkit-slider-runnable-track {
+        border: 1px solid var(--range-track-border-color);
+        box-shadow: none;
+      }
+    }
+  }
+
   /* Checkboxes */
   dnd5e-checkbox {
     &[disabled]:not([checked]) {

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -19,8 +19,6 @@ export default class ActivityUsageDialog extends Application5e {
     classes: ["activity-usage"],
     tag: "dialog",
     window: {
-      title: "DND5E.AbilityUseConfig",
-      icon: "",
       minimizable: false,
       contentTag: "form"
     },
@@ -119,8 +117,15 @@ export default class ActivityUsageDialog extends Application5e {
   /* -------------------------------------------- */
 
   /** @override */
+  get title() {
+    return this.item.name;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   get subtitle() {
-    return `${this.item.name}: ${this.activity.name}`;
+    return this.activity.name;
   }
 
   /* -------------------------------------------- */
@@ -363,6 +368,19 @@ export default class ActivityUsageDialog extends Application5e {
     }
 
     return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _renderFrame(options) {
+    const frame = await super._renderFrame(options);
+    const icon = frame.querySelector(".window-icon");
+    const newIcon = document.createElement(this.activity.img.endsWith(".svg") ? "dnd5e-icon" : "img");
+    newIcon.classList.add("window-icon");
+    newIcon.src = this.activity.img;
+    icon.replaceWith(newIcon);
+    return frame;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/activity/summon-usage-dialog.mjs
+++ b/module/applications/activity/summon-usage-dialog.mjs
@@ -34,7 +34,8 @@ export default class SummonUsageDialog extends ActivityUsageDialog {
       if ( !foundry.utils.hasProperty(this.options.display, "create.summons") ) context.summonsFields.push({
         field: new BooleanField({ label: game.i18n.localize("DND5E.SUMMON.Action.Place") }),
         name: "create.summons",
-        value: this.config.create?.summons
+        value: this.config.create?.summons,
+        input: context.inputs.createCheckboxInput
       });
 
       if ( this.config.create?.summons ) {

--- a/module/applications/api/application.mjs
+++ b/module/applications/api/application.mjs
@@ -6,11 +6,37 @@ const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 export default class Application5e extends HandlebarsApplicationMixin(ApplicationV2) {
   /** @override */
   static DEFAULT_OPTIONS = {
-    classes: ["dnd5e2"]
+    classes: ["dnd5e2"],
+    window: {
+      subtitle: ""
+    }
   };
 
   /* -------------------------------------------- */
   /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /**
+   * A reference to the window subtitle.
+   * @type {string}
+   */
+  get subtitle() {
+    return game.i18n.localize(this.options.window.subtitle ?? "");
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _configureRenderOptions(options) {
+    super._configureRenderOptions(options);
+    if ( options.isFirstRender && this.hasFrame ) {
+      options.window ||= {};
+      options.window.subtitle ||= this.subtitle;
+    }
+  }
+
   /* -------------------------------------------- */
 
   /** @inheritDoc */
@@ -19,6 +45,27 @@ export default class Application5e extends HandlebarsApplicationMixin(Applicatio
     context.CONFIG = CONFIG.DND5E;
     context.inputs = { ...foundry.applications.fields, ...dnd5e.applications.fields };
     return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _renderFrame(options) {
+    const frame = await super._renderFrame(options);
+    const subtitle = document.createElement("h2");
+    subtitle.classList.add("window-subtitle");
+    frame.querySelector(".window-title").insertAdjacentElement("afterend", subtitle);
+    return frame;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _updateFrame(options) {
+    super._updateFrame(options);
+    if ( options.window && ("subtitle" in options.window) ) {
+      this.element.querySelector(".window-header > .window-subtitle").innerText = options.window.subtitle;
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/applications/fields.mjs
+++ b/module/applications/fields.mjs
@@ -19,7 +19,7 @@ export function createCheckboxInput(field, config) {
 /**
  * Create a grid of checkboxes.
  * @param {DataField} field         The field.
- * @param {FormInputCOnfig} config  The input configuration.
+ * @param {FormInputConfig} config  The input configuration.
  * @returns {HTMLCollection}
  */
 export function createMultiCheckboxInput(field, config) {

--- a/templates/activity/activity-usage-concentration.hbs
+++ b/templates/activity/activity-usage-concentration.hbs
@@ -1,11 +1,12 @@
 <section>
+    {{~#if hasConcentration}}
     {{> "dnd5e.activity-usage-notes" }}
-    {{#if hasConcentration}}
+
     <fieldset>
         <legend>{{ localize "DND5E.Concentration" }}</legend>
         {{#each fields}}
-            {{ formField field name=name value=value options=options }}
+            {{ formField field name=name value=value options=options input=input }}
         {{/each}}
     </fieldset>
-    {{/if}}
+    {{/if~}}
 </section>

--- a/templates/activity/activity-usage-consumption.hbs
+++ b/templates/activity/activity-usage-consumption.hbs
@@ -1,15 +1,15 @@
 <section>
+    {{~#if hasConsumption}}
     {{> "dnd5e.activity-usage-notes" }}
-    {{#if hasConsumption}}
     <fieldset>
         <legend>{{ localize "DND5E.USAGE.SECTION.Consumption" }}</legend>
         {{#if spellSlot}}
-            {{ formField spellSlot.field name=spellSlot.name value=spellSlot.value }}
+            {{ formField spellSlot.field name=spellSlot.name value=spellSlot.value input=inputs.createCheckboxInput }}
         {{/if}}
         {{#if resources}}
             {{ formInput resources.field name=resources.name options=resources.options type="checkboxes"
                dataset=resources.dataset }}
         {{/if}}
     </fieldset>
-    {{/if}}
+    {{/if~}}
 </section>

--- a/templates/activity/activity-usage-creation.hbs
+++ b/templates/activity/activity-usage-creation.hbs
@@ -1,11 +1,11 @@
 <section>
+    {{~#if hasCreation}}
     {{> "dnd5e.activity-usage-notes" }}
-    {{#if hasCreation}}
     <fieldset>
         <legend>{{ localize "DND5E.USAGE.SECTION.Creation" }}</legend>
         {{#if template}}
-            {{ formField template.field name=template.name value=template.value }}
+            {{ formField template.field name=template.name value=template.value input=inputs.createCheckboxInput }}
         {{/if}}
     </fieldset>
-    {{/if}}
+    {{/if~}}
 </section>

--- a/templates/activity/activity-usage-scaling.hbs
+++ b/templates/activity/activity-usage-scaling.hbs
@@ -1,13 +1,13 @@
 <section>
+    {{~#if hasScaling}}
     {{> "dnd5e.activity-usage-notes" }}
-    {{#if hasScaling}}
     <fieldset>
         <legend>{{ localize "DND5E.USAGE.SECTION.Scaling" }}</legend>
         {{#if spellSlots}}
         {{ formField spellSlots.field name=spellSlots.name value=spellSlots.value options=spellSlots.options }}
         {{/if}}
         {{#if scaling}}
-        <div class="form-group">
+        <div class="form-group scaling-fields">
             <label>{{ localize "DND5E.ScalingValue" }}</label>
             <div class="form-fields">
                 {{#if scaling.showRange}}
@@ -16,15 +16,11 @@
                 {{else}}
                 {{ formInput scaling.field name=scaling.name value=scaling.value }}
                 {{/if}}
-            </div>
-        </div>
-        <div class="form-group">
-            <label>{{ localize "DND5E.CONSUMPTION.FIELDS.consumption.scaling.max.label" }}</label>
-            <div class="form-fields">
-                <span>{{ dnd5e-numberFormat scaling.max }}</span>
+                <span class="separator">/</span>
+                <span class="max">{{ dnd5e-numberFormat scaling.max }}</span>
             </div>
         </div>
         {{/if}}
     </fieldset>
-    {{/if}}
+    {{/if~}}
 </section>

--- a/templates/activity/enchant-usage-creation.hbs
+++ b/templates/activity/enchant-usage-creation.hbs
@@ -1,6 +1,6 @@
 <section>
+    {{~#if hasCreation}}
     {{> "dnd5e.activity-usage-notes" }}
-    {{#if hasCreation}}
     <fieldset>
         <legend>{{ localize "DND5E.USAGE.SECTION.Creation" }}</legend>
         {{#if enchantment.field}}
@@ -9,8 +9,8 @@
         <input type="hidden" name="enchantmentProfile" value="{{ enchantment }}">
         {{/if}}
         {{#if template}}
-        {{ formField template.field name=template.name value=template.value }}
+        {{ formField template.field name=template.name value=template.value input=inputs.createCheckboxInput }}
         {{/if}}
     </fieldset>
-    {{/if}}
+    {{/if~}}
 </section>

--- a/templates/activity/summon-usage-creation.hbs
+++ b/templates/activity/summon-usage-creation.hbs
@@ -1,18 +1,18 @@
 <section>
+    {{~#if hasCreation}}
     {{> "dnd5e.activity-usage-notes" }}
-    {{#if hasCreation}}
     <fieldset>
         <legend>{{ localize "DND5E.USAGE.SECTION.Creation" }}</legend>
         {{#each summonsFields}}
-        {{ formField field name=name value=value options=options }}
+        {{ formField field name=name value=value options=options input=input }}
         {{/each}}
         {{#if summonsProfile}}
         <input type="hidden" name="summons.profile" value="{{ summonsProfile }}">
         {{/if}}
         {{#if (and summonsFields template)}}<hr>{{/if}}
         {{#if template}}
-        {{ formField template.field name=template.name value=template.value }}
+        {{ formField template.field name=template.name value=template.value input=inputs.createCheckboxInput }}
         {{/if}}
     </fieldset>
-    {{/if}}
+    {{/if~}}
 </section>


### PR DESCRIPTION
Adjusts the styling of the activity usage dialog to match the V2 system styling more closely. This includes a redesigned range input which wasn't previously styled.

<img width="865" alt="Usage Dialog V2" src="https://github.com/user-attachments/assets/7fed24a7-d798-4888-b51f-880ad51072c2">

Adds a subtitle to the header of all V2 sheets configurable via `options.subtitle` or the `subtitle` getter. This will be hidden when the application is minimized.

Also changes the outer element of the usage application to be a `<dialog>` element and the content tag to be `<form>`.

Note: Resource consumption currently isn't styled awaiting a followup PR that makes more significant changes to those options.