### PR TITLE
add null guard around ammoUpdate

### DIFF
--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -241,7 +241,7 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
         "The `dnd5e.rollAttack` hook has been deprecated and replaced with `dnd5e.rollAttackV2`.",
         { since: "DnD5e 4.0", until: "DnD5e 4.4" }
       );
-      const oldAmmoUpdate = [{ _id: ammoUpdate.id, "system.quantity": ammoUpdate.quantity }];
+      const oldAmmoUpdate = ammoUpdate ? [{ _id: ammoUpdate.id, "system.quantity": ammoUpdate.quantity }] : [];
       Hooks.callAll("dnd5e.rollAttack", this.item, roll, oldAmmoUpdate);
       if ( oldAmmoUpdate[0] ) {
         ammoUpdate.id = oldAmmoUpdate[0]._id;


### PR DESCRIPTION
This null guard allows the hook to proceed even when calling the deprecated old hook, however, doing so reveals what appears to be a similar issue downstream in mixin.js, as on some subseuqent casts, in

_createDeprecatedConfigs(usageConfig, dialogConfig, messageConfig)

Uncaught (in promise) TypeError: usageConfig.consume?.resources.includes is not a function