### PR TITLE
[#3317] Consume thrown weapon quantity unless Returning is checked

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -516,7 +516,7 @@
     "Ranged": "Ranged"
   },
   "Warning": {
-    "NoQuanity": "Cannot attack with weapons with a quantity of zero."
+    "NoQuantity": "Attempting to attack with a weapon with a quantity of zero."
   }
 },
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -514,6 +514,9 @@
   "Type": {
     "Melee": "Melee",
     "Ranged": "Ranged"
+  },
+  "Warning": {
+    "NoQuanity": "Cannot attack with weapons with a quantity of zero."
   }
 },
 

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -85,8 +85,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
     const targets = getTargetDescriptors();
 
     if ( (this.item.type === "weapon") && (this.item.system.quantity === 0) ) {
-      ui.notifications.error("DND5E.ATTACK.Warning.NoQuanity", { localize: true });
-      return;
+      ui.notifications.warn("DND5E.ATTACK.Warning.NoQuantity", { localize: true });
     }
 
     let ammunitionOptions;


### PR DESCRIPTION
Reduces the quantity of a weapon by 1 each time a Thrown attack is made unless the "Returning" property is checked. Also adds a check to ensure that weapon quantity is not zero when attacking.

Closes #3317