### PR TITLE
[#1530, #2138] Re-implement `rollSkill` and `rollToolCheck`

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1193,7 +1193,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
   _onRollSkillCheck(event) {
     event.preventDefault();
     const skill = event.currentTarget.closest("[data-key]").dataset.key;
-    return this.actor.rollSkill(skill, {event: event});
+    return this.actor.rollSkill({ skill, event });
   }
 
   /* -------------------------------------------- */
@@ -1201,7 +1201,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
   _onRollToolCheck(event) {
     event.preventDefault();
     const tool = event.currentTarget.closest("[data-key]").dataset.key;
-    return this.actor.rollToolCheck(tool, {event});
+    return this.actor.rollToolCheck({ tool, event });
   }
 
   /* -------------------------------------------- */

--- a/module/applications/dice/_module.mjs
+++ b/module/applications/dice/_module.mjs
@@ -1,3 +1,4 @@
 export {default as D20RollConfigurationDialog} from "./d20-configuration-dialog.mjs";
 export {default as DamageRollConfigurationDialog} from "./damage-configuration-dialog.mjs";
 export {default as RollConfigurationDialog} from "./roll-configuration-dialog.mjs";
+export {default as SkillToolRollConfigurationDialog} from "./skill-tool-configuration-dialog.mjs";

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -6,10 +6,19 @@ const { DiceTerm } = foundry.dice.terms;
  * Dialog rendering options for a roll configuration dialog.
  *
  * @typedef {object} BasicRollConfigurationDialogOptions
- * @property {typeof BasicRoll} rollType  Roll type to use when constructing final roll.
+ * @property {typeof BasicRoll} rollType              Roll type to use when constructing final roll.
  * @property {object} [default]
- * @property {number} [default.rollMode]  Default roll mode to have selected.
+ * @property {number} [default.rollMode]              Default roll mode to have selected.
+ * @property {RollBuildConfigCallback} [buildConfig]  Callback to handle additional build configuration.
  * @property {BasicRollConfigurationDialogRenderOptions} [rendering]
+ */
+
+/**
+ * @callback {RollBuildConfigCallback}
+ * @param {BasicRollProcessConfiguration} process  Configuration for the entire rolling process.
+ * @param {BasicRollConfiguration} config          Configuration for a specific roll.
+ * @param {FormDataExtended} [formData]            Any data entered into the rolling prompt.
+ * @param {number} index                           Index of the roll within all rolls being prepared.
  */
 
 /**
@@ -54,6 +63,7 @@ export default class RollConfigurationDialog extends Dialog5e {
     position: {
       width: 400
     },
+    buildConfig: null,
     rendering: {
       dice: {
         max: 5,
@@ -311,6 +321,8 @@ export default class RollConfigurationDialog extends Dialog5e {
     } else {
       config.parts.findSplice(v => v === "@situational");
     }
+
+    this.options.buildConfig?.(this.config, config, formData, index);
 
     return config;
   }

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -14,7 +14,7 @@ const { DiceTerm } = foundry.dice.terms;
  */
 
 /**
- * @callback {RollBuildConfigCallback}
+ * @callback RollBuildConfigCallback
  * @param {BasicRollProcessConfiguration} process  Configuration for the entire rolling process.
  * @param {BasicRollConfiguration} config          Configuration for a specific roll.
  * @param {FormDataExtended} [formData]            Any data entered into the rolling prompt.

--- a/module/applications/dice/skill-tool-configuration-dialog.mjs
+++ b/module/applications/dice/skill-tool-configuration-dialog.mjs
@@ -1,0 +1,32 @@
+import D20RollConfigurationDialog from "./d20-configuration-dialog.mjs";
+
+/**
+ * @typedef {BasicRollConfigurationDialogOptions} SkillToolRollConfigurationDialogOptions
+ * @property {boolean} chooseAbility  Should the ability be selectable?
+ */
+
+/**
+ * Extended roll configuration dialog that allows selecting abilities.
+ */
+export default class SkillToolRollConfigurationDialog extends D20RollConfigurationDialog {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    chooseAbility: true
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareConfigurationContext(context, options) {
+    context = await super._prepareConfigurationContext(context, options);
+    if ( this.options.chooseAbility ) context.fields.unshift({
+      field: new foundry.data.fields.StringField({ label: game.i18n.localize("DND5E.Abilities") }),
+      name: "ability",
+      options: Object.entries(CONFIG.DND5E.abilities).map(([value, { label }]) => ({ value, label })),
+      value: this.config.ability
+    });
+    return context;
+  }
+}

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -137,8 +137,7 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
       if ( flags.diamondSoul ) abl.proficient = 1;  // Diamond Soul is proficient in all saves
       abl.mod = Math.floor((abl.value - 10) / 2);
 
-      const isRA = this.parent._isRemarkableAthlete(id);
-      abl.checkProf = new Proficiency(prof, (isRA || flags.jackOfAllTrades) ? 0.5 : 0, !isRA);
+      abl.checkProf = this.calculateAbilityCheckProficiency(0, id);
       const saveBonusAbl = simplifyBonus(abl.bonuses?.save, rollData);
 
       const cover = id === "dex" ? Math.max(ac?.cover ?? 0, this.parent.coverBonus) : 0;
@@ -157,5 +156,28 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
       // If we merged saves when transforming, take the highest bonus here.
       if ( originalSaves && abl.proficient ) abl.save = Math.max(abl.save, originalSaves[id].save);
     }
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Create the proficiency object for an ability, skill, or tool, taking remarkable athlete and Jack of All Trades
+   * into account.
+   * @param {number} multiplier  Multiplier stored on the actor.
+   * @param {string} ability     Ability associated with this proficiency.
+   * @returns {Proficiency}
+   */
+  calculateAbilityCheckProficiency(multiplier, ability) {
+    let roundDown = true;
+    if ( multiplier < 1 ) {
+      if ( this.parent._isRemarkableAthlete(ability) ) {
+        multiplier = .5;
+        roundDown = false;
+      }
+      else if ( this.parent.flags.dnd5e?.jackOfAllTrades ) multiplier = .5;
+    }
+    return new Proficiency(this.attributes.prof, multiplier, roundDown);
   }
 }

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -1,4 +1,5 @@
 import D20RollConfigurationDialog from "../applications/dice/d20-configuration-dialog.mjs";
