### PR TITLE
Add rules version & revision to source data

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2284,15 +2284,43 @@
 "DND5E.SkillPassives": "Skill Passives",
 "DND5E.Skin": "Skin",
 "DND5E.Skip": "Skip",
-"DND5E.Source": "Source",
-"DND5E.SourceBook": "Book",
-"DND5E.SourceConfig": "Configure Source",
-"DND5E.SourceCustom": "Custom Label",
-"DND5E.SourceDisplay": "{book} {page}",
-"DND5E.SourceLicense": "License",
-"DND5E.SourcePage": "Page/Section",
-"DND5E.SourcePageDisplay": "pg. {page}",
-"DND5E.SourceUUID": "Original Source",
+
+"DND5E.SOURCE": {
+  "FIELDS": {
+    "source": {
+      "label": "Source",
+      "book": {
+        "label": "Book"
+      },
+      "custom": {
+        "label": "Custom Label"
+      },
+      "license": {
+        "label": "License"
+      },
+      "page": {
+        "label": "Page/Section"
+      },
+      "revision": {
+        "label": "Revision"
+      },
+      "rules": {
+        "label": "Rules Version"
+      },
+      "uuid": {
+        "label": "Original Source"
+      }
+    }
+  },
+  "Action": {
+    "Configure": "Configure Source"
+  },
+  "Display": {
+    "Full": "{book} {page}",
+    "Page": "pg. {page}"
+  }
+},
+
 "DND5E.Special": "Special",
 "DND5E.SpecialHint": "Special values separated by semi-colons.",
 "DND5E.SpecialTraits": "Special Traits",

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -101,8 +101,8 @@ export default function DocumentSheetV2Mixin(Base) {
       elements.classList.add("header-elements");
       elements.innerHTML = `
         <div class="source-book">
-          <a class="config-button" data-action="source" data-tooltip="DND5E.SourceConfig"
-             aria-label="${game.i18n.localize("DND5E.SourceConfig")}">
+          <a class="config-button" data-action="source" data-tooltip="DND5E.SOURCE.Action.Configure"
+             aria-label="${game.i18n.localize("DND5E.SOURCE.Action.Configure")}">
             <i class="fas fa-cog"></i>
           </a>
           <span></span>
@@ -120,12 +120,12 @@ export default function DocumentSheetV2Mixin(Base) {
      */
     _renderSource() {
       const [elements] = this.element.find(".header-elements");
-      const source = this.actor?.system.details?.source ?? this.item?.system.source;
+      const source = this.document?.system.source;
       if ( !elements || !source ) return;
       const editable = this.isEditable && (this._mode === this.constructor.MODES.EDIT);
       elements.querySelector(".config-button")?.toggleAttribute("hidden", !editable);
       elements.querySelector(".source-book > span").innerText = editable
-        ? (source.label || game.i18n.localize("DND5E.Source"))
+        ? (source.label || game.i18n.localize("DND5E.SOURCE.FIELDS.source.label"))
         : source.label;
     }
 

--- a/module/applications/source-config.mjs
+++ b/module/applications/source-config.mjs
@@ -13,8 +13,7 @@ export default class SourceConfig extends DocumentSheet5e {
     },
     form: {
       closeOnSubmit: true
-    },
-    keyPath: "system.details.source"
+    }
   };
 
   /* -------------------------------------------- */
@@ -35,7 +34,7 @@ export default class SourceConfig extends DocumentSheet5e {
 
   /** @override */
   get title() {
-    return game.i18n.localize("DND5E.SourceConfig");
+    return game.i18n.localize("DND5E.SOURCE.Action.Configure");
   }
 
   /* -------------------------------------------- */
@@ -47,11 +46,16 @@ export default class SourceConfig extends DocumentSheet5e {
     const context = await super._prepareContext(options);
     context.buttons = [{ icon: "fa-regular fa-save", label: "Submit", type: "submit" }];
     context.data = foundry.utils.getProperty(this.document, this.options.keyPath);
-    context.fields = this.document.system.schema.getField(this.options.keyPath.replace(/^system\./, "")).fields;
+    context.fields = this.document.system.schema.getField("source").fields;
     context.keyPath = this.options.keyPath;
-    context.source = foundry.utils.getProperty(this.document.toObject(), this.options.keyPath);
+    context.source = this.document.toObject().system.source;
     context.sourceUuid = this.document._stats.compendiumSource;
     context.hasSourceId = !!(await fromUuid(context.sourceUuid));
+    context.rulesVersions = [
+      { value: "", label: "" },
+      { value: "2024", label: game.i18n.localize("SETTINGS.DND5E.RULESVERSION.Modern") },
+      { value: "2014", label: game.i18n.localize("SETTINGS.DND5E.RULESVERSION.Legacy") }
+    ];
     return context;
   }
 }

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -40,10 +40,18 @@ const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foun
  * @property {object} cargo                            Details on this vehicle's crew and cargo capacities.
  * @property {PassengerData[]} cargo.crew              Creatures responsible for operating the vehicle.
  * @property {PassengerData[]} cargo.passengers        Creatures just takin' a ride.
- * @property {object} details
- * @property {SourceData} details.source               Adventure or sourcebook where this vehicle originated.
+ * @property {SourceData} source                       Adventure or sourcebook where this vehicle originated.
  */
 export default class VehicleData extends CommonTemplate {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.SOURCE"];
+
+  /* -------------------------------------------- */
 
   /** @inheritDoc */
   static _systemType = "vehicle";
@@ -102,10 +110,8 @@ export default class VehicleData extends CommonTemplate {
           })
         }, { label: "DND5E.VehicleCargoCrew" })
       }, { label: "DND5E.Attributes" }),
-      details: new SchemaField({
-        ...DetailsFields.common,
-        source: new SourceField()
-      }, { label: "DND5E.Details" }),
+      details: new SchemaField(DetailsFields.common, { label: "DND5E.Details" }),
+      source: new SourceField(),
       traits: new SchemaField({
         ...TraitsFields.common,
         size: new StringField({ required: true, initial: "lg", label: "DND5E.Size" }),
@@ -135,13 +141,16 @@ export default class VehicleData extends CommonTemplate {
   /* -------------------------------------------- */
 
   /**
-   * Convert source string into custom object.
+   * Convert source string into custom object & move to top-level.
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateSource(source) {
-    if ( source.details?.source && (foundry.utils.getType(source.details.source) !== "Object") ) {
-      source.details.source = { custom: source.details.source };
+    let custom;
+    if ( ("details" in source) && ("source" in source.details) ) {
+      if ( foundry.utils.getType(source.details?.source) === "string" ) custom = source.details.source;
+      else source.source = source.details.source;
     }
+    if ( custom ) source.source.custom = custom;
   }
 
   /* -------------------------------------------- */
@@ -153,6 +162,7 @@ export default class VehicleData extends CommonTemplate {
     this.attributes.prof = 0;
     AttributesFields.prepareBaseArmorClass.call(this);
     AttributesFields.prepareBaseEncumbrance.call(this);
+    SourceField.shimActor.call(this);
   }
 
   /* -------------------------------------------- */
@@ -167,7 +177,7 @@ export default class VehicleData extends CommonTemplate {
       (item.flags.dnd5e?.vehicleCargo === true) || !["weapon", "equipment"].includes(item.type)
     });
     AttributesFields.prepareHitPoints.call(this, this.attributes.hp);
-    SourceField.prepareData.call(this.details.source, this.parent._stats?.compendiumSource ?? this.parent.uuid);
+    SourceField.prepareData.call(this.source, this.parent._stats?.compendiumSource ?? this.parent.uuid);
   }
 }
 

--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -15,6 +15,16 @@ const { ArrayField } = foundry.data.fields;
  * @property {object[]} advancement  Advancement objects for this background.
  */
 export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionTemplate, StartingEquipmentTemplate) {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.SOURCE"];
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -31,7 +31,7 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.CLASS"];
+  static LOCALIZATION_PREFIXES = ["DND5E.CLASS", "DND5E.SOURCE"];
 
   /* -------------------------------------------- */
 

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -40,7 +40,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.CONSUMABLE"];
+  static LOCALIZATION_PREFIXES = ["DND5E.CONSUMABLE", "DND5E.SOURCE"];
 
   /* -------------------------------------------- */
 

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -23,6 +23,16 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 export default class ContainerData extends ItemDataModel.mixin(
   ItemDescriptionTemplate, IdentifiableTemplate, PhysicalItemTemplate, EquippableItemTemplate, CurrencyTemplate
 ) {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.SOURCE"];
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -31,6 +31,16 @@ export default class EquipmentData extends ItemDataModel.mixin(
   ActivitiesTemplate, ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate,
   PhysicalItemTemplate, EquippableItemTemplate, MountableTemplate
 ) {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.SOURCE"];
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -25,8 +25,14 @@ export default class FeatData extends ItemDataModel.mixin(
   ActivitiesTemplate, ItemDescriptionTemplate, ItemTypeTemplate
 ) {
 
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.ENCHANTMENT", "DND5E.Prerequisites"];
+  static LOCALIZATION_PREFIXES = ["DND5E.ENCHANTMENT", "DND5E.Prerequisites", "DND5E.SOURCE"];
+
+  /* -------------------------------------------- */
 
   /** @inheritDoc */
   static defineSchema() {

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -17,6 +17,16 @@ const { SetField, StringField } = foundry.data.fields;
 export default class LootData extends ItemDataModel.mixin(
   ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate, PhysicalItemTemplate
 ) {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.SOURCE"];
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -19,6 +19,16 @@ const { ArrayField } = foundry.data.fields;
  * @property {CreatureType} type
  */
 export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplate) {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.SOURCE"];
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -40,7 +40,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
 
   /** @override */
   static LOCALIZATION_PREFIXES = [
-    "DND5E.ACTIVATION", "DND5E.DURATION", "DND5E.RANGE", "DND5E.TARGET"
+    "DND5E.ACTIVATION", "DND5E.DURATION", "DND5E.RANGE", "DND5E.SOURCE", "DND5E.TARGET"
   ];
 
   /* -------------------------------------------- */

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -16,6 +16,16 @@ const { ArrayField } = foundry.data.fields;
  * @property {SpellcastingField} spellcasting  Details on subclass's spellcasting ability.
  */
 export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTemplate) {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.SOURCE"];
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -28,6 +28,16 @@ export default class ToolData extends ItemDataModel.mixin(
   ActivitiesTemplate, ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate,
   PhysicalItemTemplate, EquippableItemTemplate
 ) {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.SOURCE"];
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -48,7 +48,7 @@ export default class WeaponData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.WEAPON", "DND5E.RANGE"];
+  static LOCALIZATION_PREFIXES = ["DND5E.WEAPON", "DND5E.RANGE", "DND5E.SOURCE"];
 
   /* -------------------------------------------- */
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -746,7 +746,7 @@ export default class ActiveEffect5e extends ActiveEffect {
     <form class="dnd5e">
       <p>${game.i18n.localize("DND5E.ConcentratingEndChoice")}</p>
       <div class="form-group">
-        <label>${game.i18n.localize("DND5E.Source")}</label>
+        <label>${game.i18n.localize("DND5E.SOURCE.FIELDS.source.label")}</label>
         <div class="form-fields">
           <select name="source">${options}</select>
         </div>

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -417,6 +417,11 @@ export function migrateActorData(actor, actorData, migrationData, flags={}, { ac
     if ( effects.length > 0 ) updateData.effects = effects;
   }
 
+  // Set source rules version to Legacy
+  if ( foundry.utils.isNewerVersion("4.0.0", actorData._stats?.systemVersion) ) {
+    updateData["system.source.rules"] = "2014";
+  }
+
   // Migrate Owned Items
   if ( !actorData.items ) return updateData;
   const items = actor.items.reduce((arr, i) => {
@@ -479,6 +484,11 @@ export function migrateItemData(item, itemData, migrationData, flags={}) {
   if ( itemData.effects ) {
     const effects = migrateEffects(itemData, migrationData);
     if ( effects.length > 0 ) updateData.effects = effects;
+  }
+
+  // Set source rules version to Legacy
+  if ( foundry.utils.isNewerVersion("4.0.0", itemData._stats?.systemVersion) ) {
+    updateData["system.source.rules"] = "2014";
   }
 
   // Migrate properties

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -43,12 +43,12 @@
                 <li class="source">
                     {{#if system.details.source.directlyEditable}}
                         <input type="text" name="system.details.source.custom" value="{{ system.details.source.custom }}"
-                                     placeholder="{{ localize 'DND5E.Source' }}">
+                               placeholder="{{ localize 'DND5E.SOURCE.FIELDS.source.label' }}">
                     {{else}}
                         <span data-tooltip="{{ system.details.source.label }}">{{ system.details.source.label }}</span>
                     {{/if}}
                     {{#if editable}}
-                        <a class="config-button" data-action="source" data-tooltip="DND5E.SourceConfig">
+                        <a class="config-button" data-action="source" data-tooltip="DND5E.SOURCE.Action.Configure">
                             <i class="fas fa-cog"></i>
                         </a>
                     {{/if}}

--- a/templates/actors/vehicle-sheet.hbs
+++ b/templates/actors/vehicle-sheet.hbs
@@ -24,12 +24,12 @@
                 <li class="source">
                     {{#if (eq system.details.source.custom system.details.source.label)}}
                         <input type="text" name="system.details.source.custom" value="{{system.details.source.custom}}"
-                                     placeholder="{{ localize 'DND5E.Source' }}">
+                                     placeholder="{{ localize 'DND5E.SOURCE.FIELDS.source.label' }}">
                     {{else}}
                         <span data-tooltip="{{system.details.source.label}}">{{system.details.source.label}}</span>
                     {{/if}}
                     {{#if editable}}
-                        <a class="config-button" data-action="source" data-tooltip="DND5E.SourceConfig">
+                        <a class="config-button" data-action="source" data-tooltip="DND5E.SOURCE.Action.Configure">
                             <i class="fas fa-cog"></i>
                         </a>
                     {{/if}}

--- a/templates/apps/source-config.hbs
+++ b/templates/apps/source-config.hbs
@@ -1,7 +1,7 @@
 <fieldset>
-    <legend>{{ localize "DND5E.Source" }}</legend>
+    <legend>{{ localize "DND5E.SOURCE.FIELDS.source.label" }}</legend>
     <div class="form-group">
-        <label>{{ localize "DND5E.SourceBook" }}</label>
+        <label>{{ localize "DND5E.SOURCE.FIELDS.source.book.label" }}</label>
         <div class="form-fields">
             <input type="text" name="{{ keyPath }}.book" value="{{ source.book }}" list="{{ partId }}-books"
                    placeholder="{{ data.bookPlaceholder }}">
@@ -10,12 +10,14 @@
             </datalist>
         </div>
     </div>
-    {{ formField fields.page value=source.page label="DND5E.SourcePage" localize=true }}
-    {{ formField fields.custom value=source.custom label="DND5E.SourceCustom" localize=true }}
-    {{ formField fields.license value=source.license label="DND5E.SourceLicense" localize=true }}
+    {{ formField fields.page value=source.page }}
+    {{ formField fields.custom value=source.custom }}
+    {{ formField fields.license value=source.license }}
+    {{ formField fields.rules value=source.rules options=rulesVersions }}
+    {{ formField fields.revision value=source.revision }}
     {{#if hasSourceId}}
     <div class="form-group">
-        <label>{{ localize "DND5E.SourceUUID" }}</label>
+        <label>{{ localize "DND5E.SOURCE.FIELDS.source.uuid.label" }}</label>
         <div class="source-uuid">
             {{{ dnd5e-linkForUuid sourceUuid }}}
         </div>

--- a/templates/items/parts/item-source.hbs
+++ b/templates/items/parts/item-source.hbs
@@ -1,11 +1,11 @@
 {{#if system.source.directlyEditable}}
 <input type="text" name="system.source.custom" value="{{ system.source.custom }}"
-       placeholder="{{ localize 'DND5E.Source' }}">
+       placeholder="{{ localize 'DND5E.SOURCE.FIELDS.source.label' }}">
 {{else}}
 <span>{{ system.source.label }}</span>
 {{/if}}
 {{#if (and editable (not concealDetails))}}
-<a class="config-button" data-action="source" data-tooltip="DND5E.SourceConfig">
+<a class="config-button" data-action="source" data-tooltip="DND5E.SOURCE.Action.Configure">
     <i class="fas fa-cog"></i>
 </a>
 {{/if}}

--- a/templates/journal/page-spell-list-unlinked-config.hbs
+++ b/templates/journal/page-spell-list-unlinked-config.hbs
@@ -19,24 +19,24 @@
         </div>
     </fieldset>
     <fieldset>
-        <legend>{{ localize "DND5E.Source" }}</legend>
+        <legend>{{ localize "DND5E.SOURCE.FIELDS.source.label" }}</legend>
         <div class="form-group">
-            <label>{{ localize "DND5E.SourceBook" }}</label>
+            <label>{{ localize "DND5E.SOURCE.FIELDS.source.book.label" }}</label>
             <input type="text" name="source.book" value="{{ source.book }}" list="{{ appId }}-books">
             <datalist id="{{ appId }}-books">
                 {{selectOptions CONFIG.sourceBooks}}
             </datalist>
         </div>
         <div class="form-group">
-            <label>{{ localize "DND5E.SourcePage" }}</label>
+            <label>{{ localize "DND5E.SOURCE.FIELDS.source.page.label" }}</label>
             <input type="text" name="source.page" value="{{ source.page }}">
         </div>
         <div class="form-group">
-            <label>{{ localize "DND5E.SourceCustom" }}</label>
+            <label>{{ localize "DND5E.SOURCE.FIELDS.source.custom.label" }}</label>
             <input type="text" name="source.custom" value="{{ source.custom }}">
         </div>
         <div class="form-group">
-            <label>{{ localize "DND5E.SourceUUID" }}</label>
+            <label>{{ localize "DND5E.SOURCE.FIELDS.source.uuid.label" }}</label>
             <input type="text" name="source.uuid" value="{{ source.uuid }}">
         </div>
     </fieldset>

--- a/templates/shared/active-effects.hbs
+++ b/templates/shared/active-effects.hbs
@@ -5,7 +5,7 @@
     {{#unless section.hidden}}
     <li class="items-header flexrow" data-effect-type="{{section.type}}">
         <h3 class="item-name effect-name flexrow">{{localize section.label}}</h3>
-        <div class="effect-source">{{localize "DND5E.Source"}}</div>
+        <div class="effect-source">{{localize "DND5E.SOURCE.FIELDS.source.label"}}</div>
         <div class="effect-source">{{localize "DND5E.Duration"}}</div>
         <div class="item-controls effect-controls flexrow">
             {{#if @root.editable}}

--- a/templates/shared/active-effects2.hbs
+++ b/templates/shared/active-effects2.hbs
@@ -14,7 +14,7 @@
             {{!-- Section Header --}}
             <div class="items-header header {{#if disabled}}disabled{{/if}}">
                 <h3 class="item-name effect-name">{{ localize label }}</h3>
-                <div class="item-header effect-source">{{ localize "DND5E.Source" }}</div>
+                <div class="item-header effect-source">{{ localize "DND5E.SOURCE.FIELDS.source.label" }}</div>
                 <div class="item-header item-controls effect-controls">
                     {{#if info}}
                     <a class="info-control" data-tooltip="{{ info }}" aria-label="{{ info }}">


### PR DESCRIPTION
Adds two new data fields to source data:
- `rules`: Was this item created for the legacy or modern rules
- `revision`: Internal revision number usable for tracking changes when a module updates.

Also moves the source data out of `system.details` for NPCs and vehicles so all documents have it in the same location.