### PR TITLE
[#3701] Set spellcasting ability when adding new class to character

### DIFF
--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -71,9 +71,7 @@ export default class AttributesFields {
         })
       }, { label: "DND5E.Attunement" }),
       senses: new SensesField(),
-      spellcasting: new StringField({
-        required: true, blank: true, initial: "int", label: "DND5E.SpellAbility"
-      }),
+      spellcasting: new StringField({ required: true, blank: true, label: "DND5E.SpellAbility" }),
       exhaustion: new NumberField({
         required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.Exhaustion"
       }),

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -200,4 +200,24 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
 
     if ( needsMigration ) foundry.utils.setProperty(source, "flags.dnd5e.persistSourceMigration", true);
   }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onCreate(data, options, userId) {
+    await super._onCreate(data, options, userId);
+    const actor = this.parent.actor;
+    if ( !actor || (userId !== game.user.id) ) return;
+
+    if ( actor.type === "character" ) {
+      const pc = actor.items.get(actor.system.details.originalClass);
+      if ( !pc ) await this.parent._assignPrimaryClass();
+    }
+
+    if ( !actor.system.attributes?.spellcasting && this.parent.spellcasting?.ability ) {
+      await actor.update({ "system.attributes.spellcasting": this.parent.spellcasting.ability });
+    }
+  }
 }

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -78,4 +78,18 @@ export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTem
     context.singleDescription = true;
     context.parts = ["dnd5e.details-subclass", "dnd5e.details-spellcasting"];
   }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onCreate(data, options, userId) {
+    await super._onCreate(data, options, userId);
+    const actor = this.parent.actor;
+    if ( !actor || (userId !== game.user.id) ) return;
+    if ( !actor.system.attributes?.spellcasting && this.parent.spellcasting?.ability ) {
+      await actor.update({ "system.attributes.spellcasting": this.parent.spellcasting.ability });
+    }
+  }
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1571,20 +1571,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  async _onCreate(data, options, userId) {
-    super._onCreate(data, options, userId);
-    if ( (userId !== game.user.id) || !this.parent ) return;
-
-    // Assign a new original class
-    if ( (this.parent.type === "character") && (this.type === "class") ) {
-      const pc = this.parent.items.get(this.parent.system.details.originalClass);
-      if ( !pc ) await this.parent._assignPrimaryClass();
-    }
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritdoc */
   async _preUpdate(changed, options, user) {
     if ( (await super._preUpdate(changed, options, user)) === false ) return false;
 


### PR DESCRIPTION
If a new class with spellcasting is added to an actor and no primary spellcasting ability is set for that actor, this will set it automatically.

Closes #3701