### PR TITLE
Add `simplify` method to `BasicRoll`

### DIFF
--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -56,17 +56,10 @@ const { DiceTerm, NumericTerm } = foundry.dice.terms;
  * Custom base roll type with methods for building rolls, presenting prompts, and creating messages.
  */
 export default class BasicRoll extends Roll {
-  constructor(formula, data={}, options={}) {
-    super(formula, data, options);
-    this.#configure();
-  }
-
-  /* -------------------------------------------- */
-
   /**
-   * Replace roll terms with numeric values.
+   * Replace number and faces of dice terms with numeric values.
    */
-  #configure() {
+  simplifyDice() {
     for ( const die of this.dice ) {
       const n = die._number;
       if ( (n instanceof BasicRoll) && n.isDeterministic ) die._number = n.evaluateSync().total;
@@ -75,12 +68,6 @@ export default class BasicRoll extends Roll {
 
       // Preserve flavor.
       if ( f.terms?.[0]?.flavor ) die.options.flavor = f.terms[0].flavor;
-    }
-
-    for ( const [i, term] of this.terms.entries() ) {
-      if ( (term.roll instanceof BasicRoll) && term.isDeterministic ) {
-        this.terms[i] = new foundry.dice.terms.NumericTerm({ number: term.roll.evaluateSync().total });
-      }
     }
 
     this.resetFormula();

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -56,22 +56,6 @@ const { DiceTerm, NumericTerm } = foundry.dice.terms;
  * Custom base roll type with methods for building rolls, presenting prompts, and creating messages.
  */
 export default class BasicRoll extends Roll {
-  /**
-   * Replace number and faces of dice terms with numeric values.
-   */
-  simplifyDice() {
-    for ( const die of this.dice ) {
-      const n = die._number;
-      if ( (n instanceof BasicRoll) && n.isDeterministic ) die._number = n.evaluateSync().total;
-      const f = die._faces;
-      if ( (f instanceof BasicRoll) && f.isDeterministic ) die._faces = f.evaluateSync().total;
-
-      // Preserve flavor.
-      if ( f.terms?.[0]?.flavor ) die.options.flavor = f.terms[0].flavor;
-    }
-
-    this.resetFormula();
-  }
 
   /**
    * Default application used for the roll configuration prompt.
@@ -278,5 +262,26 @@ export default class BasicRoll extends Roll {
     }
 
     return matchedModifier ? face * number : null;
+  }
+
+  /* -------------------------------------------- */
+  /*  Simplification Methods                      */
+  /* -------------------------------------------- */
+
+  /**
+   * Replace number and faces of dice terms with numeric values where possible.
+   */
+  simplify() {
+    for ( const die of this.dice ) {
+      const n = die._number;
+      if ( (n instanceof BasicRoll) && n.isDeterministic ) die._number = n.evaluateSync().total;
+      const f = die._faces;
+      if ( (f instanceof BasicRoll) && f.isDeterministic ) die._faces = f.evaluateSync().total;
+
+      // Preserve flavor.
+      if ( f.terms?.[0]?.flavor ) die.options.flavor = f.terms[0].flavor;
+    }
+
+    this.resetFormula();
   }
 }


### PR DESCRIPTION
re: #2254

Perhaps something that can be carried over to `DamageRoll`. I tested with making `DamageRoll` extend `BasicRoll` and found `preprocessFormula` to become entirely redundant.

![image](https://github.com/user-attachments/assets/bcb7a6db-b5af-4072-b233-0c51f779094f)

