### PR TITLE
[#3786] Add system for consolidated spell lists

### DIFF
--- a/system.json
+++ b/system.json
@@ -340,6 +340,18 @@
   "primaryTokenAttribute": "attributes.hp",
   "background": "systems/dnd5e/ui/official/dnd5e-background.webp",
   "flags": {
+    "dnd5e": {
+      "spellLists": [
+        "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.ziBzRlrpBm1KVV0j",
+        "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.cuG9d7J9fQH9InYT",
+        "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.MWiN7ILEO0Vd3zAZ",
+        "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.FhucONA0yRZQjMmb",
+        "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.sANq9JMycfSq3A5d",
+        "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.PVgly1xB2S2I8GLQ",
+        "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.mx4TsSbBIAaAkhQ7",
+        "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.k7Rs5EyXeA0SFTXD"
+      ]
+    },
     "needsMigrationVersion": "4.0.0",
     "compatibleMigrationVersion": "0.8",
     "hotReload": {


### PR DESCRIPTION
Adds a new registry entry for tracking spell lists. This contains `SpellList` objects grouped by type and identifier, with all spell list journal entry pages contributing spells to the shared list. Each `SpellList` object contains the means to access the UUIDs, indexes, and fully-loaded spell documents for all listed spells.

A new module data registration method has been added to allow for modules to declare spell lists in their package manifets using the `dnd5e.spellLists` flag.

Closes #3786

### Todo
- [ ] Add filters to `CompendiumBrowser` based on these spell lists