### PR TITLE
[#4459] Add action that triggers automatically with activity use

### DIFF
--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -57,6 +57,13 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
   }
 
   /* -------------------------------------------- */
+
+  /** @override */
+  async _triggerSubsequentActions(config, results) {
+    this.rollAttack({ event: config.event });
+  }
+
+  /* -------------------------------------------- */
   /*  Rolling                                     */
   /* -------------------------------------------- */
 

--- a/module/documents/activity/damage.mjs
+++ b/module/documents/activity/damage.mjs
@@ -47,6 +47,13 @@ export default class DamageActivity extends ActivityMixin(DamageActivityData) {
   }
 
   /* -------------------------------------------- */
+
+  /** @override */
+  async _triggerSubsequentActions(config, results) {
+    this.rollDamage({ event: config.event });
+  }
+
+  /* -------------------------------------------- */
   /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 

--- a/module/documents/activity/heal.mjs
+++ b/module/documents/activity/heal.mjs
@@ -56,6 +56,13 @@ export default class HealActivity extends ActivityMixin(HealActivityData) {
   }
 
   /* -------------------------------------------- */
+
+  /** @override */
+  async _triggerSubsequentActions(config, results) {
+    this.rollDamage({ event: config.event });
+  }
+
+  /* -------------------------------------------- */
   /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -270,8 +270,9 @@ export default Base => class extends PseudoDocumentMixin(Base) {
      * @param {Activity} activity                     Activity being activated.
      * @param {ActivityUseConfiguration} usageConfig  Configuration data for the activation.
      * @param {ActivityUsageResults} results          Final details on the activation.
+     * @returns {boolean}  Explicitly return `false` to prevent any subsequent actions from being triggered.
      */
-    Hooks.callAll("dnd5e.postUseActivity", activity, usageConfig, results);
+    if ( Hooks.call("dnd5e.postUseActivity", activity, usageConfig, results) === false ) return results;
 
     if ( "dnd5e.useItem" in Hooks.events ) {
       foundry.utils.logCompatibilityWarning(
@@ -281,6 +282,9 @@ export default Base => class extends PseudoDocumentMixin(Base) {
       const { config, options } = this._createDeprecatedConfigs(usageConfig, dialogConfig, messageConfig);
       Hooks.callAll("dnd5e.itemUsageConsumption", item, config, options, results.templates, results.effects, null);
     }
+
+    // Trigger any primary action provided by this activity
+    activity._triggerSubsequentActions(usageConfig, results);
 
     return results;
   }
@@ -896,6 +900,16 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   async _finalizeUsage(config, results) {
     results.templates = config.create?.measuredTemplate ? await this.#placeTemplate() : [];
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Trigger a primary activation action defined by the activity (such as opening the attack dialog for attack rolls).
+   * @param {ActivityUseConfiguration} config  Configuration data for the activation.
+   * @param {ActivityUsageResults} results     Final details on the activation.
+   * @protected
+   */
+  async _triggerSubsequentActions(config, results) {}
 
   /* -------------------------------------------- */
   /*  Rolling                                     */


### PR DESCRIPTION
Adds a step after the end of the activity usage that allows specific activity types to trigger a primary action. For example, this allows an `AttackActivity` to trigger its attack roll dialog immediately after the item is activated, rather than requiring a separate click in chat.

- `AttackActivity`: Triggers attack dialog
- `DamgeActivity`: Triggers damage dialog
- `HealActivity`: Triggers healing dialog

Adjusts the `dnd5e.postUseActivity` hook to be cancelable, allowing modules to prevent these subsequent actions. The new method is intentionally not awaited allowing `use` to return immediately rather than waiting for these actions to resolve.