### PR TITLE
[#4043] Refresh Create Scroll UI, allow custom spell values

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2178,7 +2178,9 @@
     "Complete": "Complete",
     "Reference": "Reference"
   },
-  "RequiresConcentration": "Requires Concentration"
+  "RequiresConcentration": "Requires Concentration",
+  "SaveDC": "Save DC",
+  "Values": "Spell Values"
 },
 "DND5E.Senses": "Senses",
 "DND5E.SensesConfig": "Configure Senses",

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -152,7 +152,7 @@ export default class ActivityUsageDialog extends Dialog5e {
 
   /** @inheritDoc */
   async _preparePartContext(partId, context, options) {
-    context = foundry.utils.deepClone(await super._preparePartContext(partId, context, options));
+    context = await super._preparePartContext(partId, context, options);
     switch ( partId ) {
       case "concentration": return this._prepareConcentrationContext(context, options);
       case "consumption": return this._prepareConsumptionContext(context, options);

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -1,12 +1,12 @@
 import { filteredKeys, simplifyBonus } from "../../utils.mjs";
-import Application5e from "../api/application.mjs";
+import Dialog5e from "../api/dialog.mjs";
 
 const { BooleanField, NumberField, StringField } = foundry.data.fields;
 
 /**
  * Dialog for configuring the usage of an activity.
  */
-export default class ActivityUsageDialog extends Application5e {
+export default class ActivityUsageDialog extends Dialog5e {
   constructor(options={}) {
     super(options);
     this.#activityId = options.activity.id;
@@ -17,11 +17,6 @@ export default class ActivityUsageDialog extends Application5e {
   /** @override */
   static DEFAULT_OPTIONS = {
     classes: ["activity-usage"],
-    tag: "dialog",
-    window: {
-      minimizable: false,
-      contentTag: "form"
-    },
     actions: {
       use: ActivityUsageDialog.#onUse
     },
@@ -382,18 +377,6 @@ export default class ActivityUsageDialog extends Application5e {
 
   /* -------------------------------------------- */
   /*  Event Listeners and Handlers                */
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  _attachFrameListeners() {
-    super._attachFrameListeners();
-
-    // Add event listeners to the form manually (see https://github.com/foundryvtt/foundryvtt/issues/11621)
-    const form = this.element.querySelector("form");
-    form.addEventListener("submit", this._onSubmitForm.bind(this, this.options.form));
-    form.addEventListener("change", this._onChangeForm.bind(this, this.options.form));
-  }
-
   /* -------------------------------------------- */
 
   /**

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -181,23 +181,19 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
 
     // Spellcasting
     context.spellcasting = [];
-    const msak = simplifyBonus(this.actor.system.bonuses.msak.attack, context.rollData);
-    const rsak = simplifyBonus(this.actor.system.bonuses.rsak.attack, context.rollData);
-
     for ( const item of Object.values(this.actor.classes).sort((a, b) => b.system.levels - a.system.levels) ) {
       const sc = item.spellcasting;
       if ( !sc?.progression || (sc.progression === "none") ) continue;
       const ability = this.actor.system.abilities[sc.ability];
       const mod = ability?.mod ?? 0;
-      const attackBonus = msak === rsak ? msak : 0;
       const name = item.system.spellcasting.progression === sc.progression ? item.name : item.subclass?.name;
       context.spellcasting.push({
         label: game.i18n.format("DND5E.SpellcastingClass", { class: name }),
         ability: { mod, ability: sc.ability },
-        attack: mod + this.actor.system.attributes.prof + attackBonus,
+        attack: sc.attack,
+        preparation: sc.preparation,
         primary: this.actor.system.attributes.spellcasting === sc.ability,
-        save: ability?.dc ?? 0,
-        preparation: sc.preparation
+        save: sc.save
       });
     }
 

--- a/module/applications/api/dialog.mjs
+++ b/module/applications/api/dialog.mjs
@@ -1,0 +1,93 @@
+import Application5e from "./application.mjs";
+
+/**
+ * Application for creating dnd5e dialogs.
+ */
+export default class Dialog5e extends Application5e {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    tag: "dialog",
+    window: {
+      contentTag: "form",
+      minimizable: false
+    }
+  };
+
+  /** @override */
+  static PARTS = {
+    content: {
+      template: ""
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Form element within the dialog.
+   * @type {HTMLFormElement|void}
+   */
+  get form() {
+    return this.options.tag === "form" ? this.element : this.element.querySelector("form");
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preparePartContext(partId, context, options) {
+    context = foundry.utils.deepClone(await super._preparePartContext(partId, context, options));
+    if ( partId === "content" ) return this._prepareContentContext(context, options);
+    if ( partId === "footer" ) return this._prepareFooterContext(context, options);
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the content section.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {Promise<ApplicationRenderContext>}
+   * @protected
+   */
+  async _prepareContentContext(context, options) {
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the footer.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {Promise<ApplicationRenderContext>}
+   * @protected
+   */
+  async _prepareFooterContext(context, options) {
+    context.buttons = this.options.buttons?.map(button => ({
+      ...button, cssClass: button.class
+    }));
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _attachFrameListeners() {
+    super._attachFrameListeners();
+
+    // Add event listeners to the form manually (see https://github.com/foundryvtt/foundryvtt/issues/11621)
+    if ( this.options.tag !== "form" ) {
+      this.form?.addEventListener("submit", this._onSubmitForm.bind(this, this.options.form));
+      this.form?.addEventListener("change", this._onChangeForm.bind(this, this.options.form));
+    }
+  }
+}

--- a/module/applications/api/dialog.mjs
+++ b/module/applications/api/dialog.mjs
@@ -41,7 +41,7 @@ export default class Dialog5e extends Application5e {
 
   /** @inheritDoc */
   async _preparePartContext(partId, context, options) {
-    context = foundry.utils.deepClone(await super._preparePartContext(partId, context, options));
+    context = { ...(await super._preparePartContext(partId, context, options)) };
     if ( partId === "content" ) return this._prepareContentContext(context, options);
     if ( partId === "footer" ) return this._prepareFooterContext(context, options);
     return context;

--- a/module/applications/item/create-scroll-dialog.mjs
+++ b/module/applications/item/create-scroll-dialog.mjs
@@ -1,0 +1,171 @@
+import Dialog5e from "../api/dialog.mjs";
+
+const { NumberField, StringField } = foundry.data.fields;
+
+/**
+ * Application for configuration spell scroll creation.
+ */
+export default class CreateScrollDialog extends Dialog5e {
+  constructor(options={}) {
+    super(options);
+    this.#config = options.config;
+    this.#spell = options.spell;
+  }
+
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["create-scroll"],
+    window: {
+      title: "DND5E.Scroll.CreateScroll",
+      icon: "fa-solid fa-scroll"
+    },
+    form: {
+      handler: CreateScrollDialog.#handleFormSubmission
+    },
+    position: {
+      width: 420
+    },
+    buttons: [{
+      action: "create",
+      label: "DND5E.Scroll.CreateScroll",
+      icon: "fa-solid fa-check",
+      default: true
+    }],
+    config: null,
+    spell: null
+  };
+
+  /** @inheritDoc */
+  static PARTS = {
+    ...super.PARTS,
+    content: {
+      template: "systems/dnd5e/templates/apps/spell-scroll-dialog.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Configuration options for scroll creation.
+   * @type {SpellScrollConfiguration}
+   */
+  #config;
+
+  get config() {
+    return this.#config;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Spell from which the scroll will be created.
+   * @type {Item5e|object}
+   */
+  #spell;
+
+  get spell() {
+    return this.#spell;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the content section.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {Promise<ApplicationRenderContext>}
+   * @protected
+   */
+  async _prepareContentContext(context, options) {
+    context.anchor = this.spell instanceof Item ? this.spell.toAnchor().outerHTML : `<span>${this.spell.name}</span>`;
+    context.config = this.config;
+    context.fields = [{
+      field: new StringField({
+        label: game.i18n.localize("DND5E.Scroll.Explanation.Label"),
+        hint: game.i18n.localize("DND5E.Scroll.Explanation.Hint")
+      }),
+      name: "explanation",
+      options: [
+        { value: "full", label: game.i18n.localize("DND5E.Scroll.Explanation.Complete") },
+        { value: "reference", label: game.i18n.localize("DND5E.Scroll.Explanation.Reference") },
+        { value: "none", label: game.i18n.localize("DND5E.None") }
+      ],
+      value: this.config.explanation ?? "reference"
+    }, {
+      field: new NumberField({ label: game.i18n.localize("DND5E.SpellLevel") }),
+      name: "level",
+      options: Object.entries(CONFIG.DND5E.spellLevels)
+        .map(([value, label]) => ({ value, label }))
+        .filter(l => Number(l.value) >= this.spell.system.level),
+      value: this.config.level ?? this.spell.system.level
+    }];
+    context.values = {
+      bonus: new NumberField({ label: game.i18n.localize("DND5E.BonusAttack") }),
+      dc: new NumberField({ label: game.i18n.localize("DND5E.Scroll.SaveDC") })
+    };
+    context.valuePlaceholders = {};
+    for ( const level of Array.fromRange(this.config.level + 1).reverse() ) {
+      context.valuePlaceholders = CONFIG.DND5E.spellScrollValues[level];
+      if ( context.valuePlaceholders ) break;
+    }
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle submission of the dialog using the form buttons.
+   * @this {CreateScrollDialog}
+   * @param {Event|SubmitEvent} event    The form submission event.
+   * @param {HTMLFormElement} form       The submitted form.
+   * @param {FormDataExtended} formData  Data from the dialog.
+   */
+  static async #handleFormSubmission(event, form, formData) {
+    foundry.utils.mergeObject(this.#config, formData.object);
+    this.#config.level = Number(this.#config.level);
+    await this.close({ dnd5e: { submitted: true } });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onChangeForm(formConfig, event) {
+    super._onChangeForm(formConfig, event);
+    const formData = new FormDataExtended(this.form);
+    foundry.utils.mergeObject(this.#config, formData.object);
+    this.#config.level = Number(this.#config.level);
+    this.render({ parts: ["content"] });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onClose(options={}) {
+    if ( !options.dnd5e?.submitted ) this.#config = null;
+  }
+
+  /* -------------------------------------------- */
+  /*  Factory Methods                             */
+  /* -------------------------------------------- */
+
+  /**
+   * Display the create spell scroll dialog.
+   * @param {Item5e|object} spell              The spell or item data to be made into a scroll.
+   * @param {SpellScrollConfiguration} config  Configuration options for scroll creation.
+   * @param {object} [options={}]              Additional options for the application.
+   * @returns {Promise<object|null>}           Form data object with results of the dialog.
+   */
+  static async create(spell, config, options={}) {
+    return new Promise(resolve => {
+      const dialog = new this({ spell, config, ...options });
+      dialog.addEventListener("close", event => resolve(dialog.config), { once: true });
+      dialog.render({ force: true });
+    });
+  }
+}

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -1,5 +1,4 @@
 import TraitAdvancement from "../../documents/advancement/trait.mjs";
-import { simplifyBonus } from "../../utils.mjs";
 import { ItemDataModel } from "../abstract.mjs";
 import AdvancementField from "../fields/advancement-field.mjs";
 import IdentifierField from "../fields/identifier-field.mjs";
@@ -87,10 +86,7 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
   /** @inheritDoc */
   prepareFinalData() {
     this.isOriginalClass = this.parent.isOriginalClass;
-    this.spellcasting.preparation.max = simplifyBonus(
-      this.spellcasting.preparation.formula,
-      this.parent.getRollData({ deterministic: true})
-    );
+    SpellcastingField.prepareData.call(this, this.parent.getRollData({ deterministic: true }));
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/fields/spellcasting-field.mjs
+++ b/module/data/item/fields/spellcasting-field.mjs
@@ -45,9 +45,9 @@ export default class SpellcastingField extends SchemaField {
     // Temp method for determining spellcasting type until this data is available directly using advancement
     if ( CONFIG.DND5E.spellcastingTypes[this.spellcasting.progression] ) {
       this.spellcasting.type = this.spellcasting.progression;
-    } else this.spellcasting.type = Object.entries(CONFIG.DND5E.spellcastingTypes).find(([type, data]) => {
-      return !!data.progression?.[this.spellcasting.progression];
-    })?.[0];
+    } else this.spellcasting.type = Object.entries(CONFIG.DND5E.spellcastingTypes).find(([, { progression }]) =>
+      progression?.[this.spellcasting.progression]
+    )?.[0];
 
     const actor = this.parent.actor;
     if ( !actor ) return;

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -1,4 +1,3 @@
-import { simplifyBonus } from "../../utils.mjs";
 import { ItemDataModel } from "../abstract.mjs";
 import AdvancementField from "../fields/advancement-field.mjs";
 import IdentifierField from "../fields/identifier-field.mjs";
@@ -68,11 +67,7 @@ export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTem
 
   /** @inheritDoc */
   prepareFinalData() {
-    this.spellcasting.preparation.value ??= 0;
-    this.spellcasting.preparation.max = simplifyBonus(
-      this.spellcasting.preparation.formula,
-      this.parent.getRollData({ deterministic: true})
-    );
+    SpellcastingField.prepareData.call(this, this.parent.getRollData({ deterministic: true }));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -460,27 +460,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const finalSC = foundry.utils.deepClone(
       ( subclassSC && (subclassSC.progression !== "none") ) ? subclassSC : classSC
     );
-    if ( !finalSC ) return null;
-    finalSC.levels = this.isEmbedded ? (this.system.levels ?? this.class?.system.levels) : null;
-
-    // Temp method for determining spellcasting type until this data is available directly using advancement
-    if ( CONFIG.DND5E.spellcastingTypes[finalSC.progression] ) finalSC.type = finalSC.progression;
-    else finalSC.type = Object.entries(CONFIG.DND5E.spellcastingTypes).find(([type, data]) => {
-      return !!data.progression?.[finalSC.progression];
-    })?.[0];
-
-    if ( this.isOwned ) {
-      const ability = this.actor.system.abilities?.[finalSC.ability];
-      const mod = ability?.mod ?? 0;
-      const modProf = mod + (this.actor.system.attributes?.prof ?? 0);
-      const rollData = this.getRollData({ determinstic: true });
-      const msak = simplifyBonus(this.actor.system.bonuses?.msak?.attack, rollData);
-      const rsak = simplifyBonus(this.actor.system.bonuses?.rsak?.attack, rollData);
-      finalSC.attack = modProf + (msak === rsak ? msak : 0);
-      finalSC.save = ability?.dc ?? (8 + modProf);
-    }
-
-    return finalSC;
+    return finalSC ?? null;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,5 +1,6 @@
 import AdvancementManager from "../applications/advancement/advancement-manager.mjs";
 import AdvancementConfirmationDialog from "../applications/advancement/advancement-confirmation-dialog.mjs";
+import CreateScrollDialog from "../applications/item/create-scroll-dialog.mjs";
 import ClassData from "../data/item/class.mjs";
 import ContainerData from "../data/item/container.mjs";
 import EquipmentData from "../data/item/equipment.mjs";
@@ -7,7 +8,7 @@ import SpellData from "../data/item/spell.mjs";
 import ActivitiesTemplate from "../data/item/templates/activities.mjs";
 import PhysicalItemTemplate from "../data/item/templates/physical-item.mjs";
 import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
-import { getSceneTargets } from "../utils.mjs";
+import { getSceneTargets, simplifyBonus } from "../utils.mjs";
 import Scaling from "./scaling.mjs";
 import Proficiency from "./actor/proficiency.mjs";
 import SelectChoices from "./actor/select-choices.mjs";
@@ -467,6 +468,17 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     else finalSC.type = Object.entries(CONFIG.DND5E.spellcastingTypes).find(([type, data]) => {
       return !!data.progression?.[finalSC.progression];
     })?.[0];
+
+    if ( this.isOwned ) {
+      const ability = this.actor.system.abilities?.[finalSC.ability];
+      const mod = ability?.mod ?? 0;
+      const modProf = mod + (this.actor.system.attributes?.prof ?? 0);
+      const rollData = this.getRollData({ determinstic: true });
+      const msak = simplifyBonus(this.actor.system.bonuses?.msak?.attack, rollData);
+      const rsak = simplifyBonus(this.actor.system.bonuses?.rsak?.attack, rollData);
+      finalSC.attack = modProf + (msak === rsak ? msak : 0);
+      finalSC.save = ability?.dc ?? (8 + modProf);
+    }
 
     return finalSC;
   }
@@ -1857,27 +1869,27 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @returns {Promise<Item5e|void>}                The created scroll consumable item.
    */
   static async createScrollFromSpell(spell, options={}, config={}) {
+    const values = {};
+    if ( (spell instanceof Item5e) && spell.isOwned && (game.settings.get("dnd5e", "rulesVersion") === "modern") ) {
+      const spellcastingClass = spell.actor.spellcastingClasses?.[spell.system.sourceClass];
+      if ( spellcastingClass ) {
+        values.bonus = spellcastingClass.spellcasting.attack;
+        values.dc = spellcastingClass.spellcasting.save;
+      } else {
+        values.bonus = spell.actor.system.attributes?.spellmod;
+        values.dc = spell.actor.system.attributes?.spelldc;
+      }
+    }
+
     config = foundry.utils.mergeObject({
       explanation: game.user.getFlag("dnd5e", "creation.scrollExplanation") ?? "reference",
-      level: spell.system.level
+      level: spell.system.level,
+      values
     }, config);
 
     if ( config.dialog !== false ) {
-      const anchor = spell instanceof Item5e ? spell.toAnchor().outerHTML : `<span>${spell.name}</span>`;
-      const result = await Dialog.prompt({
-        title: game.i18n.format("DND5E.Scroll.CreateFrom", { spell: spell.name }),
-        label: game.i18n.localize("DND5E.Scroll.CreateScroll"),
-        content: await renderTemplate("systems/dnd5e/templates/apps/spell-scroll-dialog.hbs", {
-          ...config, anchor, spellLevels: Object.entries(CONFIG.DND5E.spellLevels).reduce((obj, [k, v]) => {
-            if ( Number(k) >= spell.system.level ) obj[k] = v;
-            return obj;
-          }, {})
-        }),
-        callback: dialog => (new FormDataExtended(dialog.querySelector("form"))).object,
-        rejectClose: false,
-        options: { jQuery: false }
-      });
-      if ( result === null ) return;
+      const result = await CreateScrollDialog.create(spell, config);
+      if ( !result ) return;
       foundry.utils.mergeObject(config, result);
       await game.user.setFlag("dnd5e", "creation.scrollExplanation", config.explanation);
     }
@@ -1957,12 +1969,14 @@ export default class Item5e extends SystemDocumentMixin(Item) {
         break;
     }
 
-    let values = {};
     for ( const level of Array.fromRange(itemData.system.level + 1).reverse() ) {
-      values = CONFIG.DND5E.spellScrollValues[level];
-      if ( values ) break;
+      const values = CONFIG.DND5E.spellScrollValues[level];
+      if ( values ) {
+        config.values.bonus ??= values.bonus;
+        config.values.dc ??= values.dc;
+        break;
+      }
     }
-    values = foundry.utils.mergeObject(values, config.values ?? {}, { inplace: false });
 
     // Apply inferred spell activation, duration, range, and target data to activities
     for ( const activity of Object.values(activities) ) {

--- a/templates/apps/spell-scroll-dialog.hbs
+++ b/templates/apps/spell-scroll-dialog.hbs
@@ -1,29 +1,21 @@
-<form>
+<fieldset>
+    <legend>{{ localize "DND5E.Scroll.Details" }}</legend>
     <div class="form-group">
         <label>{{ localize "TYPES.Item.spell" }}</label>
         <div class="form-fields">
             {{{ anchor }}}
         </div>
     </div>
+    {{#each fields}}
+        {{ formField field name=name value=value options=options input=input }}
+    {{/each}}
     <div class="form-group">
-        <label>{{ localize "DND5E.Scroll.Explanation.Label" }}</label>
+        <label>{{ localize "DND5E.Scroll.Values" }}</label>
         <div class="form-fields">
-            <select name="explanation">
-                {{#select explanation}}
-                <option value="full">{{ localize "DND5E.Scroll.Explanation.Complete" }}</option>
-                <option value="reference">{{ localize "DND5E.Scroll.Explanation.Reference" }}</option>
-                <option value="none">{{ localize "DND5E.None" }}</option>
-                {{/select}}
-            </select>
-        </div>
-        <p class="hint">{{ localize "DND5E.Scroll.Explanation.Hint" }}</p>
-    </div>
-    <div class="form-group">
-        <label>{{ localize "DND5E.SpellLevel" }}</label>
-        <div class="form-fields">
-            <select name="level" data-dtype="Number">
-                {{ selectOptions spellLevels selected=level name="level" }}
-            </select>
+            {{ formField values.dc name="values.dc" value=config.values.dc placeholder=valuePlaceholders.dc
+                         classes="label-top" }}
+            {{ formField values.bonus name="values.bonus" value=config.values.bonus placeholder=valuePlaceholders.bonus
+                         classes="label-top" }}
         </div>
     </div>
-</form>
+</fieldset>


### PR DESCRIPTION
Reworks the Create Scroll using ApplicationV2 in a way that allows for dynamic updates of the form. It now displays fields for spell save DC and attack bonus with placeholders updating dynamically when the spell level is changed.

These fields can also be set manually, overriding the default DC of spells. If using the modern rules version and create a scroll directly from a spell in an actor's inventory, then these values will be initial set based on that actor's spellcasting stats.

Closes #4043