### PR TITLE
[#4061, #4613] Add Cast overrides, activity changes via enchanting

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -130,7 +130,7 @@ export default class ActiveEffect5e extends ActiveEffect {
     }
 
     // Handle activity-targeted changes
-    if ( (change.key.startsWith("activity.") || change.key.startsWith("system.activities."))
+    if ( (change.key.startsWith("activities[") || change.key.startsWith("system.activities."))
       && (doc instanceof Item) ) return this.applyActivity(doc, change);
 
     return super.apply(doc, change);
@@ -146,17 +146,17 @@ export default class ActiveEffect5e extends ActiveEffect {
    */
   applyActivity(item, change) {
     const changes = {};
-    const apply = (activity, keyPath) => {
-      const c = this.apply(activity, { ...change, key: keyPath.join(".") });
+    const apply = (activity, key) => {
+      const c = this.apply(activity, { ...change, key });
       Object.entries(c).forEach(([k, v]) => changes[`system.activities.${activity.id}.${k}`] = v);
     };
     if ( change.key.startsWith("system.activities.") ) {
       const [, , id, ...keyPath] = change.key.split(".");
       const activity = item.system.activities?.get(id);
-      if ( activity ) apply(activity, keyPath);
+      if ( activity ) apply(activity, keyPath.join("."));
     } else {
-      const [, type, ...keyPath] = change.key.split(".");
-      item.system.activities?.getByType(type)?.forEach(activity => apply(activity, keyPath));
+      const { type, key } = change.key.match(/activities\[(?<type>[^\]]+)]\.(?<key>.+)/)?.groups ?? {};
+      item.system.activities?.getByType(type)?.forEach(activity => apply(activity, key));
     }
     return changes;
   }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -119,6 +119,51 @@ export default class ActiveEffect5e extends ActiveEffect {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  apply(doc, change) {
+    // Ensure changes targeting flags use the proper types
+    if ( change.key.startsWith("flags.dnd5e.") ) change = this._prepareFlagChange(doc, change);
+
+    // Properly handle formulas that don't exist as part of the data model
+    if ( ActiveEffect5e.FORMULA_FIELDS.has(change.key) ) {
+      const field = new FormulaField({ deterministic: true });
+      return { [change.key]: this.constructor.applyField(doc, change, field) };
+    }
+
+    // Handle activity-targeted changes
+    if ( (change.key.startsWith("activity.") || change.key.startsWith("system.activities."))
+      && (doc instanceof Item) ) return this.applyActivity(doc, change);
+
+    return super.apply(doc, change);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Apply a change to activities on this item.
+   * @param {Item5e} item              The Item to whom this change should be applied.
+   * @param {EffectChangeData} change  The change data being applied.
+   * @returns {Record<string, *>}      An object of property paths and their updated values.
+   */
+  applyActivity(item, change) {
+    const changes = {};
+    const apply = (activity, keyPath) => {
+      const c = this.apply(activity, { ...change, key: keyPath.join(".") });
+      Object.entries(c).forEach(([k, v]) => changes[`system.activities.${activity.id}.${k}`] = v);
+    };
+    if ( change.key.startsWith("system.activities.") ) {
+      const [, , id, ...keyPath] = change.key.split(".");
+      const activity = item.system.activities?.get(id);
+      if ( activity ) apply(activity, keyPath);
+    } else {
+      const [, type, ...keyPath] = change.key.split(".");
+      item.system.activities?.getByType(type)?.forEach(activity => apply(activity, keyPath));
+    }
+    return changes;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   static applyField(model, change, field) {
     field ??= model.schema.getField(change.key);
     change = foundry.utils.deepClone(change);
@@ -163,22 +208,6 @@ export default class ActiveEffect5e extends ActiveEffect {
     }
 
     return super.applyField(model, change, field);
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  _applyLegacy(actor, change, changes) {
-    if ( this.system._applyLegacy?.(actor, change, changes) === false ) return;
-    if ( change.key.startsWith("flags.dnd5e.") ) change = this._prepareFlagChange(actor, change);
-
-    if ( ActiveEffect5e.FORMULA_FIELDS.has(change.key) ) {
-      const field = new FormulaField({ deterministic: true });
-      changes[change.key] = ActiveEffect5e.applyField(actor, change, field);
-      return;
-    }
-
-    super._applyLegacy(actor, change, changes);
   }
 
   /* --------------------------------------------- */

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -141,15 +141,31 @@ export default class CastActivity extends ActivityMixin(CastActivityData) {
   getSpellChanges() {
     const changes = [];
     const source = this.toObject();
+
+    // Override spell details
     for ( const type of ["activation", "duration", "range", "target"] ) {
       if ( !this[type].override ) continue;
       const data = source[type];
       delete data.override;
       changes.push({ key: `system.${type}`, mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: JSON.stringify(data) });
     }
+
+    // Remove ignored properties
     for ( const property of this.spell.properties ) {
       changes.push({ key: "system.properties", mode: CONST.ACTIVE_EFFECT_MODES.ADD, value: `-${property}` });
     }
+
+    // Set challenge overrides
+    const challenge = this.spell.challenge;
+    if ( challenge.override && challenge.attack ) changes.push(
+      { key: "activity.attack.attack.bonus", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: challenge.attack },
+      { key: "activity.attack.attack.flat", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: true }
+    );
+    if ( challenge.override && challenge.save ) changes.push(
+      { key: "activity.save.save.dc.calculation", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: "" },
+      { key: "activity.save.save.dc.formula", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: challenge.save }
+    );
+
     return changes;
   }
 }

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -158,12 +158,12 @@ export default class CastActivity extends ActivityMixin(CastActivityData) {
     // Set challenge overrides
     const challenge = this.spell.challenge;
     if ( challenge.override && challenge.attack ) changes.push(
-      { key: "activity.attack.attack.bonus", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: challenge.attack },
-      { key: "activity.attack.attack.flat", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: true }
+      { key: "activities[attack].attack.bonus", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: challenge.attack },
+      { key: "activities[attack].attack.flat", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: true }
     );
     if ( challenge.override && challenge.save ) changes.push(
-      { key: "activity.save.save.dc.calculation", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: "" },
-      { key: "activity.save.save.dc.formula", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: challenge.save }
+      { key: "activities[save].save.dc.calculation", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: "" },
+      { key: "activities[save].save.dc.formula", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: challenge.save }
     );
 
     return changes;


### PR DESCRIPTION
Makes the DC & Attack overrides on the Cast activity functional. It does this through the Spell Changes enchantment which uses a new syntax to apply directly to all Attack & Save activities on the spell.

The new syntax allows for modifying all activities of a certain type using the change key like `activity.attack.attack.bonus`, where `activity.attack` indicates this should change all attack activities and `attack.bonus` being the key path to the field to change. At the same time this also fixes some issues with applying enchantment changes directly to individual activities by ID.

Closes #4613