### PR TITLE
[#3803] Add rider activities to enchantments

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1319,6 +1319,10 @@
         },
         "riders": {
           "label": "Attached",
+          "activity": {
+            "label": "Additional Activities",
+            "hint": "These additional activities will be added to the enchant item when this enchantment is added, and removed when the enchantment is removed."
+          },
           "effect": {
             "label": "Additional Effects",
             "hint": "These additional effects will be added to the enchanted item when this enchantment is added, and removed when the enchantment is removed."

--- a/lang/en.json
+++ b/lang/en.json
@@ -1321,11 +1321,11 @@
           "label": "Attached",
           "activity": {
             "label": "Additional Activities",
-            "hint": "These additional activities will be added to the enchant item when this enchantment is added, and removed when the enchantment is removed."
+            "hint": "These additional activities will be added to the enchanted item when this enchantment is applied, and removed when the enchantment is removed."
           },
           "effect": {
             "label": "Additional Effects",
-            "hint": "These additional effects will be added to the enchanted item when this enchantment is added, and removed when the enchantment is removed."
+            "hint": "These additional effects will be added to the enchanted item when this enchantment is applied, and removed when the enchantment is removed."
           },
           "item": {
             "label": "Additional Items",

--- a/module/applications/activity/activity-choice-dialog.mjs
+++ b/module/applications/activity/activity-choice-dialog.mjs
@@ -85,8 +85,10 @@ export default class ActivityChoiceDialog extends Application5e {
         `<img src="systems/dnd5e/icons/svg/mouse-left.svg" alt="${game.i18n.localize("DND5E.Controls.LeftClick")}">`
       );
     }
-    const activities = this.#item.system.activities.map(this._prepareActivityContext.bind(this));
-    activities.sort((a, b) => a.sort - b.sort);
+    const activities = this.#item.system.activities
+      .filter(a => !this.#item.flags.dnd5e?.riders?.activity?.includes(a.id))
+      .map(this._prepareActivityContext.bind(this))
+      .sort((a, b) => a.sort - b.sort);
     return {
       ...await super._prepareContext(options),
       controlHint, activities

--- a/module/applications/activity/activity-choice-dialog.mjs
+++ b/module/applications/activity/activity-choice-dialog.mjs
@@ -86,7 +86,7 @@ export default class ActivityChoiceDialog extends Application5e {
       );
     }
     const activities = this.#item.system.activities
-      .filter(a => !this.#item.flags.dnd5e?.riders?.activity?.includes(a.id))
+      .filter(a => !this.#item.getFlag("dnd5e", "riders.activity")?.includes(a.id))
       .map(this._prepareActivityContext.bind(this))
       .sort((a, b) => a.sort - b.sort);
     return {

--- a/module/applications/activity/enchant-sheet.mjs
+++ b/module/applications/activity/enchant-sheet.mjs
@@ -39,6 +39,9 @@ export default class EnchantSheet extends ActivitySheet {
 
   /** @override */
   _prepareAppliedEffectContext(context, effect) {
+    effect.activityOptions = this.item.system.activities
+      .filter(a => a.id !== this.activity.id)
+      .map(a => ({ value: a.id, label: a.name, selected: effect.data.riders.activity.has(a.id) }));
     effect.effectOptions = context.allEffects.map(e => ({
       ...e, selected: effect.data.riders.effect.has(e.value)
     }));

--- a/module/data/activity/enchant-data.mjs
+++ b/module/data/activity/enchant-data.mjs
@@ -9,11 +9,12 @@ const {
 /**
  * @typedef {EffectApplicationData} EnchantEffectApplicationData
  * @property {object} level
- * @property {number} level.min        Minimum level at which this profile can be used.
- * @property {number} level.max        Maximum level at which this profile can be used.
+ * @property {number} level.min             Minimum level at which this profile can be used.
+ * @property {number} level.max             Maximum level at which this profile can be used.
  * @property {object} riders
- * @property {string[]} riders.effect  IDs of other effects on this item that will be added with this enchantment.
- * @property {string[]} riders.item    UUIDs of items that will be added with this enchantment.
+ * @property {Set<string>} riders.activity  IDs of other activities on this item that will be added when enchanting.
+ * @property {Set<string>} riders.effect    IDs of other effects on this item that will be added when enchanting.
+ * @property {Set<string>} riders.item      UUIDs of items that will be added with this enchantment.
  */
 
 /**
@@ -38,6 +39,7 @@ export default class EnchantActivityData extends BaseActivityData {
           max: new NumberField({ min: 0, integer: true })
         }),
         riders: new SchemaField({
+          activity: new SetField(new DocumentIdField()),
           effect: new SetField(new DocumentIdField()),
           item: new SetField(new DocumentUUIDField())
         })

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -226,7 +226,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /** @inheritDoc */
   *allApplicableEffects() {
     for ( const effect of super.allApplicableEffects() ) {
-      if ( (effect.type !== "enchantment") && !effect.getFlag("dnd5e", "rider") ) yield effect;
+      if ( (effect.type !== "enchantment")
+        && !this.getFlag("dnd5e", "riders.effect")?.includes(effect.id) ) yield effect;
     }
   }
 

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -580,7 +580,8 @@ export default class ChatMessage5e extends ChatMessage {
     if ( this.getFlag("dnd5e", "messageType") === "usage" ) {
       effects = this.getFlag("dnd5e", "use.effects")?.map(id => item?.effects.get(id));
     } else {
-      effects = item?.effects.filter(e => (e.type !== "enchantment") && !e.getFlag("dnd5e", "rider"));
+      effects = item?.effects.filter(e => (e.type !== "enchantment")
+        && !item.getFlag("dnd5e", "riders.effect")?.includes(e.id));
     }
     effects = effects?.filter(e => e && (game.user.isGM || (e.transfer && (this.author.id === game.user.id))));
     if ( !effects?.length ) return;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -801,7 +801,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       );
       event = dialog?.event;
     }
-    let activities = this.system.activities?.filter(a => !this.flags.dnd5e?.riders?.activity?.includes(a.id));
+    let activities = this.system.activities?.filter(a => !this.getFlag("dnd5e", "riders.activity")?.includes(a.id));
     if ( activities.length ) {
       let usageConfig = config;
       let dialogConfig = dialog;

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -477,10 +477,12 @@ export function migrateItemData(item, itemData, migrationData, flags={}) {
 
   // Migrate embedded effects
   if ( itemData.effects ) {
-    if ( itemData.flags?.dnd5e?.riders?.effect ) {
-      itemUpdateData["flags.dnd5e.riders.effect"] = itemData.flags.dnd5e.riders.effect;
-    }
+    const riders = foundry.utils.getProperty(itemData, "flags.dnd5e.riders.effect");
+    if ( riders?.length ) updateData["flags.dnd5e.riders.effect"] = riders;
     const effects = migrateEffects(itemData, migrationData, updateData);
+    if ( riders?.length === updateData["flags.dnd5e.riders.effect"]?.length ) {
+      delete updateData["flags.dnd5e.riders.effect"];
+    }
     if ( effects.length > 0 ) updateData.effects = effects;
   }
 

--- a/templates/activity/parts/enchant-enchantments.hbs
+++ b/templates/activity/parts/enchant-enchantments.hbs
@@ -67,6 +67,7 @@
                 <p class="hint">{{ localize "DND5E.ENCHANT.FIELDS.effects.FIELDS.level.hint" }}</p>
             </div>
             {{#with fields.riders.fields as |fields|}}
+            {{ formField fields.activity name=(concat ../prefix "riders.activity") options=../activityOptions }}
             {{ formField fields.effect name=(concat ../prefix "riders.effect") options=../effectOptions }}
             {{ formField fields.item name=(concat ../prefix "riders.item") value=../data.riders.item }}
             {{/with}}


### PR DESCRIPTION
Allows activities to be applied to the item alongside enchantments like effects and items are currently.

The previous method of using a flag on effects to mark them as riders wasn't practical in this case due to activites not having flags, so this stores the rider activities and effects in a new flag on the item itself. A migration is included to move the `rider` flag from the effects to the item flags.

Closes #3803