### PR TITLE
[#3983] Add weapon mastery support to `TraitAdvancement`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -396,6 +396,8 @@
 "DND5E.AdvancementTraitModeExpertiseHint": "Gain expertise in a trait in which you already have proficiency.",
 "DND5E.AdvancementTraitModeForceLabel": "Forced Expertise",
 "DND5E.AdvancementTraitModeForceHint": "Gain expertise in a trait regardless of your previous proficiency level.",
+"DND5E.AdvancementTraitModeMasteryLabel": "Mastery",
+"DND5E.AdvancementTraitModeMasteryHint": "Gain mastery with a weapon in which you already have proficiency.",
 "DND5E.AdvancementTraitModeUpgradeLabel": "Upgrade",
 "DND5E.AdvancementTraitModeUpgradeHint": "Gain proficiency in a trait unless you already have it, otherwise gain expertise.",
 "DND5E.AdvancementTraitType": "Trait Type",

--- a/module/applications/advancement/trait-config.mjs
+++ b/module/applications/advancement/trait-config.mjs
@@ -84,7 +84,9 @@ export default class TraitConfig extends AdvancementConfig {
     context.selectedIndex = this.selected;
 
     context.validTraitTypes = Object.entries(CONFIG.DND5E.traits).reduce((obj, [key, config]) => {
-      if ( (this.config.mode === "default") || config.expertise ) obj[key] = config.labels.title;
+      if ( (this.config.mode === "default") || (this.config.mode === "mastery" ? config.mastery : config.expertise) ) {
+        obj[key] = config.labels.title;
+      }
       return obj;
     }, {});
 
@@ -102,6 +104,11 @@ export default class TraitConfig extends AdvancementConfig {
     context.choiceOptions = await Trait.choices(this.trait, { chosen, prefixed: true, any: this.selected !== -1 });
     context.selectedTraitHeader = `${CONFIG.DND5E.traits[this.trait].labels.localization}.other`;
     context.selectedTrait = this.trait;
+
+    // Disable selecting categories in mastery mode
+    if ( this.advancement.configuration.mode === "mastery" ) {
+      context.choiceOptions.forEach((key, value) => value.disabled = !!value.children);
+    }
 
     return context;
   }
@@ -175,7 +182,8 @@ export default class TraitConfig extends AdvancementConfig {
     if ( (event.target.name === "configuration.mode")
       && (event.target.value !== "default")
       && (this.config.mode === "default") ) {
-      const validTraitTypes = filteredKeys(CONFIG.DND5E.traits, c => c.expertise);
+      const checkKey = event.target.value === "mastery" ? "mastery" : "expertise";
+      const validTraitTypes = filteredKeys(CONFIG.DND5E.traits, c => c[checkKey]);
       if ( !validTraitTypes.includes(this.trait) ) this.trait = validTraitTypes[0];
     }
 
@@ -222,7 +230,8 @@ export default class TraitConfig extends AdvancementConfig {
 
     // If one of the expertise modes is selected, filter out any traits that are not of a valid type
     if ( (configuration.mode ?? this.config.mode) !== "default" ) {
-      const validTraitTypes = filteredKeys(CONFIG.DND5E.traits, c => c.expertise);
+      const checkKey = (configuration.mode ?? this.config.mode) === "mastery" ? "mastery" : "experties";
+      const validTraitTypes = filteredKeys(CONFIG.DND5E.traits, c => c[checkKey]);
       configuration.grants = configuration.grants.filter(k => validTraitTypes.some(t => k.startsWith(t)));
       configuration.choices.forEach(c => c.pool = c.pool?.filter(k => validTraitTypes.some(t => k.startsWith(t))));
     }

--- a/module/applications/advancement/trait-config.mjs
+++ b/module/applications/advancement/trait-config.mjs
@@ -181,7 +181,7 @@ export default class TraitConfig extends AdvancementConfig {
     // If mode is changed from default to one of the others, change selected type if current type is not valid
     if ( (event.target.name === "configuration.mode")
       && (event.target.value !== "default")
-      && (this.config.mode === "default") ) {
+      && (event.target.value !== this.config.mode) ) {
       const checkKey = event.target.value === "mastery" ? "mastery" : "expertise";
       const validTraitTypes = filteredKeys(CONFIG.DND5E.traits, c => c[checkKey]);
       if ( !validTraitTypes.includes(this.trait) ) this.trait = validTraitTypes[0];
@@ -230,7 +230,7 @@ export default class TraitConfig extends AdvancementConfig {
 
     // If one of the expertise modes is selected, filter out any traits that are not of a valid type
     if ( (configuration.mode ?? this.config.mode) !== "default" ) {
-      const checkKey = (configuration.mode ?? this.config.mode) === "mastery" ? "mastery" : "experties";
+      const checkKey = (configuration.mode ?? this.config.mode) === "mastery" ? "mastery" : "expertise";
       const validTraitTypes = filteredKeys(CONFIG.DND5E.traits, c => c[checkKey]);
       configuration.grants = configuration.grants.filter(k => validTraitTypes.some(t => k.startsWith(t)));
       configuration.choices.forEach(c => c.pool = c.pool?.filter(k => validTraitTypes.some(t => k.startsWith(t))));

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3153,6 +3153,7 @@ DND5E.epicBoonInterval = 30000;
  * @property {object} [children]           Mapping of category key to an object defining its children.
  * @property {boolean} [sortCategories]    Whether top-level categories should be sorted.
  * @property {boolean} [expertise]         Can an actor receive expertise in this trait?
+ * @property {boolean} [mastery]           Can an actor receive mastery in this trait?
  */
 
 /**
@@ -3205,7 +3206,8 @@ DND5E.traits = {
     icon: "icons/skills/melee/weapons-crossed-swords-purple.webp",
     actorKeyPath: "system.traits.weaponProf",
     configKey: "weaponProficiencies",
-    subtypes: { keyPath: "weaponType", ids: ["weaponIds"] }
+    subtypes: { keyPath: "weaponType", ids: ["weaponIds"] },
+    mastery: true
   },
   tool: {
     labels: {
@@ -3277,6 +3279,10 @@ DND5E.traitModes = {
   upgrade: {
     label: "DND5E.AdvancementTraitModeUpgradeLabel",
     hint: "DND5E.AdvancementTraitModeUpgradeHint"
+  },
+  mastery: {
+    label: "DND5E.AdvancementTraitModeMasteryLabel",
+    hint: "DND5E.AdvancementTraitModeMasteryHint"
   }
 };
 preLocalize("traitModes", { keys: ["label", "hint"] });

--- a/module/documents/actor/select-choices.mjs
+++ b/module/documents/actor/select-choices.mjs
@@ -84,6 +84,19 @@ export default class SelectChoices {
   /* -------------------------------------------- */
 
   /**
+   * Execute the provided function for each entry in the object.
+   * @param {Function} func  Function to execute on each entry. Receives the trait key and value.
+   */
+  forEach(func) {
+    for ( const [key, value] of Object.entries(this) ) {
+      func(key, value);
+      if ( value.children ) value.children.forEach(func);
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Merge another SelectChoices object into this one.
    * @param {SelectChoices} other
    * @param {object} [options={}]

--- a/module/documents/actor/trait.mjs
+++ b/module/documents/actor/trait.mjs
@@ -62,6 +62,8 @@ export async function actorValues(actor, trait) {
     data.value.forEach(v => setValue(v, 1));
   }
 
+  if ( (trait === "weapon") ) data.mastery?.forEach(v => setValue(v, 2));
+
   return values;
 }
 

--- a/module/documents/actor/trait.mjs
+++ b/module/documents/actor/trait.mjs
@@ -62,7 +62,7 @@ export async function actorValues(actor, trait) {
     data.value.forEach(v => setValue(v, 1));
   }
 
-  if ( (trait === "weapon") ) data.mastery?.forEach(v => setValue(v, 2));
+  if ( trait === "weapon" ) data.mastery?.forEach(v => setValue(v, 2));
 
   return values;
 }


### PR DESCRIPTION
Weapon masteries can now be granted or chosen through `TraitAdvancement` using the new "Mastery" mode.