### PR TITLE
[#2094] Move item socket event handlers into type data models

### DIFF
--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -60,30 +60,18 @@ export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionT
   /*  Socket Event Handlers                       */
   /* -------------------------------------------- */
 
-  /**
-   * Set the background reference in actor data.
-   * @param {object} data     The initial data object provided to the document creation request
-   * @param {object} options  Additional options which modify the creation request
-   * @param {string} userId   The id of the User requesting the document update
-   * @see {Document#_onCreate}
-   * @protected
-   */
-  _onCreate(data, options, userId) {
+  /** @inheritDoc */
+  async _onCreate(data, options, userId) {
+    await super._onCreate(data, options, userId);
     if ( (game.user.id !== userId) || this.parent.actor?.type !== "character" ) return;
     this.parent.actor.update({"system.details.background": this.parent.id});
   }
 
   /* -------------------------------------------- */
 
-  /**
-   * Remove the background reference in actor data.
-   * @param {object} options            Additional options which modify the deletion request
-   * @param {documents.BaseUser} user   The User requesting the document deletion
-   * @returns {Promise<boolean|void>}   A return value of false indicates the deletion operation should be cancelled.
-   * @see {Document#_preDelete}
-   * @protected
-   */
+  /** @inheritDoc */
   async _preDelete(options, user) {
+    if ( (await super._preDelete(options, user)) === false ) return false;
     if ( this.parent.actor?.type !== "character" ) return;
     await this.parent.actor.update({"system.details.background": null});
   }

--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -61,8 +61,8 @@ export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionT
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async _onCreate(data, options, userId) {
-    await super._onCreate(data, options, userId);
+  _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
     if ( (game.user.id !== userId) || this.parent.actor?.type !== "character" ) return;
     this.parent.actor.update({"system.details.background": this.parent.id});
   }

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -258,11 +258,11 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async _onDelete(options, userId) {
-    await super._onDelete(options, userId);
-    if ( (userId !== game.user.id) ) return;
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    if ( userId !== game.user.id ) return;
     if ( this.parent.id === this.parent.actor?.system.details?.originalClass ) {
-      await this.parent.actor._assignPrimaryClass();
+      this.parent.actor._assignPrimaryClass();
     }
   }
 }

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -308,14 +308,14 @@ export default class ContainerData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   async _onDelete(options, userId) {
-    await super._onDelete(options, userId);
+    super._onDelete(options, userId);
     if ( (userId !== game.user.id) || !options.deleteContents ) return;
 
     // Delete a container's contents when it is deleted
     const contents = await this.allContainedItems;
-    if ( contents?.size ) await Item.deleteDocuments(
-      Array.from(contents.map(i => i.id)),
-      { pack: this.parent.pack, parent: this.parent.parent }
-    );
+    if ( contents?.size ) await Item.deleteDocuments(Array.from(contents.map(i => i.id)), {
+      pack: this.parent.pack,
+      parent: this.parent.parent
+    });
   }
 }

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -303,4 +303,19 @@ export default class ContainerData extends ItemDataModel.mixin(
 
     super._onUpdate(changed, options, userId);
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onDelete(options, userId) {
+    await super._onDelete(options, userId);
+    if ( (userId !== game.user.id) || !options.deleteContents ) return;
+
+    // Delete a container's contents when it is deleted
+    const contents = await this.allContainedItems;
+    if ( contents?.size ) await Item.deleteDocuments(
+      Array.from(contents.map(i => i.id)),
+      { pack: this.parent.pack, parent: this.parent.parent }
+    );
+  }
 }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -294,4 +294,14 @@ export default class EquipmentData extends ItemDataModel.mixin(
     const isProficient = (itemProf === true) || actorProfs.has(itemProf) || actorProfs.has(this.type.baseItem);
     return Number(isProficient);
   }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preCreate(data, options, user) {
+    if ( (await super._preCreate(data, options, user)) === false ) return false;
+    await this.preCreateEquipped(data, options, user);
+  }
 }

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -259,4 +259,18 @@ export default class FeatData extends ItemDataModel.mixin(
   get proficiencyMultiplier() {
     return 1;
   }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preCreate(data, options, user) {
+    if ( (await super._preCreate(data, options, user)) === false ) return false;
+
+    // Set type as "Monster Feature" if created directly on a NPC
+    if ( (this.parent.actor?.type === "npc") && !foundry.utils.hasProperty(data, "system.type.value") ) {
+      this.parent.updateSource({ "system.type.value": "monster" });
+    }
+  }
 }

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -270,7 +270,7 @@ export default class FeatData extends ItemDataModel.mixin(
 
     // Set type as "Monster Feature" if created directly on a NPC
     if ( (this.parent.actor?.type === "npc") && !foundry.utils.hasProperty(data, "system.type.value") ) {
-      this.parent.updateSource({ "system.type.value": "monster" });
+      this.updateSource({ "type.value": "monster" });
     }
   }
 }

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -181,8 +181,8 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async _onCreate(data, options, userId) {
-    await super._onCreate(data, options, userId);
+  _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
     if ( (game.user.id !== userId) || !["character", "npc"].includes(this.parent.actor?.type) ) return;
     this.parent.actor.update({ "system.details.race": this.parent.id });
   }

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -162,17 +162,11 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
   /*  Socket Event Handlers                       */
   /* -------------------------------------------- */
 
