### PR TITLE
[#1539] Add identifier field to all items

### DIFF
--- a/module/applications/source-config.mjs
+++ b/module/applications/source-config.mjs
@@ -56,6 +56,11 @@ export default class SourceConfig extends DocumentSheet5e {
       { value: "2024", label: game.i18n.localize("SETTINGS.DND5E.RULESVERSION.Modern") },
       { value: "2014", label: game.i18n.localize("SETTINGS.DND5E.RULESVERSION.Legacy") }
     ];
+    if ( this.document.system.hasOwnProperty("identifier") ) context.identifier = {
+      field: this.document.system.schema.getField("identifier"),
+      placeholder: this.document.identifier,
+      value: this.document.toObject().system.identifier
+    };
     return context;
   }
 }

--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -1,6 +1,5 @@
 import { ItemDataModel } from "../abstract.mjs";
 import AdvancementField from "../fields/advancement-field.mjs";
-import IdentifierField from "../fields/identifier-field.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import StartingEquipmentTemplate from "./templates/starting-equipment.mjs";
 
@@ -11,7 +10,6 @@ const { ArrayField } = foundry.data.fields;
  * @mixes ItemDescriptionTemplate
  * @mixes StartingEquipmentTemplate
  *
- * @property {string} identifier     Identifier slug for this background.
  * @property {object[]} advancement  Advancement objects for this background.
  */
 export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionTemplate, StartingEquipmentTemplate) {
@@ -28,7 +26,6 @@ export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionT
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      identifier: new IdentifierField({required: true, label: "DND5E.Identifier"}),
       advancement: new ArrayField(new AdvancementField(), {label: "DND5E.AdvancementTitle"})
     });
   }

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -1,7 +1,6 @@
 import TraitAdvancement from "../../documents/advancement/trait.mjs";
 import { ItemDataModel } from "../abstract.mjs";
 import AdvancementField from "../fields/advancement-field.mjs";
-import IdentifierField from "../fields/identifier-field.mjs";
 import SpellcastingField from "./fields/spellcasting-field.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import StartingEquipmentTemplate from "./templates/starting-equipment.mjs";
@@ -13,7 +12,6 @@ const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringFiel
  * @mixes ItemDescriptionTemplate
  * @mixes StartingEquipmentTemplate
  *
- * @property {string} identifier                Identifier slug for this class.
  * @property {number} levels                    Current number of levels in this class.
  * @property {object} primaryAbility
  * @property {Set<string>} primaryAbility.value List of primary abilities used by this class.
@@ -38,7 +36,6 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      identifier: new IdentifierField({ required: true, label: "DND5E.Identifier" }),
       levels: new NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 1 }),
       primaryAbility: new SchemaField({
         value: new SetField(new StringField()),

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -2,7 +2,6 @@ import Actor5e from "../../documents/actor/actor.mjs";
 import { splitSemicolons } from "../../utils.mjs";
 import { ItemDataModel } from "../abstract.mjs";
 import AdvancementField from "../fields/advancement-field.mjs";
-import IdentifierField from "../fields/identifier-field.mjs";
 import { CreatureTypeField, MovementField, SensesField } from "../shared/_module.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 
@@ -12,7 +11,6 @@ const { ArrayField } = foundry.data.fields;
  * Data definition for Race items.
  * @mixes ItemDescriptionTemplate
  *
- * @property {string} identifier       Identifier slug for this race.
  * @property {object[]} advancement    Advancement objects for this race.
  * @property {MovementField} movement
  * @property {SensesField} senses
@@ -32,7 +30,6 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      identifier: new IdentifierField({ label: "DND5E.Identifier" }),
       advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" }),
       movement: new MovementField(),
       senses: new SensesField(),

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -10,9 +10,8 @@ const { ArrayField } = foundry.data.fields;
  * Data definition for Subclass items.
  * @mixes ItemDescriptionTemplate
  *
- * @property {string} identifier       Identifier slug for this subclass.
- * @property {string} classIdentifier  Identifier slug for the class with which this subclass should be associated.
  * @property {object[]} advancement    Advancement objects for this subclass.
+ * @property {string} classIdentifier  Identifier slug for the class with which this subclass should be associated.
  * @property {SpellcastingField} spellcasting  Details on subclass's spellcasting ability.
  */
 export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTemplate) {
@@ -29,11 +28,10 @@ export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTem
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      identifier: new IdentifierField({ required: true, label: "DND5E.Identifier" }),
+      advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" }),
       classIdentifier: new IdentifierField({
         required: true, label: "DND5E.ClassIdentifier", hint: "DND5E.ClassIdentifierHint"
       }),
-      advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" }),
       spellcasting: new SpellcastingField()
     });
   }

