### PR TITLE
[#4714] Fix error when using chat action for deleted activity

### DIFF
--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1182,7 +1182,7 @@ export default Base => class extends PseudoDocumentMixin(Base) {
   async #onChatAction(event, target, message) {
     const scaling = message.getFlag("dnd5e", "scaling") ?? 0;
     const item = scaling ? this.item.clone({ "flags.dnd5e.scaling": scaling }, { keepId: true }) : this.item;
-    const activity = item.system.activities.get(this.id);
+    const activity = item.system.activities.get(this.id) ?? this;
 
     const action = target.dataset.action;
     const handler = this.metadata.usage?.actions?.[action];


### PR DESCRIPTION
Fixes an issue caused by enlarging special bastion facilities to their maximum size, which caused the Enlarge activity to be removed, and thus no subsequent chat actions could be triggered.

This fix covers the immediate problem, but the chat actions will still not be usable if the player refreshes or the chat message is re-rendered, because this fix only works because the deleted activity is still held in memory as part of the event handler.

Closes #4714