### PR TITLE
[#1964] Communicate consumption costs in usage dialog

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -935,21 +935,24 @@
   "Type": {
     "ActivityUses": {
       "Label": "Activity Uses",
-      "Prompt": "Consume Activity Use?",
+      "PromptDecrease": "Consume Activity Use?",
+      "PromptIncrease": "Restore Activity Use?",
       "PromptHintDecrease": "Spend <strong>{cost}</strong> {use} of this activity.",
       "PromptHintIncrease": "Recover <strong>{cost}</strong> {use} of this activity.",
       "Warning": "uses on {item}'s activity {activity}"
     },
     "Attribute": {
       "Label": "Attribute",
-      "Prompt": "Consume Attribute?",
+      "PromptDecrease": "Consume Attribute?",
+      "PromptIncrease": "Restore Attribute?",
       "PromptHintDecrease": "Decrease <code>{attribute}</code> by <strong>{cost}</strong>.",
       "PromptHintIncrease": "Increase <code>{attribute}</code> by <strong>{cost}</strong>.",
       "Warning": "{attribute} amount"
     },
     "HitDice": {
       "Label": "Hit Dice",
-      "Prompt": "Consume Hit Die?",
+      "PromptDecrease": "Consume Hit Die?",
+      "PromptIncrease": "Restore Hit Die?",
       "PromptHintDecrease": "Spend <strong>{cost}</strong> {denomination} {die}.",
       "PromptHintIncrease": "Recover <strong>{cost}</strong> {denomination} {die}.",
       "Warning": "{denomination} hit dice"
@@ -960,14 +963,16 @@
     },
     "ItemUses": {
       "Label": "Item Uses",
-      "Prompt": "Consume Item Use?",
+      "PromptDecrease": "Consume Item Use?",
+      "PromptIncrease": "Restore Item Use?",
       "PromptHintDecrease": "Spend <strong>{cost}</strong> {use} of {item}.",
       "PromptHintIncrease": "Recover <strong>{cost}</strong> {use} of {item}.",
       "Warning": "uses on {name}"
     },
     "Material": {
       "Label": "Material",
-      "Prompt": "Consume Material?",
+      "PromptDecrease": "Consume Material?",
+      "PromptIncrease": "Restore Material?",
       "PromptHintDecrease": "Reduce quantity of {item} by <strong>{cost}</strong>.",
       "PromptHintIncrease": "Increase quantity of {item} by <strong>{cost}</strong>.",
       "Warning": "of {name}"
@@ -978,7 +983,8 @@
     },
     "SpellSlots": {
       "Label": "Spell Slots",
-      "Prompt": "Consume Spell Slot?",
+      "PromptDecrease": "Consume Spell Slot?",
+      "PromptIncrease": "Restore Spell Slot?",
       "PromptHintDecrease": "Spend <strong>{cost}</strong> {slot}.",
       "PromptHintIncrease": "Recover <strong>{cost}</strong> {slot}.",
       "Warning": "{level} slots"

--- a/lang/en.json
+++ b/lang/en.json
@@ -936,32 +936,56 @@
     "ActivityUses": {
       "Label": "Activity Uses",
       "Prompt": "Consume Activity Use?",
+      "PromptHintDecrease": "Spend <strong>{cost}</strong> {use} of this activity.",
+      "PromptHintIncrease": "Recover <strong>{cost}</strong> {use} of this activity.",
       "Warning": "uses on {item}'s activity {activity}"
     },
     "Attribute": {
       "Label": "Attribute",
       "Prompt": "Consume Attribute?",
+      "PromptHintDecrease": "Decrease <code>{attribute}</code> by <strong>{cost}</strong>.",
+      "PromptHintIncrease": "Increase <code>{attribute}</code> by <strong>{cost}</strong>.",
       "Warning": "{attribute} amount"
     },
     "HitDice": {
       "Label": "Hit Dice",
       "Prompt": "Consume Hit Die?",
+      "PromptHintDecrease": "Spend <strong>{cost}</strong> {denomination} {die}.",
+      "PromptHintIncrease": "Recover <strong>{cost}</strong> {denomination} {die}.",
       "Warning": "{denomination} hit dice"
+    },
+    "HitDie": {
+      "one": "hit die",
+      "other": "hit dice"
     },
     "ItemUses": {
       "Label": "Item Uses",
       "Prompt": "Consume Item Use?",
+      "PromptHintDecrease": "Spend <strong>{cost}</strong> {use} of {item}.",
+      "PromptHintIncrease": "Recover <strong>{cost}</strong> {use} of {item}.",
       "Warning": "uses on {name}"
     },
     "Material": {
       "Label": "Material",
       "Prompt": "Consume Material?",
+      "PromptHintDecrease": "Reduce quantity of {item} by <strong>{cost}</strong>.",
+      "PromptHintIncrease": "Increase quantity of {item} by <strong>{cost}</strong>.",
       "Warning": "of {name}"
+    },
+    "SpellSlot": {
+      "one": "{level} slot",
+      "other": "{level} slots"
     },
     "SpellSlots": {
       "Label": "Spell Slots",
       "Prompt": "Consume Spell Slot?",
+      "PromptHintDecrease": "Spend <strong>{cost}</strong> {slot}.",
+      "PromptHintIncrease": "Recover <strong>{cost}</strong> {slot}.",
       "Warning": "{level} slots"
+    },
+    "Use": {
+      "one": "use",
+      "other": "uses"
     }
   },
   "Warning": {

--- a/less/v2/activities.less
+++ b/less/v2/activities.less
@@ -127,4 +127,11 @@
     }
     .separator { color: var(--dnd5e-color-gold); }
   }
+  .hint code {
+    background: none;
+    border: none;
+    color: var(--dnd5e-color-crimson);
+    font-size: inherit;
+    padding: 0;
+  }
 }

