### PR TITLE
[#2138] Refactor `D20Roll` for new API, deprecate `d20Roll` method

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -71,6 +71,7 @@ Hooks.once("init", function() {
   Roll.TOOLTIP_TEMPLATE = "systems/dnd5e/templates/chat/roll-breakdown.hbs";
   CONFIG.Dice.BasicRoll = dice.BasicRoll;
   CONFIG.Dice.DamageRoll = dice.DamageRoll;
+  CONFIG.Dice.D20Die = dice.D20Die;
   CONFIG.Dice.D20Roll = dice.D20Roll;
   CONFIG.MeasuredTemplate.defaults.angle = 53.13; // 5e cone RAW should be 53.13 degrees
   CONFIG.Note.objectClass = canvas.Note5e;

--- a/module/applications/dice/_module.mjs
+++ b/module/applications/dice/_module.mjs
@@ -1,2 +1,3 @@
+export {default as D20RollConfigurationDialog} from "./d20-configuration-dialog.mjs";
 export {default as DamageRollConfigurationDialog} from "./damage-configuration-dialog.mjs";
 export {default as RollConfigurationDialog} from "./roll-configuration-dialog.mjs";

--- a/module/applications/dice/d20-configuration-dialog.mjs
+++ b/module/applications/dice/d20-configuration-dialog.mjs
@@ -1,0 +1,55 @@
+import RollConfigurationDialog from "./roll-configuration-dialog.mjs";
+
+/**
+ * Dialog for configuring d20 rolls.
+ *
+ * @param {D20RollProcessConfiguration} [config={}]           Initial roll configuration.
+ * @param {BasicRollMessageConfiguration} [message={}]        Message configuration.
+ * @param {BasicRollConfigurationDialogOptions} [options={}]  Dialog rendering options.
+ */
+export default class D20RollConfigurationDialog extends RollConfigurationDialog {
+
+  /** @override */
+  static get rollType() {
+    return CONFIG.Dice.D20Roll;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareButtonsContext(context, options) {
+    context.buttons = {
+      advantage: {
+        default: this.options.defaultButton === "advantage",
+        label: game.i18n.localize("DND5E.Advantage")
+      },
+      normal: {
+        default: !["advantage", "disadvantage"].includes(this.options.defaultButton),
+        label: game.i18n.localize("DND5E.Normal")
+      },
+      disadvantage: {
+        default: this.options.defaultButton === "disadvantage",
+        label: game.i18n.localize("DND5E.Disadvantage")
+      }
+    };
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Roll Handling                               */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _finalizeRolls(action) {
+    let advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.NORMAL;
+    if ( action === "advantage" ) advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
+    else if ( action === "disadvantage" ) advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
+    return this.rolls.map(roll => {
+      roll.options.advantageMode = advantageMode;
+      roll.configureModifiers();
+      return roll;
+    });
+  }
+}

--- a/module/applications/dice/damage-configuration-dialog.mjs
+++ b/module/applications/dice/damage-configuration-dialog.mjs
@@ -31,13 +31,16 @@ export default class DamageRollConfigurationDialog extends RollConfigurationDial
   /** @override */
   async _prepareButtonsContext(context, options) {
     const allowCritical = this.config.critical?.allow !== false;
+    const defaultCritical = allowCritical && (this.options.defaultButton === "critical");
     context.buttons = {
       critical: {
-        icon: '<i class="fa-solid fa-bomb"></i>',
+        default: defaultCritical,
+        icon: '<i class="fa-solid fa-bomb" inert></i>',
         label: game.i18n.localize("DND5E.CriticalHit")
       },
       normal: {
-        icon: '<i class="fa-solid fa-dice"></i>',
+        default: !defaultCritical,
+        icon: '<i class="fa-solid fa-dice" inert></i>',
         label: game.i18n.localize(allowCritical ? "DND5E.Normal" : "DND5E.Roll")
       }
     };

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -1,4 +1,4 @@
-import Application5e from "../api/application.mjs";
+import Dialog5e from "../api/dialog.mjs";
 
 const { DiceTerm } = foundry.dice.terms;
 
@@ -30,7 +30,7 @@ const { DiceTerm } = foundry.dice.terms;
  * @param {BasicRollMessageConfiguration} [message={}]        Message configuration.
  * @param {BasicRollConfigurationDialogOptions} [options={}]  Dialog rendering options.
  */
-export default class RollConfigurationDialog extends Application5e {
+export default class RollConfigurationDialog extends Dialog5e {
   constructor(config={}, message={}, options={}) {
     super(options);
 
@@ -43,12 +43,10 @@ export default class RollConfigurationDialog extends Application5e {
 
   /** @override */
   static DEFAULT_OPTIONS = {
-    classes: ["roll-configuration", "standard-form"],
-    tag: "form",
+    classes: ["roll-configuration"],
     window: {
       title: "DND5E.RollConfiguration.Title",
-      icon: "fa-solid fa-dice",
-      minimizable: false
+      icon: "fa-solid fa-dice"
     },
     form: {
       handler: RollConfigurationDialog.#handleFormSubmission
@@ -360,7 +358,7 @@ export default class RollConfigurationDialog extends Application5e {
   _onChangeForm(formConfig, event) {
     super._onChangeForm(formConfig, event);
 
-    const formData = new FormDataExtended(this.element);
+    const formData = new FormDataExtended(this.form);
     if ( formData.has("rollMode") ) this.message.rollMode = formData.get("rollMode");
     this.#buildRolls(foundry.utils.deepClone(this.#config), formData);
     this.render({ parts: ["formulas"] });

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -224,7 +224,8 @@ export default class RollConfigurationDialog extends Application5e {
   async _prepareButtonsContext(context, options) {
     context.buttons = {
       roll: {
-        icon: '<i class="fa-solid fa-dice"></i>',
+        default: true,
+        icon: '<i class="fa-solid fa-dice" inert></i>',
         label: game.i18n.localize("DND5E.Roll")
       }
     };

--- a/module/dice/_module.mjs
+++ b/module/dice/_module.mjs
@@ -1,5 +1,6 @@
 export {default as aggregateDamageRolls} from "./aggregate-damage-rolls.mjs";
 export {default as BasicRoll} from "./basic-roll.mjs";
+export {default as D20Die} from "./d20-die.mjs";
 export {default as D20Roll} from "./d20-roll.mjs";
 export {default as DamageRoll} from "./damage-roll.mjs";
 export * from "./dice.mjs";

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -157,7 +157,7 @@ export default class BasicRoll extends Roll {
    * This function can either create the ChatMessage directly, or return the data object that will be used to create it.
    *
    * @param {BasicRoll[]} rolls              Rolls to add to the message.
-   * @param {object} messageData             The data object to use when creating the message
+   * @param {object} messageData             The data object to use when creating the message.
    * @param {options} [options]              Additional options which modify the created message.
    * @param {string} [options.rollMode]      The template roll mode to use for the message from CONFIG.Dice.rollModes
    * @param {boolean} [options.create=true]  Whether to automatically create the chat message, or only return the
@@ -174,6 +174,7 @@ export default class BasicRoll extends Roll {
     // Prepare chat data
     messageData = foundry.utils.mergeObject({ sound: CONFIG.sounds.dice }, messageData);
     messageData.rolls = rolls;
+    this._prepareMessageData(rolls, messageData);
 
     // Process the chat data
     const cls = getDocumentClass("ChatMessage");
@@ -186,6 +187,16 @@ export default class BasicRoll extends Roll {
       return msg.toObject();
     }
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Perform specific changes on message data before creating message.
+   * @param {BasicRoll[]} rolls   Rolls to add to the message.
+   * @param {object} messageData  The data object to use when creating the message.
+   * @protected
+   */
+  static _prepareMessageData(rolls, messageData) {}
 
   /* -------------------------------------------- */
   /*  Evaluate Methods                            */

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -191,7 +191,7 @@ export default class BasicRoll extends Roll {
   /* -------------------------------------------- */
 
   /**
-   * Perform specific changes on message data before creating message.
+   * Perform specific changes to message data before creating message.
    * @param {BasicRoll[]} rolls   Rolls to add to the message.
    * @param {object} messageData  The data object to use when creating the message.
    * @protected

--- a/module/dice/d20-die.mjs
+++ b/module/dice/d20-die.mjs
@@ -1,0 +1,114 @@
+const { Die } = foundry.dice.terms;
+
+/**
+ * Primary die used when performing a D20 roll.
+ */
+export default class D20Die extends Die {
+  constructor({ number = 1, faces = 20, ...args }={}) {
+    super({ number, faces, ...args });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Critical success target if no critical failure is set in options.
+   * @type {number}
+   */
+  static CRITICAL_SUCCESS_TOTAL = 20;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Critical failure target if no critical failure is set in options.
+   * @type {number}
+   */
+  static CRITICAL_FAILURE_TOTAL = 1;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is the result of this roll a critical success? Returns `undefined` if roll isn't evaluated.
+   * @type {boolean|void}
+   */
+  get isCriticalSuccess() {
+    if ( !this.isValid || !this._evaluated ) return undefined;
+    if ( !Number.isNumeric(this.options.criticalSuccess) ) return false;
+    return this.total >= this.options.criticalSuccess;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is the result of this roll a critical failure? Returns `undefined` if roll isn't evaluated.
+   * @type {boolean|void}
+   */
+  get isCriticalFailure() {
+    if ( !this.isValid || !this._evaluated ) return undefined;
+    if ( !Number.isNumeric(this.options.criticalFailure) ) return false;
+    return this.total <= this.options.criticalFailure;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this a valid challenge die?
+   * @type {boolean}
+   */
+  get isValid() {
+    return this.faces === 20;
+  }
+
+  /* -------------------------------------------- */
+  /*  Die Modification                            */
+  /* -------------------------------------------- */
+
+  /**
+   * Apply advantage mode to this die.
+   * @param {number} advantageMode  Advantage mode to apply.
+   */
+  applyAdvantage(advantageMode) {
+    this.options.advantageMode = advantageMode;
+    if ( advantageMode !== CONFIG.Dice.D20Roll.ADV_MODE.NORMAL ) {
+      const isAdvantage = advantageMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
+      this.number = (isAdvantage && this.options.elvenAccuracy) ? 3 : 2;
+      this.modifiers.push(isAdvantage ? "kh" : "kl");
+    } else {
+      this.number = 1;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Set or unset the specified flag on this die.
+   * @param {string} flag      Flag to apply.
+   * @param {boolean} enabled  Is the flag enabled?
+   */
+  applyFlag(flag, enabled) {
+    this.options[flag] = enabled;
+
+    // Halfling Lucky, re-roll a natural 1 once
+    if ( flag === "halflingLucky" ) {
+      const index = this.modifiers.findIndex(m => m === "r1=1");
+      if ( enabled && (index === -1) ) this.modifiers.push("r1=1");
+      else if ( !enabled && (index !== -1) ) this.modifiers.splice(index, 1);
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Apply a minimum or maximum value to this die.
+   * @param {object} values
+   * @param {number} [values.minimum]
+   * @param {number} [values.maximum]
+   */
+  applyRange(values) {
+    for ( const [key, value] of Object.entries(values) ) {
+      this.options[key] = value;
+      const mod = key.substring(0, 3);
+      this.modifiers.findSplice(m => m.startsWith(mod));
+      if ( value ) this.modifiers.push(`${mod}${value}`);
+    }
+  }
+}

--- a/module/dice/d20-die.mjs
+++ b/module/dice/d20-die.mjs
@@ -4,7 +4,7 @@ const { Die } = foundry.dice.terms;
  * Primary die used when performing a D20 roll.
  */
 export default class D20Die extends Die {
-  constructor({ number = 1, faces = 20, ...args }={}) {
+  constructor({ number=1, faces=20, ...args }={}) {
     super({ number, faces, ...args });
   }
 
@@ -31,7 +31,7 @@ export default class D20Die extends Die {
    * @type {boolean|void}
    */
   get isCriticalSuccess() {
-    if ( !this.isValid || !this._evaluated ) return undefined;
+    if ( !this.isValid || !this._evaluated ) return;
     if ( !Number.isNumeric(this.options.criticalSuccess) ) return false;
     return this.total >= this.options.criticalSuccess;
   }
@@ -43,7 +43,7 @@ export default class D20Die extends Die {
    * @type {boolean|void}
    */
   get isCriticalFailure() {
-    if ( !this.isValid || !this._evaluated ) return undefined;
+    if ( !this.isValid || !this._evaluated ) return;
     if ( !Number.isNumeric(this.options.criticalFailure) ) return false;
     return this.total <= this.options.criticalFailure;
   }
@@ -68,12 +68,11 @@ export default class D20Die extends Die {
    */
   applyAdvantage(advantageMode) {
     this.options.advantageMode = advantageMode;
-    if ( advantageMode !== CONFIG.Dice.D20Roll.ADV_MODE.NORMAL ) {
+    if ( advantageMode === CONFIG.Dice.D20Roll.ADV_MODE.NORMAL ) this.number = 1;
+    else {
       const isAdvantage = advantageMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
       this.number = (isAdvantage && this.options.elvenAccuracy) ? 3 : 2;
       this.modifiers.push(isAdvantage ? "kh" : "kl");
-    } else {
-      this.number = 1;
     }
   }
 

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -98,7 +98,7 @@ export default class D20Roll extends BasicRoll {
    * @param {BasicRollMessageConfiguration} [message={}]  Configuration data that guides roll message creation.
    * @returns {D20Roll[]}                                 Any rolls created.
    */
-  static async build(config = {}, dialog = {}, message = {}) {
+  static async build(config={}, dialog={}, message={}) {
     for ( const roll of config.rolls ?? [] ) {
       roll.options ??= {};
       roll.options.criticalSuccess ??= CONFIG.Dice.D20Die.CRITICAL_SUCCESS_TOTAL;
@@ -147,7 +147,8 @@ export default class D20Roll extends BasicRoll {
    * @type {D20Die|void}
    */
   get d20() {
-    if ( !(this.terms[0] instanceof foundry.dice.terms.Die) ) return undefined;
+    if ( !(this.terms[0] instanceof foundry.dice.terms.Die) ) return;
+    if ( !(this.terms[0] instanceof CONFIG.Dice.D20Die) ) this.#createD20Die();
     return this.terms[0];
   }
 
@@ -190,7 +191,6 @@ export default class D20Roll extends BasicRoll {
    * @type {boolean|void}
    */
   get isCritical() {
-    this.#createD20Die();
     return this.d20.isCriticalSuccess;
   }
 
@@ -201,7 +201,6 @@ export default class D20Roll extends BasicRoll {
    * @type {boolean|void}
    */
   get isFumble() {
-    this.#createD20Die();
     return this.d20.isCriticalFailure;
   }
 
@@ -224,7 +223,7 @@ export default class D20Roll extends BasicRoll {
     let advantage = true;
     let disadvantage = true;
 
-    const rtLabel = `(${game.i18n.localize("DND5E.FlagsReliableTalent")})`;
+    const rtLabel = game.i18n.localize("DND5E.FlagsReliableTalent");
     for ( const roll of rolls ) {
       if ( !roll.validD20Roll ) continue;
       if ( !roll.hasAdvantage ) advantage = false;
@@ -278,9 +277,9 @@ export default class D20Roll extends BasicRoll {
    * Ensure the d20 die for this roll is actually a D20Die instance.
    */
   #createD20Die() {
-    if ( this.d20 instanceof CONFIG.Dice.D20Die ) return;
-    if ( !(this.d20 instanceof foundry.dice.terms.Die) ) return;
-    this.d20 = new CONFIG.Dice.D20Die({ ...this.d20 });
+    if ( this.terms[0] instanceof CONFIG.Dice.D20Die ) return;
+    if ( !(this.terms[0] instanceof foundry.dice.terms.Die) ) return;
+    this.terms[0] = new CONFIG.Dice.D20Die({ ...this.terms[0] });
   }
 
   /* -------------------------------------------- */

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -1,14 +1,15 @@
+import D20RollConfigurationDialog from "../applications/dice/d20-configuration-dialog.mjs";
 import { areKeysPressed } from "../utils.mjs";
-
-const { Die, NumericTerm, OperatorTerm } = foundry.dice.terms;
+import BasicRoll from "./basic-roll.mjs";
 
 /**
  * Configuration data for the process of rolling d20 rolls.
  *
  * @typedef {BasicRollProcessConfiguration} D20RollProcessConfiguration
- * @property {boolean} elvenAccuracy         Use three dice when rolling with advantage.
- * @property {boolean} halflingLucky         Add a re-roll once modifier to the d20 die.
- * @property {D20RollConfiguration[]} rolls  Configuration data for individual rolls.
+ * @property {boolean} [elvenAccuracy]         Use three dice when rolling with advantage.
+ * @property {boolean} [halflingLucky]         Add a re-roll once modifier to the d20 die.
+ * @property {boolean} [reliableTalent]        Set the minimum for the d20 roll to 10.
+ * @property {D20RollConfiguration[]} rolls    Configuration data for individual rolls.
  */
 
 /**
@@ -23,33 +24,56 @@ const { Die, NumericTerm, OperatorTerm } = foundry.dice.terms;
  * Options that describe a d20 roll.
  *
  * @typedef {BasicRollOptions} D20RollOptions
- * @property {boolean} advantage       Is the roll granted advantage?
- * @property {boolean} disadvantage    Is the roll granted disadvantage?
- * @property {number} criticalSuccess  The value of the d20 die to be considered a critical success.
- * @property {number} criticalFailure  The value of the d20 die to be considered a critical failure.
- * @property {number} maximum          Maximum number the d20 die can roll.
- * @property {number} minimum          Minimum number the d20 die can roll.
+ * @property {boolean} [advantage]       Is the roll granted advantage?
+ * @property {boolean} [disadvantage]    Is the roll granted disadvantage?
+ * @property {number} [criticalSuccess]  The value of the d20 die to be considered a critical success.
+ * @property {number} [criticalFailure]  The value of the d20 die to be considered a critical failure.
+ * @property {boolean} [elvenAccuracy]   Use three dice when rolling with advantage.
+ * @property {boolean} [halflingLucky]   Add a re-roll once modifier to the d20 die.
+ * @property {number} [maximum]          Maximum number the d20 die can roll.
+ * @property {number} [minimum]          Minimum number the d20 die can roll.
  */
+
+/* -------------------------------------------- */
 
 /**
  * A type of Roll specific to a d20-based check, save, or attack roll in the 5e system.
- * @param {string} formula                       The string formula to parse
- * @param {object} data                          The data object against which to parse attributes within the formula
- * @param {object} [options={}]                  Extra optional arguments which describe or modify the D20Roll
- * @param {number} [options.advantageMode]       What advantage modifier to apply to the roll (none, advantage,
- *                                               disadvantage)
- * @param {number} [options.critical]            The value of d20 result which represents a critical success
- * @param {number} [options.fumble]              The value of d20 result which represents a critical failure
- * @param {(number)} [options.targetValue]       Assign a target value against which the result of this roll should be
- *                                               compared
- * @param {boolean} [options.elvenAccuracy=false]      Allow Elven Accuracy to modify this roll?
- * @param {boolean} [options.halflingLucky=false]      Allow Halfling Luck to modify this roll?
- * @param {boolean} [options.reliableTalent=false]     Allow Reliable Talent to modify this roll?
+ * @param {string} formula          The string formula to parse.
+ * @param {object} data             The data object against which to parse attributes within the formula.
+ * @param {D20RollOptions} options  Additional options that describe the d20 roll.
  */
-export default class D20Roll extends Roll {
+export default class D20Roll extends BasicRoll {
   constructor(formula, data, options) {
     super(formula, data, options);
+    this.#createD20Die();
     if ( !this.options.configured ) this.configureModifiers();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Advantage mode of a 5e d20 roll
+   * @enum {number}
+   */
+  static ADV_MODE = {
+    NORMAL: 0,
+    ADVANTAGE: 1,
+    DISADVANTAGE: -1
+  };
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static DefaultConfigurationDialog = D20RollConfigurationDialog;
+
+  /* -------------------------------------------- */
+  /*  Static Construction                         */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static fromConfig(config, process) {
+    const formula = [new CONFIG.Dice.D20Die().formula].concat(config.parts ?? []).join(" + ");
+    return new this(formula, config.data, config.options);
   }
 
   /* -------------------------------------------- */
@@ -68,76 +92,95 @@ export default class D20Roll extends Roll {
   /* -------------------------------------------- */
 
   /**
-   * Determine whether a d20 roll should be fast-forwarded, and whether advantage or disadvantage should be applied.
-   * @param {object} [options]
-   * @param {Event} [options.event]                               The Event that triggered the roll.
-   * @param {boolean} [options.advantage]                         Is something granting this roll advantage?
-   * @param {boolean} [options.disadvantage]                      Is something granting this roll disadvantage?
-   * @param {boolean} [options.fastForward]                       Should the roll dialog be skipped?
-   * @returns {{advantageMode: D20Roll.ADV_MODE, isFF: boolean}}  Whether the roll is fast-forwarded, and its advantage
-   *                                                              mode.
+   * Construct and perform a D20 Roll through the standard workflow.
+   * @param {D20RollProcessConfiguration} [config={}]     Roll configuration data.
+   * @param {D20RollDialogConfiguration} [dialog={}]      Data for the roll configuration dialog.
+   * @param {BasicRollMessageConfiguration} [message={}]  Configuration data that guides roll message creation.
+   * @returns {D20Roll[]}                                 Any rolls created.
    */
-  static determineAdvantageMode({event, advantage=false, disadvantage=false, fastForward}={}) {
+  static async build(config = {}, dialog = {}, message = {}) {
+    for ( const roll of config.rolls ?? [] ) {
+      roll.options ??= {};
+      roll.options.criticalSuccess ??= CONFIG.Dice.D20Die.CRITICAL_SUCCESS_TOTAL;
+      roll.options.criticalFailure ??= CONFIG.Dice.D20Die.CRITICAL_FAILURE_TOTAL;
+      roll.options.elvenAccuracy ??= config.elvenAccuracy;
+      roll.options.halflingLucky ??= config.halflingLucky;
+      roll.options.reliableTalent ??= config.reliableTalent;
+    }
+    return super.build(config, dialog, message);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Determines whether the roll should be fast forwarded and what the default advantage mode should be.
+   * @param {D20RollProcessConfiguration} config     Roll configuration data.
+   * @param {D20RollDialogConfiguration} dialog      Data for the roll configuration dialog.
+   * @param {BasicRollMessageConfiguration} message  Configuration data that guides roll message creation.
+   */
+  static applyKeybindings(config, dialog, message) {
     const keys = {
-      normal: areKeysPressed(event, "skipDialogNormal"),
-      advantage: areKeysPressed(event, "skipDialogAdvantage"),
-      disadvantage: areKeysPressed(event, "skipDialogDisadvantage")
+      normal: areKeysPressed(config.event, "skipDialogNormal"),
+      advantage: areKeysPressed(config.event, "skipDialogAdvantage"),
+      disadvantage: areKeysPressed(config.event, "skipDialogDisadvantage")
     };
-    const isFF = fastForward ?? Object.values(keys).some(k => k);
-    let advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.NORMAL;
-    if ( advantage || keys.advantage ) advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
-    else if ( disadvantage || keys.disadvantage ) advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
-    return {isFF: !!isFF, advantageMode};
+
+    // Should the roll configuration dialog be displayed?
+    dialog.configure ??= !Object.values(keys).some(k => k);
+
+    // Determine advantage mode
+    for ( const roll of config.rolls ?? [] ) {
+      const advantage = roll.options.advantage || keys.advantage;
+      const disadvantage = roll.options.disadvantage || keys.disadvantage;
+      if ( advantage && !disadvantage ) roll.options.advantageMode = this.ADV_MODE.ADVANTAGE;
+      else if ( !advantage && disadvantage ) roll.options.advantageMode = this.ADV_MODE.DISADVANTAGE;
+      else roll.options.advantageMode = this.ADV_MODE.NORMAL;
+    }
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The primary die used in this d20 roll.
+   * @type {D20Die|void}
+   */
+  get d20() {
+    if ( !(this.terms[0] instanceof foundry.dice.terms.Die) ) return undefined;
+    return this.terms[0];
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Advantage mode of a 5e d20 roll
-   * @enum {number}
+   * Set the d20 for this roll.
    */
-  static ADV_MODE = {
-    NORMAL: 0,
-    ADVANTAGE: 1,
-    DISADVANTAGE: -1
-  };
-
-  /* -------------------------------------------- */
-
-  /**
-   * The HTML template path used to configure evaluation of this Roll
-   * @type {string}
-   */
-  static EVALUATION_TEMPLATE = "systems/dnd5e/templates/chat/roll-dialog.hbs";
-
-  /* -------------------------------------------- */
-
-  /**
-   * Does this roll start with a d20?
-   * @type {boolean}
-   */
-  get validD20Roll() {
-    return (this.terms[0] instanceof Die) && (this.terms[0].faces === 20);
+  set d20(die) {
+    if ( !(die instanceof CONFIG.Dice.D20Die) ) throw new Error(
+      `D20 die must be an instance of ${CONFIG.Dice.D20Die.name}, instead a ${die.constructor.name} was provided.`
+    );
+    this.terms[0] = die;
   }
 
   /* -------------------------------------------- */
 
   /**
-   * A convenience reference for whether this D20Roll has advantage
+   * A convenience reference for whether this D20Roll has advantage.
    * @type {boolean}
    */
   get hasAdvantage() {
-    return this.options.advantageMode === D20Roll.ADV_MODE.ADVANTAGE;
+    return this.options.advantageMode === this.constructor.ADV_MODE.ADVANTAGE;
   }
 
   /* -------------------------------------------- */
 
   /**
-   * A convenience reference for whether this D20Roll has disadvantage
+   * A convenience reference for whether this D20Roll has disadvantage.
    * @type {boolean}
    */
   get hasDisadvantage() {
-    return this.options.advantageMode === D20Roll.ADV_MODE.DISADVANTAGE;
+    return this.options.advantageMode === this.constructor.ADV_MODE.DISADVANTAGE;
   }
 
   /* -------------------------------------------- */
@@ -147,9 +190,8 @@ export default class D20Roll extends Roll {
    * @type {boolean|void}
    */
   get isCritical() {
-    if ( !this.validD20Roll || !this._evaluated ) return undefined;
-    if ( !Number.isNumeric(this.options.critical) ) return false;
-    return this.dice[0].total >= this.options.critical;
+    this.#createD20Die();
+    return this.d20.isCriticalSuccess;
   }
 
   /* -------------------------------------------- */
@@ -159,13 +201,46 @@ export default class D20Roll extends Roll {
    * @type {boolean|void}
    */
   get isFumble() {
-    if ( !this.validD20Roll || !this._evaluated ) return undefined;
-    if ( !Number.isNumeric(this.options.fumble) ) return false;
-    return this.dice[0].total <= this.options.fumble;
+    this.#createD20Die();
+    return this.d20.isCriticalFailure;
   }
 
   /* -------------------------------------------- */
-  /*  D20 Roll Methods                            */
+
+  /**
+   * Does this roll start with a d20?
+   * @type {boolean}
+   */
+  get validD20Roll() {
+    return (this.d20 instanceof CONFIG.Dice.D20Die) && this.d20.isValid;
+  }
+
+  /* -------------------------------------------- */
+  /*  Chat Messages                               */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static _prepareMessageData(rolls, messageData) {
+    let advantage = true;
+    let disadvantage = true;
+
+    const rtLabel = `(${game.i18n.localize("DND5E.FlagsReliableTalent")})`;
+    for ( const roll of rolls ) {
+      if ( !roll.validD20Roll ) continue;
+      if ( !roll.hasAdvantage ) advantage = false;
+      if ( !roll.hasDisadvantage ) disadvantage = false;
+      if ( roll.options.reliableTalent && roll.d20.results.every(r => !r.active || (r.result < 10)) ) {
+        roll.d20.options.flavor = roll.d20.options.flavor ? `${roll.d20.options.flavor} (${rtLabel})` : rtLabel;
+      }
+    }
+
+    messageData.flavor ??= "";
+    if ( advantage ) messageData.flavor += ` (${game.i18n.localize("DND5E.Advantage")})`;
+    else if ( disadvantage ) messageData.flavor += ` (${game.i18n.localize("DND5E.Disadvantage")})`;
+  }
+
+  /* -------------------------------------------- */
+  /*  Roll Configuration                          */
   /* -------------------------------------------- */
 
   /**
@@ -175,35 +250,23 @@ export default class D20Roll extends Roll {
   configureModifiers() {
     if ( !this.validD20Roll ) return;
 
-    const d20 = this.terms[0];
-    d20.modifiers = [];
+    // Determine minimum, taking reliable talent into account
+    let minimum = this.options.minimum;
+    if ( this.options.reliableTalent ) minimum = Math.max(minimum ?? -Infinity, 10);
 
-    // Halfling Lucky
-    if ( this.options.halflingLucky ) d20.modifiers.push("r1=1");
-
-    // Reliable Talent
-    if ( this.options.reliableTalent ) d20.modifiers.push("min10");
-
-    // Handle Advantage or Disadvantage
-    if ( this.hasAdvantage ) {
-      d20.number = this.options.elvenAccuracy ? 3 : 2;
-      d20.modifiers.push("kh");
-      d20.options.advantage = true;
-    }
-    else if ( this.hasDisadvantage ) {
-      d20.number = 2;
-      d20.modifiers.push("kl");
-      d20.options.disadvantage = true;
-    }
-    else d20.number = 1;
+    // Directly modify the d20
+    this.d20.applyFlag("elvenAccuracy", this.options.elvenAccuracy === true);
+    this.d20.applyFlag("halflingLucky", this.options.halflingLucky === true);
+    this.d20.applyAdvantage(this.options.advantageMode ?? this.constructor.ADV_MODE.NORMAL);
+    this.d20.applyRange({ minimum, maximum: this.options.maximum });
 
     // Assign critical and fumble thresholds
-    if ( this.options.critical ) d20.options.critical = this.options.critical;
-    if ( this.options.fumble ) d20.options.fumble = this.options.fumble;
-    if ( this.options.targetValue ) d20.options.target = this.options.targetValue;
+    if ( this.options.criticalSuccess ) this.d20.options.criticalSuccess = this.options.criticalSuccess;
+    if ( this.options.criticalFailure ) this.d20.options.criticalFailure = this.options.criticalFailure;
+    if ( this.options.target ) this.d20.options.target = this.options.target;
 
     // Re-compile the underlying formula
-    this._formula = this.constructor.getFormula(this.terms);
+    this.resetFormula();
 
     // Mark configuration as complete
     this.options.configured = true;
@@ -211,30 +274,13 @@ export default class D20Roll extends Roll {
 
   /* -------------------------------------------- */
 
-  /** @inheritDoc */
-  async toMessage(messageData={}, options={}) {
-    // Record the preferred rollMode
-    options.rollMode ??= this.options.rollMode;
-    if ( options.rollMode === "roll" ) options.rollMode = undefined;
-    options.rollMode ||= game.settings.get("core", "rollMode");
-
-    // Evaluate the roll now so we have the results available to determine whether reliable talent came into play
-    if ( !this._evaluated ) await this.evaluate({ allowInteractive: options.rollMode !== CONST.DICE_ROLL_MODES.BLIND });
-
-    // Add appropriate advantage mode message flavor and dnd5e roll flags
-    messageData.flavor = messageData.flavor || this.options.flavor;
-    if ( this.hasAdvantage ) messageData.flavor += ` (${game.i18n.localize("DND5E.Advantage")})`;
-    else if ( this.hasDisadvantage ) messageData.flavor += ` (${game.i18n.localize("DND5E.Disadvantage")})`;
-
-    // Add reliable talent to the d20-term flavor text if it applied
-    if ( this.validD20Roll && this.options.reliableTalent ) {
-      const d20 = this.dice[0];
-      const isRT = d20.results.every(r => !r.active || (r.result < 10));
-      const label = `(${game.i18n.localize("DND5E.FlagsReliableTalent")})`;
-      if ( isRT ) d20.options.flavor = d20.options.flavor ? `${d20.options.flavor} (${label})` : label;
-    }
-
-    return super.toMessage(messageData, options);
+  /**
+   * Ensure the d20 die for this roll is actually a D20Die instance.
+   */
+  #createD20Die() {
+    if ( this.d20 instanceof CONFIG.Dice.D20Die ) return;
+    if ( !(this.d20 instanceof foundry.dice.terms.Die) ) return;
+    this.d20 = new CONFIG.Dice.D20Die({ ...this.d20 });
   }
 
   /* -------------------------------------------- */
@@ -261,71 +307,26 @@ export default class D20Roll extends Roll {
     title, defaultRollMode, defaultAction=D20Roll.ADV_MODE.NORMAL, ammunitionOptions,
     attackModes, chooseModifier=false, defaultAbility, masteryOptions, template
   }={}, options={}) {
-
-    // Render the Dialog inner HTML
-    const content = await renderTemplate(template ?? this.constructor.EVALUATION_TEMPLATE, {
-      formulas: [{formula: `${this.formula} + @bonus`}],
-      defaultRollMode,
-      rollModes: CONFIG.Dice.rollModes,
-      ammunitionOptions,
-      attackModes,
-      chooseModifier,
-      defaultAbility,
-      masteryOptions,
-      abilities: CONFIG.DND5E.abilities
-    });
-
-    let defaultButton = "normal";
-    switch ( defaultAction ) {
-      case D20Roll.ADV_MODE.ADVANTAGE: defaultButton = "advantage"; break;
-      case D20Roll.ADV_MODE.DISADVANTAGE: defaultButton = "disadvantage"; break;
-    }
-
-    // Create the Dialog window and await submission of the form
-    return new Promise(resolve => {
-      new Dialog({
-        title,
-        content,
-        buttons: {
-          advantage: {
-            label: game.i18n.localize("DND5E.Advantage"),
-            callback: html => resolve(this._onDialogSubmit(html, D20Roll.ADV_MODE.ADVANTAGE))
-          },
-          normal: {
-            label: game.i18n.localize("DND5E.Normal"),
-            callback: html => resolve(this._onDialogSubmit(html, D20Roll.ADV_MODE.NORMAL))
-          },
-          disadvantage: {
-            label: game.i18n.localize("DND5E.Disadvantage"),
-            callback: html => resolve(this._onDialogSubmit(html, D20Roll.ADV_MODE.DISADVANTAGE))
-          }
-        },
-        default: defaultButton,
-        close: () => resolve(null)
-      }, options).render(true);
-    });
+    foundry.utils.logCompatibilityWarning(
+      "The `configureDialog` on D20Roll has been deprecated and is now handled through `D20Roll.build`.",
+      { since: "DnD5e 4.1", until: "DnD5e 4.5" }
+    );
+    const DialogClass = this.DefaultConfigurationDialog;
+    const defaultButton = {
+      [D20Roll.ADV_MODE.NORMAL]: "normal",
+      [D20Roll.ADV_MODE.ADVANTAGE]: "advantage",
+      [D20Roll.ADV_MODE.DISADVANTAGE]: "disadvantage"
+    }[String(defaultAction ?? "0")];
+    return await DialogClass.configure(
+      {}, { options: { defaultButton, title } }, { rollMode: defaultRollMode }
+    );
+    // TODO: Select proper dialog (Skill dialog if chooseModifier is set, Attack dialog if ammo, attack, or mastery set)
   }
 
   /* -------------------------------------------- */
 
-  /**
-   * Handle submission of the Roll evaluation configuration Dialog
-   * @param {jQuery} html            The submitted dialog content
-   * @param {number} advantageMode   The chosen advantage mode
-   * @returns {D20Roll}              This damage roll.
-   * @private
-   */
+  // TODO: Delete this reference code once skill, tool, and attack rolls are properly handled
   _onDialogSubmit(html, advantageMode) {
-    const formData = new FormDataExtended(html[0].querySelector("form"));
-    const submitData = foundry.utils.expandObject(formData.object);
-
-    // Append a situational bonus term
-    if ( submitData.bonus ) {
-      const bonus = new Roll(submitData.bonus, this.data);
-      if ( !(bonus.terms[0] instanceof OperatorTerm) ) this.terms.push(new OperatorTerm({operator: "+"}));
-      this.terms = this.terms.concat(bonus.terms);
-    }
-
     // Set the ammunition
     if ( submitData.ammunition ) this.options.ammunition = submitData.ammunition;
 
@@ -349,11 +350,5 @@ export default class D20Roll extends Roll {
 
     // Set the mastery
     if ( submitData.mastery ) this.options.mastery = submitData.mastery;
-
-    // Apply advantage or disadvantage
-    this.options.advantageMode = advantageMode;
-    this.options.rollMode = submitData.rollMode;
-    this.configureModifiers();
-    return this;
   }
 }

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -45,6 +45,8 @@ const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, St
  * @property {string} [powerfulCritical]  Maximize result of extra dice added by critical, rather than rolling.
  */
 
+/* -------------------------------------------- */
+
 /**
  * A type of Roll specific to a damage (or healing) roll in the 5e system.
  * @param {string} formula                  The string formula to parse.

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -84,7 +84,7 @@ export default class DamageRoll extends BasicRoll {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  static async build(config = {}, dialog = {}, message = {}) {
+  static async build(config={}, dialog={}, message={}) {
     config.critical ??= {};
     config.critical.multiplyNumeric ??= game.settings.get("dnd5e", "criticalDamageModifiers");
     config.critical.powerfulCritical ??= game.settings.get("dnd5e", "criticalDamageMaxDice");

--- a/templates/dice/roll-buttons.hbs
+++ b/templates/dice/roll-buttons.hbs
@@ -1,5 +1,5 @@
 <nav class="dialog-buttons flexrow">
     {{#each buttons}}
-    <button type="submit" data-action="{{ @key }}">{{{ icon }}} {{ label }}</button>
+    <button type="submit" data-action="{{ @key }}" {{#if default}}autofocus{{/if}}>{{{ icon }}} {{ label }}</button>
     {{/each}}
 </nav>


### PR DESCRIPTION
Rebuilds `D20Roll` to inherit from `BasicRoll`. This involved a change to `BasicRoll` to give subclasses a way to modify message data before the message is created.

As part of this process some of the logic that originally existed in `D20Roll` has been moved to a new `D20Die` class. This includes the getters for determining whether a roll is a critical success or failure and applying advantage, minimums & maximums, and halfling lucky. This change isolates the behavior that is specific to rolling a d20 so that modules can potentially replace that die with their own (e.g. 2d10 or 3d6).

This PR does not cover converting any of the existing rolling methods over to the new API, they simply use the standalone `d20Roll` method and let it handle calling the new API. Future PRs will handle converting those methods over.