### PR TITLE
[#2508] Add spell list filter to compendium browser

### DIFF
--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -1029,9 +1029,9 @@ export default class CompendiumBrowser extends foundry.applications.api.Handleba
 
     if ( sort ) {
       if ( sort === true ) sort = "name";
-      const sortFunc = foundry.utils.getType(sort) === "function" ? sort : (lhs, rhs) => {
-        return String(foundry.utils.getProperty(lhs, sort)).localeCompare(String(foundry.utils.getProperty(rhs, sort)));
-      };
+      const sortFunc = foundry.utils.getType(sort) === "function" ? sort : (lhs, rhs) =>
+        String(foundry.utils.getProperty(lhs, sort))
+          .localeCompare(String(foundry.utils.getProperty(rhs, sort)), game.i18n.lang);
       documents.sort(sortFunc);
     }
 


### PR DESCRIPTION
Adds a new filter for spells to the Compendium Browser that allows filtering by a specific spell list. This involves some tweaks to how spell lists are stored in the registry to allow for creating a list of all lists easily.

<img width="921" alt="Screenshot 2024-09-02 at 15 13 10" src="https://github.com/user-attachments/assets/a1933847-86d6-447d-b48f-7327cd77a134">

This new filter allows for easily finding all the spells for a specific class across all modules that register spell lists. It also allows doing things like finding spells that are on the spell list of one class but not on any others.

Closes #2508