-  /**
-   * Create default advancement items when race is created.
-   * @param {object} data               The initial data object provided to the document creation request.
-   * @param {object} options            Additional options which modify the creation request.
-   * @param {User} user                 The User requesting the document creation.
-   * @returns {Promise<boolean|void>}   A return value of false indicates the creation operation should be cancelled.
-   * @see {Document#_preCreate}
-   * @protected
-   */
+  /** @inheritDoc */
   async _preCreate(data, options, user) {
+    if ( (await super._preCreate(data, options, user)) === false ) return false;
     if ( data._id || foundry.utils.hasProperty(data, "system.advancement") ) return;
+
     const toCreate = [
       { type: "AbilityScoreImprovement" }, { type: "Size" },
       { type: "Trait", configuration: { grants: ["languages:standard:common"] } }
@@ -186,30 +180,18 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
 
   /* -------------------------------------------- */
 
-  /**
-   * Set the race reference in actor data.
-   * @param {object} data     The initial data object provided to the document creation request
-   * @param {object} options  Additional options which modify the creation request
-   * @param {string} userId   The id of the User requesting the document update
-   * @see {Document#_onCreate}
-   * @protected
-   */
-  _onCreate(data, options, userId) {
+  /** @inheritDoc */
+  async _onCreate(data, options, userId) {
+    await super._onCreate(data, options, userId);
     if ( (game.user.id !== userId) || !["character", "npc"].includes(this.parent.actor?.type) ) return;
     this.parent.actor.update({ "system.details.race": this.parent.id });
   }
 
   /* -------------------------------------------- */
 
-  /**
-   * Remove the race reference in actor data.
-   * @param {object} options            Additional options which modify the deletion request
-   * @param {documents.BaseUser} user   The User requesting the document deletion
-   * @returns {Promise<boolean|void>}   A return value of false indicates the deletion operation should be cancelled.
-   * @see {Document#_preDelete}
-   * @protected
-   */
+  /** @inheritDoc */
   async _preDelete(options, user) {
+    if ( (await super._preDelete(options, user)) === false ) return false;
     if ( !["character", "npc"].includes(this.parent.actor?.type) ) return;
     await this.parent.actor.update({ "system.details.race": null });
   }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -399,7 +399,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     // Set as prepared for NPCs, and not prepared for PCs
     if ( ["character", "npc"].includes(this.parent.actor.type)
       && !foundry.utils.hasProperty(data, "system.preparation.prepared") ) {
-      this.parent.updateSource({ "system.preparation.prepared": this.parent.actor.type === "npc" });
+      this.updateSource({ "preparation.prepared": this.parent.actor.type === "npc" });
     }
 
     if ( ["atwill", "innate"].includes(this.preparation.mode) || this.sourceClass ) return;
@@ -408,11 +408,11 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
 
     // Set the source class, and ensure the preparation mode matches if adding a prepared spell to an alt class
     const setClass = cls => {
-      const update = { "system.sourceClass": cls };
+      const update = { sourceClass: cls };
       const type = this.parent.actor.classes[cls].spellcasting.type;
       if ( (type !== "leveled") && (this.preparation.mode === "prepared") && (this.level > 0)
-        && (type in CONFIG.DND5E.spellPreparationModes) ) update["system.preparation.mode"] = type;
-      this.parent.updateSource(update);
+        && (type in CONFIG.DND5E.spellPreparationModes) ) update["preparation.mode"] = type;
+      this.updateSource(update);
     };
 
     // If preparation mode matches an alt spellcasting type and matching class exists, set as that class

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -392,9 +392,17 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _preCreate(data, options, user) {
-    if ( super._preCreate(data, options, user) === false ) return false;
-    if ( !this.parent.isEmbedded || ["atwill", "innate"].includes(this.preparation.mode) || this.sourceClass ) return;
+  async _preCreate(data, options, user) {
+    if ( (await super._preCreate(data, options, user)) === false ) return false;
+    if ( !this.parent.isEmbedded ) return;
+
+    // Set as prepared for NPCs, and not prepared for PCs
+    if ( ["character", "npc"].includes(this.parent.actor.type)
+      && !foundry.utils.hasProperty(data, "system.preparation.prepared") ) {
+      this.parent.updateSource({ "system.preparation.prepared": this.parent.actor.type === "npc" });
+    }
+
+    if ( ["atwill", "innate"].includes(this.preparation.mode) || this.sourceClass ) return;
     const classes = new Set(Object.keys(this.parent.actor.spellcastingClasses));
     if ( !classes.size ) return;
 

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -100,12 +100,12 @@ export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTem
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async _onCreate(data, options, userId) {
-    await super._onCreate(data, options, userId);
+  _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
     const actor = this.parent.actor;
     if ( !actor || (userId !== game.user.id) ) return;
     if ( !actor.system.attributes?.spellcasting && this.parent.spellcasting?.ability ) {
-      await actor.update({ "system.attributes.spellcasting": this.parent.spellcasting.ability });
+      actor.update({ "system.attributes.spellcasting": this.parent.spellcasting.ability });
     }
   }
 }

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -126,7 +126,7 @@ export default class EquippableItemTemplate extends SystemDataModel {
   preCreateEquipped(data, options, user) {
     if ( ["character", "npc"].includes(this.parent.actor?.type)
       && !foundry.utils.hasProperty(data, "system.equipped") ) {
-      this.parent.updateSource({ "system.equipped": this.parent.actor.type === "npc" });
+      this.updateSource({ equipped: this.parent.actor.type === "npc" });
     }
   }
 }

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -112,4 +112,21 @@ export default class EquippableItemTemplate extends SystemDataModel {
     const attunement = this.attuned || (this.attunement !== "required");
     return attunement && this.properties.has("mgc") && this.validProperties.has("mgc");
   }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /**
+   * Set as equipped for NPCs, and unequipped for PCs.
+   * @param {object} data     The initial data object provided to the document creation request.
+   * @param {object} options  Additional options which modify the creation request.
+   * @param {User} user       The User requesting the document creation.
+   */
+  preCreateEquipped(data, options, user) {
+    if ( ["character", "npc"].includes(this.parent.actor?.type)
+      && !foundry.utils.hasProperty(data, "system.equipped") ) {
+      this.parent.updateSource({ "system.equipped": this.parent.actor.type === "npc" });
+    }
+  }
 }

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -213,7 +213,18 @@ export default class PhysicalItemTemplate extends SystemDataModel {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  async _preUpdate(changed, options, user) {
+    await super._preUpdate(changed, options, user);
+    if ( foundry.utils.hasProperty(changed, "system.container") ) {
+      options.formerContainer = (await this.parent.container)?.uuid;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
     this._renderContainers();
   }
 
@@ -221,6 +232,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
 
   /** @inheritDoc */
   _onUpdate(changed, options, userId) {
+    super._onUpdate(changed, options, userId);
     this._renderContainers({ formerContainer: options.formerContainer });
   }
 
@@ -228,6 +240,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
 
   /** @inheritDoc */
   _onDelete(options, userId) {
+    super._onDelete(options, userId);
     this._renderContainers();
   }
 

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -214,7 +214,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
 
   /** @inheritDoc */
   async _preUpdate(changed, options, user) {
-    await super._preUpdate(changed, options, user);
+    if ( await super._preUpdate(changed, options, user) === false ) return false;
     if ( foundry.utils.hasProperty(changed, "system.container") ) {
       options.formerContainer = (await this.parent.container)?.uuid;
     }

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -202,9 +202,10 @@ export default class ToolData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _preCreate(data, options, user) {
-    if ( super._preCreate(data, options, user) === false ) return false;
+  async _preCreate(data, options, user) {
+    if ( (await super._preCreate(data, options, user)) === false ) return false;
     if ( this.activities.size ) return;
+
     const activityData = new CONFIG.DND5E.activityTypes.check.documentClass({}, { parent: this.parent }).toObject();
     this.parent.updateSource({ [`system.activities.${activityData._id}`]: activityData });
   }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -494,9 +494,11 @@ export default class WeaponData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _preCreate(data, options, user) {
-    if ( super._preCreate(data, options, user) === false ) return false;
+  async _preCreate(data, options, user) {
+    if ( (await super._preCreate(data, options, user)) === false ) return false;
+    await this.preCreateEquipped(data, options, user);
     if ( this.activities.size ) return;
+
     const activityData = new CONFIG.DND5E.activityTypes.attack.documentClass({}, { parent: this.parent }).toObject();
     this.parent.updateSource({ [`system.activities.${activityData._id}`]: activityData });
   }


### PR DESCRIPTION
Moved various `_pre` and `_on` socket event handlers into item data models rather than on the item. All socket handlers have been removed from items except setting the initial identifier during `_preCreate`, performing activity rider updates in `_preUpdate` (though the implementation has been moved), and ending concentration within `_onDelete`.