### PR TITLE
Allow different base die for core d20 rolls

### DIFF
--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -38,6 +38,7 @@ const { Die, NumericTerm, OperatorTerm } = foundry.dice.terms;
  * @param {object} [options={}]                  Extra optional arguments which describe or modify the D20Roll
  * @param {number} [options.advantageMode]       What advantage modifier to apply to the roll (none, advantage,
  *                                               disadvantage)
+ * @param {number} [options.faces]               The number of faces on the base die.
  * @param {number} [options.critical]            The value of d20 result which represents a critical success
  * @param {number} [options.fumble]              The value of d20 result which represents a critical failure
  * @param {(number)} [options.targetValue]       Assign a target value against which the result of this roll should be
@@ -117,7 +118,7 @@ export default class D20Roll extends Roll {
    * @type {boolean}
    */
   get validD20Roll() {
-    return (this.terms[0] instanceof Die) && (this.terms[0].faces === 20);
+    return (this.terms[0] instanceof Die) && (this.terms[0].faces === this.options.faces);
   }
 
   /* -------------------------------------------- */

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -16,6 +16,7 @@ const { NumericTerm, OperatorTerm } = foundry.dice.terms;
  * ## D20 Properties
  * @property {boolean} [advantage]     Apply advantage to this roll (unless overridden by modifier keys or dialog)?
  * @property {boolean} [disadvantage]  Apply disadvantage to this roll (unless overridden by modifier keys or dialog)?
+ * @property {number|null} [faces=20]  The number of faces on the base die.
  * @property {number|null} [critical=20]  The value of the d20 result which represents a critical success,
  *                                     `null` will prevent critical successes.
  * @property {number|null} [fumble=1]  The value of the d20 result which represents a critical failure,
@@ -58,14 +59,14 @@ const { NumericTerm, OperatorTerm } = foundry.dice.terms;
  */
 export async function d20Roll({
   parts=[], data={}, event,
-  advantage, disadvantage, critical=20, fumble=1, targetValue, attackMode, ammunition, mastery,
+  advantage, disadvantage, faces=20, critical=20, fumble=1, targetValue, attackMode, ammunition, mastery,
   elvenAccuracy, halflingLucky, reliableTalent,
   fastForward, ammunitionOptions, attackModes, chooseModifier=false, masteryOptions, template, title, dialogOptions,
   chatMessage=true, messageData={}, rollMode, flavor
 }={}) {
 
   // Handle input arguments
-  const formula = ["1d20"].concat(parts).join(" + ");
+  const formula = [`1d${faces}`].concat(parts).join(" + ");
   const {advantageMode, isFF} = CONFIG.Dice.D20Roll.determineAdvantageMode({
     advantage, disadvantage, fastForward, event
   });
@@ -79,6 +80,7 @@ export async function d20Roll({
   const roll = new CONFIG.Dice.D20Roll(formula, data, {
     flavor: flavor || title,
     advantageMode,
+    faces,
     defaultRollMode,
     rollMode,
     critical,

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1923,7 +1923,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( flags.initiativeAdv || remarkableAthlete ) options.advantageMode ??= dnd5e.dice.D20Roll.ADV_MODE.ADVANTAGE;
 
     // Standard initiative formula
-    const parts = ["1d20"];
+    const parts = [`1d${options.faces ?? 20}`];
 
     // Special initiative bonuses
     if ( init ) {
@@ -1992,6 +1992,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<void>}           A promise which resolves once initiative has been rolled for the Actor
    */
   async rollInitiativeDialog(rollOptions={}) {
+    Hooks.call("dnd5e.preRollInitiativeDialog", this, rollOptions);
+
     // Create and configure the Initiative roll
     const roll = this.getInitiativeRoll(rollOptions);
     const choice = await roll.configureDialog({


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d493353a-dff1-4878-9678-f0ede3dbe650)

For homebrew purposes, allow modules or world scripts to modify the number of faces of the base die through hooks such as `dnd5e.preRollInitiativeDialog` (added with this PR) or `dnd5e.dnd5e.preRollAbilitySave`. Otherwise, default to the expected d20.

This change adds a `faces` property to `rollData` (or `rollOptions` in the case of initiative), which defaults to 20.

I did consider whether this meant needing to rename all the 'D20' references to something like 'AdvDisRoll', as this change is primarily to allow the base die to be changed for all rolls that use the Advantage/Disadvantage mechanic and all associated features therein. But, I think it's okay to keep the naming around the d20 and this is just a slight allowance for homebrew within that core functionality.
