### PR TITLE
[#3462] Hex grid TokenPlacement

### DIFF
--- a/module/canvas/token-placement.mjs
+++ b/module/canvas/token-placement.mjs
@@ -206,14 +206,14 @@ export default class TokenPlacement {
    */
   #onMovePlacement(event) {
     event.stopPropagation();
-    if (this.#throttle) return;
+    if ( this.#throttle ) return;
     this.#throttle = true;
     const idx = this.#currentPlacement;
     const preview = this.#previews[idx];
     const clone = preview.object;
     const local = event.data.getLocalPosition(canvas.tokens);
-    local.x = local.x - clone.w / 2;
-    local.y = local.y - clone.h / 2;
+    local.x = local.x - (clone.w / 2);
+    local.y = local.y - (clone.h / 2);
     const dest = !event.shiftKey ? clone.getSnappedPosition(local) : local;
     preview.updateSource({x: dest.x, y: dest.y});
     this.#placements[idx].x = preview.x;

--- a/module/canvas/token-placement.mjs
+++ b/module/canvas/token-placement.mjs
@@ -158,26 +158,6 @@ export default class TokenPlacement {
   }
 
   /* -------------------------------------------- */
-
-  /**
-   * Pixel offset to ensure snapping occurs in middle of grid space.
-   * @param {PrototypeToken} token  Token for which to calculate the adjustment.
-   * @returns {{x: number, y: number}}
-   */
-  #getSnapAdjustment(token) {
-    const size = canvas.dimensions.size;
-    switch ( canvas.grid.type ) {
-      case CONST.GRID_TYPES.SQUARE:
-        return {
-          x: token.width % 2 === 0 ? Math.round(size * 0.5) : 0,
-          y: token.height % 2 === 0 ? Math.round(size * 0.5) : 0
-        };
-      default:
-        return { x: 0, y: 0 };
-    }
-  }
-
-  /* -------------------------------------------- */
   /*  Event Handlers                              */
   /* -------------------------------------------- */
 
@@ -226,17 +206,16 @@ export default class TokenPlacement {
    */
   #onMovePlacement(event) {
     event.stopPropagation();
-    if ( this.#throttle ) return;
+    if (this.#throttle) return;
     this.#throttle = true;
     const idx = this.#currentPlacement;
     const preview = this.#previews[idx];
-    const adjustment = this.#getSnapAdjustment(preview);
-    const point = event.data.getLocalPosition(canvas.tokens);
-    const center = canvas.grid.getCenterPoint({ x: point.x - adjustment.x, y: point.y - adjustment.y });
-    preview.updateSource({
-      x: center.x + adjustment.x - Math.round((this.config.tokens[idx].width * canvas.dimensions.size) / 2),
-      y: center.y + adjustment.y - Math.round((this.config.tokens[idx].height * canvas.dimensions.size) / 2)
-    });
+    const clone = preview.object;
+    const local = event.data.getLocalPosition(canvas.tokens);
+    local.x = local.x - clone.w / 2;
+    local.y = local.y - clone.h / 2;
+    const dest = !event.shiftKey ? clone.getSnappedPosition(local) : local;
+    preview.updateSource({x: dest.x, y: dest.y});
     this.#placements[idx].x = preview.x;
     this.#placements[idx].y = preview.y;
     canvas.tokens.preview.children[this.#currentPlacement]?.refresh();


### PR DESCRIPTION
Closes #3462.

Possible it can be more optimized, however I tested on
- gridless with a token of size 0.5, 1, 2, 3
- square grid with a token of size 0.5, 1, 2, 3
- hexagonal rows (odd) with token of size 0.5, 1, 2, 3

and it seemed to work just fine.

Also implements the ability to hold shift to disable snapping.