### PR TITLE
Clean up a number of issues with SRD items

### DIFF
--- a/packs/_source/items/ammunition/arrow-1.json
+++ b/packs/_source/items/ammunition/arrow-1.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -59,85 +60,7 @@
       "mgc"
     ],
     "magicalBonus": 1,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -153,7 +76,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037306998,
-    "modifiedTime": 1725037306998,
+    "modifiedTime": 1725040432395,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!tEWhsb2lYF4uvF0z"

--- a/packs/_source/items/ammunition/arrow-2.json
+++ b/packs/_source/items/ammunition/arrow-2.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -59,85 +60,7 @@
       "mgc"
     ],
     "magicalBonus": 2,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -153,7 +76,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037251067,
-    "modifiedTime": 1725037251067,
+    "modifiedTime": 1725040437796,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!gLkbbUtGhQgYANM8"

--- a/packs/_source/items/ammunition/arrow-3.json
+++ b/packs/_source/items/ammunition/arrow-3.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -59,85 +60,7 @@
       "mgc"
     ],
     "magicalBonus": 3,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -153,7 +76,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037156033,
-    "modifiedTime": 1725037156033,
+    "modifiedTime": 1725040442922,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!IY5PveXrF7VoFlWg"

--- a/packs/_source/items/ammunition/arrow-of-slaying.json
+++ b/packs/_source/items/ammunition/arrow-of-slaying.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -60,83 +61,6 @@
     ],
     "magicalBonus": null,
     "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      },
       "dnd5eactivity100": {
         "_id": "dnd5eactivity100",
         "type": "save",
@@ -160,13 +84,13 @@
         "duration": {
           "concentration": false,
           "value": "",
-          "units": "",
+          "units": "inst",
           "special": "",
           "override": false
         },
         "effects": [],
         "range": {
-          "units": "",
+          "units": "self",
           "special": "",
           "override": false
         },
@@ -191,7 +115,20 @@
         },
         "damage": {
           "onSave": "half",
-          "parts": []
+          "parts": [
+            {
+              "custom": {
+                "enabled": false,
+                "formula": ""
+              },
+              "number": 6,
+              "denomination": "10",
+              "bonus": "",
+              "types": [
+                "piercing"
+              ]
+            }
+          ]
         },
         "save": {
           "ability": "con",
@@ -202,73 +139,13 @@
         },
         "uses": {
           "spent": 0,
-          "recovery": []
+          "recovery": [],
+          "max": ""
         },
-        "sort": 0
-      },
-      "dnd5eactivity300": {
-        "_id": "dnd5eactivity300",
-        "type": "utility",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "roll": {
-          "formula": "6d10",
-          "name": "",
-          "prompt": false,
-          "visible": false
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
+        "sort": 0,
+        "name": "",
+        "img": "",
+        "appliedEffects": []
       }
     },
     "attuned": false
@@ -286,7 +163,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037223206,
-    "modifiedTime": 1725037223206,
+    "modifiedTime": 1725040480903,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!aXsfZvDCdpuv3Yvb"

--- a/packs/_source/items/ammunition/arrow.json
+++ b/packs/_source/items/ammunition/arrow.json
@@ -36,11 +36,9 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "bonus": "",
-        "types": [
-          "piercing"
-        ],
+        "types": [],
         "custom": {
           "enabled": false,
           "formula": ""
@@ -63,86 +61,7 @@
     "container": null,
     "properties": [],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "value": "5",
-          "units": "ft",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -158,7 +77,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037094986,
-    "modifiedTime": 1725037094986,
+    "modifiedTime": 1725040423223,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!3c7JXOzsv55gqJS5"

--- a/packs/_source/items/ammunition/blowgun-needle.json
+++ b/packs/_source/items/ammunition/blowgun-needle.json
@@ -36,11 +36,9 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "bonus": "",
-        "types": [
-          "piercing"
-        ],
+        "types": [],
         "custom": {
           "enabled": false,
           "formula": ""
@@ -63,86 +61,7 @@
     "container": null,
     "properties": [],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "value": "5",
-          "units": "ft",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -158,7 +77,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037250790,
-    "modifiedTime": 1725037250790,
+    "modifiedTime": 1725040489262,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!gBQ8xqTA5f8wP5iu"

--- a/packs/_source/items/ammunition/bolt-of-slaying.json
+++ b/packs/_source/items/ammunition/bolt-of-slaying.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -60,83 +61,6 @@
     ],
     "magicalBonus": null,
     "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      },
       "dnd5eactivity100": {
         "_id": "dnd5eactivity100",
         "type": "save",
@@ -160,13 +84,13 @@
         "duration": {
           "concentration": false,
           "value": "",
-          "units": "",
+          "units": "inst",
           "special": "",
           "override": false
         },
         "effects": [],
         "range": {
-          "units": "",
+          "units": "self",
           "special": "",
           "override": false
         },
@@ -191,7 +115,20 @@
         },
         "damage": {
           "onSave": "half",
-          "parts": []
+          "parts": [
+            {
+              "custom": {
+                "enabled": false,
+                "formula": ""
+              },
+              "number": 6,
+              "denomination": "10",
+              "bonus": "",
+              "types": [
+                "piercing"
+              ]
+            }
+          ]
         },
         "save": {
           "ability": "con",
@@ -202,73 +139,13 @@
         },
         "uses": {
           "spent": 0,
-          "recovery": []
+          "recovery": [],
+          "max": ""
         },
-        "sort": 0
-      },
-      "dnd5eactivity300": {
-        "_id": "dnd5eactivity300",
-        "type": "utility",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "roll": {
-          "formula": "6d10",
-          "name": "",
-          "prompt": false,
-          "visible": false
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
+        "sort": 0,
+        "name": "",
+        "img": "",
+        "appliedEffects": []
       }
     },
     "attuned": false
@@ -286,7 +163,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037105483,
-    "modifiedTime": 1725037105483,
+    "modifiedTime": 1725040508575,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!6OIw31CDF6mAwFnd"

--- a/packs/_source/items/ammunition/crossbow-bolt-1.json
+++ b/packs/_source/items/ammunition/crossbow-bolt-1.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -59,86 +60,7 @@
       "mgc"
     ],
     "magicalBonus": 1,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "value": "5",
-          "units": "ft",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -154,7 +76,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037219793,
-    "modifiedTime": 1725037219793,
+    "modifiedTime": 1725040518072,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ZjUOHSyND2VFXQeP"

--- a/packs/_source/items/ammunition/crossbow-bolt-2.json
+++ b/packs/_source/items/ammunition/crossbow-bolt-2.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -59,86 +60,7 @@
       "mgc"
     ],
     "magicalBonus": 2,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "value": "5",
-          "units": "ft",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -154,7 +76,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037321294,
-    "modifiedTime": 1725037321294,
+    "modifiedTime": 1725040521753,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!x1GUgZYjMubaFavx"

--- a/packs/_source/items/ammunition/crossbow-bolt-3.json
+++ b/packs/_source/items/ammunition/crossbow-bolt-3.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -59,86 +60,7 @@
       "mgc"
     ],
     "magicalBonus": 3,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "value": "5",
-          "units": "ft",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -154,7 +76,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037210402,
-    "modifiedTime": 1725037210402,
+    "modifiedTime": 1725040525196,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!XXLznzi3rlanMhTM"

--- a/packs/_source/items/ammunition/crossbow-bolt.json
+++ b/packs/_source/items/ammunition/crossbow-bolt.json
@@ -36,11 +36,9 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "bonus": "",
-        "types": [
-          "piercing"
-        ],
+        "types": [],
         "custom": {
           "enabled": false,
           "formula": ""
@@ -63,86 +61,7 @@
     "container": null,
     "properties": [],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "value": "5",
-          "units": "ft",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -158,7 +77,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037189012,
-    "modifiedTime": 1725037189012,
+    "modifiedTime": 1725040512898,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!SItCnYBqhzqBoaWG"

--- a/packs/_source/items/ammunition/sling-bullet-1.json
+++ b/packs/_source/items/ammunition/sling-bullet-1.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -59,85 +60,7 @@
       "mgc"
     ],
     "magicalBonus": 1,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -153,7 +76,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037174203,
-    "modifiedTime": 1725037174203,
+    "modifiedTime": 1725040536377,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!NYIib9KEYDUFe9GY"

--- a/packs/_source/items/ammunition/sling-bullet-2.json
+++ b/packs/_source/items/ammunition/sling-bullet-2.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -59,85 +60,7 @@
       "mgc"
     ],
     "magicalBonus": 2,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -153,7 +76,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037123793,
-    "modifiedTime": 1725037123793,
+    "modifiedTime": 1725040538979,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!BNJmdttKvIwC08Pd"

--- a/packs/_source/items/ammunition/sling-bullet-3.json
+++ b/packs/_source/items/ammunition/sling-bullet-3.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -59,85 +60,7 @@
       "mgc"
     ],
     "magicalBonus": 3,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -153,7 +76,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037321814,
-    "modifiedTime": 1725037321814,
+    "modifiedTime": 1725040542197,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!x9I9vdo4kafHDjcO"

--- a/packs/_source/items/ammunition/sling-bullet-of-slaying.json
+++ b/packs/_source/items/ammunition/sling-bullet-of-slaying.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -60,83 +61,6 @@
     ],
     "magicalBonus": null,
     "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      },
       "dnd5eactivity100": {
         "_id": "dnd5eactivity100",
         "type": "save",
@@ -160,13 +84,13 @@
         "duration": {
           "concentration": false,
           "value": "",
-          "units": "",
+          "units": "inst",
           "special": "",
           "override": false
         },
         "effects": [],
         "range": {
-          "units": "",
+          "units": "self",
           "special": "",
           "override": false
         },
@@ -191,7 +115,20 @@
         },
         "damage": {
           "onSave": "half",
-          "parts": []
+          "parts": [
+            {
+              "custom": {
+                "enabled": false,
+                "formula": ""
+              },
+              "number": 6,
+              "denomination": "10",
+              "bonus": "",
+              "types": [
+                "piercing"
+              ]
+            }
+          ]
         },
         "save": {
           "ability": "con",
@@ -202,73 +139,13 @@
         },
         "uses": {
           "spent": 0,
-          "recovery": []
+          "recovery": [],
+          "max": ""
         },
-        "sort": 0
-      },
-      "dnd5eactivity300": {
-        "_id": "dnd5eactivity300",
-        "type": "utility",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "roll": {
-          "formula": "6d10",
-          "name": "",
-          "prompt": false,
-          "visible": false
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
+        "sort": 0,
+        "name": "",
+        "img": "",
+        "appliedEffects": []
       }
     },
     "attuned": false
@@ -286,7 +163,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037171579,
-    "modifiedTime": 1725037171579,
+    "modifiedTime": 1725040557836,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!Mj8fTo5VZKJJ7uMv"

--- a/packs/_source/items/ammunition/sling-bullet.json
+++ b/packs/_source/items/ammunition/sling-bullet.json
@@ -36,14 +36,15 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       },
       "replace": false
     },
@@ -57,86 +58,7 @@
     "container": null,
     "properties": [],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "value": "30",
-          "units": "ft",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "ranged",
-            "classification": "weapon"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -152,7 +74,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037328642,
-    "modifiedTime": 1725037328642,
+    "modifiedTime": 1725040532510,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!z9SbsMIBZzuhZOqT"

--- a/packs/_source/items/armor/demon-armor.json
+++ b/packs/_source/items/armor/demon-armor.json
@@ -87,7 +87,7 @@
         "duration": {
           "concentration": false,
           "value": "",
-          "units": "",
+          "units": "inst",
           "special": "",
           "override": false
         },
@@ -136,29 +136,28 @@
           "includeBase": true,
           "parts": [
             {
-              "number": null,
-              "denomination": null,
-              "bonus": "",
+              "custom": {
+                "enabled": false,
+                "formula": ""
+              },
+              "number": 1,
+              "denomination": "8",
+              "bonus": "@mod + 1",
               "types": [
                 "slashing"
-              ],
-              "custom": {
-                "enabled": true,
-                "formula": "1d8 + @mod +1"
-              },
-              "scaling": {
-                "mode": "whole",
-                "number": null,
-                "formula": ""
-              }
+              ]
             }
           ]
         },
         "uses": {
           "spent": 0,
-          "recovery": []
+          "recovery": [],
+          "max": ""
         },
