### PR TITLE
[#3836, #3853] Add Has Spellcasting & Class filters to subclasses

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -415,6 +415,9 @@ Hooks.once("ready", function() {
     }
   });
 
+  // Register items by type
+  dnd5e.registry.classes.initialize();
+
   // Chat message listeners
   documents.ChatMessage5e.activateListeners();
 

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -30,6 +30,32 @@ export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTem
   }
 
   /* -------------------------------------------- */
+
+  /** @override */
+  static get compendiumBrowserFilters() {
+    return new Map([
+      ["class", {
+        label: "TYPES.Item.class",
+        type: "set",
+        config: {
+          choices: dnd5e.registry.classes.choices,
+          keyPath: "system.classIdentifier"
+        }
+      }],
+      ["hasSpellcasting", {
+        label: "DND5E.CompendiumBrowser.Filters.HasSpellcasting",
+        type: "boolean",
+        createFilter: (filters, value, def) => {
+          if ( value === 0 ) return;
+          const filter = { k: "system.spellcasting.progression", v: "none" };
+          if ( value === -1 ) filters.push(filter);
+          else filters.push({ o: "NOT", v: filter });
+        }
+      }]
+    ]);
+  }
+
+  /* -------------------------------------------- */
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -103,7 +103,17 @@ class ItemRegistry {
    * Has initial loading been completed?
    * @type {number}
    */
-  #status = 0;
+  #status = ItemRegistry.#STATUS_STATES.NONE;
+
+  /**
+   * Possible preparation states for the item registry.
+   * @enum {number}
+   */
+  static #STATUS_STATES = Object.freeze({
+    NONE: 0,
+    LOADING: 1,
+    READY: 2
+  });
 
   /* -------------------------------------------- */
 
@@ -149,12 +159,12 @@ class ItemRegistry {
    * Scan compendium packs to register matching items of this type.
    */
   async initialize() {
-    if ( this.#status > 0 ) return;
+    if ( this.#status > ItemRegistry.#STATUS_STATES.NONE ) return;
     if ( !game.ready ) {
       Hooks.once("ready", () => this.initialize());
       return;
     }
-    this.#status = 1;
+    this.#status = ItemRegistry.#STATUS_STATES.LOADING;
 
     const indexes = await CompendiumBrowser.fetch(Item, {
       types: new Set([this.#itemType]),
@@ -171,7 +181,7 @@ class ItemRegistry {
       itemData.sources.push(item.uuid);
     }
 
-    this.#status = 2;
+    this.#status = ItemRegistry.#STATUS_STATES.READY;
   }
 }
 

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -1,3 +1,4 @@
+import CompendiumBrowser from "./applications/compendium-browser.mjs";
 import EnchantActivity from "./documents/activity/enchant.mjs";
 
 /* -------------------------------------------- */
@@ -58,6 +59,119 @@ class EnchantmentRegisty {
    */
   static untrack(source, enchanted) {
     EnchantmentRegisty.#appliedEnchantments.get(source)?.delete(enchanted);
+  }
+}
+
+/* -------------------------------------------- */
+/*  Item Registry                               */
+/* -------------------------------------------- */
+
+class ItemRegistry {
+  constructor(itemsType) {
+    this.#itemType = itemsType;
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * @typedef {object} RegisteredItemData
+   * @property {string} name        Name of the item.
+   * @property {string} identifier  Item identifier.
+   * @property {string} img         Item's icon.
+   * @property {string[]} sources   UUIDs of different compendium items matching this identifier.
+   */
+
+  /**
+   * Items grouped by identifiers.
+   * @type {Map<string, RegisteredItemData>}
+   */
+  #items = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Type of item represented by this registry.
+   * @type {string}
+   */
+  #itemType;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Has initial loading been completed?
+   * @type {number}
+   */
+  #status = 0;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Choices object.
+   * @type {Record<string, string>}
+   */
+  get choices() {
+    return this.options.reduce((obj, { value, label }) => {
+      obj[value] = label;
+      return obj;
+    }, {});
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * All items formatted for a select input.
+   * @type {FormSelectOption[]}
+   */
+  get options() {
+    return Array.from(this.#items.entries())
+      .map(([value, data]) => ({ value, label: data.name }))
+      .sort((lhs, rhs) => lhs.label.localeCompare(rhs.label));
+  }
+
+  /* -------------------------------------------- */
+  /*  Methods                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Get information on a single item based on its identifier.
+   * @param {string} identifier
+   * @returns {RegisteredItemData|void}
+   */
+  get(identifier) {
+    return this.#items.get(identifier);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Scan compendium packs to register matching items of this type.
+   */
+  async initialize() {
+    if ( this.#status > 0 ) return;
+    if ( !game.ready ) {
+      Hooks.once("ready", () => this.initialize());
+      return;
+    }
+    this.#status = 1;
+
+    const indexes = await CompendiumBrowser.fetch(Item, {
+      types: new Set([this.#itemType]),
+      indexFields: new Set(["system.identifier"]),
+      sort: false
+    });
+    for ( const item of indexes ) {
+      const identifier = item.system?.identifier ?? slugify(item.name, { strict: true });
+      if ( !this.#items.has(identifier) ) this.#items.set(identifier, { sources: [] });
+      const itemData = this.#items.get(identifier);
+      itemData.name = item.name;
+      itemData.img = item.img;
+      itemData.identifier = identifier;
+      itemData.sources.push(item.uuid);
+    }
+
+    this.#status = 2;
   }
 }
 
@@ -174,6 +288,7 @@ class SummonRegistry {
 
 
 export default {
+  classes: new ItemRegistry("class"),
   enchantments: EnchantmentRegisty,
   messages: MessageRegistry,
   summons: SummonRegistry


### PR DESCRIPTION
Adds a "Has Spellcasting" filter to subclasses in the compendium browser indicating the subclass provides spellcasting. Also adds the ability to filter by the class to which the subclass belongs.

<img width="915" alt="Subclass Filters" src="https://github.com/user-attachments/assets/0b0ee644-7375-4bb5-9f80-68c048d19e60">

To support the second filter, this introduces the `ItemRegistry` to the system registry that scans compendiums and loads all classes registered in different compendium packs. These are grouped by identifier and different versions of a class in different packs are consolidated with their UUIDs listed in the `sources` list. This only supports classes at the moment but could easily be expanded to incude subclasses, backgrounds, or species, which maybe useful to work on spell lists.

Closes #3836
Closes #3853