### PR TITLE
[#3879] Remove NPC check in prepared spell filtering

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -558,7 +558,6 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
       if ( schoolFilter.size && !schoolFilter.has(item.system.school) ) return false;
       if ( filters.has("prepared") ) {
         if ( alwaysPrepared.includes(item.system.preparation?.mode) ) return true;
-        if ( this.actor.type === "npc" ) return true;
         return item.system.preparation?.prepared;
       }
 


### PR DESCRIPTION
#3879 Removed check in spell filtering for actor type of npc that was causing the prepared spell filter to not work on NPC character sheets
