### PR TITLE
[#861] Null avatar of death cr

### DIFF
--- a/packs/_source/monsters/undead/avatar-of-death.json
+++ b/packs/_source/monsters/undead/avatar-of-death.json
@@ -2,7 +2,7 @@
   "_id": "XiSWKZzAUxdmFOLL",
   "name": "Avatar of Death",
   "type": "npc",
-  "img": null,
+  "img": "",
   "system": {
     "abilities": {
       "str": {
@@ -144,7 +144,7 @@
         "custom": ""
       },
       "environment": "",
-      "cr": 0,
+      "cr": null,
       "spellLevel": 1,
       "ideal": "",
       "bond": "",
@@ -570,7 +570,7 @@
       "priority": 0
     },
     "texture": {
-      "src": null,
+      "src": "",
       "tint": "#ffffff",
       "scaleX": 1,
       "scaleY": 1,
@@ -991,9 +991,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.0.2",
     "createdTime": 1726171237704,
-    "modifiedTime": 1726171445919,
+    "modifiedTime": 1726736027810,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!XiSWKZzAUxdmFOLL"


### PR DESCRIPTION
Sets the avatar of death's CR to `-`. On the npc sheet, this removes any xp too.