### PR TITLE
Fix bracers-of-defense icon

### DIFF
--- a/packs/_source/items/equipment/bracers-of-defense.json
+++ b/packs/_source/items/equipment/bracers-of-defense.json
@@ -2,7 +2,7 @@
   "_id": "DSHi7yT6OUyDoCcu",
   "name": "Bracers of Defense",
   "type": "equipment",
-  "img": "icons/equipment/wrist/bracer-banded-leather.webp",
+  "img": "icons/equipment/wrist/bracer-yellow-fancy.webp",
   "system": {
     "description": {
       "value": "<p><em>Wondrous item, (requires attunement)</em></p>\n<p>While wearing these bracers, you gain a +2 bonus to AC if you are wearing no armor and using no shield.</p>",


### PR DESCRIPTION
Fixes small mistake in #4226 with Bracers of Defense being assigned the wrong icon.