### PR TITLE
[#4489] AC cover calculation

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2955,6 +2955,7 @@ DND5E.consumableResources = [
  * @property {string} [exclusiveGroup]  Any status effects with the same group will not be able to be applied at the
  *                                      same time through the token HUD (multiple statuses applied through other
  *                                      effects can still coexist).
+ * @property {number} [coverBonus]      A bonus this condition provides to AC and dexterity saving throws.
  */
 
 /**
@@ -3161,13 +3162,15 @@ DND5E.statusEffects = {
     name: "EFFECT.DND5E.StatusHalfCover",
     icon: "systems/dnd5e/icons/svg/statuses/cover-half.svg",
     order: 2,
-    exclusiveGroup: "cover"
+    exclusiveGroup: "cover",
+    coverBonus: 2
   },
   coverThreeQuarters: {
     name: "EFFECT.DND5E.StatusThreeQuartersCover",
     icon: "systems/dnd5e/icons/svg/statuses/cover-three-quarters.svg",
     order: 3,
-    exclusiveGroup: "cover"
+    exclusiveGroup: "cover",
+    coverBonus: 5
   },
   coverTotal: {
     name: "EFFECT.DND5E.StatusTotalCover",

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -141,7 +141,7 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
       abl.checkProf = new Proficiency(prof, (isRA || flags.jackOfAllTrades) ? 0.5 : 0, !isRA);
       const saveBonusAbl = simplifyBonus(abl.bonuses?.save, rollData);
 
-      const cover = id === "dex" ? Math.max(ac?.cover ?? 0, this.parent.getCoverBonus()) : 0;
+      const cover = id === "dex" ? Math.max(ac?.cover ?? 0, this.parent.coverBonus) : 0;
       abl.saveBonus = saveBonusAbl + saveBonus + cover;
 
       abl.saveProf = new Proficiency(prof, abl.proficient);

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -129,7 +129,7 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
    */
   prepareAbilities({ rollData={}, originalSaves }={}) {
     const flags = this.parent.flags.dnd5e ?? {};
-    const prof = this.attributes?.prof ?? 0;
+    const { prof = 0, ac } = this.attributes ?? {};
     const checkBonus = simplifyBonus(this.bonuses?.abilities?.check, rollData);
     const saveBonus = simplifyBonus(this.bonuses?.abilities?.save, rollData);
     const dcBonus = simplifyBonus(this.bonuses?.spell?.dc, rollData);
@@ -140,7 +140,9 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
       const isRA = this.parent._isRemarkableAthlete(id);
       abl.checkProf = new Proficiency(prof, (isRA || flags.jackOfAllTrades) ? 0.5 : 0, !isRA);
       const saveBonusAbl = simplifyBonus(abl.bonuses?.save, rollData);
-      abl.saveBonus = saveBonusAbl + saveBonus;
+
+      const cover = id === "dex" ? Math.max(ac?.cover ?? 0, this.parent.getCoverBonus()) : 0;
+      abl.saveBonus = saveBonusAbl + saveBonus + cover;
 
       abl.saveProf = new Proficiency(prof, abl.proficient);
       const checkBonusAbl = simplifyBonus(abl.bonuses?.check, rollData);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -572,6 +572,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       ac.equippedShield = shields[0];
     }
 
+    // Compute cover.
+    ac.cover = this.statuses.has("coverThreeQuarters") ? 5 : this.statuses.has("coverHalf") ? 2 : 0;
+
     // Compute total AC and return
     ac.min = simplifyBonus(ac.min, rollData);
     ac.bonus = simplifyBonus(ac.bonus, rollData);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -71,6 +71,19 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
+   * Calculate the bonus from any cover the actor is affected by.
+   * @type {number}     The cover bonus to AC and dexterity saving throws.
+   */
+  get coverBonus() {
+    const { coverHalf, coverThreeQuarters } = CONFIG.DND5E.statusEffects;
+    if ( this.statuses.has("coverThreeQuarters") ) return coverThreeQuarters?.coverBonus;
+    else if ( this.statuses.has("coverHalf") ) return coverHalf?.coverBonus;
+    return 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Get all classes which have spellcasting ability.
    * @type {Record<string, Item5e>}
    */
@@ -273,19 +286,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     return Math.clamp(
       Math.floor(damage / 2), 10, game.settings.get("dnd5e", "rulesVersion") === "modern" ? 30 : Infinity
     );
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Calculate the bonus from any cover the actor is affected by.
-   * @returns {number}      The cover bonus to AC and dexterity saving throws.
-   */
-  getCoverBonus() {
-    const { coverHalf, coverThreeQuarters } = CONFIG.DND5E.statusEffects;
-    if ( this.statuses.has("coverThreeQuarters") ) return coverThreeQuarters?.coverBonus;
-    else if ( this.statuses.has("coverHalf") ) return coverHalf?.coverBonus;
-    return 0;
   }
 
   /* -------------------------------------------- */
@@ -586,7 +586,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     // Compute cover.
-    ac.cover = Math.max(ac.cover, this.getCoverBonus());
+    ac.cover = Math.max(ac.cover, this.coverBonus);
 
     // Compute total AC and return
     ac.min = simplifyBonus(ac.min, rollData);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -283,8 +283,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   getCoverBonus() {
     const { coverHalf, coverThreeQuarters } = CONFIG.DND5E.statusEffects;
-    if ( this.statuses.has("coverThreeQuarters") ) return coverThreeQuarters.coverBonus;
-    else if ( this.statuses.has("coverHalf") ) return coverHalf.coverBonus;
+    if ( this.statuses.has("coverThreeQuarters") ) return coverThreeQuarters?.coverBonus;
+    else if ( this.statuses.has("coverHalf") ) return coverHalf?.coverBonus;
     return 0;
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1686,7 +1686,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     // Include cover in dexterity saving throws
-    if ( abilityId === "dex" && data.attributes?.ac?.cover ) {
+    if ( (abilityId === "dex") && data.attributes?.ac?.cover ) {
       parts.push("@cover");
       data.cover = data.attributes.ac.cover;
     }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -278,6 +278,19 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
+   * Calculate the bonus from any cover the actor is affected by.
+   * @returns {number}      The cover bonus to AC and dexterity saving throws.
+   */
+  getCoverBonus() {
+    const { coverHalf, coverThreeQuarters } = CONFIG.DND5E.statusEffects;
+    if ( this.statuses.has("coverThreeQuarters") ) return coverThreeQuarters.coverBonus;
+    else if ( this.statuses.has("coverHalf") ) return coverHalf.coverBonus;
+    return 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Return the amount of experience required to gain a certain character level.
    * @param {number} level  The desired level.
    * @returns {number}      The XP required.
@@ -573,7 +586,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     // Compute cover.
-    ac.cover = Math.max(ac.cover, this.statuses.has("coverThreeQuarters") ? 5 : this.statuses.has("coverHalf") ? 2 : 0);
+    ac.cover = Math.max(ac.cover, this.getCoverBonus());
 
     // Compute total AC and return
     ac.min = simplifyBonus(ac.min, rollData);
@@ -1670,6 +1683,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( globalBonuses.save ) {
       parts.push("@saveBonus");
       data.saveBonus = Roll.replaceFormulaData(globalBonuses.save, data);
+    }
+
+    // Include cover in dexterity saving throws
+    if ( abilityId === "dex" && data.attributes?.ac?.cover ) {
+      parts.push("@cover");
+      data.cover = data.attributes.ac.cover;
     }
 
     // Add exhaustion reduction

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -573,7 +573,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     // Compute cover.
-    ac.cover = this.statuses.has("coverThreeQuarters") ? 5 : this.statuses.has("coverHalf") ? 2 : 0;
+    ac.cover = Math.max(ac.cover, this.statuses.has("coverThreeQuarters") ? 5 : this.statuses.has("coverHalf") ? 2 : 0);
 
     // Compute total AC and return
     ac.min = simplifyBonus(ac.min, rollData);

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -415,10 +415,10 @@ export default class ChatMessage5e extends ChatMessage {
         <li data-uuid="${uuid}" class="target ${isMiss ? "miss" : "hit"}">
           <i class="fas ${isMiss ? "fa-times" : "fa-check"}"></i>
           <div class="name">${name}</div>
-          ${ac ? `
+          ${(ac !== "") ? `
           <div class="ac">
             <i class="fas fa-shield-halved"></i>
-            <span>${ac}</span>
+            <span>${(ac === null) ? "<i class='fa-solid fa-infinity'></i>" : ac}</span>
           </div>
           ` : ""}
         </li>

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -418,7 +418,7 @@ export default class ChatMessage5e extends ChatMessage {
           ${(ac !== "") ? `
           <div class="ac">
             <i class="fas fa-shield-halved"></i>
-            <span>${(ac === null) ? "<i class='fa-solid fa-infinity'></i>" : ac}</span>
+            <span>${(ac === null) ? "&infin;" : ac}</span>
           </div>
           ` : ""}
         </li>

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -387,8 +387,11 @@ export function getTargetDescriptors() {
   const targets = new Map();
   for ( const token of game.user.targets ) {
     const { name } = token;
-    const { img, system, uuid } = token.actor ?? {};
-    if ( uuid ) targets.set(uuid, { name, img, uuid, ac: system?.attributes?.ac?.value });
+    const { img, system, uuid, statuses } = token.actor ?? {};
+    if ( uuid ) {
+      const ac = statuses.has("coverTotal") ? null : system.attributes?.ac?.value;
+      targets.set(uuid, { name, img, uuid, ac: ac ?? null });
+    }
   }
   return Array.from(targets.values());
 }


### PR DESCRIPTION
During AC preparation, adds +5 to AC if three-quarters cover, else +2 to AC if half cover, else 0.

If a target has full cover during an attack roll, shows their ac as infinity.

![image](https://github.com/user-attachments/assets/f8602019-931b-4a87-9633-234c54cdf453)

Closes #4489.