### PR TITLE
[#4623] Add `createScrollFromCompendiumSpell` that uses Cast

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1583,8 +1583,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       scrollUuid = id;
     }
     const scrollItem = await fromUuid(scrollUuid);
-    const scrollData = scrollItem.toObject();
-    delete scrollData._id;
+    const scrollData = game.items.fromCompendium(scrollItem);
 
     // Create a composite description from the scroll description and the spell details
     const desc = this._createScrollDescription(scrollItem, itemData, null, config);
@@ -1691,8 +1690,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       scrollUuid = id;
     }
     const scrollItem = await fromUuid(scrollUuid);
-    const scrollData = scrollItem.toObject();
-    delete scrollData._id;
+    const scrollData = game.items.fromCompendium(scrollItem);
 
     for ( const level of Array.fromRange(spell.system.level + 1).reverse() ) {
       const values = CONFIG.DND5E.spellScrollValues[level];


### PR DESCRIPTION
It probably isn't safe to use the Cast activity for spells scrolls created from world or items on actors, but for ones in compendiums it should be safe. This adds a new method that is called if the provided spell is inside a pack.

Closes #4623