### PR TITLE
Some additional chat card polish.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -499,6 +499,10 @@
       }
     }
   },
+  "Attack": {
+    "mwak": "Melee Attack",
+    "rwak": "Ranged Attack"
+  },
   "Classification": {
     "Spell": "Spell",
     "Unarmed": "Unarmed",
@@ -518,6 +522,10 @@
   },
   "Warning": {
     "NoQuantity": "Attempting to attack with a weapon with a quantity of zero."
+  },
+  "Weapon": {
+    "Melee": "Melee Weapon",
+    "Ranged": "Ranged Weapon"
   }
 },
 

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -197,6 +197,36 @@ export default class AttackActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /**
+   * The game term label for this attack.
+   * @param {string} [attackMode]  The mode the attack was made with.
+   * @returns {string}
+   */
+  getActionLabel(attackMode) {
+    let attackModeLabel;
+    if ( attackMode ) {
+      const key = attackMode.split("-").map(s => s.capitalize()).join("");
+      attackModeLabel = game.i18n.localize(`DND5E.ATTACK.Mode.${key}`);
+    }
+    let actionType = this.actionType;
+    if ( (actionType === "mwak") && (attackMode?.startsWith("thrown")) ) actionType = "rwak";
+    let actionTypeLabel = game.i18n.localize(`DND5E.Action${actionType.toUpperCase()}`);
+    const isLegacy = game.settings.get("dnd5e", "rulesVersion") === "legacy";
+    const isUnarmed = this.attack.type.classification === "unarmed";
+    if ( isUnarmed ) attackModeLabel = game.i18n.localize("DND5E.ATTACK.Classification.Unarmed");
+    const isSpell = (actionType === "rsak") || (actionType === "msak");
+    if ( isLegacy || isSpell ) return [actionTypeLabel, attackModeLabel].filterJoin(" &bull; ");
+    actionTypeLabel = game.i18n.localize(`DND5E.ATTACK.Attack.${actionType}`);
+    if ( isUnarmed ) return [actionTypeLabel, attackModeLabel].filterJoin(" &bull; ");
+    const weaponType = CONFIG.DND5E.weaponTypeMap[this.item.system.type?.value];
+    const weaponTypeLabel = weaponType
+      ? game.i18n.localize(`DND5E.ATTACK.Weapon.${weaponType.capitalize()}`)
+      : CONFIG.DND5E.weaponTypes[this.item.system.type?.value];
+    return [actionTypeLabel, weaponTypeLabel, attackModeLabel].filterJoin(" &bull; ");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Get the roll parts used to create the attack roll.
    * @returns {{ data: object, parts: string[] }}
    */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -299,8 +299,8 @@ export default class ChatMessage5e extends ChatMessage {
       const subtitle = roll.type === "damage"
         ? isCritical ? game.i18n.localize("DND5E.CriticalHit") : game.i18n.localize("DND5E.DamageRoll")
         : roll.type === "attack"
-          ? game.i18n.localize(`DND5E.Action${activity.actionType.toUpperCase()}`)
-          : item.system.type?.label ?? game.i18n.localize(CONFIG.Item.typeLabels[item.type]);
+          ? (activity?.getActionLabel(roll.attackMode) ?? "")
+          : (item.system.type?.label ?? game.i18n.localize(CONFIG.Item.typeLabels[item.type]));
       const flavor = document.createElement("div");
       flavor.classList.add("dnd5e2", "chat-card");
       flavor.innerHTML = `


### PR DESCRIPTION
- Adds activation conditions indiscriminately now under a 'trigger' label, rather than it being hard-coded to reactions only.
- Re-adds the upcast level of the spell to the spell subtitle, something we accidentally regressed during 4.0.
- Adds more rules-accurate attack type information to attack roll cards.