### PR TITLE
[#1964] Automatically create activities on new Weapons & Tools

### DIFF
--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -67,9 +67,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     return {
       _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
       type: new StringField({
-        blank: false,
-        required: true,
-        readOnly: true
+        blank: false, required: true, readOnly: true, initial: () => this.metadata.type
       }),
       name: new StringField({ initial: undefined }),
       img: new FilePathField({ initial: undefined, categories: ["IMAGE"] }),

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -192,7 +192,7 @@ export default class ToolData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   _preCreate(data, options, user) {
-    super._preCreate(data, options, user);
+    if ( super._preCreate(data, options, user) === false ) return false;
     const activityData = new CONFIG.DND5E.activityTypes.check.documentClass({}, { parent: this.parent }).toObject();
     this.parent.updateSource({ [`system.activities.${activityData._id}`]: activityData });
   }

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -185,4 +185,15 @@ export default class ToolData extends ItemDataModel.mixin(
     const categoryProf = actor.system.tools?.[this.type.value];
     return Math.max(baseItemProf?.value ?? 0, categoryProf?.value ?? 0);
   }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _preCreate(data, options, user) {
+    super._preCreate(data, options, user);
+    const activityData = new CONFIG.DND5E.activityTypes.check.documentClass({}, { parent: this.parent }).toObject();
+    this.parent.updateSource({ [`system.activities.${activityData._id}`]: activityData });
+  }
 }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -457,4 +457,15 @@ export default class WeaponData extends ItemDataModel.mixin(
     const isProficient = natural || improvised || actorProfs.has(itemProf) || actorProfs.has(this.type.baseItem);
     return Number(isProficient);
   }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _preCreate(data, options, user) {
+    super._preCreate(data, options, user);
+    const activityData = new CONFIG.DND5E.activityTypes.attack.documentClass({}, { parent: this.parent }).toObject();
+    this.parent.updateSource({ [`system.activities.${activityData._id}`]: activityData });
+  }
 }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -464,7 +464,7 @@ export default class WeaponData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   _preCreate(data, options, user) {
-    super._preCreate(data, options, user);
+    if ( super._preCreate(data, options, user) === false ) return false;
     const activityData = new CONFIG.DND5E.activityTypes.attack.documentClass({}, { parent: this.parent }).toObject();
     this.parent.updateSource({ [`system.activities.${activityData._id}`]: activityData });
   }


### PR DESCRIPTION
Automatically creates an `AttackActivity` on newly created weapons and a `CheckActivity` on newly created tools.