### PR TITLE
[#3798] Add embeddable NPC statblocks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -99,6 +99,7 @@
 "DND5E.AbilityScoreMax": "Maximum Ability Score",
 "DND5E.AbilityScoreMaxShort": "Maximum",
 "DND5E.AbilityModifier": "Ability Modifier",
+"DND5E.AbilityModifierShort": "Mod",
 "DND5E.AbilityPromptText": "What type of {ability} check?",
 "DND5E.AbilityPromptTitle": "{ability} Ability Check",
 "DND5E.AbilityUseChargesLabel": "{value} Charges",
@@ -1198,6 +1199,7 @@
 "DND5E.CreatureSwarm": "Swarm",
 "DND5E.CreatureSwarmSize": "Swarm Size",
 "DND5E.CreatureSwarmPhrase": "Swarm of {size} {type}",
+"DND5E.CreatureTag": "{size} {type}, {alignment}",
 "DND5E.CreatureTypeConfig": "Configure Creature Type",
 "DND5E.CreatureTypeSelectorCustom": "Custom Type",
 "DND5E.CreatureTypeSelectorSubtype": "Subtype",
@@ -2056,6 +2058,7 @@
 "DND5E.Formula": "Formula",
 "DND5E.FormulaMalformedError": "Problem preparing the {property} formula within {name}.",
 "DND5E.FormulaMissingReferenceWarn": "The {property} formula within {name} has references to missing data: {references}",
+"DND5E.Gear": "Gear",
 "DND5E.Gender": "Gender",
 "DND5E.GlobalBonus": "Global Bonus",
 "DND5E.GrantedAbilities": "Granted Abilities",
@@ -2421,7 +2424,18 @@
 "DND5E.Normal": "Normal",
 "DND5E.NotProficient": "Not Proficient",
 "DND5E.Notes": "Notes",
-"DND5E.NPC": "NPC",
+
+"DND5E.NPC": {
+  "Label": "NPC",
+  "SECTIONS": {
+    "Actions": "Actions",
+    "BonusActions": "Bonus Actions",
+    "LegendaryActions": "Legendary Actions",
+    "Reactions": "Reactions",
+    "Traits": "Traits"
+  }
+},
+
 "DND5E.Number": "Number",
 "DND5E.OtherFormula": "Other Formula",
 "DND5E.PactMagic": "Pact Magic",
@@ -2482,6 +2496,7 @@
 "DND5E.Price": "Price",
 "DND5E.Proficiency": "Proficiency",
 "DND5E.ProficiencyBonus": "Proficiency Bonus",
+"DND5E.ProficiencyBonusAbbr": "PB",
 "DND5E.ProficiencyConfigurationHint": "Configure proficiency and bonuses.",
 "DND5E.ProficiencyConfigureTitle": "Configure {label}",
 "DND5E.ProficiencyLevel": "Proficiency Level",
@@ -2696,6 +2711,7 @@
 "DND5E.SavingThrow": "Saving Throw",
 "DND5E.SavingThrowDC": "DC {dc} {ability} Saving Throw",
 "DND5E.SavingThrowRoll": "Roll {ability} Saving Throw",
+"DND5E.SavingThrowShort": "Save",
 "DND5E.SaveDC": "DC {dc} {ability}",
 "DND5E.SavePromptTitle": "{ability} Saving Throw",
 "DND5E.ScalingFormula": "Scaling Formula",

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -172,6 +172,132 @@
 
     p:last-of-type { margin-bottom: 0; }
   }
