### PR TITLE
[#1964] Update spell scroll creation to work with activities

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2609,7 +2609,7 @@ DND5E.spellScrollIds = {
  */
 
 /**
- * Spell scroll save DCs and attack bonus values based on level in the 2014 rules. If matching level isn't found,
+ * Spell scroll save DCs and attack bonus values based on spell level. If matching level isn't found,
  * then the nearest level lower than it will be selected.
  * @enum {SpellScrollValues}
  */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2603,6 +2603,27 @@ DND5E.spellScrollIds = {
 /* -------------------------------------------- */
 
 /**
+ * @typedef {object} SpellScrollValues
+ * @property {number} bonus  Attack to hit bonus.
+ * @property {number} dc     Saving throw DC.
+ */
+
+/**
+ * Spell scroll save DCs and attack bonus values based on level in the 2014 rules. If matching level isn't found,
+ * then the nearest level lower than it will be selected.
+ * @enum {SpellScrollValues}
+ */
+DND5E.spellScrollValues = {
+  0: { dc: 13, bonus: 5 },
+  3: { dc: 15, bonus: 7 },
+  5: { dc: 17, bonus: 9 },
+  7: { dc: 18, bonus: 10 },
+  9: { dc: 19, bonus: 11 }
+};
+
+/* -------------------------------------------- */
+
+/**
  * Compendium packs used for localized items.
  * @enum {string}
  */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -735,6 +735,11 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       }
     }, message);
 
+    // If the Item was destroyed in the process, embed a copy of its data
+    if ( !this.actor?.items.has(this.item.id) ) {
+      foundry.utils.setProperty(messageConfig, "data.flags.dnd5e.item.data", this.item.toObject());
+    }
+
     /**
      * A hook event that fires before an activity usage card is created.
      * @function dnd5e.preCreateUsageMessage


### PR DESCRIPTION
Modifies spell scroll creation to deal with activities rather than the old activation data. This involves copying over the activities, merging in data that was originally inferred from the spell, and applying save DC & attack bonus changes directly to the proper Save and Attack activities. Because the reference scroll data no longer contains the values we used to use for determining DC & attack bonus under the 2014 rules, this adds a config object to provide those values.

This also fixes a couple of bugs preventing activities from being used from destroyed items.

Note: While the API side has been updated to support custom DC and attack bonus values for the 2024 rules, the spell scroll UI hasn't been updated to provide those values yet.