### PR TITLE
Fix activity sheet crashing when AEs are deleted on the parent item.

### DIFF
--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -161,16 +161,6 @@ export default class ActivitySheet extends Application5e {
   }
 
   /* -------------------------------------------- */
-
-  /**
-   * Set to temporarily disable sheet rendering.
-   * TODO: Only needed because we cannot pass DatabaseOperation options to ClientDocument#deleteDialog.
-   * Delete this when we can.
-   * @type {boolean}
-   */
-  #disableRender = false;
-
-  /* -------------------------------------------- */
   /*  Rendering                                   */
   /* -------------------------------------------- */
 
@@ -471,7 +461,6 @@ export default class ActivitySheet extends Application5e {
     if ( !this.isVisible ) throw new Error(game.i18n.format("SHEETS.DocumentSheetPrivate", {
       type: game.i18n.localize("DND5E.ACTIVITY.Title.one")
     }));
-    if ( this.#disableRender ) return false;
   }
 
   /* -------------------------------------------- */
@@ -661,9 +650,7 @@ export default class ActivitySheet extends Application5e {
   static async #deleteEffect(event, target) {
     if ( !this.activity.effects ) return;
     const effectId = target.closest("[data-effect-id]")?.dataset.effectId;
-    this.#disableRender = true;
-    const result = await this.item.effects.get(effectId)?.deleteDialog();
-    this.#disableRender = false;
+    const result = await this.item.effects.get(effectId)?.deleteDialog({}, { render: false });
     if ( result instanceof ActiveEffect ) {
       const effects = this.activity.toObject().effects.filter(e => e._id !== effectId);
       this.activity.update({ effects });

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -239,7 +239,8 @@ export default class EffectsElement extends HTMLElement {
       case "create":
         return this._onCreate(target);
       case "delete":
-        return effect.deleteDialog();
+        await effect.deleteDialog({}, { render: false });
+        return this.#app.render();
       case "duplicate":
         return effect.clone({name: game.i18n.format("DOCUMENT.CopyOf", {name: effect.name})}, {save: true});
       case "edit":

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -759,4 +759,21 @@ export default class ActiveEffect5e extends ActiveEffect {
       classes: ["dnd5e2", "dnd5e-tooltip", "effect-tooltip"]
     };
   }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async deleteDialog(dialogOptions={}, operation={}) {
+    const type = game.i18n.localize(this.constructor.metadata.label);
+    return foundry.applications.api.DialogV2.confirm(foundry.utils.mergeObject({
+      window: { title: `${game.i18n.format("DOCUMENT.Delete", { type })}: ${this.name}` },
+      position: { width: 400 },
+      content: `
+        <p>
+            <strong>${game.i18n.localize("AreYouSure")}</strong> ${game.i18n.format("SIDEBAR.DeleteWarning", { type })}
+        </p>
+      `,
+      yes: { callback: () => this.delete(operation) }
+    }, dialogOptions));
+  }
 }


### PR DESCRIPTION
The previous solution didn't handle the case of the activity being deleted from the item sheet, only from the activity sheet, so I bit the bullet and overrode `ActiveEffect#createDialog` to give us the options we need pending any core fixes.

It doesn't behave perfectly, because deleting an AE from the parent now does not re-render the activity sheet. But given that it caused the entire sheet to close before, this is probably still an improvement.