-        "sort": 0
+        "sort": 0,
+        "name": "",
+        "img": "",
+        "appliedEffects": []
       }
     },
     "attuned": false
@@ -176,7 +175,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037243508,
-    "modifiedTime": 1725037243508,
+    "modifiedTime": 1725040657095,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ejEt6hLQxOux04lS"

--- a/packs/_source/items/armor/dragon-scale-mail.json
+++ b/packs/_source/items/armor/dragon-scale-mail.json
@@ -5,7 +5,7 @@
   "img": "icons/equipment/chest/breastplate-banded-steel.webp",
   "system": {
     "description": {
-      "value": "<p><em>(Requires attunement)</em></p>\n<p>Dragon Scale Mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued.</p>\n<p>While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and Breath Weapons of dragons, and you have resistance to one damage type that is determined by the kind of dragon that provided the scales (see the table).</p>\n<p>Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest dragon within 30 miles of you that is of the same type as the armor. This special action can't be used again until the next dawn.</p>\n<table border=\"1\">\n<tbody>\n<tr>\n<td><strong>Dragon</strong></td>\n<td><strong>Resistance</strong></td>\n</tr>\n<tr>\n<td>Black</td>\n<td>Acid</td>\n</tr>\n<tr>\n<td>Blue</td>\n<td>Lightning</td>\n</tr>\n<tr>\n<td>Brass</td>\n<td>Fire</td>\n</tr>\n<tr>\n<td>Bronze</td>\n<td>Lightning</td>\n</tr>\n<tr>\n<td>Copper</td>\n<td>Acid</td>\n</tr>\n<tr>\n<td>Gold</td>\n<td>Fire</td>\n</tr>\n<tr>\n<td>Green</td>\n<td>Poison</td>\n</tr>\n<tr>\n<td>Red</td>\n<td>Fire</td>\n</tr>\n<tr>\n<td>Silver</td>\n<td>Cold</td>\n</tr>\n<tr>\n<td>White</td>\n<td>Cold</td>\n</tr>\n</tbody>\n</table>",
+      "value": "<p><em>(Requires attunement)</em></p><p>Dragon Scale Mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued.</p><p>While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and Breath Weapons of dragons, and you have resistance to one damage type that is determined by the kind of dragon that provided the scales (see the table).</p><p>Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest dragon within 30 miles of you that is of the same type as the armor. This special action can't be used again until the next dawn.</p><table><thead><tr><th><p><strong>Dragon</strong></p></th><th><p><strong>Resistance</strong></p></th></tr></thead><tbody><tr><td><p>Black</p></td><td><p>Acid</p></td></tr><tr><td><p>Blue</p></td><td><p>Lightning</p></td></tr><tr><td><p>Brass</p></td><td><p>Fire</p></td></tr><tr><td><p>Bronze</p></td><td><p>Lightning</p></td></tr><tr><td><p>Copper</p></td><td><p>Acid</p></td></tr><tr><td><p>Gold</p></td><td><p>Fire</p></td></tr><tr><td><p>Green</p></td><td><p>Poison</p></td></tr><tr><td><p>Red</p></td><td><p>Fire</p></td></tr><tr><td><p>Silver</p></td><td><p>Cold</p></td></tr><tr><td><p>White</p></td><td><p>Cold</p></td></tr></tbody></table>",
       "chat": ""
     },
     "source": {
@@ -160,7 +160,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037308134,
-    "modifiedTime": 1725037308134,
+    "modifiedTime": 1725040743758,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!tIwoSAGJlcuyiwaQ"

--- a/packs/_source/items/armor/elven-chain.json
+++ b/packs/_source/items/armor/elven-chain.json
@@ -49,7 +49,7 @@
       "conditions": ""
     },
     "strength": null,
-    "proficient": null,
+    "proficient": 1,
     "type": {
       "value": "medium",
       "baseItem": "chainshirt"
@@ -78,7 +78,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037102426,
-    "modifiedTime": 1725037102426,
+    "modifiedTime": 1725040756785,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!6067acDZGv7KNOkP"

--- a/packs/_source/items/poison/basic-poison.json
+++ b/packs/_source/items/poison/basic-poison.json
@@ -165,8 +165,8 @@
     "attuned": false
   },
   "effects": [],
-  "folder": "gyBZp72zKb56Da84",
-  "sort": 0,
+  "folder": "ZzUfnm1OuSL02nLG",
+  "sort": 200000,
   "ownership": {
     "default": 0
   },
@@ -177,7 +177,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037241703,
-    "modifiedTime": 1725037241703,
+    "modifiedTime": 1725040923889,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!eVbPkYjpl29RE2uW"

--- a/packs/_source/items/poison/potion-of-poison.json
+++ b/packs/_source/items/poison/potion-of-poison.json
@@ -162,87 +162,13 @@
           "recovery": []
         },
         "sort": 0
-      },
-      "dnd5eactivity300": {
-        "_id": "dnd5eactivity300",
-        "type": "utility",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "spec",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "touch",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "1",
-            "type": "creature",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "roll": {
-          "formula": "1d6",
-          "name": "",
-          "prompt": false,
-          "visible": false
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
       }
     },
     "attuned": false
   },
   "effects": [],
   "folder": "ZzUfnm1OuSL02nLG",
-  "sort": 0,
+  "sort": 300000,
   "ownership": {
     "default": 0
   },
@@ -253,7 +179,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037292318,
-    "modifiedTime": 1725037292318,
+    "modifiedTime": 1725040923889,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!qBSEGJyHxdKIlBfj"

--- a/packs/_source/items/poison/truth-serum.json
+++ b/packs/_source/items/poison/truth-serum.json
@@ -57,85 +57,76 @@
     "properties": [],
     "magicalBonus": null,
     "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "utility",
+      "IXiAkr30YyhobMw8": {
+        "type": "save",
+        "_id": "IXiAkr30YyhobMw8",
         "activation": {
           "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
+          "value": null,
+          "override": false,
+          "condition": ""
         },
         "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
           "scaling": {
-            "allowed": false,
-            "max": ""
+            "allowed": false
           },
-          "spellSlot": true
+          "spellSlot": true,
+          "targets": []
         },
         "description": {
           "chatFlavor": ""
         },
         "duration": {
+          "units": "inst",
           "concentration": false,
-          "value": "1",
-          "units": "hour",
-          "special": "",
           "override": false
         },
         "effects": [],
         "range": {
-          "units": "",
-          "special": "",
-          "override": false
+          "override": false,
+          "units": "self",
+          "special": ""
         },
         "target": {
           "template": {
-            "count": "",
             "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
+            "units": "ft",
+            "type": ""
           },
           "affects": {
-            "count": "",
-            "type": "self",
             "choice": false,
-            "special": ""
+            "count": "",
+            "type": ""
           },
-          "prompt": true,
-          "override": false
-        },
-        "roll": {
-          "formula": "",
-          "name": "",
-          "prompt": false,
-          "visible": false
+          "override": false,
+          "prompt": true
         },
         "uses": {
           "spent": 0,
-          "recovery": []
+          "recovery": [],
+          "max": ""
         },
-        "sort": 0
+        "sort": 0,
+        "damage": {
+          "parts": [],
+          "onSave": "half"
+        },
+        "save": {
+          "ability": "con",
+          "dc": {
+            "calculation": "",
+            "formula": "11"
+          }
+        },
+        "name": "",
+        "img": "",
+        "appliedEffects": []
       }
     },
     "attuned": false
   },
   "effects": [],
-  "sort": 0,
+  "sort": 100000,
   "flags": {},
   "_id": "a86F565Pjdzym1jH",
   "folder": "ZzUfnm1OuSL02nLG",
@@ -148,7 +139,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037220965,
-    "modifiedTime": 1725037220965,
+    "modifiedTime": 1725040923889,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!a86F565Pjdzym1jH"

--- a/packs/_source/items/scroll/spell-scroll-1st-level.json
+++ b/packs/_source/items/scroll/spell-scroll-1st-level.json
@@ -59,95 +59,7 @@
       "mgc"
     ],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Spell must be on the caster's spell list.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "5",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "melee",
-            "classification": "spell"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -163,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037117038,
-    "modifiedTime": 1725037117038,
+    "modifiedTime": 1725040984094,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!9GSfMg0VOA2b4uFN"

--- a/packs/_source/items/scroll/spell-scroll-2nd-level.json
+++ b/packs/_source/items/scroll/spell-scroll-2nd-level.json
@@ -59,95 +59,7 @@
       "mgc"
     ],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Spell must be on the caster's spell list.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "5",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "melee",
-            "classification": "spell"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -163,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037211680,
-    "modifiedTime": 1725037211680,
+    "modifiedTime": 1725040991299,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!XdDp6CKh9qEvPTuS"

--- a/packs/_source/items/scroll/spell-scroll-3rd-level.json
+++ b/packs/_source/items/scroll/spell-scroll-3rd-level.json
@@ -59,95 +59,7 @@
       "mgc"
     ],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Spell must be on the caster's spell list.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "7",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "melee",
-            "classification": "spell"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -163,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037258142,
-    "modifiedTime": 1725037258142,
+    "modifiedTime": 1725040995188,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!hqVKZie7x9w3Kqds"

--- a/packs/_source/items/scroll/spell-scroll-4th-level.json
+++ b/packs/_source/items/scroll/spell-scroll-4th-level.json
@@ -59,95 +59,7 @@
       "mgc"
     ],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Spell must be on the caster's spell list.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "7",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "melee",
-            "classification": "spell"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -163,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037130829,
-    "modifiedTime": 1725037130829,
+    "modifiedTime": 1725040997697,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!DM7hzgL836ZyUFB1"

--- a/packs/_source/items/scroll/spell-scroll-5th-level.json
+++ b/packs/_source/items/scroll/spell-scroll-5th-level.json
@@ -59,95 +59,7 @@
       "mgc"
     ],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Spell must be on the caster's spell list.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "9",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "melee",
-            "classification": "spell"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -163,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037318835,
-    "modifiedTime": 1725037318835,
+    "modifiedTime": 1725041000067,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!wa1VF8TXHmkrrR35"

--- a/packs/_source/items/scroll/spell-scroll-6th-level.json
+++ b/packs/_source/items/scroll/spell-scroll-6th-level.json
@@ -59,95 +59,7 @@
       "mgc"
     ],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Spell must be on the caster's spell list.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "9",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "melee",
-            "classification": "spell"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -163,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037307859,
-    "modifiedTime": 1725037307859,
+    "modifiedTime": 1725041002503,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!tI3rWx4bxefNCexS"

--- a/packs/_source/items/scroll/spell-scroll-7th-level.json
+++ b/packs/_source/items/scroll/spell-scroll-7th-level.json
@@ -59,95 +59,7 @@
       "mgc"
     ],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Spell must be on the caster's spell list.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "10",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "melee",
-            "classification": "spell"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -163,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037280230,
-    "modifiedTime": 1725037280230,
+    "modifiedTime": 1725041004869,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!mtyw4NS1s7j2EJaD"

--- a/packs/_source/items/scroll/spell-scroll-8th-level.json
+++ b/packs/_source/items/scroll/spell-scroll-8th-level.json
@@ -59,95 +59,7 @@
       "mgc"
     ],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Spell must be on the caster's spell list.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "10",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "melee",
-            "classification": "spell"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -163,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037222888,
-    "modifiedTime": 1725037222888,
+    "modifiedTime": 1725041007284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!aOrinPg7yuDZEuWr"

--- a/packs/_source/items/scroll/spell-scroll-9th-level.json
+++ b/packs/_source/items/scroll/spell-scroll-9th-level.json
@@ -59,95 +59,7 @@
       "mgc"
     ],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Spell must be on the caster's spell list.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "11",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "melee",
-            "classification": "spell"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -163,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037176222,
-    "modifiedTime": 1725037176222,
+    "modifiedTime": 1725041009885,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!O4YbkJkLlnsgUszZ"

