### PR TITLE
[#2359] Automatically reset legendary actions during combat

### DIFF
--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -391,6 +391,15 @@ export class ActorDataModel extends SystemDataModel {
     data.prof.deterministic = deterministic;
     return data;
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Reset combat-related uses.
+   * @param {Set<string>} periods              Which recovery periods should be considered.
+   * @param {{ actor: {}, item: [] }} updates  Updates to perform on the actor and containing items.
+   */
+  async recoverCombatUses(periods, updates) {}
 }
 
 /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -381,4 +381,14 @@ export default class NPCData extends CreatureTemplate {
     if ( spell.system.preparation.mode === "innate" ) return this.details.cr;
     return this.details.level ? this.details.level : this.details.spellLevel;
   }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  recoverCombatUses(periods, updates) {
+    // Reset legendary actions at the start of a combat encounter or at the end of the creature's turn
+    if ( this.resources.legact.max && (periods.has("encounter") || periods.has("turnEnd")) ) {
+      updates.actor["system.resources.legact.value"] = this.resources.legact.max;
+    }
+  }
 }

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -385,7 +385,7 @@ export default class NPCData extends CreatureTemplate {
   /* -------------------------------------------- */
 
   /** @override */
-  recoverCombatUses(periods, updates) {
+  async recoverCombatUses(periods, updates) {
     // Reset legendary actions at the start of a combat encounter or at the end of the creature's turn
     if ( this.resources.legact.max && (periods.has("encounter") || periods.has("turnEnd")) ) {
       updates.actor["system.resources.legact.value"] = this.resources.legact.max;

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -11,13 +11,69 @@ export default class Combatant5e extends Combatant {
   /* -------------------------------------------- */
 
   /**
+   * Reset combat-related uses.
+   * @param {Set<string>} periods  Which recovery periods should be considered.
+   */
+  async recoverCombatUses(periods) {
+    /**
+     * A hook event that fires before combat-related recovery changes.
+     * @function dnd5e.preCombatRecovery
+     * @memberof hookEvents
+     * @param {Combatant5e} combatant     Combatant that is being recovered.
+     * @param {object} data
+     * @param {Set<string>} data.periods  Periods to be recovered.
+     * @returns {boolean}                 Explicitly return `false` to prevent recovery from being performed.
+     */
+    if ( Hooks.call("dnd5e.preCombatRecovery", this, { periods }) === false ) return;
+
+    const updates = { actor: {}, item: [] };
+    await this.actor?.system.recoverCombatUses?.(periods, updates);
+
+    // TODO: If https://github.com/foundryvtt/dnd5e/issues/3214 is implemented, this is where
+    // item/activity uses with combat related recovery can be recovered
+
+    /**
+     * A hook event that fires after combat-related recovery changes have been prepared, but before they have been
+     * applied to the actor.
+     * @function dnd5e.combatRecovery
+     * @memberof hookEvents
+     * @param {Combatant5e} combatant              Combatant that is being recovered.
+     * @param {object} data
+     * @param {Set<string>} data.periods           Periods that were recovered.
+     * @param {{ actor: object, item: object[] }}  Update that will be applied to the actor and their items.
+     * @returns {boolean}                          Explicitly return `false` to prevent updates from being performed.
+     */
+    if ( Hooks.call("dnd5e.combatRecovery", this, { periods, updates }) === false ) return;
+
+    if ( !foundry.utils.isEmpty(updates.actor) ) await this.actor.update(updates.actor);
+    if ( updates.item.length ) await this.actor.updateEmbeddedDocuments("Item", updates.item);
+
+    // TODO: Consider adding a chat message indicating what was recovered with a "Revert" button
+    // Not sure if this should be GM-only or whispered to the owners of the actor
+
+    /**
+     * A hook event that fires after combat-related recovery changes have been applied.
+     * @function dnd5e.postCombatRecovery
+     * @memberof hookEvents
+     * @param {Combatant5e} combatant     Combatant that is being recovered.
+     * @param {object} data
+     * @param {Set<string>} data.periods  Periods that were recovered.
+     */
+    Hooks.callAll("dnd5e.postCombatRecovery", this, { periods });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Trigger this combatant's dynamic token to refresh.
    */
   refreshDynamicRing() {
     if ( !this.token?.hasDynamicRing ) return;
-    this.token.object?.renderFlags.set({refreshRingVisuals: true});
+    this.token.object?.renderFlags.set({ refreshRingVisuals: true });
   }
 
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
   /* -------------------------------------------- */
 
   /** @inheritDoc */

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -19,12 +19,11 @@ export default class Combatant5e extends Combatant {
      * A hook event that fires before combat-related recovery changes.
      * @function dnd5e.preCombatRecovery
      * @memberof hookEvents
-     * @param {Combatant5e} combatant     Combatant that is being recovered.
-     * @param {object} data
-     * @param {Set<string>} data.periods  Periods to be recovered.
-     * @returns {boolean}                 Explicitly return `false` to prevent recovery from being performed.
+     * @param {Combatant5e} combatant  Combatant that is being recovered.
+     * @param {Set<string>} periods    Periods to be recovered.
+     * @returns {boolean}              Explicitly return `false` to prevent recovery from being performed.
      */
-    if ( Hooks.call("dnd5e.preCombatRecovery", this, { periods }) === false ) return;
+    if ( Hooks.call("dnd5e.preCombatRecovery", this, periods) === false ) return;
 
     const updates = { actor: {}, item: [] };
     await this.actor?.system.recoverCombatUses?.(periods, updates);
@@ -37,13 +36,12 @@ export default class Combatant5e extends Combatant {
      * applied to the actor.
      * @function dnd5e.combatRecovery
      * @memberof hookEvents
-     * @param {Combatant5e} combatant              Combatant that is being recovered.
-     * @param {object} data
-     * @param {Set<string>} data.periods           Periods that were recovered.
-     * @param {{ actor: object, item: object[] }}  Update that will be applied to the actor and their items.
-     * @returns {boolean}                          Explicitly return `false` to prevent updates from being performed.
+     * @param {Combatant5e} combatant                      Combatant that is being recovered.
+     * @param {Set<string>} periods                        Periods that were recovered.
+     * @param {{ actor: object, item: object[] }} updates  Update that will be applied to the actor and its items.
+     * @returns {boolean}  Explicitly return `false` to prevent updates from being performed.
      */
-    if ( Hooks.call("dnd5e.combatRecovery", this, { periods, updates }) === false ) return;
+    if ( Hooks.call("dnd5e.combatRecovery", this, periods, updates) === false ) return;
 
     if ( !foundry.utils.isEmpty(updates.actor) ) await this.actor.update(updates.actor);
     if ( updates.item.length ) await this.actor.updateEmbeddedDocuments("Item", updates.item);
@@ -55,11 +53,10 @@ export default class Combatant5e extends Combatant {
      * A hook event that fires after combat-related recovery changes have been applied.
      * @function dnd5e.postCombatRecovery
      * @memberof hookEvents
-     * @param {Combatant5e} combatant     Combatant that is being recovered.
-     * @param {object} data
-     * @param {Set<string>} data.periods  Periods that were recovered.
+     * @param {Combatant5e} combatant  Combatant that is being recovered.
+     * @param {Set<string>} periods    Periods that were recovered.
      */
-    Hooks.callAll("dnd5e.postCombatRecovery", this, { periods });
+    Hooks.callAll("dnd5e.postCombatRecovery", this, periods);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Automatically resets NPCs legendary actions count at the start of a new combat and at the end of the actor's turn. The reset is at the end of the turn to avoid issues with using legendary actions between the end of the previous combatant's turn and this one.

This works using a new `_recoverUses` method on `Combat5e` that is called by `startCombat` and `nextTurn`. It is passed a series of recovery periods with either `true` (indicating that this should be recovered for all combatants) or a specific combatant (indicating that this should only be recovered for that specific combatant). At the start of combat the `encounter` recovery is called for all combatants, and on `nextTurn` the `turnEnd` is called for the previous combatant and `turnStart` is called for the incoming combatant.

This then calls `recoverCombatUses` on the individual combatants, so long as they have at least one relevant period. This method handles calling `recoverCombatUses` on the actor's system data and sending out the necessary hooks. If additional combat recovery types requested in #3214 are implemented this is where they will also be handled.

Closes #2359