### PR TITLE
[#4174] Defer item regsitry loading if Babel is present

### DIFF
--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -161,7 +161,10 @@ class ItemRegistry {
   async initialize() {
     if ( this.#status > ItemRegistry.#STATUS_STATES.NONE ) return;
     RegistryStatus.set(this.#itemType, false);
-    if ( !game.ready ) {
+    if ( game.modules.get("babele")?.active && (game.babele?.initialized === false) ) {
+      Hooks.once("babele.ready", () => this.initialize());
+      return;
+    } else if ( !game.ready ) {
       Hooks.once("ready", () => this.initialize());
       return;
     }


### PR DESCRIPTION
If the Babele module is enabled, defer loading of item registries until Babele has fired its ready hook to ensure that registered items are translted.

Closes #4174