### PR TITLE
[#4669] Add level filter for facilities in Compendium Browser

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -498,8 +498,12 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
    */
   async _onAddFacility(event) {
     const { type } = event.target.closest("[data-type]").dataset;
+    const otherType = type === "basic" ? "special" : "basic";
     const result = await CompendiumBrowser.selectOne({
-      filters: { locked: { types: new Set(["facility"]), additional: { type: { [type]: 1 } } } }
+      filters: { locked: {
+        types: new Set(["facility"]),
+        additional: { type: { [type]: 1, [otherType]: -1 }, level: { max: this.actor.system.details.level } }
+      } }
     });
     if ( result ) this._onDropItemCreate(await fromUuid(result));
   }

--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -117,7 +117,18 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
 
   /** @override */
   static get compendiumBrowserFilters() {
+    const { basic, special } = CONFIG.DND5E.facilities.advancement;
+    const min = Math.min(...Object.keys(basic), ...Object.keys(special));
     return new Map([
+      ["level", {
+        label: "DND5E.FACILITY.FIELDS.level.label",
+        type: "range",
+        config: {
+          keyPath: "system.level",
+          min,
+          max: CONFIG.DND5E.maxLevel
+        }
+      }],
       ["type", {
         label: "DND5E.FACILITY.FIELDS.type.value.label",
         type: "set",


### PR DESCRIPTION
Adds a range filter for the facility level requirement when using the Compendium Browser and automatically adds a restriction for that when opening using the "Add Facility" control on the sheet.

<img width="880" alt="Bastion Filters" src="https://github.com/user-attachments/assets/6917ec96-de68-4580-bf18-74b501b29bb1">

Also adds a negative filter restriction for the non-selected type, so you cannot use filters to display Special facilities when clicking the add basic facility button and vice versa.

Closes #4669