### PR TITLE
[#1012] Select source class for spells when added to sheet

### DIFF
--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -342,23 +342,29 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   /** @inheritDoc */
   _preCreate(data, options, user) {
     if ( super._preCreate(data, options, user) === false ) return false;
-    if ( !this.parent.isEmbedded || ["atwill", "innate"].includes(this.preparation.mode) ) return;
+    if ( !this.parent.isEmbedded || ["atwill", "innate"].includes(this.preparation.mode) || this.sourceClass ) return;
     const classes = new Set(Object.keys(this.parent.actor.spellcastingClasses));
     if ( !classes.size ) return;
 
-    // If only a single spellcasting class is present, use that
-    if ( classes.size === 1 ) {
-      this.parent.updateSource({ "system.sourceClass": classes.first() });
-      return;
-    }
+    // Set the source class, and ensure the preparation mode is pact if adding a prepared spell to a pact class
+    const setClass = cls => {
+      const update = { "system.sourceClass": cls };
+      if ( (this.parent.actor.classes[cls].spellcasting.type === "pact") && (this.preparation.mode === "prepared")
+        && (this.level > 0) ) update["system.preparation.mode"] = "pact";
+      this.parent.updateSource(update);
+    };
 
     // If preparation mode is "pact" and pact class exists, set as that class
     if ( this.preparation.mode === "pact" ) {
-      const pactClass = classes.find(i => this.parent.actor.classes[i].spellcasting.type === "pact");
-      if ( pactClass ) {
-        this.parent.updateSource({ "system.sourceClass": pactClass });
-        return;
-      }
+      const pactClasses = classes.filter(i => this.parent.actor.classes[i].spellcasting.type === "pact");
+      if ( pactClasses.size === 1 ) setClass(pactClasses.first());
+      return;
+    }
+
+    // If only a single spellcasting class is present, use that
+    if ( classes.size === 1 ) {
+      setClass(classes.first());
+      return;
     }
 
     // Create intersection of spellcasting classes and classes that offer the spell
@@ -366,7 +372,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
       dnd5e.registry.spellLists.forSpell(this.parent._stats.compendiumSource).map(l => l.metadata.identifier)
     );
     const intersection = classes.intersection(spellClasses);
-    this.parent.updateSource({ "system.sourceClass": intersection.first() ?? classes.first() });
+    if ( intersection.size === 1 ) setClass(intersection.first());
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Using the new consolidated spell lists this attempts to pick the proper `sourceClass` for spells when they are added to a character sheet. It uses the following logic:

1. Grab spellcasting classes, if none exists then don't set source
2. If only one spellcasting class exists, set it as the source
3. If preparation mode is pact and a class exists that offers pact casting, then set that class as the source
4. Create intersection of classes on actor with classes that offer the spell, set source as first intersecting class or first class on actor if no intersections are found

Closes #1012