--- a/packs/_source/items/scroll/spell-scroll-cantrip.json
+++ b/packs/_source/items/scroll/spell-scroll-cantrip.json
@@ -59,95 +59,7 @@
       "mgc"
     ],
     "magicalBonus": null,
-    "activities": {
-      "dnd5eactivity000": {
-        "_id": "dnd5eactivity000",
-        "type": "attack",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Spell must be on the caster's spell list.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "attack": {
-          "ability": "",
-          "bonus": "5",
-          "critical": {
-            "threshold": null
-          },
-          "flat": false,
-          "type": {
-            "value": "melee",
-            "classification": "spell"
-          }
-        },
-        "damage": {
-          "critical": {
-            "bonus": ""
-          },
-          "includeBase": true,
-          "parts": []
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      }
-    },
+    "activities": {},
     "attuned": false
   },
   "effects": [],
@@ -163,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037298555,
-    "modifiedTime": 1725037298555,
+    "modifiedTime": 1725041015288,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!rQ6sO7HDWzqMhSI3"

--- a/packs/_source/items/trinket/alchemy-jug.json
+++ b/packs/_source/items/trinket/alchemy-jug.json
@@ -129,7 +129,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 5300000,
   "ownership": {
     "default": 0
   },
@@ -140,7 +140,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037193569,
-    "modifiedTime": 1725037193569,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!TZggpdbOYqOCG7mY"

--- a/packs/_source/items/trinket/apparatus-of-the-crab.json
+++ b/packs/_source/items/trinket/apparatus-of-the-crab.json
@@ -129,7 +129,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 7800000,
   "ownership": {
     "default": 0
   },
@@ -140,7 +140,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037273984,
-    "modifiedTime": 1725037273984,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!lSd5QHnIJbKvP1bh"

--- a/packs/_source/items/trinket/bag-of-beans.json
+++ b/packs/_source/items/trinket/bag-of-beans.json
@@ -261,7 +261,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 3100000,
   "ownership": {
     "default": 0
   },
@@ -272,7 +272,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037141214,
-    "modifiedTime": 1725037141214,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!F8QpasPjLrw2POzE"

--- a/packs/_source/items/trinket/bag-of-tricks-grey.json
+++ b/packs/_source/items/trinket/bag-of-tricks-grey.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 1800000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037117348,
-    "modifiedTime": 1725037117348,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!9Ifr8fGvJ1bArzOW"

--- a/packs/_source/items/trinket/bag-of-tricks-rust.json
+++ b/packs/_source/items/trinket/bag-of-tricks-rust.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 2900000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037135128,
-    "modifiedTime": 1725037135128,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!DxIdfGoJEYQj8o3D"

--- a/packs/_source/items/trinket/bag-of-tricks-tan.json
+++ b/packs/_source/items/trinket/bag-of-tricks-tan.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 3900000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037166685,
-    "modifiedTime": 1725037166685,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!LHaqMvrx3PfSzWMQ"

--- a/packs/_source/items/trinket/ball-bearings.json
+++ b/packs/_source/items/trinket/ball-bearings.json
@@ -142,7 +142,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 800000,
   "ownership": {
     "default": 0
   },
@@ -153,7 +153,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037094429,
-    "modifiedTime": 1725037094429,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!3YSUIp4eFo26YxJr"

--- a/packs/_source/items/trinket/bead-of-force.json
+++ b/packs/_source/items/trinket/bead-of-force.json
@@ -220,7 +220,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 5100000,
   "ownership": {
     "default": 0
   },
@@ -231,7 +231,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037191006,
-    "modifiedTime": 1725037191006,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!SqTtbBCfiEsmZ36N"

--- a/packs/_source/items/trinket/block-and-tackle.json
+++ b/packs/_source/items/trinket/block-and-tackle.json
@@ -127,7 +127,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 7700000,
   "ownership": {
     "default": 0
   },
@@ -138,7 +138,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037266134,
-    "modifiedTime": 1725037266134,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!jlI44g90pp4VazBU"

--- a/packs/_source/items/trinket/bowl-of-commanding-water-elementals.json
+++ b/packs/_source/items/trinket/bowl-of-commanding-water-elementals.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 9200000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037298834,
-    "modifiedTime": 1725037298834,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!rRMaaGZ7qbzqMvoI"

--- a/packs/_source/items/trinket/brass-horn-of-valhalla.json
+++ b/packs/_source/items/trinket/brass-horn-of-valhalla.json
@@ -161,7 +161,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 4900000,
   "ownership": {
     "default": 0
   },
@@ -172,7 +172,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037184690,
-    "modifiedTime": 1725037184690,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!QYJyQCnIQeLiMrmJ"

--- a/packs/_source/items/trinket/brazier-of-commanding-fire-elementals.json
+++ b/packs/_source/items/trinket/brazier-of-commanding-fire-elementals.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 4500000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037177644,
-    "modifiedTime": 1725037177644,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!OcjcplcUWH07Kn9k"

--- a/packs/_source/items/trinket/bronze-horn-of-valhalla.json
+++ b/packs/_source/items/trinket/bronze-horn-of-valhalla.json
@@ -161,7 +161,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 9700000,
   "ownership": {
     "default": 0
   },
@@ -172,7 +172,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037304611,
-    "modifiedTime": 1725037304611,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!sqcerAMszpe3hwyI"

--- a/packs/_source/items/trinket/broom-of-flying.json
+++ b/packs/_source/items/trinket/broom-of-flying.json
@@ -130,7 +130,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 7100000,
   "ownership": {
     "default": 0
   },
@@ -141,7 +141,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037255100,
-    "modifiedTime": 1725037255100,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!hFAVm9pTJDm0nu3g"

--- a/packs/_source/items/trinket/bullseye-lantern.json
+++ b/packs/_source/items/trinket/bullseye-lantern.json
@@ -137,7 +137,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 5800000,
   "ownership": {
     "default": 0
   },
@@ -148,7 +148,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037198803,
-    "modifiedTime": 1725037198803,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!UkWdyJYQTfVX2cJW"

--- a/packs/_source/items/trinket/caltrops.json
+++ b/packs/_source/items/trinket/caltrops.json
@@ -166,7 +166,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 1700000,
   "ownership": {
     "default": 0
   },
@@ -177,7 +177,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037115906,
-    "modifiedTime": 1725037115906,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!8tvhh5wqG5FRh3Sf"

--- a/packs/_source/items/trinket/candle-of-invocation.json
+++ b/packs/_source/items/trinket/candle-of-invocation.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 6400000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037220102,
-    "modifiedTime": 1725037220102,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ZoUVmRA3HfAK2eZy"

--- a/packs/_source/items/trinket/candle.json
+++ b/packs/_source/items/trinket/candle.json
@@ -137,7 +137,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 100000,
   "ownership": {
     "default": 0
   },
@@ -148,7 +148,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037082489,
-    "modifiedTime": 1725037082489,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!0NoBBP3MMkvJlwZY"

--- a/packs/_source/items/trinket/carpet-of-flying-3x5.json
+++ b/packs/_source/items/trinket/carpet-of-flying-3x5.json
@@ -135,11 +135,11 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037212268,
-    "modifiedTime": 1725037212268,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 6300000,
   "ownership": {
     "default": 0
   },

--- a/packs/_source/items/trinket/carpet-of-flying-4x6.json
+++ b/packs/_source/items/trinket/carpet-of-flying-4x6.json
@@ -135,11 +135,11 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037133407,
-    "modifiedTime": 1725037133407,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 2700000,
   "ownership": {
     "default": 0
   },

--- a/packs/_source/items/trinket/carpet-of-flying-5x7.json
+++ b/packs/_source/items/trinket/carpet-of-flying-5x7.json
@@ -135,11 +135,11 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037208119,
-    "modifiedTime": 1725037208119,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 6100000,
   "ownership": {
     "default": 0
   },

--- a/packs/_source/items/trinket/carpet-of-flying-6x9.json
+++ b/packs/_source/items/trinket/carpet-of-flying-6x9.json
@@ -129,7 +129,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 5400000,
   "ownership": {
     "default": 0
   },
@@ -140,7 +140,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037194122,
-    "modifiedTime": 1725037194122,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!TjWk2mpNXjDdfIDM"

--- a/packs/_source/items/trinket/censer-of-controlling-air-elementals.json
+++ b/packs/_source/items/trinket/censer-of-controlling-air-elementals.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 9600000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037302560,
-    "modifiedTime": 1725037302560,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!sXEkkTDXWQDUMzsC"

--- a/packs/_source/items/trinket/chain-10-feet.json
+++ b/packs/_source/items/trinket/chain-10-feet.json
@@ -194,7 +194,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 3800000,
   "ownership": {
     "default": 0
   },
@@ -205,7 +205,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037160642,
-    "modifiedTime": 1725037160642,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!JvoufrTkSDMsS9Sm"

--- a/packs/_source/items/trinket/chime-of-opening.json
+++ b/packs/_source/items/trinket/chime-of-opening.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 10500000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037315479,
-    "modifiedTime": 1725037315479,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!vZdLYfHlLcZqQ8zc"

--- a/packs/_source/items/trinket/climbers-kit.json
+++ b/packs/_source/items/trinket/climbers-kit.json
@@ -127,7 +127,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 10400000,
   "ownership": {
     "default": 0
   },
@@ -138,7 +138,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037313885,
-    "modifiedTime": 1725037313885,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ugzwHl8vYaPu2GNd"

--- a/packs/_source/items/trinket/crystal-ball-of-mind-reading.json
+++ b/packs/_source/items/trinket/crystal-ball-of-mind-reading.json
@@ -134,7 +134,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 5600000,
   "ownership": {
     "default": 0
   },
@@ -145,7 +145,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037195309,
-    "modifiedTime": 1725037195309,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!TwYeck6buBZ602mg"

--- a/packs/_source/items/trinket/crystal-ball-of-telepathy.json
+++ b/packs/_source/items/trinket/crystal-ball-of-telepathy.json
@@ -149,7 +149,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 1200000,
   "ownership": {
     "default": 0
   },
@@ -160,7 +160,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037100710,
-    "modifiedTime": 1725037100710,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!5KiRtMMSTnJmMtBr"

--- a/packs/_source/items/trinket/crystal-ball-of-true-seeing.json
+++ b/packs/_source/items/trinket/crystal-ball-of-true-seeing.json
@@ -134,7 +134,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 2200000,
   "ownership": {
     "default": 0
   },
@@ -145,7 +145,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037122058,
-    "modifiedTime": 1725037122058,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ADH0UZ8bf7Op0dgf"

--- a/packs/_source/items/trinket/crystal-ball.json
+++ b/packs/_source/items/trinket/crystal-ball.json
@@ -134,7 +134,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 3600000,
   "ownership": {
     "default": 0
   },
@@ -145,7 +145,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037157737,
-    "modifiedTime": 1725037157737,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ItoGjtOtDOQ2noNM"

