### PR TITLE
[#3955] Concentration check triggered when reverting hp.tempmax and the actor's hp.value is higher than hp.max

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3410,7 +3410,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
       if ( Number.isInteger(changes.total) && (changes.total !== 0) ) {
         this._displayTokenEffect(changes);
-        if ( !game.settings.get("dnd5e", "disableConcentration") && (userId === game.userId) && (changes.total < 0) ) {
+        if ( !game.settings.get("dnd5e", "disableConcentration") && (userId === game.userId) && (changes.total < 0) && (curr.value != curr.effectiveMax) ) {
           this.challengeConcentration({ dc: this.getConcentrationDC(-changes.total) });
         }
 


### PR DESCRIPTION
Closes #3955, by not triggering concentration checks when any changes to temporary Max HP are being reverted, making use of that fact if the effectiveMax is being lowered it will lower the hp.value to the same number.