### PR TITLE
Add Offhand Throw attack mode & returning property to ammunition

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -509,6 +509,7 @@
     "Offhand": "Offhand",
     "OneHanded": "One-Handed",
     "Thrown": "Thrown",
+    "ThrownOffhand": "Offhand Throw",
     "TwoHanded": "Two-Handed"
   },
   "Type": {

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -232,8 +232,8 @@ export default class AttackActivityData extends BaseActivityData {
 
   /**
    * @typedef {AttackDamageRollProcessConfiguration} [config={}]
-   * @property {Item5e} ammunition                                      Ammunition used with the attack.
-   * @property {"oneHanded"|"twoHanded"|"offhand"|"thrown"} attackMode  Attack mode.
+   * @property {Item5e} ammunition  Ammunition used with the attack.
+   * @property {"oneHanded"|"twoHanded"|"offhand"|"thrown"|"thrown-offhand"} attackMode  Attack mode.
    */
 
   /**
@@ -308,7 +308,7 @@ export default class AttackActivityData extends BaseActivityData {
 
     if ( this.item.type === "weapon" ) {
       // Ensure `@mod` is present in damage unless it is positive and an off-hand attack
-      const includeMod = (rollConfig.attackMode !== "offhand") || (roll.data.mod < 0);
+      const includeMod = !rollConfig.attackMode.endsWith("offhand") || (roll.data.mod < 0);
       if ( includeMod && !roll.parts.some(p => p.includes("@mod")) ) roll.parts.push("@mod");
 
       // Add magical bonus

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -240,6 +240,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
     const valid = super.validProperties;
     if ( this.type.value === "ammo" ) Object.entries(CONFIG.DND5E.itemProperties).forEach(([k, v]) => {
       if ( v.isPhysical ) valid.add(k);
+      valid.add("ret");
     });
     else if ( this.type.value === "scroll" ) CONFIG.DND5E.validProperties.spell
       .filter(p => p !== "material").forEach(p => valid.add(p));

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -311,10 +311,12 @@ export default class WeaponData extends ItemDataModel.mixin(
       });
     }
 
+    const isLight = this.properties.has("lgt") || (this.parent.actor?.getFlag("dnd5e", "enhancedDualWielding")
+      && ((this.attackType === "melee") && !this.properties.has("two")));
+
     // Weapons with the "Light" property will have Offhand attack
-    // If player has the "Enhanced Duel Wielding" flag, then allow any melee weapon without the "Two-Handed" property
-    if ( this.properties.has("lgt") || (this.parent.actor?.getFlag("dnd5e", "enhancedDualWielding")
-      && ((this.attackType === "melee") && !this.properties.has("two"))) ) modes.push({
+    // If player has the "Enhanced Dual Wielding" flag, then allow any melee weapon without the "Two-Handed" property
+    if ( isLight ) modes.push({
       value: "offhand", label: game.i18n.localize("DND5E.ATTACK.Mode.Offhand")
     });
 
@@ -322,6 +324,11 @@ export default class WeaponData extends ItemDataModel.mixin(
     if ( this.properties.has("thr") ) {
       if ( modes.length ) modes.push({ rule: true });
       modes.push({ value: "thrown", label: game.i18n.localize("DND5E.ATTACK.Mode.Thrown") });
+
+      // Weapons with the "Thrown" & "Light" properties will have an Offhand Throw attack
+      if ( isLight ) modes.push({
+        value: "thrown-offhand", label: game.i18n.localize("DND5E.ATTACK.Mode.ThrownOffhand")
+      });
     }
 
     return modes;

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -213,11 +213,13 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
     if ( roll.options.ammunition ) {
       const ammo = this.actor?.items.get(roll.options.ammunition);
       if ( ammo ) {
-        ammoUpdate = { id: ammo.id, quantity: Math.max(0, ammo.system.quantity - 1) };
-        ammoUpdate.destroy = ammo.system.uses.autoDestroy && (ammoUpdate.quantity === 0);
+        if ( !ammo.system.properties?.has("ret") ) {
+          ammoUpdate = { id: ammo.id, quantity: Math.max(0, ammo.system.quantity - 1) };
+          ammoUpdate.destroy = ammo.system.uses.autoDestroy && (ammoUpdate.quantity === 0);
+        }
         flags.ammunition = roll.options.ammunition;
       }
-    } else if ( (roll.options.attackMode === "thrown") && !this.item.system.properties?.has("ret") ) {
+    } else if ( roll.options.attackMode?.startsWith("thrown") && !this.item.system.properties?.has("ret") ) {
       ammoUpdate = { id: this.item.id, quantity: Math.max(0, this.item.system.quantity - 1) };
     }
     if ( roll.options.attackMode ) flags.attackMode = roll.options.attackMode;


### PR DESCRIPTION
Light thrown weapons can now use the "Offhand Throw" attack mode that consumes weapon quantity and ignores the modifier to damage.

Ammunition can now get the "Returning" property which prevents its quantity from being reduced when fired.