### PR TITLE
[#2138] Re-implement `rollAttack` using new rolling APIs

### DIFF
--- a/module/applications/dice/_module.mjs
+++ b/module/applications/dice/_module.mjs
@@ -1,3 +1,4 @@
+export {default as AttackRollConfigurationDialog} from "./attack-configuration-dialog.mjs";
 export {default as D20RollConfigurationDialog} from "./d20-configuration-dialog.mjs";
 export {default as DamageRollConfigurationDialog} from "./damage-configuration-dialog.mjs";
 export {default as RollConfigurationDialog} from "./roll-configuration-dialog.mjs";

--- a/module/applications/dice/attack-configuration-dialog.mjs
+++ b/module/applications/dice/attack-configuration-dialog.mjs
@@ -1,0 +1,43 @@
+import D20RollConfigurationDialog from "./d20-configuration-dialog.mjs";
+
+/**
+ * @typedef {BasicRollConfigurationDialogOptions} AttackRollConfigurationDialogOptions
+ * @property {FormSelectOption[]} ammunitionOptions - Ammunition that can be used with the attack.
+ * @property {FormSelectOption[]} attackModeOptions - Different modes of attack.
+ * @property {FormSelectOption[]} masteryOptions - Available masteries for the attacking weapon.
+ */
+
+/**
+ * Extended roll configuration dialog that allows selecting attack mode, ammunition, and weapon mastery.
+ */
+export default class AttackRollConfigurationDialog extends D20RollConfigurationDialog {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    ammunitionOptions: [],
+    attackModeOptions: [],
+    masteryOptions: []
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareConfigurationContext(context, options) {
+    context = await super._prepareConfigurationContext(context, options);
+    const optionsFields = [
+      { key: "attackMode", label: "DND5E.ATTACK.Mode.Label", options: this.options.attackModeOptions },
+      { key: "ammunition", label: "DND5E.CONSUMABLE.Type.Ammunition.Label", options: this.options.ammunitionOptions },
+      { key: "mastery", label: "DND5E.WEAPON.Mastery.Label", options: this.options.masteryOptions }
+    ];
+    for ( const { key, label, options } of optionsFields.reverse() ) {
+      if ( options?.length ) context.fields.unshift({
+        field: new foundry.data.fields.StringField({ label: game.i18n.localize(label) }),
+        name: key,
+        options,
+        value: this.config[key]
+      });
+    }
+    return context;
+  }
+}

--- a/module/applications/dice/attack-configuration-dialog.mjs
+++ b/module/applications/dice/attack-configuration-dialog.mjs
@@ -2,9 +2,9 @@ import D20RollConfigurationDialog from "./d20-configuration-dialog.mjs";
 
 /**
  * @typedef {BasicRollConfigurationDialogOptions} AttackRollConfigurationDialogOptions
- * @property {FormSelectOption[]} ammunitionOptions - Ammunition that can be used with the attack.
- * @property {FormSelectOption[]} attackModeOptions - Different modes of attack.
- * @property {FormSelectOption[]} masteryOptions - Available masteries for the attacking weapon.
+ * @property {FormSelectOption[]} ammunitionOptions  Ammunition that can be used with the attack.
+ * @property {FormSelectOption[]} attackModeOptions  Different modes of attack.
+ * @property {FormSelectOption[]} masteryOptions     Available masteries for the attacking weapon.
  */
 
 /**
@@ -30,14 +30,15 @@ export default class AttackRollConfigurationDialog extends D20RollConfigurationD
       { key: "ammunition", label: "DND5E.CONSUMABLE.Type.Ammunition.Label", options: this.options.ammunitionOptions },
       { key: "mastery", label: "DND5E.WEAPON.Mastery.Label", options: this.options.masteryOptions }
     ];
-    for ( const { key, label, options } of optionsFields.reverse() ) {
-      if ( options?.length ) context.fields.unshift({
+    context.fields = [
+      ...optionsFields.map(({ key, label, options }) => options.length ? {
         field: new foundry.data.fields.StringField({ label: game.i18n.localize(label) }),
         name: key,
         options,
         value: this.config[key]
-      });
-    }
+      } : null).filter(_ => _),
+      ...context.fields
+    ];
     return context;
   }
 }

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -228,32 +228,28 @@ export default class AttackActivityData extends BaseActivityData {
 
   /**
    * Get the roll parts used to create the attack roll.
+   * @param {Partial<AttackRollProcessConfiguration>} [config]
+   * @param {string} [situational]
    * @returns {{ data: object, parts: string[] }}
    */
-  getAttackData() {
-    const parts = [];
-    const data = this.getRollData();
-    const item = this.item.system;
+  getAttackData(config, situational) {
+    const rollData = this.getRollData();
+    if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);
 
-    if ( this.actor && !this.attack.flat ) {
-      // Ability modifier & proficiency bonus
-      if ( this.attack.ability !== "none" ) parts.push("@mod");
-      if ( item.prof?.hasProficiency ) {
-        parts.push("@prof");
-        data.prof = item.prof.term;
-      }
+    const weapon = this.item.system;
+    const ammo = this.actor?.items.get(config?.ammunition)?.system;
+    const { parts, data } = CONFIG.Dice.BasicRoll.constructParts({
+      mod: this.attack.ability !== "none" ? rollData.mod : null,
+      prof: weapon.prof?.term,
+      bonus: this.attack.bonus,
+      weaponMagic: weapon.magicAvailable ? weapon.magicalBonus : null,
+      ammoMagic: ammo?.magicAvailable ? ammo.magicalBonus : null,
+      actorBonus: this.actor?.system.bonuses?.[this.actionType]?.attack,
+      situational
+    }, this.getRollData());
 
-      // Actor-level global bonus to attack rolls
-      const actorBonus = this.actor.system.bonuses?.[this.actionType];
-      if ( actorBonus?.attack ) parts.push(actorBonus.attack);
-
-      // Add exhaustion reduction
-      this.actor.addRollExhaustion(parts, data);
-    }
-
-    // Include the activity's attack bonus & item's magical bonus
-    if ( this.attack.bonus ) parts.push(this.attack.bonus);
-    if ( item.magicalBonus && item.magicAvailable && !this.attack.flat ) parts.push(item.magicalBonus);
+    // Add exhaustion reduction
+    this.actor?.addRollExhaustion(parts, data);
 
     return { data, parts };
   }

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -228,16 +228,18 @@ export default class AttackActivityData extends BaseActivityData {
 
   /**
    * Get the roll parts used to create the attack roll.
-   * @param {Partial<AttackRollProcessConfiguration>} [config]
-   * @param {string} [situational]
+   * @param {object} [config={}]
+   * @param {string} [config.ammunition]
+   * @param {string} [config.attackMode]
+   * @param {string} [config.situational]
    * @returns {{ data: object, parts: string[] }}
    */
-  getAttackData(config, situational) {
+  getAttackData({ ammunition, attackMode, situational }={}) {
     const rollData = this.getRollData();
     if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);
 
     const weapon = this.item.system;
-    const ammo = this.actor?.items.get(config?.ammunition)?.system;
+    const ammo = this.actor?.items.get(ammunition)?.system;
     const { parts, data } = CONFIG.Dice.BasicRoll.constructParts({
       mod: this.attack.ability !== "none" ? rollData.mod : null,
       prof: weapon.prof?.term,
@@ -246,7 +248,7 @@ export default class AttackActivityData extends BaseActivityData {
       ammoMagic: ammo?.magicAvailable ? ammo.magicalBonus : null,
       actorBonus: this.actor?.system.bonuses?.[this.actionType]?.attack,
       situational
-    }, this.getRollData());
+    }, rollData);
 
     // Add exhaustion reduction
     this.actor?.addRollExhaustion(parts, data);

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -286,6 +286,23 @@ export default class WeaponData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /**
+   * Ammunition that can be used with this weapon.
+   * @type {FormSelectOption[]}
+   */
+  get ammunitionOptions() {
+    if ( !this.parent.actor ) return [];
+    return this.parent.actor.items
+      .filter(i => (i.type === "consumable") && (i.system.type.value === "ammo")
+        && (!this.ammunition?.type || (i.system.type.subtype === this.ammunition.type)))
+      .map(i => ({
+        value: i.id, label: `${i.name} (${i.system.quantity})`, item: i, disabled: !i.system.quantity
+      }))
+      .sort((lhs, rhs) => lhs.label.localeCompare(rhs.label, game.i18n.lang));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Attack classification of this weapon.
    * @type {"weapon"|"unarmed"}
    */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -291,11 +291,14 @@ export default class WeaponData extends ItemDataModel.mixin(
    */
   get ammunitionOptions() {
     if ( !this.parent.actor ) return [];
-    return this.parent.actor.items
-      .filter(i => (i.type === "consumable") && (i.system.type.value === "ammo")
+    return this.parent.actor.itemTypes.consumable
+      .filter(i => (i.system.type.value === "ammo")
         && (!this.ammunition?.type || (i.system.type.subtype === this.ammunition.type)))
-      .map(i => ({
-        value: i.id, label: `${i.name} (${i.system.quantity})`, item: i, disabled: !i.system.quantity
+      .map(item => ({
+        item,
+        value: item.id,
+        label: `${item.name} (${item.system.quantity})`,
+        disabled: !item.system.quantity
       }))
       .sort((lhs, rhs) => lhs.label.localeCompare(rhs.label, game.i18n.lang));
   }

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -208,7 +208,8 @@ export default class UsesField extends SchemaField {
     }
 
     const createMessage = messageConfig.create !== false;
-    const rolls = await CONFIG.Dice.BasicRoll.build(rollConfig, dialogConfig, { ...messageConfig, create: false });
+    messageConfig.create = false;
+    const rolls = await CONFIG.Dice.BasicRoll.build(rollConfig, dialogConfig, messageConfig);
     if ( !rolls.length ) return;
     if ( createMessage ) {
       messageConfig.data.flavor = game.i18n.format("DND5E.ItemRechargeCheck", {

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -159,9 +159,9 @@ export default class BasicRoll extends Roll {
     if ( config.evaluate === false ) return rolls;
     for ( const roll of rolls ) await roll.evaluate();
 
-    message = foundry.utils.expandObject(message);
+    message.data = foundry.utils.expandObject(message.data ?? {});
     const messageId = config.event?.target.closest("[data-message-id]")?.dataset.messageId;
-    if ( messageId ) foundry.utils.setProperty(message, "data.flags.dnd5e.originatingMessage", messageId);
+    if ( messageId ) foundry.utils.setProperty(message.data, "flags.dnd5e.originatingMessage", messageId);
 
     if ( rolls?.length && (message.create !== false) ) {
       await this.toMessage(rolls, message.data, { rollMode: message.rollMode });

--- a/module/dice/dice.mjs
+++ b/module/dice/dice.mjs
@@ -1,4 +1,4 @@
-const { NumericTerm, OperatorTerm } = foundry.dice.terms;
+const { OperatorTerm } = foundry.dice.terms;
 
 /* -------------------------------------------- */
 /* D20 Roll                                     */
@@ -105,36 +105,6 @@ export async function d20Roll({
   const rolls = await CONFIG.Dice.D20Roll.build(rollConfig, dialogConfig, messageConfig);
 
   return rolls?.[0] ?? null;
-
-  // TODO: Delete this reference code once skill, tool, and attack rolls are properly handled
-
-  // Prompt a Dialog to further configure the D20Roll
-  if ( !isFF ) {
-  } else {
-    roll.options.ammunition ??= ammunition ?? ammunitionOptions?.[0]?.value;
-    roll.options.attackMode ??= attackMode ?? attackModes?.[0]?.value;
-    roll.options.rollMode ??= defaultRollMode;
-  }
-
-  // If ammunition has a magical bonus, add it to the roll
-  const ammo = ammunitionOptions?.find(a => a.value === roll.options.ammunition);
-  if ( ammo?.item.system.magicAvailable && ammo.item.system.magicalBonus ) {
-    roll.terms.push(new OperatorTerm({ operator: "+" }), new NumericTerm({ number: ammo.item.system.magicalBonus }));
-    roll.resetFormula();
-  }
-
-  // Attach original message ID to the message
-  messageData = foundry.utils.expandObject(messageData);
-  const messageId = event?.target.closest("[data-message-id]")?.dataset.messageId;
-  if ( messageId ) foundry.utils.setProperty(messageData, "flags.dnd5e.originatingMessage", messageId);
-
-  // Store the ammunition used in the chat message
-  if ( ammo ) foundry.utils.setProperty(messageData, "flags.dnd5e.roll.ammunition", ammo.value);
-
-  // Set the attack mode
-  if ( roll.options.attackMode ) foundry.utils.setProperty(
-    messageData, "flags.dnd5e.roll.attackMode", roll.options.attackMode
-  );
 }
 
 /* -------------------------------------------- */

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -267,15 +267,15 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
    * @param {number} index                                 Index of the roll within all rolls being prepared.
    */
   _buildAttackConfig(initialRoll, process, config, formData, index) {
-    if ( formData?.has("ammunition") ) process.ammunition = formData.get("ammunition");
-    if ( formData?.has("attackMode") ) process.attackMode = formData.get("attackMode");
-    if ( formData?.has("mastery") ) process.mastery = formData.get("mastery");
+    const ammunition = formData?.get("ammunition") ?? process.ammunition;
+    const attackMode = formData?.get("attackMode") ?? process.attackMode;
+    const mastery = formData?.get("mastery") ?? process.mastery;
 
-    let { parts, data } = this.getAttackData(process, config.data?.situational);
+    let { parts, data } = this.getAttackData({ ammunition, attackMode, situational: config.data?.situational });
     const options = config.options ?? {};
-    if ( process?.ammunition ) options.ammunition = process.ammunition;
-    if ( process?.attackMode ) options.attackMode = process.attackMode;
-    if ( process?.mastery ) options.mastery = process.mastery;
+    if ( ammunition !== undefined ) options.ammunition = ammunition;
+    if ( attackMode !== undefined ) options.attackMode = attackMode;
+    if ( mastery !== undefined ) options.mastery = mastery;
 
     if ( index === 0 ) {
       if ( initialRoll?.data ) data = { ...data, ...initialRoll.data };

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1367,7 +1367,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
 
   /**
-   * @typedef {D20RollDialogConfiguration} SkillToolRollDialogConfiguration
+   * @typedef {BasicRollDialogConfiguration} SkillToolRollDialogConfiguration
    * @property {SkillToolRollConfigurationDialogOptions} [options]  Configuration options.
    */
 
@@ -1410,8 +1410,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const rollConfig = foundry.utils.mergeObject({
       ability: relevant?.ability ?? (type === "skill" ? skillConfig.ability : toolConfig.ability),
       halflingLucky: this.getFlag("dnd5e", "halflingLucky"),
-      reliableTalent: (relevant?.value >= 1) && this.getFlag("dnd5e", "reliableTalent"),
-      rolls: []
+      reliableTalent: (relevant?.value >= 1) && this.getFlag("dnd5e", "reliableTalent")
     }, config);
     rollConfig.hookNames = [...(config.hookNames ?? []), type, "abilityCheck", "d20Test"];
     rollConfig.rolls = [{

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -7,6 +7,7 @@ import EquipmentData from "../data/item/equipment.mjs";
 import SpellData from "../data/item/spell.mjs";
 import ActivitiesTemplate from "../data/item/templates/activities.mjs";
 import PhysicalItemTemplate from "../data/item/templates/physical-item.mjs";
+import { _applyDeprecatedD20Configs } from "../dice/d20-roll.mjs";
 import Scaling from "./scaling.mjs";
 import Proficiency from "./actor/proficiency.mjs";
 import SelectChoices from "./actor/select-choices.mjs";
@@ -963,7 +964,12 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const activity = item.system.activities?.getByType("attack")[0];
     if ( !activity ) throw new Error("This Item does not have an Attack activity to roll!");
 
-    const rolls = await activity.rollAttack(options);
+    const rollConfig = {};
+    const dialogConfig = {};
+    const messageConfig = {};
+    _applyDeprecatedD20Configs(rollConfig, dialogConfig, messageConfig, options);
+
+    const rolls = await activity.rollAttack(rollConfig, dialogConfig, messageConfig);
     return rolls?.[0] ?? null;
   }
 
@@ -1035,6 +1041,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /**
    * Perform an ability recharge test for an item which uses the d6 recharge mechanic.
    * @returns {Promise<Roll|void>}   A Promise which resolves to the created Roll instance
+   * @deprecated since DnD5e 4.0, targeted for removal in DnD5e 4.4
    */
   async rollRecharge() {
     foundry.utils.logCompatibilityWarning(


### PR DESCRIPTION
Reworks `rollAttack` to use the new `build` method on `D20Roll` and implement a custom configuration application to support ammunition, attack modes, and mastery.

In the process this moves the preparation of ammunition options into `WeaponData` and reorders the logic for ammunition, attack mode, and mastery options to be easier to follow.

Closes #2138