### PR TITLE
[#1012] Handle alt-spellcasting types properly

### DIFF
--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -346,18 +346,19 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     const classes = new Set(Object.keys(this.parent.actor.spellcastingClasses));
     if ( !classes.size ) return;
 
-    // Set the source class, and ensure the preparation mode is pact if adding a prepared spell to a pact class
+    // Set the source class, and ensure the preparation mode matches if adding a prepared spell to an alt class
     const setClass = cls => {
       const update = { "system.sourceClass": cls };
-      if ( (this.parent.actor.classes[cls].spellcasting.type === "pact") && (this.preparation.mode === "prepared")
-        && (this.level > 0) ) update["system.preparation.mode"] = "pact";
+      const type = this.parent.actor.classes[cls].spellcasting.type;
+      if ( (type !== "leveled") && (this.preparation.mode === "prepared") && (this.level > 0)
+        && (type in CONFIG.DND5E.spellPreparationModes) ) update["system.preparation.mode"] = type;
       this.parent.updateSource(update);
     };
 
-    // If preparation mode is "pact" and pact class exists, set as that class
-    if ( this.preparation.mode === "pact" ) {
-      const pactClasses = classes.filter(i => this.parent.actor.classes[i].spellcasting.type === "pact");
-      if ( pactClasses.size === 1 ) setClass(pactClasses.first());
+    // If preparation mode matches an alt spellcasting type and matching class exists, set as that class
+    if ( this.preparation.mode in CONFIG.DND5E.spellcastingTypes ) {
+      const altClasses = classes.filter(i => this.parent.actor.classes[i].spellcasting.type === this.preparation.mode);
+      if ( altClasses.size === 1 ) setClass(altClasses.first());
       return;
     }
 


### PR DESCRIPTION
Handle alternate spellcasting types, not just pact casting, when selecting a class for a spell added to the sheet.