### PR TITLE
[#4076] Allow removal of Perception for ActorSheet5eNPC2

### DIFF
--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -119,7 +119,8 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     context.skills = Object.fromEntries(Object.entries(context.skills).filter(([, v]) => v.value));
 
     // Senses
-    context.senses.passivePerception = {
+    if (Object.hasOwn(this.actor.system.skills, 'prc')) {
+      context.senses.passivePerception = {
       label: game.i18n.localize("DND5E.PassivePerception"), value: this.actor.system.skills.prc.passive
     };
 

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -119,7 +119,7 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     context.skills = Object.fromEntries(Object.entries(context.skills).filter(([, v]) => v.value));
 
     // Senses
-    if (this.actor.system.skills.prc) {
+    if ( this.actor.system.skills.prc ) {
       context.senses.passivePerception = {
         label: game.i18n.localize("DND5E.PassivePerception"), value: this.actor.system.skills.prc.passive
       };

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -119,10 +119,11 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     context.skills = Object.fromEntries(Object.entries(context.skills).filter(([, v]) => v.value));
 
     // Senses
-    if (Object.hasOwn(this.actor.system.skills, 'prc')) {
+    if (this.actor.system.skills.prc) {
       context.senses.passivePerception = {
-      label: game.i18n.localize("DND5E.PassivePerception"), value: this.actor.system.skills.prc.passive
-    };
+        label: game.i18n.localize("DND5E.PassivePerception"), value: this.actor.system.skills.prc.passive
+      };
+    }
 
     // Legendary Actions & Resistances
     const plurals = new Intl.PluralRules(game.i18n.lang, { type: "ordinal" });


### PR DESCRIPTION
Allows the removal of the Perception skill without error by checking if the actor has the `prc` skill before adding it to senses.