--- a/less/v2/dark/activities.less
+++ b/less/v2/dark/activities.less
@@ -2,3 +2,11 @@
   .separated-list > li { background: var(--dnd5e-background-10); }
   &.summon-activity .separated-list :is(.drop-area, .content-link) { border-color: var(--dnd5e-color-blue-gray-3); }
 }
+
+/* ----------------------------------------- */
+/*  Usage Dialog                             */
+/* ----------------------------------------- */
+
+.theme-dark .activity-usage {
+  .hint code { color: var(--dnd5e-color-beige); }
+}

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -237,10 +237,7 @@ export default class ActivityUsageDialog extends Application5e {
       const isArray = foundry.utils.getType(this.config.consume?.resources) === "Array";
       for ( const [index, target] of this.activity.consumption.targets.entries() ) {
         context.resources.push({
-          field: new BooleanField({
-            label: CONFIG.DND5E.activityConsumptionTypes[target.type].prompt,
-            hint: target.getConsumptionHint(this.config)
-          }),
+          field: new BooleanField(target.getConsumptionLabels(this.config)),
           name: `consume.resources.${index}`,
           value: (isArray && this.config.consume.resources.includes(index))
             || (!isArray && (this.config.consume?.resources !== false) && (this.config.consume !== false)),

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -720,9 +720,8 @@ preLocalize("abilityConsumptionTypes", { sort: true });
 /**
  * @typedef {object} ActivityConsumptionTargetConfig
  * @property {string} label                                     Localized label for the target type.
- * @property {string} prompt                                    Localized label displayed in the usage dialog.
  * @property {ConsumptionConsumeFunction} consume               Function used to consume according to this type.
- * @property {ConsumptionHintFunction} consumptionHint          Function used to generate a hint of consumption amount.
+ * @property {ConsumptionLabelsFunction} consumptionLabels      Function used to generate a hint of consumption amount.
  * @property {{value: string, label: string}[]} [scalingModes]  Additional scaling modes for this consumption type in
  *                                                              addition to the default "amount" scaling.
  * @property {boolean} [targetRequiresEmbedded]                 Use text input rather than select when not embedded.
@@ -738,10 +737,10 @@ preLocalize("abilityConsumptionTypes", { sort: true });
  */
 
 /**
- * @callback ConsumptionHintFunction
+ * @callback ConsumptionLabelsFunction
  * @this {ConsumptionTargetData}
- * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
- * @returns {string}  Hint text.
+ * @param {ActivityUseConfiguration} config    Configuration data for the activity usage.
+ * @returns {{ label: string, hint: string }}  Label and hint text.
  */
 
 /**
@@ -757,51 +756,45 @@ preLocalize("abilityConsumptionTypes", { sort: true });
 DND5E.activityConsumptionTypes = {
   activityUses: {
     label: "DND5E.CONSUMPTION.Type.ActivityUses.Label",
-    prompt: "DND5E.CONSUMPTION.Type.ActivityUses.Prompt",
     consume: ConsumptionTargetData.consumeActivityUses,
-    consumptionHint: ConsumptionTargetData.consumptionHintActivityUses
+    consumptionLabels: ConsumptionTargetData.consumptionLabelsActivityUses
   },
   itemUses: {
     label: "DND5E.CONSUMPTION.Type.ItemUses.Label",
-    prompt: "DND5E.CONSUMPTION.Type.ItemUses.Prompt",
     consume: ConsumptionTargetData.consumeItemUses,
-    consumptionHint: ConsumptionTargetData.consumptionHintItemUses,
+    consumptionLabels: ConsumptionTargetData.consumptionLabelsItemUses,
     targetRequiresEmbedded: true,
     validTargets: ConsumptionTargetData.validItemUsesTargets
   },
   material: {
     label: "DND5E.CONSUMPTION.Type.Material.Label",
-    prompt: "DND5E.CONSUMPTION.Type.Material.Prompt",
     consume: ConsumptionTargetData.consumeMaterial,
-    consumptionHint: ConsumptionTargetData.consumptionHintMaterial,
+    consumptionLabels: ConsumptionTargetData.consumptionLabelsMaterial,
     targetRequiresEmbedded: true,
     validTargets: ConsumptionTargetData.validMaterialTargets
   },
   hitDice: {
     label: "DND5E.CONSUMPTION.Type.HitDice.Label",
-    prompt: "DND5E.CONSUMPTION.Type.HitDice.Prompt",
     consume: ConsumptionTargetData.consumeHitDice,
-    consumptionHint: ConsumptionTargetData.consumptionHintHitDice,
+    consumptionLabels: ConsumptionTargetData.consumptionLabelsHitDice,
     validTargets: ConsumptionTargetData.validHitDiceTargets
   },
   spellSlots: {
     label: "DND5E.CONSUMPTION.Type.SpellSlots.Label",
-    prompt: "DND5E.CONSUMPTION.Type.SpellSlots.Prompt",
     consume: ConsumptionTargetData.consumeSpellSlots,
-    consumptionHint: ConsumptionTargetData.consumptionHintSpellSlots,
+    consumptionLabels: ConsumptionTargetData.consumptionLabelsSpellSlots,
     scalingModes: [{ value: "level", label: "DND5E.CONSUMPTION.Scaling.SlotLevel" }],
     validTargets: ConsumptionTargetData.validSpellSlotsTargets
   },
   attribute: {
     label: "DND5E.CONSUMPTION.Type.Attribute.Label",
-    prompt: "DND5E.CONSUMPTION.Type.Attribute.Prompt",
     consume: ConsumptionTargetData.consumeAttribute,
-    consumptionHint: ConsumptionTargetData.consumptionHintAttribute,
+    consumptionLabels: ConsumptionTargetData.consumptionLabelsAttribute,
     targetRequiresEmbedded: true,
     validTargets: ConsumptionTargetData.validAttributeTargets
   }
 };
-preLocalize("activityConsumptionTypes", { keys: ["label", "prompt"] });
+preLocalize("activityConsumptionTypes", { key: "label" });
 
 /* -------------------------------------------- */
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -721,11 +721,12 @@ preLocalize("abilityConsumptionTypes", { sort: true });
  * @typedef {object} ActivityConsumptionTargetConfig
  * @property {string} label                                     Localized label for the target type.
  * @property {string} prompt                                    Localized label displayed in the usage dialog.
- * @property {ConsumptionConsumeFunction} consume               Method used to consume according to this type.
+ * @property {ConsumptionConsumeFunction} consume               Function used to consume according to this type.
+ * @property {ConsumptionHintFunction} consumptionHint          Function used to generate a hint of consumption amount.
  * @property {{value: string, label: string}[]} [scalingModes]  Additional scaling modes for this consumption type in
  *                                                              addition to the default "amount" scaling.
  * @property {boolean} [targetRequiresEmbedded]                 Use text input rather than select when not embedded.
- * @property {ConsumptionValidTargetsFunction} [validTargets]   Method for creating an array of consumption targets.
+ * @property {ConsumptionValidTargetsFunction} [validTargets]   Function for creating an array of consumption targets.
  */
 
 /**
@@ -734,6 +735,13 @@ preLocalize("abilityConsumptionTypes", { sort: true });
  * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
  * @param {ActivityUsageUpdates} updates     Updates to be performed.
  * @throws ConsumptionError
+ */
+
+/**
+ * @callback ConsumptionHintFunction
+ * @this {ConsumptionTargetData}
+ * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
+ * @returns {string}  Hint text.
  */
 
 /**
@@ -750,12 +758,14 @@ DND5E.activityConsumptionTypes = {
   activityUses: {
     label: "DND5E.CONSUMPTION.Type.ActivityUses.Label",
     prompt: "DND5E.CONSUMPTION.Type.ActivityUses.Prompt",
-    consume: ConsumptionTargetData.consumeActivityUses
+    consume: ConsumptionTargetData.consumeActivityUses,
+    consumptionHint: ConsumptionTargetData.consumptionHintActivityUses
   },
   itemUses: {
     label: "DND5E.CONSUMPTION.Type.ItemUses.Label",
     prompt: "DND5E.CONSUMPTION.Type.ItemUses.Prompt",
     consume: ConsumptionTargetData.consumeItemUses,
+    consumptionHint: ConsumptionTargetData.consumptionHintItemUses,
     targetRequiresEmbedded: true,
     validTargets: ConsumptionTargetData.validItemUsesTargets
   },
@@ -763,6 +773,7 @@ DND5E.activityConsumptionTypes = {
     label: "DND5E.CONSUMPTION.Type.Material.Label",
     prompt: "DND5E.CONSUMPTION.Type.Material.Prompt",
     consume: ConsumptionTargetData.consumeMaterial,
+    consumptionHint: ConsumptionTargetData.consumptionHintMaterial,
     targetRequiresEmbedded: true,
     validTargets: ConsumptionTargetData.validMaterialTargets
   },
@@ -770,12 +781,14 @@ DND5E.activityConsumptionTypes = {
     label: "DND5E.CONSUMPTION.Type.HitDice.Label",
     prompt: "DND5E.CONSUMPTION.Type.HitDice.Prompt",
     consume: ConsumptionTargetData.consumeHitDice,
+    consumptionHint: ConsumptionTargetData.consumptionHintHitDice,
     validTargets: ConsumptionTargetData.validHitDiceTargets
   },
   spellSlots: {
     label: "DND5E.CONSUMPTION.Type.SpellSlots.Label",
     prompt: "DND5E.CONSUMPTION.Type.SpellSlots.Prompt",
     consume: ConsumptionTargetData.consumeSpellSlots,
+    consumptionHint: ConsumptionTargetData.consumptionHintSpellSlots,
     scalingModes: [{ value: "level", label: "DND5E.CONSUMPTION.Scaling.SlotLevel" }],
     validTargets: ConsumptionTargetData.validSpellSlotsTargets
   },
@@ -783,6 +796,7 @@ DND5E.activityConsumptionTypes = {
     label: "DND5E.CONSUMPTION.Type.Attribute.Label",
     prompt: "DND5E.CONSUMPTION.Type.Attribute.Prompt",
     consume: ConsumptionTargetData.consumeAttribute,
+    consumptionHint: ConsumptionTargetData.consumptionHintAttribute,
     targetRequiresEmbedded: true,
     validTargets: ConsumptionTargetData.validAttributeTargets
   }

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -1,3 +1,4 @@
+import simplifyRollFormula from "../../../dice/simplify-roll-formula.mjs";
 import { formatNumber } from "../../../utils.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 
@@ -285,7 +286,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    */
   static async consumeSpellSlots(config, updates) {
     const cost = (await this.resolveCost({ config, rolls: updates.rolls })).total;
-    const levelNumber = (await this.resolveLevel({ config, rolls: updates.rolls })).total;
+    const levelNumber = this.resolveLevel({ config, rolls: updates.rolls });
 
     // Check to see if enough slots are available at the specified level
     const levelData = this.actor.system.spells?.[`spell${levelNumber}`];
@@ -327,6 +328,150 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
     );
 
     return { spent: uses.spent + cost };
+  }
+
+  /* -------------------------------------------- */
+  /*  Consumption Hints                           */
+  /* -------------------------------------------- */
+
+  /**
+   * Create hint text indicating how much of this resource will be consumed/recovered.
+   * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
+   * @returns {string}
+   */
+  getConsumptionHint(config) {
+    const typeConfig = CONFIG.DND5E.activityConsumptionTypes[this.type];
+    if ( !typeConfig?.consumptionHint ) return "";
+    return typeConfig.consumptionHint.call(this, config);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create hint text indicating how much of this resource will be consumed/recovered.
+   * @this {ConsumptionTargetData}
+   * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
+   * @returns {string}
+   */
+  static consumptionHintActivityUses(config) {
+    const { cost, isNegative, pluralRule } = this._resolveHintCost(config);
+    return game.i18n.format(
+      `DND5E.CONSUMPTION.Type.ActivityUses.PromptHint${isNegative ? "Increase" : "Decrease"}`,
+      { cost, use: game.i18n.localize(`DND5E.CONSUMPTION.Type.Use.${pluralRule}`) }
+    );
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create hint text indicating how much of this resource will be consumed/recovered.
+   * @this {ConsumptionTargetData}
+   * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
+   * @returns {string}
+   */
+  static consumptionHintAttribute(config) {
+    const { cost, isNegative } = this._resolveHintCost(config);
+    return game.i18n.format(
+      `DND5E.CONSUMPTION.Type.Attribute.PromptHint${isNegative ? "Increase" : "Decrease"}`,
+      { cost, attribute: this.target }
+    );
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create hint text indicating how much of this resource will be consumed/recovered.
+   * @this {ConsumptionTargetData}
+   * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
+   * @returns {string}
+   */
+  static consumptionHintHitDice(config) {
+    const { cost, isNegative, pluralRule } = this._resolveHintCost(config);
+    let denomination;
+    if ( this.target === "smallest" ) denomination = game.i18n.localize("DND5E.ConsumeHitDiceSmallest");
+    else if ( this.target === "largest" ) denomination = game.i18n.localize("DND5E.ConsumeHitDiceLargest");
+    else denomination = this.target;
+    return game.i18n.format(
+      `DND5E.CONSUMPTION.Type.HitDice.PromptHint${isNegative ? "Increase" : "Decrease"}`,
+      {
+        cost, denomination: denomination.toLowerCase(),
+        die: game.i18n.localize(`DND5E.CONSUMPTION.Type.HitDie.${pluralRule}`)
+      }
+    );
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create hint text indicating how much of this resource will be consumed/recovered.
+   * @this {ConsumptionTargetData}
+   * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
+   * @returns {string}
+   */
+  static consumptionHintItemUses(config) {
+    const { cost, isNegative, pluralRule } = this._resolveHintCost(config);
+    const item = this.actor.items.get(this.target);
+    return game.i18n.format(
+      `DND5E.CONSUMPTION.Type.ItemUses.PromptHint${isNegative ? "Increase" : "Decrease"}`,
+      {
+        cost, use: game.i18n.localize(`DND5E.CONSUMPTION.Type.Use.${pluralRule}`),
+        item: item ? `<em>${item.name}</em>` : game.i18n.localize("DND5E.CONSUMPTION.Target.ThisItem").toLowerCase()
+      }
+    );
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create hint text indicating how much of this resource will be consumed/recovered.
+   * @this {ConsumptionTargetData}
+   * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
+   * @returns {string}
+   */
+  static consumptionHintMaterial(config) {
+    const { cost, isNegative } = this._resolveHintCost(config);
+    return game.i18n.format(
+      `DND5E.CONSUMPTION.Type.Material.PromptHint${isNegative ? "Increase" : "Decrease"}`,
+      { cost, item: `<em>${this.actor.items.get(this.target).name}</em>` }
+    );
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create hint text indicating how much of this resource will be consumed/recovered.
+   * @this {ConsumptionTargetData}
+   * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
+   * @returns {string}
+   */
+  static consumptionHintSpellSlots(config) {
+    const { cost, isNegative, pluralRule } = this._resolveHintCost(config);
+    const levelNumber = this.resolveLevel({ config });
+    const level = CONFIG.DND5E.spellLevels[levelNumber].toLowerCase();
+    return game.i18n.format(
+      `DND5E.CONSUMPTION.Type.SpellSlots.PromptHint${isNegative ? "Increase" : "Decrease"}`,
+      { cost, slot: game.i18n.format(`DND5E.CONSUMPTION.Type.SpellSlot.${pluralRule}`, { level }) }
+    );
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Resolve the cost for the consumption hint.
+   * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
+   * @returns {{ cost: string, isNegative: boolean, pluralRule: string }}
+   */
+  _resolveHintCost(config) {
+    const costRoll = this.resolveCost({ config, evaluate: false });
+    let cost = costRoll.isDeterministic
+      ? String(costRoll.evaluateSync().total)
+      : simplifyRollFormula(costRoll.formula);
+    const isNegative = cost.startsWith("-");
+    if ( isNegative ) cost = cost.replace("-", "");
+    let pluralRule;
+    if ( costRoll.isDeterministic ) pluralRule = new Intl.PluralRules(game.i18n.lang).select(Number(cost));
+    else pluralRule = "other";
+    return { cost, isNegative, pluralRule };
   }
 
   /* -------------------------------------------- */
@@ -423,9 +568,9 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * @param {ActivityUseConfiguration} [options.config]  Usage configuration.
    * @param {boolean} [options.evaluate=true]            Should the cost roll be evaluated?
    * @param {BasicRoll[]} [options.rolls]                Rolls performed as part of the usages.
-   * @returns {Promise<BasicRoll>}
+   * @returns {Promise<BasicRoll>|BasicRoll}             Returns Promise if evaluate is `true`.
    */
-  async resolveCost({ config={}, ...options }={}) {
+  resolveCost({ config={}, ...options }={}) {
     return this._resolveScaledRoll(this.value, this.scaling.mode === "amount" ? config.scaling ?? 0 : 0, options);
   }
 
@@ -435,12 +580,15 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * Resolve the spell level to consume, taking scaling into account.
    * @param {object} [options={}]
    * @param {ActivityUseConfiguration} [options.config]  Usage configuration.
-   * @param {boolean} [options.evaluate=true]            Should the slot roll be evaluated?
    * @param {BasicRoll[]} [options.rolls]                Rolls performed as part of the usages.
-   * @returns {Promise<BasicRoll>}
+   * @returns {number}
    */
-  async resolveLevel({ config={}, ...options }={}) {
-    return this._resolveScaledRoll(this.value, this.scaling.mode === "level" ? config.scaling ?? 0 : 0, options);
+  resolveLevel({ config={}, ...options }={}) {
+    const roll = this._resolveScaledRoll(
+      this.target, this.scaling.mode === "level" ? config.scaling ?? 0 : 0, { ...options, evaluate: false }
+    );
+    roll.evaluateSync();
+    return roll.total;
   }
 
   /* -------------------------------------------- */
@@ -455,7 +603,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * @returns {Promise<BasicRoll>}
    * @internal
    */
-  async _resolveScaledRoll(formula, scaling, { evaluate=true, rolls }={}) {
+  _resolveScaledRoll(formula, scaling, { evaluate=true, rolls }={}) {
     const rollData = this.activity.getRollData();
     const roll = new CONFIG.Dice.BasicRoll(formula, rollData);
 
@@ -477,7 +625,10 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
       roll.resetFormula();
     }
 
-    if ( evaluate ) await roll.evaluate();
+    if ( evaluate ) return roll.evaluate().then(roll => {
+      if ( rolls && !roll.isDeterministic ) rolls.push(roll);
+      return roll;
+    });
     if ( rolls && !roll.isDeterministic ) rolls.push(roll);
     return roll;
   }

--- a/templates/activity/activity-usage-consumption.hbs
+++ b/templates/activity/activity-usage-consumption.hbs
@@ -6,10 +6,15 @@
         {{#if spellSlot}}
             {{ formField spellSlot.field name=spellSlot.name value=spellSlot.value input=inputs.createCheckboxInput }}
         {{/if}}
-        {{#if resources}}
-            {{ formInput resources.field name=resources.name options=resources.options type="checkboxes"
-               dataset=resources.dataset }}
-        {{/if}}
+        {{#each resources}}
+        <div class="form-group">
+            <label>{{ field.label }}</label>
+            <div class="form-fields">
+                {{ formInput field name=name value=value input=input }}
+            </div>
+            {{#if field.hint}}<p class="hint">{{{ field.hint }}}{{/if}}
+        </div>
+        {{/each}}
     </fieldset>
     {{/if~}}
 </section>


### PR DESCRIPTION
Creates hints for each resource consumption target in the usage dialog displaying what will be consumed and how much, adjusting automatically based on the scaling.

<img width="958" alt="Screenshot 2024-08-23 at 15 49 38" src="https://github.com/user-attachments/assets/850e458a-adda-4033-b88b-2784282dc765">
