### PR TITLE
Restore hint text to label-top form groups.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -901,7 +901,7 @@
           },
           "value": {
             "label": "Consumption Amount",
-            "hint": "Amount to consume of the target."
+            "hint": "Enter a negative value to restore rather than consume."
           },
           "scaling": {
             "label": "Consumption Scaling",

--- a/less/v2/dark/forms.less
+++ b/less/v2/dark/forms.less
@@ -11,6 +11,7 @@
 
   .form-group {
     &.card { background: var(--dnd5e-background-10); }
+    &.label-top > label > p.hint::before { color: var(--dnd5e-color-gold); }
   }
 
   :is(.form-group, fieldset) :is(select, input) {

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -228,6 +228,7 @@
     }
 
     &.label-top {
+      --label-height: 10px;
       flex-direction: column;
       align-items: stretch;
       gap: 2px;
@@ -239,7 +240,27 @@
         text-transform: uppercase;
         font-size: var(--font-size-10);
         font-weight: bold;
-        line-height: 1;
+        line-height: var(--label-height);
+        height: var(--label-height);
+
+        > p.hint {
+          cursor: help;
+          font-size: var(--font-size-10);
+          display: inline-block;
+          margin: 0 0 0 3px;
+          line-height: var(--label-height);
+          height: var(--label-height);
+
+          &:empty { min-height: unset; }
+          &:hover { text-shadow: 0 0 6px var(--color-shadow-primary); }
+
+          &::before {
+            content: "\f059";
+            font-family: var(--font-awesome);
+            font-weight: normal;
+            color: var(--color-text-dark-5);
+          }
+        }
       }
 
       + .form-group { align-self: end; }

--- a/module/applications/api/application.mjs
+++ b/module/applications/api/application.mjs
@@ -26,12 +26,24 @@ export default class Application5e extends HandlebarsApplicationMixin(Applicatio
   /** @inheritDoc */
   _onRender(context, options) {
     super._onRender(context, options);
+
+    // Allow multi-select tags to be removed when the whole tag is clicked.
     this.element.querySelectorAll("multi-select").forEach(select => {
       if ( select.disabled ) return;
       select.querySelectorAll(".tag").forEach(tag => {
         tag.classList.add("remove");
         tag.querySelector(":scope > span")?.classList.add("remove");
       });
+    });
+
+    // Add special styling for label-top hints.
+    this.element.querySelectorAll(".label-top > p.hint").forEach(hint => {
+      const label = hint.parentElement.querySelector(":scope > label");
+      if ( !label ) return;
+      hint.ariaLabel = hint.innerText;
+      hint.dataset.tooltip = hint.innerHTML;
+      hint.innerHTML = "";
+      label.insertAdjacentElement("beforeend", hint);
     });
   }
 }

--- a/templates/activity/parts/activity-consumption.hbs
+++ b/templates/activity/parts/activity-consumption.hbs
@@ -15,7 +15,7 @@
                     {{ formField fields.type name=(concat prefix "type") value=data.type label="DND5E.Type"
                                  localize=true hint=false options=typeOptions classes="label-top" }}
                     {{ formField fields.value name=(concat prefix "value") value=data.value label="DND5E.Amount"
-                                 localize=true hint=false classes="label-top" }}
+                                 localize=true classes="label-top" }}
                 </div>
                 {{#if showTargets}}
                 <div class="field-group">


### PR DESCRIPTION
We can't really use normal hint text in these form groups because they are of variable height, so I've made this PR to restore the use of them via a tooltipped icon. Having lots of these in a form will make it very busy so they should still be used sparingly though, and not on every single input.

![image](https://github.com/user-attachments/assets/dacbdb04-4f1b-4329-927a-58a3e94f3c31)