--- a/packs/_source/items/trinket/crystal.json
+++ b/packs/_source/items/trinket/crystal.json
@@ -57,14 +57,15 @@
       },
       "base": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "types": [],
         "custom": {
           "enabled": false
         },
         "scaling": {
           "number": 1
-        }
+        },
+        "bonus": ""
       }
     },
     "armor": {
@@ -157,11 +158,12 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
-  "folder": "MLMTCAvKsuFE3vYA",
-  "sort": 0,
+  "folder": "UnUwTG4YIgd0kaUJ",
+  "sort": 200000,
   "ownership": {
     "default": 0
   },
@@ -172,7 +174,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037313094,
-    "modifiedTime": 1725037313094,
+    "modifiedTime": 1725041129126,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!uXOT4fYbgPY8DGdd"

--- a/packs/_source/items/trinket/cube-of-force.json
+++ b/packs/_source/items/trinket/cube-of-force.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 9500000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037301147,
-    "modifiedTime": 1725037301147,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!s4fR8bxQGSt4wbH7"

--- a/packs/_source/items/trinket/cubic-gate.json
+++ b/packs/_source/items/trinket/cubic-gate.json
@@ -144,7 +144,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 1300000,
   "ownership": {
     "default": 0
   },
@@ -155,7 +155,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037106205,
-    "modifiedTime": 1725037106205,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!6ai1pEde3iQX30Fr"

--- a/packs/_source/items/trinket/decanter-of-endless-water.json
+++ b/packs/_source/items/trinket/decanter-of-endless-water.json
@@ -158,7 +158,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 9100000,
   "ownership": {
     "default": 0
   },
@@ -169,7 +169,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037295363,
-    "modifiedTime": 1725037295363,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!qXcUKfCVxEvV3VU8"

--- a/packs/_source/items/trinket/deck-of-illusions.json
+++ b/packs/_source/items/trinket/deck-of-illusions.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 100000,
+  "sort": 11300000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037205886,
-    "modifiedTime": 1725037205886,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!Wk7EOYoY3b2tgGoS"

--- a/packs/_source/items/trinket/deck-of-many-things.json
+++ b/packs/_source/items/trinket/deck-of-many-things.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 150000,
+  "sort": 11400000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037286639,
-    "modifiedTime": 1725037286639,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!oSarKEU8x1AupB6z"

--- a/packs/_source/items/trinket/dimensional-shackles.json
+++ b/packs/_source/items/trinket/dimensional-shackles.json
@@ -134,7 +134,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 10600000,
   "ownership": {
     "default": 0
   },
@@ -145,7 +145,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037318013,
-    "modifiedTime": 1725037318013,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!wGKykLRS8UqChNXI"

--- a/packs/_source/items/trinket/dust-of-disappearance.json
+++ b/packs/_source/items/trinket/dust-of-disappearance.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 6500000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037230098,
-    "modifiedTime": 1725037230098,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!cGUPm15mLfhGDz2b"

--- a/packs/_source/items/trinket/dust-of-dryness.json
+++ b/packs/_source/items/trinket/dust-of-dryness.json
@@ -168,7 +168,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 6900000,
   "ownership": {
     "default": 0
   },
@@ -179,7 +179,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037240323,
-    "modifiedTime": 1725037240323,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!eMR6B4bIoJPUDJG8"

--- a/packs/_source/items/trinket/dust-of-sneezing-and-choking.json
+++ b/packs/_source/items/trinket/dust-of-sneezing-and-choking.json
@@ -144,7 +144,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 1900000,
   "ownership": {
     "default": 0
   },
@@ -155,7 +155,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037119085,
-    "modifiedTime": 1725037119085,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!9eyZY9tL3fXD1Mbm"

--- a/packs/_source/items/trinket/efreeti-bottle.json
+++ b/packs/_source/items/trinket/efreeti-bottle.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 7000000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037248493,
-    "modifiedTime": 1725037248493,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!fbcQsOgWCjhEAGY7"

--- a/packs/_source/items/trinket/elemental-gem-of-air.json
+++ b/packs/_source/items/trinket/elemental-gem-of-air.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 11100000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037329426,
-    "modifiedTime": 1725037329426,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!zDJ4oEt5HArN1xmP"

--- a/packs/_source/items/trinket/elemental-gem-of-earth.json
+++ b/packs/_source/items/trinket/elemental-gem-of-earth.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 3500000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037155444,
-    "modifiedTime": 1725037155444,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!IGwDN9gtYxCrlrCr"

--- a/packs/_source/items/trinket/elemental-gem-of-fire.json
+++ b/packs/_source/items/trinket/elemental-gem-of-fire.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 6600000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037236532,
-    "modifiedTime": 1725037236532,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!dsjke4vPPsc9gsxH"

--- a/packs/_source/items/trinket/elemental-gem-of-water.json
+++ b/packs/_source/items/trinket/elemental-gem-of-water.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 3400000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037149770,
-    "modifiedTime": 1725037149770,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!HLEhnzLbpRbYdAHo"

--- a/packs/_source/items/trinket/eversmoking-bottle.json
+++ b/packs/_source/items/trinket/eversmoking-bottle.json
@@ -129,7 +129,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 2600000,
   "ownership": {
     "default": 0
   },
@@ -140,7 +140,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037129892,
-    "modifiedTime": 1725037129892,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!CvzjhUy9ekRieR1A"

--- a/packs/_source/items/trinket/feather-token-anchor.json
+++ b/packs/_source/items/trinket/feather-token-anchor.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 2800000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037134233,
-    "modifiedTime": 1725037134233,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!DnlQkH6Bpwkd5n5Y"

--- a/packs/_source/items/trinket/feather-token-bird.json
+++ b/packs/_source/items/trinket/feather-token-bird.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 7200000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037257011,
-    "modifiedTime": 1725037257011,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!hWqImieUaLo08l9l"

--- a/packs/_source/items/trinket/feather-token-fan.json
+++ b/packs/_source/items/trinket/feather-token-fan.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 6800000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037238323,
-    "modifiedTime": 1725037238323,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!e98hfROZjztt7ccO"

--- a/packs/_source/items/trinket/feather-token-swan-boat.json
+++ b/packs/_source/items/trinket/feather-token-swan-boat.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 5700000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037198518,
-    "modifiedTime": 1725037198518,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!UgnUJhu0tW1tLt7g"

--- a/packs/_source/items/trinket/feather-token-tree.json
+++ b/packs/_source/items/trinket/feather-token-tree.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 4400000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037175057,
-    "modifiedTime": 1725037175057,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!NjTgPn2o0M1TGk93"

--- a/packs/_source/items/trinket/feather-token-whip.json
+++ b/packs/_source/items/trinket/feather-token-whip.json
@@ -177,7 +177,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 3200000,
   "ownership": {
     "default": 0
   },
@@ -188,7 +188,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037143784,
-    "modifiedTime": 1725037143784,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!Fgkj11diTJJ7H3JC"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-bronze-griffon.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-bronze-griffon.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 2500000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037127840,
-    "modifiedTime": 1725037127840,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!CI58LNiwrTpmWYMp"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-ebony-fly.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-ebony-fly.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 9400000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037300878,
-    "modifiedTime": 1725037300878,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!s2kQs21J3cFg7ZSs"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-golden-lions.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-golden-lions.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 4300000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037171306,
-    "modifiedTime": 1725037171306,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!Minr6xegwoHFvAjG"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-ivory-goat-of-terror.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-ivory-goat-of-terror.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 1600000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037111549,
-    "modifiedTime": 1725037111549,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!8CaODbNQtxHGuVjn"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-ivory-goat-of-travail.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-ivory-goat-of-travail.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 900000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037097276,
-    "modifiedTime": 1725037097276,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!41kYCmKq0PbGVKaM"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-ivory-goat-of-traveling.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-ivory-goat-of-traveling.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 7500000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037260728,
-    "modifiedTime": 1725037260728,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!iLt7wTWr4cJnQulJ"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-marble-elephant.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-marble-elephant.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 3300000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037147446,
-    "modifiedTime": 1725037147446,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!GP2bvHlxVi30OEmo"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-obsidian-steed.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-obsidian-steed.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 4100000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037168990,
-    "modifiedTime": 1725037168990,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!M5qkJ7erLqWYUHa0"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-onyx-dog.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-onyx-dog.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 2000000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037119926,
-    "modifiedTime": 1725037119926,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!9nxSHbqlDdngtuuz"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-serpentine-owl.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-serpentine-owl.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 6200000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037208395,
-    "modifiedTime": 1725037208395,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!XEH5YErAN1WSytln"

--- a/packs/_source/items/trinket/figurine-of-wondrous-power-silver-raven.json
+++ b/packs/_source/items/trinket/figurine-of-wondrous-power-silver-raven.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 8300000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037281863,
-    "modifiedTime": 1725037281863,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!nMtmxeYrbyFdv0bg"

--- a/packs/_source/items/trinket/folding-boat.json
+++ b/packs/_source/items/trinket/folding-boat.json
@@ -129,7 +129,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 10300000,
   "ownership": {
     "default": 0
   },
@@ -140,7 +140,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037310887,
-    "modifiedTime": 1725037310887,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!u4ewpAFZjLrWrmQv"

--- a/packs/_source/items/trinket/gem-of-brightness.json
+++ b/packs/_source/items/trinket/gem-of-brightness.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 10100000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037309513,
-    "modifiedTime": 1725037309513,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!thkvJ5QBRORIwkkV"

--- a/packs/_source/items/trinket/gem-of-seeing.json
+++ b/packs/_source/items/trinket/gem-of-seeing.json
@@ -146,7 +146,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 7600000,
   "ownership": {
     "default": 0
   },
@@ -157,7 +157,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037264694,
-    "modifiedTime": 1725037264694,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!jJU8vFhHLQeKe2wu"

--- a/packs/_source/items/trinket/healers-kit.json
+++ b/packs/_source/items/trinket/healers-kit.json
@@ -137,7 +137,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 1400000,
   "ownership": {
     "default": 0
   },
@@ -148,7 +148,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037107694,
-    "modifiedTime": 1725037107694,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!6rocoBx5jdzG1QQH"

--- a/packs/_source/items/trinket/hempen-rope-50-ft.json
+++ b/packs/_source/items/trinket/hempen-rope-50-ft.json
@@ -214,7 +214,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 4800000,
   "ownership": {
     "default": 0
   },
@@ -225,7 +225,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037184390,
-    "modifiedTime": 1725037184390,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!QXmaarJ4X8P0C1HV"

--- a/packs/_source/items/trinket/hooded-lantern.json
+++ b/packs/_source/items/trinket/hooded-lantern.json
@@ -137,7 +137,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 10200000,
   "ownership": {
     "default": 0
   },
@@ -148,7 +148,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037309801,
-    "modifiedTime": 1725037309801,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!trmWAdUoR6Y2B7rA"

--- a/packs/_source/items/trinket/horn-of-blasting.json
+++ b/packs/_source/items/trinket/horn-of-blasting.json
@@ -222,7 +222,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 9900000,
   "ownership": {
     "default": 0
   },
@@ -233,7 +233,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037306138,
-    "modifiedTime": 1725037306138,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!t7GfyRp3dB3lqS9i"

--- a/packs/_source/items/trinket/horseshoes-of-a-zephyr.json
+++ b/packs/_source/items/trinket/horseshoes-of-a-zephyr.json
@@ -64,7 +64,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 600000,
   "ownership": {
     "default": 0
   },
@@ -75,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037090903,
-    "modifiedTime": 1725037090903,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!2mvXGvDmHHhzbT04"

--- a/packs/_source/items/trinket/horseshoes-of-speed.json
+++ b/packs/_source/items/trinket/horseshoes-of-speed.json
@@ -64,7 +64,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 8200000,
   "ownership": {
     "default": 0
   },
@@ -75,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037281026,
-    "modifiedTime": 1725037281026,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!nAqDwI9GyXS1diiz"

--- a/packs/_source/items/trinket/hunting-trap.json
+++ b/packs/_source/items/trinket/hunting-trap.json
@@ -257,7 +257,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 4000000,
   "ownership": {
     "default": 0
   },
@@ -268,7 +268,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037167567,
-    "modifiedTime": 1725037167567,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!LiOD83I4MIZlpoQQ"

--- a/packs/_source/items/trinket/instant-fortress.json
+++ b/packs/_source/items/trinket/instant-fortress.json
@@ -158,7 +158,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 2100000,
   "ownership": {
     "default": 0
   },
@@ -169,7 +169,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037120567,
-    "modifiedTime": 1725037120567,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!9stfX2i2I1YPo8vx"

--- a/packs/_source/items/trinket/iron-bands-of-binding.json
+++ b/packs/_source/items/trinket/iron-bands-of-binding.json
@@ -178,7 +178,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 3000000,
   "ownership": {
     "default": 0
   },
@@ -189,7 +189,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037136255,
-    "modifiedTime": 1725037136255,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!E9G4jALlSA96fKAN"

--- a/packs/_source/items/trinket/iron-flask.json
+++ b/packs/_source/items/trinket/iron-flask.json
@@ -135,7 +135,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 8000000,
   "ownership": {
     "default": 0
   },
@@ -146,7 +146,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037276543,
-    "modifiedTime": 1725037276543,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!lvLrkAR7k8DS7J3W"

--- a/packs/_source/items/trinket/iron-horn-of-valhalla.json
+++ b/packs/_source/items/trinket/iron-horn-of-valhalla.json
@@ -161,7 +161,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 9000000,
   "ownership": {
     "default": 0
   },
@@ -172,7 +172,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037294801,
-    "modifiedTime": 1725037294801,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!qVuZznv0MnIjDU70"

--- a/packs/_source/items/trinket/iron-spike.json
+++ b/packs/_source/items/trinket/iron-spike.json
@@ -137,7 +137,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 5000000,
   "ownership": {
     "default": 0
   },
@@ -148,7 +148,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037187242,
-    "modifiedTime": 1725037187242,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!RiOeHR2qaYktz5Ys"

--- a/packs/_source/items/trinket/lamp.json
+++ b/packs/_source/items/trinket/lamp.json
@@ -137,7 +137,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 8900000,
   "ownership": {
     "default": 0
   },
@@ -148,7 +148,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037293981,
-    "modifiedTime": 1725037293981,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!qMzHmlmha8qMDnEF"

--- a/packs/_source/items/trinket/lantern-of-revealing.json
+++ b/packs/_source/items/trinket/lantern-of-revealing.json
@@ -140,7 +140,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 1500000,
   "ownership": {
     "default": 0
   },
@@ -151,7 +151,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037108596,
-    "modifiedTime": 1725037108596,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!7FLs8qIGdOFnz9oL"

--- a/packs/_source/items/trinket/lock.json
+++ b/packs/_source/items/trinket/lock.json
@@ -214,7 +214,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 10900000,
   "ownership": {
     "default": 0
   },
@@ -225,7 +225,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037325128,
-    "modifiedTime": 1725037325128,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!xwUWrV15s9jLnmfZ"

--- a/packs/_source/items/trinket/manacles.json
+++ b/packs/_source/items/trinket/manacles.json
@@ -214,7 +214,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 10000000,
   "ownership": {
     "default": 0
   },
@@ -225,7 +225,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037308976,
-    "modifiedTime": 1725037308976,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!tWJLHIL6ZIZUez9k"

--- a/packs/_source/items/trinket/manual-of-bodily-health.json
+++ b/packs/_source/items/trinket/manual-of-bodily-health.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 2300000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037124947,
-    "modifiedTime": 1725037124947,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!BjyTJn9oGvURWKJR"

--- a/packs/_source/items/trinket/manual-of-gainful-exercise.json
+++ b/packs/_source/items/trinket/manual-of-gainful-exercise.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 11000000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037327017,
-    "modifiedTime": 1725037327017,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ykefWXBjq3y6y9Se"

--- a/packs/_source/items/trinket/manual-of-golems.json
+++ b/packs/_source/items/trinket/manual-of-golems.json
@@ -164,7 +164,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 5900000,
   "ownership": {
     "default": 0
   },
@@ -175,7 +175,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037199912,
-    "modifiedTime": 1725037199912,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!UxkP6FvDzPbsIY6o"

--- a/packs/_source/items/trinket/manual-of-quickness-of-action.json
+++ b/packs/_source/items/trinket/manual-of-quickness-of-action.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 4700000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037182741,
-    "modifiedTime": 1725037182741,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!Q4jmng3i9Lb2nL5F"

--- a/packs/_source/items/trinket/marvelous-pigments.json
+++ b/packs/_source/items/trinket/marvelous-pigments.json
@@ -65,7 +65,7 @@
   "flags": {},
   "_id": "e3XQygrXkzNvkDGF",
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 6700000,
   "ownership": {
     "default": 0
   },
@@ -75,7 +75,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037237709,
-    "modifiedTime": 1725037237709,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!e3XQygrXkzNvkDGF"

--- a/packs/_source/items/trinket/mirror-of-life-trapping.json
+++ b/packs/_source/items/trinket/mirror-of-life-trapping.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 7300000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037257853,
-    "modifiedTime": 1725037257853,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!hf5j1meGsA33HkUj"

--- a/packs/_source/items/trinket/necklace-of-fireballs.json
+++ b/packs/_source/items/trinket/necklace-of-fireballs.json
@@ -244,7 +244,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 700000,
   "ownership": {
     "default": 0
   },
@@ -255,7 +255,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037092424,
-    "modifiedTime": 1725037092424,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!3ALOhh6JNInIK4o7"

--- a/packs/_source/items/trinket/oil-flask.json
+++ b/packs/_source/items/trinket/oil-flask.json
@@ -175,7 +175,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 8800000,
   "ownership": {
     "default": 0
   },
@@ -186,7 +186,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037291158,
-    "modifiedTime": 1725037291158,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!psoZaItkOScMVaHL"

--- a/packs/_source/items/trinket/pearl-of-power.json
+++ b/packs/_source/items/trinket/pearl-of-power.json
@@ -144,7 +144,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 1000000,
   "ownership": {
     "default": 0
   },
@@ -155,7 +155,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037097549,
-    "modifiedTime": 1725037097549,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!44XNWmMGnwXn7bNW"

--- a/packs/_source/items/trinket/pipes-of-haunting.json
+++ b/packs/_source/items/trinket/pipes-of-haunting.json
@@ -151,7 +151,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 8600000,
   "ownership": {
     "default": 0
   },
@@ -162,7 +162,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037286054,
-    "modifiedTime": 1725037286054,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!oNLfJNRQgUHpU8c7"

--- a/packs/_source/items/trinket/pipes-of-the-sewers.json
+++ b/packs/_source/items/trinket/pipes-of-the-sewers.json
@@ -224,7 +224,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 8400000,
   "ownership": {
     "default": 0
   },
@@ -235,7 +235,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037284913,
-    "modifiedTime": 1725037284913,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!nvhk1quD0Dg1ZtSH"

--- a/packs/_source/items/trinket/piton.json
+++ b/packs/_source/items/trinket/piton.json
@@ -138,7 +138,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 5500000,
   "ownership": {
     "default": 0
   },
@@ -149,7 +149,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037195001,
-    "modifiedTime": 1725037195001,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!TqyvIglHDj5kfohR"

--- a/packs/_source/items/trinket/portable-hole.json
+++ b/packs/_source/items/trinket/portable-hole.json
@@ -196,7 +196,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 9300000,
   "ownership": {
     "default": 0
   },
@@ -207,7 +207,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037300564,
-    "modifiedTime": 1725037300564,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!rvxGvcUzoQXVNbAu"

--- a/packs/_source/items/trinket/portable-ram.json
+++ b/packs/_source/items/trinket/portable-ram.json
@@ -129,7 +129,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 9800000,
   "ownership": {
     "default": 0
   },
@@ -140,7 +140,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037304892,
-    "modifiedTime": 1725037304892,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!srTRzwTfWKO5opOo"

--- a/packs/_source/items/trinket/rope-of-climbing.json
+++ b/packs/_source/items/trinket/rope-of-climbing.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 300000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037088284,
-    "modifiedTime": 1725037088284,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!29e6gHwWKNLaRUoz"

--- a/packs/_source/items/trinket/rope-of-entanglement.json
+++ b/packs/_source/items/trinket/rope-of-entanglement.json
@@ -135,7 +135,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 3700000,
   "ownership": {
     "default": 0
   },
@@ -146,7 +146,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037158319,
-    "modifiedTime": 1725037158319,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!J8gQdJJi5e8LmD7H"

--- a/packs/_source/items/trinket/scarab-of-protection.json
+++ b/packs/_source/items/trinket/scarab-of-protection.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 10700000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037323702,
-    "modifiedTime": 1725037323702,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!xjRSY2ECcc9viSz3"

--- a/packs/_source/items/trinket/silk-rope-50-ft.json
+++ b/packs/_source/items/trinket/silk-rope-50-ft.json
@@ -214,7 +214,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 8700000,
   "ownership": {
     "default": 0
   },
@@ -225,7 +225,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037286925,
-    "modifiedTime": 1725037286925,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!oY8KbpGmB5H2Deoy"

--- a/packs/_source/items/trinket/silver-horn-of-valhalla.json
+++ b/packs/_source/items/trinket/silver-horn-of-valhalla.json
@@ -161,7 +161,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 7900000,
   "ownership": {
     "default": 0
   },
@@ -172,7 +172,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037274276,
-    "modifiedTime": 1725037274276,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!lTfo6OVvAY2iJ4oq"

--- a/packs/_source/items/trinket/sovereign-glue.json
+++ b/packs/_source/items/trinket/sovereign-glue.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 11200000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037329958,
-    "modifiedTime": 1725037329958,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!zJ5LhDvTxYKzPIx4"

--- a/packs/_source/items/trinket/sphere-of-annihilation.json
+++ b/packs/_source/items/trinket/sphere-of-annihilation.json
@@ -159,7 +159,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 500000,
   "ownership": {
     "default": 0
   },
@@ -170,7 +170,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037089464,
-    "modifiedTime": 1725037089464,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!2YNqk5zm9jDTvd7q"

--- a/packs/_source/items/trinket/stone-of-controlling-earth-elementals.json
+++ b/packs/_source/items/trinket/stone-of-controlling-earth-elementals.json
@@ -145,7 +145,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 5200000,
   "ownership": {
     "default": 0
   },
@@ -156,7 +156,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037193275,
-    "modifiedTime": 1725037193275,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!TWFS1BtruQeE10BY"

--- a/packs/_source/items/trinket/talisman-of-pure-good.json
+++ b/packs/_source/items/trinket/talisman-of-pure-good.json
@@ -261,7 +261,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 7400000,
   "ownership": {
     "default": 0
   },
@@ -272,7 +272,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037259857,
-    "modifiedTime": 1725037259857,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!iB3gunzgxZ8xK6Z5"

--- a/packs/_source/items/trinket/talisman-of-the-sphere.json
+++ b/packs/_source/items/trinket/talisman-of-the-sphere.json
@@ -132,7 +132,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 1100000,
   "ownership": {
     "default": 0
   },
@@ -143,7 +143,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037098121,
-    "modifiedTime": 1725037098121,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!46ikeR4RrSim6DsN"

--- a/packs/_source/items/trinket/talisman-of-ultimate-evil.json
+++ b/packs/_source/items/trinket/talisman-of-ultimate-evil.json
@@ -261,7 +261,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 4600000,
   "ownership": {
     "default": 0
   },
@@ -272,7 +272,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037179912,
-    "modifiedTime": 1725037179912,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!PAXfmZ2ErDlCVy0N"

--- a/packs/_source/items/trinket/tome-of-clear-thought.json
+++ b/packs/_source/items/trinket/tome-of-clear-thought.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 400000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037088569,
-    "modifiedTime": 1725037088569,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!2BYm8to5KldN8eYu"

--- a/packs/_source/items/trinket/tome-of-leadership-and-influence.json
+++ b/packs/_source/items/trinket/tome-of-leadership-and-influence.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 8500000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037285779,
-    "modifiedTime": 1725037285779,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!oN4Glcmi4BhdAI3k"

--- a/packs/_source/items/trinket/tome-of-understanding.json
+++ b/packs/_source/items/trinket/tome-of-understanding.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 6000000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037206437,
-    "modifiedTime": 1725037206437,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!WnKWD1FuAFUE7f4v"

--- a/packs/_source/items/trinket/torch.json
+++ b/packs/_source/items/trinket/torch.json
@@ -174,7 +174,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 2400000,
   "ownership": {
     "default": 0
   },
@@ -185,7 +185,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037125533,
-    "modifiedTime": 1725037125533,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!BnOCLuNWhVvzHLjl"

--- a/packs/_source/items/trinket/universal-solvent.json
+++ b/packs/_source/items/trinket/universal-solvent.json
@@ -139,7 +139,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 4200000,
   "ownership": {
     "default": 0
   },
@@ -150,7 +150,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037169569,
-    "modifiedTime": 1725037169569,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!MAwoj2suj6cvb9Ti"

--- a/packs/_source/items/trinket/well-of-many-worlds.json
+++ b/packs/_source/items/trinket/well-of-many-worlds.json
@@ -230,7 +230,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 10800000,
   "ownership": {
     "default": 0
   },
@@ -241,7 +241,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037323970,
-    "modifiedTime": 1725037323970,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!xjme5oSQZmdAy1fc"

--- a/packs/_source/items/trinket/wind-fan.json
+++ b/packs/_source/items/trinket/wind-fan.json
@@ -309,7 +309,7 @@
   },
   "effects": [],
   "folder": "UnUwTG4YIgd0kaUJ",
