### PR TITLE
[#3983] Add mastery selection & display mastery property in chat

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2954,6 +2954,7 @@
   },
   "Mastery": {
     "Label": "Weapon Mastery",
+    "Flavor": "<strong>Mastery</strong> {mastery}",
     "Cleave": "Cleave",
     "Graze": "Graze",
     "Nick": "Nick",

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -54,8 +54,11 @@ const {
  * @property {string} details.bond                        Character's bonds.
  * @property {string} details.flaw                        Character's flaws.
  * @property {object} traits
- * @property {SimpleTraitData} traits.weaponProf          Character's weapon proficiencies.
- * @property {SimpleTraitData} traits.armorProf           Character's armor proficiencies.
+ * @property {SimpleTraitData} traits.weaponProf             Character's weapon proficiencies.
+ * @property {Set<string>} traits.weaponProf.mastery         Weapon masteries.
+ * @property {Set<string>} traits.weaponProf.bonusMasteries  Extra mastery properties that can be chosen when making an
+ *                                                           attack with a weapon that has mastery.
+ * @property {SimpleTraitData} traits.armorProf              Character's armor proficiencies.
  * @property {object} resources
  * @property {CharacterResourceData} resources.primary    Resource number one.
  * @property {CharacterResourceData} resources.secondary  Resource number two.
@@ -139,7 +142,8 @@ export default class CharacterData extends CreatureTemplate {
         ...TraitsFields.creature,
         weaponProf: TraitsFields.makeSimpleTrait({ label: "DND5E.TraitWeaponProf" }, {
           extraFields: {
-            mastery: new SetField(new StringField())
+            mastery: new SetField(new StringField()),
+            bonusMasteries: new SetField(new StringField())
           }
         }),
         armorProf: TraitsFields.makeSimpleTrait({ label: "DND5E.TraitArmorProf" })

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -431,6 +431,26 @@ export default class WeaponData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /**
+   * Mastery options that can be used when attacking with this weapon.
+   * @type {FormSelectOption[]|null}
+   */
+  get masteryOptions() {
+    if ( !this.parent.actor?.system.traits?.weaponProf?.mastery?.has(this.type.baseItem) || !this.mastery ) return null;
+    const extras = [];
+    for ( const mastery of this.parent.actor.system.traits.weaponProf.bonusMasteries ?? [] ) {
+      if ( mastery === this.mastery ) continue;
+      if ( !extras.length ) extras.push({ rule: true });
+      extras.push({ value: mastery, label: CONFIG.DND5E.weaponMasteries[mastery]?.label ?? mastery });
+    }
+    return [
+      { value: this.mastery, label: CONFIG.DND5E.weaponMasteries[this.mastery]?.label ?? this.mastery },
+      ...extras
+    ];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Does this item have base damage defined in `damage.base` to offer to an activity?
    * @type {boolean}
    */

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -244,6 +244,7 @@ export default class D20Roll extends Roll {
    * @param {FormSelectOption[]} [data.attackModes]        Selectable attack modes.
    * @param {boolean} [data.chooseModifier]   Choose which ability modifier should be applied to the roll?
    * @param {string} [data.defaultAbility]    For tool rolls, the default ability modifier applied to the roll
+   * @param {FormSelectOption[]} [data.masteryOptions]     Selectable weapon masteries.
    * @param {string} [data.template]          A custom path to an HTML template to use instead of the default
    * @param {object} options                  Additional Dialog customization options
    * @returns {Promise<D20Roll|null>}         A resulting D20Roll object constructed with the dialog, or null if the
@@ -251,7 +252,7 @@ export default class D20Roll extends Roll {
    */
   async configureDialog({
     title, defaultRollMode, defaultAction=D20Roll.ADV_MODE.NORMAL, ammunitionOptions,
-    attackModes, chooseModifier=false, defaultAbility, template
+    attackModes, chooseModifier=false, defaultAbility, masteryOptions, template
   }={}, options={}) {
 
     // Render the Dialog inner HTML
@@ -263,6 +264,7 @@ export default class D20Roll extends Roll {
       attackModes,
       chooseModifier,
       defaultAbility,
+      masteryOptions,
       abilities: CONFIG.DND5E.abilities
     });
 
@@ -337,6 +339,9 @@ export default class D20Roll extends Roll {
       });
       this.options.flavor += ` (${CONFIG.DND5E.abilities[submitData.ability]?.label ?? ""})`;
     }
+
+    // Set the mastery
+    if ( submitData.mastery ) this.options.mastery = submitData.mastery;
 
     // Apply advantage or disadvantage
     this.options.advantageMode = advantageMode;

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -21,6 +21,7 @@ const { NumericTerm, OperatorTerm } = foundry.dice.terms;
  * @property {number|null} [fumble=1]  The value of the d20 result which represents a critical failure,
  *                                     `null` will prevent critical failures.
  * @property {number} [targetValue]    The value of the d20 result which should represent a successful roll.
+ * @property {string} [mastery]        Weapon mastery to use with an attack roll.
  *
  * ## Flags
  * @property {boolean} [elvenAccuracy]   Allow Elven Accuracy to modify this roll?
@@ -33,6 +34,7 @@ const { NumericTerm, OperatorTerm } = foundry.dice.terms;
  * @property {FormSelectOption[]} [attackModes]  Modes that can be used when making an attack.
  * @property {boolean} [chooseModifier=false]    If the configuration dialog is shown, should the ability modifier be
  *                                               configurable within that interface?
+ * @property {FormSelectOption[]} [masteryOptions]  Weapon masteries that can be selected when making an attack.
  * @property {string} [template]                 The HTML template used to display the roll configuration dialog.
  * @property {string} [title]                    Title of the roll configuration dialog.
  * @property {object} [dialogOptions]            Additional options passed to the roll configuration dialog.
@@ -54,9 +56,9 @@ const { NumericTerm, OperatorTerm } = foundry.dice.terms;
  */
 export async function d20Roll({
   parts=[], data={}, event,
-  advantage, disadvantage, critical=20, fumble=1, targetValue,
+  advantage, disadvantage, critical=20, fumble=1, targetValue, mastery,
   elvenAccuracy, halflingLucky, reliableTalent,
-  fastForward, ammunitionOptions, attackModes, chooseModifier=false, template, title, dialogOptions,
+  fastForward, ammunitionOptions, attackModes, chooseModifier=false, masteryOptions, template, title, dialogOptions,
   chatMessage=true, messageData={}, rollMode, flavor
 }={}) {
 
@@ -80,6 +82,7 @@ export async function d20Roll({
     critical,
     fumble,
     targetValue,
+    mastery,
     elvenAccuracy,
     halflingLucky,
     reliableTalent
@@ -95,6 +98,7 @@ export async function d20Roll({
       defaultRollMode,
       defaultAction: advantageMode,
       defaultAbility: data?.item?.ability || data?.defaultAbility,
+      masteryOptions,
       template
     }, dialogOptions);
     if ( configured === null ) return null;

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -373,10 +373,25 @@ export default class ChatMessage5e extends ChatMessage {
    */
   _enrichAttackTargets(html) {
     const attackRoll = this.rolls[0];
-    const targets = this.getFlag("dnd5e", "targets");
     const visibility = game.settings.get("dnd5e", "attackRollVisibility");
     const isVisible = game.user.isGM || (visibility !== "none");
-    if ( !isVisible || !(attackRoll instanceof dnd5e.dice.D20Roll) || !targets?.length ) return;
+    if ( !isVisible || !(attackRoll instanceof dnd5e.dice.D20Roll) ) return;
+
+    const masteryConfig = CONFIG.DND5E.weaponMasteries[attackRoll.options.mastery];
+    if ( masteryConfig ) {
+      const p = document.createElement("p");
+      p.classList.add("supplement");
+      let mastery = masteryConfig.label;
+      if ( masteryConfig.reference ) mastery = `
+        <a class="content-link" draggable="true" data-link data-uuid="${masteryConfig.reference}"
+           data-tooltip="${mastery}">${mastery}</a>
+      `;
+      p.innerHTML = game.i18n.format("DND5E.WEAPON.Mastery.Flavor", { mastery });
+      (html.querySelector(".chat-card") ?? html.querySelector(".message-content"))?.appendChild(p);
+    }
+
+    const targets = this.getFlag("dnd5e", "targets");
+    if ( !targets?.length ) return;
     const tray = document.createElement("div");
     tray.classList.add("dnd5e2");
     tray.innerHTML = `

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -37,6 +37,14 @@
         </select>
     </div>
     {{/if}}
+    {{#if masteryOptions}}
+    <div class="form-group">
+        <label>{{ localize "DND5E.WEAPON.Mastery.Label" }}</label>
+        <select name="mastery">
+            {{ selectOptions masteryOptions }}
+        </select>
+    </div>
+    {{/if}}
     <div class="form-group">
         <label>{{ localize "DND5E.RollSituationalBonus" }}</label>
         <input type="text" name="bonus" value="" placeholder="{{ localize 'DND5E.RollExample' }}"/>


### PR DESCRIPTION
Adds the `traits.weaponProf.bonsuMasteries` data to characters that contains extra masteries that can be applied to any weapon in which they have mastery, in place of the weapon's existing mastery.

When making an attack roll using a weapon with which the character has mastery, a dropdown will appear in the dialog if there is more then one mastery option, otherwise the first mastery will be selected automatically for the attack.

<img width="298" alt="Mastery in Chat" src="https://github.com/user-attachments/assets/c5f1fa16-b8e2-4f27-82b5-0695994a3158">

The mastery used will appear in the attack roll chat card and if a reference was provided for that mastery, it will be a link so players can hover and see a description of the mastery property.

Closes #3983