### PR TITLE
[#1964] Remember attack mode, ammunition, & damage types

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -271,13 +271,15 @@ export default class AttackActivityData extends BaseActivityData {
         // If mode is "replace" and base part is present, replace the base part
         if ( ammo.damage.replace & (basePartIndex !== -1) ) {
           damage.base = true;
-          rollConfig.rolls.splice(basePartIndex, 1, this._processDamagePart(damage, config, rollData));
+          rollConfig.rolls.splice(basePartIndex, 1, this._processDamagePart(damage, config, rollData, basePartIndex));
         }
 
         // Otherwise stick the ammo damage after base part (or as first part)
         else {
           damage.ammo = true;
-          rollConfig.rolls.splice(basePartIndex + 1, 0, this._processDamagePart(damage, rollConfig, rollData));
+          rollConfig.rolls.splice(
+            basePartIndex + 1, 0, this._processDamagePart(damage, rollConfig, rollData, basePartIndex + 1)
+          );
         }
       }
     }
@@ -293,8 +295,8 @@ export default class AttackActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _processDamagePart(damage, rollConfig, rollData) {
-    if ( !damage.base ) return super._processDamagePart(damage, rollConfig, rollData);
+  _processDamagePart(damage, rollConfig, rollData, index=0) {
+    if ( !damage.base ) return super._processDamagePart(damage, rollConfig, rollData, index);
 
     // Swap base damage for versatile if two-handed attack is made on versatile weapon
     if ( this.item.system.isVersatile && (rollConfig.attackMode === "twoHanded") ) {
@@ -306,7 +308,7 @@ export default class AttackActivityData extends BaseActivityData {
       damage = versatile;
     }
 
-    const roll = super._processDamagePart(damage, rollConfig, rollData);
+    const roll = super._processDamagePart(damage, rollConfig, rollData, index);
     roll.base = true;
 
     if ( this.item.type === "weapon" ) {

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -575,7 +575,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     const rollConfig = foundry.utils.mergeObject({ scaling: 0 }, config);
     const rollData = this.getRollData();
     rollConfig.rolls = this.damage.parts
-      .map(d => this._processDamagePart(d, rollConfig, rollData))
+      .map((d, index) => this._processDamagePart(d, rollConfig, rollData, index))
       .filter(d => d.parts.length)
       .concat(config.rolls ?? []);
 
@@ -589,10 +589,11 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * @param {DamageData} damage                                   Damage to prepare for the roll.
    * @param {Partial<DamageRollProcessConfiguration>} rollConfig  Roll configuration being built.
    * @param {object} rollData                                     Roll data to populate with damage data.
+   * @param {number} [index=0]                                    Index of the damage part.
    * @returns {DamageRollConfiguration}
    * @protected
    */
-  _processDamagePart(damage, rollConfig, rollData) {
+  _processDamagePart(damage, rollConfig, rollData, index=0) {
     const scaledFormula = damage.scaledFormula(rollData.scaling);
     const parts = scaledFormula ? [scaledFormula] : [];
     const data = { ...rollData };
@@ -606,6 +607,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     return {
       data, parts,
       options: {
+        type: this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`) ?? damage.types.first(),
         types: Array.from(damage.types),
         properties: Array.from(this.item.system.properties ?? [])
           .filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical)

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -323,9 +323,10 @@ export default class DamageRoll extends Roll {
       formulas: rolls.map((roll, index) => ({
         formula: `${roll.formula}${index === 0 ? " + @bonus" : ""}`,
         type: roll.options.types?.length > 1 ? null
-          : damageTypeLabel(roll.options.types?.[0] ?? roll.options.type) ?? null,
-        types: roll.options.types?.length > 1
-          ? roll.options.types?.map(value => ({ value, label: damageTypeLabel(value) })) : null
+          : damageTypeLabel(roll.options.type ?? roll.options.types?.[0]) ?? null,
+        types: roll.options.types?.length > 1 ? roll.options.types?.map(value =>
+          ({ value, label: damageTypeLabel(value), selected: value === roll.options.type })
+        ) : null
       })),
       defaultRollMode,
       rollModes: CONFIG.Dice.rollModes

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -831,6 +831,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       actor: this.actor,
       rollConfigs: rollConfig.rolls.map(r => ({
         parts: r.parts,
+        type: r.options?.type,
         types: r.options?.types,
         properties: r.options?.properties
       })),
@@ -866,6 +867,13 @@ export default Base => class extends PseudoDocumentMixin(Base) {
 
     const rolls = await damageRoll(oldRollConfig);
     if ( !rolls?.length ) return;
+    const lastDamageTypes = rolls.reduce((obj, roll, index) => {
+      if ( roll.options.type ) obj[index] = roll.options.type;
+      return obj;
+    }, {});
+    if ( !foundry.utils.isEmpty(lastDamageTypes) ) {
+      await this.item.setFlag("dnd5e", `last.${this.id}.damageType`, lastDamageTypes);
+    }
 
     /**
      * A hook event that fires after damage has been rolled.


### PR DESCRIPTION
Stores previously selected attack mode, ammunition, and damage types in a flag on the item on a per-activity basis and uses those stored values to pre-populate fields in the attack and damage dialogs.