### PR TITLE
[#4061] Move spells to separate section & control their visibility

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -624,13 +624,18 @@
         "label": "Ignored Properties",
         "hint": "Spell components & tags to ignore while casting."
       },
+      "spellbook": {
+        "label": "Display in Spellbook",
+        "hint": "Display spell in the Spells tab of the character sheet."
+      },
       "uuid": {
         "label": "Spell to Cast"
       }
     }
   },
   "SECTIONS": {
-    "Spell": "Spell"
+    "Spell": "Spell",
+    "Spellbook": "Item Spells"
   },
   "Action": {
     "RemoveSpell": "Remove Spell"

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -460,8 +460,15 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
       let s = spell.system.level || 0;
       const sl = `spell${s}`;
 
+      // Spells from items
+      if ( spell.getFlag("dnd5e", "cachedFor") ) {
+        s = "item";
+        if ( !spell.system.linkedActivity?.displayInSpellbook ) return;
+        if ( !spellbook[s] ) registerSection(null, s, game.i18n.localize("DND5E.CAST.SECTIONS.Spellbook"));
+      }
+
       // Specialized spellcasting modes (if they exist)
-      if ( mode in sections ) {
+      else if ( mode in sections ) {
         s = sections[mode];
         if ( !spellbook[s] ) {
           const l = levels[mode] || {};

--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -305,6 +305,7 @@ export default function ActorSheetV2Mixin(Base) {
 
       // Spells
       if ( item.type === "spell" ) {
+        const linked = item.system.linkedActivity?.item;
 
         // Activation
         const cost = system.activation?.value ?? "";
@@ -334,7 +335,7 @@ export default function ActorSheetV2Mixin(Base) {
         // Prepared
         const mode = system.preparation?.mode;
         const config = CONFIG.DND5E.spellPreparationModes[mode] ?? {};
-        if ( config.prepares ) {
+        if ( config.prepares && !linked ) {
           const isAlways = mode === "always";
           const prepared = isAlways || system.preparation.prepared;
           ctx.preparation = {
@@ -353,7 +354,7 @@ export default function ActorSheetV2Mixin(Base) {
 
         // Subtitle
         ctx.subtitle = [
-          this.actor.classes[system.sourceClass]?.name,
+          linked ? linked.name : this.actor.classes[system.sourceClass]?.name,
           item.labels.components.vsm
         ].filterJoin(" &bull; ");
       }

--- a/module/data/activity/cast-data.mjs
+++ b/module/data/activity/cast-data.mjs
@@ -12,6 +12,7 @@ const { BooleanField, DocumentUUIDField, NumberField, SchemaField, SetField, Str
  * @property {boolean} spell.challenge.override  Use custom attack bonus & DC rather than creature's.
  * @property {number} spell.level                Base level at which to cast the spell.
  * @property {Set<string>} spell.properties      Spell components & tags to ignore while casting.
+ * @property {boolean} spell.spellbook           Display spell in the Spells tab of the character sheet.
  * @property {string} spell.uuid                 UUID of the spell to cast.
  */
 export default class CastActivityData extends BaseActivityData {
@@ -29,6 +30,7 @@ export default class CastActivityData extends BaseActivityData {
         }),
         level: new NumberField(),
         properties: new SetField(new StringField()),
+        spellbook: new BooleanField({ initial: true }),
         uuid: new DocumentUUIDField()
       })
     };

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -349,6 +349,18 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   /* -------------------------------------------- */
 
   /**
+   * Retrieve a linked activity that granted this spell using the stored `cachedFor` value.
+   * @returns {Activity|null}
+   */
+  get linkedActivity() {
+    const relative = this.parent.actor;
+    if ( !relative ) return null;
+    return fromUuidSync(this.parent.getFlag("dnd5e", "cachedFor"), { relative, strict: false }) ?? null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * The proficiency multiplier for this item.
    * @returns {number}
    */

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -47,6 +47,16 @@ export default class CastActivity extends ActivityMixin(CastActivityData) {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Should this spell be listed in the actor's spellbook?
+   * @type {boolean}
+   */
+  get displayInSpellbook() {
+    return this.item.system.magicAvailable && this.spell.spellbook;
+  }
+
+  /* -------------------------------------------- */
   /*  Activation                                  */
   /* -------------------------------------------- */
 

--- a/templates/activity/cast-identity.hbs
+++ b/templates/activity/cast-identity.hbs
@@ -1,3 +1,7 @@
 <section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
     {{> "systems/dnd5e/templates/activity/parts/activity-identity.hbs" }}
+    <fieldset>
+        <legend>{{ localize "DND5E.ACTIVITY.SECTIONS.Behavior" }}</legend>
+        {{ formField fields.spell.fields.spellbook value=source.spell.spellbook input=inputs.createCheckboxInput }}
+    </fieldset>
 </section>


### PR DESCRIPTION
Moves spells granted by items into their own section beneath the other spell sections and display the name of the item that granted them in the subheading.

<img width="548" alt="Cast Spellbook" src="https://github.com/user-attachments/assets/4687bc05-1a6e-44be-8a79-8f2843d4b016">

Spells will be hidden from this list if the magic isn't available for the granting item (e.g. if requires attunement & not attuned). Spells can also be hidden manually in the activity sheet.

Closes #4061