### PR TITLE
[#3762] Add arbitrary effects to summoned creatures

### DIFF
--- a/less/v2/activities.less
+++ b/less/v2/activities.less
@@ -92,7 +92,7 @@
 /*  Summon Activity                          */
 /* ----------------------------------------- */
 
-.summon-activity.sheet {
+.summon-activity.sheet .separated-list:not(.effects-list) {
   .content-link, .drop-area, .name {
     display: flex;
     align-items: center;

--- a/module/applications/activity/summon-sheet.mjs
+++ b/module/applications/activity/summon-sheet.mjs
@@ -26,6 +26,7 @@ export default class SummonSheet extends ActivitySheet {
     effect: {
       template: "systems/dnd5e/templates/activity/summon-effect.hbs",
       templates: [
+        "systems/dnd5e/templates/activity/parts/activity-effects.hbs",
         "systems/dnd5e/templates/activity/parts/summon-changes.hbs",
         "systems/dnd5e/templates/activity/parts/summon-profiles.hbs"
       ]

--- a/module/data/activity/summon-data.mjs
+++ b/module/data/activity/summon-data.mjs
@@ -46,10 +46,8 @@ const {
 export default class SummonActivityData extends BaseActivityData {
   /** @inheritDoc */
   static defineSchema() {
-    const fields = super.defineSchema();
-    delete fields.effects;
     return {
-      ...fields,
+      ...super.defineSchema(),
       bonuses: new SchemaField({
         ac: new FormulaField(),
         hd: new FormulaField(),
@@ -66,12 +64,12 @@ export default class SummonActivityData extends BaseActivityData {
         saves: new BooleanField()
       }),
       profiles: new ArrayField(new SchemaField({
-        _id: new DocumentIdField({initial: () => foundry.utils.randomID()}),
+        _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
         count: new FormulaField(),
-        cr: new FormulaField({deterministic: true}),
+        cr: new FormulaField({ deterministic: true }),
         level: new SchemaField({
-          min: new NumberField({integer: true, min: 0}),
-          max: new NumberField({integer: true, min: 0})
+          min: new NumberField({ integer: true, min: 0 }),
+          max: new NumberField({ integer: true, min: 0 })
         }),
         name: new StringField(),
         types: new SetField(new StringField()),
@@ -92,6 +90,13 @@ export default class SummonActivityData extends BaseActivityData {
   /** @override */
   get actionType() {
     return "summ";
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  get applicableEffects() {
+    return null;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -540,6 +540,9 @@ export default class SummonActivity extends ActivityMixin(SummonActivityData) {
       }
     }
 
+    // Add applied effects
+    actorUpdates.effects.push(...this.effects.map(e => e.effect?.toObject()).filter(e => e));
+
     return { actorUpdates, tokenUpdates };
   }
 

--- a/templates/activity/parts/summon-changes.hbs
+++ b/templates/activity/parts/summon-changes.hbs
@@ -22,4 +22,5 @@
         {{ formField fields.bonuses.fields.saveDamage value=source.bonuses.saveDamage }}
         {{ formField fields.bonuses.fields.healing value=source.bonuses.healing }}
     </fieldset>
+    {{> "systems/dnd5e/templates/activity/parts/activity-effects.hbs" }}
 </section>


### PR DESCRIPTION
Uses the effects system in activities to set an active effect that is added to summons when placed, allowing the setting of arbitrary values on the summoned creature.

<img width="511" alt="Screenshot 2024-09-04 at 09 43 36" src="https://github.com/user-attachments/assets/e435b046-e4a8-4c96-ab2b-f8c0da92908e">

Closes #3242
Closes #3762