### PR TITLE
[#4376] Sort activities on initialisation

### DIFF
--- a/module/applications/activity/activity-choice-dialog.mjs
+++ b/module/applications/activity/activity-choice-dialog.mjs
@@ -145,9 +145,9 @@ export default class ActivityChoiceDialog extends Application5e {
 
   /**
    * Display the activity choice dialog.
-   * @param {Item5e} item                       The Item whose activities are being chosen.
-   * @param {ApplicationConfiguration} options  Application configuration options.
-   * @returns {Promise<Activity|null>}          The chosen activity, or null if the dialog was dismissed.
+   * @param {Item5e} item                         The Item whose activities are being chosen.
+   * @param {ApplicationConfiguration} [options]  Application configuration options.
+   * @returns {Promise<Activity|null>}            The chosen activity, or null if the dialog was dismissed.
    */
   static create(item, options) {
     return new Promise(resolve => {

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -138,7 +138,7 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
     context.activities = (activities ?? []).map(({ _id: id, name, img, sort }) => ({
       id, name, sort,
       img: { src: img, svg: img?.endsWith(".svg") }
-    })).sort((a, b) => a.sort - b.sort);
+    }));
 
     return context;
   }

--- a/module/data/fields/activities-field.mjs
+++ b/module/data/fields/activities-field.mjs
@@ -13,7 +13,9 @@ export class ActivitiesField extends MappingField {
 
   /** @inheritDoc */
   initialize(value, model, options) {
-    return new ActivityCollection(model, super.initialize(value, model, options));
+    const activities = Object.values(super.initialize(value, model, options));
+    activities.sort((a, b) => a.sort - b.sort);
+    return new ActivityCollection(model, activities);
   }
 }
 
@@ -75,16 +77,16 @@ export class ActivityField extends foundry.data.fields.ObjectField {
 
 /**
  * Specialized collection type for stored activities.
- * @param {DataModel} model                   The parent DataModel to which this ActivityCollection belongs.
- * @param {Record<string, Activity>} entries  Object containing the activities to store.
+ * @param {DataModel} model     The parent DataModel to which this ActivityCollection belongs.
+ * @param {Activity[]} entries  The activities to store.
  */
 export class ActivityCollection extends Collection {
   constructor(model, entries) {
     super();
     this.#model = model;
-    for ( const [id, entry] of Object.entries(entries) ) {
+    for ( const entry of entries ) {
       if ( !(entry instanceof BaseActivityData) ) continue;
-      this.set(id, entry);
+      this.set(entry._id, entry);
     }
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -765,12 +765,11 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       );
       event = dialog?.event;
     }
-    let activities = this.system.activities?.filter(a => !this.getFlag("dnd5e", "riders.activity")?.includes(a.id));
+    const activities = this.system.activities?.filter(a => !this.getFlag("dnd5e", "riders.activity")?.includes(a.id));
     if ( activities?.length ) {
       let usageConfig = config;
       let dialogConfig = dialog;
       let messageConfig = message;
-      activities.sort((a, b) => a.sort - b.sort);
       let activity = activities[0];
       if ( (activities.length > 1) && !event?.shiftKey ) activity = await ActivityChoiceDialog.create(this);
       if ( !activity ) return;


### PR DESCRIPTION
- Closes #4376 

Ensures activities are sorted on initialisation, so that any code that checks the first activity always receives the user-sorted first activity, rather than the first created activity. It also means we don't have to sort activities in multiple places.