--- a/module/data/item/templates/item-description.mjs
+++ b/module/data/item/templates/item-description.mjs
@@ -1,4 +1,5 @@
 import SystemDataModel from "../../abstract.mjs";
+import IdentifierField from "../../fields/identifier-field.mjs";
 import SourceField from "../../shared/source-field.mjs";
 
 const { SchemaField, HTMLField } = foundry.data.fields;
@@ -9,6 +10,7 @@ const { SchemaField, HTMLField } = foundry.data.fields;
  * @property {object} description               Various item descriptions.
  * @property {string} description.value         Full item description.
  * @property {string} description.chat          Description displayed in chat card.
+ * @property {string} identifier                Identifier slug for this item.
  * @property {SourceData} source                Adventure or sourcebook where this item originated.
  * @mixin
  */
@@ -20,6 +22,7 @@ export default class ItemDescriptionTemplate extends SystemDataModel {
         value: new HTMLField({required: true, nullable: true, label: "DND5E.Description"}),
         chat: new HTMLField({required: true, nullable: true, label: "DND5E.DescriptionChat"})
       }),
+      identifier: new IdentifierField({ required: true, label: "DND5E.Identifier" }),
       source: new SourceField()
     };
   }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -264,7 +264,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @type {string}
    */
   get identifier() {
-    return this.system.identifier || this.name.slugify({strict: true});
+    if ( this.system.identifier ) return this.system.identifier;
+    const identifier = this.name.replaceAll(/(\w+)([\\|/])(\w+)/g, "$1-$3");
+    return identifier.slugify({ strict: true });
   }
 
   /* --------------------------------------------- */
@@ -1290,8 +1292,8 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     if ( (await super._preCreate(data, options, user)) === false ) return false;
 
     // Create class identifier based on name
-    if ( ["class", "subclass"].includes(this.type) && !this.system.identifier ) {
-      await this.updateSource({ "system.identifier": data.name.slugify({strict: true}) });
+    if ( this.system.hasOwnProperty("identifier") && !this.system.identifier ) {
+      await this.updateSource({ "system.identifier": this.identifier });
     }
 
     if ( !this.isEmbedded || (this.parent.type === "vehicle") ) return;

--- a/templates/apps/source-config.hbs
+++ b/templates/apps/source-config.hbs
@@ -13,7 +13,11 @@
     {{ formField fields.page value=source.page }}
     {{ formField fields.custom value=source.custom }}
     {{ formField fields.license value=source.license }}
+    <hr class="ampersand">
     {{ formField fields.rules value=source.rules options=rulesVersions }}
+    {{#if identifier}}
+    {{ formField identifier.field value=identifier.value placeholder=identifier.placeholder localize=true }}
+    {{/if}}
     {{ formField fields.revision value=source.revision }}
     {{#if hasSourceId}}
     <div class="form-group">


### PR DESCRIPTION
Adds `identifier` field to `ItemDescriptionTemplate` so it is added to all items. For classes, subclasses, backgrounds, and species it can still be edited from the details tab, but for other item types it is now available in the Configure Source app.

<img width="423" alt="Source with Identifier" src="https://github.com/user-attachments/assets/ac564505-9e12-4862-bfb9-d8908ae5913a">

Also makes a small change to how identifiers are created to handle slashes in the middle of words. This avoids an issue where a name like "Blindness/Deafness" would result in an identifier of only one word (e.g. `blindnessdeafness`) and instead adds a dash in place of the slash (e.g. `blindness-deafness`).

### Todo
- [ ] Create migration to automatically create identifier for any item that doesn't have one
- [ ] Add identifiers to all content in the SRD