### PR TITLE
[#4061] Allow Cast Activity to trigger linked spells

### DIFF
--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -157,7 +157,7 @@ export default class ActivityUsageDialog extends Dialog5e {
     return {
       ...await super._prepareContext(options),
       activity: this.activity,
-      linkedActivity: !this.config.triggering ? null : this.activity.getLinkedActivity(this.config.triggering.activity)
+      linkedActivity: this.config.cause ? this.activity.getLinkedActivity(this.config.cause.activity) : null
     };
   }
 
@@ -241,7 +241,7 @@ export default class ActivityUsageDialog extends Dialog5e {
     context.notes = [];
 
     if ( this.activity.requiresSpellSlot && this.activity.consumption.spellSlot
-      && this._shouldDisplay("consume.spellSlot") && !this.config.triggering ) context.spellSlot = {
+      && this._shouldDisplay("consume.spellSlot") && !this.config.cause ) context.spellSlot = {
       field: new BooleanField({ label: game.i18n.localize("DND5E.SpellCastConsume") }),
       name: "consume.spellSlot",
       value: this.config.consume?.spellSlot
@@ -267,7 +267,7 @@ export default class ActivityUsageDialog extends Dialog5e {
         }
       };
       addResources(this.activity.consumption.targets, "consume.resources");
-      if ( context.linkedActivity ) addResources(context.linkedActivity.consumption.targets, "triggering.resources");
+      if ( context.linkedActivity ) addResources(context.linkedActivity.consumption.targets, "cause.resources");
     }
 
     context.hasConsumption = context.spellSlot || context.resources;
@@ -472,7 +472,7 @@ export default class ActivityUsageDialog extends Dialog5e {
       submitData.scaling = submitData.scalingValue - 1;
       delete submitData.scalingValue;
     }
-    for ( const key of ["consume", "triggering"] ) {
+    for ( const key of ["consume", "cause"] ) {
       if ( foundry.utils.getType(submitData[key]?.resources) === "Object" ) {
         submitData[key].resources = filteredKeys(submitData[key].resources).map(i => Number(i));
       }

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -156,7 +156,8 @@ export default class ActivityUsageDialog extends Dialog5e {
     if ( "scaling" in this.config ) this.#item = this.#item.clone({ "flags.dnd5e.scaling": this.config.scaling });
     return {
       ...await super._prepareContext(options),
-      activity: this.activity
+      activity: this.activity,
+      linkedActivity: !this.config.triggering ? null : this.activity.getLinkedActivity(this.config.triggering.activity)
     };
   }
 
@@ -240,7 +241,7 @@ export default class ActivityUsageDialog extends Dialog5e {
     context.notes = [];
 
     if ( this.activity.requiresSpellSlot && this.activity.consumption.spellSlot
-      && this._shouldDisplay("consume.spellSlot") ) context.spellSlot = {
+      && this._shouldDisplay("consume.spellSlot") && !this.config.triggering ) context.spellSlot = {
       field: new BooleanField({ label: game.i18n.localize("DND5E.SpellCastConsume") }),
       name: "consume.spellSlot",
       value: this.config.consume?.spellSlot
@@ -248,20 +249,25 @@ export default class ActivityUsageDialog extends Dialog5e {
 
     if ( this._shouldDisplay("consume.resources") ) {
       context.resources = [];
-      const isArray = foundry.utils.getType(this.config.consume?.resources) === "Array";
-      for ( const [index, target] of this.activity.consumption.targets.entries() ) {
-        const value = (isArray && this.config.consume.resources.includes(index))
-          || (!isArray && (this.config.consume?.resources !== false) && (this.config.consume !== false));
-        const { label, hint, notes, warn } = target.getConsumptionLabels(this.config, value);
-        if ( notes?.length ) context.notes.push(...notes);
-        context.resources.push({
-          field: new BooleanField({ label, hint }),
-          input: context.inputs.createCheckboxInput,
-          name: `consume.resources.${index}`,
-          value,
-          warn: value ? warn : false
-        });
-      }
+      const addResources = (targets, keyPath) => {
+        const consume = foundry.utils.getProperty(this.config, keyPath);
+        const isArray = foundry.utils.getType(consume) === "Array";
+        for ( const [index, target] of targets.entries() ) {
+          const value = (isArray && consume.includes(index))
+            || (!isArray && (consume !== false) && (this.config.consume !== false));
+          const { label, hint, notes, warn } = target.getConsumptionLabels(this.config, value);
+          if ( notes?.length ) context.notes.push(...notes);
+          context.resources.push({
+            field: new BooleanField({ label, hint }),
+            input: context.inputs.createCheckboxInput,
+            name: `${keyPath}.${index}`,
+            value,
+            warn: value ? warn : false
+          });
+        }
+      };
+      addResources(this.activity.consumption.targets, "consume.resources");
+      if ( context.linkedActivity ) addResources(context.linkedActivity.consumption.targets, "triggering.resources");
     }
 
     context.hasConsumption = context.spellSlot || context.resources;
@@ -327,7 +333,26 @@ export default class ActivityUsageDialog extends Dialog5e {
       return context;
     }
 
-    if ( this.activity.requiresSpellSlot && (this.config.scaling !== false) ) {
+    const scale = (context.linkedActivity ?? this.activity).consumption.scaling;
+    const rollData = (context.linkedActivity ?? this.activity).getRollData({ deterministic: true });
+
+    if ( this.activity.requiresSpellSlot && context.linkedActivity && (this.config.scaling !== false) ) {
+      const max = simplifyBonus(scale.max, rollData);
+      const minimumLevel = this.item.system.level ?? 1;
+      const maximumLevel = scale.allowed ? scale.max ? minimumLevel + max - 1 : Infinity : minimumLevel;
+      const spellSlotOptions = Object.entries(CONFIG.DND5E.spellLevels).map(([level, label]) => {
+        if ( (Number(level) < minimumLevel) || (Number(level) > maximumLevel) ) return null;
+        return { value: `spell${level}`, label };
+      }).filter(_ => _);
+      context.spellSlots = {
+        field: new StringField({ label: game.i18n.localize("DND5E.SpellCastUpcast") }),
+        name: "spell.slot",
+        value: this.config.spell?.slot,
+        options: spellSlotOptions
+      };
+    }
+
+    else if ( this.activity.requiresSpellSlot && (this.config.scaling !== false) ) {
       const minimumLevel = this.item.system.level ?? 1;
       const maximumLevel = Object.values(this.actor.system.spells)
         .reduce((max, d) => d.max ? Math.max(max, d.level) : max, 0);
@@ -347,9 +372,9 @@ export default class ActivityUsageDialog extends Dialog5e {
         const disabled = (slot.value === 0) && consumeSlot;
         if ( !disabled && !spellSlotValue ) spellSlotValue = value;
         return { value, label, disabled, selected: spellSlotValue === value };
-      }).filter(o => o);
+      }).filter(_ => _);
 
-      if ( spellSlotOptions ) context.spellSlots = {
+      context.spellSlots = {
         field: new StringField({ label: game.i18n.localize("DND5E.SpellCastUpcast") }),
         name: "spell.slot",
         value: spellSlotValue,
@@ -363,9 +388,8 @@ export default class ActivityUsageDialog extends Dialog5e {
       });
     }
 
-    else if ( this.activity.consumption.scaling.allowed && (this.config.scaling !== false) ) {
-      const scale = this.activity.consumption.scaling;
-      const max = scale.max ? simplifyBonus(scale.max, this.activity.getRollData({ deterministic: true })) : Infinity;
+    else if ( scale.allowed && (this.config.scaling !== false) ) {
+      const max = scale.max ? simplifyBonus(scale.max, rollData) : Infinity;
       if ( max > 1 ) context.scaling = {
         field: new NumberField({ min: 1, max, label: game.i18n.localize("DND5E.ScalingValue") }),
         name: "scalingValue",
@@ -448,8 +472,10 @@ export default class ActivityUsageDialog extends Dialog5e {
       submitData.scaling = submitData.scalingValue - 1;
       delete submitData.scalingValue;
     }
-    if ( foundry.utils.getType(submitData.consume?.resources) === "Object" ) {
-      submitData.consume.resources = filteredKeys(submitData.consume.resources).map(i => Number(i));
+    for ( const key of ["consume", "triggering"] ) {
+      if ( foundry.utils.getType(submitData[key]?.resources) === "Object" ) {
+        submitData[key].resources = filteredKeys(submitData[key].resources).map(i => Number(i));
+      }
     }
     return submitData;
   }

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -72,13 +72,13 @@ export default class CastActivity extends ActivityMixin(CastActivityData) {
 
     let spell = this.cachedSpell;
     if ( !spell ) {
-      spell = await this.actor.createEmbeddedDocuments("Item", [await this.getCachedSpellData()])[0];
+      [spell] = await this.actor.createEmbeddedDocuments("Item", [await this.getCachedSpellData()]);
     }
 
     const results = await spell.use({ ...usage, legacy: false }, dialog, message);
 
     /**
-     * A hook event that fires after an linked spell is used by a Cast activity.
+     * A hook event that fires after a linked spell is used by a Cast activity.
      * @function dnd5e.postUseLinkedSpell
      * @memberof hookEvents
      * @param {Activity} activity                              Activity being activated.

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -138,6 +138,10 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    *                                                 scaling is not allowed.
    * @property {object} spell
    * @property {number} spell.slot                   The spell slot to consume.
+   * @property {object} [triggering]
+   * @property {string} [triggering.activity]        Relative UUID to the activity triggering this one. Activity must
+   *                                                 be on the same actor as this one.
+   * @property {boolean|number[]} [triggering.resources]  Control resource consumption on linked item.
    */
 
   /**
@@ -427,14 +431,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @returns {ActivityConsumptionDescriptor}  Information on consumption performed to store in message flag.
    */
   async #applyUsageUpdates(updates) {
-    // Merge activity changes into the item updates
-    if ( !foundry.utils.isEmpty(updates.activity) ) {
-      const itemIndex = updates.item.findIndex(i => i._id === this.item.id);
-      const keyPath = `system.activities.${this.id}`;
-      const activityUpdates = foundry.utils.expandObject(updates.activity);
-      if ( itemIndex === -1 ) updates.item.push({ _id: this.item.id, [keyPath]: activityUpdates });
-      else updates.item[itemIndex][keyPath] = activityUpdates;
-    }
+    this._mergeActivityUpdates(updates);
 
     // Create the consumed flag
     const getDeltas = (document, updates) => {
@@ -614,6 +611,13 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       })?.id ?? effects.first()?.id ?? null;
     }
 
+    const linked = this.getLinkedActivity();
+    if ( linked ) {
+      config.triggering ??= {};
+      config.triggering.activity ??= linked.relativeUUID;
+      config.triggering.resources ??= true;
+    }
+
     return config;
   }
 
@@ -660,11 +664,14 @@ export default Base => class extends PseudoDocumentMixin(Base) {
 
   /**
    * Calculate changes to actor, items, & this activity based on resource consumption.
-   * @param {ActivityUseConfiguration} config  Usage configuration.
-   * @returns {ActivityUsageUpdates|false}     Updates to perform, or `false` if a consumption error occurred.
+   * @param {ActivityUseConfiguration} config                  Usage configuration.
+   * @param {object} [options={}]
+   * @param {boolean} [options.returnErrors=false]             Return array of errors, rather than displaying them.
+   * @returns {ActivityUsageUpdates|ConsumptionError[]|false}  Updates to perform, an array of ConsumptionErrors,
+   *                                                           or `false` if a consumption error occurred.
    * @protected
    */
-  async _prepareUsageUpdates(config) {
+  async _prepareUsageUpdates(config, { returnErrors=false }={}) {
     const updates = { activity: {}, actor: {}, delete: [], item: [], rolls: [] };
     if ( config.consume === false ) return updates;
     const errors = [];
@@ -684,8 +691,31 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       }
     }
 
+    // Handle consumption on a linked activity
+    if ( config.triggering ) {
+      const linkedActivity = this.getLinkedActivity(config.triggering.activity);
+      if ( linkedActivity ) {
+        const consume = {
+          resources: (config.consume === true) || (config.triggering?.resources === true)
+            ? linkedActivity.consumption.targets.keys() : config.triggering?.resources,
+          spellSlot: false
+        };
+        const usageConfig = foundry.utils.mergeObject(config, { consume, triggering: false }, { inplace: true });
+        const results = await linkedActivity._prepareUsageUpdates(usageConfig, { returnErrors: true });
+        if ( foundry.utils.getType(results) === "Object" ) {
+          linkedActivity._mergeActivityUpdates(results);
+          foundry.utils.mergeObject(updates.actor, results.actor);
+          updates.delete.push(...results.delete);
+          updates.item.push(...results.item);
+          updates.rolls.push(...results.rolls);
+        } else if ( results?.length ) {
+          errors.push(...results);
+        }
+      }
+    }
+
     // Handle spell slot consumption
-    if ( ((config.consume === true) || config.consume.spellSlot)
+    else if ( ((config.consume === true) || config.consume.spellSlot)
       && this.requiresSpellSlot && this.consumption.spellSlot ) {
       const mode = this.item.system.preparation.mode;
       const isLeveled = ["always", "prepared"].includes(mode);
@@ -722,8 +752,8 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       );
     }
 
-    errors.forEach(err => ui.notifications.error(err.message, { console: false }));
-    return errors.length ? false : updates;
+    if ( !returnErrors ) errors.forEach(err => ui.notifications.error(err.message, { console: false }));
+    return errors.length ? returnErrors ? errors : false : updates;
   }
 
   /* -------------------------------------------- */
@@ -1193,7 +1223,10 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   async #consumeResource(event, target, message) {
     const messageConfig = {};
     const scaling = message.getFlag("dnd5e", "scaling");
-    await this.consume({ consume: true, event, scaling }, messageConfig);
+    const usageConfig = { consume: true, event, scaling };
+    const linkedActivity = this.getLinkedActivity();
+    if ( linkedActivity ) usageConfig.triggering = { activity: linkedActivity.relativeUUID, resources: true };
+    await this.consume(usageConfig, messageConfig);
     if ( !foundry.utils.isEmpty(messageConfig.data) ) await message.update(messageConfig.data);
   }
 
@@ -1257,6 +1290,19 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   /* -------------------------------------------- */
 
   /**
+   * Retrieve a linked activity based on the provided relative UUID, or the stored `cachedFor` value.
+   * @param {string} relativeUUID  Relative UUID for an activity on this actor.
+   * @returns {Activity|null}
+   */
+  getLinkedActivity(relativeUUID) {
+    if ( !this.actor ) return null;
+    relativeUUID ??= this.item.getFlag("dnd5e", "cachedFor");
+    return fromUuidSync(relativeUUID, { relative: this.actor, strict: false });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Prepare a data object which defines the data schema used by dice roll commands against this Activity.
    * @param {object} [options]
    * @param {boolean} [options.deterministic]  Whether to force deterministic values for data properties that could
@@ -1268,5 +1314,22 @@ export default Base => class extends PseudoDocumentMixin(Base) {
     rollData.activity = { ...this };
     rollData.mod = this.actor?.system.abilities?.[this.ability]?.mod ?? 0;
     return rollData;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Merge the activity updates into this activity's item updates.
+   * @param {ActivityUsageUpdates} updates
+   * @internal
+   */
+  _mergeActivityUpdates(updates) {
+    if ( !foundry.utils.isEmpty(updates.activity) ) {
+      const itemIndex = updates.item.findIndex(i => i._id === this.item.id);
+      const keyPath = `system.activities.${this.id}`;
+      const activityUpdates = foundry.utils.expandObject(updates.activity);
+      if ( itemIndex === -1 ) updates.item.push({ _id: this.item.id, [keyPath]: activityUpdates });
+      else updates.item[itemIndex][keyPath] = activityUpdates;
+    }
   }
 };


### PR DESCRIPTION
Overrides the `use` method on `CastActivity` to trigger the cached spell, rather than the activity itself. If the spell isn't cached, it will first create a new cached copy. Triggers the `use` method on the spell item so that the activity selection dialog can be shown if necessary.

The `CastActivity` introduces two new hooks: `dnd5e.preUseLinkedSpell` and `dnd5e.poseUseLinkedSpell`.

Adds a new option to `ActivtyUseConfiguration` called `triggering` which contains the relative UUID of the activity triggering this one as well as resource consumption options. This value is filled automatically if the item has the `cachedFor` flag unless it is explicitly set to `false`.

If `triggering` is set in the usage configuration, then during the consumption process the system will also trigger the consumption process on the triggering activity and merge its changes with that of the main activity.

Some changes have been made to `ActivityUsageDialog` to show consumption for both the triggering and triggered activities, and to modify the spell slots list to reflect the scaling restriction on the triggering activity.

## Todo
- [x] Properly handle consumption warnings on triggering activity once #4261 is resolved