### PR TITLE
[#4536] Fix typo in variable name causing `ReferenceError` in deprecated hooks

### DIFF
--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -479,7 +479,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
     } else if ( foundry.utils.getType(usageConfig.consume?.resources) === "Array" ) {
       for ( const index of usageConfig.consume.resources ) {
         if ( ["activityUses", "itemUses"].includes(this.consumption.targets[index]?.type) ) consumeUsage = true;
-        else consummeResource = true;
+        else consumeResource = true;
       }
     }
     return {


### PR DESCRIPTION
Closes #4536