### PR TITLE
Add context menus to in-sheet Activities.

### DIFF
--- a/less/v2/dark/activities.less
+++ b/less/v2/dark/activities.less
@@ -10,3 +10,11 @@
 .theme-dark .activity-usage {
   .hint code { color: var(--dnd5e-color-beige); }
 }
+
+/* ---------------------------------- */
+/*  Choice Dialog                     */
+/* ---------------------------------- */
+
+.theme-dark .activity-choice {
+  button { --icon-fill: var(--dnd5e-color-gold); }
+}

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -312,9 +312,11 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
 
     // Apply special context menus for items outside inventory elements
     const featuresElement = html[0].querySelector(`[data-tab="features"] ${this.options.elements.inventory}`);
-    if ( featuresElement ) new ContextMenu5e(html, ".pills-lg [data-item-id]", [], {
-      onOpen: (...args) => featuresElement._onOpenContextMenu(...args)
-    });
+    if ( featuresElement ) {
+      new ContextMenu5e(html, ".pills-lg [data-item-id], .favorites [data-item-id]", [], {
+        onOpen: (...args) => featuresElement._onOpenContextMenu(...args)
+      });
+    }
 
     // Edit mode only.
     if ( this._mode === this.constructor.MODES.EDIT ) {
@@ -592,7 +594,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     if ( !this.isEditable ) return;
     const { favoriteId } = event.currentTarget.closest("[data-favorite-id]").dataset;
     const favorite = await fromUuid(favoriteId, { relative: this.actor });
-    if ( favorite instanceof dnd5e.documents.Item5e ) return favorite.use({}, { event });
+    if ( favorite instanceof dnd5e.documents.Item5e ) return favorite.use({ legacy: false, event });
     if ( favorite instanceof dnd5e.documents.ActiveEffect5e ) return favorite.update({ disabled: !favorite.disabled });
   }
 

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -189,25 +189,26 @@ export default class InventoryElement extends HTMLElement {
       {
         name: "DND5E.ContextMenuActionEdit",
         icon: "<i class='fas fa-edit fa-fw'></i>",
-        condition: () => item.isOwner,
+        condition: () => item.isOwner && !item.compendium?.locked,
         callback: li => this._onAction(li[0], "edit")
       },
       {
         name: "DND5E.ItemView",
         icon: '<i class="fas fa-eye"></i>',
-        condition: () => !item.isOwner,
+        condition: () => !item.isOwner || item.compendium?.locked,
         callback: li => this._onAction(li[0], "view")
       },
       {
         name: "DND5E.ContextMenuActionDuplicate",
         icon: "<i class='fas fa-copy fa-fw'></i>",
-        condition: () => !item.system.metadata?.singleton && !["class", "subclass"].includes(item.type) && item.isOwner,
+        condition: () => !item.system.metadata?.singleton && !["class", "subclass"].includes(item.type) && item.isOwner
+          && !item.compendium?.locked,
         callback: li => this._onAction(li[0], "duplicate")
       },
       {
         name: "DND5E.ContextMenuActionDelete",
         icon: "<i class='fas fa-trash fa-fw'></i>",
-        condition: () => item.isOwner,
+        condition: () => item.isOwner && !item.compendium?.locked,
         callback: li => this._onAction(li[0], "delete")
       },
       {
@@ -217,7 +218,7 @@ export default class InventoryElement extends HTMLElement {
           const scroll = await Item5e.createScrollFromSpell(item);
           if ( scroll ) Item5e.create(scroll, { parent: this.actor });
         },
-        condition: li => (item.type === "spell") && this.actor?.isOwner,
+        condition: li => (item.type === "spell") && this.actor?.isOwner && !this.actor?.compendium?.locked,
         group: "action"
       },
       {
@@ -236,7 +237,7 @@ export default class InventoryElement extends HTMLElement {
       options.push({
         name: item.system.attuned ? "DND5E.ContextMenuActionUnattune" : "DND5E.ContextMenuActionAttune",
         icon: "<i class='fas fa-sun fa-fw'></i>",
-        condition: () => item.isOwner,
+        condition: () => item.isOwner && !item.compendium?.locked,
         callback: li => this._onAction(li[0], "attune"),
         group: "state"
       });
@@ -246,7 +247,7 @@ export default class InventoryElement extends HTMLElement {
     if ( "equipped" in item.system ) options.push({
       name: item.system.equipped ? "DND5E.ContextMenuActionUnequip" : "DND5E.ContextMenuActionEquip",
       icon: "<i class='fas fa-shield-alt fa-fw'></i>",
-      condition: () => item.isOwner,
+      condition: () => item.isOwner && !item.compendium?.locked,
       callback: li => this._onAction(li[0], "equip"),
       group: "state"
     });
@@ -255,7 +256,7 @@ export default class InventoryElement extends HTMLElement {
     if ( item.hasRecharge ) options.push({
       name: item.isOnCooldown ? "DND5E.ContextMenuActionCharge" : "DND5E.ContextMenuActionExpendCharge",
       icon: '<i class="fa-solid fa-bolt"></i>',
-      condition: () => item.isOwner,
+      condition: () => item.isOwner && !item.compendium?.locked,
       callback: li => this._onAction(li[0], "toggleCharge"),
       group: "state"
     });
@@ -264,7 +265,7 @@ export default class InventoryElement extends HTMLElement {
     else if ( ("preparation" in item.system) && (item.system.preparation?.mode === "prepared") ) options.push({
       name: item.system?.preparation?.prepared ? "DND5E.ContextMenuActionUnprepare" : "DND5E.ContextMenuActionPrepare",
       icon: "<i class='fas fa-sun fa-fw'></i>",
-      condition: () => item.isOwner,
+      condition: () => item.isOwner && !item.compendium?.locked,
       callback: li => this._onAction(li[0], "prepare"),
       group: "state"
     });
@@ -273,7 +274,7 @@ export default class InventoryElement extends HTMLElement {
     if ( "identified" in item.system ) options.push({
       name: "DND5E.Identify",
       icon: '<i class="fas fa-magnifying-glass"></i>',
-      condition: () => item.isOwner && !item.system.identified,
+      condition: () => item.isOwner && !item.compendium?.locked && !item.system.identified,
       callback: () => item.update({ "system.identified": true }),
       group: "state"
     });
@@ -285,7 +286,7 @@ export default class InventoryElement extends HTMLElement {
       options.push({
         name: isFavorited ? "DND5E.FavoriteRemove" : "DND5E.Favorite",
         icon: "<i class='fas fa-star fa-fw'></i>",
-        condition: () => item.isOwner,
+        condition: () => item.isOwner && !item.compendium?.locked,
         callback: li => this._onAction(li[0], isFavorited ? "unfavorite" : "favorite"),
         group: "state"
       });

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -48,8 +48,14 @@ export default class InventoryElement extends HTMLElement {
       });
     }
 
+    // Bind activity menu to child to work around lack of stopImmediatePropagation in ContextMenu#bind
+    new ContextMenu5e(this.querySelector(".items-list"), ".activity-row[data-activity-id]", [], {
+      onOpen: this._onOpenContextMenu.bind(this)
+    });
+
+    // Item context menus
     const MenuCls = this.hasAttribute("v2") ? ContextMenu5e : ContextMenu;
-    new MenuCls(this, "[data-item-id]", [], {onOpen: this._onOpenContextMenu.bind(this)});
+    new MenuCls(this, "[data-item-id]", [], { onOpen: this._onOpenContextMenu.bind(this) });
   }
 
   /* -------------------------------------------- */
@@ -496,7 +502,11 @@ export default class InventoryElement extends HTMLElement {
     const item = this.getItem(element.closest("[data-item-id]")?.dataset.itemId);
     // Parts of ContextMenu doesn't play well with promises, so don't show menus for containers in packs
     if ( !item || (item instanceof Promise) ) return;
-    ui.context.menuItems = this._getContextOptions(item, element);
-    Hooks.call("dnd5e.getItemContextOptions", item, ui.context.menuItems);
+    if ( element.closest("[data-activity-id]") ) {
+      dnd5e.documents.activity.UtilityActivity.onContextMenu(item, element);
+    } else {
+      ui.context.menuItems = this._getContextOptions(item, element);
+      Hooks.call("dnd5e.getItemContextOptions", item, ui.context.menuItems);
+    }
   }
 }

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -195,47 +195,9 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
       html.find("button.control-button").on("click", this._onSheetAction.bind(this));
     }
 
-    new ContextMenu5e(html, ".activity[data-id]", [], { onOpen: this._onOpenActivityContext.bind(this) });
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Construct context menu options for a given Activity.
-   * @param {Activity} activity  The Activity.
-   * @returns {ContextMenuEntry[]}
-   * @protected
-   */
-  _getActivityContextMenuOptions(activity) {
-    const entries = [];
-
-    if ( this.isEditable ) {
-      entries.push({
-        name: "DND5E.ContextMenuActionEdit",
-        icon: '<i class="fas fa-pen-to-square fa-fw"></i>',
-        callback: () => activity.sheet.render({ force: true })
-      }, {
-        name: "DND5E.ContextMenuActionDuplicate",
-        icon: '<i class="fas fa-copy fa-fw"></i>',
-        callback: () => {
-          const createData = activity.toObject();
-          delete createData._id;
-          this.item.createActivity(createData.type, createData, { renderSheet: false });
-        }
-      }, {
-        name: "DND5E.ContextMenuActionDelete",
-        icon: '<i class="fas fa-trash fa-fw"></i>',
-        callback: () => activity.deleteDialog()
-      });
-    } else {
-      entries.push({
-        name: "DND5E.ContextMenuActionView",
-        icon: '<i class="fas fa-eye fa-fw"></i>',
-        callback: () => activity.sheet.render({ force: true })
-      });
-    }
-
-    return entries;
+    new ContextMenu5e(html, ".activity[data-activity-id]", [], {
+      onOpen: target => dnd5e.documents.activity.UtilityActivity.onContextMenu(this.item, target)
+    });
   }
 
   /* -------------------------------------------- */
@@ -286,34 +248,9 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
    * @protected
    */
   _onEditActivity(event) {
-    const { id } = event.currentTarget.closest("[data-id]").dataset;
-    const activity = this.item.system.activities.get(id);
+    const { activityId } = event.currentTarget.closest("[data-activity-id]").dataset;
+    const activity = this.item.system.activities.get(activityId);
     return activity?.sheet?.render({ force: true });
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Handle opening the context menu on an Activity.
-   * @param {HTMLElement} target  The element the menu was triggered for.
-   * @protected
-   */
-  _onOpenActivityContext(target) {
-    const { id } = target.closest(".activity[data-id]")?.dataset ?? {};
-    const activity = this.item.system.activities.get(id);
-    if ( !activity ) return;
-    const menuItems = this._getActivityContextMenuOptions(activity);
-
-    /**
-     * A hook even that fires when the context menu for an Activity is opened.
-     * @function dnd5e.getItemActivityContext
-     * @memberof hookEvents
-     * @param {Activity} activity             The Activity.
-     * @param {HTMLElement} target            The element that menu was triggered for.
-     * @param {ContextMenuEntry[]} menuItems  The context menu entries.
-     */
-    Hooks.callAll("dnd5e.getItemActivityContext", activity, target, menuItems);
-    ui.context.menuItems = menuItems;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1025,6 +1025,44 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   /* -------------------------------------------- */
 
   /**
+   * Construct context menu options for this Activity.
+   * @returns {ContextMenuEntry[]}
+   */
+  getContextMenuOptions() {
+    const entries = [];
+
+    if ( this.item.isOwner ) {
+      entries.push({
+        name: "DND5E.ContextMenuActionEdit",
+        icon: '<i class="fas fa-pen-to-square fa-fw"></i>',
+        callback: () => this.sheet.render({ force: true })
+      }, {
+        name: "DND5E.ContextMenuActionDuplicate",
+        icon: '<i class="fas fa-copy fa-fw"></i>',
+        callback: () => {
+          const createData = this.toObject();
+          delete createData._id;
+          this.item.createActivity(createData.type, createData, { renderSheet: false });
+        }
+      }, {
+        name: "DND5E.ContextMenuActionDelete",
+        icon: '<i class="fas fa-trash fa-fw"></i>',
+        callback: () => this.deleteDialog()
+      });
+    } else {
+      entries.push({
+        name: "DND5E.ContextMenuActionView",
+        icon: '<i class="fas fa-eye fa-fw"></i>',
+        callback: () => this.sheet.render({ force: true })
+      });
+    }
+
+    return entries;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Handle an action activated from an activity's chat message.
    * @param {PointerEvent} event     Triggering click event.
    * @param {HTMLElement} target     The capturing HTML element which defined a [data-action].
@@ -1062,6 +1100,31 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @protected
    */
   async _onChatAction(event, target, message) {}
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle context menu events on activities.
+   * @param {Item5e} item         The Item the Activity belongs to.
+   * @param {HTMLElement} target  The element the menu was triggered on.
+   */
+  static onContextMenu(item, target) {
+    const { activityId } = target.closest("[data-activity-id]")?.dataset ?? {};
+    const activity = item.system.activities?.get(activityId);
+    if ( !activity ) return;
+    const menuItems = activity.getContextMenuOptions();
+
+    /**
+     * A hook even that fires when the context menu for an Activity is opened.
+     * @function dnd5e.getItemActivityContext
+     * @memberof hookEvents
+     * @param {Activity} activity             The Activity.
+     * @param {HTMLElement} target            The element that menu was triggered on.
+     * @param {ContextMenuEntry[]} menuItems  The context menu entries.
+     */
+    Hooks.callAll("dnd5e.getItemActivityContext", activity, target, menuItems);
+    ui.context.menuItems = menuItems;
+  }
 
   /* -------------------------------------------- */
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1031,7 +1031,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   getContextMenuOptions() {
     const entries = [];
 
-    if ( this.item.isOwner ) {
+    if ( this.item.isOwner && !this.item.compendium?.locked ) {
       entries.push({
         name: "DND5E.ContextMenuActionEdit",
         icon: '<i class="fas fa-pen-to-square fa-fw"></i>',

--- a/templates/actors/tabs/creature-features.hbs
+++ b/templates/actors/tabs/creature-features.hbs
@@ -74,7 +74,7 @@
                         <div class="wrapper">
 
                             {{!-- Activities --}}
-                            {{#if (gt ctx.activities.length 1)}}
+                            {{#if ctx.activities.length}}
                             <div class="activities">
                                 {{#each ctx.activities}}
                                 {{> "dnd5e.activity-row-summary" categories=../../categories }}

--- a/templates/actors/tabs/creature-spells.hbs
+++ b/templates/actors/tabs/creature-spells.hbs
@@ -292,7 +292,7 @@
                         <div class="wrapper">
 
                             {{!-- Activities --}}
-                            {{#if (gt ctx.activities.length 1)}}
+                            {{#if ctx.activities.length}}
                             <div class="activities">
                                 {{#each ctx.activities}}
                                 {{> "dnd5e.activity-row-summary" categories=../../categories }}

--- a/templates/items/parts/item-activities.hbs
+++ b/templates/items/parts/item-activities.hbs
@@ -1,6 +1,6 @@
 <div class="tab activities" data-group="primary" data-tab="activities">
     {{#each activities}}
-    <div class="activity card" data-id="{{ id }}">
+    <div class="activity card" data-activity-id="{{ id }}">
 
         {{!-- Icon --}}
         <div class="icon {{#if img.svg}}svg{{/if}}">

--- a/templates/shared/inventory2.hbs
+++ b/templates/shared/inventory2.hbs
@@ -294,7 +294,7 @@
                         <div class="wrapper">
 
                             {{!-- Activities --}}
-                            {{#if (gt ctx.activities.length 1)}}
+                            {{#if ctx.activities.length}}
                             <div class="activities">
                                 {{#each ctx.activities}}
                                 {{> "dnd5e.activity-row-summary" categories=../../categories }}


### PR DESCRIPTION
Some additional polish for activities.

- Fires the Activity's context menu if you right-click an activity row inside the character sheet, rather than firing the parent Item's context menu.
- Always show activities in the expanded view, even if the Item only has one.
- Adds context menu to Items inside favourites.