### PR TITLE
[#4192] Support multiple save abilities to `SaveActivity`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2544,8 +2544,8 @@
     "save": {
       "label": "Save Details",
       "ability": {
-        "label": "Challenge Ability",
-        "hint": "Ability that must be rolled to attempt to save."
+        "label": "Challenge Abilities",
+        "hint": "Abilities that may be rolled to attempt to save."
       },
       "dc": {
         "label": "Difficulty Class",

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -875,9 +875,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
       if ( foundry.utils.getType(save?.ability) === "Set" ) save = {
         ...save, ability: save.ability.size > 2
           ? game.i18n.localize("DND5E.AbbreviationDC")
-          : game.i18n.getListFormatter({ style: "narrow" }).format(
-            Array.from(save.ability).map(k => CONFIG.DND5E.abilities[k].abbreviation)
-          )
+          : Array.from(save.ability).map(k => CONFIG.DND5E.abilities[k].abbreviation).join(" / ")
       };
 
       const css = [];

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -872,6 +872,14 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
         save, range, reference, toggle, suppressed, level
       } = data;
 
+      if ( foundry.utils.getType(save?.ability) === "Set" ) save = {
+        ...save, ability: save.ability.size > 2
+          ? game.i18n.localize("DND5E.AbbreviationDC")
+          : game.i18n.getListFormatter({ style: "narrow" }).format(
+            Array.from(save.ability).map(k => CONFIG.DND5E.abilities[k].abbreviation)
+          )
+      };
+
       const css = [];
       if ( uses?.max ) {
         css.push("uses");

--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -402,7 +402,10 @@ export default function ActorSheetV2Mixin(Base) {
       ctx.toHit = item.hasAttack && !isNaN(toHit) ? toHit : null;
 
       // Save
-      ctx.save = item.system.activities?.getByType("save")[0]?.save;
+      ctx.save = { ...item.system.activities?.getByType("save")[0]?.save };
+      ctx.save.ability = ctx.save.ability?.size ? ctx.save.ability.size === 1
+        ? CONFIG.DND5E.abilities[ctx.save.ability.first()]?.abbreviation
+        : game.i18n.localize("DND5E.AbbreviationDC") : null;
 
       // Activities
       ctx.activities = item.system.activities

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -4,7 +4,7 @@ import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 import AppliedEffectField from "./fields/applied-effect-field.mjs";
 
-const { ArrayField, BooleanField, SchemaField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @typedef {EffectApplicationData} SaveEffectApplicationData
@@ -19,7 +19,7 @@ const { ArrayField, BooleanField, SchemaField, StringField } = foundry.data.fiel
  * @property {DamageData[]} damage.parts            Parts of damage to inflict.
  * @property {SaveEffectApplicationData[]} effects  Linked effects that can be applied.
  * @property {object} save
- * @property {string} save.ability                  Make the saving throw with this ability.
+ * @property {Set<string>} save.ability             Make the saving throw with one of these abilities.
  * @property {object} save.dc
  * @property {string} save.dc.calculation           Method or ability used to calculate the difficulty class.
  * @property {string} save.dc.formula               Custom DC formula or flat value.
@@ -37,7 +37,7 @@ export default class SaveActivityData extends BaseActivityData {
         onSave: new BooleanField()
       })),
       save: new SchemaField({
-        ability: new StringField({ initial: () => Object.keys(CONFIG.DND5E.abilities)[0] }),
+        ability: new SetField(new StringField()),
         dc: new SchemaField({
           calculation: new StringField({ initial: "initial" }),
           formula: new FormulaField({ deterministic: true })
@@ -54,11 +54,21 @@ export default class SaveActivityData extends BaseActivityData {
   get ability() {
     if ( this.save.dc.calculation in CONFIG.DND5E.abilities ) return this.save.dc.calculation;
     if ( this.save.dc.calculation === "spellcasting" ) return this.spellcastingAbility;
-    return this.save.ability;
+    return this.save.ability.first() ?? null;
   }
 
   /* -------------------------------------------- */
   /*  Data Migrations                             */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static migrateData(source) {
+    if ( foundry.utils.getType(source.save?.ability) === "string" ) {
+      if ( source.save.ability ) source.save.ability = [source.save.ability];
+      else source.save.ability = [];
+    }
+  }
+
   /* -------------------------------------------- */
 
   /** @override */
@@ -73,7 +83,7 @@ export default class SaveActivityData extends BaseActivityData {
         parts: source.system.damage?.parts?.map(part => this.transformDamagePartData(source, part)) ?? []
       },
       save: {
-        ability: source.system.save?.ability ?? Object.keys(CONFIG.DND5E.abilities)[0],
+        ability: [source.system.save?.ability ?? Object.keys(CONFIG.DND5E.abilities)[0]],
         dc: {
           calculation,
           formula: String(source.system.save?.dc ?? "")

--- a/module/documents/activity/save.mjs
+++ b/module/documents/activity/save.mjs
@@ -38,21 +38,26 @@ export default class SaveActivity extends ActivityMixin(SaveActivityData) {
 
   /** @override */
   _usageChatButtons(message) {
-    const ability = CONFIG.DND5E.abilities[this.save.ability]?.label ?? "";
+    const buttons = [];
     const dc = this.save.dc.value;
-    const buttons = [{
-      label: `
-        <span class="visible-dc">${game.i18n.format("DND5E.SavingThrowDC", { dc, ability })}</span>
-        <span class="hidden-dc">${game.i18n.format("DND5E.SavePromptTitle", { ability })}</span>
-      `,
-      icon: '<i class="fa-solid fa-shield-heart" inert></i>',
-      dataset: {
-        dc,
-        ability: this.save.ability,
-        action: "rollSave",
-        visibility: "all"
-      }
-    }];
+
+    for ( const abilityId of this.save.ability ) {
+      const ability = CONFIG.DND5E.abilities[abilityId]?.label ?? "";
+      buttons.push({
+        label: `
+          <span class="visible-dc">${game.i18n.format("DND5E.SavingThrowDC", { dc, ability })}</span>
+          <span class="hidden-dc">${game.i18n.format("DND5E.SavePromptTitle", { ability })}</span>
+        `,
+        icon: '<i class="fa-solid fa-shield-heart" inert></i>',
+        dataset: {
+          dc,
+          ability: abilityId,
+          action: "rollSave",
+          visibility: "all"
+        }
+      });
+    }
+
     if ( this.damage.parts.length ) buttons.push({
       label: game.i18n.localize("DND5E.Damage"),
       icon: '<i class="fas fa-burst" inert></i>',
@@ -109,7 +114,7 @@ export default class SaveActivity extends ActivityMixin(SaveActivityData) {
       const speaker = ChatMessage.getSpeaker({ scene: canvas.scene, token: token.document });
       await token.actor.rollSavingThrow({
         event,
-        ability: target.dataset.ability ?? this.save.ability,
+        ability: target.dataset.ability ?? this.save.ability.first(),
         target: Number.isFinite(dc) ? dc : this.save.dc.value
       }, {}, { data: { speaker } });
     }

--- a/templates/actors/character-sheet-2.hbs
+++ b/templates/actors/character-sheet-2.hbs
@@ -405,7 +405,7 @@
                                     {{else if save.dc.value}}
                                     {{#with save}}
                                     <span class="ability">
-                                        {{ lookup (lookup @root.config.abilities ability) "abbreviation" }}
+                                        {{ ability }}
                                     </span>
                                     <span class="value">{{ dc.value }}</span>
                                     {{/with}}

--- a/templates/actors/parts/columns/column-roll.hbs
+++ b/templates/actors/parts/columns/column-roll.hbs
@@ -3,9 +3,7 @@
     <span class="value">{{ dnd5e-formatModifier ctx.toHit }}</span>
     {{else if ctx.save.ability}}
     <div class="stacked">
-        <span class="ability">
-            {{ lookup (lookup @root.config.abilities ctx.save.ability) "abbreviation" }}
-        </span>
+        <span class="ability">{{ ctx.save.ability }}</span>
         <span class="value">{{ ctx.save.dc.value }}</span>
     </div>
     {{/if}}

--- a/templates/actors/tabs/creature-spells.hbs
+++ b/templates/actors/tabs/creature-spells.hbs
@@ -210,9 +210,7 @@
                             <span class="value">{{ dnd5e-formatModifier ctx.toHit }}</span>
                             {{else if ctx.save.ability}}
                             <div class="stacked">
-                                <span class="ability">
-                                    {{ lookup (lookup @root.config.abilities ctx.save.ability) "abbreviation" }}
-                                </span>
+                                <span class="ability">{{ ctx.save.ability }}</span>
                                 <span class="value">{{ ctx.save.dc.value }}</span>
                             </div>
                             {{/if}}


### PR DESCRIPTION
Modifies `SaveActivity` to store a set of abilities rather than a single one that can be rolled to save. When multiple are selected if will display multiple buttons in chat to roll.

Closes #4192