### PR TITLE
[#3913, #3914] Handle enchantments that target moved fields

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -115,6 +115,7 @@ Hooks.once("init", function() {
   CONFIG.Dice.rolls = [dice.BasicRoll, dice.D20Roll, dice.DamageRoll];
 
   // Hook up system data types
+  CONFIG.ActiveEffect.dataModels = dataModels.activeEffect.config;
   CONFIG.Actor.dataModels = dataModels.actor.config;
   CONFIG.Item.dataModels = dataModels.item.config;
   CONFIG.JournalEntryPage.dataModels = dataModels.journal.config;

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -146,6 +146,13 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
   /* -------------------------------------------- */
 
   /** @override */
+  _getItemOverrides() {
+    return [];
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   _getItemAdvancementTags(advancement) {
     if ( this.item.isEmbedded && (this._mode !== this.constructor.MODES.EDIT) ) return [];
     const tags = [];

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -722,13 +722,7 @@ export default class ItemSheet5e extends ItemSheet {
     const effectData = effect.toObject();
     let keepOrigin = false;
 
-    // Validate against the enchantment's restraints on the origin item
     if ( effect.type === "enchantment" ) {
-      const errors = effect.parent.system.enchantment?.canEnchant(this.item);
-      if ( errors?.length ) {
-        errors.forEach(err => ui.notifications.error(err.message));
-        return false;
-      }
       effectData.origin ??= effect.parent.uuid;
       keepOrigin = true;
     }

--- a/module/applications/item/sheet-v2-mixin.mjs
+++ b/module/applications/item/sheet-v2-mixin.mjs
@@ -134,7 +134,7 @@ export default function ItemSheetV2Mixin(Base) {
       context.editable = this.isEditable && (this._mode === this.constructor.MODES.EDIT);
       context.cssClass = context.editable ? "editable" : this.isEditable ? "interactable" : "locked";
       context.inputs = { ...foundry.applications.fields, ...dnd5e.applications.fields };
-      const { description, identified, properties, schema, unidentified, validProperties } = this.item.system;
+      const { description, identified, schema, unidentified, validProperties } = this.item.system;
       context.fields = schema.fields;
 
       // Set some default collapsed states on first open.
@@ -176,7 +176,7 @@ export default function ItemSheetV2Mixin(Base) {
         object: Object.fromEntries((context.system.properties ?? []).map(p => [p, true])),
         options: (validProperties ?? []).reduce((arr, k) => {
           const { label } = CONFIG.DND5E.itemProperties[k];
-          arr.push({ label, value: k, selected: properties.has(k) });
+          arr.push({ label, value: k, selected: this.item._source.system.properties?.includes(k) });
           return arr;
         }, [])
       };

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -1,6 +1,7 @@
 export {default as SystemDataModel, ActorDataModel, ItemDataModel, SparseDataModel} from "./abstract.mjs";
 export * as fields from "./fields/_module.mjs";
 
+export * as activeEffect from "./active-effect/_module.mjs";
 export * as activity from "./activity/_module.mjs";
 export * as actor from "./actor/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";

--- a/module/data/active-effect/_module.mjs
+++ b/module/data/active-effect/_module.mjs
@@ -1,0 +1,7 @@
+import EnchantmentData from "./enchantment.mjs";
+
+export { EnchantmentData };
+
+export const config = {
+  enchantment: EnchantmentData
+};

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -19,9 +19,8 @@ export default class EnchantmentData extends foundry.abstract.TypeDataModel {
    * @returns {boolean|void}             Return false to prevent normal application from occurring.
    */
   _applyLegacy(item, change, changes) {
-    console.log("EnchantmentData#_applyLegacy", item, change, changes);
     let key = change.key.replace("system.", "");
-    switch (change.key) {
+    switch ( change.key ) {
       case "system.attack.bonus":
       case "system.attack.flat":
         for ( const activity of item.system.activities?.getByTypes("attack") ?? [] ) {
@@ -39,19 +38,16 @@ export default class EnchantmentData extends foundry.abstract.TypeDataModel {
             value.enchantment = true;
             value.locked = true;
             changes[`system.activities.${activity.id}.damage.parts`] = ActiveEffect.applyField(
-              activity, { ...change, key: "damage.parts", value: value }
+              activity, { ...change, key, value: value }
             );
           }
           return false;
-        } catch(err) {
-          console.log(err);
-        }
+        } catch(err) {}
       case "system.save.dc":
       case "system.save.scaling":
         let value = change.value;
-        if ( key === "save.dc" ) {
-          key = "save.dc.formula";
-        } else {
+        if ( key === "save.dc" ) key = "save.dc.formula";
+        else {
           key = "save.dc.calculation";
           if ( value === "flat" ) value = "";
           else if ( (value === "") && (item.type === "spell") ) value = "spellcasting";

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -1,0 +1,67 @@
+import { DamageData } from "../shared/damage-field.mjs";
+
+/**
+ * System data model for enchantment active effects.
+ */
+export default class EnchantmentData extends foundry.abstract.TypeDataModel {
+  /** @override */
+  static defineSchema() {
+    return {};
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle enchantment-specific changes to the item.
+   * @param {Item5e} item                The Item to whom this effect should be applied.
+   * @param {EffectChangeData} change    The change data being applied.
+   * @param {Record<string, *>} changes  The aggregate update paths and their updated values.
+   * @returns {boolean|void}             Return false to prevent normal application from occurring.
+   */
+  _applyLegacy(item, change, changes) {
+    console.log("EnchantmentData#_applyLegacy", item, change, changes);
+    let key = change.key.replace("system.", "");
+    switch (change.key) {
+      case "system.attack.bonus":
+      case "system.attack.flat":
+        for ( const activity of item.system.activities?.getByTypes("attack") ?? [] ) {
+          changes[`system.activities.${activity.id}.${key}`] = ActiveEffect.applyField(activity, { ...change, key });
+        }
+        return false;
+      case "system.damage.parts":
+        try {
+          let damage;
+          const parsed = JSON.parse(change.value);
+          if ( foundry.utils.getType(parsed) === "Object" ) damage = new DamageData(parsed);
+          else damage = new DamageData({ custom: { enabled: true, formula: parsed[0][0] }, types: [parsed[0][1]] });
+          for ( const activity of item.system.activities?.getByTypes("attack", "damage", "save") ?? [] ) {
+            const value = damage.clone();
+            value.enchantment = true;
+            value.locked = true;
+            changes[`system.activities.${activity.id}.damage.parts`] = ActiveEffect.applyField(
+              activity, { ...change, key: "damage.parts", value: value }
+            );
+          }
+          return false;
+        } catch(err) {
+          console.log(err);
+        }
+      case "system.save.dc":
+      case "system.save.scaling":
+        let value = change.value;
+        if ( key === "save.dc" ) {
+          key = "save.dc.formula";
+        } else {
+          key = "save.dc.calculation";
+          if ( value === "flat" ) value = "";
+          else if ( (value === "") && (item.type === "spell") ) value = "spellcasting";
+        }
+        for ( const activity of item.system.activities?.getByTypes("save") ?? [] ) {
+          changes[`system.activities.${activity.id}.${key}`] = ActiveEffect.applyField(
+            activity, { ...change, key, value }
+          );
+        }
+        return false;
+    }
+  }
+}

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -179,6 +179,7 @@ export default class AttackActivityData extends BaseActivityData {
     if ( this.damage.includeBase && this.item.system.offersBaseDamage && this.item.system.damage.base.formula ) {
       const basePart = this.item.system.damage.base.clone();
       basePart.base = true;
+      basePart.locked = true;
       this.damage.parts.unshift(basePart);
     }
 

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -627,7 +627,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * @param {object} [options={}]
    * @param {boolean} [options.evaluate=true]  Should the slot roll be evaluated?
    * @param {BasicRoll[]} [options.rolls]      Rolls performed as part of the usages.
-   * @returns {Promise<BasicRoll>}
+   * @returns {Promise<BasicRoll>|BasicRoll}
    * @internal
    */
   _resolveScaledRoll(formula, scaling, { evaluate=true, rolls }={}) {

--- a/module/data/fields/activities-field.mjs
+++ b/module/data/fields/activities-field.mjs
@@ -121,6 +121,19 @@ export class ActivityCollection extends Collection {
 
   /* -------------------------------------------- */
 
+  /**
+   * Generator that yields activities for each of the provided types.
+   * @param {string[]} types  Types to fetch.
+   * @yields {Activity}
+   */
+  *getByTypes(...types) {
+    for ( const type of types ) {
+      for ( const activity of this.getByType(type) ) yield activity;
+    }
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   set(key, value) {
     if ( !this.#types.has(value.type) ) this.#types.set(value.type, new Set());

--- a/module/data/item/fields/spellcasting-field.mjs
+++ b/module/data/item/fields/spellcasting-field.mjs
@@ -1,5 +1,5 @@
 import { simplifyBonus } from "../../../utils.mjs";
-import { FormulaField } from "../../fields.mjs";
+import FormulaField from "../../fields/formula-field.mjs";
 
 const { SchemaField, StringField } = foundry.data.fields;
 

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -296,7 +296,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
 
   /** @inheritDoc */
   get _typeAbilityMod() {
-    return availableAbilities.first() ?? "int";
+    return this.availableAbilities.first() ?? "int";
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -1,5 +1,4 @@
 import FormulaField from "../data/fields/formula-field.mjs";
-import { EnchantmentData } from "../data/item/fields/enchantment-field.mjs";
 import { staticID } from "../utils.mjs";
 
 /**
@@ -125,9 +124,6 @@ export default class ActiveEffect5e extends ActiveEffect {
       ? actor.system.schema.getField(change.key.slice(7))
       : actor.schema.getField(change.key);
 
-    // Get the current value of the target field
-    const current = foundry.utils.getProperty(actor, change.key) ?? null;
-
     const getTargetType = field => {
       if ( (field instanceof FormulaField) || ActiveEffect5e.FORMULA_FIELDS.has(change.key) ) return "formula";
       else if ( field instanceof foundry.data.fields.ArrayField ) return "Array";
@@ -140,6 +136,9 @@ export default class ActiveEffect5e extends ActiveEffect {
     const targetType = getTargetType(field);
     if ( !targetType ) return super.apply(actor, change);
     const modes = CONST.ACTIVE_EFFECT_MODES;
+
+    // Get the current value of the target field
+    const current = foundry.utils.getProperty(actor, change.key) ?? null;
 
     // Special handling for FormulaField
     if ( targetType === "formula" ) {
@@ -192,6 +191,14 @@ export default class ActiveEffect5e extends ActiveEffect {
     // Apply all changes to the Actor data
     foundry.utils.mergeObject(actor, changes);
     return changes;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _applyLegacy(actor, change, changes) {
+    if ( this.system._applyLegacy?.(actor, change, changes) === false ) return;
+    super._applyLegacy(actor, change, changes);
   }
 
   /* -------------------------------------------- */
@@ -456,7 +463,7 @@ export default class ActiveEffect5e extends ActiveEffect {
 
     if ( this.isAppliedEnchantment ) {
       const origin = await fromUuid(this.origin);
-      const errors = origin?.canEnchant(this.parent);
+      const errors = origin?.canEnchant?.(this.parent);
       if ( errors?.length ) {
         errors.forEach(err => console.error(err));
         return false;

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -119,7 +119,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
     if ( config.mastery ) rollConfig.rolls[0].options.mastery = config.mastery;
     else {
       const stored = this.item.getFlag("dnd5e", `last.${this.id}.mastery`);
-      const match = masteryOptions.find(m => m.value === stored);
+      const match = masteryOptions?.find(m => m.value === stored);
       if ( match ) {
         rollConfig.rolls[0].options.mastery = stored;
         match.selected = true;

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1005,6 +1005,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    */
   getRollData(options) {
     const rollData = this.item.getRollData(options);
+    rollData.activity = { ...this };
     rollData.mod = this.actor?.system.abilities?.[this.ability]?.mod ?? 0;
     return rollData;
   }

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -293,12 +293,13 @@ export default class ChatMessage5e extends ChatMessage {
     // Enriched roll flavor
     const roll = this.getFlag("dnd5e", "roll");
     const item = this.getAssociatedItem();
+    const activity = this.getAssociatedActivity();
     if ( this.isContentVisible && item && roll ) {
       const isCritical = (roll.type === "damage") && this.rolls[0]?.options?.critical;
       const subtitle = roll.type === "damage"
         ? isCritical ? game.i18n.localize("DND5E.CriticalHit") : game.i18n.localize("DND5E.DamageRoll")
         : roll.type === "attack"
-          ? game.i18n.localize(`DND5E.Action${item.system.actionType.toUpperCase()}`)
+          ? game.i18n.localize(`DND5E.Action${activity.actionType.toUpperCase()}`)
           : item.system.type?.label ?? game.i18n.localize(CONFIG.Item.typeLabels[item.type]);
       const flavor = document.createElement("div");
       flavor.classList.add("dnd5e2", "chat-card");

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -531,8 +531,12 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /** @inheritDoc */
   clone(data={}, options={}) {
     if ( options.save ) return super.clone(data, options);
+    if ( this.parent ) this.parent._embeddedPreparation = true;
     const item = super.clone(data, options);
-    if ( item.parent ) item.prepareFinalAttributes();
+    if ( item.parent ) {
+      delete item.parent._embeddedPreparation;
+      item.prepareFinalAttributes();
+    }
     return item;
   }
 

--- a/templates/activity/parts/damage-part.hbs
+++ b/templates/activity/parts/damage-part.hbs
@@ -25,7 +25,7 @@
     <input type="hidden" name="{{ prefix }}custom.formula" value="{{ data.custom.formula }}">
 
     {{/if}}
-    {{#unless data.base}}
+    {{#unless data.locked}}
     <button type="button" class="unbutton control-button" data-action="deleteDamagePart"
             data-tooltip="DND5E.DAMAGE.Part.Action.Delete"
             aria-label="{{ localize 'DND5E.DAMAGE.Part.Action.Delete' }}">
@@ -36,7 +36,7 @@
 
 <div class="field-group">
     {{ formField fields.types name=(concat prefix "types") value=data.types options=typeOptions hint=false
-                 disabled=data.base label="DND5E.Type" localize=true classes="label-top multi-select" }}
+                 disabled=data.locked label="DND5E.Type" localize=true classes="label-top multi-select" }}
     <!-- TODO: This disabled is only necessary because of https://github.com/foundryvtt/foundryvtt/issues/11564 -->
 </div>
 

--- a/templates/activity/parts/damage-parts.hbs
+++ b/templates/activity/parts/damage-parts.hbs
@@ -1,5 +1,5 @@
 {{#each damageParts}}
-<fieldset class="unfieldset" {{ disabled data.base }}>
+<fieldset class="unfieldset" {{ disabled data.locked }}>
     <div class="form-group split-group full-width card" {{#if data.base}}class="base-part"{{/if}}
          data-index="{{ index }}">
         <div class="form-fields field-groups">
@@ -9,6 +9,6 @@
 </fieldset>
 {{else}}
 <div class="empty">
-    {{{ localize "DND5E.None" }}}
+    {{ localize "DND5E.None" }}
 </div>
 {{/each}}


### PR DESCRIPTION
Adds system data model for enchantment active effects that has custom application logic to handle enchantments targeting fields that no longer exist on items. These handle `attack.bonus`, `attack.flat`, `damage.parts`, `save.dc`, `save.scaling`. These fields cover everything applied by summoning as well as the most common fields modified by enchantment spells or features.