-  "sort": 0,
+  "sort": 8100000,
   "ownership": {
     "default": 0
   },
@@ -320,7 +320,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037278778,
-    "modifiedTime": 1725037278778,
+    "modifiedTime": 1725041129284,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!mYFfH24uzuKh4IPS"

--- a/packs/_source/items/weapon/battleaxe-1.json
+++ b/packs/_source/items/weapon/battleaxe-1.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -178,7 +178,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +194,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037196470,
-    "modifiedTime": 1725037196470,
+    "modifiedTime": 1725041038153,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!UAXu4MNvAvaKz9JO"

--- a/packs/_source/items/weapon/battleaxe-2.json
+++ b/packs/_source/items/weapon/battleaxe-2.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -178,7 +178,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +194,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037230899,
-    "modifiedTime": 1725037230899,
+    "modifiedTime": 1725041044002,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!cQ94oKUZN8FDAI8U"

--- a/packs/_source/items/weapon/battleaxe-3.json
+++ b/packs/_source/items/weapon/battleaxe-3.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -178,7 +178,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +194,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037268359,
-    "modifiedTime": 1725037268359,
+    "modifiedTime": 1725041049197,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!kNlvoSTcdMqxJPmI"

--- a/packs/_source/items/weapon/battleaxe.json
+++ b/packs/_source/items/weapon/battleaxe.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -177,7 +177,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -192,7 +193,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037154013,
-    "modifiedTime": 1725037154013,
+    "modifiedTime": 1725041027756,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!I0WocDSuNpGJayPb"

