### PR TITLE
Adjust enchantment and summon level limits to refer to character level

### DIFF
--- a/module/data/activity/enchant-data.mjs
+++ b/module/data/activity/enchant-data.mjs
@@ -89,7 +89,7 @@ export default class EnchantActivityData extends BaseActivityData {
    * @type {EnchantEffectApplicationData[]}
    */
   get availableEnchantments() {
-    const keyPath = this.item.type === "spell" ? "item.level"
+    const keyPath = (this.item.type === "spell") && (this.item.system.level > 0) ? "item.level"
       : this.classIdentifier ? `classes.${this.classIdentifier}.levels` : "details.level";
     const level = foundry.utils.getProperty(this.getRollData(), keyPath) ?? 0;
     return this.effects.filter(e => ((e.level.min ?? -Infinity) <= level) && (level <= (e.level.max ?? Infinity)));

--- a/module/data/activity/summon-data.mjs
+++ b/module/data/activity/summon-data.mjs
@@ -118,7 +118,7 @@ export default class SummonActivityData extends BaseActivityData {
    * @type {number}
    */
   get relevantLevel() {
-    const keyPath = this.item.type === "spell" ? "item.level"
+    const keyPath = (this.item.type === "spell") && (this.item.system.level > 0) ? "item.level"
       : this.summon.identifier ? `classes.${this.summon.identifier}.levels` : "details.level";
     return foundry.utils.getProperty(this.getRollData(), keyPath) ?? 0;
   }


### PR DESCRIPTION
This adjusts the level limits for effects associated with enchant or summon activities to refer to the character level, rather than the spell level for cantrips only. Since cantrips scale with character level, this matches other spells that have their activities gated behind the level they are cast at, in order to provide different effects at different levels of scaling.

If you agree with this reasoning, we can make this change, otherwise it's fine to skip.