### PR TITLE
[#2138] Refactor `DamageRoll` to use new rolling API

### DIFF
--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1050,9 +1050,11 @@ dialog.dnd5e2.application {
       padding: 6px;
 
       li {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
+        .formula-line {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
       }
 
       .formula {
@@ -1061,11 +1063,20 @@ dialog.dnd5e2.application {
       }
 
       .label {
+        --icon-size: 20px;
+
+        display: flex;
+        align-items: center;
+        gap: 8px;
         color: var(--color-text-dark-5);
         font-style: italic;
         font-size: var(--font-size-12);
       }
     }
+  }
+
+  .dialog-buttons {
+    gap: 6px;
   }
 }
 

--- a/less/v2/dark/apps.less
+++ b/less/v2/dark/apps.less
@@ -93,6 +93,14 @@
   &.application {
     background: var(--dnd5e-color-dark-gray) url("../../ui/denim075.png");
   }
+
+  /* ---------------------------------- */
+  /*  Roll Configuration Dialog         */
+  /* ---------------------------------- */
+
+  &.application.roll-configuration {
+    .rolls .formulas .label { --icon-fill: var(--dnd5e-color-gold); }
+  }
 }
 
 /* ---------------------------------- */

--- a/module/applications/dice/_module.mjs
+++ b/module/applications/dice/_module.mjs
@@ -1,1 +1,2 @@
+export {default as DamageRollConfigurationDialog} from "./damage-configuration-dialog.mjs";
 export {default as RollConfigurationDialog} from "./roll-configuration-dialog.mjs";