--- a/packs/_source/items/weapon/berserker-battleaxe.json
+++ b/packs/_source/items/weapon/berserker-battleaxe.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -264,7 +264,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -279,7 +280,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037237138,
-    "modifiedTime": 1725037237138,
+    "modifiedTime": 1725041053827,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!dvNzJqb7vq6oJlA2"

--- a/packs/_source/items/weapon/blowgun-1.json
+++ b/packs/_source/items/weapon/blowgun-1.json
@@ -57,14 +57,14 @@
       },
       "base": {
         "number": null,
-        "denomination": null,
-        "bonus": "",
+        "denomination": 0,
+        "bonus": "1",
         "types": [
           "piercing"
         ],
         "custom": {
-          "enabled": true,
-          "formula": "1 + @mod"
+          "enabled": false,
+          "formula": ""
         },
         "scaling": {
           "mode": "",
@@ -179,7 +179,10 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {
+      "type": ""
+    },
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -194,7 +197,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037172743,
-    "modifiedTime": 1725037172743,
+    "modifiedTime": 1725041083961,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!N8XNP3vjVZmM2r9S"

--- a/packs/_source/items/weapon/blowgun-2.json
+++ b/packs/_source/items/weapon/blowgun-2.json
@@ -57,14 +57,14 @@
       },
       "base": {
         "number": null,
-        "denomination": null,
-        "bonus": "",
+        "denomination": 0,
+        "bonus": "1",
         "types": [
           "piercing"
         ],
         "custom": {
-          "enabled": true,
-          "formula": "1 + @mod"
+          "enabled": false,
+          "formula": ""
         },
         "scaling": {
           "mode": "",
@@ -179,7 +179,10 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {
+      "type": ""
+    },
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -194,7 +197,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037249056,
-    "modifiedTime": 1725037249056,
+    "modifiedTime": 1725041091549,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!fu7DJcrYWfGMeVt9"

--- a/packs/_source/items/weapon/blowgun-3.json
+++ b/packs/_source/items/weapon/blowgun-3.json
@@ -57,14 +57,14 @@
       },
       "base": {
         "number": null,
-        "denomination": null,
-        "bonus": "",
+        "denomination": 0,
+        "bonus": "1",
         "types": [
           "piercing"
         ],
         "custom": {
-          "enabled": true,
-          "formula": "1 + @mod"
+          "enabled": false,
+          "formula": ""
         },
         "scaling": {
           "mode": "",
@@ -179,7 +179,10 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {
+      "type": ""
+    },
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -194,7 +197,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037150312,
-    "modifiedTime": 1725037150312,
+    "modifiedTime": 1725041100396,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!HQJ8tiyyrJJSUSyF"

--- a/packs/_source/items/weapon/blowgun.json
+++ b/packs/_source/items/weapon/blowgun.json
@@ -57,14 +57,14 @@
       },
       "base": {
         "number": null,
-        "denomination": null,
-        "bonus": "",
+        "denomination": 0,
+        "bonus": "1",
         "types": [
           "piercing"
         ],
         "custom": {
-          "enabled": true,
-          "formula": "1 + @mod"
+          "enabled": false,
+          "formula": ""
         },
         "scaling": {
           "mode": "",
@@ -178,7 +178,10 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {
+      "type": ""
+    },
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +196,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037318573,
-    "modifiedTime": 1725037318573,
+    "modifiedTime": 1725041073530,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!wNWK6yJMHG9ANqQV"

--- a/packs/_source/items/weapon/club.json
+++ b/packs/_source/items/weapon/club.json
@@ -177,7 +177,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -192,7 +193,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037283284,
-    "modifiedTime": 1725037283284,
+    "modifiedTime": 1725041109101,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!nfIRTECQIG81CvM4"

--- a/packs/_source/items/weapon/dagger-of-venom.json
+++ b/packs/_source/items/weapon/dagger-of-venom.json
@@ -90,8 +90,8 @@
     "properties": [
       "fin",
       "lgt",
-      "thr",
-      "mgc"
+      "mgc",
+      "thr"
     ],
     "proficient": null,
     "type": {
@@ -368,7 +368,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -383,7 +384,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037109200,
-    "modifiedTime": 1725037109200,
+    "modifiedTime": 1725041139996,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!7i4s9msZWpAw4Ynv"

--- a/packs/_source/items/weapon/defender-longsword.json
+++ b/packs/_source/items/weapon/defender-longsword.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -178,7 +178,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +194,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037314143,
-    "modifiedTime": 1725037314143,
+    "modifiedTime": 1725041156468,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ukcKemEoTTRB9yLC"

--- a/packs/_source/items/weapon/dragon-slayer-longsword.json
+++ b/packs/_source/items/weapon/dragon-slayer-longsword.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -243,7 +243,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -258,7 +259,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037189874,
-    "modifiedTime": 1725037189874,
+    "modifiedTime": 1725041149884,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!SXjs8JghAPBv7d6j"

--- a/packs/_source/items/weapon/flame-tongue-longsword.json
+++ b/packs/_source/items/weapon/flame-tongue-longsword.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -243,7 +243,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -258,7 +259,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037236830,
-    "modifiedTime": 1725037236830,
+    "modifiedTime": 1725041187643,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ducaFdrqwLZ0l3c7"

--- a/packs/_source/items/weapon/frost-brand-greatsword.json
+++ b/packs/_source/items/weapon/frost-brand-greatsword.json
@@ -84,8 +84,8 @@
     },
     "properties": [
       "hvy",
-      "two",
-      "mgc"
+      "mgc",
+      "two"
     ],
     "proficient": null,
     "type": {
@@ -207,7 +207,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -222,7 +223,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037326752,
-    "modifiedTime": 1725037326752,
+    "modifiedTime": 1725041198443,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!ykB6UKv5BuQnSRSL"

--- a/packs/_source/items/weapon/frost-brand-longsword.json
+++ b/packs/_source/items/weapon/frost-brand-longsword.json
@@ -42,12 +42,12 @@
     "damage": {
       "versatile": {
         "number": null,
-        "denomination": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
-          "enabled": true,
-          "formula": "1d10 + @mod + 1d6"
+          "enabled": false,
+          "formula": ""
         },
         "scaling": {
           "mode": "",
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -206,7 +206,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -221,7 +222,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037175351,
-    "modifiedTime": 1725037175351,
+    "modifiedTime": 1725041183054,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!NmZMx2u6bHpRyGUa"

--- a/packs/_source/items/weapon/frost-brand-rapier.json
+++ b/packs/_source/items/weapon/frost-brand-rapier.json
@@ -206,7 +206,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -221,7 +222,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037242870,
-    "modifiedTime": 1725037242870,
+    "modifiedTime": 1725041197821,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!efluRemOguW2YeZY"

--- a/packs/_source/items/weapon/frost-brand-scimitar.json
+++ b/packs/_source/items/weapon/frost-brand-scimitar.json
@@ -207,7 +207,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -222,7 +223,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037081045,
-    "modifiedTime": 1725037081045,
+    "modifiedTime": 1725041197360,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!07R6JFioylOCpVoL"

--- a/packs/_source/items/weapon/frost-brand-shortsword.json
+++ b/packs/_source/items/weapon/frost-brand-shortsword.json
@@ -207,7 +207,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -222,7 +223,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037132242,
-    "modifiedTime": 1725037132242,
+    "modifiedTime": 1725041195616,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!DT02xK1DzxLNlVaI"

--- a/packs/_source/items/weapon/giant-slayer-longsword.json
+++ b/packs/_source/items/weapon/giant-slayer-longsword.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -331,7 +331,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -346,7 +347,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037324602,
-    "modifiedTime": 1725037324602,
+    "modifiedTime": 1725041205072,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!xw2kL7Puwg4wfjW3"

--- a/packs/_source/items/weapon/glaive.json
+++ b/packs/_source/items/weapon/glaive.json
@@ -84,8 +84,8 @@
     },
     "properties": [
       "hvy",
-      "two",
-      "rch"
+      "rch",
+      "two"
     ],
     "proficient": null,
     "type": {
@@ -179,7 +179,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -194,7 +195,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037298246,
-    "modifiedTime": 1725037298246,
+    "modifiedTime": 1725041214758,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!rOG1OM2ihgPjOvFW"

--- a/packs/_source/items/weapon/halberd.json
+++ b/packs/_source/items/weapon/halberd.json
@@ -84,8 +84,8 @@
     },
     "properties": [
       "hvy",
-      "two",
-      "rch"
+      "rch",
+      "two"
     ],
     "proficient": null,
     "type": {
@@ -179,7 +179,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -194,7 +195,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037131107,
-    "modifiedTime": 1725037131107,
+    "modifiedTime": 1725041223878,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!DMejWAc8r8YvDPP1"

--- a/packs/_source/items/weapon/handaxe.json
+++ b/packs/_source/items/weapon/handaxe.json
@@ -178,7 +178,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +194,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037240596,
-    "modifiedTime": 1725037240596,
+    "modifiedTime": 1725041231234,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!eO7Fbv5WBk5zvGOc"

--- a/packs/_source/items/weapon/holy-avenger-longsword.json
+++ b/packs/_source/items/weapon/holy-avenger-longsword.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -243,7 +243,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -258,7 +259,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037235614,
-    "modifiedTime": 1725037235614,
+    "modifiedTime": 1725041236035,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!dZ9zWfhsIlabadKL"

--- a/packs/_source/items/weapon/javelin.json
+++ b/packs/_source/items/weapon/javelin.json
@@ -177,7 +177,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -192,7 +193,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037132820,
-    "modifiedTime": 1725037132820,
+    "modifiedTime": 1725041243162,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!DWLMnODrnHn8IbAG"

--- a/packs/_source/items/weapon/longsword-1.json
+++ b/packs/_source/items/weapon/longsword-1.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -178,7 +178,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +194,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037155730,
-    "modifiedTime": 1725037155730,
+    "modifiedTime": 1725041286645,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!IPkf0XNowClwXnjQ"

--- a/packs/_source/items/weapon/longsword-2.json
+++ b/packs/_source/items/weapon/longsword-2.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -178,7 +178,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +194,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037228408,
-    "modifiedTime": 1725037228408,
+    "modifiedTime": 1725041282369,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!bcv7J9culilK68zp"

--- a/packs/_source/items/weapon/longsword-3.json
+++ b/packs/_source/items/weapon/longsword-3.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -178,7 +178,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +194,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037148888,
-    "modifiedTime": 1725037148888,
+    "modifiedTime": 1725041277804,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!H6SIiRIig7OMM2Z0"

--- a/packs/_source/items/weapon/longsword-of-life-stealing.json
+++ b/packs/_source/items/weapon/longsword-of-life-stealing.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -243,7 +243,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -258,7 +259,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037320473,
-    "modifiedTime": 1725037320473,
+    "modifiedTime": 1725041273271,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!wtctR6tCcYbQPiS0"

--- a/packs/_source/items/weapon/longsword-of-sharpness.json
+++ b/packs/_source/items/weapon/longsword-of-sharpness.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -243,7 +243,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -258,7 +259,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037112992,
-    "modifiedTime": 1725037112992,
+    "modifiedTime": 1725041267829,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!8MNDhKb1Q87QszOJ"

--- a/packs/_source/items/weapon/longsword-of-wounding.json
+++ b/packs/_source/items/weapon/longsword-of-wounding.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -331,7 +331,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -346,7 +347,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037290584,
-    "modifiedTime": 1725037290584,
+    "modifiedTime": 1725041262147,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!pG6dddIcb9NmPrdt"

--- a/packs/_source/items/weapon/longsword.json
+++ b/packs/_source/items/weapon/longsword.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -177,7 +177,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -192,7 +193,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037083672,
-    "modifiedTime": 1725037083672,
+    "modifiedTime": 1725041291215,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!10ZP2Bu3vnCuYMIB"

--- a/packs/_source/items/weapon/luck-blade-longsword.json
+++ b/packs/_source/items/weapon/luck-blade-longsword.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -188,7 +188,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -203,7 +204,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037207828,
-    "modifiedTime": 1725037207828,
+    "modifiedTime": 1725041257312,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!X6PHssSGnwiJRgcx"

--- a/packs/_source/items/weapon/nine-lives-stealer-longsword.json
+++ b/packs/_source/items/weapon/nine-lives-stealer-longsword.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -286,7 +286,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -301,7 +302,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037124666,
-    "modifiedTime": 1725037124666,
+    "modifiedTime": 1725041314185,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!BefbYlWbRYyy6R8s"

--- a/packs/_source/items/weapon/vicious-battleaxe.json
+++ b/packs/_source/items/weapon/vicious-battleaxe.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -178,7 +178,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +194,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037232935,
-    "modifiedTime": 1725037232935,
+    "modifiedTime": 1725041339341,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!dG7iFak1YH1nXRpC"

--- a/packs/_source/items/weapon/vicious-longsword.json
+++ b/packs/_source/items/weapon/vicious-longsword.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -178,7 +178,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -193,7 +194,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037290317,
-    "modifiedTime": 1725037290317,
+    "modifiedTime": 1725041331888,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!pC3202gDTy8G5i4r"

--- a/packs/_source/items/weapon/vorpal-longsword.json
+++ b/packs/_source/items/weapon/vorpal-longsword.json
@@ -41,8 +41,8 @@
     },
     "damage": {
       "versatile": {
-        "number": 1,
-        "denomination": 10,
+        "number": null,
+        "denomination": 0,
         "bonus": "",
         "types": [],
         "custom": {
@@ -83,8 +83,8 @@
       "conditions": ""
     },
     "properties": [
-      "ver",
-      "mgc"
+      "mgc",
+      "ver"
     ],
     "proficient": null,
     "type": {
@@ -243,7 +243,8 @@
       }
     },
     "attuned": false,
-    "ammunition": {}
+    "ammunition": {},
+    "mastery": ""
   },
   "effects": [],
   "folder": "MLMTCAvKsuFE3vYA",
@@ -258,7 +259,7 @@
     "systemId": "dnd5e",
     "systemVersion": "4.0.0",
     "createdTime": 1725037153173,
-    "modifiedTime": 1725037153173,
+    "modifiedTime": 1725041351008,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!HokQ1loVJTFxt27u"

--- a/packs/_source/monsters/beast/goat.json
+++ b/packs/_source/monsters/beast/goat.json
@@ -742,7 +742,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -779,34 +779,19 @@
             },
             "damage": {
               "onSave": "half",
-              "parts": [
-                {
-                  "number": 1,
-                  "denomination": 4,
-                  "bonus": "",
-                  "types": [
-                    "bludgeoning"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "parts": []
             },
             "save": {
               "ability": "str",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "10"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -832,8 +817,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387317072,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!y8sRU8Ks2lcrGsaf.fmILoB0arLdodNGB"
     },

--- a/packs/_source/monsters/construct/stone-golem.json
+++ b/packs/_source/monsters/construct/stone-golem.json
@@ -1157,12 +1157,8 @@
               "targets": [
                 {
                   "type": "itemUses",
-                  "target": "",
                   "value": "1",
-                  "scaling": {
-                    "mode": "",
-                    "formula": ""
-                  }
+                  "target": ""
                 }
               ],
               "scaling": {
@@ -1220,10 +1216,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "17"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1249,8 +1248,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387762983,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!z3gSIXHHWYaHjfBT.9aTwUWuZQLhMxjcD"
     }

--- a/packs/_source/monsters/dragon/adult-black-dragon.json
+++ b/packs/_source/monsters/dragon/adult-black-dragon.json
@@ -1444,10 +1444,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "16"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1473,8 +1476,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387178700,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.A3azHlbNcHLRgogu"
     },
@@ -1713,12 +1716,8 @@
               "targets": [
                 {
                   "type": "itemUses",
-                  "target": "",
                   "value": "1",
-                  "scaling": {
-                    "mode": "",
-                    "formula": ""
-                  }
+                  "target": ""
                 }
               ],
               "scaling": {
@@ -1771,21 +1770,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 12,
-                  "denomination": 8,
-                  "bonus": "",
-                  "types": [
-                    "acid"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 12,
+                  "denomination": "8",
+                  "bonus": "",
+                  "types": [
+                    "acid"
+                  ]
                 }
               ]
             },
@@ -1793,10 +1787,13 @@
               "ability": "dex",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "18"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1822,8 +1819,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387188142,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.6bromElr0abqNXJL"
     },

--- a/packs/_source/monsters/dragon/adult-blue-dragon.json
+++ b/packs/_source/monsters/dragon/adult-blue-dragon.json
@@ -1305,10 +1305,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "17"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1334,8 +1337,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387566648,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.zMT1Uj814On8O1Hg"
     },
@@ -2361,12 +2364,8 @@
               "targets": [
                 {
                   "type": "attribute",
-                  "target": "resources.legact.value",
                   "value": "2",
-                  "scaling": {
-                    "mode": "",
-                    "formula": ""
-                  }
+                  "target": "resources.legact.value"
                 }
               ],
               "scaling": {
@@ -2381,7 +2380,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -2420,21 +2419,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 2,
-                  "denomination": 6,
-                  "bonus": "@mod",
-                  "types": [
-                    "bludgeoning"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 2,
+                  "denomination": "6",
+                  "bonus": "@mod",
+                  "types": [
+                    "bludgeoning"
+                  ]
                 }
               ]
             },
@@ -2442,15 +2436,19 @@
               "ability": "dex",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "20"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -2466,8 +2464,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387586498,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.GcUNB4m0NAPgP0Nx"
     }

--- a/packs/_source/monsters/dragon/adult-silver-dragon.json
+++ b/packs/_source/monsters/dragon/adult-silver-dragon.json
@@ -1556,10 +1556,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "18"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1585,8 +1588,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387712094,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.F8gfPJkHrrlTwVUs"
     },

--- a/packs/_source/monsters/dragon/adult-white-dragon.json
+++ b/packs/_source/monsters/dragon/adult-white-dragon.json
@@ -1464,10 +1464,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "14"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1493,8 +1496,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387647649,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3uIursokd3KdZrW3.nKX7IFrwLJsAsWXU"
     },

--- a/packs/_source/monsters/dragon/ancient-black-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-black-dragon.json
@@ -1630,10 +1630,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "19"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1659,8 +1662,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387660824,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qNdFhY3JOkCfhG3d.M3VJyuM63OKH7JH0"
     },
