### PR TITLE
[#4063] Add cylinder AoE type, split AoE list into sections

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2663,6 +2663,7 @@
 "DND5E.TargetPl": "Targets",
 "DND5E.TargetAlly": "Ally",
 "DND5E.TargetAny": "Any",
+"DND5E.TargetCircle": "Circle",
 "DND5E.TargetCone": "Cone",
 "DND5E.TargetCreature": "Creature",
 "DND5E.TargetCreatureOrObject": "Creature or Object",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2116,6 +2116,7 @@ preLocalize("individualTargetTypes");
  * @property {string[]} [sizes]    List of available sizes for this template. Options are chosen from the list:
  *                                 "radius", "width", "height", "length", "thickness". No more than 3 dimensions may
  *                                 be specified.
+ * @property {boolean} [standard]  Is this a standard area of effect as defined explicitly by the rules?
  */
 
 /**
@@ -2123,45 +2124,56 @@ preLocalize("individualTargetTypes");
  * @enum {AreaTargetDefinition}
  */
 DND5E.areaTargetTypes = {
-  radius: {
-    label: "DND5E.TargetRadius",
+  circle: {
+    label: "DND5E.TargetCircle",
     template: "circle",
     sizes: ["radius"]
-  },
-  sphere: {
-    label: "DND5E.TargetSphere",
-    template: "circle",
-    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.npdEWb2egUPnB5Fa",
-    sizes: ["radius"]
-  },
-  cylinder: {
-    label: "DND5E.TargetCylinder",
-    template: "circle",
-    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.jZFp4R7tXsIqkiG3",
-    sizes: ["radius", "height"]
   },
   cone: {
     label: "DND5E.TargetCone",
     template: "cone",
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.DqqAOr5JnX71OCOw",
-    sizes: ["length"]
-  },
-  square: {
-    label: "DND5E.TargetSquare",
-    template: "rect",
-    sizes: ["width"]
+    sizes: ["length"],
+    standard: true
   },
   cube: {
     label: "DND5E.TargetCube",
     template: "rect",
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.dRfDIwuaHmUQ06uA",
-    sizes: ["width"]
+    sizes: ["width"],
+    standard: true
+  },
+  cylinder: {
+    label: "DND5E.TargetCylinder",
+    template: "circle",
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.jZFp4R7tXsIqkiG3",
+    sizes: ["radius", "height"],
+    standard: true
   },
   line: {
     label: "DND5E.TargetLine",
     template: "ray",
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.6DOoBgg7okm9gBc6",
-    sizes: ["length", "width"]
+    sizes: ["length", "width"],
+    standard: true
+  },
+  radius: {
+    label: "DND5E.TargetRadius",
+    template: "circle",
+    sizes: ["radius"],
+    standard: true
+  },
+  sphere: {
+    label: "DND5E.TargetSphere",
+    template: "circle",
+    reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.npdEWb2egUPnB5Fa",
+    sizes: ["radius"],
+    standard: true
+  },
+  square: {
+    label: "DND5E.TargetSquare",
+    template: "rect",
+    sizes: ["width"]
   },
   wall: {
     label: "DND5E.TargetWall",
@@ -2170,6 +2182,18 @@ DND5E.areaTargetTypes = {
   }
 };
 preLocalize("areaTargetTypes", { key: "label", sort: true });
+
+Object.defineProperty(DND5E, "areaTargetOptions", {
+  get() {
+    const { primary, secondary } = Object.entries(this.areaTargetTypes).reduce((obj, [value, data]) => {
+      const entry = { value, label: data.label };
+      if ( data.standard ) obj.primary.push(entry);
+      else obj.secondary.push(entry);
+      return obj;
+    }, { primary: [], secondary: [] });
+    return [{ value: "", label: "" }, ...primary, { rule: true }, ...secondary];
+  }
+});
 
 /* -------------------------------------------- */
 

--- a/templates/shared/fields/field-targets.hbs
+++ b/templates/shared/fields/field-targets.hbs
@@ -42,7 +42,7 @@
 
     {{!-- Template Type --}}
     {{ formField fields.template.fields.type value=data.template.type label="DND5E.Shape" localize=true hint=false
-                 choices=CONFIG.areaTargetTypes }}
+                 options=CONFIG.areaTargetOptions }}
 
     {{!-- Dimensions --}}
     {{#if data.template.type}}


### PR DESCRIPTION
Modifies how the area of effect types are listed to split them into a list of the six standard types defined in the rules, and the other non-standard types separated by an `<hr>`.

<img width="515" alt="Screenshot 2024-08-28 at 13 29 18" src="https://github.com/user-attachments/assets/79e1500e-a42f-47e6-a74f-b8c70c2dd612">

Also adds a new "Circle" type for spells that need a circle template without associated height.

Closes #4063