### PR TITLE
[#1011] Adjust emanation template size when placing

### DIFF
--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -284,20 +284,7 @@ export default class ActivitySheet extends Application5e {
     }));
 
     // Template dimensions
-    const sizes = CONFIG.DND5E.areaTargetTypes[context.data.target.template.type]?.sizes;
-    if ( sizes ) {
-      context.dimensions = {
-        size: "DND5E.AreaOfEffect.Size.Label",
-        width: sizes.includes("width") && (sizes.includes("length") || sizes.includes("radius")),
-        height: sizes.includes("height")
-      };
-      if ( sizes.includes("radius") ) context.dimensions.size = "DND5E.AreaOfEffect.Size.Radius";
-      else if ( sizes.includes("length") ) context.dimensions.size = "DND5E.AreaOfEffect.Size.Length";
-      else if ( sizes.includes("width") ) context.dimensions.size = "DND5E.AreaOfEffect.Size.Width";
-      if ( sizes.includes("thickness") ) context.dimensions.width = "DND5E.AreaOfEffect.Size.Thickness";
-      else if ( context.dimensions.width ) context.dimensions.width = "DND5E.AreaOfEffect.Size.Width";
-      if ( context.dimensions.height ) context.dimensions.height = "DND5E.AreaOfEffect.Size.Height";
-    }
+    context.dimensions = context.activity.target.template.dimensions;
 
     return context;
   }

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -104,20 +104,7 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
     ];
 
     // Templates
-    const { sizes } = CONFIG.DND5E.areaTargetTypes[target?.template?.type] ?? {};
-    if ( sizes ) {
-      context.dimensions = {
-        size: "DND5E.AreaOfEffect.Size.Label",
-        width: sizes.includes("width") && (sizes.includes("length") || sizes.includes("radius")),
-        height: sizes.includes("height")
-      };
-      if ( sizes.includes("radius") ) context.dimensions.size = "DND5E.AreaOfEffect.Size.Radius";
-      else if ( sizes.includes("length") ) context.dimensions.size = "DND5E.AreaOfEffect.Size.Length";
-      else if ( sizes.includes("width") ) context.dimensions.size = "DND5E.AreaOfEffect.Size.Width";
-      if ( sizes.includes("thickness") ) context.dimensions.width = "DND5E.AreaOfEffect.Size.Thickness";
-      else if ( context.dimensions.width ) context.dimensions.width = "DND5E.AreaOfEffect.Size.Width";
-      if ( context.dimensions.height ) context.dimensions.height = "DND5E.AreaOfEffect.Size.Height";
-    }
+    context.dimensions = target?.template?.dimensions;
 
     // Equipment
     context.equipmentTypes = [

--- a/module/canvas/ability-template.mjs
+++ b/module/canvas/ability-template.mjs
@@ -242,13 +242,13 @@ export default class AbilityTemplate extends MeasuredTemplate {
     const baseDistance = this.document.flags.dnd5e?.dimensions?.size;
     if ( this.document.flags.dnd5e?.dimensions?.adjustedSize && baseDistance ) {
       const rectangle = new PIXI.Rectangle(center.x, center.y, 1, 1);
-      const hoveredToken = canvas.tokens.placeables
-        .find(t => t.visible && !t.document.isSecret && t._overlapsSelection(rectangle));
+      const hoveredToken = canvas.tokens.quadtree.getObjects(rectangle, {
+        collisionTest: ({ t }) => t.visible && !t.document.isSecret }).first();
       if ( hoveredToken && (hoveredToken !== this.#hoveredToken) ) {
         this.#hoveredToken = hoveredToken;
         this.#hoveredToken._onHoverIn(event);
         const size = Math.max(hoveredToken.document.width, hoveredToken.document.height);
-        updates.distance = baseDistance + (size * canvas.grid.distance * .5);
+        updates.distance = baseDistance + (size * canvas.grid.distance / 2);
       } else if ( !hoveredToken && this.#hoveredToken ) {
         this.#hoveredToken._onHoverOut(event);
         this.#hoveredToken = null;

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2160,7 +2160,6 @@ DND5E.areaTargetTypes = {
   radius: {
     label: "DND5E.TargetRadius",
     template: "circle",
-    sizes: ["radius"],
     standard: true
   },
   sphere: {

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -72,6 +72,8 @@ export default class TargetField extends SchemaField {
       this.target.template.height = null;
     }
 
+    this.target.template.dimensions = TargetField.templateDimensions(this.target.template.type);
+
     if ( labels ) {
       const parts = [];
 
@@ -89,5 +91,28 @@ export default class TargetField extends SchemaField {
 
       labels.target = parts.filterJoin(" ");
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create the template dimensions labels for a template type.
+   * @param {string} type  Area of effect type.
+   * @returns {{ size: string, width: [string], height: [string] }}
+   */
+  static templateDimensions(type) {
+    const sizes = CONFIG.DND5E.areaTargetTypes[type]?.sizes;
+    const dimensions = { size: "DND5E.AreaOfEffect.Size.Label" };
+    if ( sizes ) {
+      dimensions.width = sizes.includes("width") && (sizes.includes("length") || sizes.includes("radius"));
+      dimensions.height = sizes.includes("height");
+      if ( sizes.includes("radius") ) dimensions.size = "DND5E.AreaOfEffect.Size.Radius";
+      else if ( sizes.includes("length") ) dimensions.size = "DND5E.AreaOfEffect.Size.Length";
+      else if ( sizes.includes("width") ) dimensions.size = "DND5E.AreaOfEffect.Size.Width";
+      if ( sizes.includes("thickness") ) dimensions.width = "DND5E.AreaOfEffect.Size.Thickness";
+      else if ( dimensions.width ) dimensions.width = "DND5E.AreaOfEffect.Size.Width";
+      if ( dimensions.height ) dimensions.height = "DND5E.AreaOfEffect.Size.Height";
+    }
+    return dimensions;
   }
 }

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -98,7 +98,7 @@ export default class TargetField extends SchemaField {
   /**
    * Create the template dimensions labels for a template type.
    * @param {string} type  Area of effect type.
-   * @returns {{ size: string, width: [string], height: [string] }}
+   * @returns {{ size: string, [width]: string, [height]: string }}
    */
   static templateDimensions(type) {
     const sizes = CONFIG.DND5E.areaTargetTypes[type]?.sizes;


### PR DESCRIPTION
Dynamically updates the template size for the emanation area of effect to take the hovered token's size into account when placing the template.

https://github.com/user-attachments/assets/8ed3c78b-ed01-481c-98b0-8e48fb3a9966

Also adjust the code for area of effect dimensions to handle one without a sizes object and merged the two implementations.

Closes #1011