### PR TITLE
[#4024] Rework Check Activity to support multiple checks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -636,8 +636,8 @@
         "hint": "Ability to use when making the check."
       },
       "associated": {
-        "label": "Associated Skill or Tool",
-        "hint": "Proficiency and bonuses with this skill or tool will contribute to the ability check."
+        "label": "Associated Skills or Tools",
+        "hint": "Present ability checks using proficiency and bonuses with these skills or tools."
       },
       "dc": {
         "label": "Difficulty Class",

--- a/module/applications/activity/check-sheet.mjs
+++ b/module/applications/activity/check-sheet.mjs
@@ -39,15 +39,15 @@ export default class CheckSheet extends ActivitySheet {
       ...Object.entries(CONFIG.DND5E.abilities).map(([value, config]) => ({ value, label: config.label }))
     ];
     let ability;
-    if ( this.item.type === "tool" ) ability = CONFIG.DND5E.abilities[this.item.system.ability]?.label?.toLowerCase();
-    else if ( this.activity.checkType === "skill" ) ability = CONFIG.DND5E.abilities[
-      CONFIG.DND5E.skills[this.activity.check.associated].ability
-    ]?.label?.toLowerCase();
+    const associated = this.activity.check.associated;
+    if ( (this.item.type === "tool") && !associated.size ) {
+      ability = CONFIG.DND5E.abilities[this.item.system.ability]?.label?.toLowerCase();
+    } else if ( (associated.size === 1) && associated.first() in CONFIG.DND5E.skills ) {
+      ability = CONFIG.DND5E.abilities[CONFIG.DND5E.skills[associated.first()].ability]?.label?.toLowerCase();
+    }
     if ( ability ) context.abilityOptions[0].label = game.i18n.format("DND5E.DefaultSpecific", { default: ability });
 
     context.associatedOptions = [
-      { value: "", label: this.item.type === "tool" ? game.i18n.format("DND5E.DefaultSpecific", {
-        default: game.i18n.localize("DND5E.CHECK.ThisTool").toLowerCase() }) : "" },
       ...Object.entries(CONFIG.DND5E.skills).map(([value, { label }]) => ({
         value, label, group: game.i18n.localize("DND5E.Skills")
       })),

--- a/module/applications/activity/check-sheet.mjs
+++ b/module/applications/activity/check-sheet.mjs
@@ -42,7 +42,7 @@ export default class CheckSheet extends ActivitySheet {
     const associated = this.activity.check.associated;
     if ( (this.item.type === "tool") && !associated.size ) {
       ability = CONFIG.DND5E.abilities[this.item.system.ability]?.label?.toLowerCase();
-    } else if ( (associated.size === 1) && associated.first() in CONFIG.DND5E.skills ) {
+    } else if ( (associated.size === 1) && (associated.first() in CONFIG.DND5E.skills) ) {
       ability = CONFIG.DND5E.abilities[CONFIG.DND5E.skills[associated.first()].ability]?.label?.toLowerCase();
     }
     if ( ability ) context.abilityOptions[0].label = game.i18n.format("DND5E.DefaultSpecific", { default: ability });

--- a/module/data/activity/check-data.mjs
+++ b/module/data/activity/check-data.mjs
@@ -46,28 +46,7 @@ export default class CheckActivityData extends BaseActivityData {
   }
 
   /* -------------------------------------------- */
-
-  /**
-   * Is this a flat ability check, skill check, or tool check?
-   * @type {"ability"|"skill"|"tool"}
-   */
-  get checkType() {
-    if ( this.check.associated in CONFIG.DND5E.skills ) return "skill";
-    if ( this.check.associated in CONFIG.DND5E.toolIds ) return "tool";
-    return "ability";
-  }
-
-  /* -------------------------------------------- */
   /*  Data Migrations                             */
-  /* -------------------------------------------- */
-
-  /** @override */
-  static migrateData(source) {
-    if ( foundry.utils.getType(source.check?.associated) === "string" ) {
-      source.check.associated = source.check.associated ? [source.check.associated] : [];
-    }
-  }
-
   /* -------------------------------------------- */
 
   /** @override */

--- a/module/data/activity/check-data.mjs
+++ b/module/data/activity/check-data.mjs
@@ -2,17 +2,17 @@ import { simplifyBonus } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
-const { SchemaField, StringField } = foundry.data.fields;
+const { SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * Data model for a check activity.
  *
  * @property {object} check
- * @property {string} check.ability         Ability used with the check.
- * @property {string} check.associated      Skill or tool that can contribute to the check.
+ * @property {string} check.ability          Ability used with the check.
+ * @property {Set<string>} check.associated  Skills or tools that can contribute to the check.
  * @property {object} check.dc
- * @property {string} check.dc.calculation  Method or ability used to calculate the difficulty class of the check.
- * @property {string} check.dc.formula      Custom DC formula or flat value.
+ * @property {string} check.dc.calculation   Method or ability used to calculate the difficulty class of the check.
+ * @property {string} check.dc.formula       Custom DC formula or flat value.
  */
 export default class CheckActivityData extends BaseActivityData {
   /** @inheritDoc */
@@ -21,7 +21,7 @@ export default class CheckActivityData extends BaseActivityData {
       ...super.defineSchema(),
       check: new SchemaField({
         ability: new StringField(),
-        associated: new StringField(),
+        associated: new SetField(new StringField()),
         dc: new SchemaField({
           calculation: new StringField(),
           formula: new FormulaField({ deterministic: true })
@@ -62,6 +62,15 @@ export default class CheckActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @override */
+  static migrateData(source) {
+    if ( foundry.utils.getType(source.check?.associated) === "string" ) {
+      source.check.associated = source.check.associated ? [source.check.associated] : [];
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   static transformTypeData(source, activityData, options) {
     return foundry.utils.mergeObject(activityData, {
       check: {
@@ -79,15 +88,6 @@ export default class CheckActivityData extends BaseActivityData {
     rollData ??= this.getRollData({ deterministic: true });
     super.prepareFinalData(rollData);
 
-    if ( this.item.type === "tool" ) {
-      if ( !this.check.associated ) this.check.associated = this.item.system.type.baseItem;
-      if ( !this.check.ability ) this.check.ability = this.item.system.ability
-        || this.actor?.system.tools?.[this.check.associated]?.ability
-        || Object.keys(CONFIG.DND5E.abilities)[0];
-    } else if ( !this.check.ability && (this.checkType === "skill") ) {
-      this.check.ability = CONFIG.DND5E.skills[this.check.associated].ability;
-    }
-
     let ability;
     if ( this.check.dc.calculation ) ability = this.ability;
     else this.check.dc.value = simplifyBonus(this.check.dc.formula, rollData);
@@ -95,5 +95,24 @@ export default class CheckActivityData extends BaseActivityData {
       ?? 8 + (this.actor?.system.attributes?.prof ?? 0);
 
     if ( !this.check.dc.value ) this.check.dc.value = null;
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Get the ability to use with an associated value.
+   * @param {string} associated  Skill or tool ID.
+   * @returns {string|null}      Ability to use.
+   */
+  getAbility(associated) {
+    if ( this.check.ability ) return this.check.ability;
+    if ( associated in CONFIG.DND5E.skills ) return CONFIG.DND5E.skills[associated].ability ?? null;
+    else if ( associated in CONFIG.DND5E.toolIds ) {
+      if ( (this.item.type === "tool") && this.item.system.ability ) return this.item.system.ability;
+      return this.actor?.system.tools?.[associated]?.ability ?? null;
+    }
+    return null;
   }
 }

--- a/module/documents/activity/check.mjs
+++ b/module/documents/activity/check.mjs
@@ -38,31 +38,45 @@ export default class CheckActivity extends ActivityMixin(CheckActivityData) {
 
   /** @override */
   _usageChatButtons() {
-    const ability = CONFIG.DND5E.abilities[this.check.ability]?.label;
-    if ( !ability ) return super._usageChatButtons();
+    const buttons = [];
     const dc = this.check.dc.value;
 
-    let label = ability;
-    let type;
-    if ( this.checkType === "skill" ) type = CONFIG.DND5E.skills[this.check.associated]?.label;
-    else if ( this.checkType === "tool" ) type = Trait.keyLabel(this.check.associated, { trait: "tool" });
-    if ( type ) label = game.i18n.format("EDITOR.DND5E.Inline.SpecificCheck", { ability, type });
-    else label = ability;
+    const createButton = (abilityKey, associated) => {
+      const ability = CONFIG.DND5E.abilities[abilityKey]?.label;
+      const checkType = (associated in CONFIG.DND5E.skills) ? "skill"
+        : (associated in CONFIG.DND5E.toolIds) ? "tool": "ability";
+      const dataset = { ability: abilityKey, action: "rollCheck", visibility: "all" };
+      if ( dc ) dataset.dc = dc;
+      if ( checkType !== "ability" ) dataset[checkType] = associated;
+
+      let label = ability;
+      let type;
+      if ( checkType === "skill" ) type = CONFIG.DND5E.skills[associated]?.label;
+      else if ( checkType === "tool" ) type = Trait.keyLabel(associated, { trait: "tool" });
+      if ( type ) label = game.i18n.format("EDITOR.DND5E.Inline.SpecificCheck", { ability, type });
+      else label = ability;
+
+      buttons.push({
+        label: dc ? `
+          <span class="visible-dc">${game.i18n.format("EDITOR.DND5E.Inline.DC", { dc, check: wrap(label) })}</span>
+          <span class="hidden-dc">${wrap(label)}</span>
+        ` : wrap(label),
+        icon: checkType === "tool" ? '<i class="fa-solid fa-hammer" inert></i>'
+          : '<i class="dnd5e-icon" data-src="systems/dnd5e/icons/svg/ability-score-improvement.svg" inert></i>',
+        dataset
+      });
+    };
     const wrap = check => game.i18n.format("EDITOR.DND5E.Inline.CheckShort", { check });
 
-    return [{
-      label: dc ? `
-        <span class="visible-dc">${game.i18n.format("EDITOR.DND5E.Inline.DC", { dc, check: wrap(label) })}</span>
-        <span class="hidden-dc">${wrap(label)}</span>
-      ` : wrap(label),
-      icon: this.checkType === "tool" ? '<i class="fa-solid fa-hammer" inert></i>'
-        : '<i class="dnd5e-icon" data-src="systems/dnd5e/icons/svg/ability-score-improvement.svg" inert></i>',
-      dataset: {
-        ability: this.check.ability, dc: dc || undefined,
-        action: "rollCheck",
-        visibility: "all"
-      }
-    }].concat(super._usageChatButtons());
+    const associated = Array.from(this.check.associated);
+    if ( !associated.length && (this.item.type === "tool") ) associated.push(this.item.system.type.baseItem);
+    if ( associated.length ) associated.forEach(a => {
+      const ability = this.getAbility(a);
+      if ( ability ) createButton(ability, a);
+    });
+    else if ( this.check.ability ) createButton(this.check.ability);
+
+    return buttons.concat(super._usageChatButtons());
   }
 
   /* -------------------------------------------- */
@@ -79,25 +93,23 @@ export default class CheckActivity extends ActivityMixin(CheckActivityData) {
   static async #rollCheck(event, target, message) {
     const targets = getSceneTargets();
     if ( !targets.length ) ui.notifications.warn("DND5E.ActionWarningNoToken", { localize: true });
-    const dc = parseInt(target.dataset.dc);
+    let { ability, dc, skill, tool } = target.dataset;
+    dc = parseInt(dc);
     const data = { event, targetValue: Number.isFinite(dc) ? dc : this.check.dc.value };
+
     for ( const token of targets ) {
       data.speaker = ChatMessage.getSpeaker({ scene: canvas.scene, token: token.document });
-      switch ( this.checkType ) {
-        case "ability":
-          await token.actor.rollAbilityTest(this.check.ability, data);
-          break;
-        case "skill":
-          await token.actor.rollSkill(this.check.associated, { ...data, ability: this.check.ability });
-          break;
-        case "tool":
-          const checkData = { ...data, ability: this.check.ability };
-          if ( (this.item.type === "tool") && !this._source.check.associated ) {
-            checkData.bonus = this.item.system.bonus;
-            checkData.prof = this.item.system.prof;
-          }
-          await token.actor.rollToolCheck(this.check.associated, checkData);
-          break;
+      if ( skill ) {
+        await token.actor.rollSkill(skill, { ...data, ability });
+      } else if ( tool ) {
+        const checkData = { ...data, ability };
+        if ( (this.item.type === "tool") && !this.check.associated.size ) {
+          checkData.bonus = this.item.system.bonus;
+          checkData.prof = this.item.system.prof;
+        }
+        await token.actor.rollToolCheck(tool, checkData);
+      } else {
+        await token.actor.rollAbilityTest(ability, data);
       }
     }
   }

--- a/templates/activity/parts/check-details.hbs
+++ b/templates/activity/parts/check-details.hbs
@@ -4,7 +4,7 @@
     {{ formField fields.check.fields.ability value=source.check.ability options=abilityOptions }}
     {{#with fields.check.fields.dc.fields as |fields|}}
     {{ formField fields.calculation value=../activity.check.dc.calculation options=../calculationOptions }}
-    {{#if (eq ../source.check.dc.calculation "")}}
+    {{#if (not ../source.check.dc.calculation)}}
     {{ formField fields.formula value=../source.check.dc.formula }}
     {{else}}
     {{ formField fields.formula name="" value=(localize "DND5E.SAVE.FIELDS.save.dc.DefaultFormula") disabled=true }}


### PR DESCRIPTION
Changes the `check.associated` value on `CheckActivity` to be a set of associated values rather than a single value. If multiple associated values are set then more than one button will appear in the chat card.

<img width="839" alt="Check Activity - Multiple Associated" src="https://github.com/user-attachments/assets/fce29537-813e-44dd-990b-b44889d4f714">

Setting an explicit ability for the activity will cause all of the created checks to use that ability, otherwise they will attempt to determine the best ability to use (skills from the default value in config, tools from the tool item or character data).