### PR TITLE
[#4143] Move Active Effect formula changes into FormulaField

### DIFF
--- a/module/data/fields/formula-field.mjs
+++ b/module/data/fields/formula-field.mjs
@@ -29,5 +29,54 @@ export default class FormulaField extends foundry.data.fields.StringField {
     }
     super._validateType(value);
   }
+
+  /* -------------------------------------------- */
+  /*  Active Effect Integration                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _castChangeDelta(delta) {
+    return this._cast(delta).trim();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _applyChangeAdd(value, delta, model, change) {
+    if (!value) return delta;
+    const operator = delta.startsWith("-") ? "-" : "+";
+    delta = delta.replace(/^[+-]?/, "").trim();
+    return `${value} ${operator} ${delta}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _applyChangeMultiply(value, delta, model, change) {
+    if (!value) return delta;
+    const terms = new Roll(value).terms;
+    if ( terms.length > 1 ) return `(${value}) * ${delta}`;
+    return `${value} * ${delta}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _applyChangeUpgrade(value, delta, model, change) {
+    if (!value) return delta;
+    const terms = new Roll(value).terms;
+    if ( (terms.length === 1) && (terms[0].fn === "max") ) return current.replace(/\)$/, `, ${delta})`);
+    return `max(${value}, ${delta})`;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _applyChangeDowngrade(value, delta, model, change) {
+    if (!value) return delta;
+    const terms = new Roll(value).terms;
+    if ( (terms.length === 1) && (terms[0].fn === "min") ) return current.replace(/\)$/, `, ${delta})`);
+    return `min(${value}, ${delta})`;
+  }
 }
 

--- a/module/data/fields/formula-field.mjs
+++ b/module/data/fields/formula-field.mjs
@@ -43,9 +43,9 @@ export default class FormulaField extends foundry.data.fields.StringField {
 
   /** @override */
   _applyChangeAdd(value, delta, model, change) {
-    if (!value) return delta;
+    if ( !value ) return delta;
     const operator = delta.startsWith("-") ? "-" : "+";
-    delta = delta.replace(/^[+-]?/, "").trim();
+    delta = delta.replace(/^[+-]/, "").trim();
     return `${value} ${operator} ${delta}`;
   }
 
@@ -53,7 +53,7 @@ export default class FormulaField extends foundry.data.fields.StringField {
 
   /** @override */
   _applyChangeMultiply(value, delta, model, change) {
-    if (!value) return delta;
+    if ( !value ) return delta;
     const terms = new Roll(value).terms;
     if ( terms.length > 1 ) return `(${value}) * ${delta}`;
     return `${value} * ${delta}`;
@@ -63,7 +63,7 @@ export default class FormulaField extends foundry.data.fields.StringField {
 
   /** @override */
   _applyChangeUpgrade(value, delta, model, change) {
-    if (!value) return delta;
+    if ( !value ) return delta;
     const terms = new Roll(value).terms;
     if ( (terms.length === 1) && (terms[0].fn === "max") ) return current.replace(/\)$/, `, ${delta})`);
     return `max(${value}, ${delta})`;
@@ -73,7 +73,7 @@ export default class FormulaField extends foundry.data.fields.StringField {
 
   /** @override */
   _applyChangeDowngrade(value, delta, model, change) {
-    if (!value) return delta;
+    if ( !value ) return delta;
     const terms = new Roll(value).terms;
     if ( (terms.length === 1) && (terms[0].fn === "min") ) return current.replace(/\)$/, `, ${delta})`);
     return `min(${value}, ${delta})`;


### PR DESCRIPTION
Moves the custom active effect handling for formulas into the `FormulaField` class using the new system offered by Foundry V12.

Also refactors a lot of the other application behavior in `ActiveEffect5e` to avoid duplicating a bunch of core's code. This includes removing some handling of overriding sets because that is properly handled by core now.

Closes #4143