### PR TITLE
Do not delete `proficient` when dropping an item onto actor.

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1055,7 +1055,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
    */
   _onDropResetData(itemData) {
     if ( !itemData.system ) return;
-    ["attuned", "equipped", "proficient", "prepared"].forEach(k => delete itemData.system[k]);
+    ["attuned", "equipped", "prepared"].forEach(k => delete itemData.system[k]);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
re: #2418.

The need for a migration was a year ago, so perhaps it is simply too late to migrate; if so, we should stop deleting `system.proficient` and assume that any item set to "Proficient"/"Not Proficient" instead of "Automatic" is intentionally an item that ignores the proficiencies of the actor it is embedded on.