### PR TITLE
[#4603] Stored deleted items in consumed flag, add item restore

### DIFF
--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -348,8 +348,9 @@ export default class ActivitiesTemplate extends SystemDataModel {
     if ( (userId !== game.user.id) || !this.parent.isEmbedded ) return;
 
     // If item has any Cast activities, create locally cached copies of the spells
-    const spells = (await Promise.all(this.activities.getByType("cast").map(a => a.getCachedSpellData())))
-      .filter(_ => _);
+    const spells = (await Promise.all(
+      this.activities.getByType("cast").map(a => !a.cachedSpell && a.getCachedSpellData())
+    )).filter(_ => _);
     if ( spells.length ) this.parent.actor.createEmbeddedDocuments("Item", spells);
   }
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -724,6 +724,11 @@ export default Base => class extends PseudoDocumentMixin(Base) {
           updates.delete.push(...results.delete);
           updates.item.push(...results.item);
           updates.rolls.push(...results.rolls);
+          // Mark this item for deletion if it is linked to a cast activity that will be deleted
+          if ( updates.delete.includes(linkedActivity.item.id)
+            && (this.item.getFlag("dnd5e", "cachedFor") === linkedActivity.relativeUUID) ) {
+            updates.delete.push(this.item.id);
+          }
         } else if ( results?.length ) {
           errors.push(...results);
         }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -397,7 +397,9 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @param {ActivityConsumptionDescriptor} consumed  Data on the consumption that occurred.
    */
   async refund(consumed) {
-    const updates = { activity: {}, actor: {}, item: [] };
+    const updates = {
+      activity: {}, actor: {}, create: consumed.deleted ?? [], delete: consumed.created ?? [], item: []
+    };
     for ( const { keyPath, delta } of consumed.actor ?? [] ) {
       const value = foundry.utils.getProperty(this.actor, keyPath) - delta;
       if ( !Number.isNaN(value) ) updates.actor[keyPath] = value;
@@ -433,6 +435,10 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   async #applyUsageUpdates(updates) {
     this._mergeActivityUpdates(updates);
 
+    // Ensure no existing items are created again & no non-existent items try to be deleted
+    updates.create = updates.create?.filter(i => !this.actor.items.has(i));
+    updates.delete = updates.delete?.filter(i => this.actor.items.has(i));
+
     // Create the consumed flag
     const getDeltas = (document, updates) => {
       updates = foundry.utils.flattenObject(updates);
@@ -457,9 +463,14 @@ export default Base => class extends PseudoDocumentMixin(Base) {
     };
     if ( foundry.utils.isEmpty(consumed.actor) ) delete consumed.actor;
     if ( foundry.utils.isEmpty(consumed.item) ) delete consumed.item;
+    if ( updates.create?.length ) consumed.created = updates.create;
+    if ( updates.delete?.length ) consumed.deleted = updates.delete.map(i => this.actor.items.get(i).toObject());
 
     // Update documents with consumption
     if ( !foundry.utils.isEmpty(updates.actor) ) await this.actor.update(updates.actor);
+    if ( !foundry.utils.isEmpty(updates.create) ) {
+      await this.actor.createEmbeddedDocuments("Item", updates.create, { keepId: true });
+    }
     if ( !foundry.utils.isEmpty(updates.delete) ) await this.actor.deleteEmbeddedDocuments("Item", updates.delete);
     if ( !foundry.utils.isEmpty(updates.item) ) await this.actor.updateEmbeddedDocuments("Item", updates.item);
 
@@ -661,6 +672,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @typedef {object} ActivityUsageUpdates
    * @property {object} activity  Updates applied to activity that performed the activation.
    * @property {object} actor     Updates applied to the actor that performed the activation.
+   * @property {object[]} create  Full data for Items to create (with IDs maintained).
    * @property {string[]} delete  IDs of items to be deleted from the actor.
    * @property {object[]} item    Updates applied to items on the actor that performed the activation.
    * @property {Roll[]} rolls     Any rolls performed as part of the activation.
@@ -676,7 +688,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
    * @protected
    */
   async _prepareUsageUpdates(config, { returnErrors=false }={}) {
-    const updates = { activity: {}, actor: {}, delete: [], item: [], rolls: [] };
+    const updates = { activity: {}, actor: {}, create: [], delete: [], item: [], rolls: [] };
     if ( config.consume === false ) return updates;
     const errors = [];
 
@@ -899,11 +911,6 @@ export default Base => class extends PseudoDocumentMixin(Base) {
         }
       }
     }, message);
-
-    // If the Item was destroyed in the process, embed a copy of its data
-    if ( !this.actor?.items.has(this.item.id) ) {
-      foundry.utils.setProperty(messageConfig, "data.flags.dnd5e.item.data", this.item.toObject());
-    }
 
     /**
      * A hook event that fires before an activity usage card is created.

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -90,7 +90,7 @@ export default class ChatMessage5e extends ChatMessage {
     this._shimFlags();
     if ( !this.flags.dnd5e?.item?.data && this.flags.dnd5e?.item?.id ) {
       const itemData = this.getFlag("dnd5e", "use.consumed.deleted")?.find(i => i._id === this.flags.dnd5e.item.id);
-      if ( itemData ) Object.defineProperty(this.flags.dnd5e.item, "data", { value: itemData, writable: false });
+      if ( itemData ) Object.defineProperty(this.flags.dnd5e.item, "data", { value: itemData });
     }
     dnd5e.registry.messages.track(this);
   }

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -88,6 +88,10 @@ export default class ChatMessage5e extends ChatMessage {
   prepareData() {
     super.prepareData();
     this._shimFlags();
+    if ( !this.flags.dnd5e?.item?.data && this.flags.dnd5e?.item?.id ) {
+      const itemData = this.getFlag("dnd5e", "use.consumed.deleted")?.find(i => i._id === this.flags.dnd5e.item.id);
+      if ( itemData ) Object.defineProperty(this.flags.dnd5e.item, "data", { value: itemData, writable: false });
+    }
     dnd5e.registry.messages.track(this);
   }
 


### PR DESCRIPTION
Stores the data for any items deleted as part of the item usage process within the chat message `dnd5e.use.consumed` flag. This allows for entire items to be restored when the "Refund Resource" button is pressed in chat.

As part of this process the deleted item data previously stored in the `dnd5e.item.data` flag has been removed and a reference from that to the data in the consumed flag has been added, so all existing workflows should continue working.

These changes also allow for the Cast activity to be used on items that are consumed on empty such as spell scrolls.

Closes #4603