### PR TITLE
masteryOptions can be null, account for this in attack activity

### DIFF
--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -115,7 +115,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
       }
     }].concat(config.rolls ?? []);
 
-    const masteryOptions = this.item.system.masteryOptions;
+    const masteryOptions = this.item.system.masteryOptions ?? [];
     if ( config.mastery ) rollConfig.rolls[0].options.mastery = config.mastery;
     else {
       const stored = this.item.getFlag("dnd5e", `last.${this.id}.mastery`);


### PR DESCRIPTION
If not weapon mastery options, weapon attacks failed. Null can be returned by masteryOptions get.