### PR TITLE
[#4135] Pre-create `MappingField` data before applying effects

### DIFF
--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -6,15 +6,6 @@ import CommonTemplate from "./common.mjs";
 const { NumberField, SchemaField } = foundry.data.fields;
 
 /**
- * @typedef {object} SkillData
- * @property {number} value            Proficiency level creature has in this skill.
- * @property {string} ability          Default ability used for this skill.
- * @property {object} bonuses          Bonuses for this skill.
- * @property {string} bonuses.check    Numeric or dice bonus to skill's check.
- * @property {string} bonuses.passive  Numeric bonus to skill's passive check.
- */
-
-/**
  * A template for all actors that are creatures
  *
  * @property {object} bonuses
@@ -28,8 +19,9 @@ const { NumberField, SchemaField } = foundry.data.fields;
  * @property {string} bonuses.abilities.skill        Numeric or dice bonus to skill checks.
  * @property {object} bonuses.spell                  Bonuses to spells.
  * @property {string} bonuses.spell.dc               Numeric bonus to spellcasting DC.
- * @property {Object<string, SkillData>} skills      Actor's skills.
- * @property {Object<string, SpellSlotData>} spells  Actor's spell slots.
+ * @property {Record<string, ToolData>} tools        Actor's tools.
+ * @property {Record<string, SkillData>} skills      Actor's skills.
+ * @property {Record<string, SpellSlotData>} spells  Actor's spell slots.
  */
 export default class CreatureTemplate extends CommonTemplate {
   static defineSchema() {
@@ -187,7 +179,20 @@ export default class CreatureTemplate extends CommonTemplate {
   }
 }
 
-/* -------------------------------------------- */
+/**
+ * @typedef {RollConfigData} SkillData
+ * @property {number} value            Proficiency level creature has in this skill.
+ * @property {object} bonuses          Bonuses for this skill.
+ * @property {string} bonuses.check    Numeric or dice bonus to skill's check.
+ * @property {string} bonuses.passive  Numeric bonus to skill's passive check.
+ */
+
+/**
+ * @typedef {RollConfigData} ToolData
+ * @property {number} value            Proficiency level creature has in this tool.
+ * @property {object} bonuses          Bonuses for this tool.
+ * @property {string} bonuses.check    Numeric or dice bonus to tool's check.
+ */
 
 /**
  * Data on configuration of a specific spell slot.

--- a/module/data/fields/mapping-field.mjs
+++ b/module/data/fields/mapping-field.mjs
@@ -36,6 +36,7 @@ export default class MappingField extends foundry.data.fields.ObjectField {
      * @type {DataField}
      */
     this.model = model;
+    model.parent = this;
   }
 
   /* -------------------------------------------- */

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -1,6 +1,15 @@
 const { StringField, NumberField, SchemaField } = foundry.data.fields;
 
 /**
+ * @typedef {object} RollConfigData
+ * @property {string} ability   Default ability associated with this roll.
+ * @property {object} roll
+ * @property {number} roll.min   Minimum number on the die rolled.
+ * @property {number} roll.max   Maximum number on the die rolled.
+ * @property {number} roll.mode  Should the roll be with disadvantage or advantage by default?
+ */
+
+/**
  * Field for storing data for a specific type of roll.
  */
 export default class RollConfigField extends foundry.data.fields.SchemaField {

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -145,15 +145,12 @@ export default class ActiveEffect5e extends ActiveEffect {
 
     // If attempting to apply active effect to empty MappingField entry, create it
     if ( (current === undefined) && change.key.startsWith("system.") ) {
+      let keyPath = change.key;
       let mappingField = field;
-      const [, ...parts] = change.key.split(".");
-      let last;
-      while ( !(mappingField instanceof MappingField) ) {
-        last = parts.pop();
-        mappingField = model.system.schema.getField(parts.join("."));
-        if ( !mappingField || !parts.length ) break;
+      while ( !(mappingField instanceof MappingField) && mappingField ) {
+        if ( mappingField.name ) keyPath = keyPath.substring(0, keyPath.length - mappingField.name.length - 1);
+        mappingField = mappingField.parent;
       }
-      const keyPath = ["system", ...parts, last].join(".");
       if ( mappingField && (foundry.utils.getProperty(model, keyPath) === undefined) ) {
         const created = mappingField.model.initialize(mappingField.model.getInitialValue(), mappingField);
         foundry.utils.setProperty(model, keyPath, created);


### PR DESCRIPTION
Fix bugs caused by applying an active effect targeting a value in and entry in `system.tools` when the actor doesn't currently have that entry. The bug was caused by the whole object not being created and other parts of the code expecting it to exist.

This solves the problem by checking if an active effect is trying to apply to an `MappingField` entry that doesn't exist yet, and if so it will first create the initial entry before continuing with the application process.

Closes #4135