@@ -2307,12 +2310,8 @@
               "targets": [
                 {
                   "type": "attribute",
-                  "target": "resources.legact.value",
                   "value": "2",
-                  "scaling": {
-                    "mode": "",
-                    "formula": ""
-                  }
+                  "target": "resources.legact.value"
                 }
               ],
               "scaling": {
@@ -2327,7 +2326,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -2366,21 +2365,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 2,
-                  "denomination": 6,
-                  "bonus": "@mod",
-                  "types": [
-                    "bludgeoning"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 2,
+                  "denomination": "6",
+                  "bonus": "@mod",
+                  "types": [
+                    "bludgeoning"
+                  ]
                 }
               ]
             },
@@ -2388,15 +2382,19 @@
               "ability": "dex",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "23"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -2412,8 +2410,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387668637,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qNdFhY3JOkCfhG3d.i4ggPCju3QyYJslH"
     },

--- a/packs/_source/monsters/dragon/ancient-blue-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-blue-dragon.json
@@ -1615,10 +1615,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "20"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1644,8 +1647,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387684940,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.NhYVY7hHFu2YsFpN"
     },
@@ -1696,12 +1699,8 @@
               "targets": [
                 {
                   "type": "itemUses",
-                  "target": "",
                   "value": "1",
-                  "scaling": {
-                    "mode": "",
-                    "formula": ""
-                  }
+                  "target": ""
                 }
               ],
               "scaling": {
@@ -1754,21 +1753,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 16,
-                  "denomination": 10,
-                  "bonus": "",
-                  "types": [
-                    "lightning"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 16,
+                  "denomination": "10",
+                  "bonus": "",
+                  "types": [
+                    "lightning"
+                  ]
                 }
               ]
             },
@@ -1776,10 +1770,13 @@
               "ability": "dex",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "23"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1805,8 +1802,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387692084,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.834XVlRwHOXkE2rK"
     },
@@ -2307,12 +2304,8 @@
               "targets": [
                 {
                   "type": "attribute",
-                  "target": "resources.legact.value",
                   "value": "2",
-                  "scaling": {
-                    "mode": "",
-                    "formula": ""
-                  }
+                  "target": "resources.legact.value"
                 }
               ],
               "scaling": {
@@ -2327,7 +2320,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -2366,21 +2359,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 2,
-                  "denomination": 6,
-                  "bonus": "@mod",
-                  "types": [
-                    "bludgeoning"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 2,
+                  "denomination": "6",
+                  "bonus": "@mod",
+                  "types": [
+                    "bludgeoning"
+                  ]
                 }
               ]
             },
@@ -2388,15 +2376,19 @@
               "ability": "dex",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "24"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -2412,8 +2404,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387699557,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.ZF7ixqLMH0gc0qlL"
     },

--- a/packs/_source/monsters/dragon/ancient-red-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-red-dragon.json
@@ -1320,10 +1320,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "21"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1349,8 +1352,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387596953,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.LQKBexRS91dTMEKa"
     },
@@ -1401,12 +1404,8 @@
               "targets": [
                 {
                   "type": "itemUses",
-                  "target": "",
                   "value": "1",
-                  "scaling": {
-                    "mode": "",
-                    "formula": ""
-                  }
+                  "target": ""
                 }
               ],
               "scaling": {
@@ -1459,21 +1458,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 26,
-                  "denomination": 6,
-                  "bonus": "",
-                  "types": [
-                    "fire"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 26,
+                  "denomination": "6",
+                  "bonus": "",
+                  "types": [
+                    "fire"
+                  ]
                 }
               ]
             },
@@ -1481,10 +1475,13 @@
               "ability": "dex",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "24"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1510,8 +1507,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387604008,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.wUEVmK5TEnYsMuwJ"
     },
@@ -2212,7 +2209,8 @@
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -2228,8 +2226,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387610629,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.0fheJO7kmH1UV99g"
     },

