### PR TITLE
Use the template's `getSnappedPosition` method when dragging preview

### DIFF
--- a/module/canvas/ability-template.mjs
+++ b/module/canvas/ability-template.mjs
@@ -238,7 +238,7 @@ export default class AbilityTemplate extends MeasuredTemplate {
     const now = Date.now(); // Apply a 20ms throttle
     if ( now - this.#moveTime <= 20 ) return;
     const center = event.data.getLocalPosition(this.layer);
-    const updates = canvas.templates.getSnappedPoint(center);
+    const updates = this.getSnappedPosition(center);
 
     // Adjust template size to take hovered token into account if `adjustedSize` is set
     const baseDistance = this.document.flags.dnd5e?.dimensions?.size;


### PR DESCRIPTION
`PlaceableObject`, from which `AbilityTemplate` (via `MeasuredTemplate`) inherits, has a `getSnappedPosition` method. When dragging the template preview, it is preferable that the snapped position is determined by using the template's own `getSnappedPosition` method instead of the layer's method. This allows modules (e.g., my Walled Templates module) to affect snapping of the specific template associated with a given spell. 

Note that by default, `MeasuredTemplate#getSnappedPosition` just calls `this.layer.getSnappedPoint` so this should not affect anything for a default setup.