### PR TITLE
[#3785] Add refund button to chat cards

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -916,7 +916,8 @@
   "Action": {
     "ConsumeResource": "Consume Resource",
     "Create": "Create Consumption Target",
-    "Delete": "Delete Consumption Target"
+    "Delete": "Delete Consumption Target",
+    "RefundResource": "Refund Resource"
   },
   "Scaling": {
     "Amount": "Amount",

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -318,6 +318,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * @param {string} options.type              Type label to be used in warning messages.
    * @param {BasicRoll[]} options.rolls        Rolls performed as part of the usages.
    * @returns {{ spent: number, quantity: number }|null}
+   * @internal
    */
   async _usesConsumption(config, { uses, type, rolls }) {
     const cost = (await this.resolveCost({ config, rolls })).total;
@@ -480,6 +481,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * Resolve the cost for the consumption hint.
    * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
    * @returns {{ cost: string, increaseKey: string, pluralRule: string }}
+   * @internal
    */
   _resolveHintCost(config) {
     const costRoll = this.resolveCost({ config, evaluate: false });

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -37,7 +37,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
   /* -------------------------------------------- */
 
   /** @override */
-  _usageChatButtons() {
+  _usageChatButtons(message) {
     const buttons = [{
       label: game.i18n.localize("DND5E.Attack"),
       icon: '<i class="dnd5e-icon" data-src="systems/dnd5e/icons/svg/trait-weapon-proficiencies.svg" inert></i>',
@@ -52,7 +52,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
         action: "rollDamage"
       }
     });
-    return buttons.concat(super._usageChatButtons());
+    return buttons.concat(super._usageChatButtons(message));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/check.mjs
+++ b/module/documents/activity/check.mjs
@@ -37,7 +37,7 @@ export default class CheckActivity extends ActivityMixin(CheckActivityData) {
   /* -------------------------------------------- */
 
   /** @override */
-  _usageChatButtons() {
+  _usageChatButtons(message) {
     const buttons = [];
     const dc = this.check.dc.value;
 
@@ -76,7 +76,7 @@ export default class CheckActivity extends ActivityMixin(CheckActivityData) {
     });
     else if ( this.check.ability ) createButton(this.check.ability);
 
-    return buttons.concat(super._usageChatButtons());
+    return buttons.concat(super._usageChatButtons(message));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/damage.mjs
+++ b/module/documents/activity/damage.mjs
@@ -35,15 +35,15 @@ export default class DamageActivity extends ActivityMixin(DamageActivityData) {
   /* -------------------------------------------- */
 
   /** @override */
-  _usageChatButtons() {
-    if ( !this.damage.parts.length ) return super._usageChatButtons();
+  _usageChatButtons(message) {
+    if ( !this.damage.parts.length ) return super._usageChatButtons(message);
     return [{
       label: game.i18n.localize("DND5E.Damage"),
       icon: '<i class="fa-solid fa-burst" inert></i>',
       dataset: {
         action: "rollDamage"
       }
-    }].concat(super._usageChatButtons());
+    }].concat(super._usageChatButtons(message));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/heal.mjs
+++ b/module/documents/activity/heal.mjs
@@ -44,15 +44,15 @@ export default class HealActivity extends ActivityMixin(HealActivityData) {
   /* -------------------------------------------- */
 
   /** @override */
-  _usageChatButtons() {
-    if ( !this.healing.formula ) return super._usageChatButtons();
+  _usageChatButtons(message) {
+    if ( !this.healing.formula ) return super._usageChatButtons(message);
     return [{
       label: game.i18n.localize("DND5E.Healing"),
       icon: '<i class="dnd5e-icon" data-src="systems/dnd5e/icons/svg/damage/healing.svg"></i>',
       dataset: {
         action: "rollHealing"
       }
-    }].concat(super._usageChatButtons());
+    }].concat(super._usageChatButtons(message));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/save.mjs
+++ b/module/documents/activity/save.mjs
@@ -37,7 +37,7 @@ export default class SaveActivity extends ActivityMixin(SaveActivityData) {
   /* -------------------------------------------- */
 
   /** @override */
-  _usageChatButtons() {
+  _usageChatButtons(message) {
     const ability = CONFIG.DND5E.abilities[this.save.ability]?.label ?? "";
     const dc = this.save.dc.value;
     const buttons = [{
@@ -60,7 +60,7 @@ export default class SaveActivity extends ActivityMixin(SaveActivityData) {
         action: "rollDamage"
       }
     });
-    return buttons.concat(super._usageChatButtons());
+    return buttons.concat(super._usageChatButtons(message));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -125,15 +125,15 @@ export default class SummonActivity extends ActivityMixin(SummonActivityData) {
   /* -------------------------------------------- */
 
   /** @override */
-  _usageChatButtons() {
-    if ( !this.availableProfiles.length ) return super._usageChatButtons();
+  _usageChatButtons(message) {
+    if ( !this.availableProfiles.length ) return super._usageChatButtons(message);
     return [{
       label: game.i18n.localize("DND5E.SUMMON.Action.Summon"),
       icon: '<i class="fa-solid fa-spaghetti-monster-flying" inert></i>',
       dataset: {
         action: "placeSummons"
       }
-    }].concat(super._usageChatButtons());
+    }].concat(super._usageChatButtons(message));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -35,8 +35,8 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
   /* -------------------------------------------- */
 
   /** @override */
-  _usageChatButtons() {
-    if ( !this.roll.formula ) return super._usageChatButtons();
+  _usageChatButtons(message) {
+    if ( !this.roll.formula ) return super._usageChatButtons(message);
     return [{
       label: this.roll.name || game.i18n.localize("DND5E.Roll"),
       icon: '<i class="fa-solid fa-dice" inert></i>',
@@ -44,7 +44,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
         action: "rollFormula",
         visibility: this.roll.visible ? "all" : undefined
       }
-    }].concat(super._usageChatButtons());
+    }].concat(super._usageChatButtons(message));
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Adds a button for refunding consumption to chat cards. To support this the system calculates deltas on the actor and item changes during the consumption process and stores those values in the message flags.

Closes #3785