### PR TITLE
[#4334] Add bonus field to `CheckActivity` and `SaveActivity`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1461,6 +1461,10 @@
         "label": "Associated Skills or Tools",
         "hint": "Present ability checks using proficiency and bonuses with these skills or tools."
       },
+      "bonus": {
+        "label": "Check Bonus",
+        "hint": "Bonus added to all check rolls made using this activity."
+      },
       "dc": {
         "label": "Difficulty Class",
         "calculation": {
@@ -3801,6 +3805,10 @@
       "ability": {
         "label": "Challenge Abilities",
         "hint": "Abilities that may be rolled to attempt to save."
+      },
+      "bonus": {
+        "label": "Save Bonus",
+        "hint": "Bonus added to all save rolls made using this activity."
       },
       "dc": {
         "label": "Difficulty Class",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1463,7 +1463,7 @@
       },
       "bonus": {
         "label": "Check Bonus",
-        "hint": "Bonus added to all check rolls made using this activity."
+        "hint": "Bonus added to all checks made using this activity."
       },
       "dc": {
         "label": "Difficulty Class",
@@ -3808,7 +3808,7 @@
       },
       "bonus": {
         "label": "Save Bonus",
-        "hint": "Bonus added to all save rolls made using this activity."
+        "hint": "Bonus added to all saving throws made using this activity."
       },
       "dc": {
         "label": "Difficulty Class",

--- a/module/data/activity/_types.mjs
+++ b/module/data/activity/_types.mjs
@@ -80,6 +80,7 @@
  * @property {object} check
  * @property {string} check.ability          Ability used with the check.
  * @property {Set<string>} check.associated  Skills or tools that can contribute to the check.
+ * @property {string} check.bonus            Bonus added to all checks made through this activity.
  * @property {object} check.dc
  * @property {string} check.dc.calculation   Method or ability used to calculate the difficulty class of the check.
  * @property {string} check.dc.formula       Custom DC formula or flat value.
@@ -140,6 +141,7 @@
  * @property {SaveEffectApplicationData[]} effects  Linked effects that can be applied.
  * @property {object} save
  * @property {Set<string>} save.ability             Make the saving throw with one of these abilities.
+ * @property {string} save.bonus                    Bonus added to all saves made through this activity.
  * @property {object} save.dc
  * @property {string} save.dc.calculation           Method or ability used to calculate the difficulty class.
  * @property {string} save.dc.formula               Custom DC formula or flat value.

--- a/module/data/activity/check-data.mjs
+++ b/module/data/activity/check-data.mjs
@@ -21,6 +21,7 @@ export default class BaseCheckActivityData extends BaseActivityData {
       check: new SchemaField({
         ability: new StringField(),
         associated: new SetField(new StringField()),
+        bonus: new FormulaField(),
         dc: new SchemaField({
           calculation: new StringField(),
           formula: new FormulaField({ deterministic: true })

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -29,6 +29,7 @@ export default class BaseSaveActivityData extends BaseActivityData {
       })),
       save: new SchemaField({
         ability: new SetField(new StringField()),
+        bonus: new FormulaField(),
         dc: new SchemaField({
           calculation: new StringField({ initial: "initial" }),
           formula: new FormulaField({ deterministic: true })

--- a/module/documents/activity/check.mjs
+++ b/module/documents/activity/check.mjs
@@ -98,12 +98,14 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
     let { ability, dc, skill, tool } = target.dataset;
     dc = parseInt(dc);
     const rollData = { event, target: Number.isFinite(dc) ? dc : this.check.dc.value };
+    const bonusData = CONFIG.Dice.BasicRoll.constructParts({ activityBonus: this.check.bonus }, this.getRollData());
     if ( ability in CONFIG.DND5E.abilities ) rollData.ability = ability;
 
     for ( const token of targets ) {
       const actor = token instanceof Actor ? token : token.actor;
       const speaker = ChatMessage.getSpeaker({ actor, scene: canvas.scene, token: token.document });
       const messageData = { data: { speaker } };
+      if ( bonusData.parts.length ) rollData.rolls = [bonusData];
       if ( skill ) await actor.rollSkill({ ...rollData, skill }, {}, messageData);
       else if ( tool ) {
         rollData.tool = tool;

--- a/module/documents/activity/save.mjs
+++ b/module/documents/activity/save.mjs
@@ -112,14 +112,17 @@ export default class SaveActivity extends ActivityMixin(BaseSaveActivityData) {
     if ( !targets.length && game.user.character ) targets.push(game.user.character);
     if ( !targets.length ) ui.notifications.warn("DND5E.ActionWarningNoToken", { localize: true });
     const dc = parseInt(target.dataset.dc);
+    const bonusData = CONFIG.Dice.BasicRoll.constructParts({ activityBonus: this.save.bonus }, this.getRollData());
     for ( const token of targets ) {
       const actor = token instanceof Actor ? token : token.actor;
       const speaker = ChatMessage.getSpeaker({ actor, scene: canvas.scene, token: token.document });
-      await actor.rollSavingThrow({
+      const rollData = {
         event,
         ability: target.dataset.ability ?? this.save.ability.first(),
         target: Number.isFinite(dc) ? dc : this.save.dc.value
-      }, {}, { data: { speaker } });
+      };
+      if ( bonusData.parts.length ) rollData.rolls = [bonusData];
+      await actor.rollSavingThrow(rollData, {}, { data: { speaker } });
     }
   }
 

--- a/templates/activity/parts/check-details.hbs
+++ b/templates/activity/parts/check-details.hbs
@@ -2,6 +2,7 @@
     <legend>{{ localize "DND5E.CHECK.FIELDS.check.label" }}</legend>
     {{ formField fields.check.fields.associated value=source.check.associated options=associatedOptions rootId=partId }}
     {{ formField fields.check.fields.ability value=source.check.ability options=abilityOptions rootId=partId }}
+    {{ formField fields.check.fields.bonus value=source.check.bonus rootId=partId }}
     {{#with fields.check.fields.dc.fields as |fields|}}
     {{ formField fields.calculation value=../activity.check.dc.calculation options=../calculationOptions
                  rootId=@root.partId }}

--- a/templates/activity/parts/save-details.hbs
+++ b/templates/activity/parts/save-details.hbs
@@ -1,6 +1,7 @@
 <fieldset>
     <legend>{{ localize "DND5E.SAVE.FIELDS.save.label" }}</legend>
     {{ formField fields.save.fields.ability value=source.save.ability options=abilityOptions rootId=@root.partId }}
+    {{ formField fields.save.fields.bonus value=source.save.bonus rootId=@root.partId }}
     {{#with fields.save.fields.dc.fields as |fields|}}
     {{ formField fields.calculation value=../activity.save.dc.calculation options=../calculationOptions
                  rootId=@root.partId }}


### PR DESCRIPTION
Added bonus formulas that are added to all check & save rolls performed through these activities. These bonuses are based off the roll data of the actor who owns the activity, not the actor doing the roll.

Closes #4334