### PR TITLE
[#3801] Automatically determine source book from module

### DIFF
--- a/module/applications/actor/api/base-config-sheet.mjs
+++ b/module/applications/actor/api/base-config-sheet.mjs
@@ -1,27 +1,15 @@
-const { DocumentSheetV2, HandlebarsApplicationMixin } = foundry.applications.api;
+import DocumentSheet5e from "../../api/document-sheet.mjs";
 
 /**
- * Base document sheet from which all system applications should be based.
+ * Base document sheet from which all actor configuration sheets should be based.
  */
-export default class BaseConfigSheet extends HandlebarsApplicationMixin(DocumentSheetV2) {
+export default class BaseConfigSheet extends DocumentSheet5e {
   /** @override */
   static DEFAULT_OPTIONS = {
-    classes: ["dnd5e2", "config-sheet"],
+    classes: ["config-sheet"],
     sheetConfig: false,
     form: {
       submitOnChange: true
     }
   };
-
-  /* -------------------------------------------- */
-  /*  Rendering                                   */
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  async _prepareContext(options) {
-    const context = await super._prepareContext(options);
-    context.CONFIG = CONFIG.DND5E;
-    context.inputs = { ...foundry.applications.fields, ...dnd5e.applications.fields };
-    return context;
-  }
 }

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -767,7 +767,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
         app = new ActorSensesConfig(this.actor);
         break;
       case "source":
-        app = new SourceConfig(this.actor);
+        app = new SourceConfig({ document: this.actor });
         break;
       case "type":
         app = new ActorTypeConfig(this.actor);

--- a/module/applications/api/document-sheet.mjs
+++ b/module/applications/api/document-sheet.mjs
@@ -1,0 +1,30 @@
+const { DocumentSheetV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+/**
+ * Base document sheet from which all document-based application should be based.
+ */
+export default class DocumentSheet5e extends HandlebarsApplicationMixin(DocumentSheetV2) {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["dnd5e2"]
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.CONFIG = CONFIG.DND5E;
+    context.inputs = { ...foundry.applications.fields, ...dnd5e.applications.fields };
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preparePartContext(partId, context, options) {
+    return { ...await super._preparePartContext(partId, context, options) };
+  }
+}

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -563,7 +563,7 @@ export default class ItemSheet5e extends ItemSheet {
         app = new ActorSensesConfig(this.item, { keyPath: "system.senses" });
         break;
       case "source":
-        app = new SourceConfig(this.item, { keyPath: "system.source" });
+        app = new SourceConfig({ document: this.item, keyPath: "system.source" });
         break;
       case "starting-equipment":
         app = new StartingEquipmentConfig(this.item);

--- a/module/applications/source-config.mjs
+++ b/module/applications/source-config.mjs
@@ -47,7 +47,7 @@ export default class SourceConfig extends DocumentSheet5e {
     const context = await super._prepareContext(options);
     context.buttons = [{ icon: "fa-regular fa-save", label: "Submit", type: "submit" }];
     context.data = foundry.utils.getProperty(this.document, this.options.keyPath);
-    context.fields = this.document.system.schema.getField(this.options.keyPath.replace("system.", "")).fields;
+    context.fields = this.document.system.schema.getField(this.options.keyPath.replace(/^system\./, "")).fields;
     context.keyPath = this.options.keyPath;
     context.source = foundry.utils.getProperty(this.document.toObject(), this.options.keyPath);
     context.sourceUuid = this.document._stats.compendiumSource;

--- a/module/applications/source-config.mjs
+++ b/module/applications/source-config.mjs
@@ -1,25 +1,41 @@
+import DocumentSheet5e from "./api/document-sheet.mjs";
+
 /**
  * Application for configuring the source data on actors and items.
  */
-export default class SourceConfig extends DocumentSheet {
-
-  /** @inheritDoc */
-  static get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["dnd5e", "source-config", "dialog"],
-      template: "systems/dnd5e/templates/apps/source-config.hbs",
-      width: 400,
-      height: "auto",
-      sheetConfig: false,
-      keyPath: "system.details.source"
-    });
-  }
+export default class SourceConfig extends DocumentSheet5e {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["source-config"],
+    sheetConfig: false,
+    position: {
+      width: 400
+    },
+    form: {
+      closeOnSubmit: true
+    },
+    keyPath: "system.details.source"
+  };
 
   /* -------------------------------------------- */
 
   /** @override */
+  static PARTS = {
+    source: {
+      template: "systems/dnd5e/templates/apps/source-config.hbs"
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
   get title() {
-    return `${game.i18n.localize("DND5E.SourceConfig")}: ${this.document.name}`;
+    return game.i18n.localize("DND5E.SourceConfig");
   }
 
   /* -------------------------------------------- */
@@ -27,24 +43,15 @@ export default class SourceConfig extends DocumentSheet {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async getData(options) {
-    const context = super.getData(options);
-    context.appId = this.id;
-    context.CONFIG = CONFIG.DND5E;
-    context.source = foundry.utils.getProperty(this.document, this.options.keyPath);
-    context.sourceUuid = this.document._stats.compendiumSource
-      ?? foundry.utils.getProperty(this.document, "flags.core.sourceId");
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.buttons = [{ icon: "fa-regular fa-save", label: "Submit", type: "submit" }];
+    context.data = foundry.utils.getProperty(this.document, this.options.keyPath);
+    context.fields = this.document.system.schema.getField(this.options.keyPath.replace("system.", "")).fields;
+    context.keyPath = this.options.keyPath;
+    context.source = foundry.utils.getProperty(this.document.toObject(), this.options.keyPath);
+    context.sourceUuid = this.document._stats.compendiumSource;
     context.hasSourceId = !!(await fromUuid(context.sourceUuid));
     return context;
-  }
-
-  /* -------------------------------------------- */
-  /*  Event Handlers                              */
-  /* -------------------------------------------- */
-
-  /** @override */
-  async _updateObject(event, formData) {
-    const source = foundry.utils.expandObject(formData).source;
-    return this.document.update({[this.options.keyPath]: source});
   }
 }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3800,9 +3800,7 @@ preLocalize("tokenRings.effects");
  * List of books available as sources.
  * @enum {string}
  */
-DND5E.sourceBooks = {
-  "SRD 5.1": "SOURCE.BOOK.SRD"
-};
+DND5E.sourceBooks = {};
 preLocalize("sourceBooks", { sort: true });
 
 /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -38,7 +38,7 @@ const { BooleanField, NumberField, SchemaField, StringField } = foundry.data.fie
  * @property {string} details.environment        Common environments in which this NPC is found.
  * @property {number} details.cr                 NPC's challenge rating.
  * @property {number} details.spellLevel         Spellcasting level of this NPC.
- * @property {SourceField} details.source        Adventure or sourcebook where this NPC originated.
+ * @property {SourceData} details.source         Adventure or sourcebook where this NPC originated.
  * @property {object} resources
  * @property {object} resources.legact           NPC's legendary actions.
  * @property {number} resources.legact.value     Currently available legendary actions.
@@ -336,6 +336,7 @@ export default class NPCData extends CreatureTemplate {
     AttributesFields.prepareExhaustionLevel.call(this);
     AttributesFields.prepareMovement.call(this);
     AttributesFields.prepareConcentration.call(this, rollData);
+    SourceField.prepareData.call(this.details.source, this.parent._stats?.compendiumSource ?? this.parent.uuid);
     TraitsFields.prepareResistImmune.call(this);
 
     // Hit Dice

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -41,7 +41,7 @@ const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foun
  * @property {PassengerData[]} cargo.crew              Creatures responsible for operating the vehicle.
  * @property {PassengerData[]} cargo.passengers        Creatures just takin' a ride.
  * @property {object} details
- * @property {SourceField} details.source              Adventure or sourcebook where this vehicle originated.
+ * @property {SourceData} details.source               Adventure or sourcebook where this vehicle originated.
  */
 export default class VehicleData extends CommonTemplate {
 
@@ -167,6 +167,7 @@ export default class VehicleData extends CommonTemplate {
       (item.flags.dnd5e?.vehicleCargo === true) || !["weapon", "equipment"].includes(item.type)
     });
     AttributesFields.prepareHitPoints.call(this, this.attributes.hp);
+    SourceField.prepareData.call(this.details.source, this.parent._stats?.compendiumSource ?? this.parent.uuid);
   }
 }
 

--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -35,6 +35,14 @@ export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionT
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    this.prepareDescriptionData();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   async getSheetData(context) {
     context.subtitles = [{ label: context.itemType }];
     context.singleDescription = true;

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -84,6 +84,14 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    this.prepareDescriptionData();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   prepareFinalData() {
     this.isOriginalClass = this.parent.isOriginalClass;
     SpellcastingField.prepareData.call(this, this.parent.getRollData({ deterministic: true }));

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -133,6 +133,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
   prepareDerivedData() {
     ActivitiesTemplate._applyActivityShims.call(this);
     super.prepareDerivedData();
+    this.prepareDescriptionData();
     if ( !this.type.value ) return;
     const config = CONFIG.DND5E.consumableTypes[this.type.value];
     if ( config ) {

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -94,6 +94,14 @@ export default class ContainerData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    this.prepareDescriptionData();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   prepareFinalData() {
     this.prepareFinalEquippableData();
   }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -163,6 +163,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
   prepareDerivedData() {
     ActivitiesTemplate._applyActivityShims.call(this);
     super.prepareDerivedData();
+    this.prepareDescriptionData();
     this.armor.value = (this._source.armor.value ?? 0) + (this.magicAvailable ? (this.armor.magicalBonus ?? 0) : 0);
     this.type.label = CONFIG.DND5E.equipmentTypes[this.type.value]
       ?? game.i18n.localize(CONFIG.Item.typeLabels.equipment);

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -82,6 +82,7 @@ export default class FeatData extends ItemDataModel.mixin(
   prepareDerivedData() {
     ActivitiesTemplate._applyActivityShims.call(this);
     super.prepareDerivedData();
+    this.prepareDescriptionData();
 
     if ( this.type.value ) {
       const config = CONFIG.DND5E.featureTypes[this.type.value];

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -59,6 +59,7 @@ export default class LootData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.prepareDescriptionData();
     this.type.label = CONFIG.DND5E.lootTypes[this.type.value]?.label ?? game.i18n.localize(CONFIG.Item.typeLabels.loot);
   }
 

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -102,6 +102,14 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    this.prepareDescriptionData();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   async getSheetData(context) {
     context.subtitles = [{ label: context.itemType }];
     context.singleDescription = true;

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -166,6 +166,8 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     ActivitiesTemplate._applyActivityShims.call(this);
     this._applySpellShims();
     super.prepareDerivedData();
+    this.prepareDescriptionData();
+
     this.preparation.mode ||= "prepared";
     this.properties.add("mgc");
     this.duration.concentration = this.properties.has("concentration");

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -66,6 +66,14 @@ export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTem
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    this.prepareDescriptionData();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   prepareFinalData() {
     SpellcastingField.prepareData.call(this, this.parent.getRollData({ deterministic: true }));
   }

--- a/module/data/item/templates/item-description.mjs
+++ b/module/data/item/templates/item-description.mjs
@@ -9,7 +9,7 @@ const { SchemaField, HTMLField } = foundry.data.fields;
  * @property {object} description               Various item descriptions.
  * @property {string} description.value         Full item description.
  * @property {string} description.chat          Description displayed in chat card.
- * @property {SourceField} source               Adventure or sourcebook where this item originated.
+ * @property {SourceData} source                Adventure or sourcebook where this item originated.
  * @mixin
  */
 export default class ItemDescriptionTemplate extends SystemDataModel {
@@ -44,6 +44,18 @@ export default class ItemDescriptionTemplate extends SystemDataModel {
     if ( ("source" in source) && (foundry.utils.getType(source.source) !== "Object") ) {
       source.source = { custom: source.source };
     }
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the source label.
+   */
+  prepareDescriptionData() {
+    const uuid = this.parent.flags.dnd5e?.sourceId ?? this.parent._stats?.compendiumSource ?? this.parent.uuid;
+    SourceField.prepareData.call(this.source, uuid);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -99,6 +99,7 @@ export default class ToolData extends ItemDataModel.mixin(
   prepareDerivedData() {
     ActivitiesTemplate._applyActivityShims.call(this);
     super.prepareDerivedData();
+    this.prepareDescriptionData();
     this.type.label = CONFIG.DND5E.toolTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.tool);
   }
 

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -194,6 +194,7 @@ export default class WeaponData extends ItemDataModel.mixin(
   prepareDerivedData() {
     ActivitiesTemplate._applyActivityShims.call(this);
     super.prepareDerivedData();
+    this.prepareDescriptionData();
     this.type.label = CONFIG.DND5E.weaponTypes[this.type.value] ?? game.i18n.localize(CONFIG.Item.typeLabels.weapon);
 
     const labels = this.parent.labels ??= {};

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -1,6 +1,14 @@
 const { SchemaField, StringField } = foundry.data.fields;
 
 /**
+ * @typedef {object} SourceData
+ * @property {string} book     Book/publication where the item originated.
+ * @property {string} page     Page or section where the item can be found.
+ * @property {string} custom   Fully custom source label.
+ * @property {string} license  Type of license that covers this item.
+ */
+
+/**
  * Data fields that stores information on the adventure or sourcebook where this document originated.
  *
  * @property {string} book     Book/publication where the item originated.
@@ -22,27 +30,51 @@ export default class SourceField extends SchemaField {
   }
 
   /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
 
-  /** @inheritDoc */
-  initialize(value, model, options={}) {
-    const obj = super.initialize(value, model, options);
+  /**
+   * Prepare the source label.
+   * @this {SourceData}
+   * @param {string} uuid  Compendium source or document UUID.
+   */
+  static prepareData(uuid) {
+    this.bookPlaceholder = SourceField.getModuleBook(uuid) ?? "";
+    if ( !this.book ) this.book = this.bookPlaceholder;
 
-    Object.defineProperty(obj, "label", {
-      get() {
-        if ( this.custom ) return this.custom;
-        const page = Number.isNumeric(this.page)
-          ? game.i18n.format("DND5E.SourcePageDisplay", { page: this.page }) : this.page;
-        return game.i18n.format("DND5E.SourceDisplay", { book: this.book ?? "", page: page ?? "" }).trim();
-      },
+    if ( this.custom ) this.label = this.custom;
+    else {
+      const page = Number.isNumeric(this.page)
+        ? game.i18n.format("DND5E.SourcePageDisplay", { page: this.page }) : (this.page ?? "");
+      this.label = game.i18n.format("DND5E.SourceDisplay", { book: this.book, page }).trim();
+    }
+
+    Object.defineProperty(this, "directlyEditable", {
+      value: (this.custom ?? "") === this.label,
       enumerable: false
     });
-    Object.defineProperty(obj, "directlyEditable", {
-      get() {
-        return (this.custom ?? "") === this.label;
-      },
-      enumerable: false
-    });
+  }
 
-    return obj;
+  /* -------------------------------------------- */
+
+  /**
+   * Based on the provided UUID, find the associated system/module and check it if has any source books registered
+   * in its manifest. If it has only one, then return that book's key.
+   * @param {string} uuid  Compendium source or document UUID.
+   * @returns {string|null}
+   */
+  static getModuleBook(uuid) {
+    let manifest;
+    const pack = foundry.utils.parseUuid(uuid)?.collection?.metadata;
+    switch ( pack?.packageType ) {
+      case "module": manifest = game.modules.get(pack.packageName); break;
+      case "system": manifest = game.system; break;
+      case "world": manifest = game.world; break;
+    }
+    if ( !manifest ) return null;
+    const sourceBooks = manifest.flags?.dnd5e?.sourceBooks;
+    const keys = Array.from(Object.keys(sourceBooks ?? {}));
+    if ( keys.length !== 1 ) return null;
+    return keys[0];
   }
 }

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -73,7 +73,7 @@ export default class SourceField extends SchemaField {
     }
     if ( !manifest ) return null;
     const sourceBooks = manifest.flags?.dnd5e?.sourceBooks;
-    const keys = Array.from(Object.keys(sourceBooks ?? {}));
+    const keys = Object.keys(sourceBooks ?? {});
     if ( keys.length !== 1 ) return null;
     return keys[0];
   }

--- a/module/module-registration.mjs
+++ b/module/module-registration.mjs
@@ -27,8 +27,8 @@ const methods = [registerSourceBooks, registerSpellLists];
  */
 function registerSourceBooks(manifest) {
   if ( !manifest.flags.dnd5e?.sourceBooks ) return;
-  Object.assign(CONFIG.DND5E.sourceBooks, manifest.flags.sourceBooks);
-  return "source book";
+  Object.assign(CONFIG.DND5E.sourceBooks, manifest.flags.dnd5e.sourceBooks);
+  return "source books";
 }
 
 /* -------------------------------------------- */

--- a/system.json
+++ b/system.json
@@ -341,6 +341,9 @@
   "background": "systems/dnd5e/ui/official/dnd5e-background.webp",
   "flags": {
     "dnd5e": {
+      "sourceBooks": {
+        "SRD 5.1": "SOURCE.BOOK.SRD"
+      },
       "spellLists": [
         "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.ziBzRlrpBm1KVV0j",
         "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.cuG9d7J9fQH9InYT",

--- a/templates/apps/source-config.hbs
+++ b/templates/apps/source-config.hbs
@@ -1,5 +1,5 @@
 <fieldset>
-    <legend>{{ localize "DND5E.Source" }}</legend>{{log this}}
+    <legend>{{ localize "DND5E.Source" }}</legend>
     <div class="form-group">
         <label>{{ localize "DND5E.SourceBook" }}</label>
         <div class="form-fields">

--- a/templates/apps/source-config.hbs
+++ b/templates/apps/source-config.hbs
@@ -1,32 +1,24 @@
-<form autocomplete="off">
+<fieldset>
+    <legend>{{ localize "DND5E.Source" }}</legend>{{log this}}
     <div class="form-group">
-        <label>{{localize "DND5E.SourceBook"}}</label>
-        <input type="text" name="source.book" value="{{source.book}}" list="{{appId}}-books">
-        <datalist id="{{appId}}-books">
-            {{#each CONFIG.sourceBooks as |label key|}}
-            <option value="{{key}}">{{label}}</option>
-            {{/each}}
-        </datalist>
+        <label>{{ localize "DND5E.SourceBook" }}</label>
+        <div class="form-fields">
+            <input type="text" name="{{ keyPath }}.book" value="{{ source.book }}" list="{{ partId }}-books"
+                   placeholder="{{ data.bookPlaceholder }}">
+            <datalist id="{{ partId }}-books">
+                {{ selectOptions CONFIG.sourceBooks }}
+            </datalist>
+        </div>
     </div>
-    <div class="form-group">
-        <label>{{localize "DND5E.SourcePage"}}</label>
-        <input type="text" name="source.page" value="{{source.page}}">
-    </div>
-    <div class="form-group">
-        <label>{{localize "DND5E.SourceCustom"}}</label>
-        <input type="text" name="source.custom" value="{{source.custom}}">
-    </div>
-    <div class="form-group">
-        <label>{{localize "DND5E.SourceLicense"}}</label>
-        <input type="text" name="source.license" value="{{source.license}}">
-    </div>
+    {{ formField fields.page value=source.page label="DND5E.SourcePage" localize=true }}
+    {{ formField fields.custom value=source.custom label="DND5E.SourceCustom" localize=true }}
+    {{ formField fields.license value=source.license label="DND5E.SourceLicense" localize=true }}
     {{#if hasSourceId}}
     <div class="form-group">
-        <label>{{localize "DND5E.SourceUUID"}}</label>
+        <label>{{ localize "DND5E.SourceUUID" }}</label>
         <div class="source-uuid">
-            {{{dnd5e-linkForUuid sourceUuid}}}
+            {{{ dnd5e-linkForUuid sourceUuid }}}
         </div>
     </div>
     {{/if}}
-    <button type="submit"><i class="far fa-save"></i> {{ localize "Submit"}}</button>
-</form>
+</fieldset>


### PR DESCRIPTION
Uses the new `sourceBooks` manifest flag to automatically select the proper source book to use for source labels if no source book is specified. This only works for documents in compendiums (or imported from compendiums) for modules that define a single source book.

Also re-designs the source configuration app using ApplicationV2.

<img width="418" alt="Screenshot 2024-09-02 at 16 36 41" src="https://github.com/user-attachments/assets/9e49bf98-e7f6-4d88-8bc5-d903abfd2f64">

Closes #3801