### PR TITLE
[#4812] Add setting to use initiative scores rather than rolls

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3814,6 +3814,13 @@
     "Name": "Default Skills",
     "Hint": "The default skills that appear on NPC sheets regardless of level of proficiency."
   },
+  "INITIATIVESCORE": {
+    "Name": "Initiative Score",
+    "Hint": "Use a creature's initiative score (10 + bonus) rather than rolling for initiative.",
+    "All": "Use Score for Everyone",
+    "None": "Always Roll for Initiative",
+    "NPCs": "Use Score for GM NPCs"
+  },
   "LEVELING": {
     "Name": "Leveling Mode",
     "Hint": "Determine how the players gain new levels.",

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -210,6 +210,21 @@ export function registerSystemSettings() {
     type: Boolean
   });
 
+  // Use initiative scores for NPCs
+  game.settings.register("dnd5e", "initiativeScore", {
+    name: "SETTINGS.DND5E.INITIATIVESCORE.Name",
+    hint: "SETTINGS.DND5E.INITIATIVESCORE.Hint",
+    scope: "world",
+    config: true,
+    default: "none",
+    type: String,
+    choices: {
+      none: "SETTINGS.DND5E.INITIATIVESCORE.None",
+      npcs: "SETTINGS.DND5E.INITIATIVESCORE.NPCs",
+      all: "SETTINGS.DND5E.INITIATIVESCORE.All"
+    }
+  });
+
   // Record Currency Weight
   game.settings.register("dnd5e", "currencyWeight", {
     name: "SETTINGS.5eCurWtN",


### PR DESCRIPTION
Adds a new property to `InitiativeRollOptions` that allows using a flat value rather than rolling. This pairs with a new setting that controls whether initiative should always be rolled, whether GM-controlled NPCs should use their initiative score instead, or whether all initiative should be handled using scores.

Closes #4812