### PR TITLE
[#1964] Support activities on spells that don't consume slots

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -887,6 +887,10 @@
           "hint": "Maximum number of scaling levels for this item, including the base level."
         }
       },
+      "spellSlot": {
+        "label": "Consume Spell Slot",
+        "hint": "Should using this activity consume a slot for this spell?"
+      },
       "targets": {
         "label": "Consumption Targets",
         "hint": "Targets of possible consumption when this activity is activated.",

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -259,6 +259,7 @@ export default class ActivitySheet extends Application5e {
         validTargets: showTextTarget ? null : data.validTargets
       };
     });
+    context.showConsumeSpellSlot = this.activity.isSpell && (this.item.system.level !== 0);
 
     // Uses recovery
     context.recoveryPeriods = [

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -222,7 +222,8 @@ export default class ActivityUsageDialog extends Application5e {
     context.fields = [];
     context.notes = [];
 
-    if ( this.activity.requiresSpellSlot && this._shouldDisplay("consume.spellSlot") ) context.spellSlot = {
+    if ( this.activity.requiresSpellSlot && this.activity.consumption.spellSlot
+      && this._shouldDisplay("consume.spellSlot") ) context.spellSlot = {
       field: new BooleanField({ label: game.i18n.localize("DND5E.SpellCastConsume") }),
       name: "consume.spellSlot",
       value: this.config.consume?.spellSlot

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -30,10 +30,11 @@ const {
  * @property {ActivationField} activation        Activation time & conditions.
  * @property {boolean} activation.override       Override activation values inferred from item.
  * @property {object} consumption
- * @property {ConsumptionTargetData[]} consumption.targets  Collection of consumption targets.
  * @property {object} consumption.scaling
- * @property {boolean} consumption.scaling.allowed  Can this non-spell activity be activated at higher levels?
- * @property {string} consumption.scaling.max    Maximum number of scaling levels for this item.
+ * @property {boolean} consumption.scaling.allowed          Can this non-spell activity be activated at higher levels?
+ * @property {string} consumption.scaling.max               Maximum number of scaling levels for this item.
+ * @property {boolean} consumption.spellSlot                If this is on a spell, should it consume a spell slot?
+ * @property {ConsumptionTargetData[]} consumption.targets  Collection of consumption targets.
  * @property {object} description
  * @property {string} description.chatFlavor     Extra text displayed in the activation chat message.
  * @property {DurationField} duration            Duration of the effect.
@@ -76,11 +77,12 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
         override: new BooleanField()
       }),
       consumption: new SchemaField({
-        targets: new ConsumptionTargetsField(),
         scaling: new SchemaField({
           allowed: new BooleanField(),
           max: new FormulaField({ deterministic: true })
-        })
+        }),
+        spellSlot: new BooleanField({ initial: true }),
+        targets: new ConsumptionTargetsField()
       }),
       description: new SchemaField({
         chatFlavor: new StringField()

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -471,7 +471,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
     if ( config.consume !== false ) {
       config.consume ??= {};
       config.consume.resources ??= this.consumption.targets.length > 0;
-      config.consume.spellSlot ??= this.requiresSpellSlot;
+      config.consume.spellSlot ??= this.requiresSpellSlot && this.consumption.spellSlot;
     }
 
     const levelingFlag = this.item.getFlag("dnd5e", "spellLevel");

--- a/templates/activity/parts/activity-consumption.hbs
+++ b/templates/activity/parts/activity-consumption.hbs
@@ -8,6 +8,12 @@
                 <i class="fas fa-plus" inert></i>
             </button>
         </legend>
+
+        {{#if showConsumeSpellSlot}}
+        {{ formField fields.consumption.fields.spellSlot value=source.consumption.spellSlot
+                     input=inputs.createCheckboxInput }}
+        {{/if}}
+
         {{#each consumptionTargets}}
         <div class="form-group split-group full-width card" data-index="{{ @index }}">
             <div class="form-fields field-groups">
@@ -46,11 +52,6 @@
         {{else}}
         <div class="empty">{{ localize "DND5E.None" }}</div>
         {{/each}}
-
-        {{#if showConsumeSpellSlot}}
-        {{ formField fields.consumption.fields.spellSlot value=source.consumption.spellSlot
-           input=inputs.createCheckboxInput }}
-        {{/if}}
     </fieldset>
 
     {{#unless activity.isSpell}}

--- a/templates/activity/parts/activity-consumption.hbs
+++ b/templates/activity/parts/activity-consumption.hbs
@@ -46,6 +46,11 @@
         {{else}}
         <div class="empty">{{ localize "DND5E.None" }}</div>
         {{/each}}
+
+        {{#if showConsumeSpellSlot}}
+        {{ formField fields.consumption.fields.spellSlot value=source.consumption.spellSlot
+           input=inputs.createCheckboxInput }}
+        {{/if}}
     </fieldset>
 
     {{#unless activity.isSpell}}


### PR DESCRIPTION
Adds `consumption.spellSlot` that only appears when an activity is on a spell that controls whether a spell consumes a slot. If a spell wouldn't normally consume a slot then this setting does nothing. Unchecking this still allows upcasting the spell.