### PR TITLE
[#1012, #1229] Display classes providing spells on spell sheet

### DIFF
--- a/less/v2/items.less
+++ b/less/v2/items.less
@@ -139,6 +139,13 @@
         }
 
         &:first-child::before { content: ""; }
+
+        &.full-width {
+          flex: 1 0 100%;
+          font-size: var(--font-size-12);
+          text-align: center;
+          &::before { display: none; }
+        }
       }
 
       /* Rarity */

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -186,6 +186,16 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
       return obj;
     }, { all: [], vsm: [], tags: [] });
     labels.components.vsm = game.i18n.getListFormatter({ style: "narrow" }).format(labels.components.vsm);
+
+    dnd5e.registry.whenReady(() => {
+      labels.classes = game.i18n.getListFormatter({ style: "narrow" }).format(
+        Array.from(dnd5e.registry.spellLists
+          .forSpell(this.parent._stats.compendiumSource ?? this.parent.uuid))
+          .filter(list => list.metadata.type === "class")
+          .map(list => list.name)
+          .sort((lhs, rhs) => lhs.localeCompare(rhs))
+      );
+    });
   }
 
   /* -------------------------------------------- */
@@ -240,7 +250,8 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     context.subtitles = [
       { label: context.labels.level },
       { label: context.labels.school },
-      { label: context.itemStatus }
+      { label: context.itemStatus },
+      { label: context.labels.classes, classes: "full-width" }
     ];
     context.properties.active = this.parent.labels?.components?.tags;
     context.parts = ["dnd5e.details-spell", "dnd5e.field-uses"];

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -187,14 +187,17 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     }, { all: [], vsm: [], tags: [] });
     labels.components.vsm = game.i18n.getListFormatter({ style: "narrow" }).format(labels.components.vsm);
 
