### PR TITLE
[#2138] Refactor `rollRecharge` to use `BasicRoll` & new hooks

### DIFF
--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -397,7 +397,7 @@ export default class InventoryElement extends HTMLElement {
 
     switch ( action ) {
       case "activity-recharge":
-        return activity?.uses?.rollRecharge();
+        return activity?.uses?.rollRecharge({ event });
       case "activity-use":
         return activity?.use({ event });
       case "attune":
@@ -425,7 +425,7 @@ export default class InventoryElement extends HTMLElement {
       case "prepare":
         return item.update({"system.preparation.prepared": !item.system.preparation?.prepared});
       case "recharge":
-        return item.rollRecharge();
+        return item.system.uses?.rollRecharge({ event });
       case "toggleCharge":
         return item.update({ "system.uses.spent": 1 - item.system.uses.spent });
       case "unfavorite":

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -157,62 +157,111 @@ export default class UsesField extends SchemaField {
   /**
    * Rolls a recharge test for an Item or Activity that uses the d6 recharge mechanic.
    * @this {Item5e|Activity}
-   * @returns {Promise<Roll|void>}
+   * @param {BasicRollProcessConfiguration} config   Configuration information for the roll.
+   * @param {BasicRollDialogConfiguration} dialog    Configuration for the roll dialog.
+   * @param {BasicRollMessageConfiguration} message  Configuration for the roll message.
+   * @returns {Promise<BasicRoll[]|void>}            The created Roll instances, or `null` if no die was rolled.
    */
-  static async rollRecharge() {
+  static async rollRecharge(config={}, dialog={}, message={}) {
     const uses = this.system ? this.system.uses : this.uses;
     const recharge = uses?.recovery.find(({ period }) => period === "recharge");
     if ( !recharge ) return;
 
-    const rollConfig = {
-      formula: "1d6",
-      data: this.getRollData(),
-      target: parseInt(recharge.formula),
-      chatMessage: true
-    };
+    const rollConfig = foundry.utils.mergeObject({
+      rolls: [{
+        parts: ["1d6"],
+        data: this.getRollData(),
+        options: {
+          target: parseInt(recharge.formula)
+        }
+      }]
+    }, config);
+    rollConfig.subject = this;
 
-    /**
-     * A hook event that fires before the Item or Activity is rolled to recharge.
-     * @function dnd5e.preRollRecharge
-     * @memberof hookEvents
-     * @param {Item5e|Activity} subject     Item or Activity for which the roll is being performed.
-     * @param {object} config               Configuration data for the pending roll.
-     * @param {string} config.formula       Formula that will be used to roll the recharge.
-     * @param {object} config.data          Data used when evaluating the roll.
-     * @param {number} config.target        Total required to be considered recharged.
-     * @param {boolean} config.chatMessage  Should a chat message be created for this roll?
-     * @returns {boolean}                   Explicitly return false to prevent the roll from being performed.
-     */
-    if ( Hooks.call("dnd5e.preRollRecharge", this, rollConfig) === false ) return;
+    const dialogConfig = foundry.utils.mergeObject({ configure: false }, dialog);
 
-    const roll = await new Roll(rollConfig.formula, rollConfig.data).evaluate();
-    const success = roll.total >= rollConfig.target;
-
-    if ( rollConfig.chatMessage ) {
-      const resultMessage = game.i18n.localize(`DND5E.ItemRecharge${success ? "Success" : "Failure"}`);
-      roll.toMessage({
-        flavor: `${game.i18n.format("DND5E.ItemRechargeCheck", { name: this.name, result: resultMessage })}`,
+    const messageConfig = foundry.utils.mergeObject(({
+      create: true,
+      data: {
         speaker: ChatMessage.getSpeaker({ actor: this.actor, token: this.actor.token })
-      });
+      },
+      preCreate: (rolls, rollConfig, messageConfig) => {
+        messageConfig.data.flavor = game.i18n.format("DND5E.ItemRechargeCheck", {
+          name: this.name,
+          result: game.i18n.localize(`DND5E.ItemRecharge${rolls[0].isSuccess ? "Success" : "Failure"}`)
+        });
+      },
+      rollMode: game.settings.get("core", "rollMode")
+    }));
+
+    /**
+     * A hook event that fires before recharge is rolled for an Item or Activity.
+     * @function dnd5e.preRollRechargeV2
+     * @memberof hookEvents
+     * @param {BasicRollProcessConfiguration} config   Configuration information for the roll.
+     * @param {BasicRollDialogConfiguration} dialog    Configuration for the roll dialog.
+     * @param {BasicRollMessageConfiguration} message  Configuration for the roll message.
+     * @returns {boolean}                              Explicitly return `false` to prevent recharge from being rolled.
+     */
+    if ( Hooks.call("dnd5e.preRollRechargeV2", rollConfig, dialogConfig, messageConfig) === false ) return;
+
+    if ( "dnd5e.preRollRecharge" in Hooks.events ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `dnd5e.preRollRecharge` hook has been deprecated and replaced with `dnd5e.preRollRechargeV2`.",
+        { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+      );
+      const hookData = {
+        formula: rollConfig.rolls[0].parts[0], data: rollConfig.rolls[0].data,
+        target: rollConfig.rolls[0].options.target, chatMessage: messageConfig.create
+      };
+      if ( Hooks.call("dnd5e.preRollRecharge", this, hookData) === false ) return;
+      rollConfig.rolls[0].parts[0] = hookData.formula;
+      rollConfig.rolls[0].data = hookData.data;
+      rollConfig.rolls[0].options.target = hookData.target;
+      messageConfig.create = hookData.chatMessage;
+    }
+
+    const rolls = await CONFIG.Dice.BasicRoll.build(rollConfig, dialogConfig, messageConfig);
+
+    const updates = {};
+    if ( rolls[0].isSuccess ) {
+      if ( this instanceof Item ) updates["system.uses.spent"] = 0;
+      else updates["uses.spent"] = 0;
     }
 
     /**
-     * A hook event that fires after the Item or Activity has rolled to recharge, but before any changes have been
-     * made.
-     * @function dnd5e.rollRecharge
+     * A hook event that fires after an Item or Activity has rolled to recharge, but before any usage changes have
+     * been made.
+     * @function dnd5e.rollRechargeV2
      * @memberof hookEvents
-     * @param {Item5e|Activity} subject  Item or Activity for which the roll was performed.
-     * @param {Roll} roll                The resulting roll.
-     * @returns {boolean}                Explicitly return false to prevent the item from being recharged.
+     * @param {BasicRoll[]} rolls     The resulting rolls.
+     * @param {object} data
+     * @param {Actor5e} data.subject  Item or Activity for which the roll was performed.
+     * @param {object} data.updates   Updates to be applied to the subject.
+     * @returns {boolean}             Explicitly return `false` to prevent updates from being performed.
      */
-    if ( Hooks.call("dnd5e.rollRecharge", this, roll) === false ) return roll;
+    if ( Hooks.call("dnd5e.rollRechargeV2", rolls, { subject: this, updates }) === false ) return rolls;
 
-    // Recharge the Item or Activity
-    if ( success ) {
-      if ( this instanceof Item ) await this.update({ "system.uses.spent": 0 });
-      else await this.item.updateActivity(this.id, { "uses.spent": 0 });
+    if ( "dnd5e.rollRecharge" in Hooks.events ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `dnd5e.rollRecharge` hook has been deprecated and replaced with `dnd5e.rollRechargeV2`.",
+        { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+      );
+      if ( Hooks.call("dnd5e.rollRecharge", this, rolls[0]) === false ) return rolls;
     }
 
-    return roll;
+    if ( !foundry.utils.isEmpty(updates) ) await this.update(updates);
+
+    /**
+     * A hook event that fires after an Item or Activity has rolled recharge and usage updates have been performed.
+     * @function dnd5e.postRollRecharge
+     * @memberof hookEvents
+     * @param {BasicRoll[]} rolls     The resulting rolls.
+     * @param {object} data
+     * @param {Actor5e} data.subject  Item or Activity for which the roll was performed.
+     */
+    Hooks.callAll("dnd5e.postRollRecharge", rolls, { subject: this });
+
+    return rolls;
   }
 }

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -8,7 +8,7 @@ const { DiceTerm, NumericTerm } = foundry.dice.terms;
  * @typedef {object} BasicRollProcessConfiguration
  * @property {BasicRollConfiguration[]} rolls  Configuration data for individual rolls.
  * @property {Event} [event]                   Event that triggered the rolls.
- * @property {Document} [origin]               Document that initiated this roll.
+ * @property {Document} [subject]              Document that initiated this roll.
  */
 
 /**
@@ -46,8 +46,18 @@ const { DiceTerm, NumericTerm } = foundry.dice.terms;
  *
  * @typedef {object} BasicRollMessageConfiguration
  * @property {boolean} [create=true]  Create a message when the rolling is complete.
+ * @property {PreCreateRollMessageCallback} [preCreate]  Message configuration callback.
  * @property {string} [rollMode]      The roll mode to apply to this message from `CONFIG.Dice.rollModes`.
  * @property {object} [data={}]       Additional data used when creating the message.
+ */
+
+/**
+ * Method called after the rolls are completed but before the message is created for further message customization.
+ *
+ * @callback PreCreateRollMessageCallback
+ * @param {BasicRoll[]} rolls                      Rolls that have been executed.
+ * @param {BasicRollProcessConfiguration} config   Roll process configuration information.
+ * @param {BasicRollMessageConfiguration} message  Message configuration information.
  */
 
 /* -------------------------------------------- */
@@ -99,6 +109,7 @@ export default class BasicRoll extends Roll {
     for ( const roll of rolls ) await roll.evaluate();
 
     if ( rolls?.length && (message.create !== false) ) {
+      if ( foundry.utils.getType(message.preCreate) === "function" ) message.preCreate(rolls, config, message);
       await this.toMessage(rolls, message.data, {
         rollMode: message.rollMode ?? rolls.reduce((mode, r) => mode ?? r.options.rollMode)
       });

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -46,18 +46,8 @@ const { DiceTerm, NumericTerm } = foundry.dice.terms;
  *
  * @typedef {object} BasicRollMessageConfiguration
  * @property {boolean} [create=true]  Create a message when the rolling is complete.
- * @property {PreCreateRollMessageCallback} [preCreate]  Message configuration callback.
  * @property {string} [rollMode]      The roll mode to apply to this message from `CONFIG.Dice.rollModes`.
  * @property {object} [data={}]       Additional data used when creating the message.
- */
-
-/**
- * Method called after the rolls are completed but before the message is created for further message customization.
- *
- * @callback PreCreateRollMessageCallback
- * @param {BasicRoll[]} rolls                      Rolls that have been executed.
- * @param {BasicRollProcessConfiguration} config   Roll process configuration information.
- * @param {BasicRollMessageConfiguration} message  Message configuration information.
  */
 
 /* -------------------------------------------- */
@@ -109,10 +99,7 @@ export default class BasicRoll extends Roll {
     for ( const roll of rolls ) await roll.evaluate();
 
     if ( rolls?.length && (message.create !== false) ) {
-      if ( foundry.utils.getType(message.preCreate) === "function" ) message.preCreate(rolls, config, message);
-      await this.toMessage(rolls, message.data, {
-        rollMode: message.rollMode ?? rolls.reduce((mode, r) => mode ?? r.options.rollMode)
-      });
+      await this.toMessage(rolls, message.data, { rollMode: message.rollMode });
     }
 
     return rolls;
@@ -176,6 +163,7 @@ export default class BasicRoll extends Roll {
   static async toMessage(rolls, messageData={}, { rollMode, create=true }={}) {
     for ( const roll of rolls ) {
       if ( !roll._evaluated ) await roll.evaluate({ allowInteractive: rollMode !== CONST.DICE_ROLL_MODES.BLIND });
+      rollMode ??= roll.options.rollMode;
     }
 
     // Prepare chat data

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -106,7 +106,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
         && CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(this.ability),
       halflingLucky: this.actor?.getFlag("dnd5e", "halflingLucky")
     }, config);
-    rollConfig.origin = this;
+    rollConfig.subject = this;
     rollConfig.rolls = [{
       parts, data,
       options: {
@@ -220,10 +220,10 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
      * @memberof hookEvents
      * @param {D20Roll[]} rolls                        The resulting rolls.
      * @param {object} data
-     * @param {AttackActivity} data.activity           The activity that performed the attack.
+     * @param {AttackActivity} data.subject            The Activity that performed the attack.
      * @param {AmmunitionUpdate|null} data.ammoUpdate  Any updates related to ammo consumption for this attack.
      */
-    Hooks.callAll("dnd5e.rollAttackV2", [roll], { activity: this, ammoUpdate });
+    Hooks.callAll("dnd5e.rollAttackV2", [roll], { subject: this, ammoUpdate });
 
     if ( "dnd5e.rollAttack" in Hooks.events ) {
       foundry.utils.logCompatibilityWarning(
@@ -255,11 +255,11 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
      * A hook event that fires after an attack has been rolled and ammunition has been consumed.
      * @function dnd5e.postRollAttack
      * @memberof hookEvents
-     * @param {D20Roll[]} rolls               The resulting rolls.
+     * @param {D20Roll[]} rolls              The resulting rolls.
      * @param {object} data
-     * @param {AttackActivity} data.activity  The activity that performed the attack.
+     * @param {AttackActivity} data.subject  The activity that performed the attack.
      */
-    Hooks.callAll("dnd5e.postRollAttack", [roll], { activity: this });
+    Hooks.callAll("dnd5e.postRollAttack", [roll], { subject: this });
 
     return [roll];
   }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -793,7 +793,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    */
   async rollDamage(config={}, dialog={}, message={}) {
     const rollConfig = this.getDamageConfig(config);
-    rollConfig.origin = this;
+    rollConfig.subject = this;
 
     const dialogConfig = foundry.utils.mergeObject({
       configure: true,
@@ -882,11 +882,11 @@ export default Base => class extends PseudoDocumentMixin(Base) {
      * A hook event that fires after damage has been rolled.
      * @function dnd5e.rollDamageV2
      * @memberof hookEvents
-     * @param {DamageRoll[]} rolls        The resulting rolls.
+     * @param {DamageRoll[]} rolls       The resulting rolls.
      * @param {object} [data]
-     * @param {Activity} [data.activity]  The activity that performed the roll.
+     * @param {Activity} [data.subject]  The activity that performed the roll.
      */
-    Hooks.callAll("dnd5e.rollDamageV2", rolls, { activity: this });
+    Hooks.callAll("dnd5e.rollDamageV2", rolls, { subject: this });
 
     if ( "dnd5e.rollDamage" in Hooks.events ) {
       foundry.utils.logCompatibilityWarning(

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -65,7 +65,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
     }
 
     const rollConfig = foundry.utils.deepClone(config);
-    rollConfig.origin = this;
+    rollConfig.subject = this;
     rollConfig.rolls = [{ parts: [this.roll.formula], data: this.getRollData() }].concat(config.rolls ?? []);
 
     const dialogConfig = foundry.utils.mergeObject({
@@ -94,7 +94,7 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
     }, message);
 
     /**
-     * A hook event that fires before a formula is rolled for an Utility activity.
+     * A hook event that fires before a formula is rolled for a Utility activity.
      * @function dnd5e.preRollFormulaV2
      * @memberof hookEvents
      * @param {BasicRollProcessConfiguration} config   Configuration information for the roll.
@@ -121,14 +121,14 @@ export default class UtilityActivity extends ActivityMixin(UtilityActivityData) 
     const rolls = await CONFIG.Dice.BasicRoll.build(rollConfig, dialogConfig, messageConfig);
 
     /**
-     * A hook event that fires after a hit die has been rolled for an Actor, but before updates have been performed.
+     * A hook event that fires after a formula has been rolled for a Utility activity.
      * @function dnd5e.rollFormulaV2
      * @memberof hookEvents
-     * @param {BasicRoll[]} rolls              The resulting rolls.
+     * @param {BasicRoll[]} rolls             The resulting rolls.
      * @param {object} data
-     * @param {UtilityActivity} data.activity  The activity that performed the roll.
+     * @param {UtilityActivity} data.subject  The Activity that performed the roll.
      */
-    Hooks.callAll("dnd5e.rollFormulaV2", rolls, { activity: this });
+    Hooks.callAll("dnd5e.rollFormulaV2", rolls, { subject: this });
 
     if ( "dnd5e.rollFormula" in Hooks.events ) {
       foundry.utils.logCompatibilityWarning(

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -979,7 +979,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   async rollAttack({ spellLevel, ...options }={}) {
     foundry.utils.logCompatibilityWarning(
-      "The Item5e#rollAttack method has been deprecated and should now be called directly on the attack activity.",
+      "The `Item5e#rollAttack` method has been deprecated and should now be called directly on the attack activity.",
       { since: "DnD5e 4.0", until: "DnD5e 4.4" }
     );
 
@@ -1031,7 +1031,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   async rollDamage({ spellLevel, ...options }={}) {
     foundry.utils.logCompatibilityWarning(
-      "The Item5e#rollDamage method has been deprecated and should now be called directly on an activity.",
+      "The `Item5e#rollDamage` method has been deprecated and should now be called directly on an activity.",
       { since: "DnD5e 4.0", until: "DnD5e 4.4" }
     );
 
@@ -1061,7 +1061,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   async rollFormula({spellLevel}={}) {
     foundry.utils.logCompatibilityWarning(
-      "The Item5e#rollFormula method has been deprecated and should now be called directly on the utility activity.",
+      "The `Item5e#rollFormula` method has been deprecated and should now be called directly on the utility activity.",
       { since: "DnD5e 4.0", until: "DnD5e 4.4" }
     );
 
@@ -1084,7 +1084,11 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @returns {Promise<Roll|void>}   A Promise which resolves to the created Roll instance
    */
   async rollRecharge() {
-    return this.system.uses?.rollRecharge();
+    foundry.utils.logCompatibilityWarning(
+      "The `rollRecharge` method on `Item5e` has been moved to `system.uses.rollRecharge`.",
+      { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+    );
+    return (await this.system.uses?.rollRecharge())?.[0];
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
The roll recharge method now makes use of the new configuration structure and rolling hooks to be consistant with other rolls in the system. It also gains a `dnd5e.postRollRecharge` hook that fires after the usage updates have been performed. A similar post hook has been added to `rollHitDice` so that all rolls that perform updates now have a `post*` hook after those updates are complete.

In order to support modifying the chat message flavor based on the result of the recharge roll, a `preCreate` callback has been added to `BasicRollMessageConfiguration` that is called right before the message is creating, allowing for any last-minute changes to the message. This hook will also be very helpful when attack rolls are hit by the roll refactor.

A small tweak has been made to the config and hooks to consistantly use `subject` for the Document performing the roll, rather than using `origin` in the initial config and a document-type specific key in the other hooks.