### PR TITLE
[#4024] Add spellcasting ability as option for Check activity

### DIFF
--- a/module/applications/activity/check-sheet.mjs
+++ b/module/applications/activity/check-sheet.mjs
@@ -33,10 +33,12 @@ export default class CheckSheet extends ActivitySheet {
   async _prepareEffectContext(context) {
     context = await super._prepareEffectContext(context);
 
+    const group = game.i18n.localize("DND5E.Abilities");
     context.abilityOptions = [
       { value: "", label: "" },
       { rule: true },
-      ...Object.entries(CONFIG.DND5E.abilities).map(([value, config]) => ({ value, label: config.label }))
+      { value: "spellcasting", label: game.i18n.localize("DND5E.SpellAbility") },
+      ...Object.entries(CONFIG.DND5E.abilities).map(([value, config]) => ({ value, label: config.label, group }))
     ];
     let ability;
     const associated = this.activity.check.associated;
@@ -60,9 +62,7 @@ export default class CheckSheet extends ActivitySheet {
       { value: "", label: game.i18n.localize("DND5E.SAVE.FIELDS.save.dc.CustomFormula") },
       { rule: true },
       { value: "spellcasting", label: game.i18n.localize("DND5E.SpellAbility") },
-      ...Object.entries(CONFIG.DND5E.abilities).map(([value, config]) => ({
-        value, label: config.label, group: game.i18n.localize("DND5E.Abilities")
-      }))
+      ...Object.entries(CONFIG.DND5E.abilities).map(([value, config]) => ({ value, label: config.label, group }))
     ];
 
     return context;

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -58,9 +58,7 @@ export default class AttackActivityData extends BaseActivityData {
   /** @override */
   get ability() {
     if ( this.attack.ability === "none" ) return null;
-    if ( this.attack.ability === "spellcasting" ) {
-      return this.isSpell ? super.ability : this.actor?.system.attributes?.spellcasting ?? null;
-    }
+    if ( this.attack.ability === "spellcasting" ) return this.spellcastingAbility;
     if ( this.attack.ability in CONFIG.DND5E.abilities ) return this.attack.ability;
 
     const availableAbilities = this.availableAbilities;

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -111,11 +111,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * @type {string|null}
    */
   get ability() {
-    if ( this.isSpell ) {
-      return this.item.system.availableAbilities?.first()
-        ?? this.actor?.system.attributes?.spellcasting ?? null;
-    }
-    return null;
+    return this.isSpell ? this.spellcastingAbility : null;
   }
 
   /* -------------------------------------------- */
@@ -198,6 +194,18 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   get requiresSpellSlot() {
     if ( !this.isSpell || !this.actor?.system.spells ) return false;
     return this.canScale;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieve the spellcasting ability that can be used with this activity.
+   * @type {string|null}
+   */
+  get spellcastingAbility() {
+    let ability;
+    if ( this.isSpell ) ability = this.item.system.availableAbilities?.first();
+    return ability ?? this.actor?.system.attributes?.spellcasting ?? null;
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/check-data.mjs
+++ b/module/data/activity/check-data.mjs
@@ -37,11 +37,7 @@ export default class CheckActivityData extends BaseActivityData {
   /** @override */
   get ability() {
     if ( this.check.dc.calculation in CONFIG.DND5E.abilities ) return this.check.dc.calculation;
-    if ( this.check.dc.calculation === "spellcasting" ) {
-      let ability = this.isSpell ? this.item.system.availableAbilities?.first() : null;
-      ability ??= this.actor?.system.attributes?.spellcasting;
-      return ability ?? null;
-    }
+    if ( this.check.dc.calculation === "spellcasting" ) return this.spellcastingAbility;
     return this.check.ability;
   }
 
@@ -66,6 +62,8 @@ export default class CheckActivityData extends BaseActivityData {
   prepareFinalData(rollData) {
     rollData ??= this.getRollData({ deterministic: true });
     super.prepareFinalData(rollData);
+
+    if ( this.check.ability === "spellcasting" ) this.check.ability = this.spellcastingAbility;
 
     let ability;
     if ( this.check.dc.calculation ) ability = this.ability;

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -53,11 +53,7 @@ export default class SaveActivityData extends BaseActivityData {
   /** @override */
   get ability() {
     if ( this.save.dc.calculation in CONFIG.DND5E.abilities ) return this.save.dc.calculation;
-    if ( this.save.dc.calculation === "spellcasting" ) {
-      let ability = this.isSpell ? this.item.system.availableAbilities?.first() : null;
-      ability ??= this.actor?.system.attributes?.spellcasting;
-      return ability ?? null;
-    }
+    if ( this.save.dc.calculation === "spellcasting" ) return this.spellcastingAbility;
     return this.save.ability;
   }
 


### PR DESCRIPTION
Adds "Spellcasting Ability" as one of the options for the check required, allowing something like "Counterspell" to automatically select the correct ability to roll.