### PR TITLE
[#4548] Save chat tray state between message renders

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -77,8 +77,9 @@ Hooks.once("init", function() {
   CONFIG.Dice.D20Roll = dice.D20Roll;
   CONFIG.MeasuredTemplate.defaults.angle = 53.13; // 5e cone RAW should be 53.13 degrees
   CONFIG.Note.objectClass = canvas.Note5e;
+  CONFIG.ui.chat = applications.ChatLog5e;
   CONFIG.ui.combat = applications.combat.CombatTracker5e;
-  CONFIG.ui.items = dnd5e.applications.item.ItemDirectory5e;
+  CONFIG.ui.items = applications.item.ItemDirectory5e;
 
   // Register System Settings
   registerSystemSettings();

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -14,6 +14,7 @@ export * as shared from "./shared/_module.mjs";
 
 export {default as Accordion} from "./accordion.mjs";
 export {default as Award} from "./award.mjs";
+export {default as ChatLog5e} from "./chat-log.mjs";
 export {default as CompendiumBrowser} from "./compendium-browser.mjs";
 export {default as ContextMenu5e} from "./context-menu.mjs";
 export {default as CurrencyManager} from "./currency-manager.mjs";

--- a/module/applications/chat-log.mjs
+++ b/module/applications/chat-log.mjs
@@ -1,0 +1,17 @@
+import ChatMessage5e from "../documents/chat-message.mjs";
+
+/**
+ * Custom implementation of the chat log to support saving tray states.
+ */
+export default class ChatLog5e extends ChatLog {
+  /** @inheritDoc */
+  async updateMessage(message, notify=false) {
+    const element = this.element[0].querySelector(`.message[data-message-id="${message.id}"]`);
+    if ( element ) message._trayStates = new Map([
+      ...Array.from(element.querySelectorAll(".card-tray"))
+        .map(t => [t.className.replace(" collapsed", ""), t.classList.contains("collapsed")]),
+      ...Array.from(element.querySelectorAll(ChatMessage5e.TRAY_TYPES.join(", "))).map(t => [t.tagName, t.open])
+    ]);
+    await super.updateMessage(message, notify);
+  }
+}

--- a/module/applications/chat-log.mjs
+++ b/module/applications/chat-log.mjs
@@ -6,11 +6,12 @@ import ChatMessage5e from "../documents/chat-message.mjs";
 export default class ChatLog5e extends ChatLog {
   /** @inheritDoc */
   async updateMessage(message, notify=false) {
-    const element = this.element[0].querySelector(`.message[data-message-id="${message.id}"]`);
-    if ( element ) message._trayStates = new Map([
-      ...Array.from(element.querySelectorAll(".card-tray"))
+    const element = this.element instanceof HTMLElement ? this.element : this.element[0];
+    const card = element.querySelector(`.message[data-message-id="${message.id}"]`);
+    if ( card ) message._trayStates = new Map([
+      ...Array.from(card.querySelectorAll(".card-tray"))
         .map(t => [t.className.replace(" collapsed", ""), t.classList.contains("collapsed")]),
-      ...Array.from(element.querySelectorAll(ChatMessage5e.TRAY_TYPES.join(", "))).map(t => [t.tagName, t.open])
+      ...Array.from(card.querySelectorAll(ChatMessage5e.TRAY_TYPES.join(", "))).map(t => [t.tagName, t.open])
     ]);
     await super.updateMessage(message, notify);
   }

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -4,6 +4,12 @@ import simplifyRollFormula from "../dice/simplify-roll-formula.mjs";
 
 export default class ChatMessage5e extends ChatMessage {
 
+  /**
+   * HTML tag names for chat trays that can open and close.
+   * @type {string[]}
+   */
+  static TRAY_TYPES = ["damage-application", "effect-application"];
+
   /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
@@ -59,6 +65,15 @@ export default class ChatMessage5e extends ChatMessage {
       default: return false;
     }
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Store the state of any trays in the message.
+   * @type {Map<string, boolean>}
+   * @protected
+   */
+  _trayStates;
 
   /* -------------------------------------------- */
   /*  Data Migrations                             */
@@ -147,11 +162,11 @@ export default class ChatMessage5e extends ChatMessage {
       // Collapse chat message trays older than 5 minutes
       case "older": collapse = this.timestamp < Date.now() - (5 * 60 * 1000); break;
     }
-    for ( const tray of html.querySelectorAll(".card-tray, .effects-tray") ) {
-      tray.classList.toggle("collapsed", collapse);
+    for ( const tray of html.querySelectorAll(".card-tray") ) {
+      tray.classList.toggle("collapsed", this._trayStates?.get(tray.className.replace(" collapsed", "")) ?? collapse);
     }
-    for ( const element of html.querySelectorAll("damage-application, effect-application") ) {
-      element.toggleAttribute("open", !collapse);
+    for ( const element of html.querySelectorAll(this.constructor.TRAY_TYPES.join(", ")) ) {
+      element.toggleAttribute("open", this._trayStates?.get(element.tagName) ?? !collapse);
     }
   }
 


### PR DESCRIPTION
Stores the state of each chat tray present in a given chat message as well as their collapsed state, and then reuses these details when re-rendering the message.

Because of the way the chat log re-renders messages, the state is stored in the `updateMessage` method on a new custom `ChatLog5e` class.

Closes #4548