+import SkillToolRollConfigurationDialog from "../applications/dice/skill-tool-configuration-dialog.mjs";
 import { areKeysPressed } from "../utils.mjs";
 import BasicRoll from "./basic-roll.mjs";
 
@@ -311,7 +312,8 @@ export default class D20Roll extends BasicRoll {
       "The `configureDialog` on D20Roll has been deprecated and is now handled through `D20Roll.build`.",
       { since: "DnD5e 4.1", until: "DnD5e 4.5" }
     );
-    const DialogClass = this.constructor.DefaultConfigurationDialog;
+    let DialogClass = this.constructor.DefaultConfigurationDialog;
+    if ( chooseModifier ) DialogClass = SkillToolRollConfigurationDialog;
     const defaultButton = {
       [D20Roll.ADV_MODE.NORMAL]: "normal",
       [D20Roll.ADV_MODE.ADVANTAGE]: "advantage",
@@ -383,7 +385,7 @@ export function _createDeprecatedD20Config(rollConfig, dialogConfig, messageConf
     reliableTalent: rollConfig.reliableTalent,
     // TODO: ammunitionOptions
     // TODO: attackModes
-    // TODO: chooseModifier
+    chooseModifier: dialogConfig.options?.chooseAbility,
     // TODO: masteryOptions
     title: dialogConfig.options?.title,
     dialogOptions: dialogConfig.options,
@@ -430,9 +432,9 @@ export function _applyDeprecatedD20Configs(rollConfig, dialogConfig, messageConf
   if ( "fastForward" in options ) dialogConfig.configure = !options.fastForward;
   // TODO: ammunitionOptions
   // TODO: attackModes
-  // TODO: chooseModifier
   // TODO: masteryOptions
   set(dialogConfig, "options", options.dialogOptions);
+  set(dialogConfig, "options.chooseAbility", options.chooseModifier);
   set(dialogConfig, "options.title", options.title);
   set(messageConfig, "create", options.chatMessage);
   set(messageConfig, "data", options.messageData);

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -108,11 +108,6 @@ export async function d20Roll({
 
   // TODO: Delete this reference code once skill, tool, and attack rolls are properly handled
 
-  if ( chooseModifier && !isFF ) {
-    data.mod = "@mod";
-    if ( "abilityCheckBonus" in data ) data.abilityCheckBonus = "@abilityCheckBonus";
-  }
-
   // Prompt a Dialog to further configure the D20Roll
   if ( !isFF ) {
   } else {

--- a/module/documents/activity/check.mjs
+++ b/module/documents/activity/check.mjs
@@ -95,26 +95,22 @@ export default class CheckActivity extends ActivityMixin(CheckActivityData) {
     if ( !targets.length ) ui.notifications.warn("DND5E.ActionWarningNoToken", { localize: true });
     let { ability, dc, skill, tool } = target.dataset;
     dc = parseInt(dc);
-    const data = { event, targetValue: Number.isFinite(dc) ? dc : this.check.dc.value };
+    const rollData = { event, target: Number.isFinite(dc) ? dc : this.check.dc.value };
+    if ( ability in CONFIG.DND5E.abilities ) rollData.ability = ability;
 
     for ( const token of targets ) {
-      data.speaker = ChatMessage.getSpeaker({ scene: canvas.scene, token: token.document });
-      if ( skill ) {
-        await token.actor.rollSkill(skill, { ...data, ability });
-      } else if ( tool ) {
-        const checkData = { ...data, ability };
+      const messageData = { data: { speaker: ChatMessage.getSpeaker({ scene: canvas.scene, token: token.document }) } };
+      if ( skill ) await token.actor.rollSkill({ ...rollData, skill }, {}, messageData);
+      else if ( tool ) {
+        rollData.tool = tool;
         if ( (this.item.type === "tool") && !this.check.associated.size ) {
-          checkData.bonus = this.item.system.bonus;
-          checkData.prof = this.item.system.prof;
-          checkData.item = this.item;
+          rollData.bonus = this.item.system.bonus;
+          rollData.prof = this.item.system.prof;
+          rollData.item = this.item;
         }
-        await token.actor.rollToolCheck(tool, checkData);
-      } else {
-        await token.actor.rollAbilityCheck({
-          ability,
-          target: data.targetValue
-        }, {}, { data: { speaker: data.speaker } });
+        await token.actor.rollToolCheck(rollData, {}, messageData);
       }
+      else await token.actor.rollAbilityCheck(rollData, {}, messageData);
     }
   }
 }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -443,7 +443,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     // Compute modifier
     const checkBonusAbl = simplifyBonus(abilityData?.bonuses?.check, rollData);
-    skillData.baseValue = skillData.value;
+    skillData.effectValue = skillData.value;
     skillData.bonus = baseBonus + globalCheckBonus + checkBonusAbl + globalSkillBonus;
     skillData.mod = abilityData?.mod ?? 0;
     skillData.prof = this.system.calculateAbilityCheckProficiency(skillData.value, skillData.ability);
@@ -474,7 +474,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       const ability = this.system.abilities[tool.ability];
       const baseBonus = simplifyBonus(tool.bonuses.check, bonusData);
       const checkBonusAbl = simplifyBonus(ability?.bonuses?.check, bonusData);
-      tool.baseValue = tool.value;
+      tool.effectValue = tool.value;
       tool.bonus = baseBonus + checkBonus + checkBonusAbl;
       tool.mod = ability?.mod ?? 0;
       tool.prof = this.system.calculateAbilityCheckProficiency(tool.value, tool.ability);
@@ -1508,7 +1508,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const rollData = this.getRollData();
     const abilityId = formData?.get("ability") ?? process.ability;
     const ability = this.system.abilities?.[abilityId];
-    const prof = this.system.calculateAbilityCheckProficiency(relevant.baseValue, abilityId);
+    const prof = this.system.calculateAbilityCheckProficiency(relevant.effectValue, abilityId);
 
     let { parts, data } = CONFIG.Dice.BasicRoll.constructParts({
       mod: ability?.mod,

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -443,10 +443,11 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     // Compute modifier
     const checkBonusAbl = simplifyBonus(abilityData?.bonuses?.check, rollData);
+    skillData.baseValue = skillData.value;
     skillData.bonus = baseBonus + globalCheckBonus + checkBonusAbl + globalSkillBonus;
     skillData.mod = abilityData?.mod ?? 0;
     skillData.prof = this.system.calculateAbilityCheckProficiency(skillData.value, skillData.ability);
-    skillData.proficient = skillData.value;
+    skillData.value = skillData.proficient = skillData.prof.multiplier;
     skillData.total = skillData.mod + skillData.bonus;
     if ( Number.isNumeric(skillData.prof.term) ) skillData.total += skillData.prof.flat;
 
@@ -473,11 +474,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       const ability = this.system.abilities[tool.ability];
       const baseBonus = simplifyBonus(tool.bonuses.check, bonusData);
       const checkBonusAbl = simplifyBonus(ability?.bonuses?.check, bonusData);
+      tool.baseValue = tool.value;
       tool.bonus = baseBonus + checkBonus + checkBonusAbl;
       tool.mod = ability?.mod ?? 0;
       tool.prof = this.system.calculateAbilityCheckProficiency(tool.value, tool.ability);
       tool.total = tool.mod + tool.bonus;
       if ( Number.isNumeric(tool.prof.term) ) tool.total += tool.prof.flat;
+      tool.value = tool.prof.multiplier;
     }
   }
 
@@ -1503,11 +1506,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   _buildSkillToolConfig(type, initialRoll, process, config, formData, index) {
     const relevant = type === "skill" ? this.system.skills?.[process.skill] : this.system.tools?.[process.tool];
     const rollData = this.getRollData();
-    const defaultAbility = relevant?.ability
-      ?? (type === "skill" ? CONFIG.DND5E.skills[process.skill].ability : CONFIG.DND5E.tools[process.tool].ability);
-    const abilityId = formData?.get("ability") ?? process.ability ?? defaultAbility;
+    const abilityId = formData?.get("ability") ?? process.ability;
     const ability = this.system.abilities?.[abilityId];
-    const prof = this.system.calculateAbilityCheckProficiency(relevant.value, abilityId);
+    const prof = this.system.calculateAbilityCheckProficiency(relevant.baseValue, abilityId);
 
     let { parts, data } = CONFIG.Dice.BasicRoll.constructParts({
       mod: ability?.mod,

--- a/module/documents/actor/proficiency.mjs
+++ b/module/documents/actor/proficiency.mjs
@@ -29,23 +29,14 @@ export default class Proficiency {
   }
 
   /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
 
   /**
    * Should only deterministic proficiency be returned, regardless of system settings?
    * @type {boolean}
    */
   deterministic = false;
-
-  /* -------------------------------------------- */
-
-  /**
-   * Calculate an actor's proficiency modifier based on level or CR.
-   * @param {number} level  Level or CR To use for calculating proficiency modifier.
-   * @returns {number}      Proficiency modifier.
-   */
-  static calculateMod(level) {
-    return Math.floor((level + 7) / 4);
-  }
 
   /* -------------------------------------------- */
 
@@ -96,10 +87,40 @@ export default class Proficiency {
   }
 
   /* -------------------------------------------- */
+  /*  Methods                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Calculate an actor's proficiency modifier based on level or CR.
+   * @param {number} level  Level or CR To use for calculating proficiency modifier.
+   * @returns {number}      Proficiency modifier.
+   */
+  static calculateMod(level) {
+    return Math.floor((level + 7) / 4);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Return a clone of this proficiency with any changes applied.
+   * @param {object} [updates={}]
+   * @param {number} updates.proficiency  Actor's flat proficiency bonus based on their current level.
+   * @param {number} updates.multiplier   Value by which to multiply the actor's base proficiency value.
+   * @param {boolean} updates.roundDown   Should half-values be rounded up or down?
+   * @returns {Proficiency}
+   */
+  clone({ proficiency, multiplier, roundDown }={}) {
+    proficiency ??= this._baseProficiency;
+    multiplier ??= this.multiplier;
+    roundDown ??= this.rounding === "down";
+    return new this.constructor(proficiency, multiplier, roundDown);
+  }
+
+  /* -------------------------------------------- */
 
   /**
    * Override the default `toString` method to return flat proficiency for backwards compatibility in formula.
-   * @returns {string}  Flat proficiency value.
+   * @returns {string}  Either flat or dice proficiency term based on configured setting.
    */
   toString() {
     return this.term;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1053,11 +1053,12 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   async rollToolCheck(options={}) {
     if ( this.type !== "tool" ) throw new Error("Wrong item type!");
-    return this.actor?.rollToolCheck(this.system.type.baseItem, {
+    return this.actor?.rollToolCheck({
       ability: this.system.ability,
       bonus: this.system.bonus,
       prof: this.system.prof,
       item: this,
+      tool: this.system.type.baseItem,
       ...options
     });
   }

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -799,7 +799,8 @@ async function rollAction(event) {
 
   const { type, ability, skill, tool, dc } = target.dataset;
   const options = { event };
-  if ( dc ) options.targetValue = dc;
+  if ( ability in CONFIG.DND5E.abilities ) options.ability = ability;
+  if ( dc ) options.target = dc;
 
   const action = event.target.closest("a")?.dataset.action ?? "roll";
 
@@ -822,22 +823,19 @@ async function rollAction(event) {
         const actor = token.actor;
         switch ( type ) {
           case "check":
-            await actor.rollAbilityCheck({ ability, event: options.event, target: options.targetValue });
+            await actor.rollAbilityCheck(options);
             break;
           case "concentration":
-            if ( ability in CONFIG.DND5E.abilities ) options.ability = ability;
             await actor.rollConcentration({ ...options, legacy: false });
             break;
           case "save":
-            await actor.rollSavingThrow({ ability, event: options.event, target: options.targetValue });
+            await actor.rollSavingThrow(options);
             break;
           case "skill":
-            if ( ability ) options.ability = ability;
-            await actor.rollSkill(skill, options);
+            await actor.rollSkill({ skill, ...options });
             break;
           case "tool":
-            options.ability = ability;
-            await actor.rollToolCheck(tool, options);
+            await actor.rollToolCheck({ tool, ...options });
             break;
         }
       }

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -186,7 +186,7 @@
             <ul class="skills-list">
             {{#each config.skills as |obj s|}}
             {{#with (lookup ../skills s) as |skill|}}
-                <li class="proficiency-row skill flexrow {{#if skill.value}}proficient{{/if}}"
+                <li class="proficiency-row skill flexrow {{#if skill.prof.hasProficiency}}proficient{{/if}}"
                     data-property="skills" data-key="{{s}}">
                     <input type="hidden" name="system.skills.{{s}}.value"
                            value="{{skill.baseValue}}" data-dtype="Number">

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -158,8 +158,8 @@
             <ul class="skills-list">
             {{#each config.skills as |obj s|}}
             {{#with (lookup ../skills s) as |skill|}}
-                <li class="skill proficiency-row flexrow {{#if skill.value}}proficient{{/if}}" data-property="skills"
-                    data-key="{{s}}">
+                <li class="skill proficiency-row flexrow {{#if skill.prof.hasProficiency}}proficient{{/if}}"
+                    data-property="skills" data-key="{{s}}">
                     <input type="hidden" name="system.skills.{{s}}.value"
                            value="{{skill.baseValue}}" data-dtype="Number">
                     <input type="hidden" name="system.skills.{{s}}.ability" value="{{skill.ability}}">


### PR DESCRIPTION
Merges the functionality ot skill & tool checks into a single method that takes advantage of the new rolling APIs. These new methods make use of a `buildConfig` callback that is called by `RollConfigurationDialog` during its `buildConfig` method. This allows for more extensive modifications of the configuration when the ability is changed.

Closes #1530