+
+  /* NPC Stat Blocks */
+  .statblock.npc {
+    --statblock-background: rgb(235 228 214 / .35);
+    --statblock-ability-header-1st: rgb(234 229 217);
+    --statblock-ability-header-2nd: rgb(215 217 208);
+    --statblock-ability-stat-1st: rgb(218 211 203);
+    --statblock-ability-stat-2nd: rgb(205 201 201);
+    --statblock-border: rgb(78 76 74);
+    --statblock-column-width: 400px;
+    --statblock-text-header: rgb(79 29 21);
+    --statblock-text-primary: rgb(31, 30, 30);
+    --statblock-text-secondary: rgba(73 72 73 / .75);
+
+    max-width: var(--statblock-column-width);
+    background: var(--statblock-background);
+    border: 3px double var(--statblock-border);
+    border-radius: 8px;
+    padding-block: 4px;
+    padding-inline: 8px;
+    box-shadow: 2px 2px 2px rgb(0 0 0 / .15);
+
+    h4.statblock-title, h5.statblock-actions-title {
+      border-block-end: 1px solid currentcolor;
+      font-variant: small-caps;
+    }
+    h4.statblock-title {
+      color: color-mix(in oklab, var(--statblock-text-header) 75%, transparent);
+      font-size: var(--font-size-18);
+    }
+    h5.statblock-actions-title {
+      margin-block-start: 8px;
+      color: var(--statblock-text-header);
+      font-size: var(--font-size-16);
+      font-weight: normal;
+    }
+    .statblock-tags {
+      color: var(--statblock-text-secondary);
+      font-style: italic;
+    }
+
+    .statblock-content {
+      display: column;
+      column-width: var(--statblock-column-width);
+    }
+    .statblock-header {
+      break-inside: avoid;
+      color: var(--statblock-text-header);
+
+      dl {
+        display: flex;
+        flex-wrap: wrap;
+
+        > div {
+          flex: 1 0 100%;
+          &.half-width { flex: 1 0 50%; }
+        }
+
+        div > :is(dt, dd) {
+          display: inline;
+          line-height: 1.5;
+        }
+      }
+      .abilities {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 6px;
+
+        table, thead, tbody, tr, th, td { all: revert; }
+        table { border-collapse: collapse; }
+        thead th {
+          color: var(--statblock-text-secondary);
+          font-family: var(--dnd5e-font-roboto);
+          font-size: var(--font-size-10);
+          font-weight: normal;
+          text-transform: uppercase;
+
+          &.visually-hidden {
+            clip: rect(0 0 0 0);
+            clip-path: inset(50%);
+            font-size: 1px;
+            overflow: hidden;
+            white-space: nowrap;
+          }
+        }
+        tbody {
+          tr {
+            border-block: 1px solid white;
+            &:nth-of-type(odd) {
+              th, .score { background: var(--statblock-ability-header-1st); }
+              td { background: var(--statblock-ability-stat-1st); }
+            }
+            &:nth-of-type(even) {
+              th, .score { background: var(--statblock-ability-header-2nd); }
+              td { background: var(--statblock-ability-stat-2nd); }
+            }
+          }
+          th { font-variant: small-caps; }
+          td { text-align: center; }
+        }
+      }
+    }
+
+    .statblock-actions {
+      color: var(--statblock-text-primary);
+
+      .statblock-action {
+        > p:first-child > .name {
+          font-style: italic;
+          font-weight: bold;
+          &::after { content: ". "; }
+        }
+        a, button {
+          display: contents;
+          cursor: inherit;
+          pointer-events: none;
+          :is(.fas, .fa-solid, .far, .fa-regular) { display: none; }
+        }
+      }
+    }
+  }
+
+  .double-column .statblock {
+    max-width: calc(var(--statblock-column-width) * 2);
+    .statblock-content { columns: 2; }
+  }
 }
 
 :is(.dnd5e2, .dnd5e2-journal) {

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -192,7 +192,7 @@
     border-radius: 8px;
     padding-block: 4px;
     padding-inline: 8px;
-    box-shadow: 2px 2px 2px rgb(0 0 0 / .15);
+    box-shadow: 2px 2px 2px var(--dnd5e-shadow-15);
 
     h4.statblock-title, h5.statblock-actions-title {
       border-block-end: 1px solid currentcolor;
@@ -233,6 +233,10 @@
         div > :is(dt, dd) {
           display: inline;
           line-height: 1.5;
+        }
+        dt {
+          color: var(--statblock-text-header);
+          text-shadow: none;
         }
       }
       .abilities {

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -255,7 +255,9 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     const mod = spellAbility?.mod ?? 0;
     const attackBonus = msak === rsak ? msak : 0;
     context.spellcasting.push({
-      label: game.i18n.format("DND5E.SpellcastingClass", { class: spellcaster?.name ?? game.i18n.format("DND5E.NPC") }),
+      label: game.i18n.format("DND5E.SpellcastingClass", {
+        class: spellcaster?.name ?? game.i18n.format("DND5E.NPC.Label")
+      }),
       level: spellcaster?.system.levels ?? details.spellLevel,
       ability: {
         ability, mod,

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3634,7 +3634,7 @@ DND5E.epicBoonInterval = 30000;
  *                                         this trait's data stored on the actor?
  * @property {string} [configKey]          If the list of trait options doesn't match the name of the trait, where can
  *                                         the options be found within `CONFIG.DND5E`?
- * @property {Boolean|Number} [dataType]   Type of data represented.
+ * @property {boolean|number} [dataType]   Type of data represented.
  * @property {string} [labelKeyPath]       If config is an enum of objects, where can the label be found?
  * @property {object} [subtypes]           Configuration for traits that take some sort of base item.
  * @property {string} [subtypes.keyPath]   Path to subtype value on base items, should match a category key.

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -469,7 +469,7 @@ export default class NPCData extends CreatureTemplate {
 
         // Initiative (e.g. `+0 (10)`)
         initiative: `${formatNumber(this.attributes.init.mod, { signDisplay: "always" })} (${
-          formatNumber(this.attributes.init.mod + 10)})`, // TODO: Prepare passive initiative during data prep
+          formatNumber(this.attributes.init.score)})`,
 
         // Languages (e.g. `Common, Draconic`)
         languages: prepareTrait(this.traits.languages, "languages") || game.i18n.localize("None"),
@@ -483,7 +483,7 @@ export default class NPCData extends CreatureTemplate {
             ...splitSemicolons(this.attributes.senses.special)
           ].sort((lhs, rhs) => lhs.localeCompare(rhs, game.i18n.lang))),
           `${game.i18n.localize("DND5E.PassivePerception")} ${formatNumber(this.skills.prc.passive)}`
-        ].filter(_ => _).join("; "),
+        ].filterJoin("; "),
 
         // Skills (e.g. `Perception +17, Stealth +7`)
         skills: formatter.format(
@@ -551,7 +551,7 @@ export default class NPCData extends CreatureTemplate {
       if ( category in context.actionSections ) {
         const description = (await TextEditor.enrichHTML(item.system.description.value, {
           secrets: false, rollData: item.getRollData(), relativeTo: item
-        })).replace(/^\s*<p>/, "").replace(/<\/p>\s*$/, "");
+        })).replace(/^\s*<p>/g, "").replace(/<\/p>\s*$/g, "");
         // TODO: Add standard uses to item names (e.g. `Recharge 5-6`, `1/day`, etc.)
         context.actionSections[category].actions.push({ name: item.name, description });
       }

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -1,4 +1,7 @@
+import Actor5e from "../../documents/actor/actor.mjs";
 import Proficiency from "../../documents/actor/proficiency.mjs";
+import * as Trait from "../../documents/actor/trait.mjs";
+import { formatCR, formatNumber, splitSemicolons } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
 import RollConfigField from "../shared/roll-config-field.mjs";
@@ -393,5 +396,170 @@ export default class NPCData extends CreatureTemplate {
     if ( this.resources.legact.max && (periods.has("encounter") || periods.has("turnEnd")) ) {
       updates.actor["system.resources.legact.value"] = this.resources.legact.max;
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async toEmbed(config, options={}) {
+    for ( const value of config.values ) {
+      if ( value === "statblock" ) config.statblock = true;
+    }
+    if ( !config.statblock ) return super.toEmbed(config, options);
+
+    const context = await this._prepareEmbedContext();
+    const section = document.createElement("section");
+    section.innerHTML = await renderTemplate("systems/dnd5e/templates/actors/embeds/npc-embed.hbs", context);
+    return section.children;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the context information for the embed template rendering.
+   * @returns {object}
+   */
+  async _prepareEmbedContext() {
+    const formatter = game.i18n.getListFormatter({ type: "unit" });
+    const prepareMeasured = (value, units, label) => {
+      value = `${formatNumber(value)} ${units}.`;
+      return label ? `${label} ${value}` : value;
+    };
+    const prepareTrait = ({ value, custom }, trait) => formatter.format([
+      ...Array.from(value).map(t => Trait.keyLabel(t, { trait })).filter(_ => _),
+      ...splitSemicolons(custom ?? "")
+    ].sort((lhs, rhs) => lhs.localeCompare(rhs, game.i18n.lang)));
+
+    const context = {
+      abilityTables: Array.fromRange(3).map(_ => ({ abilities: [] })),
+      actionSections: {
+        trait: {
+          label: game.i18n.localize("DND5E.NPC.SECTIONS.Traits"),
+          actions: []
+        },
+        action: {
+          label: game.i18n.localize("DND5E.NPC.SECTIONS.Actions"),
+          actions: []
+        },
+        bonus: {
+          label: game.i18n.localize("DND5E.NPC.SECTIONS.BonusActions"),
+          actions: []
+        },
+        reaction: {
+          label: game.i18n.localize("DND5E.NPC.SECTIONS.Reactions"),
+          actions: []
+        },
+        legendary: {
+          label: game.i18n.localize("DND5E.NPC.SECTIONS.LegendaryActions"),
+          // TODO: Add legendary description
+          actions: []
+        }
+      },
+      document: this.parent,
+      summary: {
+        // Challenge Rating (e.g. `23 (XP 50,000; PB +7`))
+        // TODO: Handle increased XP in lair for 2024 creatures
+        cr: `${formatCR(this.details.cr, { narrow: false })} (${game.i18n.localize("DND5E.ExperiencePointsAbbr")} ${
+          formatNumber(this.details.xp.value)}; ${game.i18n.localize("DND5E.ProficiencyBonusAbbr")} ${
+          formatNumber(this.attributes.prof, { signDisplay: "always" })})`,
+
+        // Gear
+        // TODO: Handle once gear is implemented by system
+        gear: "",
+
+        // Initiative (e.g. `+0 (10)`)
+        initiative: `${formatNumber(this.attributes.init.mod, { signDisplay: "always" })} (${
+          formatNumber(this.attributes.init.mod + 10)})`, // TODO: Prepare passive initiative during data prep
+
+        // Languages (e.g. `Common, Draconic`)
+        languages: prepareTrait(this.traits.languages, "languages") || game.i18n.localize("None"),
+
+        // Senses (e.g. `Blindsight 60 ft., Darkvision 120 ft.; Passive Perception 27`)
+        senses: [
+          formatter.format([
+            ...Object.entries(CONFIG.DND5E.senses)
+              .filter(([k]) => this.attributes.senses[k])
+              .map(([k, label]) => prepareMeasured(this.attributes.senses[k], this.attributes.senses.units, label)),
+            ...splitSemicolons(this.attributes.senses.special)
+          ].sort((lhs, rhs) => lhs.localeCompare(rhs, game.i18n.lang))),
+          `${game.i18n.localize("DND5E.PassivePerception")} ${formatNumber(this.skills.prc.passive)}`
+        ].filter(_ => _).join("; "),
+
+        // Skills (e.g. `Perception +17, Stealth +7`)
+        skills: formatter.format(
+          Object.entries(CONFIG.DND5E.skills)
+            .filter(([k]) => this.skills[k].value > 0)
+            .map(([k, { label }]) => `${label} ${formatNumber(this.skills[k].total, { signDisplay: "always" })}`)
+        ),
+
+        // Speed (e.g. `40 ft., Burrow 40 ft., Fly 80 ft.`)
+        speed: formatter.format([
+          prepareMeasured(this.attributes.movement.walk, this.attributes.movement.units),
+          ...Object.entries(CONFIG.DND5E.movementTypes)
+            .filter(([k]) => this.attributes.movement[k] && (k !== "walk"))
+            .map(([k, label]) => {
+              let prepared = prepareMeasured(this.attributes.movement[k], this.attributes.movement.units, label);
+              if ( (k === "fly") && this.attributes.movement.hover ) {
+                prepared = `${prepared} (${game.i18n.localize("DND5E.MovementHover").toLowerCase()})`;
+              }
+              return prepared;
+            })
+        ]),
+
+        // Tag (e.g. `Gargantuan Dragon, Lawful Evil`)
+        tag: game.i18n.format("DND5E.CreatureTag", {
+          size: CONFIG.DND5E.actorSizes[this.traits.size]?.label ?? "",
+          type: Actor5e.formatCreatureType(this.details.type),
+          alignment: this.details.alignment
+        })
+      },
+      system: this
+    };
+
+    for ( const [index, [key, { abbreviation }]] of Object.entries(CONFIG.DND5E.abilities).entries() ) {
+      context.abilityTables[index % 3].abilities.push({ ...this.abilities[key], label: abbreviation.capitalize() });
+    }
+
+    for ( const type of ["vulnerabilities", "resistances", "immunities"] ) {
+      const entries = [];
+      for ( const category of ["damage", "condition"] ) {
+        if ( (category === "condition") && (type !== "immunities") ) continue;
+        const trait = `${category[0]}${type[0]}`;
+        const data = this.traits[trait];
+        const { value, physical } = data.value.reduce((acc, t) => {
+          if ( data.bypasses?.size && CONFIG.DND5E.damageTypes[t]?.isPhysical ) acc.physical.push(t);
+          else acc.value.push(t);
+          return acc;
+        }, { value: [], physical: [] });
+        const list = prepareTrait({ value, custom: data.custom }, trait);
+        if ( list ) entries.push(list);
+        if ( physical.length ) entries.push(game.i18n.format("DND5E.DamagePhysicalBypasses", {
+          damageTypes: game.i18n.getListFormatter({ style: "long", type: "conjunction" }).format(
+            physical.map(t => CONFIG.DND5E.damageTypes[t].label)
+          ),
+          bypassTypes: game.i18n.getListFormatter({ style: "long", type: "disjunction" }).format(
+            Array.from(data.bypasses).map(t => CONFIG.DND5E.itemProperties[t]?.label).filter(_ => _)
+          )
+        }));
+      }
+      if ( entries.length ) context.summary[type] = entries.join("; ");
+    }
+
+    for ( const item of this.parent.items ) {
+      if ( !["feat", "weapon"].includes(item.type) ) continue;
+      const category = item.system.activities.contents[0]?.activation.type ?? "trait";
+      if ( category in context.actionSections ) {
+        const description = (await TextEditor.enrichHTML(item.system.description.value, {
+          secrets: false, rollData: item.getRollData(), relativeTo: item
+        })).replace(/^\s*<p>/, "").replace(/<\/p>\s*$/, "");
+        // TODO: Add standard uses to item names (e.g. `Recharge 5-6`, `1/day`, etc.)
+        context.actionSections[category].actions.push({ name: item.name, description });
+      }
+    }
+    for ( const key of Object.keys(context.actionSections) ) {
+      if ( !context.actionSections[key].actions.length ) delete context.actionSections[key];
+    }
+
+    return context;
   }
 }

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -4,12 +4,15 @@
 
 /**
  * Format a Challenge Rating using the proper fractional symbols.
- * @param {number} value  CR value for format.
+ * @param {number} value                   CR value to format.
+ * @param {object} [options={}]
+ * @param {boolean} [options.narrow=true]  Use narrow fractions (e.g. ⅛) rather than wide ones (e.g. 1/8).
  * @returns {string}
  */
-export function formatCR(value) {
+export function formatCR(value, { narrow=true }={}) {
   if ( value === null ) return "—";
-  return { 0.125: "⅛", 0.25: "¼", 0.5: "½" }[value] ?? formatNumber(value);
+  const fractions = narrow ? { 0.125: "⅛", 0.25: "¼", 0.5: "½" } : { 0.125: "1/8", 0.25: "1/4", 0.5: "1/2" };
+  return fractions[value] ?? formatNumber(value);
 }
 
 /* -------------------------------------------- */

--- a/templates/actors/embeds/npc-embed.hbs
+++ b/templates/actors/embeds/npc-embed.hbs
@@ -1,0 +1,109 @@
+<div class="statblock npc">
+    <h4 class="statblock-title">{{ document.name }}</h4>
+    <span class="statblock-tags">{{ summary.tag }}</span>
+    <div class="statblock-content">
+        <div class="statblock-header">
+            <dl>
+                <div class="half-width">
+                    <dt>{{ localize "DND5E.AC" }}</dt>
+                    <dd>{{ system.attributes.ac.value }}</dd>
+                </div>
+                <div class="half-width">
+                    <dt>{{ localize "DND5E.Initiative" }}</dt>
+                    <dd>{{ summary.initiative }}</dd>
+                </div>
+                <div>
+                    <dt>{{ localize "DND5E.HP" }}</dt><dd>{{ system.attributes.hp.max }}</dd>
+                    {{~#if system.attributes.hp.formula~}}
+                    <dd>({{ system.attributes.hp.formula }})</dd>
+                    {{~/if~}}
+                </div>
+                <div>
+                    <dt>{{ localize "DND5E.Speed" }}</dt>
+                    <dd>{{ summary.speed }}</dd>
+                </div>
+            </dl>
+            <div class="abilities">
+                {{#each abilityTables}}
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col" class="visually-hidden">{{ localize "DND5E.Ability" }}</th>
+                            <th scope="col" class="visually-hidden">{{ localize "DND5E.AbilityScoreShort" }}</th>
+                            <th scope="col">{{ localize "DND5E.AbilityModifierShort" }}</th>
+                            <th scope="col">{{ localize "DND5E.SavingThrowShort" }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{#each abilities}}
+                        <tr>
+                            <th scope="row">{{ label }}</th>
+                            <td class="score">{{ dnd5e-numberFormat value }}</td>
+                            <td>{{ dnd5e-numberFormat mod signDisplay="always" }}</td>
+                            <td>{{ dnd5e-numberFormat save signDisplay="always" }}</td>
+                        </tr>
+                        {{/each}}
+                    </tbody>
+                </table>
+                {{/each}}
+            </div>
+            <dl>
+                {{#if summary.skills}}
+                <div>
+                    <dt>{{ localize "DND5E.Skills" }}</dt>
+                    <dd>{{ summary.skills }}</dd>
+                </div>
+                {{/if}}
+                {{#if summary.gear}}
+                <div>
+                    <dt>{{ localize "DND5E.Gear" }}</dt>
+                    <dd>{{ summary.gear }}</dd>
+                </div>
+                {{/if}}
+                {{#if summary.vulnerabilities}}
+                <div>
+                    <dt>{{ localize "DND5E.Vulnerabilities" }}</dt>
+                    <dd>{{ summary.vulnerabilities }}</dd>
+                </div>
+                {{/if}}
+                {{#if summary.resistances}}
+                <div>
+                    <dt>{{ localize "DND5E.Resistances" }}</dt>
+                    <dd>{{ summary.resistances }}</dd>
+                </div>
+                {{/if}}
+                {{#if summary.immunities}}
+                <div>
+                    <dt>{{ localize "DND5E.Immunities" }}</dt>
+                    <dd>{{ summary.immunities }}</dd>
+                </div>
+                {{/if}}
+                <div>
+                    <dt>{{ localize "DND5E.Senses" }}</dt>
+                    <dd>{{ summary.senses }}</dd>
+                </div>
+                <div>
+                    <dt>{{ localize "DND5E.Languages" }}</dt>
+                    <dd>{{ summary.languages }}</dd>
+                </div>
+                <div>
+                    <dt>{{ localize "DND5E.AbbreviationCR" }}</dt>
+                    <dd>{{ summary.cr }}</dd>
+                </div>
+            </dl>
+        </div>
+        {{#each actionSections}}
+        <div class="statblock-actions {{ @key }}">
+            <h5 class="statblock-actions-title">{{ label }}</h5>
+            {{#each actions}}
+            <div class="statblock-action">
+                <p>
+                    <span class="name">{{ name }}</span>
+                    {{{ description }}}
+                </p>
+            </div>
+            {{/each}}
+        </div>
+        {{/each}}
+    </div>
+</div>


### PR DESCRIPTION
Adds a new option when embedding NPC actors that allows displaying the NPC's statblock (in 2024 style) rather than the description:

```
@Embed[Compendium.dnd5e.monsters.Actor.8aCTKP5qaBPFOqxM statblock]
```

<img width="414" alt="Statblock Embeds 1" src="https://github.com/user-attachments/assets/84f827e4-1249-4213-ab0e-ab5464f2c466">

Embeds also support two-column layout for larger statblocks. This is handled by using the `double-column` class on the embed.

<img width="719" alt="Statblock Embeds 2" src="https://github.com/user-attachments/assets/3bb12711-8de2-4bde-879a-231e65263f06">

### Todo
- [ ] Display limited uses on ability names
- [ ] Add legendary actions introduction paragraph
- [ ] Gear section
- [ ] In-lair/not-in-lair XP values