--- a/packs/_source/monsters/dragon/ancient-silver-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-silver-dragon.json
@@ -1556,10 +1556,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "21"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1585,8 +1588,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387723476,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.ohWgcdw603aWWXum"
     },

--- a/packs/_source/monsters/dragon/young-white-dragon.json
+++ b/packs/_source/monsters/dragon/young-white-dragon.json
@@ -1078,12 +1078,8 @@
               "targets": [
                 {
                   "type": "itemUses",
-                  "target": "",
                   "value": "1",
-                  "scaling": {
-                    "mode": "",
-                    "formula": ""
-                  }
+                  "target": ""
                 }
               ],
               "scaling": {
@@ -1136,21 +1132,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 10,
-                  "denomination": 8,
-                  "bonus": "",
-                  "types": [
-                    "cold"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 10,
+                  "denomination": "8",
+                  "bonus": "",
+                  "types": [
+                    "cold"
+                  ]
                 }
               ]
             },
@@ -1158,10 +1149,13 @@
               "ability": "con",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "15"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1187,8 +1181,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387741390,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u1UQfHutP5eEKkjM.78LbjdfWaZcAqVE7"
     },

--- a/packs/_source/monsters/fey/sea-hag.json
+++ b/packs/_source/monsters/fey/sea-hag.json
@@ -717,14 +717,14 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
             "effects": [],
             "range": {
               "value": "30",
-              "units": "",
+              "units": "self",
               "special": "",
               "override": false
             },
@@ -760,10 +760,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "11"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -789,8 +792,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387339292,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!OQqybZoMeDFn5AFD.XeAyeJsNjKZKPWEN"
     },
@@ -1044,7 +1047,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1087,10 +1090,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "11"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1116,8 +1122,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387346569,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!OQqybZoMeDFn5AFD.7AGmP2dRLYmORUX7"
     },

--- a/packs/_source/monsters/fey/sprite.json
+++ b/packs/_source/monsters/fey/sprite.json
@@ -1361,7 +1361,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1403,10 +1403,13 @@
               "ability": "cha",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "10"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1432,8 +1435,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387394720,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MUpBNDoJEr09bLaO.qJHrH8Q3q1JB5xe5"
     }

--- a/packs/_source/monsters/fiend/succubus-incubus.json
+++ b/packs/_source/monsters/fiend/succubus-incubus.json
@@ -1000,7 +1000,7 @@
       "img": "icons/magic/air/wind-tornado-spiral-pink-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>One humanoid the fiend can see within 30 feet of it must make a <strong>Wisdom</strong> saving throw or be magically charmed for 1 day. The charmed target obeys the fiend's verbal or telepathic commands.</p><p>If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend's Charm for the next 24 hours.The fiend can have only one target charmed at a time. If it charms another, the effect on the previous target ends.</p></section><p>One humanoid the fiend can see within 30 feet of it must make a <strong>Wisdom</strong> saving throw.</p>",
+          "value": "<section class=\"secret\" id=\"secret-JgJC4PuKfndwnA7h\"><p>One humanoid the fiend can see within 30 feet of it must make a <strong>DC 15</strong> <strong>Wisdom</strong> saving throw or be magically charmed for 1 day. The charmed target obeys the fiend's verbal or telepathic commands.</p><p>If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend's Charm for the next 24 hours.The fiend can have only one target charmed at a time. If it charms another, the effect on the previous target ends.</p></section><p>One humanoid the fiend can see within 30 feet of it must make a <strong>Wisdom</strong> saving throw.</p>",
           "chat": ""
         },
         "source": {
@@ -1087,10 +1087,13 @@
               "ability": "wis",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "15"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1116,8 +1119,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387471681,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.2bFCfFfjRNmhyE8A"
     },
@@ -1172,13 +1175,13 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
             "effects": [],
             "range": {
-              "units": "",
+              "units": "self",
               "special": "",
               "override": false
             },
@@ -1210,21 +1213,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 5,
-                  "denomination": 10,
-                  "bonus": "@mod",
-                  "types": [
-                    "psychic"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 5,
+                  "denomination": "10",
+                  "bonus": "@mod",
+                  "types": [
+                    "psychic"
+                  ]
                 }
               ]
             },
@@ -1232,10 +1230,13 @@
               "ability": "con",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "15"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1261,8 +1262,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387480759,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.eb0O9cQ8N6lovLyI"
     },

--- a/packs/_source/monsters/giant/stone-giant.json
+++ b/packs/_source/monsters/giant/stone-giant.json
@@ -1131,7 +1131,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1168,39 +1168,25 @@
             },
             "damage": {
               "onSave": "half",
-              "parts": [
-                {
-                  "number": 4,
-                  "denomination": 10,
-                  "bonus": "@mod",
-                  "types": [
-                    "bludgeoning"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "parts": []
             },
             "save": {
               "ability": "str",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "17"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -1216,8 +1202,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387233716,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SOin81NWijHRvXFK.eiNNUlTgJyVFcQkO"
     },

--- a/packs/_source/monsters/giant/storm-giant.json
+++ b/packs/_source/monsters/giant/storm-giant.json
@@ -942,7 +942,7 @@
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 100000,
       "ownership": {
         "default": 0
       },
@@ -958,8 +958,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387271690,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!68bAMIpe4jvDeR9G.iwN0z7f5LF9AAbRJ"
     },
@@ -1138,7 +1138,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1177,21 +1177,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 12,
-                  "denomination": 8,
-                  "bonus": "",
-                  "types": [
-                    "lightning"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 12,
+                  "denomination": "8",
+                  "bonus": "",
+                  "types": [
+                    "lightning"
+                  ]
                 }
               ]
             },
@@ -1199,19 +1194,23 @@
               "ability": "dex",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "17"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 350000,
       "ownership": {
         "default": 0
       },
@@ -1223,8 +1222,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387275005,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!68bAMIpe4jvDeR9G.k0g8uqoYdJ4LVxcn"
     },
@@ -1345,8 +1344,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387276621,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!68bAMIpe4jvDeR9G.KUffpBEiNWnVK3W6"
     },
@@ -1528,11 +1527,12 @@
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 300000,
       "ownership": {
         "default": 0
       },
@@ -1544,8 +1544,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387271690,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!68bAMIpe4jvDeR9G.bRdk2uZ6iTuNGUIL"
     },

--- a/packs/_source/monsters/humanoid/werebear.json
+++ b/packs/_source/monsters/humanoid/werebear.json
@@ -1109,7 +1109,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1146,39 +1146,25 @@
             },
             "damage": {
               "onSave": "half",
-              "parts": [
-                {
-                  "number": 2,
-                  "denomination": 10,
-                  "bonus": "@mod",
-                  "types": [
-                    "piercing"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "parts": []
             },
             "save": {
               "ability": "con",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "14"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -1194,8 +1180,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387885764,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oRBnO5OHoOZzlCOr.h9XO0f5Un3EhJqHm"
     },

--- a/packs/_source/monsters/humanoid/wereboar.json
+++ b/packs/_source/monsters/humanoid/wereboar.json
@@ -788,25 +788,7 @@
             },
             "damage": {
               "onSave": "half",
-              "parts": [
-                {
-                  "number": 2,
-                  "denomination": 6,
-                  "bonus": "",
-                  "types": [
-                    "slashing"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "parts": []
             },
             "save": {
               "ability": "str",
@@ -837,8 +819,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387833671,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J9hgSaZODGjrNl9B.TizBVS6hRuBa8JYY"
     },
@@ -1341,7 +1323,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1378,39 +1360,25 @@
             },
             "damage": {
               "onSave": "half",
-              "parts": [
-                {
-                  "number": 2,
-                  "denomination": 6,
-                  "bonus": "@mod",
-                  "types": [
-                    "slashing"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "parts": []
             },
             "save": {
               "ability": "con",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "12"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -1426,8 +1394,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387827746,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J9hgSaZODGjrNl9B.3TD2NpdjIDJxeLl9"
     },

--- a/packs/_source/monsters/humanoid/wererat.json
+++ b/packs/_source/monsters/humanoid/wererat.json
@@ -1105,7 +1105,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1142,39 +1142,25 @@
             },
             "damage": {
               "onSave": "half",
-              "parts": [
-                {
-                  "number": 1,
-                  "denomination": 4,
-                  "bonus": "@mod",
-                  "types": [
-                    "piercing"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "parts": []
             },
             "save": {
               "ability": "con",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "11"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -1190,8 +1176,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387810775,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!CrnUJhTbkdZjCZsH.ldz0yUpzhV9Xlhss"
     },

--- a/packs/_source/monsters/humanoid/weretiger.json
+++ b/packs/_source/monsters/humanoid/weretiger.json
@@ -1295,7 +1295,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1332,39 +1332,25 @@
             },
             "damage": {
               "onSave": "half",
-              "parts": [
-                {
-                  "number": 1,
-                  "denomination": 10,
-                  "bonus": "@mod",
-                  "types": [
-                    "piercing"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "parts": []
             },
             "save": {
               "ability": "con",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "13"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -1380,8 +1366,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387861113,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.FOkSL18gU0Sli5ZA"
     },

--- a/packs/_source/monsters/humanoid/werewolf.json
+++ b/packs/_source/monsters/humanoid/werewolf.json
@@ -813,7 +813,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -850,39 +850,25 @@
             },
             "damage": {
               "onSave": "half",
-              "parts": [
-                {
-                  "number": 1,
-                  "denomination": 8,
-                  "bonus": "@mod",
-                  "types": [
-                    "piercing"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "parts": []
             },
             "save": {
               "ability": "con",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "12"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -898,8 +884,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387786875,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7tRhrxuknTpHpYcA.tWfR8uJNnQxpXgDw"
     },

--- a/packs/_source/monsters/plant/shambling-mound.json
+++ b/packs/_source/monsters/plant/shambling-mound.json
@@ -844,13 +844,13 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
             "effects": [],
             "range": {
-              "units": "",
+              "units": "self",
               "special": "",
               "override": false
             },
@@ -882,21 +882,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 2,
-                  "denomination": 8,
-                  "bonus": "@mod",
-                  "types": [
-                    "bludgeoning"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 2,
+                  "denomination": "8",
+                  "bonus": "@mod",
+                  "types": [
+                    "bludgeoning"
+                  ]
                 }
               ]
             },
@@ -904,10 +899,13 @@
               "ability": "con",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "14"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -933,8 +931,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387412087,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gGeLeV411iQ5Yijs.N42BQALoCmeYphD1"
     },

--- a/packs/_source/monsters/undead/wight.json
+++ b/packs/_source/monsters/undead/wight.json
@@ -1495,7 +1495,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1532,39 +1532,25 @@
             },
             "damage": {
               "onSave": "half",
-              "parts": [
-                {
-                  "number": 1,
-                  "denomination": 6,
-                  "bonus": "@mod",
-                  "types": [
-                    "necrotic"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "parts": []
             },
             "save": {
               "ability": "con",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "13"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
-        "magicalBonus": null
+        "magicalBonus": null,
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -1580,8 +1566,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387522051,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rbyp54px2D0ql4QK.NX8cqG6aZMns8wvY"
     }

--- a/packs/_source/monsters/undead/will-o-wisp.json
+++ b/packs/_source/monsters/undead/will-o-wisp.json
@@ -679,7 +679,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -718,21 +718,14 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 3,
-                  "denomination": 6,
-                  "bonus": "",
-                  "types": [
-                    "healing"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 3,
+                  "denomination": "6",
+                  "bonus": "",
+                  "types": []
                 }
               ]
             },
@@ -740,10 +733,13 @@
               "ability": "con",
               "dc": {
                 "calculation": "",
-                "formula": ""
+                "formula": "10"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -769,8 +765,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1725387545714,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8KSVpQZyzius93ko.RAnyTfj3CGaiGK3W"
     },


### PR DESCRIPTION
- Move Basic Poison into the poisons folder
- Move Crystal into the trinkets folder
- Remove Attack activities from ammunition items
- Remove Attack activities from spell scrolls
- Remove redundant versatile damage from Battleaxe & Longsword
- Fix versatile formula on Frost Brand Longsword
- Add missing save DCs to a number of monasters