--- a/module/applications/dice/damage-configuration-dialog.mjs
+++ b/module/applications/dice/damage-configuration-dialog.mjs
@@ -1,0 +1,87 @@
+import RollConfigurationDialog from "./roll-configuration-dialog.mjs";
+
+/**
+ * Dialog for configuring damage rolls.
+ *
+ * @param {DamageRollProcessConfiguration} [config={}]        Initial roll configuration.
+ * @param {BasicRollMessageConfiguration} [message={}]        Message configuration.
+ * @param {BasicRollConfigurationDialogOptions} [options={}]  Dialog rendering options.
+ */
+export default class DamageRollConfigurationDialog extends RollConfigurationDialog {
+
+  /** @inheritDoc */
+  static PARTS = {
+    ...super.PARTS,
+    formulas: {
+      template: "systems/dnd5e/templates/dice/damage-formulas.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static get rollType() {
+    return CONFIG.Dice.DamageRoll;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareButtonsContext(context, options) {
+    const allowCritical = this.config.critical?.allow !== false;
+    context.buttons = {
+      critical: {
+        icon: '<i class="fa-solid fa-bomb"></i>',
+        label: game.i18n.localize("DND5E.CriticalHit")
+      },
+      normal: {
+        icon: '<i class="fa-solid fa-dice"></i>',
+        label: game.i18n.localize(allowCritical ? "DND5E.Normal" : "DND5E.Roll")
+      }
+    };
+    if ( !allowCritical ) delete context.buttons.critical;
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareFormulasContext(context, options) {
+    context = await super._prepareFormulasContext(context, options);
+    const allTypes = foundry.utils.mergeObject(CONFIG.DND5E.damageTypes, CONFIG.DND5E.healingTypes, { inplace: false });
+    context.rolls = context.rolls.map(({ roll }) => ({
+      roll,
+      damageConfig: allTypes[roll.options.type] ?? allTypes[roll.options.types?.[0]],
+      damageTypes: roll.options.types?.length > 1 ? Object.entries(allTypes).map(([key, config]) => {
+        if ( !roll.options.types?.includes(key) ) return null;
+        return { value: key, label: config.label };
+      }).filter(_ => _) : null
+    }));
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Roll Handling                               */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _buildConfig(config, formData, index) {
+    config = super._buildConfig(config, formData, index);
+    const damageType = formData?.get(`roll.${index}.damageType`);
+    if ( damageType ) config.options.type = damageType;
+    return config;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _finalizeRolls(action) {
+    return this.rolls.map(roll => {
+      roll.options.isCritical = action === "critical";
+      roll.configureDamage({ critical: this.config.critical });
+      return roll;
+    });
+  }
+}

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -218,7 +218,7 @@ export default class RollConfigurationDialog extends Application5e {
    * Prepare the context for the buttons.
    * @param {ApplicationRenderContext} context  Shared context provided by _prepareContext.
    * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
-   * @returns {ApplicationRenderContext}
+   * @returns {Promise<ApplicationRenderContext>}
    * @protected
    */
   async _prepareButtonsContext(context, options) {
@@ -237,7 +237,7 @@ export default class RollConfigurationDialog extends Application5e {
    * Prepare the context for the roll configuration section.
    * @param {ApplicationRenderContext} context  Shared context provided by _prepareContext.
    * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
-   * @returns {ApplicationRenderContext}
+   * @returns {Promise<ApplicationRenderContext>}
    * @protected
    */
   async _prepareConfigurationContext(context, options) {
@@ -256,7 +256,7 @@ export default class RollConfigurationDialog extends Application5e {
    * Prepare the context for the formulas list.
    * @param {ApplicationRenderContext} context  Shared context provided by _prepareContext.
    * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
-   * @returns {ApplicationRenderContext}
+   * @returns {Promise<ApplicationRenderContext>}
    * @protected
    */
   async _prepareFormulasContext(context, options) {
@@ -306,7 +306,7 @@ export default class RollConfigurationDialog extends Application5e {
     Hooks.callAll("dnd5e.buildRollConfig", this, config, formData, index);
 
     const situational = formData?.get(`roll.${index}.situational`);
-    if ( situational && (config.situation !== false) ) {
+    if ( situational && (config.situational !== false) ) {
       config.parts.push("@situational");
       config.data.situational = situational;
     } else {

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -147,7 +147,7 @@ export default class RollConfigurationDialog extends Application5e {
    * @protected
    */
   _identifyDiceTerms() {
-    const dice = [];
+    let dice = [];
     let shouldDisplay = true;
 
     /**
@@ -164,7 +164,8 @@ export default class RollConfigurationDialog extends Application5e {
       if ( !this.options.rendering.dice.denominations.has(term.denomination) ) return shouldDisplay = false;
       for ( let i = 0; i < term.number; i++ ) dice.push({
         icon: `systems/dnd5e/icons/svg/dice/${term.denomination}.svg`,
-        label: term.denomination
+        label: term.denomination,
+        denomination: term.denomination
       });
     };
 
@@ -180,7 +181,17 @@ export default class RollConfigurationDialog extends Application5e {
     };
 
     this.rolls.forEach(roll => identifyDice(roll.terms));
-    if ( !dice.length || (dice.length > this.options.rendering.dice.max) ) shouldDisplay = false;
+    if ( dice.length > this.options.rendering.dice.max ) {
+      // Compact dice display.
+      const byDenom = dice.reduce((obj, { icon, denomination }) => {
+        obj[denomination] ??= { icon, count: 0 };
+        obj[denomination].count++;
+        return obj;
+      }, {});
+      dice = Object.entries(byDenom).map(([d, { icon, count }]) => ({ icon, label: `${count}${d}` }));
+      if ( dice.length > this.options.rendering.dice.max ) shouldDisplay = false;
+    }
+    else if ( !dice.length ) shouldDisplay = false;
     return shouldDisplay ? dice : [];
   }
 

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -210,7 +210,7 @@ export default class RollConfigurationDialog extends Application5e {
    * @returns {ApplicationRenderContext}
    * @protected
    */
-  _prepareButtonsContext(context, options) {
+  async _prepareButtonsContext(context, options) {
     context.buttons = {
       roll: {
         icon: '<i class="fa-solid fa-dice"></i>',
@@ -229,7 +229,7 @@ export default class RollConfigurationDialog extends Application5e {
    * @returns {ApplicationRenderContext}
    * @protected
    */
-  _prepareConfigurationContext(context, options) {
+  async _prepareConfigurationContext(context, options) {
     context.fields = [{
       field: new foundry.data.fields.StringField({ label: game.i18n.localize("DND5E.RollMode") }),
       name: "rollMode",
@@ -248,9 +248,8 @@ export default class RollConfigurationDialog extends Application5e {
    * @returns {ApplicationRenderContext}
    * @protected
    */
-  _prepareFormulasContext(context, options) {
-    context.rolls = this.rolls;
-    context.situational = this.rolls[0].data.situational;
+  async _prepareFormulasContext(context, options) {
+    context.rolls = this.rolls.map(roll => ({ roll }));
     context.dice = this._identifyDiceTerms() || [];
     return context;
   }
@@ -295,9 +294,12 @@ export default class RollConfigurationDialog extends Application5e {
      */
     Hooks.callAll("dnd5e.buildRollConfig", this, config, formData, index);
 
-    if ( formData?.get("situational") && (config.situational !== false) ) {
+    const situational = formData?.get(`roll.${index}.situational`);
+    if ( situational && (config.situation !== false) ) {
       config.parts.push("@situational");
-      config.data.situational = formData.get("situational");
+      config.data.situational = situational;
+    } else {
+      config.parts.findSplice(v => v === "@situational");
     }
 
     return config;

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -1,3 +1,6 @@
+import DamageRollConfigurationDialog from "../applications/dice/damage-configuration-dialog.mjs";
+import BasicRoll from "./basic-roll.mjs";
+
 const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, StringTerm } = foundry.dice.terms;
 
 /**
@@ -43,56 +46,47 @@ const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, St
 
 /**
  * A type of Roll specific to a damage (or healing) roll in the 5e system.
- * @param {string} formula                       The string formula to parse
- * @param {object} data                          The data object against which to parse attributes within the formula
- * @param {object} [options={}]                  Extra optional arguments which describe or modify the DamageRoll
- * @param {number} [options.criticalBonusDice=0]      A number of bonus damage dice that are added for critical hits
- * @param {number} [options.criticalMultiplier=2]     A critical hit multiplier which is applied to critical hits
- * @param {boolean} [options.multiplyNumeric=false]   Multiply numeric terms by the critical multiplier
- * @param {boolean} [options.powerfulCritical=false]  Apply the "powerful criticals" house rule to critical hits
- * @param {string} [options.criticalBonusDamage]      An extra damage term that is applied only on a critical hit
+ * @param {string} formula                  The string formula to parse.
+ * @param {object} data                     The data object against which to parse attributes within the formula.
+ * @param {DamageRollOptions} [options={}]  Extra optional arguments which describe or modify the DamageRoll.
  */
-export default class DamageRoll extends Roll {
+export default class DamageRoll extends BasicRoll {
   constructor(formula, data, options) {
     super(formula, data, options);
     if ( !this.options.preprocessed ) this.preprocessFormula();
-    // For backwards compatibility, skip rolls which do not have the "critical" option defined
-    if ( (this.options.critical !== undefined) && !this.options.configured ) this.configureDamage();
+    if ( !this.options.configured ) this.configureDamage();
   }
 
   /* -------------------------------------------- */
 
-  /**
-   * Create a DamageRoll from a standard Roll instance.
-   * @param {Roll} roll
-   * @returns {DamageRoll}
-   */
-  static fromRoll(roll) {
-    const newRoll = new this(roll.formula, roll.data, roll.options);
-    Object.assign(newRoll, roll);
-    return newRoll;
+  /** @inheritDoc */
+  static DefaultConfigurationDialog = DamageRollConfigurationDialog;
+
+  /* -------------------------------------------- */
+  /*  Static Construction                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static applyKeybindings(config, dialog, message) {
+    const event = config.event;
+    dialog.configure ??= !(event && (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey));
+    if ( event?.altKey ) config.rolls.forEach(r => r.isCritical = true);
   }
 
   /* -------------------------------------------- */
-
-  /**
-   * The HTML template path used to configure evaluation of this Roll
-   * @type {string}
-   */
-  static EVALUATION_TEMPLATE = "systems/dnd5e/templates/chat/roll-dialog.hbs";
-
+  /*  Properties                                  */
   /* -------------------------------------------- */
 
   /**
-   * A convenience reference for whether this DamageRoll is a critical hit
+   * Is this damage critical.
    * @type {boolean}
    */
   get isCritical() {
-    return this.options.critical;
+    return this.options.isCritical === true;
   }
 
   /* -------------------------------------------- */
-  /*  Damage Roll Methods                         */
+  /*  Roll Configuration                          */
   /* -------------------------------------------- */
 
   /**
@@ -144,7 +138,7 @@ export default class DamageRoll extends Roll {
     }
 
     // Re-compile the underlying formula
-    this._formula = this.constructor.getFormula(this.terms);
+    this.resetFormula();
 
     // Mark configuration as complete
     this.options.preprocessed = true;
@@ -154,9 +148,14 @@ export default class DamageRoll extends Roll {
 
   /**
    * Apply optional modifiers which customize the behavior of the d20term.
+   * @param {object} [options={}]
+   * @param {CriticalDamageConfiguration} [options.critical={}]  Critical configuration to take into account, will be
+   *                                                             superseded by the roll's configuration.
    * @protected
    */
-  configureDamage() {
+  configureDamage({ critical={} }={}) {
+    foundry.utils.mergeObject(critical, this.options.critical ?? {});
+
     const flatBonus = new Map();
     for ( let [i, term] of this.terms.entries() ) {
       // Multiply dice terms
@@ -169,10 +168,10 @@ export default class DamageRoll extends Roll {
         term.options.baseNumber = term.options.baseNumber ?? term.number; // Reset back
         term.number = term.options.baseNumber;
         if ( this.isCritical ) {
-          let cm = this.options.criticalMultiplier ?? 2;
+          let cm = critical.multiplier ?? 2;
 
           // Powerful critical - maximize damage and reduce the multiplier by 1
-          if ( this.options.powerfulCritical ) {
+          if ( critical.powerfulCritical ) {
             const bonus = Roll.create(term.formula).evaluateSync({ maximize: true }).total;
             if ( bonus > 0 ) {
               const flavor = term.flavor?.toLowerCase().trim() ?? game.i18n.localize("DND5E.PowerfulCritical");
@@ -182,25 +181,25 @@ export default class DamageRoll extends Roll {
           }
 
           // Alter the damage term
-          let cb = (this.options.criticalBonusDice && (i === 0)) ? this.options.criticalBonusDice : 0;
+          let cb = (critical.bonusDice && (i === 0)) ? critical.bonusDice : 0;
           term.alter(cm, cb);
           term.options.critical = true;
         }
       }
 
       // Multiply numeric terms
-      else if ( this.options.multiplyNumeric && (term instanceof NumericTerm) ) {
+      else if ( critical.multiplyNumeric && (term instanceof NumericTerm) ) {
         term.options.baseNumber = term.options.baseNumber ?? term.number; // Reset back
         term.number = term.options.baseNumber;
         if ( this.isCritical ) {
-          term.number *= (this.options.criticalMultiplier ?? 2);
+          term.number *= (critical.multiplier ?? 2);
           term.options.critical = true;
         }
       }
     }
 
     // Add powerful critical bonus
-    if ( this.options.powerfulCritical && flatBonus.size ) {
+    if ( critical.powerfulCritical && flatBonus.size ) {
       for ( const [type, number] of flatBonus.entries() ) {
         this.terms.push(new OperatorTerm({operator: "+"}));
         this.terms.push(new NumericTerm({number, options: {flavor: type}}));
@@ -208,73 +207,17 @@ export default class DamageRoll extends Roll {
     }
 
     // Add extra critical damage term
-    if ( this.isCritical && this.options.criticalBonusDamage ) {
-      const extra = new Roll(this.options.criticalBonusDamage, this.data);
+    if ( this.isCritical && critical.bonusDamage ) {
+      const extra = new Roll(critical.bonusDamage, this.data);
       if ( !(extra.terms[0] instanceof OperatorTerm) ) this.terms.push(new OperatorTerm({operator: "+"}));
       this.terms.push(...extra.terms);
     }
 
     // Re-compile the underlying formula
-    this._formula = this.constructor.getFormula(this.terms);
+    this.resetFormula();
 
     // Mark configuration as complete
     this.options.configured = true;
-  }
-
-  /* -------------------------------------------- */
-  /*  Chat Messages                               */
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  toMessage(messageData={}, options={}) {
-    return this.constructor.toMessage([this], messageData, options);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Transform a Roll instance into a ChatMessage, displaying the roll result.
-   * This function can either create the ChatMessage directly, or return the data object that will be used to create.
-   *
-   * @param {DamageRoll[]} rolls             Rolls to add to the message.
-   * @param {object} messageData             The data object to use when creating the message.
-   * @param {options} [options]              Additional options which modify the created message.
-   * @param {string} [options.rollMode]      The template roll mode to use for the message from CONFIG.Dice.rollModes.
-   * @param {boolean} [options.create=true]  Whether to automatically create the chat message, or only return the
-   *                                         prepared chatData object.
-   * @returns {Promise<ChatMessage|object>}  A promise which resolves to the created ChatMessage document if create is
-   *                                         true, or the Object of prepared chatData otherwise.
-   */
-  static async toMessage(rolls, messageData={}, {rollMode, create=true}={}) {
-    rollMode = rolls.at(-1)?.options.rollMode ?? rollMode ?? game.settings.get("core", "rollMode");
-    let isCritical = false;
-    for ( const roll of rolls ) {
-      if ( !roll._evaluated ) await roll.evaluate({ allowInteractive: rollMode !== CONST.DICE_ROLL_MODES.BLIND });
-      messageData.flavor ??= roll.options.flavor;
-      isCritical ||= roll.isCritical;
-    }
-    if ( isCritical ) {
-      const label = game.i18n.localize("DND5E.CriticalHit");
-      messageData.flavor = messageData.flavor ? `${messageData.flavor} (${label})` : label;
-    }
-
-    // Prepare chat data
-    messageData = foundry.utils.mergeObject({
-      user: game.user.id,
-      sound: CONFIG.sounds.dice
-    }, messageData);
-    messageData.rolls = rolls;
-
-    // Either create the message or just return the chat data
-    const cls = getDocumentClass("ChatMessage");
-    const msg = new cls(messageData);
-
-    // Either create or return the data
-    if ( create ) return cls.create(msg.toObject(), { rollMode });
-    else {
-      if ( rollMode ) msg.applyRollMode(rollMode);
-      return msg.toObject();
-    }
   }
 
   /* -------------------------------------------- */
@@ -315,86 +258,14 @@ export default class DamageRoll extends Roll {
    */
   static async configureDialog(rolls, {
     title, defaultRollMode, defaultCritical=false, template, allowCritical=true}={}, options={}) {
-
-    const damageTypeLabel = k => CONFIG.DND5E.damageTypes[k]?.label ?? CONFIG.DND5E.healingTypes[k]?.label;
-
-    // Render the Dialog inner HTML
-    const content = await renderTemplate(template ?? this.EVALUATION_TEMPLATE, {
-      formulas: rolls.map((roll, index) => ({
-        formula: `${roll.formula}${index === 0 ? " + @bonus" : ""}`,
-        type: roll.options.types?.length > 1 ? null
-          : damageTypeLabel(roll.options.type ?? roll.options.types?.[0]) ?? null,
-        types: roll.options.types?.length > 1 ? roll.options.types?.map(value =>
-          ({ value, label: damageTypeLabel(value), selected: value === roll.options.type })
-        ) : null
-      })),
-      defaultRollMode,
-      rollModes: CONFIG.Dice.rollModes
-    });
-
-    const handleSubmit = (html, isCritical) => {
-      const formData = new FormDataExtended(html[0].querySelector("form"));
-      const submitData = foundry.utils.expandObject(formData.object);
-      return rolls.map((r, i) => r._onDialogSubmit(submitData, isCritical, i));
-    };
-
-    // Create the Dialog window and await submission of the form
-    return new Promise(resolve => {
-      new Dialog({
-        title,
-        content,
-        buttons: {
-          critical: {
-            condition: allowCritical,
-            label: game.i18n.localize("DND5E.CriticalHit"),
-            callback: html => resolve(handleSubmit(html, true))
-          },
-          normal: {
-            label: game.i18n.localize(allowCritical ? "DND5E.Normal" : "DND5E.Roll"),
-            callback: html => resolve(handleSubmit(html, false))
-          }
-        },
-        default: defaultCritical ? "critical" : "normal",
-        close: () => resolve(null)
-      }, options).render(true);
-    });
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Handle submission of the Roll evaluation configuration Dialog
-   * @param {object} submitData   The submitted dialog data.
-   * @param {boolean} isCritical  Is the damage a critical hit?
-   * @param {number} index        Index of the roll.
-   * @returns {DamageRoll}        This damage roll.
-   * @private
-   */
-  _onDialogSubmit(submitData, isCritical, index) {
-    // Set damage types on rolls
-    const rollData = submitData.roll?.[index] ?? {};
-    if ( rollData.type ) this.options.type = rollData.type;
-
-    // Append a situational bonus term
-    if ( submitData.bonus && (index === 0) ) {
-      const bonus = new DamageRoll(submitData.bonus, this.data);
-      if ( !(bonus.terms[0] instanceof OperatorTerm) ) this.terms.push(new OperatorTerm({operator: "+"}));
-      this.terms = this.terms.concat(bonus.terms);
-    }
-
-    // Apply advantage or disadvantage
-    this.options.critical = isCritical;
-    this.options.rollMode = submitData.rollMode;
-    this.configureDamage();
-    return this;
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  static fromData(data) {
-    const roll = super.fromData(data);
-    roll._formula = this.getFormula(roll.terms);
-    return roll;
+    foundry.utils.logCompatibilityWarning(
+      "The `configureDialog` on DamageRoll has been deprecated and is now handled through the build process.",
+      { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+    );
+    const DialogClass = this.DefaultConfigurationDialog;
+    rolls = await DialogClass.configure(
+      { critical: { allow: allowCritical } }, { options: { title } }, { rollMode: defaultRollMode }
+    );
+    return nulls;
   }
 }

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -259,13 +259,12 @@ export default class DamageRoll extends BasicRoll {
   static async configureDialog(rolls, {
     title, defaultRollMode, defaultCritical=false, template, allowCritical=true}={}, options={}) {
     foundry.utils.logCompatibilityWarning(
-      "The `configureDialog` on DamageRoll has been deprecated and is now handled through the build process.",
+      "The `configureDialog` on DamageRoll has been deprecated and is now handled through `DamageRoll.build`.",
       { since: "DnD5e 4.0", until: "DnD5e 4.4" }
     );
     const DialogClass = this.DefaultConfigurationDialog;
-    rolls = await DialogClass.configure(
+    return await DialogClass.configure(
       { critical: { allow: allowCritical } }, { options: { title } }, { rollMode: defaultRollMode }
     );
-    return nulls;
   }
 }

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -198,57 +198,55 @@ export async function damageRoll({
   fastForward, template, title, dialogOptions,
   chatMessage=true, messageData={}, rollMode, flavor
 }={}) {
+  foundry.utils.logCompatibilityWarning(
+    "The `damageRoll` standalone method has been deprecated and replaced with `CONFIG.dice.DamageRoll.build`.",
+    { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+  );
 
-  // Handle input arguments
-  const defaultRollMode = rollMode || game.settings.get("core", "rollMode");
+  const rollConfig = {
+    event,
+    critical: {
+      allow: allowCritical,
+      multiplier: criticalMultiplier,
+      multiplyNumeric: multiplyNumeric ?? game.settings.get("dnd5e", "criticalDamageModifiers"),
+      powerfulCritical: powerfulCritical ?? game.settings.get("dnd5e", "criticalDamageMaxDice")
+    },
+    rolls: rollConfigs.map(r => ({
+      data,
+      parts: r.parts,
+      options: {
+        isCritical: critical,
+        properties: r.properties,
+        type: r.type,
+        types: r.types
+      }
+    }))
+  };
+  if ( parts.length ) rollConfig.rolls.unshift({ data, parts });
+  if ( rollConfig.rolls[0] ) {
+    foundry.utils.setProperty(rollConfig.rolls[0], "options.critical.bonusDice", criticalBonusDice);
+    foundry.utils.setProperty(rollConfig.rolls[0], "options.critical.bonusDamage", criticalBonusDamage);
+  }
 
-  // If parts are still provided, treat it as the first roll
-  if ( parts.length ) rollConfigs.unshift({ parts });
-
-  const {isCritical, isFF} = _determineCriticalMode({critical, fastForward, event});
-  const rolls = [];
-  flavor ??= title;
-  multiplyNumeric ??= game.settings.get("dnd5e", "criticalDamageModifiers");
-  powerfulCritical ??= game.settings.get("dnd5e", "criticalDamageMaxDice");
-  critical = isFF ? isCritical : false;
-  for ( const [index, { parts, type, types, properties }] of rollConfigs.entries() ) {
-    const formula = parts.join(" + ");
-    const rollOptions = {
-      flavor, rollMode, critical, criticalMultiplier, multiplyNumeric, powerfulCritical, type, types, properties
-    };
-    if ( index === 0 ) {
-      rollOptions.criticalBonusDice = criticalBonusDice;
-      rollOptions.criticalBonusDamage = criticalBonusDamage;
+  const dialogConfig = {
+    configure: !fastForward,
+    options: {
+      ...(dialogOptions ?? {}),
+      title
     }
-    if ( formula ) rolls.push(new CONFIG.Dice.DamageRoll(formula, data, rollOptions));
-  }
+  };
 
-  // Prompt a Dialog to further configure the DamageRoll
-  if ( !isFF ) {
-    const configured = await CONFIG.Dice.DamageRoll.configureDialog(rolls, {
-      title,
-      defaultRollMode: defaultRollMode,
-      defaultCritical: isCritical,
-      template,
-      allowCritical
-    }, dialogOptions);
-    if ( configured === null ) return null;
-  }
+  const messageConfig = {
+    create: chatMessage,
+    data: {
+      ...messageData,
+      flavor
+    },
+    rollMode: rollMode ?? game.settings.get("core", "rollMode")
+  };
 
-  // Evaluate the configured roll
-  for ( const roll of rolls ) {
-    const rollMode = rolls.at(-1).options.rollMode ?? defaultRollMode;
-    if ( !roll.options.type ) roll.options.type = roll.options.types?.[0];
-    await roll.evaluate({ allowInteractive: rollMode !== CONST.DICE_ROLL_MODES.BLIND });
-  }
+  const rolls = await CONFIG.Dice.DamageRoll.build(rollConfig, dialogConfig, messageConfig);
 
-  // Attach original message ID to the message
-  messageData = foundry.utils.expandObject(messageData);
-  const messageId = event?.target.closest("[data-message-id]")?.dataset.messageId;
-  if ( messageId ) foundry.utils.setProperty(messageData, "flags.dnd5e.originatingMessage", messageId);
-
-  // Create a Chat Message
-  if ( rolls?.length && chatMessage ) await CONFIG.Dice.DamageRoll.toMessage(rolls, messageData, { rollMode });
   if ( returnMultiple ) return rolls;
   if ( rolls?.length <= 1 ) return rolls[0];
 
@@ -267,20 +265,4 @@ export async function damageRoll({
   mergedRoll._evaluated = true;
   mergedRoll.resetFormula();
   return mergedRoll;
-}
-
-/* -------------------------------------------- */
-
-/**
- * Determines whether this d20 roll should be fast-forwarded, and whether advantage or disadvantage should be applied
- * @param {object} [config]
- * @param {Event} [config.event]          Event that triggered the roll.
- * @param {boolean} [config.critical]     Is this roll treated as a critical by default?
- * @param {boolean} [config.fastForward]  Should the roll dialog be skipped?
- * @returns {{isFF: boolean, isCritical: boolean}}  Whether the roll is fast-forward, and whether it is a critical hit
- */
-function _determineCriticalMode({event, critical=false, fastForward}={}) {
-  const isFF = (event && (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey)) ?? fastForward;
-  if ( event?.altKey ) critical = true;
-  return {isFF: !!isFF, isCritical: critical};
 }

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -199,7 +199,7 @@ export async function damageRoll({
   chatMessage=true, messageData={}, rollMode, flavor
 }={}) {
   foundry.utils.logCompatibilityWarning(
-    "The `damageRoll` standalone method has been deprecated and replaced with `CONFIG.dice.DamageRoll.build`.",
+    "The `damageRoll` standalone method has been deprecated and replaced with `CONFIG.Dice.DamageRoll.build`.",
     { since: "DnD5e 4.0", until: "DnD5e 4.4" }
   );
 

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -295,7 +295,7 @@ export default class ChatMessage5e extends ChatMessage {
     const item = this.getAssociatedItem();
     const activity = this.getAssociatedActivity();
     if ( this.isContentVisible && item && roll ) {
-      const isCritical = (roll.type === "damage") && this.rolls[0]?.options?.critical;
+      const isCritical = (roll.type === "damage") && this.rolls[0]?.isCritical;
       const subtitle = roll.type === "damage"
         ? isCritical ? game.i18n.localize("DND5E.CriticalHit") : game.i18n.localize("DND5E.DamageRoll")
         : roll.type === "attack"

--- a/templates/dice/damage-formulas.hbs
+++ b/templates/dice/damage-formulas.hbs
@@ -14,10 +14,23 @@
     <ul class="formulas unlist">
         {{#each rolls}}
         <li>
-            {{!-- Formula --}}
+            {{!-- Formula & Type --}}
             <div class="formula-line">
                 <span class="formula">{{ roll.formula }}</span>
-                <span class="label">{{#if type}}{{ roll.type }}{{else}}{{ localize "DND5E.Formula" }}{{/if}}</span>
+                <span class="label">
+                    {{#if damageTypes}}
+                    <select name="roll.{{ @index }}.damageType">
+                        {{ selectOptions damageTypes selected=roll.options.type }}
+                    </select>
+                    {{else if damageConfig}}
+                    {{ damageConfig.label }}
+                    {{else}}
+                    {{ localize "DND5E.Formula" }}
+                    {{/if}}
+                    {{#if damageConfig.icon}}
+                    <dnd5e-icon src="{{ damageConfig.icon }}" alt="{{ damageConfig.label }}"></dnd5e-icon>
+                    {{/if}}
+                </span>
             </div>
 
             {{!-- Situational Bonus --}}

--- a/templates/dice/roll-buttons.hbs
+++ b/templates/dice/roll-buttons.hbs
@@ -1,4 +1,4 @@
-<nav class="dialog-buttons">
+<nav class="dialog-buttons flexrow">
     {{#each buttons}}
     <button type="submit" data-action="{{ @key }}">{{{ icon }}} {{ label }}</button>
     {{/each}}


### PR DESCRIPTION
Reworks parts of `DamageRoll` to match the design of `BasicRoll` and removed a number of methods not needed anymore. Deprecated the `damageRoll` standalone method and changed it internally to use the new `DamageRoll#build` method. Finally adjusted `rollDamage` to use the new build process.

<img width="422" alt="Damage Dialog" src="https://github.com/user-attachments/assets/8b5b0b7b-8ce1-4f20-a291-355ce3eb9a2e">

Implemented a new roll configuration dialog for damage rolls that allows for selecting damage type and improved the base dialog to support entering situational bonuses for each damage part, rather than for just the first one.