### PR TITLE
Update config.mjs humanoid icon

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -989,7 +989,7 @@ DND5E.creatureTypes = {
   humanoid: {
     label: "DND5E.CreatureHumanoid",
     plural: "DND5E.CreatureHumanoidPl",
-    icon: "icons/magic/unholy/strike-body-explode-disintegrate.webp",
+    icon: "icons/magic/control/silhouette-hold-change-green.webpp",
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.iFzQs4AenN8ALRvw"
   },
   monstrosity: {


### PR DESCRIPTION
Since the vast majority of races in the game are of type "Humanoid", and this is displayed on the front of every character sheet, I think it would be wise to choose a different icon. The current one  appears to be a dude exploding and disintegrating which is a little dark.

I propose the included icon which is a more generic silhouette. Other options also exist.

![image](https://github.com/user-attachments/assets/cc76a237-2432-4d91-bcdc-9fec1c8dd7ff)


