### PR TITLE
[#4278, #4279, #4297] Fix concentration from activities

### DIFF
--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -45,5 +45,30 @@ export default class DurationField extends SchemaField {
       labels.concentrationDuration = this.properties?.has("concentration")
         ? game.i18n.format("DND5E.ConcentrationDuration", { duration }) : duration;
     }
+
+    Object.defineProperty(this.duration, "getEffectData", {
+      value: DurationField.getEffectDuration.bind(this.duration),
+      configurable: true
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create duration data usable for an active effect based on this duration.
+   * @this {DurationData}
+   * @returns {EffectDurationData}
+   */
+  static getEffectDuration() {
+    if ( !Number.isNumeric(this.value) ) return {};
+    switch ( this.units ) {
+      case "turn": return { turns: this.value };
+      case "round": return { rounds: this.value };
+      case "minute": return { seconds: this.value * 60 };
+      case "hour": return { seconds: this.value * 60 * 60 };
+      case "day": return { seconds: this.value * 60 * 60 * 24 };
+      case "year": return { seconds: this.value * 60 * 60 * 24 * 365 };
+      default: return {};
+    }
   }
 }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -244,7 +244,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
 
     // Create concentration effect & end previous effects
     if ( usageConfig.concentration?.begin ) {
-      const effect = await item.actor.beginConcentrating(item);
+      const effect = await item.actor.beginConcentrating(activity, { "flags.dnd5e.scaling": usageConfig.scaling });
       if ( effect ) {
         results.effects ??= [];
         results.effects.push(effect);
@@ -570,7 +570,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       }
     }
 
-    if ( this.item.requiresConcentration && !game.settings.get("dnd5e", "disableConcentration") ) {
+    if ( this.requiresConcentration && !game.settings.get("dnd5e", "disableConcentration") ) {
       config.concentration ??= {};
       config.concentration.begin ??= true;
       const { effects } = this.actor.concentration;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1168,12 +1168,21 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
   /**
    * Initiate concentration on an item.
-   * @param {Item5e} item                        The item on which to being concentration.
+   * @param {Activity} activity                  The activity on which to being concentration.
    * @param {object} [effectData]                Effect data to merge into the created effect.
    * @returns {Promise<ActiveEffect5e|void>}     A promise that resolves to the created effect.
    */
-  async beginConcentrating(item, effectData={}) {
-    effectData = ActiveEffect5e.createConcentrationEffectData(item, effectData);
+  async beginConcentrating(activity, effectData={}) {
+    if ( activity instanceof Item ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `beginConcentrating` method on Actor5e now takes an Activity, rather than an Item.",
+        { since: "DnD5e 4.0", until: "DnD5e 4.4" }
+      );
+      activity = activity.system.activities?.contents[0];
+      if ( !activity ) return;
+    }
+
+    effectData = ActiveEffect5e.createConcentrationEffectData(activity, effectData);
 
     /**
      * A hook that is called before a concentration effect is created.
@@ -1182,9 +1191,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * @param {Actor5e} actor         The actor initiating concentration.
      * @param {Item5e} item           The item that will be concentrated on.
      * @param {object} effectData     Data used to create the ActiveEffect.
+     * @param {Activity} activity     The activity that triggered the concentration.
      * @returns {boolean}             Explicitly return false to prevent the effect from being created.
      */
-    if ( Hooks.call("dnd5e.preBeginConcentrating", this, item, effectData) === false ) return;
+    if ( Hooks.call("dnd5e.preBeginConcentrating", this, activity.item, effectData, activity) === false ) return;
 
     const effect = await ActiveEffect5e.create(effectData, { parent: this });
 
@@ -1195,8 +1205,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * @param {Actor5e} actor             The actor initiating concentration.
      * @param {Item5e} item               The item that is being concentrated on.
      * @param {ActiveEffect5e} effect     The created ActiveEffect instance.
+     * @param {Activity} activity         The activity that triggered the concentration.
      */
-    Hooks.callAll("dnd5e.beginConcentrating", this, item, effect);
+    Hooks.callAll("dnd5e.beginConcentrating", this, activity.item, effect, activity);
 
     return effect;
   }


### PR DESCRIPTION
Changes a number of concentration implementation details to fully work with activities and fix issues with concentration on non-spell items or activities that offer concentration even if the base item does not.

Modified `beginConcentrating` and `createConcentrationEffectData` to accept an activity rather than an item, with a fallback that selects the first activity and shows a deprecation warning.

Deprecated `ActiveEffect5e#getEffectDurationFromItem` and replaced it with a `getEffectData` method on `DurationField` which serves the same purpose.

Modified concentration checks in the activity usage process to use `requiresConcentration` on the activity rather than the item so that activities that require concentration on items that do not still properly trigger.

Also tweaked the flags added to the concentration effect to include
activity and scaling data.

Closes #4278
Closes #4279
Closes #4297