### PR TITLE
[#4708] Convert `AdvancementManager` to V2 app & styles

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -298,6 +298,33 @@
       "Invalid": "Hit points must be a valid whole number."
     }
   },
+  "Manager": {
+    "Action": {
+      "Complete": "Complete",
+      "NextStep": "Next",
+      "PreviousStep": "Previous",
+      "Restart": "Restart"
+    },
+    "ClosePrompt": {
+      "Action": {
+        "Continue": "Continue",
+        "Stop": "Stop Advancement"
+      },
+      "Message": "<p>If the advancement process is cancelled, choices made so far will be discarded and no changes will be made to the actor.</p>",
+      "Title": "Stop Advancement"
+    },
+    "RestartPrompt": {
+      "Message": "Are you sure you wish to undo all choices so far?",
+      "Title": "Restart Advancement Choices"
+    },
+    "Steps": "Step {current} of {total}",
+    "Title": {
+      "Default": "Advancement",
+      "LevelIncreased": "Level Up Character",
+      "LevelNewClass": "Add Class",
+      "ModifyChoices": "Modify Choices"
+    }
+  },
   "SPELLCONFIG": {
     "FIELDS": {
       "uses": {
@@ -378,21 +405,6 @@
 "DND5E.AdvancementLevelNoneHeader": "No Level",
 "DND5E.AdvancementLevelDownConfirmationMessage": "Leveling this class down will also undo all advancement choices made for it. These changes will be removed from your character as long as the checkbox below is checked.",
 "DND5E.AdvancementLevelDownConfirmationTitle": "Confirm Leveling Down",
-"DND5E.AdvancementManagerCloseTitle": "Stop Advancement",
-"DND5E.AdvancementManagerCloseMessage": "<p>If the advancement process is cancelled, choices made so far will be discarded and no changes will be made to the actor.</p>",
-"DND5E.AdvancementManagerCloseButtonContinue": "Continue",
-"DND5E.AdvancementManagerCloseButtonStop": "Stop Advancement",
-"DND5E.AdvancementManagerComplete": "Complete",
-"DND5E.AdvancementManagerLevelIncreasedTitle": "Level Up Character",
-"DND5E.AdvancementManagerLevelNewClassTitle": "Add Class",
-"DND5E.AdvancementManagerModifyChoicesTitle": "Modify Choices",
-"DND5E.AdvancementManagerNextStep": "Next",
-"DND5E.AdvancementManagerPreviousStep": "Previous",
-"DND5E.AdvancementManagerRestart": "Restart",
-"DND5E.AdvancementManagerRestartConfirm": "Are you sure you wish to undo all choices so far?",
-"DND5E.AdvancementManagerRestartConfirmTitle": "Restart Advancement Choices",
-"DND5E.AdvancementManagerSteps": "Step {current} of {total}",
-"DND5E.AdvancementManagerTitle": "Advancement",
 "DND5E.AdvancementMigrationConfirm": "Apply Migrations",
 "DND5E.AdvancementMigrationHint": "Select which of the following advancements will be added to {name}.",
 "DND5E.AdvancementMigrationTitle": "Migrate Advancement",

--- a/less/v1/advancement.less
+++ b/less/v1/advancement.less
@@ -452,6 +452,10 @@
     .replaced h4 {
       text-decoration: rgb(200 0 0) line-through 2px;
     }
+    label.flexrow {
+      justify-content: space-between;
+      input[type=checkbox] { flex: none; }
+    }
   }
 
   form[data-type="ScaleValue"] {

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -1,3 +1,35 @@
+/* ----------------------------------------- */
+/*  Advancement Manager                      */
+/* ----------------------------------------- */
+
+.dnd5e2.advancement.manager.application {
+  [data-application-part="manager"] {
+    gap: 12px;
+
+    > .step {
+      h3 {
+        padding-block-end: 0;
+        color: var(--color-text-dark-primary);
+        font-family: var(--dnd5e-font-roboto-condensed);
+        font-size: var(--font-size-20);
+        text-shadow: none;
+      }
+      &.dnd5e {
+        h4 {
+          color: var(--color-text-dark-primary);
+          font-family: var(--dnd5e-font-roboto);
+          text-shadow: none;
+        }
+      }
+    }
+    nav { gap: 6px; }
+  }
+}
+
+/* ----------------------------------------- */
+/*  Visualizer                               */
+/* ----------------------------------------- */
+
 .advancement-visualizer {
   .step {
     position: relative;

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -22,7 +22,24 @@
         }
       }
     }
+
     nav { gap: 6px; }
+
+    /* V1 Compatibility */
+    button { height: var(--input-height); }
+
+    label > span {
+      font-family: var(--dnd5e-font-roboto-slab);
+      font-weight: bold;
+      font-size: var(--font-size-12);
+    }
+
+    input[type=checkbox]{
+      &:hover, &:focus {
+        box-shadow: none;
+        border: none;
+      }
+    }
   }
 }
 

--- a/templates/advancement/advancement-manager.hbs
+++ b/templates/advancement/advancement-manager.hbs
@@ -1,26 +1,27 @@
-<div>
-    <div class="step">
-        <h1>{{header}}</h1>
-        <h2>{{subheader}}</h2>
-
-        <template id="{{flowId}}"></template>
+<div class="flexcol">
+    <div class="step {{ flowClasses }}">
+        <template id="{{ flowId }}"></template>
     </div>
-    <nav>
+    <nav class="flexrow">
         {{#if steps.hasPrevious}}
         <button type="button" data-action="previous">
-            <i class="fas fa-angle-double-left"></i> {{localize "DND5E.AdvancementManagerPreviousStep"}}
+            <i class="fas fa-angle-double-left" inert></i>
+            {{ localize "DND5E.ADVANCEMENT.Manager.Action.PreviousStep" }}
         </button>
         <button type="button" data-action="restart">
-            <i class="fas fa-undo"></i> {{localize "DND5E.AdvancementManagerRestart"}}
+            <i class="fas fa-undo" inert></i>
+            {{ localize "DND5E.ADVANCEMENT.Manager.Action.Restart" }}
         </button>
         {{/if}}
         {{#if steps.hasNext}}
         <button type="button" data-action="next">
-            <i class="fas fa-angle-double-right"></i> {{localize "DND5E.AdvancementManagerNextStep"}}
+            <i class="fas fa-angle-double-right" inert></i>
+            {{ localize "DND5E.ADVANCEMENT.Manager.Action.NextStep" }}
         </button>
         {{else}}
         <button type="button" data-action="complete">
-            <i class="fas fa-check"></i> {{localize "DND5E.AdvancementManagerComplete"}}
+            <i class="fas fa-check" inert></i>
+            {{ localize "DND5E.ADVANCEMENT.Manager.Action.Complete" }}
         </button>
         {{/if}}
     </nav>


### PR DESCRIPTION
Converts `AdvancementManager` to use `ApplicationV2` and V2 system styles. Because old V1 advancement flow applications are embedded within this application, there are some V1 classes added to ensure that styling of old flows aren't completely broken.

<img width="480" alt="Flow V2 Manager" src="https://github.com/user-attachments/assets/babcbd24-5bdf-4d08-aa35-e024c88d3295">

This also takes a number of soft-private properties and methods on the manager and makes them hard-private.