### PR TITLE
[#4485] Check for HP-related update in `_onUpdate`

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3405,7 +3405,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   async _onUpdate(data, options, userId) {
     super._onUpdate(data, options, userId);
 
-    const isHpUpdate = !!data.system?.attributes?.hp
+    const isHpUpdate = !!data.system?.attributes?.hp;
 
     if ( userId === game.userId ) {
       if ( isHpUpdate ) await this.updateBloodied(options);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3404,14 +3404,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /** @inheritDoc */
   async _onUpdate(data, options, userId) {
     super._onUpdate(data, options, userId);
+
+    const isHpUpdate = !!data.system?.attributes?.hp
+
     if ( userId === game.userId ) {
-      await this.updateBloodied(options);
+      if ( isHpUpdate ) await this.updateBloodied(options);
       await this.updateEncumbrance(options);
       this._onUpdateExhaustion(data, options);
     }
 
     const hp = options.dnd5e?.hp;
-    if ( hp && !options.isRest && !options.isAdvancement ) {
+    if ( isHpUpdate && hp && !options.isRest && !options.isAdvancement ) {
       const curr = this.system.attributes.hp;
       const changes = {
         hp: curr.value - hp.value,


### PR DESCRIPTION
Fixes issues noted in #4485 with actor's `_onUpdate` by adding a check for a HP-related update in the `data`.