### PR TITLE
Enricher access to select data from document

### DIFF
--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -396,8 +396,6 @@ async function enrichDamage(config, label, options) {
     }
   });
 
-  console.log(config)
-
   config.formula = Roll.defaultImplementation.replaceFormulaData(formulaParts.join(" "), options.rollData ?? {});
   if ( !config.formula ) return null;
   config.damageType = config.type ?? (config._isHealing ? "healing" : null);

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -232,6 +232,19 @@ async function enrichCheck(config, label, options) {
   }
   if ( abilityConfig?.key ) config.ability = abilityConfig.key;
 
+  if (options.relativeTo) foundry.utils.mergeObject(options, {
+    rollData: {
+      document: {
+        name: options.relativeTo.name,
+        flags: options.relativeTo.flags,
+        parent: options.relativeTo?.parent ? {
+          name: options.relativeTo.parent.name,
+          flags: options.relativeTo.parent.flags
+        } : undefined
+      }
+    }
+  });
+
   if ( config.dc && !Number.isNumeric(config.dc) ) config.dc = simplifyBonus(config.dc, options.rollData);
 
   if ( invalid ) return null;
@@ -291,6 +304,19 @@ async function enrichSave(config, label, options) {
     return null;
   }
   if ( abilityConfig?.key ) config.ability = abilityConfig.key;
+
+  if (options.relativeTo) foundry.utils.mergeObject(options, {
+    rollData: {
+      document: {
+        name: options.relativeTo.name,
+        flags: options.relativeTo.flags,
+        parent: options.relativeTo?.parent ? {
+          name: options.relativeTo.parent.name,
+          flags: options.relativeTo.parent.flags
+        } : undefined
+      }
+    }
+  });
 
   if ( config.dc && !Number.isNumeric(config.dc) ) config.dc = simplifyBonus(config.dc, options.rollData);
 
@@ -356,6 +382,22 @@ async function enrichDamage(config, label, options) {
     else if ( value === "temp" ) config.type = "temphp";
     else formulaParts.push(value);
   }
+
+  if (options.relativeTo) foundry.utils.mergeObject(options, {
+    rollData: {
+      document: {
+        name: options.relativeTo.name,
+        flags: options.relativeTo.flags,
+        parent: options.relativeTo?.parent ? {
+          name: options.relativeTo.parent.name,
+          flags: options.relativeTo.parent.flags
+        } : undefined
+      }
+    }
+  });
+
+  console.log(config)
+
   config.formula = Roll.defaultImplementation.replaceFormulaData(formulaParts.join(" "), options.rollData ?? {});
   if ( !config.formula ) return null;
   config.damageType = config.type ?? (config._isHealing ? "healing" : null);


### PR DESCRIPTION
Implements #4408

This is a prototype / proof of concept PR for adding the ability to reference data, specifically flags, that originate specifically from the document the enricher is being rendered "on", as opposed to relying entirely on `getRollData`.

The naming has been chosen purely to avoid colliding with any other properties. This would probably be best wrapped into `getRollData` function itself, but that would also require adding it to documents such as Journals as this is the primary intent of this PR.

Here is an example of what such a feature would allow for premium adventure modules to do:

https://github.com/user-attachments/assets/84eb78b3-85a9-463b-9d13-f44f1bc0ff1f
