### PR TITLE
Add sources filtering to compendium browser.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -671,7 +671,8 @@
   "Column": {
     "Icon": "Icon",
     "Name": "Name",
-    "Results": "Results"
+    "Results": "Results",
+    "Source": "Source"
   },
   "Filters": {
     "Label": "Filters",

--- a/less/v2/compendium-browser.less
+++ b/less/v2/compendium-browser.less
@@ -159,6 +159,8 @@
     .filter {
       > label { line-height: 1; }
 
+      &.filter-set:has(> .collapsible-content > .wrapper:empty) { display: none; }
+
       &.filter-set .filter-choice, &.filter-boolean > label { cursor: pointer; }
 
       &.filter-set .wrapper {
@@ -222,7 +224,7 @@
       z-index: 1;
     }
 
-    .items-section .item .item-controls {
+    .items-section .item-controls {
       width: 50px;
       align-items: center;
       padding: 0;

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -317,6 +317,7 @@
       }
 
       .item-weight { width: 60px; }
+      .item-source { width: 120px; }
 
       .item-price {
         width: 80px;

--- a/less/v2/tooltips.less
+++ b/less/v2/tooltips.less
@@ -23,6 +23,12 @@
         font-weight: bold;
       }
     }
+
+    h3 {
+      margin: 0;
+      padding: 0;
+      border: none;
+    }
   }
 
   &.locked-tooltip {

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -49,7 +49,7 @@ export default class SourceField extends SchemaField {
       this.label = game.i18n.format("DND5E.SOURCE.Display.Full", { book: this.book, page }).trim();
     }
 
-    this.value = this.custom ? this.custom : this.book ? this.book : (pkg?.title ?? "");
+    this.value = this.book || (pkg?.title ?? "");
     this.slug = this.value.slugify({ strict: true });
 
     Object.defineProperty(this, "directlyEditable", {

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -38,7 +38,8 @@ export default class SourceField extends SchemaField {
    * @param {string} uuid  Compendium source or document UUID.
    */
   static prepareData(uuid) {
-    this.bookPlaceholder = SourceField.getModuleBook(uuid) ?? "";
+    const pkg = SourceField.getPackage(uuid);
+    this.bookPlaceholder = SourceField.getModuleBook(pkg) ?? "";
     if ( !this.book ) this.book = this.bookPlaceholder;
 
     if ( this.custom ) this.label = this.custom;
@@ -47,6 +48,9 @@ export default class SourceField extends SchemaField {
         ? game.i18n.format("DND5E.SOURCE.Display.Page", { page: this.page }) : (this.page ?? "");
       this.label = game.i18n.format("DND5E.SOURCE.Display.Full", { book: this.book, page }).trim();
     }
+
+    this.value = this.custom ? this.custom : this.book ? this.book : (pkg?.title ?? "");
+    this.slug = this.value.slugify({ strict: true });
 
     Object.defineProperty(this, "directlyEditable", {
       value: (this.custom ?? "") === this.label,
@@ -57,24 +61,34 @@ export default class SourceField extends SchemaField {
   /* -------------------------------------------- */
 
   /**
-   * Based on the provided UUID, find the associated system/module and check it if has any source books registered
-   * in its manifest. If it has only one, then return that book's key.
-   * @param {string} uuid  Compendium source or document UUID.
+   * Check if the provided package has any source books registered in its manifest. If it has only one, then return
+   * that book's key.
+   * @param {ClientPackage} pkg  The package.
    * @returns {string|null}
    */
-  static getModuleBook(uuid) {
-    let manifest;
-    const pack = foundry.utils.parseUuid(uuid)?.collection?.metadata;
-    switch ( pack?.packageType ) {
-      case "module": manifest = game.modules.get(pack.packageName); break;
-      case "system": manifest = game.system; break;
-      case "world": manifest = game.world; break;
-    }
-    if ( !manifest ) return null;
-    const sourceBooks = manifest.flags?.dnd5e?.sourceBooks;
+  static getModuleBook(pkg) {
+    if ( !pkg ) return null;
+    const sourceBooks = pkg.flags?.dnd5e?.sourceBooks;
     const keys = Object.keys(sourceBooks ?? {});
     if ( keys.length !== 1 ) return null;
     return keys[0];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the package associated with the given UUID, if any.
+   * @param {string} uuid  The UUID.
+   * @returns {ClientPackage|null}
+   */
+  static getPackage(uuid) {
+    const pack = foundry.utils.parseUuid(uuid)?.collection?.metadata;
+    switch ( pack?.packageType ) {
+      case "module": return game.modules.get(pack.packageName);
+      case "system": return game.system;
+      case "world": return game.world;
+    }
+    return null;
   }
 
   /* -------------------------------------------- */

--- a/templates/compendium/browser-entry.hbs
+++ b/templates/compendium/browser-entry.hbs
@@ -16,7 +16,12 @@
         </div>
 
         {{!-- TODO: Display dynamic columns as appropriate --}}
-        {{!-- TODO: Display source column --}}
+
+        <div class="item-detail item-source {{#unless entry.source}}empty{{/unless}}">
+            {{#if entry.source}}
+            <span class="condensed">{{ entry.source }}</span>
+            {{/if}}
+        </div>
 
         <div class="item-detail item-controls">
 

--- a/templates/compendium/browser-results.hbs
+++ b/templates/compendium/browser-results.hbs
@@ -7,6 +7,7 @@
             <div class="items-header header">
 
                 <h3 class="item-name">{{ localize "DND5E.CompendiumBrowser.Column.Results" }}</h3>
+                <div class="item-header item-source">{{ localize "DND5E.CompendiumBrowser.Column.Source" }}</div>
                 <div class="item-header item-controls"></div>
 
             </div>

--- a/templates/compendium/browser-sidebar-filter-set.hbs
+++ b/templates/compendium/browser-sidebar-filter-set.hbs
@@ -1,0 +1,26 @@
+<div class="filter filter-set collapsible" data-filter-id="{{ key }}">
+    <div class="filter-header">
+        <label data-action="toggleCollapse">
+            <span class="roboto-upper">{{ localize label }}</span>
+            <i class="fa-solid fa-caret-down"></i>
+        </label>
+    </div>
+    <div class="collapsible-content">
+        <div class="wrapper">
+            {{~#if config.blank}}
+            <label class="filter-choice">
+                <filter-state name="additional.{{ key }}._blank" value="{{ value._blank }}"
+                              {{ disabled locked._blank }}></filter-state>
+                <span>{{ localize config.blank }}</span>
+            </label>
+            {{/if~}}
+            {{~#each config.choices}}
+            <label class="filter-choice">
+                <filter-state name="additional.{{ ../key }}.{{ @key }}" value="{{ lookup ../value @key }}"
+                              {{ disabled (lookup ../locked @key) }}></filter-state>
+                <span>{{ ifThen label label this }}</span>
+            </label>
+            {{/each~}}
+        </div>
+    </div>
+</div>

--- a/templates/compendium/browser-sidebar-filters.hbs
+++ b/templates/compendium/browser-sidebar-filters.hbs
@@ -21,32 +21,7 @@
         </div>
     </div>
     {{else if (eq type "set")}}
-    <div class="filter filter-set collapsible" data-filter-id="{{ key }}">
-        <div class="filter-header">
-            <label data-action="toggleCollapse">
-                <span class="roboto-upper">{{ localize label }}</span>
-                <i class="fa-solid fa-caret-down"></i>
-            </label>
-        </div>
-        <div class="collapsible-content">
-            <div class="wrapper">
-                {{#if config.blank}}
-                <label class="filter-choice">
-                    <filter-state name="additional.{{ key }}._blank" value="{{ value._blank }}"
-                                  {{ disabled locked._blank }}></filter-state>
-                    <span>{{ localize config.blank }}</span>
-                </label>
-                {{/if}}
-                {{#each config.choices}}
-                <label class="filter-choice">
-                    <filter-state name="additional.{{ ../key }}.{{ @key }}" value="{{ lookup ../value @key }}"
-                                  {{ disabled (lookup ../locked @key) }}></filter-state>
-                    <span>{{ ifThen label label this }}</span>
-                </label>
-                {{/each}}
-            </div>
-        </div>
-    </div>
+    {{> "systems/dnd5e/templates/compendium/browser-sidebar-filter-set.hbs" }}
     {{else}}
     <div class="filter" data-filter-id="{{ key }}">{{ label }}</div>
     {{/if}}


### PR DESCRIPTION
Some challenges here around filtering on a derived field. I also wasn't able to figure out how to use `compendiumBrowserFilters` without either: scanning all packs at startup in order to identify custom source fields; or only using pack metadata and then losing the ability to filter on custom source fields.

I think this approach ended up not being too messy, with only a small amount of special-casing that is maybe warranted for something as ubiquitous as the source field.

### TODO
- [ ] Provide setting for excluding compendium packs from compendium browser entirely.
- [ ] Update SRD to commit source field migrations so that NPC sources are available in the index.