### PR TITLE
[#4341] Wand of Secrets

### DIFF
--- a/packs/_source/items/wand/wand-of-secrets.json
+++ b/packs/_source/items/wand/wand-of-secrets.json
@@ -32,7 +32,7 @@
       "max": "3",
       "recovery": [
         {
-          "period": "lr",
+          "period": "dawn",
           "type": "formula",
           "formula": "1d3"
         }
@@ -80,12 +80,9 @@
           "targets": [
             {
               "type": "itemUses",
-              "target": "",
               "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
+              "target": "",
+              "scaling": {}
             }
           ],
           "scaling": {
@@ -100,7 +97,7 @@
         "duration": {
           "concentration": false,
           "value": "",
-          "units": "",
+          "units": "inst",
           "special": "",
           "override": false
         },
@@ -108,7 +105,8 @@
         "range": {
           "units": "self",
           "special": "",
-          "override": false
+          "override": false,
+          "value": ""
         },
         "target": {
           "template": {
@@ -118,7 +116,7 @@
             "size": "30",
             "width": "",
             "height": "",
-            "units": ""
+            "units": "ft"
           },
           "affects": {
             "count": "",
@@ -126,111 +124,24 @@
             "choice": false,
             "special": ""
           },
-          "prompt": true,
+          "prompt": false,
           "override": false
         },
         "roll": {
-          "formula": "1d3",
+          "formula": "",
           "name": "",
           "prompt": false,
           "visible": false
         },
         "uses": {
           "spent": 0,
-          "recovery": []
+          "recovery": [],
+          "max": ""
         },
-        "sort": 0
-      },
-      "dnd5eactivity200": {
-        "_id": "dnd5eactivity200",
-        "type": "damage",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "self",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "radius",
-            "size": "30",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "",
-            "type": "",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "damage": {
-          "critical": {
-            "allow": false,
-            "bonus": ""
-          },
-          "parts": [
-            {
-              "number": 1,
-              "denomination": 4,
-              "bonus": "1",
-              "types": [],
-              "custom": {
-                "enabled": false,
-                "formula": ""
-              },
-              "scaling": {
-                "mode": "whole",
-                "number": null,
-                "formula": ""
-              }
-            }
-          ]
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
+        "sort": 0,
+        "name": "Detect Secret",
+        "img": "",
+        "appliedEffects": []
       }
     },
     "attuned": false,
@@ -242,14 +153,21 @@
   "ownership": {
     "default": 0
   },
-  "flags": {},
+  "flags": {
+    "dnd5e": {
+      "riders": {
+        "activity": [],
+        "effect": []
+      }
+    }
+  },
   "_stats": {
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.0.2",
     "createdTime": 1725037201319,
-    "modifiedTime": 1725992517783,
+    "modifiedTime": 1726737092299,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!VQ6NWjWV37wiB29O"


### PR DESCRIPTION
- Changes recovery to dawn instead of LR.
- Removes forced template prompt.
- Adds missing units to template.
- Removes damage activity (a wand of secrets does not deal damage).
- Removes "Other" roll from utility activity.

Closes #4341.