### PR TITLE
[#4596] Allow activity usage dialog to be skipped

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1144,7 +1144,12 @@
   "MiddleClick": "Middle Click",
   "Name": "Enable Control Hints",
   "Activity": {
-    "FastForwardHint": "<kbd>Shift</kbd> + <left-click> the item to skip this dialog"
+    "FastForwardHint": "<kbd>{key}</kbd> + <left-click> the item to skip this dialog"
+  },
+  "Key": {
+    "Alt": "Alt",
+    "Control": "Control",
+    "Shift": "Shift"
   }
 },
 "DND5E.Challenge": "Challenge",

--- a/module/applications/activity/activity-choice-dialog.mjs
+++ b/module/applications/activity/activity-choice-dialog.mjs
@@ -1,3 +1,4 @@
+import { localizedKeybinding } from "../../utils.mjs";
 import Application5e from "../api/application.mjs";
 
 /**
@@ -92,8 +93,9 @@ export default class ActivityChoiceDialog extends Application5e {
   /** @inheritDoc */
   async _prepareContext(options) {
     let controlHint;
-    if ( game.settings.get("dnd5e", "controlHints") ) {
-      controlHint = game.i18n.localize("DND5E.Controls.Activity.FastForwardHint");
+    const key = localizedKeybinding("skipDialogNormal");
+    if ( game.settings.get("dnd5e", "controlHints") && key ) {
+      controlHint = game.i18n.format("DND5E.Controls.Activity.FastForwardHint", { key });
       controlHint = controlHint.replace(
         "<left-click>",
         `<img src="systems/dnd5e/icons/svg/mouse-left.svg" alt="${game.i18n.localize("DND5E.Controls.LeftClick")}">`

--- a/module/applications/activity/activity-choice-dialog.mjs
+++ b/module/applications/activity/activity-choice-dialog.mjs
@@ -49,6 +49,18 @@ export default class ActivityChoiceDialog extends Application5e {
   /* -------------------------------------------- */
 
   /**
+   * The user event when an activity is chosen.
+   * @type {Event|null}
+   */
+  get event() {
+    return this.#event ?? null;
+  }
+
+  #event;
+
+  /* -------------------------------------------- */
+
+  /**
    * The Item whose activities are being chosen.
    * @type {Item5e}
    */
@@ -139,6 +151,7 @@ export default class ActivityChoiceDialog extends Application5e {
   static async #onChooseActivity(event, target) {
     const { activityId } = target.dataset;
     this.#activity = this.#item.system.activities.get(activityId);
+    this.#event = event;
     this.close();
   }
 
@@ -148,14 +161,17 @@ export default class ActivityChoiceDialog extends Application5e {
 
   /**
    * Display the activity choice dialog.
-   * @param {Item5e} item                         The Item whose activities are being chosen.
-   * @param {ApplicationConfiguration} [options]  Application configuration options.
-   * @returns {Promise<Activity|null>}            The chosen activity, or null if the dialog was dismissed.
+   * @param {Item5e} item                                           The Item whose activities are being chosen.
+   * @param {ApplicationConfiguration} [options]                    Application configuration options.
+   * @returns {Promise<{ activity: Activity, event: Event }|null>}  The chosen activity & click event, or null if the
+   *                                                                dialog was dismissed.
    */
   static create(item, options) {
     return new Promise(resolve => {
       const dialog = new this(item, options);
-      dialog.addEventListener("close", () => resolve(dialog.activity), { once: true });
+      dialog.addEventListener("close", () =>
+        resolve({ activity: dialog.activity, event: dialog.event }),
+      { once: true });
       dialog.render({ force: true });
     });
   }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -2,7 +2,7 @@ import ActivitySheet from "../../applications/activity/activity-sheet.mjs";
 import ActivityUsageDialog from "../../applications/activity/activity-usage-dialog.mjs";
 import AbilityTemplate from "../../canvas/ability-template.mjs";
 import { ConsumptionError } from "../../data/activity/fields/consumption-targets-field.mjs";
-import { formatNumber, getTargetDescriptors, localizeSchema } from "../../utils.mjs";
+import { areKeysPressed, formatNumber, getTargetDescriptors, localizeSchema } from "../../utils.mjs";
 import PseudoDocumentMixin from "../mixins/pseudo-document.mjs";
 
 /**
@@ -223,7 +223,6 @@ export default function ActivityMixin(Base) {
       const usageConfig = activity._prepareUsageConfig(usage);
 
       const dialogConfig = foundry.utils.mergeObject({
-        configure: true,
         applicationClass: this.metadata.usage.dialog
       }, dialog);
 
@@ -242,6 +241,8 @@ export default function ActivityMixin(Base) {
         },
         hasConsumption: usageConfig.hasConsumption
       }, message);
+
+      this._applyKeybindings(usageConfig, dialogConfig, messageConfig);
 
       /**
        * A hook event that fires before an activity usage is configured.
@@ -411,6 +412,21 @@ export default function ActivityMixin(Base) {
         }
       }
       await this.#applyUsageUpdates(updates);
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Apply any keybindings that might affect usage process.
+     * @param {ActivityUseConfiguration} config       Configuration info for the activation.
+     * @param {ActivityDialogConfiguration} dialog    Configuration info for the configuration dialog.
+     * @param {ActivityMessageConfiguration} message  Configuration info for the chat message created.
+     * @protected
+     */
+    _applyKeybindings(config, dialog, message) {
+      dialog.configure ??= !areKeysPressed(config.event, "skipDialogNormal")
+        && !areKeysPressed(config.event, "skipDialogAdvantage")
+        && !areKeysPressed(config.event, "skipDialogDisadvantage");
     }
 
     /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -712,9 +712,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
         || areKeysPressed(event, "skipDialogAdvantage")
         || areKeysPressed(event, "skipDialogDisadvantage");
       if ( ((activities.length > 1) || chooseActivity) && !skipDialog ) {
-        const result = await ActivityChoiceDialog.create(this);
-        activity = result.activity;
-        event = result.event;
+        ({ activity, event } = await ActivityChoiceDialog.create(this) ?? {});
       }
       if ( !activity ) return;
       return activity.use(usageConfig, dialogConfig, messageConfig);

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -9,7 +9,7 @@ import EquipmentData from "../data/item/equipment.mjs";
 import SpellData from "../data/item/spell.mjs";
 import ActivitiesTemplate from "../data/item/templates/activities.mjs";
 import PhysicalItemTemplate from "../data/item/templates/physical-item.mjs";
-import { formatIdentifier, staticID } from "../utils.mjs";
+import { areKeysPressed, formatIdentifier, staticID } from "../utils.mjs";
 import Scaling from "./scaling.mjs";
 import Proficiency from "./actor/proficiency.mjs";
 import SelectChoices from "./actor/select-choices.mjs";
@@ -708,8 +708,13 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       let dialogConfig = dialog;
       let messageConfig = message;
       let activity = activities[0];
-      if ( ((activities.length > 1) || chooseActivity) && !event?.shiftKey ) {
-        activity = await ActivityChoiceDialog.create(this);
+      const skipDialog = areKeysPressed(event, "skipDialogNormal")
+        || areKeysPressed(event, "skipDialogAdvantage")
+        || areKeysPressed(event, "skipDialogDisadvantage");
+      if ( ((activities.length > 1) || chooseActivity) && !skipDialog ) {
+        const result = await ActivityChoiceDialog.create(this);
+        activity = result.activity;
+        event = result.event;
       }
       if ( !activity ) return;
       return activity.use(usageConfig, dialogConfig, messageConfig);

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -446,6 +446,20 @@ export function areKeysPressed(event, action) {
 }
 
 /* -------------------------------------------- */
+
+/**
+ * Localized name for the first key provided by a keybinding.
+ * @param {string} name  Name of the key binding within the `dnd5e` namespace.
+ * @returns {string|null}
+ */
+export function localizedKeybinding(name) {
+  const keybinding = game.keybindings.get("dnd5e", name)[0];
+  if ( !keybinding ) return null;
+  const keyName = `DND5E.Controls.Key.${keybinding.key.replace(/(?:Left|Right)$/, "")}`;
+  return game.i18n.has(keyName) ? game.i18n.localize(keyName) : KeyboardManager.getKeycodeDisplayString(keybinding.key);
+}
+
+/* -------------------------------------------- */
 /*  Logging                                     */
 /* -------------------------------------------- */
 
@@ -461,7 +475,6 @@ export function log(message, { color="#6e0000", extras=[], level="log" }={}) {
   console[level](
     `%cD&D 5e | %c${message}`, `color: ${color}; font-variant: small-caps`, "color: revert", ...extras
   );
-}
 
 /* -------------------------------------------- */
 /*  Object Helpers                              */


### PR DESCRIPTION
Uses the various "Skip Dialog" keybindings to skip the activity usage dialog, using the activity with the default configuration. Does some modifications for the `ActivityChoiceDialog` to return an event so the usage dialog can be skipped from there also.

The same keybindings will now also skip the activity choice dialog rather than just being hardcoded to the Shift key. This does not yet attempt to change the hint displayed in the UI of that dialog.

Closes #4596