### PR TITLE
Various fixes to Hammer of Thunderbolts

### DIFF
--- a/packs/_source/items/weapon/hammer-of-thunderbolts.json
+++ b/packs/_source/items/weapon/hammer-of-thunderbolts.json
@@ -33,13 +33,13 @@
       "value": null,
       "long": 60,
       "units": "ft",
-      "reach": 20
+      "reach": null
     },
     "uses": {
       "max": "5",
       "recovery": [
         {
-          "period": "lr",
+          "period": "dawn",
           "type": "formula",
           "formula": "1d4 + 1"
         }
@@ -91,8 +91,8 @@
     },
     "properties": [
       "hvy",
-      "two",
-      "mgc"
+      "mgc",
+      "two"
     ],
     "proficient": null,
     "type": {
@@ -116,17 +116,7 @@
           "override": false
         },
         "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
+          "targets": [],
           "scaling": {
             "allowed": false,
             "max": ""
@@ -139,13 +129,13 @@
         "duration": {
           "concentration": false,
           "value": "",
-          "units": "",
+          "units": "inst",
           "special": "",
           "override": false
         },
         "effects": [],
         "range": {
-          "value": "20",
+          "value": "",
           "units": "ft",
           "special": "",
           "override": false
@@ -161,8 +151,8 @@
             "units": ""
           },
           "affects": {
-            "count": "",
-            "type": "",
+            "count": "1",
+            "type": "creature",
             "choice": false,
             "special": ""
           },
@@ -190,31 +180,25 @@
         },
         "uses": {
           "spent": 0,
-          "recovery": []
+          "recovery": [],
+          "max": ""
         },
-        "sort": 0
+        "sort": 0,
+        "name": "",
+        "img": "",
+        "appliedEffects": []
       },
       "dnd5eactivity100": {
         "_id": "dnd5eactivity100",
         "type": "save",
         "activation": {
-          "type": "action",
+          "type": "special",
           "value": 1,
           "condition": "",
           "override": false
         },
         "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
+          "targets": [],
           "scaling": {
             "allowed": false,
             "max": ""
@@ -222,21 +206,21 @@
           "spellSlot": true
         },
         "description": {
-          "chatFlavor": ""
+          "chatFlavor": "A giant must succeed or die"
         },
         "duration": {
           "concentration": false,
           "value": "",
-          "units": "",
+          "units": "inst",
           "special": "",
           "override": false
         },
         "effects": [],
         "range": {
-          "value": "20",
-          "units": "ft",
+          "value": "",
+          "units": "spec",
           "special": "",
-          "override": false
+          "override": true
         },
         "target": {
           "template": {
@@ -259,25 +243,7 @@
         },
         "damage": {
           "onSave": "half",
-          "parts": [
-            {
-              "number": 2,
-              "denomination": 6,
-              "bonus": "@mod",
-              "types": [
-                "bludgeoning"
-              ],
-              "custom": {
-                "enabled": false,
-                "formula": ""
-              },
-              "scaling": {
-                "mode": "whole",
-                "number": null,
-                "formula": ""
-              }
-            }
-          ]
+          "parts": []
         },
         "save": {
           "ability": "con",
@@ -288,29 +254,241 @@
         },
         "uses": {
           "spent": 0,
-          "recovery": []
+          "recovery": [],
+          "max": ""
         },
-        "sort": 0
+        "sort": 0,
+        "name": "Crit a Giant: Saving Throw",
+        "img": "",
+        "appliedEffects": []
+      },
+      "HUaufCvw2ISsEtbL": {
+        "type": "attack",
+        "name": "Ranged Attack",
+        "_id": "HUaufCvw2ISsEtbL",
+        "sort": 0,
+        "activation": {
+          "type": "action",
+          "value": null,
+          "override": false,
+          "condition": ""
+        },
+        "consumption": {
+          "scaling": {
+            "allowed": false
+          },
+          "spellSlot": true,
+          "targets": [
+            {
+              "type": "itemUses",
+              "value": "1",
+              "target": "",
+              "scaling": {}
+            }
+          ]
+        },
+        "description": {
+          "chatFlavor": ""
+        },
+        "duration": {
+          "units": "inst",
+          "concentration": false,
+          "override": false
+        },
+        "effects": [],
+        "range": {
+          "override": true,
+          "units": "ft",
+          "special": "",
+          "value": "20"
+        },
+        "target": {
+          "template": {
+            "contiguous": false,
+            "units": "ft",
+            "type": ""
+          },
+          "affects": {
+            "choice": false,
+            "count": "1",
+            "type": "creature",
+            "special": ""
+          },
+          "override": false,
+          "prompt": true
+        },
+        "uses": {
+          "spent": 0,
+          "recovery": [],
+          "max": ""
+        },
+        "attack": {
+          "critical": {
+            "threshold": null
+          },
+          "flat": false,
+          "type": {
+            "value": "ranged",
+            "classification": ""
+          },
+          "ability": "",
+          "bonus": ""
+        },
+        "damage": {
+          "critical": {
+            "bonus": ""
+          },
+          "includeBase": true,
+          "parts": []
+        },
+        "img": "",
+        "appliedEffects": []
+      },
+      "raoOPd1C5wdDhOed": {
+        "type": "save",
+        "name": "Ranged Attack: Saving Throw",
+        "_id": "raoOPd1C5wdDhOed",
+        "sort": 0,
+        "activation": {
+          "type": "special",
+          "value": null,
+          "override": false,
+          "condition": ""
+        },
+        "consumption": {
+          "scaling": {
+            "allowed": false
+          },
+          "spellSlot": true,
+          "targets": []
+        },
+        "description": {
+          "chatFlavor": "Succeed or be stunned"
+        },
+        "duration": {
+          "units": "inst",
+          "concentration": false,
+          "override": false
+        },
+        "effects": [],
+        "range": {
+          "override": true,
+          "units": "spec",
+          "special": ""
+        },
+        "target": {
+          "template": {
+            "contiguous": false,
+            "units": "ft",
+            "type": "sphere",
+            "size": "30",
+            "count": ""
+          },
+          "affects": {
+            "choice": false,
+            "count": "",
+            "type": "creature",
+            "special": ""
+          },
+          "override": false,
+          "prompt": true
+        },
+        "uses": {
+          "spent": 0,
+          "recovery": [],
+          "max": ""
+        },
+        "damage": {
+          "parts": [],
+          "onSave": "half"
+        },
+        "save": {
+          "ability": "con",
+          "dc": {
+            "calculation": "",
+            "formula": "17"
+          }
+        },
+        "img": "",
+        "appliedEffects": []
       }
     },
     "attuned": false,
     "ammunition": {},
