### PR TITLE
[#3958] Improve localization of rest messages

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2279,6 +2279,14 @@
 "DND5E.HealingRoll": "Healing Roll",
 "DND5E.HealingTemp": "Healing (Temporary)",
 "DND5E.Height": "Height",
+
+"DND5E.HITPOINTS": {
+  "Counted": {
+    "one": "{number} hit point",
+    "other": "{number} hit points"
+  }
+},
+
 "DND5E.HitPoints": "Hit Points",
 "DND5E.HitPointsBonusLevel": "Per Level Bonus",
 "DND5E.HitPointsBonusOverall": "Overall Bonus",
@@ -2305,7 +2313,11 @@
     "Increase": "Increase"
   },
   "Available": "{number} available",
-  "Config": "Adjust Hit Dice"
+  "Config": "Adjust Hit Dice",
+  "Counted": {
+    "one": "{number} hit die",
+    "other": "{number} hit dice"
+  }
 },
 
 "DND5E.HitDie": "Hit Die",
@@ -2751,16 +2763,10 @@
     "LabelShort": "L. Rest",
     "Recovery": "Recovers after Long Rest",
     "Result": {
-      "Full": "{name} takes a long rest and recovers {health} Hit Points and {dice} Hit Dice.",
-      "HitDice": "{name} takes a long rest and recovers {dice} Hit Dice.",
-      "HitPoints": "{name} takes a long rest and recovers {health} Hit Points.",
+      "Full": "{name} takes a long rest and recovers {health} and {dice}.",
+      "HitDice": "{name} takes a long rest and recovers {dice}.",
+      "HitPoints": "{name} takes a long rest and recovers {health}.",
       "Short": "{name} takes a long rest."
-    },
-    "Type": {
-      "Epic": "Long Rest (1 hour)",
-      "Gritty": "Long Rest (7 days)",
-      "Normal": "Long Rest (8 hours)",
-      "Overnight": "Long Rest (New Day)"
     }
   },
   "NewDay": {
@@ -2777,14 +2783,8 @@
     "LabelShort": "S. Rest",
     "Recovery": "Recovers after Short Rest",
     "Result": {
-      "Full": "{name} takes a short rest spending {dice} Hit Dice to recover {health} Hit Points.",
+      "Full": "{name} takes a short rest spending {dice} to recover {health}.",
       "Short": "{name} takes a short rest."
-    },
-    "Type": {
-      "Epic": "Short Rest (5 minutes)",
-      "Gritty": "Short Rest (8 hours)",
-      "Normal": "Short Rest (1 hour)",
-      "Overnight": "Short Rest (New Day)"
     }
   }
 },
