### PR TITLE
[#4061] Add spell caching system to Cast activities

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -624,6 +624,9 @@
   },
   "Action": {
     "RemoveSpell": "Remove Spell"
+  },
+  "Enchantment": {
+    "Name": "Spell Changes"
   }
 },
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -580,7 +580,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
       // Re-link UUIDs in consumption fields to explicit items on the actor
       if ( target.target.includes(".") ) {
-        const item = actor.sourcedItems?.get(target.target);
+        const item = actor.sourcedItems?.get(target.target, { legacy: false })?.first();
         if ( item ) target.target = item.id;
       }
 

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -140,7 +140,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
     // Substitute source UUIDs in consumption targets
     if ( !this.parent.isEmbedded ) return;
     if ( ["ammo", "charges", "material"].includes(this.consume.type) && this.consume.target?.includes(".") ) {
-      const item = this.parent.actor.sourcedItems?.get(this.consume.target);
+      const item = this.parent.actor.sourcedItems?.get(this.consume.target, { legacy: false })?.first();
       if ( item ) this.consume.target = item.id;
     }
   }

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -412,7 +412,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
     const cachedInserts = [];
     for ( const id of Object.keys(changed.system.activities) ) {
       const activity = this.activities.get(id);
-      if ( !activity ) continue;
+      if ( !(activity instanceof CastActivity) ) continue;
       const existingSpell = activity.cachedSpell;
       if ( existingSpell ) {
         const enchantment = existingSpell.effects.get(CastActivity.ENCHANTMENT_ID);

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -357,7 +357,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
 
   /**
    * Prepare any item or actor changes based on activity changes.
-   * @param {object} changed  The differential data that is changed relative to the documents prior values.
+   * @param {object} changed  The differential data that is changed relative to the document's prior values.
    * @param {object} options  Additional options which modify the update request.
    * @param {User} user       The User requesting the document update.
    */
@@ -395,7 +395,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
 
   /**
    * Perform any additional updates when an item with activities is updated.
-   * @param {object} changed  The differential data that is changed relative to the documents prior values.
+   * @param {object} changed  The differential data that is changed relative to the document's prior values.
    * @param {object} options  Additional options which modify the update request.
    * @param {string} userId   The id of the User requesting the document update.
    */

--- a/module/data/item/templates/identifiable.mjs
+++ b/module/data/item/templates/identifiable.mjs
@@ -66,7 +66,7 @@ export default class IdentifiableTemplate extends SystemDataModel {
   /**
    * If no unidentified name or description are set when the identified checkbox is unchecked, then fetch values
    * from base item if possible.
-   * @param {object} changed            The differential data that is changed relative to the documents prior values
+   * @param {object} changed            The differential data that is changed relative to the document's prior values.
    * @param {object} options            Additional options which modify the update request
    * @param {documents.BaseUser} user   The User requesting the document update
    * @returns {Promise<boolean|void>}   A return value of false indicates the update operation should be cancelled.

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -2,7 +2,7 @@ import FormulaField from "../data/fields/formula-field.mjs";
 import MappingField from "../data/fields/mapping-field.mjs";
 import { staticID } from "../utils.mjs";
 
-const { SetField, StringField } = foundry.data.fields;
+const { ObjectField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * Extend the base ActiveEffect class to implement system-specific logic.
@@ -155,6 +155,11 @@ export default class ActiveEffect5e extends ActiveEffect {
         const created = mappingField.model.initialize(mappingField.model.getInitialValue(), mappingField);
         foundry.utils.setProperty(model, keyPath, created);
       }
+    }
+
+    // Parse any JSON provided when targeting an object
+    if ( (field instanceof ObjectField) || (field instanceof SchemaField) ) {
+      change = { ...change, value: this.prototype._parseOrString(change.value) };
     }
 
     return super.applyField(model, change, field);

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -92,6 +92,9 @@ export default class CastActivity extends ActivityMixin(CastActivityData) {
       delete data.override;
       changes.push({ key: `system.${type}`, mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: JSON.stringify(data) });
     }
+    for ( const property of this.spell.properties ) {
+      changes.push({ key: "system.properties", mode: CONST.ACTIVE_EFFECT_MODES.ADD, value: `-${property}` });
+    }
     return changes;
   }
 }

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -43,7 +43,7 @@ export default class CastActivity extends ActivityMixin(CastActivityData) {
    */
   get cachedSpell() {
     return this.actor?.sourcedItems.get(this.spell.uuid, { legacy: false })
-      ?.find(i => i.getFlag("dnd5e", "cachedFor") === this.id);
+      ?.find(i => i.getFlag("dnd5e", "cachedFor") === this.relativeUUID);
   }
 
   /* -------------------------------------------- */
@@ -71,7 +71,7 @@ export default class CastActivity extends ActivityMixin(CastActivityData) {
       ],
       flags: {
         dnd5e: {
-          cachedFor: this.id
+          cachedFor: this.relativeUUID
         }
       },
       _stats: { compendiumSource: this.spell.uuid }

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -86,9 +86,10 @@ export default class CastActivity extends ActivityMixin(CastActivityData) {
    */
   getSpellChanges() {
     const changes = [];
+    const source = this.toObject();
     for ( const type of ["activation", "duration", "range", "target"] ) {
       if ( !this[type].override ) continue;
-      const data = this.toObject()[type];
+      const data = source[type];
       delete data.override;
       changes.push({ key: `system.${type}`, mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: JSON.stringify(data) });
     }

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -1,5 +1,6 @@
 import CastSheet from "../../applications/activity/cast-sheet.mjs";
 import CastActivityData from "../../data/activity/cast-data.mjs";
+import { staticID } from "../../utils.mjs";
 import ActivityMixin from "./mixin.mjs";
 
 /**
@@ -8,6 +9,13 @@ import ActivityMixin from "./mixin.mjs";
 export default class CastActivity extends ActivityMixin(CastActivityData) {
   /* -------------------------------------------- */
   /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /**
+   * Static ID used for the enchantment that modifies spell data.
+   */
+  static ENCHANTMENT_ID = staticID("dnd5espellchanges");
+
   /* -------------------------------------------- */
 
   /** @inheritDoc */
@@ -24,4 +32,66 @@ export default class CastActivity extends ActivityMixin(CastActivityData) {
       sheetClass: CastSheet
     }, { inplace: false })
   );
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Cached copy of the associated spell stored on the actor.
+   * @type {Item5e|void}
+   */
+  get cachedSpell() {
+    return this.actor?.sourcedItems.get(this.spell.uuid, { legacy: false })
+      ?.find(i => i.getFlag("dnd5e", "cachedFor") === this.id);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the data for the cached spell to store on the actor.
+   * @returns {Promise<object|void>}
+   */
+  async getCachedSpellData() {
+    const originalSpell = await fromUuid(this.spell.uuid);
+    if ( !originalSpell ) return;
+    return originalSpell.clone({
+      effects: [
+        ...originalSpell.effects.map(e => e.toObject()),
+        {
+          _id: this.constructor.ENCHANTMENT_ID,
+          type: "enchantment",
+          name: game.i18n.localize("DND5E.CAST.Enchantment.Name"),
+          img: "systems/dnd5e/icons/svg/activity/cast.svg",
+          origin: this.uuid,
+          changes: this.getSpellChanges()
+        }
+      ],
+      flags: {
+        dnd5e: {
+          cachedFor: this.id
+        }
+      },
+      _stats: { compendiumSource: this.spell.uuid }
+    }).toObject();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create spell changes based on the activity's configuration.
+   * @returns {object}
+   */
+  getSpellChanges() {
+    const changes = [];
+    for ( const type of ["activation", "duration", "range", "target"] ) {
+      if ( !this[type].override ) continue;
+      const data = this.toObject()[type];
+      delete data.override;
+      changes.push({ key: `system.${type}`, mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: JSON.stringify(data) });
+    }
+    return changes;
+  }
 }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -96,6 +96,16 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   /* -------------------------------------------- */
 
   /**
+   * Relative UUID for this activity on an actor.
+   * @type {string}
+   */
+  get relativeUUID() {
+    return `.Item.${this.item.id}.Activity.${this.id}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Consumption targets that can be use for this activity.
    * @type {Set<string>}
    */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3660,6 +3660,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
 /* -------------------------------------------- */
 
+/**
+ * @extends {Map<string, Set<Item5e>>}
+ */
 class SourcedItemsMap extends Map {
   /** @inheritDoc */
   get(key, { legacy=true }={}) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1319,6 +1319,14 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  async _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
+    await this.system.onCreateActivities?.(data, options, userId);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   async _preUpdate(changed, options, user) {
     if ( (await super._preUpdate(changed, options, user)) === false ) return false;
 
@@ -1326,18 +1334,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       options.formerContainer = (await this.container)?.uuid;
     }
 
-    if ( changed.system?.activities ) {
-      const riders = this.clone(changed).system.activities.getByType("enchant").reduce((riders, a) => {
-        a.effects.forEach(e => {
-          e.riders.activity.forEach(activity => riders.activity.add(activity));
-          e.riders.effect.forEach(effect => riders.effect.add(effect));
-        });
-        return riders;
-      }, { activity: new Set(), effect: new Set() });
-      foundry.utils.setProperty(changed, "flags.dnd5e.riders", {
-        activity: Array.from(riders.activity), effect: Array.from(riders.effect)
-      });
-    }
+    await this.system.preUpdateActivities?.(changed, options, user);
 
     if ( (this.type !== "class") || !("levels" in (changed.system || {})) ) return;
 
@@ -1365,8 +1362,17 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  async _onUpdate(changed, options, userId) {
+    super._onUpdate(changed, options, userId);
+    await this.system.onUpdateActivities?.(changed, options, userId);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   async _onDelete(options, userId) {
     super._onDelete(options, userId);
+    await this.system.onDeleteActivities?.(options, userId);
     if ( userId !== game.user.id ) return;
 
     // Delete a container's contents when it is deleted

--- a/module/documents/mixins/document.mjs
+++ b/module/documents/mixins/document.mjs
@@ -38,7 +38,7 @@ export default Base => class extends SystemFlagsMixin(Base) {
   /**
    * Perform preliminary operations before a Document of this type is updated.
    * Pre-update operations only occur for the client which requested the operation.
-   * @param {object} changed            The differential data that is changed relative to the documents prior values
+   * @param {object} changed            The differential data that is changed relative to the document's prior values.
    * @param {object} options            Additional options which modify the update request
    * @param {documents.BaseUser} user   The User requesting the document update
    * @returns {Promise<boolean|void>}   A return value of false indicates the update operation should be cancelled.


### PR DESCRIPTION
Adds a system for Cast activities to automatically import a copy with changes applied when added to the actor, keep the cached spell updated when the activities change, and remove the cached copy when the item is removed.

Uses an enchantment effect on the spell to apply the actualy changes needed for easy updating.

Currently does nothing to change how these spells appear on the actor sheet, so they will all display in the spell list as if they were normal spells.

In order to better support multiple spells on an actor sheet with the same compendium source, `Actor#sourcedItems` has been changed to store sets of items, rather than just a single item.

### Todo
- [x] Handle ignored properties
- [ ] Hide cached spells on actor sheet
- [x] Apply consumption changes to cached spells based on activity
- [x] Activate cached spell with Cast activity is used