### PR TITLE
[#3357] Support variable types & multiple damage parts in enricher

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3558,6 +3558,7 @@
   "AwardEach": "{award} each",
   "CheckShort": "{check}",
   "CheckLong": "{check} check",
+  "DamageDouble": "{first} plus {second}",
   "DamageShort": "{formula} {type}",
   "DamageLong": "{average} ({formula}) {type}",
   "DC": "DC {dc} {check}",

--- a/less/v1/chat.less
+++ b/less/v1/chat.less
@@ -106,7 +106,7 @@
 /*  Inline Roll Actions                      */
 /* ----------------------------------------- */
 
-.roll-link, .reference-link {
+.roll-link-group, .roll-link, .reference-link {
   a {
     background: #DDD;
     padding: 1px 4px;

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -292,7 +292,7 @@
     }
   }
 
-  .roll-link a > i.fa-dice-d20, a.inline-roll > i.fa-dice-d20 {
+  .roll-link > i.fa-dice-d20, a.inline-roll > i.fa-dice-d20 {
     display: inline-block;
     width: 1em;
     height: 1em;

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -251,7 +251,7 @@
     }
   }
 
-  a:is(.content-link, .inline-roll), :is(.roll-link, .reference-link) a {
+  a:is(.content-link, .inline-roll), a.roll-link-group .roll-link, :is(.roll-link-group, .reference-link) a {
     background: transparent;
     border: none;
     text-decoration: underline currentcolor;
@@ -277,6 +277,7 @@
 
     &:focus-visible { text-shadow: 0 0 8px var(--color-shadow-primary); }
   }
+  a.roll-link-group:hover { text-shadow: none; }
 
   a.enricher-action {
     text-decoration: none;

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -43,7 +43,7 @@ export function registerCustomEnrichers() {
  */
 async function enrichString(match, options) {
   let { type, config, label } = match.groups;
-  config = parseConfig(config);
+  config = parseConfig(config, { multiple: ["damage", "healing"].includes(type) });
   config._input = match[0];
   switch ( type.toLowerCase() ) {
     case "attack": return enrichAttack(config, label, options);
@@ -67,9 +67,13 @@ async function enrichString(match, options) {
 /**
  * Parse a roll string into a configuration object.
  * @param {string} match  Matched configuration string.
- * @returns {object}
+ * @param {object} [options={}]
+ * @param {boolean} [options.multiple=false]  Support splitting configuration by "&" into multiple sub-configurations.
+ *                                            If set to `true` then an array of configs will be returned.
+ * @returns {object|object[]}
  */
-function parseConfig(match) {
+function parseConfig(match, { multiple=false }={}) {
+  if ( multiple ) return match.split("&").map(s => parseConfig(s));
   const config = { _config: match, values: [] };
   for ( const part of match.match(/(?:[^\s"]+|"[^"]*")+/g) ) {
     if ( !part ) continue;
@@ -280,7 +284,7 @@ async function enrichCheck(config, label, options) {
   const type = config.skill ? "skill" : config.tool ? "tool" : "check";
   config = { type, ...config };
   if ( !label ) label = createRollLabel(config);
-  return config.passive ? createPassiveTag(label, config) : createRollLink(label, config);
+  return config.passive ? createPassiveTag(label, config) : createRequestLink(createRollLink(label), config);
 }
 
 /* -------------------------------------------- */
@@ -337,7 +341,7 @@ async function enrichSave(config, label, options) {
 
   config = { type: config._isConcentration ? "concentration" : "save", ...config };
   if ( !label ) label = createRollLabel(config);
-  return createRollLink(label, config);
+  return createRequestLink(createRollLink(label), config);
 }
 
 /* -------------------------------------------- */
@@ -346,7 +350,7 @@ async function enrichSave(config, label, options) {
 
 /**
  * Enrich a damage link.
- * @param {object} config              Configuration data.
+ * @param {object[]} configs           Configuration data.
  * @param {string} [label]             Optional label to replace default text.
  * @param {EnrichmentOptions} options  Options provided to customize text enrichment.
  * @returns {HTMLElement|null}         An HTML link if the save could be built, otherwise null.
@@ -387,44 +391,69 @@ async function enrichSave(config, label, options) {
  * </a> healing
  * ```
  */
-async function enrichDamage(config, label, options) {
-  const formulaParts = [];
-  if ( config.formula ) formulaParts.push(config.formula);
-  for ( const value of config.values ) {
-    if ( value in CONFIG.DND5E.damageTypes ) config.type = value;
-    else if ( value in CONFIG.DND5E.healingTypes ) config.type = value;
-    else if ( value === "average" ) config.average = true;
-    else if ( value === "temp" ) config.type = "temphp";
-    else formulaParts.push(value);
-  }
-  config.formula = Roll.defaultImplementation.replaceFormulaData(formulaParts.join(" "), options.rollData ?? {});
-  if ( !config.formula ) return null;
-  config.damageType = config.type ?? (config._isHealing ? "healing" : null);
-  config.type = "damage";
-
-  if ( label ) return createRollLink(label, config);
-
-  const typeConfig = CONFIG.DND5E.damageTypes[config.damageType] ?? CONFIG.DND5E.healingTypes[config.damageType];
-  const localizationData = {
-    formula: createRollLink(config.formula, config).outerHTML,
-    type: game.i18n.localize(typeConfig?.label ?? "").toLowerCase()
-  };
-
-  let localizationType = "Short";
-  if ( config.average ) {
-    localizationType = "Long";
-    if ( config.average === true ) {
-      const minRoll = Roll.create(config.formula).evaluate({ minimize: true });
-      const maxRoll = Roll.create(config.formula).evaluate({ maximize: true });
-      localizationData.average = Math.floor(((await minRoll).total + (await maxRoll).total) / 2);
-    } else if ( Number.isNumeric(config.average) ) {
-      localizationData.average = config.average;
+async function enrichDamage(configs, label, options) {
+  const config = { type: "damage", formulas: [], damageTypes: [], rollType: configs._isHealing ? "healing" : "damage" };
+  for ( const c of configs ) {
+    const formulaParts = [];
+    if ( c.average ) config.average = c.average;
+    if ( c.formula ) formulaParts.push(c.formula);
+    for ( const value of c.values ) {
+      if ( value in CONFIG.DND5E.damageTypes ) c.type = value;
+      else if ( value in CONFIG.DND5E.healingTypes ) c.type = value;
+      else if ( value === "average" ) config.average = true;
+      else if ( value === "temp" ) c.type = "temphp";
+      else formulaParts.push(value);
+    }
+    c.formula = Roll.defaultImplementation.replaceFormulaData(formulaParts.join(" "), options.rollData ?? {});
+    c.type ??= configs._isHealing ? "healing" : null;
+    if ( c.formula ) {
+      config.formulas.push(c.formula);
+      config.damageTypes.push(c.type);
     }
   }
+  const formulas = config.formulas.join("&");
+  const damageTypes = config.damageTypes.join("&");
 
-  const span = document.createElement("span");
-  span.innerHTML = game.i18n.format(`EDITOR.DND5E.Inline.Damage${localizationType}`, localizationData);
-  return span;
+  if ( !config.formulas.length ) return null;
+  if ( label ) return createRollLink(label, { ...config, formulas, damageTypes });
+
+  const parts = [];
+  for ( const [idx, formula] of config.formulas.entries() ) {
+    const type = config.damageTypes[idx];
+    const types = type?.split("|")
+      .map(t => CONFIG.DND5E.damageTypes[t]?.label ?? CONFIG.DND5E.healingTypes[t]?.label)
+      .filter(_ => _);
+    const localizationData = {
+      formula: createRollLink(formula, {}, { tag: "span" }).outerHTML,
+      type: game.i18n.getListFormatter({ type: "disjunction" }).format(types).toLowerCase()
+    };
+
+    let localizationType = "Short";
+    if ( config.average ) {
+      localizationType = "Long";
+      if ( config.average === true ) {
+        const minRoll = Roll.create(formula).evaluate({ minimize: true });
+        const maxRoll = Roll.create(formula).evaluate({ maximize: true });
+        localizationData.average = Math.floor(((await minRoll).total + (await maxRoll).total) / 2);
+      } else if ( Number.isNumeric(config.average) ) {
+        localizationData.average = config.average;
+      } else {
+        localizationType = "Short";
+      }
+    }
+
+    parts.push(game.i18n.format(`EDITOR.DND5E.Inline.Damage${localizationType}`, localizationData));
+  }
+
+  const link = document.createElement("a");
+  link.className = "roll-link-group";
+  _addDataset(link, { ...config, formulas, damageTypes });
+  if ( config.average && parts.length === 2 ) {
+    link.innerHTML = game.i18n.format("EDITOR.DND5E.Inline.DamageDouble", { first: parts[0], second: parts[1] });
+  } else {
+    link.innerHTML = game.i18n.getListFormatter().format(parts);
+  }
+  return link;
 }
 
 /* -------------------------------------------- */
@@ -636,6 +665,14 @@ async function enrichItem(config, label, options) {
     } catch(err) { return null; }
   }
 
+  const makeLink = (label, dataset) => {
+    const span = document.createElement("span");
+    span.classList.add("roll-link-group");
+    _addDataset(span, dataset);
+    span.append(createRollLink(label));
+    return span;
+  };
+
   if ( foundItem ) {
     let foundActivity;
     if ( config.activity ) {
@@ -646,16 +683,16 @@ async function enrichItem(config, label, options) {
         return null;
       }
       if ( !label ) label = `${foundItem.name}: ${foundActivity.name}`;
-      return createRollLink(label, { type: "item", rollActivityUuid: foundActivity.uuid });
+      return makeLink(label, { type: "item", rollActivityUuid: foundActivity.uuid });
     }
 
     if ( !label ) label = foundItem.name;
-    return createRollLink(label, { type: "item", rollItemUuid: foundItem.uuid });
+    return makeLink(label, { type: "item", rollItemUuid: foundItem.uuid });
   }
 
   // Finally, if config is an item name
   if ( !label ) label = config.activity ? `${givenItem}: ${config.activity}` : givenItem;
-  return createRollLink(label, {
+  return makeLink(label, {
     type: "item", rollItemActor: foundActor?.uuid, rollItemName: givenItem, rollActivityName: config.activity
   });
 }
@@ -760,25 +797,20 @@ export function createRollLabel(config) {
 /* -------------------------------------------- */
 
 /**
- * Create a rollable link.
- * @param {string} label    Label to display.
- * @param {object} dataset  Data that will be added to the link for the rolling method.
+ * Create a rollable link with a request section for GMs.
+ * @param {HTMLElement|string} label  Label to display
+ * @param {object} dataset            Data that will be added to the link for the rolling method.
  * @returns {HTMLElement}
  */
-function createRollLink(label, dataset) {
+function createRequestLink(label, dataset) {
   const span = document.createElement("span");
-  span.classList.add("roll-link");
+  span.classList.add("roll-link-group");
   _addDataset(span, dataset);
-
-  // Add main link
-  const link = document.createElement("a");
-  link.dataset.action = "roll";
-  link.innerHTML = '<i class="fa-solid fa-dice-d20"></i>';
-  link.append(label);
-  span.insertAdjacentElement("afterbegin", link);
+  if (label instanceof HTMLElement) span.insertAdjacentElement("afterbegin", label);
+  else span.insertAdjacentHTML("afterbegin", label);
 
   // Add chat request link for GMs
-  if ( game.user.isGM && !["attack", "damage", "item"].includes(dataset.type) ) {
+  if ( game.user.isGM ) {
     const gmLink = document.createElement("a");
     gmLink.classList.add("enricher-action");
     gmLink.dataset.action = "request";
@@ -789,6 +821,25 @@ function createRollLink(label, dataset) {
   }
 
   return span;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Create a rollable link.
+ * @param {string} label                           Label to display.
+ * @param {object} [dataset={}]                    Data that will be added to the link for the rolling method.
+ * @param {object} [options={}]
+ * @param {boolean} [options.classes="roll-link"]  Class to add to the link.
+ * @param {string} [options.tag="a"]               Tag to use for the main link.
+ * @returns {HTMLElement}
+ */
+function createRollLink(label, dataset={}, { classes="roll-link", tag="a" }={}) {
+  const link = document.createElement(tag);
+  link.className = classes;
+  link.innerHTML = `<i class="fa-solid fa-dice-d20" inert></i>${label}`;
+  _addDataset(link, dataset);
+  return link;
 }
 
 /* -------------------------------------------- */
@@ -836,7 +887,7 @@ async function awardAction(event) {
  * @returns {Promise}
  */
 async function rollAction(event) {
-  const target = event.target.closest('.roll-link, [data-action="rollRequest"], [data-action="concentration"]');
+  const target = event.target.closest('.roll-link-group, [data-action="rollRequest"], [data-action="concentration"]');
   if ( !target ) return;
   event.stopPropagation();
 
@@ -960,13 +1011,21 @@ async function rollAttack(event) {
  * @returns {Promise<void>}
  */
 async function rollDamage(event) {
-  const target = event.target.closest(".roll-link");
-  const { formula, damageType } = target.dataset;
+  const target = event.target.closest(".roll-link-group");
+  let { formulas, damageTypes, rollType } = target.dataset;
+  formulas = formulas.split("&");
+  damageTypes = damageTypes.split("&");
 
   const rollConfig = {
     event,
     hookNames: ["damage"],
-    rolls: [{ parts: [formula], options: { type: damageType } }]
+    rolls: formulas.map((formula, idx) => {
+      const types = damageTypes[idx]?.split("|") ?? [];
+      return {
+        parts: [formula],
+        options: { type: types[0], types }
+      };
+    })
   };
 
   const messageConfig = {
@@ -975,11 +1034,11 @@ async function rollDamage(event) {
       flags: {
         dnd5e: {
           messageType: "roll",
-          roll: { type: "damage" },
+          roll: { type: rollType },
           targets: getTargetDescriptors()
         }
       },
-      flavor: game.i18n.localize(`DND5E.${damageType in CONFIG.DND5E.healingTypes ? "Healing" : "Damage"}Roll`),
+      flavor: game.i18n.localize(`DND5E.${rollType === "healing" ? "Healing" : "Damage"}Roll`),
       speaker: ChatMessage.implementation.getSpeaker()
     }
   };

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -118,8 +118,10 @@ async function enrichAttack(config, label, options) {
   if ( label ) return createRollLink(label, config);
 
   const span = document.createElement("span");
+  span.className = "roll-link-group";
+  _addDataset(span, config);
   span.innerHTML = game.i18n.format(`EDITOR.DND5E.Inline.Attack${config.format === "long" ? "Long" : "Short"}`, {
-    formula: createRollLink(simplifyRollFormula(config.formula), config).outerHTML
+    formula: createRollLink(simplifyRollFormula(config.formula)).outerHTML
   });
   return span;
 }
@@ -985,7 +987,7 @@ async function rollAction(event) {
  * @returns {Promise|void}
  */
 async function rollAttack(event) {
-  const target = event.target.closest(".roll-link");
+  const target = event.target.closest(".roll-link-group");
   const { formula } = target.dataset;
 
   const targets = getTargetDescriptors();


### PR DESCRIPTION
Adds support for variable damage types when rolling damage through a damage enricher as well as multiple damage parts.

<img width="648" alt="Variable Damage Types   Multiple Damages" src="https://github.com/user-attachments/assets/71f53a77-4125-4ca2-ab23-b6eb23f8381d">

To indicate variable damage types, the explicit `type` key must be used when writing the enricher and the different types must be separated by a pipe (`|`) character:

```
[[/damage 2d6 type=fire|cold]]
```

To specify multiple damage parts the enricher config is split by an amperand (`&`), with each side supporting its own formula and damage types:

```
[[/damage 1d6 fire & 1d6 cold]]
[[/damage 1d6 fire & 1d6 cold average]]
```

Any configuration options that apply to the whole enricher can be placed anywhere in the configuration.

If the average option is used and there are exactly two damage parts, then they will be written as "A plus B", otherwise they will be written "A and B". This is to match the format of NPC statblocks.

Closes #3357