### PR TITLE
[#4358] Fix chat pills not showing properties from the correct activity

### DIFF
--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -495,15 +495,16 @@ export class ItemDataModel extends SystemDataModel {
 
   /**
    * Prepare item card template data.
-   * @param {EnrichmentOptions} enrichmentOptions  Options for text enrichment.
+   * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
+   * @param {Activity} [enrichmentOptions.activity]     Specific activity on item to use for customizing the data.
    * @returns {Promise<object>}
    */
-  async getCardData(enrichmentOptions={}) {
+  async getCardData({ activity, ...enrichmentOptions }={}) {
     const { name, type, img } = this.parent;
     let {
       price, weight, uses, identified, unidentified, description, school, materials
     } = this;
-    const rollData = this.parent.getRollData();
+    const rollData = (activity ?? this.parent).getRollData();
     const isIdentified = identified !== false;
     const chat = isIdentified ? description.chat || description.value : unidentified?.description;
     description = game.user.isGM || isIdentified ? description.value : unidentified?.description;
@@ -515,7 +516,7 @@ export class ItemDataModel extends SystemDataModel {
       name, type, img, price, weight, uses, school, materials,
       config: CONFIG.DND5E,
       controlHints: game.settings.get("dnd5e", "controlHints"),
-      labels: foundry.utils.deepClone(this.parent.labels),
+      labels: foundry.utils.deepClone((activity ?? this.parent).labels),
       tags: this.parent.labels?.components?.tags,
       subtitle: subtitle.filterJoin(" &bull; "),
       description: {
@@ -533,7 +534,7 @@ export class ItemDataModel extends SystemDataModel {
     if ( game.user.isGM || isIdentified ) {
       context.properties.push(
         ...this.cardProperties ?? [],
-        ...Object.values(this.parent.labels.activations[0] ?? {}),
+        ...Object.values((activity ? activity?.activationLabels : this.parent.labels.activations?.[0]) ?? {}),
         ...this.equippableItemCardProperties ?? []
       );
     }

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -127,6 +127,18 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * A specific set of activation-specific labels displayed in chat cards.
+   * @type {object|null}
+   */
+  get activationLabels() {
+    if ( !this.activation.type || this.isSpell ) return null;
+    const { activation, duration, range, target } = this.labels;
+    return { activation, duration, range, target };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Effects that can be applied from this activity.
    * @type {ActiveEffect5e[]|null}
    */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -731,7 +731,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @protected
    */
   async _usageChatContext(message) {
-    const data = await this.item.system.getCardData();
+    const data = await this.item.system.getCardData({ activity: this });
     const properties = [...(data.tags ?? []), ...(data.properties ?? [])];
     const supplements = [];
     if ( this.activation.condition ) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -661,10 +661,10 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const damages = this.labels.damages = [];
     if ( !this.system.activities?.size ) return;
     for ( const activity of this.system.activities ) {
-      if ( activity.activation.type && (this.type !== "spell") ) {
-        const { activation, concentrationDuration, duration, range, target } = activity.labels;
-        activations.push({ activation, concentrationDuration, duration, range, target });
-      }
+      const activationLabels = activity.activationLabels;
+      if ( activationLabels ) activations.push(
+        { ...activationLabels, concentrationDuration: activity.labels.concentrationDuration }
+      );
       if ( activity.type === "attack" ) {
         const { toHit, modifier } = activity.labels;
         attacks.push({ toHit, modifier });


### PR DESCRIPTION
The `getCardData` method can now take an activity and if passed, it will grab labels from the activity rather that the item.

Closes #4358