### PR TITLE
Allow legacy system.ability to transfer on enchantment effects

### DIFF
--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -21,6 +21,13 @@ export default class EnchantmentData extends foundry.abstract.TypeDataModel {
   _applyLegacy(item, change, changes) {
     let key = change.key.replace("system.", "");
     switch ( change.key ) {
+      case "system.ability":
+        for ( const activity of item.system.activities?.getByTypes("attack") ?? [] ) {
+          changes[`system.activities.${activity.id}.attack.ability`] = ActiveEffect.applyField(
+            activity, { ...change, key: "attack.ability" }
+          );
+        }
+        return false;
       case "system.attack.bonus":
       case "system.attack.flat":
         for ( const activity of item.system.activities?.getByTypes("attack") ?? [] ) {


### PR DESCRIPTION
I use(d) system.ability for things like Shillelagh