### PR TITLE
[#4708] Redesign `AdvancementConfig` & `HitPointsConfig` for V2

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,7 @@
 {
 "DOCUMENT.DND5E": {
   "Activity": "Activity",
+  "Advancement": "Advancement",
   "Warning": {
     "SelectType": "{name} type must be selected for creation."
   }
@@ -277,6 +278,13 @@
       "Level": "Must be at least level {level} to take this feat.",
       "Type": "Only features with the \"feat\" type can be selected."
     }
+  },
+  "Config": {
+    "Details": "Advancement Details"
+  },
+  "HITPOINTS": {
+    "Average": "Average",
+    "Starting": "Hit Points at 1st Level"
   },
   "SPELLCONFIG": {
     "FIELDS": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -282,9 +282,21 @@
   "Config": {
     "Details": "Advancement Details"
   },
-  "HITPOINTS": {
+  "HitPoints": {
+    "Action": {
+      "Roll": "Roll {die}"
+    },
     "Average": "Average",
-    "Starting": "Hit Points at 1st Level"
+    "Hint": "Track the player's hit points for each level in the class.",
+    "MaxAtFirstLevel": "Max at 1st Level: <strong>{max}</strong>",
+    "Roll": "Roll {class} Hit Points",
+    "Starting": "Hit Points at 1st Level",
+    "TakeAverage": "Take Average",
+    "Title": "Hit Points",
+    "Warning": {
+      "Empty": "Hit points must be rolled or the average value must be taken.",
+      "Invalid": "Hit points must be a valid whole number."
+    }
   },
   "SPELLCONFIG": {
     "FIELDS": {
@@ -332,14 +344,6 @@
 "DND5E.AdvancementDeleteConfirmationTitle": "Confirm Deletion",
 "DND5E.AdvancementFlowDropAreaHint": "Drop an Item here to choose it.",
 "DND5E.AdvancementHint": "Hint",
-"DND5E.AdvancementHitPointsTitle": "Hit Points",
-"DND5E.AdvancementHitPointsHint": "Track the player's hit points for each level in the class.",
-"DND5E.AdvancementHitPointsAverage": "Take Average",
-"DND5E.AdvancementHitPointsEmptyError": "Hit points must be rolled or the average value must be taken.",
-"DND5E.AdvancementHitPointsInvalidError": "Hit points must be a valid whole number.",
-"DND5E.AdvancementHitPointsMaxAtFirstLevel": "Max at 1st Level: <strong>{max}</strong>",
-"DND5E.AdvancementHitPointsRollMessage": "Roll {class} Hit Points",
-"DND5E.AdvancementHitPointsRollButton": "Roll {die}",
 "DND5E.AdvancementItemChoiceTitle": "Choose Items",
 "DND5E.AdvancementItemChoiceHint": "Present the player with a choice of items (such as equipment, features, or spells) that they can choose for their character at one or more levels.",
 "DND5E.AdvancementItemChoiceChoices": "Choices",

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -371,13 +371,10 @@
   }
 
   /* Form Fields */
-  select, input[type="text"], input[type="number"], input[type="search"], input[type="file"] {
-    --input-height: var(--form-field-height);
+  textarea, select, input[type="text"], input[type="number"], input[type="search"], input[type="file"] {
     --input-border-color: transparent;
     transition: all 250ms ease;
     line-height: normal;
-    padding: 0 6px;
-    background: var(--input-background-color);
     outline: none;
 
     &:focus { outline: none; }
@@ -385,6 +382,17 @@
       --input-border-color: var(--dnd5e-color-gold);
       box-shadow: 0 0 6px var(--dnd5e-color-gold);
     }
+  }
+  select, input[type="text"], input[type="number"], input[type="search"], input[type="file"] {
+    --input-height: var(--form-field-height);
+    padding: 0 6px;
+    background: var(--input-background-color);
+  }
+  textarea {
+    border: 1px solid var(--input-border-color);
+    padding: 6px;
+    background: rgba(0, 0, 0, 0.1);
+    font-size: var(--font-size-11);
   }
 
   :is(.form-group, fieldset) :is(select, input):not([type="range"]) {

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -1,26 +1,14 @@
 import { ConsumptionTargetData } from "../../data/activity/fields/consumption-targets-field.mjs";
 import { formatNumber, formatRange } from "../../utils.mjs";
-import Application5e from "../api/application.mjs";
+import PseudoDocumentSheet from "../api/pseudo-document-sheet.mjs";
 
 /**
  * Default sheet for activities.
  */
-export default class ActivitySheet extends Application5e {
-  constructor(options={}) {
-    super(options);
-    this.#activityId = options.document.id;
-    this.#item = options.document.item;
-  }
-
-  /* -------------------------------------------- */
-
+export default class ActivitySheet extends PseudoDocumentSheet {
   /** @inheritDoc */
   static DEFAULT_OPTIONS = {
-    classes: ["activity", "sheet", "standard-form"],
-    tag: "form",
-    document: null,
-    viewPermission: CONST.DOCUMENT_OWNERSHIP_LEVELS.LIMITED,
-    editPermission: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+    classes: ["activity"],
     window: {
       icon: "fa-solid fa-gauge"
     },
@@ -35,10 +23,6 @@ export default class ActivitySheet extends Application5e {
       deleteRecovery: ActivitySheet.#deleteRecovery,
       dissociateEffect: ActivitySheet.#dissociateEffect,
       toggleCollapsed: ActivitySheet.#toggleCollapsed
-    },
-    form: {
-      handler: ActivitySheet.#onSubmitForm,
-      submitOnChange: true
     },
     position: {
       width: 500,
@@ -100,14 +84,8 @@ export default class ActivitySheet extends Application5e {
    * @type {Activity}
    */
   get activity() {
-    return this.item.system.activities.get(this.#activityId);
+    return this.document;
   }
-
-  /**
-   * ID of this activity on the parent item.
-   * @type {string}
-   */
-  #activityId;
 
   /* -------------------------------------------- */
 
@@ -119,40 +97,6 @@ export default class ActivitySheet extends Application5e {
 
   get expandedSections() {
     return this.#expandedSections;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Is this Activity sheet visible to the current user?
-   * @type {boolean}
-   */
-  get isVisible() {
-    return this.item.testUserPermission(game.user, this.options.viewPermission);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Is this Document sheet editable by the current User?
-   * This is governed by the editPermission threshold configured for the class.
-   * @type {boolean}
-   */
-  get isEditable() {
-    if ( game.packs.get(this.item.pack)?.locked ) return false;
-    return this.item.testUserPermission(game.user, this.options.editPermission);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Parent item to which this activity belongs.
-   * @type {Item5e}
-   */
-  #item;
-
-  get item() {
-    return this.#item;
   }
 
   /* -------------------------------------------- */
@@ -467,24 +411,6 @@ export default class ActivitySheet extends Application5e {
   /*  Life-Cycle Handlers                         */
   /* -------------------------------------------- */
 
-  /** @override */
-  _canRender(options) {
-    if ( !this.isVisible ) throw new Error(game.i18n.format("SHEETS.DocumentSheetPrivate", {
-      type: game.i18n.localize("DND5E.ACTIVITY.Title.one")
-    }));
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  _onFirstRender(context, options) {
-    super._onFirstRender(context, options);
-    this.activity.constructor._registerApp(this.activity, this);
-    this.item.apps[this.id] = this;
-  }
-
-  /* -------------------------------------------- */
-
   /** @inheritDoc */
   _onRender(context, options) {
     super._onRender(context, options);
@@ -493,24 +419,6 @@ export default class ActivitySheet extends Application5e {
         .toggle("collapsed", !this.#expandedSections.get(element.dataset.expandId));
     }
     this.#toggleNestedTabs();
-    if ( !this.isEditable ) this._disableFields();
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  _onClose(_options) {
-    this.activity?.constructor._unregisterApp(this.activity, this);
-    delete this.item.apps[this.id];
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  async _renderFrame(options) {
-    const frame = await super._renderFrame(options);
-    frame.autocomplete = "off";
-    return frame;
   }
 
   /* -------------------------------------------- */
@@ -720,19 +628,6 @@ export default class ActivitySheet extends Application5e {
   /* -------------------------------------------- */
 
   /**
-   * Handle form submission.
-   * @param {SubmitEvent} event          Triggering submit event.
-   * @param {HTMLFormElement} form       The form that was submitted.
-   * @param {FormDataExtended} formData  Data from the submitted form.
-   */
-  static async #onSubmitForm(event, form, formData) {
-    const submitData = this._prepareSubmitData(event, formData);
-    await this._processSubmitData(event, submitData);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
    * Perform any pre-processing of the form data to prepare it for updating.
    * @param {SubmitEvent} event          Triggering submit event.
    * @param {FormDataExtended} formData  Data from the submitted form.
@@ -752,21 +647,6 @@ export default class ActivitySheet extends Application5e {
         submitData.effects.push({ _id });
       }
     }
-    // Workaround for https://github.com/foundryvtt/foundryvtt/issues/11610
-    this.element.querySelectorAll("fieldset legend :is(input, select, dnd5e-checkbox)").forEach(input => {
-      foundry.utils.setProperty(submitData, input.name, input.value);
-    });
     return submitData;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Handle updating the activity based on processed submit data.
-   * @param {SubmitEvent} event  Triggering submit event.
-   * @param {object} submitData  Prepared object for updating.
-   */
-  async _processSubmitData(event, submitData) {
-    await this.activity.update(submitData);
   }
 }

--- a/module/applications/advancement/_module.mjs
+++ b/module/applications/advancement/_module.mjs
@@ -1,4 +1,5 @@
 export {default as AdvancementConfig} from "./advancement-config.mjs";
+export {default as AdvancementConfigV2} from "./advancement-config-v2.mjs";
 export {default as AdvancementConfirmationDialog} from "./advancement-confirmation-dialog.mjs";
 export {default as AdvancementFlow} from "./advancement-flow.mjs";
 export {default as AdvancementManager} from "./advancement-manager.mjs";

--- a/module/applications/advancement/advancement-config-v2.mjs
+++ b/module/applications/advancement/advancement-config-v2.mjs
@@ -1,50 +1,48 @@
+import Advancement from "../../documents/advancement/advancement.mjs";
+import PseudoDocumentSheet from "../api/pseudo-document-sheet.mjs";
+
 /**
  * Base configuration application for advancements that can be extended by other types to implement custom
  * editing interfaces.
- *
- * @param {Advancement} advancement            The advancement item being edited.
- * @param {object} [options={}]                Additional options passed to FormApplication.
- * @param {string} [options.dropKeyPath=null]  Path within advancement configuration where dropped items are stored.
- *                                             If populated, will enable default drop & delete behavior.
  */
-export default class AdvancementConfig extends FormApplication {
-  constructor(advancement, options={}) {
-    super(advancement, options);
-    this.#advancementId = advancement.id;
-    this.item = advancement.item;
+export default class AdvancementConfig extends PseudoDocumentSheet {
+  constructor(advancement={}, options={}) {
+    if ( advancement instanceof Advancement ) {
+      options.document = advancement;
+      // TODO: Add deprecation warning for this calling pattern once system has switched over to using the sheet
+      // getter on Advancement, rather than creating separately
+    } else options = { ...advancement, ...options };
+    super(options);
   }
 
   /* -------------------------------------------- */
 
-  /**
-   * The ID of the advancement being created or edited.
-   * @type {string}
-   */
-  #advancementId;
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["advancement"],
+    window: {
+      icon: "fa-solid fa-person-rays"
+    },
+    actions: {
+      deleteItem: AdvancementConfig.#deleteDroppedItem
+    },
+    dropKeyPath: null,
+    position: {
+      width: 400
+    }
+  };
 
   /* -------------------------------------------- */
 
-  /**
-   * Parent item to which this advancement belongs.
-   * @type {Item5e}
-   */
-  item;
+  /** @override */
+  static PARTS = {
+    config: {
+      template: "systems/dnd5e/templates/advancement/advancement-controls-section.hbs"
+    }
+  };
 
   /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  static get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["dnd5e", "advancement", "dialog"],
-      template: "systems/dnd5e/templates/advancement/advancement-config.hbs",
-      width: 400,
-      height: "auto",
-      submitOnChange: true,
-      closeOnSubmit: false,
-      dropKeyPath: null
-    });
-  }
-
+  /*  Properties                                  */
   /* -------------------------------------------- */
 
   /**
@@ -52,37 +50,29 @@ export default class AdvancementConfig extends FormApplication {
    * @type {Advancement}
    */
   get advancement() {
-    return this.item.advancement.byId[this.#advancementId];
+    return this.document;
   }
 
   /* -------------------------------------------- */
 
   /** @inheritDoc */
   get title() {
-    const type = this.advancement.constructor.metadata.title;
-    return `${game.i18n.format("DND5E.AdvancementConfigureTitle", { item: this.item.name })}: ${type}`;
+    return this.advancement.constructor.metadata.title;
   }
 
   /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  async close(options={}) {
-    await super.close(options);
-    delete this.advancement?.apps[this.appId];
-  }
-
+  /*  Rendering                                   */
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  getData() {
-    const levels = Object.fromEntries(Array.fromRange(CONFIG.DND5E.maxLevel + 1).map(l => [l, l]));
+  async _prepareContext(options) {
+    const levels = Array.fromRange(CONFIG.DND5E.maxLevel + 1).map(l => ({ value: l, label: l }));
     if ( ["class", "subclass"].includes(this.item.type) ) delete levels[0];
-    else levels[0] = game.i18n.localize("DND5E.AdvancementLevelAnyHeader");
+    else levels[0].label = game.i18n.localize("DND5E.AdvancementLevelAnyHeader");
     const context = {
-      appId: this.id,
-      CONFIG: CONFIG.DND5E,
-      ...this.advancement.toObject(false),
-      src: this.advancement._source,
+      ...(await super._prepareContext(options)),
+      advancement: this.advancement,
+      configuration: this.advancement.configuration,
       source: this.advancement._source,
       default: {
         title: this.advancement.constructor.metadata.title,
@@ -102,6 +92,29 @@ export default class AdvancementConfig extends FormApplication {
   }
 
   /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle deleting an existing Item entry from the Advancement.
+   * @param {Event} event        The originating click event.
+   * @returns {Promise<Item5e>}  The updated parent Item after the application re-renders.
+   * @this {AdvancementConfig}
+   */
+  static async #deleteDroppedItem(event) {
+    event.preventDefault();
+    const uuidToDelete = event.currentTarget.closest("[data-item-uuid]")?.dataset.itemUuid;
+    if ( !uuidToDelete ) return;
+    const items = foundry.utils.getProperty(this.advancement.configuration, this.options.dropKeyPath);
+    const updates = { configuration: await this.prepareConfigurationUpdate({
+      [this.options.dropKeyPath]: items.filter(i => i.uuid !== uuidToDelete)
+    }) };
+    await this.advancement.update(updates);
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
 
   /**
    * Perform any changes to configuration data before it is saved to the advancement.
@@ -115,32 +128,10 @@ export default class AdvancementConfig extends FormApplication {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  activateListeners(html) {
-    super.activateListeners(html);
-
-    // Remove an item from the list
-    if ( this.options.dropKeyPath ) html.on("click", "[data-action='delete']", this._onItemDelete.bind(this));
-
-    for ( const element of html[0].querySelectorAll("multi-select") ) {
-      element.addEventListener("change", this._onChangeInput.bind(this));
-    }
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  render(force=false, options={}) {
-    this.advancement.apps[this.appId] = this;
-    return super.render(force, options);
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  async _updateObject(event, formData) {
-    let updates = foundry.utils.expandObject(formData);
-    if ( updates.configuration ) updates.configuration = await this.prepareConfigurationUpdate(updates.configuration);
-    await this.advancement.update(updates);
+  async _processSubmitData(event, submitData) {
+    submitData.configuration ??= {};
+    submitData.configuration = await this.prepareConfigurationUpdate(submitData.configuration);
+    await this.advancement.update(submitData);
   }
 
   /* -------------------------------------------- */
@@ -168,24 +159,7 @@ export default class AdvancementConfig extends FormApplication {
   /*  Drag & Drop for Item Pools                  */
   /* -------------------------------------------- */
 
-  /**
-   * Handle deleting an existing Item entry from the Advancement.
-   * @param {Event} event        The originating click event.
-   * @returns {Promise<Item5e>}  The updated parent Item after the application re-renders.
-   * @protected
-   */
-  async _onItemDelete(event) {
-    event.preventDefault();
-    const uuidToDelete = event.currentTarget.closest("[data-item-uuid]")?.dataset.itemUuid;
-    if ( !uuidToDelete ) return;
-    const items = foundry.utils.getProperty(this.advancement.configuration, this.options.dropKeyPath);
-    const updates = { configuration: await this.prepareConfigurationUpdate({
-      [this.options.dropKeyPath]: items.filter(i => i.uuid !== uuidToDelete)
-    }) };
-    await this.advancement.update(updates);
-  }
-
-  /* -------------------------------------------- */
+  // TODO: Re-implement drag & drop for ApplicationV2
 
   /** @inheritDoc */
   _canDragDrop() {
@@ -244,5 +218,4 @@ export default class AdvancementConfig extends FormApplication {
    * @protected
    */
   _validateDroppedItem(event, item) {}
-
 }

--- a/module/applications/advancement/advancement-config-v2.mjs
+++ b/module/applications/advancement/advancement-config-v2.mjs
@@ -146,9 +146,8 @@ export default class AdvancementConfig extends PseudoDocumentSheet {
   static _cleanedObject(object) {
     return Object.entries(object).reduce((obj, [key, value]) => {
       let keep = false;
-      if ( foundry.utils.getType(value) === "Object" ) {
-        keep = Object.values(value).some(v => v);
-      } else if ( value ) keep = true;
+      if ( foundry.utils.getType(value) === "Object" ) keep = Object.values(value).some(v => v);
+      else if ( value ) keep = true;
       if ( keep ) obj[key] = value;
       else obj[`-=${key}`] = null;
       return obj;

--- a/module/applications/advancement/hit-points-config.mjs
+++ b/module/applications/advancement/hit-points-config.mjs
@@ -1,23 +1,32 @@
-import AdvancementConfig from "./advancement-config.mjs";
+import AdvancementConfig from "./advancement-config-v2.mjs";
 
 /**
  * Configuration application for hit points.
  */
 export default class HitPointsConfig extends AdvancementConfig {
-
-  /** @inheritDoc */
-  static get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      template: "systems/dnd5e/templates/advancement/hit-points-config.hbs"
-    });
-  }
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["hit-points"]
+  };
 
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  getData() {
-    return foundry.utils.mergeObject(super.getData(), {
-      hitDie: this.advancement.hitDie
-    });
+  static PARTS = {
+    ...super.PARTS,
+    hitPoints: {
+      template: "systems/dnd5e/templates/advancement/hit-points-config.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.hitDie = this.advancement.hitDie;
+    return context;
   }
 }

--- a/module/applications/advancement/hit-points-flow.mjs
+++ b/module/applications/advancement/hit-points-flow.mjs
@@ -78,7 +78,7 @@ export default class HitPointsFlow extends AdvancementFlow {
 
     this.form.querySelector(".rollResult")?.classList.add("error");
     const errorType = formData.value ? "Invalid" : "Empty";
-    throw new Advancement.ERROR(game.i18n.localize(`DND5E.AdvancementHitPoints${errorType}Error`));
+    throw new Advancement.ERROR(game.i18n.localize(`DND5E.ADVANCEMENT.HitPoints.Warning.${errorType}`));
   }
 
 }

--- a/module/applications/api/_module.mjs
+++ b/module/applications/api/_module.mjs
@@ -2,3 +2,4 @@ export { default as Application5e } from "./application.mjs";
 export { default as ApplicationV2Mixin } from "./application-v2-mixin.mjs";
 export { default as Dialog5e } from "./dialog.mjs";
 export { default as DocumentSheet5e } from "./document-sheet.mjs";
+export { default as PseudoDocumentSheet } from "./pseudo-document-sheet.mjs";

--- a/module/applications/api/pseudo-document-sheet.mjs
+++ b/module/applications/api/pseudo-document-sheet.mjs
@@ -1,0 +1,220 @@
+import Application5e from "../api/application.mjs";
+
+/**
+ * Default sheet for activities.
+ */
+export default class PseudoDocumentSheet extends Application5e {
+  constructor(options={}) {
+    super(options);
+    this.#documentId = options.document.id;
+    this.#documentType = options.document.metadata.name;
+    this.#item = options.document.item;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static DEFAULT_OPTIONS = {
+    classes: ["pseudo-document", "sheet", "standard-form"],
+    tag: "form",
+    document: null,
+    viewPermission: CONST.DOCUMENT_OWNERSHIP_LEVELS.LIMITED,
+    editPermission: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+    actions: {
+      copyUuid: { handler: PseudoDocumentSheet.#onCopyUuid, buttons: [0, 2] }
+    },
+    form: {
+      handler: PseudoDocumentSheet.#onSubmitForm,
+      submitOnChange: true
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The PseudoDocument associated with this application.
+   * @type {PseudoDocument}
+   */
+  get document() {
+    return this.item.getEmbeddedDocument(this.#documentType, this.#documentId);
+  }
+
+  /**
+   * ID of this PseudoDocument on the parent item.
+   * @type {string}
+   */
+  #documentId;
+
+  /**
+   * Collection representing this PseudoDocument.
+   * @type {string}
+   */
+  #documentType;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this PseudoDocument sheet visible to the current user?
+   * @type {boolean}
+   */
+  get isVisible() {
+    return this.item.testUserPermission(game.user, this.options.viewPermission);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this PseudoDocument sheet editable by the current User?
+   * This is governed by the editPermission threshold configured for the class.
+   * @type {boolean}
+   */
+  get isEditable() {
+    if ( game.packs.get(this.item.pack)?.locked ) return false;
+    return this.item.testUserPermission(game.user, this.options.editPermission);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Parent item to which this PseudoDocument belongs.
+   * @type {Item5e}
+   */
+  #item;
+
+  get item() {
+    return this.#item;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    return {
+      ...await super._prepareContext(options),
+      document: this.document,
+      editable: this.isEditable,
+      options: this.options
+    };
+  }
+
+  /* -------------------------------------------- */
+  /*  Life-Cycle Handlers                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _canRender(options) {
+    if ( !this.isVisible ) throw new Error(game.i18n.format("SHEETS.DocumentSheetPrivate", {
+      type: game.i18n.localize(this.document.metadata.label)
+    }));
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onFirstRender(context, options) {
+    super._onFirstRender(context, options);
+    this.document.constructor._registerApp(this.document, this);
+    this.item.apps[this.id] = this;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onRender(context, options) {
+    super._onRender(context, options);
+    if ( !this.isEditable ) this._disableFields();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onClose(_options) {
+    this.document?.constructor._unregisterApp(this.document, this);
+    delete this.item.apps[this.id];
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _renderFrame(options) {
+    const frame = await super._renderFrame(options);
+    frame.autocomplete = "off";
+
+    // Add document ID copy
+    const copyLabel = game.i18n.localize("SHEETS.CopyUuid");
+    const copyId = `<button type="button" class="header-control fa-solid fa-passport" data-action="copyUuid"
+                            data-tooltip="${copyLabel}" aria-label="${copyLabel}"></button>`;
+    this.window.close.insertAdjacentHTML("beforebegin", copyId);
+
+    return frame;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle click events to copy the UUID of this document to clipboard.
+   * @this {PseudoDocumentSheet}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   * @this {PseudoDocumentSheet}
+   */
+  static #onCopyUuid(event, target) {
+    event.preventDefault();
+    event.stopPropagation();
+    if ( event.detail > 1 ) return;
+    const id = event.button === 2 ? this.document.id : this.document.uuid;
+    const type = event.button === 2 ? "id" : "uuid";
+    const label = game.i18n.localize(this.document.metadata.label);
+    game.clipboard.copyPlainText(id);
+    ui.notifications.info(game.i18n.format("DOCUMENT.IdCopiedClipboard", { label, type, id }));
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle form submission.
+   * @param {SubmitEvent} event          Triggering submit event.
+   * @param {HTMLFormElement} form       The form that was submitted.
+   * @param {FormDataExtended} formData  Data from the submitted form.
+   */
+  static async #onSubmitForm(event, form, formData) {
+    const submitData = this._prepareSubmitData(event, formData);
+    await this._processSubmitData(event, submitData);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Perform any pre-processing of the form data to prepare it for updating.
+   * @param {SubmitEvent} event          Triggering submit event.
+   * @param {FormDataExtended} formData  Data from the submitted form.
+   * @returns {object}
+   */
+  _prepareSubmitData(event, formData) {
+    const submitData = foundry.utils.expandObject(formData.object);
+    // Workaround for https://github.com/foundryvtt/foundryvtt/issues/11610
+    this.element.querySelectorAll("fieldset legend :is(input, select, dnd5e-checkbox)").forEach(input => {
+      foundry.utils.setProperty(submitData, input.name, input.value);
+    });
+    return submitData;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle updating the PseudoDocument based on processed submit data.
+   * @param {SubmitEvent} event  Triggering submit event.
+   * @param {object} submitData  Prepared object for updating.
+   */
+  async _processSubmitData(event, submitData) {
+    await this.document.update(submitData);
+  }
+}

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -6,6 +6,10 @@ import { formatNumber, getTargetDescriptors } from "../../utils.mjs";
 import PseudoDocumentMixin from "../mixins/pseudo-document.mjs";
 
 /**
+ * @import { PseudoDocumentsMetadata } from "../mixins/pseudo-document.mjs";
+ */
+
+/**
  * Mixin used to provide base logic to all activities.
  * @template {BaseActivityData} T
  * @param {typeof T} Base  The base activity data class to wrap.
@@ -34,6 +38,7 @@ export default function ActivityMixin(Base) {
      */
     static metadata = Object.freeze({
       name: "Activity",
+      label: "DOCUMENT.DND5E.Activity",
       sheetClass: ActivitySheet,
       usage: {
         actions: {},

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2360,7 +2360,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       data: item.getRollData(),
       chatMessage
     };
-    const flavor = game.i18n.format("DND5E.AdvancementHitPointsRollMessage", { class: item.name });
+    const flavor = game.i18n.format("DND5E.ADVANCEMENT.HitPoints.Roll", { class: item.name });
     const messageData = {
       title: `${flavor}: ${this.name}`,
       flavor,

--- a/module/documents/advancement/advancement.mjs
+++ b/module/documents/advancement/advancement.mjs
@@ -1,6 +1,11 @@
-import AdvancementConfig from "../../applications/advancement/advancement-config.mjs";
+import AdvancementConfig from "../../applications/advancement/advancement-config-v2.mjs";
 import AdvancementFlow from "../../applications/advancement/advancement-flow.mjs";
 import BaseAdvancement from "../../data/advancement/base-advancement.mjs";
+import PseudoDocumentMixin from "../mixins/pseudo-document.mjs";
+
+/**
+ * @import { PseudoDocumentsMetadata } from "../mixins/pseudo-document.mjs";
+ */
 
 /**
  * Error that can be thrown during the advancement update preparation process.
@@ -19,7 +24,7 @@ class AdvancementError extends Error {
  * @param {object} [options={}]  Options which affect DataModel construction.
  * @abstract
  */
-export default class Advancement extends BaseAdvancement {
+export default class Advancement extends PseudoDocumentMixin(BaseAdvancement) {
   constructor(data, {parent=null, ...options}={}) {
     if ( parent instanceof Item ) parent = parent.system;
     super(data, {parent, ...options});
@@ -52,7 +57,7 @@ export default class Advancement extends BaseAdvancement {
   /**
    * Information on how an advancement type is configured.
    *
-   * @typedef {object} AdvancementMetadata
+   * @typedef {PseudoDocumentsMetadata} AdvancementMetadata
    * @property {object} dataModels
    * @property {DataModel} configuration  Data model used for validating configuration data.
    * @property {DataModel} value          Data model used for validating value data.
@@ -77,6 +82,8 @@ export default class Advancement extends BaseAdvancement {
    */
   static get metadata() {
     return {
+      name: "Advancement",
+      label: "DOCUMENT.DND5E.Advancement",
       order: 100,
       icon: "icons/svg/upgrade.svg",
       typeIcon: "icons/svg/upgrade.svg",
@@ -91,56 +98,8 @@ export default class Advancement extends BaseAdvancement {
     };
   }
 
-  /**
-   * Configuration information for this advancement type.
-   * @type {AdvancementMetadata}
-   */
-  get metadata() {
-    return this.constructor.metadata;
-  }
-
   /* -------------------------------------------- */
   /*  Instance Properties                         */
-  /* -------------------------------------------- */
-
-  /**
-   * Unique identifier for this advancement within its item.
-   * @type {string}
-   */
-  get id() {
-    return this._id;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Globally unique identifier for this advancement.
-   * @type {string}
-   */
-  get uuid() {
-    return `${this.item.uuid}.Advancement.${this.id}`;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Item to which this advancement belongs.
-   * @type {Item5e}
-   */
-  get item() {
-    return this.parent.parent;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Actor to which this advancement's item belongs, if the item is embedded.
-   * @type {Actor5e|null}
-   */
-  get actor() {
-    return this.item.parent ?? null;
-  }
-
   /* -------------------------------------------- */
 
   /**
@@ -251,42 +210,7 @@ export default class Advancement extends BaseAdvancement {
   }
 
   /* -------------------------------------------- */
-
-  /**
-   * Render all of the Application instances which are connected to this advancement.
-   * @param {boolean} [force=false]     Force rendering
-   * @param {object} [context={}]       Optional context
-   */
-  render(force=false, context={}) {
-    for ( const app of Object.values(this.apps) ) app.render(force, context);
-  }
-
-  /* -------------------------------------------- */
   /*  Editing Methods                             */
-  /* -------------------------------------------- */
-
-  /**
-   * Update this advancement.
-   * @param {object} updates          Updates to apply to this advancement.
-   * @returns {Promise<Advancement>}  This advancement after updates have been applied.
-   */
-  async update(updates) {
-    await this.item.updateAdvancement(this.id, updates);
-    return this;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Update this advancement's data on the item without performing a database commit.
-   * @param {object} updates  Updates to apply to this advancement.
-   * @returns {Advancement}   This advancement after updates have been applied.
-   */
-  updateSource(updates) {
-    super.updateSource(updates);
-    return this;
-  }
-
   /* -------------------------------------------- */
 
   /**
@@ -296,19 +220,6 @@ export default class Advancement extends BaseAdvancement {
    */
   static availableForItem(item) {
     return true;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Serialize salient information for this Advancement when dragging it.
-   * @returns {object}  An object of drag data.
-   */
-  toDragData() {
-    const dragData = { type: "Advancement" };
-    if ( this.id ) dragData.uuid = this.uuid;
-    else dragData.data = this.toObject();
-    return dragData;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/advancement/hit-points.mjs
+++ b/module/documents/advancement/hit-points.mjs
@@ -16,8 +16,8 @@ export default class HitPointsAdvancement extends Advancement {
       order: 10,
       icon: "icons/magic/life/heart-pink.webp",
       typeIcon: "systems/dnd5e/icons/svg/hit-points.svg",
-      title: game.i18n.localize("DND5E.AdvancementHitPointsTitle"),
-      hint: game.i18n.localize("DND5E.AdvancementHitPointsHint"),
+      title: game.i18n.localize("DND5E.ADVANCEMENT.HitPoints.Title"),
+      hint: game.i18n.localize("DND5E.ADVANCEMENT.HitPoints.Hint"),
       multiLevel: true,
       apps: {
         config: HitPointsConfig,

--- a/module/documents/advancement/hit-points.mjs
+++ b/module/documents/advancement/hit-points.mjs
@@ -30,6 +30,16 @@ export default class HitPointsAdvancement extends Advancement {
   /*  Instance Properties                         */
   /* -------------------------------------------- */
 
+  /**
+   * The amount gained if the average is taken.
+   * @type {number}
+   */
+  get average() {
+    return (this.hitDieValue / 2) + 1;
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   get levels() {
     return Array.fromRange(CONFIG.DND5E.maxLevel + 1).slice(1);

--- a/module/documents/mixins/pseudo-document.mjs
+++ b/module/documents/mixins/pseudo-document.mjs
@@ -36,8 +36,9 @@ export default function PseudoDocumentMixin(Base) {
     /**
      * Configuration information for PseudoDocuments.
      *
-     * @typedef {object} PseudoDocumentsMetadata
+     * @typedef PseudoDocumentsMetadata
      * @property {string} name        Base type name of this PseudoDocument (e.g. "Activity", "Advancement").
+     * @property {string} label       Localized name for this PseudoDocument type.
      */
 
     /**

--- a/templates/advancement/advancement-controls-section.hbs
+++ b/templates/advancement/advancement-controls-section.hbs
@@ -1,0 +1,4 @@
+<fieldset>
+    <legend>{{ localize "DND5E.ADVANCEMENT.Config.Details" }}</legend>
+    {{> "dnd5e.advancement-controls" }}
+</fieldset>

--- a/templates/advancement/hit-points-config.hbs
+++ b/templates/advancement/hit-points-config.hbs
@@ -5,11 +5,11 @@
         <span class="form-field-readonly">{{ hitDie }}</span>
     </div>
     <div class="form-group">
-        <label>{{ localize "DND5E.ADVANCEMENT.HITPOINTS.Starting" }}</label>
+        <label>{{ localize "DND5E.ADVANCEMENT.HitPoints.Starting" }}</label>
         <span class="form-field-readonly">{{ advancement.hitDieValue }}</span>
     </div>
     <div class="form-group">
-        <label>{{ localize "DND5E.ADVANCEMENT.HITPOINTS.Average" }}</label>
+        <label>{{ localize "DND5E.ADVANCEMENT.HitPoints.Average" }}</label>
         <span class="form-field-readonly">{{ advancement.average }}</span>
     </div>
 </fieldset>

--- a/templates/advancement/hit-points-config.hbs
+++ b/templates/advancement/hit-points-config.hbs
@@ -1,7 +1,15 @@
-<form autocomplete="off">
-    {{> "dnd5e.advancement-controls"}}
+<fieldset>
+    <legend>{{ localize "DND5E.HitPoints" }}</legend>
     <div class="form-group">
-        <label>{{localize "DND5E.HitDie"}}</label>
-        <span class="form-field-readonly">{{hitDie}}</span>
+        <label>{{ localize "DND5E.HitDie" }}</label>
+        <span class="form-field-readonly">{{ hitDie }}</span>
     </div>
-</form>
+    <div class="form-group">
+        <label>{{ localize "DND5E.ADVANCEMENT.HITPOINTS.Starting" }}</label>
+        <span class="form-field-readonly">{{ advancement.hitDieValue }}</span>
+    </div>
+    <div class="form-group">
+        <label>{{ localize "DND5E.ADVANCEMENT.HITPOINTS.Average" }}</label>
+        <span class="form-field-readonly">{{ advancement.average }}</span>
+    </div>
+</fieldset>

--- a/templates/advancement/hit-points-flow.hbs
+++ b/templates/advancement/hit-points-flow.hbs
@@ -1,11 +1,11 @@
-<form id="{{appId}}" data-level="{{level}}" data-id="{{advancement.id}}" data-type="{{type}}">
-    <h3>{{{title}}}</h3>
+<form id="{{ appId }}" data-level="{{ level }}" data-id="{{ advancement.id }}" data-type="{{ type }}">
+    <h3>{{{ title }}}</h3>
     {{#if hint}}<p>{{ hint }}</p>{{/if}}
 
     {{#if isFirstClassLevel}}
 
     <div>
-        {{{localize "DND5E.AdvancementHitPointsMaxAtFirstLevel" max=dieValue}}}
+        {{{ localize "DND5E.ADVANCEMENT.HitPoints.MaxAtFirstLevel" max=dieValue }}}
         <input type="hidden" name="useMax" value="true" data-dtype="Boolean">
     </div>
 
@@ -13,12 +13,12 @@
 
     <div class="rolls">
         <label class="averageLabel">
-            <span>{{localize "DND5E.AdvancementHitPointsAverage"}}</span>
-            <input class="averageCheckbox" type="checkbox" name="useAverage" {{checked data.useAverage}}>
+            <span>{{ localize "DND5E.ADVANCEMENT.HitPoints.TakeAverage" }}</span>
+            <input class="averageCheckbox" type="checkbox" name="useAverage" {{ checked data.useAverage }}>
         </label>
-        <input class="rollResult" type="number" name="value" value="{{data.value}}" {{disabled data.useAverage}}>
-        <button class="rollButton" type="button" name="roll" {{disabled data.useAverage}}>
-            <i class="fas fa-dice-d20"></i> {{localize "DND5E.AdvancementHitPointsRollButton" die=hitDie}}
+        <input class="rollResult" type="number" name="value" value="{{ data.value }}" {{ disabled data.useAverage }}>
+        <button class="rollButton" type="button" name="roll" {{ disabled data.useAverage }}>
+            <i class="fas fa-dice-d20"></i> {{ localize "DND5E.ADVANCEMENT.HitPoints.Actions.Roll" die=hitDie }}
         </button>
     </div>
 

--- a/templates/advancement/hit-points-flow.hbs
+++ b/templates/advancement/hit-points-flow.hbs
@@ -18,7 +18,7 @@
         </label>
         <input class="rollResult" type="number" name="value" value="{{ data.value }}" {{ disabled data.useAverage }}>
         <button class="rollButton" type="button" name="roll" {{ disabled data.useAverage }}>
-            <i class="fas fa-dice-d20"></i> {{ localize "DND5E.ADVANCEMENT.HitPoints.Actions.Roll" die=hitDie }}
+            <i class="fas fa-dice-d20" inert></i> {{ localize "DND5E.ADVANCEMENT.HitPoints.Action.Roll" die=hitDie }}
         </button>
     </div>
 

--- a/templates/advancement/parts/advancement-controls.hbs
+++ b/templates/advancement/parts/advancement-controls.hbs
@@ -1,14 +1,14 @@
 <div class="form-group">
     <label>{{ localize "DND5E.AdvancementCustomTitle" }}</label>
     <div class="form-fields">
-        <input type="text" name="title" value="{{ src.title }}" placeholder="{{ default.title }}">
+        <input type="text" name="title" value="{{ source.title }}" placeholder="{{ default.title }}">
     </div>
 </div>
 
 <div class="form-group">
     <label>{{ localize "DND5E.AdvancementCustomIcon" }}</label>
     <div class="form-fields">
-        <file-picker type="image" name="icon" value="{{ src.icon }}" placeholder="{{ default.icon }}"></file-picker>
+        <file-picker type="image" name="icon" value="{{ source.icon }}" placeholder="{{ default.icon }}"></file-picker>
     </div>
 </div>
 
@@ -17,7 +17,7 @@
     <label>{{ localize "DND5E.AdvancementClassRestriction" }}</label>
     <div class="form-fields">
         <select name="classRestriction">
-            {{ selectOptions classRestrictionOptions selected=classRestriction}}
+            {{ selectOptions classRestrictionOptions selected=source.classRestriction}}
         </select>
     </div>
 </div>
@@ -28,7 +28,7 @@
     <label>{{ localize "DND5E.Level" }}</label>
     <div class="form-fields">
         <select name="level" data-dtype="Number">
-            {{ selectOptions levels selected=level }}
+            {{ selectOptions levels selected=source.level }}
         </select>
     </div>
 </div>
@@ -36,5 +36,7 @@
 
 <div class="form-group">
     <label>{{ localize "DND5E.AdvancementHint" }}</label>
-    <textarea name="hint" {{~#if default.hint}} placeholder="{{ default.hint }}"{{/if}}>{{ hint }}</textarea>
+    <div class="form-fields">
+        <textarea name="hint" {{~#if default.hint}} placeholder="{{ default.hint }}"{{/if}}>{{ source.hint }}</textarea>
+    </div>
 </div>


### PR DESCRIPTION
Creates `AdvancementConfigV2` based on `ApplicationV2` and converts `HitPointsConfig` to use the new application and styles. Shared functionality between this application and the activity sheets has been moved into a new `PseudoDocumentSheet` class to avoid duplication.

<img width="421" alt="Hit Points Config V2" src="https://github.com/user-attachments/assets/ce8d36fc-8b37-4ffd-ad83-cae45726fb0d">

Also uses the `PseudoDocumentMixin` for advancement to get a number of improvements that were added for activities.