### PR TITLE
Divorce system Appv2 apps from Appv1 styles.

### DIFF
--- a/less/v2/activities.less
+++ b/less/v2/activities.less
@@ -141,12 +141,10 @@
 /*  Choice Dialog                     */
 /* ---------------------------------- */
 
-.activity-choice {
-  menu {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
+.activity-choice menu {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 
   button {
     --icon-fill: var(--color-text-dark-primary);

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -77,6 +77,7 @@
       flex-direction: column;
       gap: .25rem;
       z-index: -1;
+      border: none;
 
       > .item {
         --icon-size: 14px;
@@ -350,6 +351,7 @@
       padding: .1875rem .375rem;
       display: flex;
       gap: .25rem;
+      margin: 0;
 
       &.green, &.maroon { color: var(--color-text-light-0); }
       &.green { background-color: var(--dnd5e-color-green); }
@@ -852,6 +854,7 @@
 
     button.header-control {
       --color-light-text-heading: var(--color-light-1);
+      --button-text-color: var(--color-light-text-heading);
       font-size: var(--font-size-12);
       &:hover { color: var(--color-light-text-heading); }
     }
@@ -887,6 +890,7 @@
     [data-tab] {
       flex: 1;
       padding: 0;
+      line-height: 1;
 
       label { padding-bottom: 1px; }
 
@@ -1257,16 +1261,20 @@ dialog.dnd5e2.application {
   min-width: 145px;
 
   .context-item {
+    border: none;
     padding: 0 .75rem;
+    margin: 0;
     cursor: pointer;
     display: flex;
     align-items: baseline;
     gap: 5px;
+    transition: all 250ms ease;
 
     &:hover {
       color: var(--color-text-dark-primary);
       text-shadow: none;
       background: var(--dnd5e-color-parchment);
+      border: none;
     }
 
     i {
@@ -1285,6 +1293,8 @@ dialog.dnd5e2.application {
     &:first-child { border-radius: 3px 3px 0 0; }
     &:last-child { border-radius: 0 0 3px 3px; }
   }
+
+  .context-group { border: none; }
 
   .context-group:first-child > ol > .context-item:first-child { border-radius: 3px 3px 0 0; }
   .context-group:last-child > ol > .context-item:last-child { border-radius: 0 0 3px 3px; }

--- a/less/v2/character.less
+++ b/less/v2/character.less
@@ -1064,9 +1064,11 @@
     }
 
     > .middle {
+      display: flex;
       gap: 1rem;
 
       > * {
+        flex: 1;
         display: flex;
         flex-direction: column;
         gap: .5rem;

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -562,3 +562,38 @@
     }
   }
 }
+
+/* App V2 Standard Form */
+.dnd5e2 .standard-form,
+.dnd5e2.standard-form {
+  --color-form-label: var(--color-text-dark-primary);
+  --color-form-label-hover: var(--color-form-label);
+  --input-height: 26px;
+  gap: 0;
+
+  .form-group:not(.label-top) {
+    gap: 0;
+
+    > label {
+      flex: 2;
+      line-height: var(--input-height);
+    }
+
+    > .form-fields { flex: 3; }
+  }
+
+  fieldset { padding: revert; }
+  .hint { line-height: 16px; }
+
+  button:not(.icon, .fa-solid, .fas) {
+    height: unset;
+    &:not(.unbutton) { line-height: 28px; }
+  }
+
+  :is(document-tags, multi-select) .tags.input-element-tags .tag {
+    padding: 1px 4px;
+    color: var(--color-text-dark-primary);
+    height: unset;
+    opacity: unset;
+  }
+}

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -117,12 +117,6 @@
           min-height: 0;
         }
       }
-
-      // TODO: Restyle context menus and give them fixed positioning.
-      #context-menu {
-        left: unset;
-        right: 0;
-      }
     }
   }
 

--- a/less/v2/items.less
+++ b/less/v2/items.less
@@ -213,6 +213,7 @@
     font-weight: bold;
     color: var(--color-text-dark-5);
     align-items: start;
+    border: none;
 
     .item {
       text-align: center;

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -240,6 +240,11 @@
 
         tr:nth-child(n) { background: unset; }
         td { word-break: normal; }
+
+        th {
+          line-height: normal;
+          font-size: var(--font-size-14);
+        }
       }
 
       tr:nth-child(even) { background-color: var(--dnd5e-color-table-row-even); }
@@ -255,9 +260,10 @@
     text-underline-offset: 2px;
 
     > i {
-      color: var(--dnd5e-color-text-dark-primary);
+      color: var(--color-text-dark-primary);
       opacity: .75;
       transition: opacity 250ms ease;
+      margin-right: .25em;
     }
 
     &.broken {

--- a/less/v2/tooltips.less
+++ b/less/v2/tooltips.less
@@ -5,6 +5,7 @@
     text-align: start;
     color: var(--color-text-dark-primary);
     border-radius: 5px;
+    padding: 6px 8px;
     background: url("ui/texture-gray1.webp") no-repeat top left,
       url("ui/texture-gray2.webp") no-repeat bottom right,
       var(--dnd5e-color-parchment);
@@ -13,6 +14,12 @@
     border-width: 2px;
 
     .content { padding: 0 .5rem .25rem; }
+
+    h1, h2, h3, h4 {
+      line-height: normal;
+      text-shadow: none;
+      color: var(--color-text-dark-primary);
+    }
 
     .header {
       h2 {
@@ -134,16 +141,6 @@
       margin-right: -.5rem;
       scrollbar-width: thin;
       scrollbar-color: var(--dnd5e-color-gold) transparent;
-
-      &::-webkit-scrollbar-track {
-        box-shadow: none;
-        border-radius: 0;
-      }
-
-      &::-webkit-scrollbar-thumb {
-        border: none;
-        background: var(--dnd5e-color-gold);
-      }
 
       table { display: none; }
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -21,6 +21,16 @@
 /* ----------------------------------------- */
 
 :root {
+  --color-text-dark-primary: #191813;
+  --color-text-dark-5: #666;
+  --color-text-light-6: #999;
+  --color-border-light-1: #ddd;
+  --color-border-dark-5: #666;
+  --color-border-light-tertiary: #7a7971;
+  --form-field-height: 26px;
+  --color-shadow-primary: #ff0000;
+  --color-border-light-2: #999;
+
   --dnd5e-color-black: #000;
   --dnd5e-color-dark: #191813;
   --dnd5e-color-faint: #c9c7b8;

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -14,7 +14,7 @@ export default class ActivitySheet extends Application5e {
 
   /** @inheritDoc */
   static DEFAULT_OPTIONS = {
-    classes: ["activity", "sheet"],
+    classes: ["activity", "sheet", "standard-form"],
     tag: "form",
     document: null,
     viewPermission: CONST.DOCUMENT_OWNERSHIP_LEVELS.LIMITED,

--- a/module/applications/api/dialog.mjs
+++ b/module/applications/api/dialog.mjs
@@ -9,6 +9,7 @@ export default class Dialog5e extends Application5e {
     tag: "dialog",
     window: {
       contentTag: "form",
+      contentClasses: ["standard-form"],
       minimizable: false
     }
   };

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -632,7 +632,7 @@ export default class CompendiumBrowser extends foundry.applications.api.Handleba
     const frame = await super._renderFrame(options);
     if ( game.user.isGM ) {
       frame.querySelector('[data-action="close"]').insertAdjacentHTML("beforebegin", `
-        <button type="button" class="header-control fas fa-cog" data-action="configureSources"
+        <button type="button" class="header-control fas fa-cog icon" data-action="configureSources"
                 data-tooltip="DND5E.CompendiumBrowser.Sources.Label"
                 aria-label="${game.i18n.localize("DND5E.CompendiumBrowser.Sources.Label")}"></button>
       `);

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -43,7 +43,7 @@ export default class RollConfigurationDialog extends Application5e {
 
   /** @override */
   static DEFAULT_OPTIONS = {
-    classes: ["roll-configuration"],
+    classes: ["roll-configuration", "standard-form"],
     tag: "form",
     window: {
       title: "DND5E.RollConfiguration.Title",

--- a/module/applications/source-config.mjs
+++ b/module/applications/source-config.mjs
@@ -6,7 +6,7 @@ import DocumentSheet5e from "./api/document-sheet.mjs";
 export default class SourceConfig extends DocumentSheet5e {
   /** @override */
   static DEFAULT_OPTIONS = {
-    classes: ["source-config"],
+    classes: ["source-config", "standard-form"],
     sheetConfig: false,
     position: {
       width: 400

--- a/templates/actors/tabs/character-biography.hbs
+++ b/templates/actors/tabs/character-biography.hbs
@@ -19,7 +19,7 @@
     </div>
 
     {{!-- Ideals, Bonds, Flaws, Personality Traits, & Appearance --}}
-    <div class="middle flexrow">
+    <div class="middle">
         <div class="left">
             {{~> "dnd5e.biography-textbox" name="system.details.ideal" value=system.details.ideal label="DND5E.Ideals"
                 icon="fas fa-seedling" class="textbox-half" ~}}

--- a/templates/apps/source-config.hbs
+++ b/templates/apps/source-config.hbs
@@ -22,7 +22,7 @@
     {{#if hasSourceId}}
     <div class="form-group">
         <label>{{ localize "DND5E.SOURCE.FIELDS.source.uuid.label" }}</label>
-        <div class="source-uuid">
+        <div class="source-uuid form-fields">
             {{{ dnd5e-linkForUuid sourceUuid }}}
         </div>
     </div>


### PR DESCRIPTION
This fixes issues where we were mixing App v1 styles into App v2 apps. I've added `.standard-form` classes where they were missing in order to have the appropriate App v2 styles.

Note that this doesn't change the look of anything (or it shouldn't, anyway), it just means that the V1 compatibility layer in v13 applies appropriately to app v1 apps, and doesn't distort our app v2 apps. The system should look identical between v12 and v13 with only these changes.