-    dnd5e.registry.whenReady(() => {
-      labels.classes = game.i18n.getListFormatter({ style: "narrow" }).format(
-        Array.from(dnd5e.registry.spellLists
-          .forSpell(this.parent._stats.compendiumSource ?? this.parent.uuid))
-          .filter(list => list.metadata.type === "class")
-          .map(list => list.name)
-          .sort((lhs, rhs) => lhs.localeCompare(rhs))
-      );
+    const uuid = this.parent._stats.compendiumSource ?? this.parent.uuid;
+    Object.defineProperty(labels, "classes", {
+      get() {
+        return game.i18n.getListFormatter({ style: "narrow" }).format(
+          Array.from(dnd5e.registry.spellLists.forSpell(uuid))
+            .filter(list => list.metadata.type === "class")
+            .map(list => list.name)
+            .sort((lhs, rhs) => lhs.localeCompare(rhs))
+        );
+      },
+      configurable: true
     });
   }
 

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -160,6 +160,7 @@ class ItemRegistry {
    */
   async initialize() {
     if ( this.#status > ItemRegistry.#STATUS_STATES.NONE ) return;
+    RegistryStatus.set(this.#itemType, false);
     if ( !game.ready ) {
       Hooks.once("ready", () => this.initialize());
       return;
@@ -182,6 +183,7 @@ class ItemRegistry {
     }
 
     this.#status = ItemRegistry.#STATUS_STATES.READY;
+    RegistryStatus.set(this.#itemType, true);
   }
 }
 
@@ -252,10 +254,49 @@ class MessageRegistry {
 
 class SpellListRegistry {
   /**
+   * Spell lists organized by the UUID of a spell they contain.
+   * @type {Map<string, Set<SpellList>>}
+   */
+  static #bySpell = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
    * Registration of spell lists grouped by type and identifier.
    * @type {Map<string, SpellList>}
    */
-  static #lists = new Map();
+  static #byType = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * UUIDs of spell lists in the process of being loaded.
+   * @type {Set<string>}
+   */
+  static #loading = new Set();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Have spell lists finished loading?
+   * @type {boolean}
+   */
+  static get ready() {
+    return this.#loading.size === 0;
+  }
+
+  /* -------------------------------------------- */
+  /*  Methods                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieve a list of spell lists a spell belongs to.
+   * @param {string} uuid  UUID of a spell item.
+   * @returns {Set<SpellList>}
+   */
+  static forSpell(uuid) {
+    return this.#bySpell.get(uuid) ?? new Set();
+  }
 
   /* -------------------------------------------- */
 
@@ -265,8 +306,8 @@ class SpellListRegistry {
    * @param {string} identifier  Identifier of the specific spell list.
    * @returns {SpellList|null}
    */
-  static list(type, identifier) {
-    return this.#lists.get(`${type}.${identifier}`) ?? null;
+  static forType(type, identifier) {
+    return this.#byType.get(`${type}.${identifier}`) ?? null;
   }
 
   /* -------------------------------------------- */
@@ -276,6 +317,8 @@ class SpellListRegistry {
    * @param {string} uuid  UUID of a spell list journal entry page.
    */
   static async register(uuid) {
+    RegistryStatus.set("spellLists", false);
+    this.#loading.add(uuid);
     if ( !game.ready ) {
       Hooks.once("ready", () => this.register(uuid));
       return;
@@ -286,8 +329,18 @@ class SpellListRegistry {
     if ( page.type !== "spells" ) throw new Error(`Journal entry page "${uuid}" is not a Spell List.`);
 
     const id = `${page.system.type}.${page.system.identifier}`;
-    if ( !SpellListRegistry.#lists.has(id) ) SpellListRegistry.#lists.set(id, new SpellList());
-    SpellListRegistry.#lists.get(id).contribute(page);
+    if ( !SpellListRegistry.#byType.has(id) ) SpellListRegistry.#byType.set(id, new SpellList({
+      identifier: page.system.identifier, name: page.name, type: page.system.type
+    }));
+
+    const list = SpellListRegistry.#byType.get(id);
+    list.contribute(page).forEach(uuid => {
+      if ( !SpellListRegistry.#bySpell.has(uuid) ) SpellListRegistry.#bySpell.set(uuid, new Set());
+      SpellListRegistry.#bySpell.get(uuid).add(list);
+    });
+
+    this.#loading.delete(uuid);
+    if ( this.ready ) RegistryStatus.set("spellLists", true);
   }
 }
 
@@ -295,6 +348,20 @@ class SpellListRegistry {
  * Type that represents a unified spell list for a specific class, subclass, species, or something else.
  */
 export class SpellList {
+  constructor(metadata) {
+    this.#metadata = Object.freeze(metadata);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Mapping of spell list types to item registries.
+   * @enum {string}
+   */
+  static #REGISTRIES = {
+    class: "classes"
+  };
+
   /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
@@ -307,6 +374,29 @@ export class SpellList {
     return Array.from(this.#spells.keys())
       .map(s => fromUuidSync(s))
       .sort((lhs, rhs) => lhs.name.localeCompare(rhs.name));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Information on the spell list.
+   * @type {{ identifier: string, type: string }}
+   */
+  #metadata;
+
+  get metadata() {
+    return this.#metadata;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Display name for the spell list.
+   * @type {string}
+   */
+  get name() {
+    return dnd5e.registry[SpellList.#REGISTRIES[this.metadata.type]]?.get(this.metadata.identifier)?.name
+      ?? this.metadata.name;
   }
 
   /* -------------------------------------------- */
@@ -347,17 +437,26 @@ export class SpellList {
   /**
    * Add a spell list page to this unified spell list.
    * @param {JournalEntryPage} page  Spells page to contribute.
+   * @returns {Set<string>}          Newly added UUIDs.
    */
   contribute(page) {
-    page.system.spells.forEach(s => this.#spells.set(s, { page: page.uuid }));
+    const added = new Set();
+
+    page.system.spells.forEach(s => {
+      if ( !this.#spells.has(s) ) added.add(s);
+      this.#spells.set(s, { page: page.uuid });
+    });
 
     for ( const unlinked of page.system.unlinkedSpells ) {
       if ( fromUuidSync(unlinked.source?.uuid) ) {
+        if ( !this.#spells.has(unlinked.source.uuid) ) added.add(unlinked.source.uuid);
         this.#spells.set(unlinked.source.uuid, { page: page.uuid });
       } else {
         this.#unlinked.push(foundry.utils.mergeObject({ page: page.uuid }, unlinked));
       }
     }
+
+    return added;
   }
 
   /* -------------------------------------------- */
@@ -421,11 +520,64 @@ class SummonRegistry {
   }
 }
 
+/* -------------------------------------------- */
+/*  Public API                                  */
+/* -------------------------------------------- */
+
+/**
+ * Track the ready status of various registries.
+ * @type {Map<string, boolean>}
+ */
+const RegistryStatus = new class extends Map {
+  /**
+   * Callbacks to call when spell lists are ready.
+   * @type {Function[]}
+   */
+  callbacks = [];
+
+  /* -------------------------------------------- */
+
+  /**
+   * Are all registries ready?
+   * @returns {boolean}
+   */
+  get isReady() {
+    return Array.from(this.values()).every(s => s);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  set(key, value) {
+    super.set(key, value);
+    if ( this.isReady ) {
+      let callback = this.callbacks.shift();
+      while ( callback ) {
+        callback();
+        callback = this.callbacks.shift();
+      }
+    }
+  }
+}();
+
+/* -------------------------------------------- */
+
+/**
+ * Execute a callback when all registries have finished loading.
+ * @param {Function} callback
+ */
+function whenReady(callback) {
+  if ( RegistryStatus.isReady ) callback();
+  RegistryStatus.callbacks.push(callback);
+}
+
+/* -------------------------------------------- */
 
 export default {
   classes: new ItemRegistry("class"),
   enchantments: EnchantmentRegisty,
   messages: MessageRegistry,
   spellLists: SpellListRegistry,
-  summons: SummonRegistry
+  summons: SummonRegistry,
+  whenReady
 };


### PR DESCRIPTION
Modifies the `SpellListRegistry` to keep track of what spell lists provide a spell in addition to spell lists by type. This allows spells to retrieve a list of spell lists they appear on and turn it into a list of classes to be displayed on the spell sheet.

<img width="510" alt="Class Lists" src="https://github.com/user-attachments/assets/c48add8d-d55a-4328-b07f-67eca902185b">

Part of this work involves fetching the name of the class from the item registry rather than using the name of the spell list itself. In order to get around the loading time involved a new API has been added to the registry that allows defering a callback until all registries have fully loaded.

Closes #1229