### PR TITLE
[#3914] Fix enchanted damage types into activities

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -177,7 +177,7 @@ export default class AttackActivityData extends BaseActivityData {
   /** @inheritDoc */
   prepareFinalData(rollData) {
     if ( this.damage.includeBase && this.item.system.offersBaseDamage && this.item.system.damage.base.formula ) {
-      const basePart = this.item.system.damage.base.clone();
+      const basePart = this.item.system.damage.base.clone(this.item.system.damage.base.toObject(false));
       basePart.base = true;
       basePart.locked = true;
       this.damage.parts.unshift(basePart);

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -171,7 +171,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
       ...this.physicalItemSheetFields
     ];
     context.damageTypes = Object.entries(CONFIG.DND5E.damageTypes).map(([value, { label }]) => {
-      return { value, label, selected: this.damage.base.types.has(value) };
+      return { value, label, selected: context.source.damage.base.types.includes(value) };
     });
     context.denominationOptions = [
       { value: "", label: "" },

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -267,7 +267,7 @@ export default class WeaponData extends ItemDataModel.mixin(
 
     // Damage
     context.damageTypes = Object.entries(CONFIG.DND5E.damageTypes).map(([value, { label }]) => {
-      return { value, label, selected: this.damage.base.types.has(value) };
+      return { value, label, selected: context.source.damage.base.types.includes(value) };
     });
     const makeDenominationOptions = placeholder => [
       { value: "", label: placeholder ? `d${placeholder}` : "" },


### PR DESCRIPTION
Uses source data rather than system data for displaying damage types on weapons & armor to avoid polluting base data with enchantment data.

Ensures that the damage clone created for the attack activity includes changes caused by enchantments.