### PR TITLE
[#4079] Handle limited uses on granted spells

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -265,6 +265,17 @@
       "Type": "Only features with the \"feat\" type can be selected."
     }
   },
+  "SPELLCONFIG": {
+    "FIELDS": {
+      "uses": {
+        "requireSlot": {
+          "label": "Require Slot",
+          "hint": "Require a spell slot to be spent when using the limited uses. If not checked then the uses will be additional free uses that don't consume a slot."
+        }
+      }
+    },
+    "FreeCasting": "Free Casting"
+  },
   "Subclass": {
     "Title": "Subclass",
     "Hint": "Specify what level this class receives its subclass.",

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -29,6 +29,8 @@ export default class ItemChoiceConfig extends AdvancementConfig {
       }, {}),
       showContainerWarning: indexes.some(i => i?.type === "container"),
       showSpellConfig: this.advancement.configuration.type === "spell",
+      showRequireSpellSlot: !this.advancement.configuration.spell?.preparation
+        || CONFIG.DND5E.spellPreparationModes[this.advancement.configuration.spell?.preparation]?.upcast,
       validTypes: this.advancement.constructor.VALID_TYPES.reduce((obj, type) => {
         obj[type] = game.i18n.localize(CONFIG.Item.typeLabels[type]);
         return obj;

--- a/module/applications/advancement/item-grant-config.mjs
+++ b/module/applications/advancement/item-grant-config.mjs
@@ -27,6 +27,8 @@ export default class ItemGrantConfig extends AdvancementConfig {
     }, {});
     context.showContainerWarning = indexes.some(i => i?.type === "container");
     context.showSpellConfig = indexes.some(i => i?.type === "spell");
+    context.showRequireSpellSlot = !this.advancement.configuration.spell?.preparation
+      || CONFIG.DND5E.spellPreparationModes[this.advancement.configuration.spell?.preparation]?.upcast;
     return context;
   }
 

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -108,7 +108,7 @@ export default class SaveActivityData extends BaseActivityData {
     let ability;
     if ( this.save.dc.calculation ) ability = this.ability;
     else this.save.dc.value = simplifyBonus(this.save.dc.formula, rollData);
-    if ( ability ) this.save.dc.value = this.actor?.system.abilities?.[ability]?.dc
+    this.save.dc.value ??= this.actor?.system.abilities?.[ability]?.dc
       ?? 8 + (this.actor?.system.attributes?.prof ?? 0);
 
     if ( this.save.dc.value ) this.labels.save = game.i18n.format("DND5E.SaveDC", {

--- a/module/data/advancement/spell-config.mjs
+++ b/module/data/advancement/spell-config.mjs
@@ -43,8 +43,9 @@ export default class SpellConfigurationData extends foundry.abstract.DataModel {
     if ( this.preparation ) foundry.utils.setProperty(itemData, "system.preparation.mode", this.preparation);
 
     if ( this.uses.max && this.uses.per ) {
-      foundry.utils.setProperty(itemData, "system.uses.per", this.uses.per);
       foundry.utils.setProperty(itemData, "system.uses.max", this.uses.max);
+      itemData.system.uses.recovery ??= [];
+      itemData.system.uses.recovery.push({ period: this.uses.per, type: "recoverAll" });
 
       const preparationConfig = CONFIG.DND5E.spellPreparationModes[itemData.system.preparation?.mode];
       const createForwardActivity = !this.uses.requireSlot && preparationConfig?.upcast;

--- a/module/data/advancement/spell-config.mjs
+++ b/module/data/advancement/spell-config.mjs
@@ -1,17 +1,18 @@
 import FormulaField from "../fields/formula-field.mjs";
 
-const { SchemaField, SetField, StringField } = foundry.data.fields;
+const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 export default class SpellConfigurationData extends foundry.abstract.DataModel {
   /** @inheritDoc */
   static defineSchema() {
     return {
       ability: new SetField(new StringField()),
-      preparation: new StringField({label: "DND5E.SpellPreparation.Mode"}),
+      preparation: new StringField({ label: "DND5E.SpellPreparation.Mode" }),
       uses: new SchemaField({
-        max: new FormulaField({deterministic: true, label: "DND5E.UsesMax"}),
-        per: new StringField({label: "DND5E.UsesPeriod"})
-      }, {label: "DND5E.LimitedUses"})
+        max: new FormulaField({ deterministic: true, label: "DND5E.UsesMax" }),
+        per: new StringField({ label: "DND5E.UsesPeriod" }),
+        requireSlot: new BooleanField()
+      }, { label: "DND5E.LimitedUses" })
     };
   }
 
@@ -31,11 +32,57 @@ export default class SpellConfigurationData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Apply changes to a spell item based on this spell configuration.
+   * @param {object} itemData          Data for the item to modify.
+   * @param {object} [config={}]
+   * @param {string} [config.ability]  Spellcasting ability selected during advancement process.
+   */
+  applySpellChanges(itemData, { ability }={}) {
+    ability = this.ability.size ? this.ability.has(ability) ? ability : this.ability.first() : null;
+    if ( ability ) foundry.utils.setProperty(itemData, "system.ability", ability);
+    if ( this.preparation ) foundry.utils.setProperty(itemData, "system.preparation.mode", this.preparation);
+
+    if ( this.uses.max && this.uses.per ) {
+      foundry.utils.setProperty(itemData, "system.uses.per", this.uses.per);
+      foundry.utils.setProperty(itemData, "system.uses.max", this.uses.max);
+
+      const preparationConfig = CONFIG.DND5E.spellPreparationModes[itemData.system.preparation?.mode];
+      const createForwardActivity = !this.uses.requireSlot && preparationConfig?.upcast;
+
+      for ( const activity of Object.values(itemData.system.activities ?? {}) ) {
+        if ( !activity.consumption?.spellSlot ) continue;
+
+        const activityData = foundry.utils.deepClone(activity);
+        activityData.consumption.targets ??= [];
+        activityData.consumption.targets.push({ type: "itemUses", target: "", value: "1" });
+        if ( createForwardActivity ) {
+          activityData._id = foundry.utils.randomID();
+          activityData.name ??= game.i18n.localize(
+            CONFIG.DND5E.activityTypes[activityData.type]?.documentClass.metadata.title
+          );
+          activityData.name += ` (${game.i18n.localize("DND5E.ADVANCEMENT.SPELLCONFIG.FreeCasting").toLowerCase()})`;
+          activityData.sort = (activityData.sort ?? 0) + 1;
+          activityData.consumption.spellSlot = false;
+        }
+
+        foundry.utils.setProperty(itemData, `system.activities.${activityData._id}`, activityData);
+      }
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Changes that this spell configuration indicates should be performed on spells.
    * @param {object} data  Data for the advancement process.
    * @returns {object}
+   * @deprecated since DnD5e 4.0, available until DnD5e 4.4
    */
   getSpellChanges(data={}) {
+    foundry.utils.logCompatibilityWarning(
+      "The `getSpellChanges` method on `SpellConfigurationData` has been deprecated and replaced with `applySpellChanges`.",
+      { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+    );
     const updates = {};
     if ( this.ability.size ) {
       updates["system.ability"] = this.ability.has(data.ability) ? data.ability : this.ability.first();
@@ -44,15 +91,6 @@ export default class SpellConfigurationData extends foundry.abstract.DataModel {
     if ( this.uses.max && this.uses.per ) {
       updates["system.uses.max"] = this.uses.max;
       updates["system.uses.per"] = this.uses.per;
-      if ( Number.isNumeric(this.uses.max) ) updates["system.uses.value"] = parseInt(this.uses.max);
-      else {
-        try {
-          const rollData = this.parent.parent.actor.getRollData({ deterministic: true });
-          const formula = Roll.replaceFormulaData(this.uses.max, rollData, {missing: 0});
-          const roll = new Roll(formula);
-          updates["system.uses.value"] = roll.evaluateSync().total;
-        } catch(e) { }
-      }
     }
     return updates;
   }

--- a/module/documents/advancement/item-grant.mjs
+++ b/module/documents/advancement/item-grant.mjs
@@ -88,16 +88,15 @@ export default class ItemGrantAdvancement extends Advancement {
   async apply(level, data, retainedData={}) {
     const items = [];
     const updates = {};
-    const spellChanges = this.configuration.spell?.getSpellChanges({
-      ability: data.ability ?? this.retainedData?.ability ?? this.value?.ability
-    }) ?? {};
     for ( const uuid of filteredKeys(data) ) {
       let itemData = retainedData[uuid];
       if ( !itemData ) {
         itemData = await this.createItemData(uuid);
         if ( !itemData ) continue;
       }
-      if ( itemData.type === "spell" ) foundry.utils.mergeObject(itemData, spellChanges);
+      if ( itemData.type === "spell" ) this.configuration.spell?.applySpellChanges(itemData, {
+        ability: data.ability ?? this.retainedData?.ability ?? this.value?.ability
+      });
 
       items.push(itemData);
       updates[itemData._id] = uuid;

--- a/templates/advancement/parts/advancement-spell-config.hbs
+++ b/templates/advancement/parts/advancement-spell-config.hbs
@@ -30,3 +30,14 @@
         </select>
     </div>
 </div>
+
+{{#if showRequireSpellSlot}}
+<div class="form-group">
+    <label>{{ localize "DND5E.ADVANCEMENT.SPELLCONFIG.FIELDS.uses.requireSlot.label" }}</label>
+    <div class="form-fields">
+        <input type="checkbox" name="configuration.spell.uses.requireSlot"
+               {{ checked configuration.spell.uses.requireSlot }}>
+    </div>
+    <p class="hint">{{ localize "DND5E.ADVANCEMENT.SPELLCONFIG.FIELDS.uses.requireSlot.hint" }}</p>
+</div>
+{{/if}}

--- a/templates/items/details/details-spell.hbs
+++ b/templates/items/details/details-spell.hbs
@@ -65,6 +65,9 @@
     {{#if isEmbedded}}
     {{ formField fields.sourceClass value=source.sourceClass localize=true choices=item.parent.spellcastingClasses
                  labelAttr="name" blank="" }}
+
+    {{ formField fields.ability value=source.ability localize=true choices=config.abilities
+                 labelAttr="label" blank=defaultAbility }}
     {{/if}}
 </fieldset>
 


### PR DESCRIPTION
Handles setting the limited uses on spells granted through an advancement in a way that respects activities. To support all the desired workflows, a "Requires Slot" checkbox has been added to the spell config which controls how the limited uses are applied.

- If preparation mode doesn't require a spell slot by default or "Requires Slot" is checked, then consumption is added to all activities on the spell marked to "Consume Spell Slot"
- If preparation mode requies a slot and "Requires Slot" isn't checked, then each activity marked to "Consume Spell Slot" is duplicated, given consumption, removed spell slot consumption, and has "Free Casting" added to its name

This combination should handle all of the standard configurations needed for official content.

This PR also reintroduces `system.ability` to spells as a means of overriding the default ability from the class or actor. This field only appears for embedded spells and shows the default ability when not set.

Closes #4079