### PR TITLE
Fix for `Glass Bottle` capacity and `Hourglass` description

### DIFF
--- a/packs/_source/items/container/glass-bottle/_container.json
+++ b/packs/_source/items/container/glass-bottle/_container.json
@@ -30,7 +30,7 @@
     "identified": true,
     "capacity": {
       "type": "weight",
-      "value": 6
+      "value": 1.5
     },
     "currency": {
       "cp": 0,

--- a/packs/_source/items/loot/hourglass.json
+++ b/packs/_source/items/loot/hourglass.json
@@ -5,7 +5,7 @@
   "img": "icons/tools/navigation/hourglass-grey.webp",
   "system": {
     "description": {
-      "value": "<p>It is a device used to measure the psaage of time. It comprises two glass bulbs connected vertically by a narrow neck that allows a regulated trickle of sand from the upper bulb to the lower one.</p>",
+      "value": "<p>A device used to measure the passage of time. It is comprised of two glass bulbs connected vertically by a narrow neck that allows a regulated trickle of sand from the upper bulb to the lower one.</p>",
       "chat": ""
     },
     "source": {


### PR DESCRIPTION
The `Glass Bottle` container item is set to a capacity of 6 (pounds). The official description says it can hold 1.5 pints of liquid.

Assuming the liquid is water (or any broadly comparable liquid); 1.5 pints = 1.562 pounds.

Taking a 1:1 ratio for simplicity, the capacity has been updated to 1.5 lbs.


Additionally the `Hourglass` item had a typo saying `psaage` instead of `passage`. Description updated.