@@ -3716,6 +3716,46 @@
     "Mile": {
       "Label": "Miles",
       "Abbreviation": "mi"
+    }
+  },
+  "TIME": {
+    "Day": {
+      "Label": "Day"
+    },
+    "Hour": {
+      "Label": "Hour"
+    },
+    "Minute": {
+      "Label": "Minute"
+    },
+    "Month": {
+      "Label": "Month"
+    },
+    "Round": {
+      "Label": "Round",
+      "Counted": {
+        "narrow": "{number}r",
+        "one": "{number} round",
+        "other": "{number} rounds"
+      }
+    },
+    "Second": {
+      "Label": "Second"
+    },
+    "Turn": {
+      "Label": "Turn",
+      "Abbreviation": "t",
+      "Counted": {
+        "narrow": "{number}t",
+        "one": "{number} turn",
+        "other": "{number} turns"
+      }
+    },
+    "Week": {
+      "Label": "Week"
+    },
+    "Year": {
+      "Label": "Year"
     }
   },
   "VOLUME": {

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -63,7 +63,10 @@ export default class BaseRestDialog extends Dialog5e {
    * @type {boolean}
    */
   get promptNewDay() {
-    return false;
+    const duration = CONFIG.DND5E.restTypes[this.config.type]
+      ?.duration?.[game.settings.get("dnd5e", "restVariant")] ?? 0;
+    // Only prompt if rest is longer than 10 minutes and less than 24 hours
+    return (duration > 10) && (duration < 1440);
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/rest/long-rest-dialog.mjs
+++ b/module/applications/actor/rest/long-rest-dialog.mjs
@@ -23,17 +23,6 @@ export default class LongRestDialog extends BaseRestDialog {
   };
 
   /* -------------------------------------------- */
-  /*  Properties                                  */
-  /* -------------------------------------------- */
-
-  /** @override */
-  get promptNewDay() {
-    // It's always a new day when resting 1 week
-    // TODO: Adjust based on actual variant duration, rather than hard-coding
-    return context.variant !== "gritty";
-  }
-
-  /* -------------------------------------------- */
   /*  Factory Methods                             */
   /* -------------------------------------------- */
 

--- a/module/applications/actor/rest/short-rest-dialog.mjs
+++ b/module/applications/actor/rest/short-rest-dialog.mjs
@@ -38,15 +38,6 @@ export default class ShortRestDialog extends BaseRestDialog {
   #denom;
 
   /* -------------------------------------------- */
-
-  /** @override */
-  get promptNewDay() {
-    // It's never a new day when resting 1 minute
-    // TODO: Adjust based on actual variant duration, rather than hard-coding
-    return context.variant !== "epic";
-  }
-
-  /* -------------------------------------------- */
   /*  Rendering                                   */
   /* -------------------------------------------- */
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -845,21 +845,95 @@ DND5E.toolIds = new Proxy(DND5E.tools, {
 });
 
 /* -------------------------------------------- */
+/*  Time                                        */
+/* -------------------------------------------- */
+
+/**
+ * @typedef {object} TimeUnitConfiguration
+ * @property {string} label            Localized label for this unit.
+ * @property {string} [counted]        Localization path for counted plural forms. Only necessary if non-supported unit
+ *                                     or using non-standard name for a supported unit. List of supported units can be
+ *                                     found here: https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers
+ * @property {number} conversion       Conversion multiplier used to converting between units.
+ * @property {boolean} [combat=false]  Is this a combat-specific time unit?
+ * @property {boolean} [option=true]   Should this be available when users can select from a list of units?
+ */
+
+/**
+ * Configuration for time units available to the system.
+ * @enum {TimeUnitConfiguration}
+ */
+DND5E.timeUnits = {
+  turn: {
+    label: "DND5E.UNITS.TIME.Turn.Label",
+    counted: "DND5E.UNITS.TIME.Turn.Counted",
+    conversion: .1,
+    combat: true
+  },
+  round: {
+    label: "DND5E.UNITS.TIME.Round.Label",
+    counted: "DND5E.UNITS.TIME.Round.Counted",
+    conversion: .1,
+    combat: true
+  },
+  second: {
+    label: "DND5E.UNITS.TIME.Second.Label",
+    conversion: 1 / 60,
+    option: false
+  },
+  minute: {
+    label: "DND5E.UNITS.TIME.Minute.Label",
+    conversion: 1
+  },
+  hour: {
+    label: "DND5E.UNITS.TIME.Hour.Label",
+    conversion: 60
+  },
+  day: {
+    label: "DND5E.UNITS.TIME.Day.Label",
+    conversion: 1_440
+  },
+  week: {
+    label: "DND5E.UNITS.TIME.Week.Label",
+    conversion: 10_080,
+    option: false
+  },
+  month: {
+    label: "DND5E.UNITS.TIME.Month.Label",
+    conversion: 43_200
+  },
+  year: {
+    label: "DND5E.UNITS.TIME.Year.Label",
+    conversion: 525_600
+  }
+};
+preLocalize("timeUnits", { key: "label" });
+
+/* -------------------------------------------- */
 
 /**
  * Time periods that accept a numeric value.
  * @enum {string}
  */
-DND5E.scalarTimePeriods = {
-  turn: "DND5E.TimeTurn",
-  round: "DND5E.TimeRound",
-  minute: "DND5E.TimeMinute",
-  hour: "DND5E.TimeHour",
-  day: "DND5E.TimeDay",
-  month: "DND5E.TimeMonth",
-  year: "DND5E.TimeYear"
-};
-preLocalize("scalarTimePeriods");
+DND5E.scalarTimePeriods = new Proxy(DND5E.timeUnits, {
+  get(target, prop) {
+    return target[prop]?.label;
+  },
+  has(target, key) {
+    return target[key] && target[key].option !== false;
+  },
+  set(target, prop, value) {
+    foundry.utils.logCompatibilityWarning(
+      "Appending to CONFIG.DND5E.scalarTimePeriods is deprecated, use CONFIG.DND5E.timeUnits instead.",
+      { since: "DnD5e 4.2", until: "DnD5e 4.4", once: true }
+    );
+    target[prop] ??= {};
+    target[prop].label = value;
+  },
+  ownKeys(target) {
+    return Object.keys(target).filter(k => target[k]?.option !== false);
+  }
+});
 
 /* -------------------------------------------- */
 
@@ -2789,13 +2863,14 @@ DND5E.hitDieTypes = ["d4", "d6", "d8", "d10", "d12"];
  * Configuration data for rest types.
  *
  * @typedef {object} RestConfiguration
- * @property {Record<string, number>} duration    Duration of different rest variants in minutes.
- * @property {boolean} recoverHitDice             Should hit dice be recovered during this rest?
- * @property {boolean} recoverHitPoints           Should hit points be recovered during this rest?
- * @property {string[]} recoverPeriods            What recovery periods should be applied when this rest is taken. The
- *                                                ordering of the periods determines which is applied if more than one
- *                                                recovery profile is found.
- * @property {Set<string>} recoverSpellSlotTypes  Types of spellcasting slots to recover during this rest.
+ * @property {Record<string, number>} duration      Duration of different rest variants in minutes.
+ * @property {string} label                         Localized label for the rest type.
+ * @property {boolean} [recoverHitDice]             Should hit dice be recovered during this rest?
+ * @property {boolean} [recoverHitPoints]           Should hit points be recovered during this rest?
+ * @property {string[]} [recoverPeriods]            What recovery periods should be applied when this rest is taken. The
+ *                                                  ordering of the periods determines which is applied if more than one
+ *                                                  recovery profile is found.
+ * @property {Set<string>} [recoverSpellSlotTypes]  Types of spellcasting slots to recover during this rest.
  */
 
 /**
@@ -2809,21 +2884,24 @@ DND5E.restTypes = {
       gritty: 480,
       epic: 1
     },
+    label: "DND5E.REST.Short.Label",
     recoverPeriods: ["sr"],
     recoverSpellSlotTypes: new Set(["pact"])
   },
   long: {
     duration: {
       normal: 480,
-      gritty: 10080,
+      gritty: 10_080,
       epic: 60
     },
+    label: "DND5E.REST.Long.Label",
     recoverHitDice: true,
     recoverHitPoints: true,
     recoverPeriods: ["lr", "sr"],
     recoverSpellSlotTypes: new Set(["leveled", "pact"])
   }
 };
+preLocalize("restTypes", { key: "label" });
 
 /* -------------------------------------------- */
 


### PR DESCRIPTION
Updates the rest message to select the proper plural form of Hit Points and Hit Dice to match the number recovered.

Also adjusts the flavor to automatically display the rest time in the message flavor, rather than relying on hard-coded labels for each rest variant. This ensures the flavor will properly display the rest time even if it doesn't exactly match the default values.

In order to support this as well as improve other time-based localization in the future, this PR adds two new utlity methods:
- `convertTime` converts a time from one set of units to another. It will also attempt to pick the best unit automatically if the `to` units are not defined, selecting the largest unit that can fully represent the value (with some wiggle room so it will display 90 minutes, rather than 1.5 hours).
- `formatTime` converts a time value and units into a string for display, relying on the system-provided plural localization if available and if not using Javascript's standard unit formatting for numbers.