### PR TITLE
[#4249] Add "Select Class" pill when in editing mode

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -95,6 +95,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     context.labels.class = Object.values(this.actor.classes).sort((a, b) => {
       return b.system.levels - a.system.levels;
     }).map(c => `${c.name} ${c.system.levels}`).join(" / ");
+    context.showClassDrop = !context.labels.class || (this._mode === this.constructor.MODES.EDIT);
 
     // Exhaustion
     const max = CONFIG.DND5E.conditionTypes.exhaustion.levels;
@@ -489,6 +490,10 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     if ( !this.isEditable ) return;
     const filters = { locked: { types: new Set([type]) } };
     if ( classIdentifier ) filters.locked.additional = { class: { [classIdentifier]: 1 } };
+    if ( type === "class" ) {
+      const existingIdentifiers = new Set(Object.keys(this.actor.classes));
+      filters.locked.arbitrary = [{ o: "NOT", v: { k: "system.identifier", o: "in", v: existingIdentifiers } }];
+    }
     const result = await CompendiumBrowser.selectOne({ filters });
     if ( result ) this._onDropItemCreate(await fromUuid(result));
   }

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -21,6 +21,8 @@ import CompendiumBrowserSourceConfig from "./compendium-browser-source-config.mj
  * @property {string} [documentClass]  Document type to fetch (e.g. Actor or Item).
  * @property {Set<string>} [types]     Individual document subtypes to filter upon (e.g. "loot", "class", "npc").
  * @property {object} [additional]     Additional type-specific filters applied.
+ * @property {FilterDescription[]} [arbitrary]  Additional arbitrary filters to apply, not displayed in the UI.
+ *                                     Only available as part of locked filters.
  * @property {string} [name]           A substring to filter by Document name.
  */
 
@@ -589,8 +591,9 @@ export default class CompendiumBrowser extends foundry.applications.api.Handleba
     // TODO: Determine if new set of results need to be fetched, otherwise use old results and re-sort as necessary
     // Sorting changes alone shouldn't require a re-fetch, but any change to filters will
     const filters = CompendiumBrowser.applyFilters(context.filterDefinitions, context.filters.additional);
-    // Add the name filter
+    // Add the name & arbitrary filters
     if ( this.#filters.name?.length ) filters.push({ k: "name", o: "icontains", v: this.#filters.name });
+    if ( context.filters.arbitrary?.length ) filters.push(...context.filters.arbitrary);
     this.#results = CompendiumBrowser.fetch(CONFIG[context.filters.documentClass].documentClass, {
       filters,
       types: context.filters.types,

--- a/templates/actors/character-sheet-2.hbs
+++ b/templates/actors/character-sheet-2.hbs
@@ -487,8 +487,7 @@
 
                 {{!-- Features --}}
                 <div class="tab features" data-group="primary" data-tab="features">
-                    {{> "dnd5e.creature-features" sections=features.sections filters=features.filters
-                        showClassDrop=true }}
+                    {{> "dnd5e.creature-features" sections=features.sections filters=features.filters }}
                 </div>
 
                 {{!-- Spells --}}

--- a/templates/actors/parts/actor-classes.hbs
+++ b/templates/actors/parts/actor-classes.hbs
@@ -58,11 +58,10 @@
     </div>
     {{/dnd5e-itemContext}}
     {{/if}}
-    {{else}}
-    {{#if showClassDrop}}
+    {{/each}}
+    {{#if @root.showClassDrop}}
     <div class="pill-lg empty roboto-upper" data-action="findItem" data-item-type="class">
         {{ localize "DND5E.ClassAdd" }}
     </div>
     {{/if}}
-    {{/each}}
 </section>


### PR DESCRIPTION
Shows the "Select Class" button on the features tab of a character sheet whenever the sheet is in edit mode, even if the character already has a class. When clicking on this, it will show a list of classes excluding any they already have, allowing players to easily add an additional class.

<img width="943" alt="Multiclass Selector" src="https://github.com/user-attachments/assets/a344b67b-e36f-4b80-bdf5-3b09c1f1586d">

To support the extra filters, the Compendium Browser has been modified to support arbitrary filters in the `locked` filters section. These additional filters won't be displayed in the UI and cannot be controled by the user, but will allow for additional control when programatically bringing up the browser. In this case the browser filters out any classes that match the identifiers for the classes already on the character's sheet.

Closes #4249