-    "identifier": "hammer-of-thunderbolts"
+    "identifier": "hammer-of-thunderbolts",
+    "mastery": ""
   },
-  "effects": [],
+  "effects": [
+    {
+      "name": "Hammer of Thunderbolts",
+      "img": "icons/weapons/hammers/hammer-double-glowing-yellow.webp",
+      "_id": "95tYhecAl2D69Gtv",
+      "type": "base",
+      "system": {},
+      "changes": [
+        {
+          "key": "system.abilities.str.value",
+          "mode": 2,
+          "value": "4",
+          "priority": null
+        },
+        {
+          "key": "system.abilities.str.max",
+          "mode": 4,
+          "value": "30",
+          "priority": null
+        }
+      ],
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>While attuned to the Hammer of Thunderbolts, your Strength score increases by 4 and can exceed 20, but not 30.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "dnd5e",
+        "systemVersion": "4.1.0",
+        "createdTime": 1727820504791,
+        "modifiedTime": 1727820574644,
+        "lastModifiedBy": "dnd5ebuilder0000"
+      },
+      "_key": "!items.effects!wGDDt17DpBcXPuUD.95tYhecAl2D69Gtv"
+    }
+  ],
   "folder": "MLMTCAvKsuFE3vYA",
   "sort": 0,
   "ownership": {
     "default": 0
   },
-  "flags": {},
+  "flags": {
+    "dnd5e": {
+      "riders": {
+        "activity": [],
+        "effect": []
+      }
+    }
+  },
   "_stats": {
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.1.0",
     "createdTime": 1725037317730,
-    "modifiedTime": 1725992556958,
+    "modifiedTime": 1727821208343,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!wGDDt17DpBcXPuUD"


### PR DESCRIPTION
This item was a mess.
- Fixed recovery being set to LR instead of Dawn.
- Fixed both activities consuming limited uses (neither should).
- Changed and renamed the save activity.
- Added two new activities: Ranged attack and the "ranged" saving throw. The ranged attack is the only activity that consumes a charge.
- Set the range of the weapon to 5 ft, and the range of the ranged attack to 20ft. Not possible to give it a 20/60 range.
- Added an effect for +4 STR and STR max raised to 30.
- Moved the template into the ranged saving throw.