### PR TITLE
[#4751] Split `BasicRoll#build` into three parts

### DIFF
--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -207,17 +207,14 @@ export default class UsesField extends SchemaField {
       messageConfig.create = hookData.chatMessage;
     }
 
-    const createMessage = messageConfig.create !== false;
-    messageConfig.create = false;
-    const rolls = await CONFIG.Dice.BasicRoll.build(rollConfig, dialogConfig, messageConfig);
+    const rolls = await CONFIG.Dice.BasicRoll.buildConfigure(rollConfig, dialogConfig, messageConfig);
+    await CONFIG.Dice.BasicRoll.buildEvaluate(rolls, rollConfig, messageConfig);
     if ( !rolls.length ) return;
-    if ( createMessage ) {
-      messageConfig.data.flavor = game.i18n.format("DND5E.ItemRechargeCheck", {
-        name: this.name,
-        result: game.i18n.localize(`DND5E.ItemRecharge${rolls[0].isSuccess ? "Success" : "Failure"}`)
-      });
-      await CONFIG.Dice.BasicRoll.toMessage(rolls, messageConfig.data, { rollMode: messageConfig.rollMode });
-    }
+    messageConfig.data.flavor = game.i18n.format("DND5E.ItemRechargeCheck", {
+      name: this.name,
+      result: game.i18n.localize(`DND5E.ItemRecharge${rolls[0].isSuccess ? "Success" : "Failure"}`)
+    });
+    await CONFIG.Dice.BasicRoll.buildPost(rolls, rollConfig, messageConfig);
 
     const updates = {};
     if ( rolls[0].isSuccess ) {

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -187,7 +187,7 @@ export default class BasicRoll extends Roll {
    * @param {BasicRollMessageConfiguration} [message={}]  Configuration for message creation.
    */
   static async buildEvaluate(rolls, config={}, message={}) {
-    if ( (config.evaluate !== false) ) {
+    if ( config.evaluate !== false ) {
       for ( const roll of rolls ) await roll.evaluate();
     }
   }
@@ -207,10 +207,10 @@ export default class BasicRoll extends Roll {
     if ( messageId ) foundry.utils.setProperty(message.data, "flags.dnd5e.originatingMessage", messageId);
 
     if ( rolls?.length && (config.evaluate !== false) && (message.create !== false) ) {
-      message.created = await this.toMessage(rolls, message.data, { rollMode: message.rollMode });
+      message.document = await this.toMessage(rolls, message.data, { rollMode: message.rollMode });
     }
 
-    return message.created;
+    return message.document;
   }
 
   /* -------------------------------------------- */

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -49,9 +49,10 @@ const { DiceTerm, NumericTerm } = foundry.dice.terms;
  * Configuration data for creating a roll message.
  *
  * @typedef {object} BasicRollMessageConfiguration
- * @property {boolean} [create=true]  Create a message when the rolling is complete.
- * @property {string} [rollMode]      The roll mode to apply to this message from `CONFIG.Dice.rollModes`.
- * @property {object} [data={}]       Additional data used when creating the message.
+ * @property {boolean} [create=true]     Create a message when the rolling is complete.
+ * @property {ChatMessage5e} [document]  Final created chat message document once process is completed.
+ * @property {string} [rollMode]         The roll mode to apply to this message from `CONFIG.Dice.rollModes`.
+ * @property {object} [data={}]          Additional data used when creating the message.
  */
 
 /* -------------------------------------------- */
@@ -114,7 +115,23 @@ export default class BasicRoll extends Roll {
    * @returns {BasicRoll[]}
    */
   static async build(config={}, dialog={}, message={}) {
-    const hookNames = [...(config.hookNames ?? []), ""];
+    const rolls = await this.buildConfigure(config, dialog, message);
+    await this.buildEvaluate(rolls, config, message);
+    await this.buildPost(rolls, config, message);
+    return rolls;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Stage one of the standard rolling workflow, configuring the roll.
+   * @param {BasicRollProcessConfiguration} [config={}]   Configuration for the rolls.
+   * @param {BasicRollDialogConfiguration} [dialog={}]    Configuration for roll prompt.
+   * @param {BasicRollMessageConfiguration} [message={}]  Configuration for message creation.
+   * @returns {BasicRoll[]}
+   */
+  static async buildConfigure(config={}, dialog={}, message={}) {
+    config.hookNames = [...(config.hookNames ?? []), ""];
 
     /**
      * A hook event that fires before a roll is performed. Multiple hooks may be called depending on the rolling
@@ -127,7 +144,7 @@ export default class BasicRoll extends Roll {
      * @param {BasicRollMessageConfiguration} message  Configuration data for the roll's message.
      * @returns {boolean}                              Explicitly return `false` to prevent the roll.
      */
-    for ( const hookName of hookNames ) {
+    for ( const hookName of config.hookNames ) {
       if ( Hooks.call(`dnd5e.preRoll${hookName.capitalize()}V2`, config, dialog, message) === false ) return [];
     }
 
@@ -153,23 +170,47 @@ export default class BasicRoll extends Roll {
      * @param {BasicRollMessageConfiguration} message  Configuration for the roll message.
      * @returns {boolean}                              Explicitly return `false` to prevent rolls.
      */
-    for ( const hookName of hookNames ) {
+    for ( const hookName of config.hookNames ) {
       const name = `dnd5e.post${hookName.capitalize()}RollConfiguration`;
       if ( Hooks.call(name, rolls, config, dialog, message) === false ) return [];
     }
 
-    if ( config.evaluate === false ) return rolls;
-    for ( const roll of rolls ) await roll.evaluate();
+    return rolls;
+  }
 
+  /* -------------------------------------------- */
+
+  /**
+   * Stage two of the standard rolling workflow, evaluating the rolls.
+   * @param {BasicRoll[]} rolls                           Rolls to evaluate.
+   * @param {BasicRollProcessConfiguration} [config={}]   Configuration for the rolls.
+   * @param {BasicRollMessageConfiguration} [message={}]  Configuration for message creation.
+   */
+  static async buildEvaluate(rolls, config={}, message={}) {
+    if ( (config.evaluate !== false) ) {
+      for ( const roll of rolls ) await roll.evaluate();
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Stage three of the standard rolling workflow, posting a message to chat.
+   * @param {BasicRoll[]} rolls                      Rolls to evaluate.
+   * @param {BasicRollProcessConfiguration} config   Configuration for the rolls.
+   * @param {BasicRollMessageConfiguration} message  Configuration for message creation.
+   * @returns {ChatMessage5e|void}
+   */
+  static async buildPost(rolls, config, message) {
     message.data = foundry.utils.expandObject(message.data ?? {});
     const messageId = config.event?.target.closest("[data-message-id]")?.dataset.messageId;
     if ( messageId ) foundry.utils.setProperty(message.data, "flags.dnd5e.originatingMessage", messageId);
 
-    if ( rolls?.length && (message.create !== false) ) {
-      await this.toMessage(rolls, message.data, { rollMode: message.rollMode });
+    if ( rolls?.length && (config.evaluate !== false) && (message.create !== false) ) {
+      message.created = await this.toMessage(rolls, message.data, { rollMode: message.rollMode });
     }
 
-    return rolls;
+    return message.created;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -179,16 +179,15 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
       _applyDeprecatedD20Configs(rollConfig, dialogConfig, messageConfig, oldConfig);
     }
 
-    const createMessage = messageConfig.create !== false;
-    messageConfig.create = false;
     const rolls = await CONFIG.Dice.D20Roll.build(rollConfig, dialogConfig, messageConfig);
     if ( !rolls.length ) return null;
-    if ( createMessage ) {
+    if ( messageConfig.document ) {
+      const flags = {};
       for ( const key of ["ammunition", "attackMode", "mastery"] ) {
         if ( !rolls[0].options[key] ) continue;
-        foundry.utils.setProperty(messageConfig.data, `flags.dnd5e.roll.${key}`, rolls[0].options[key]);
+        foundry.utils.setProperty(flags, `dnd5e.roll.${key}`, rolls[0].options[key]);
       }
-      await CONFIG.Dice.D20Roll.toMessage(rolls, messageConfig.data, { rollMode: messageConfig.rollMode });
+      if ( !foundry.utils.isEmpty(flags) ) messageConfig.document.update(flags);
     }
 
     const flags = {};

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -179,16 +179,14 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
       _applyDeprecatedD20Configs(rollConfig, dialogConfig, messageConfig, oldConfig);
     }
 
-    const rolls = await CONFIG.Dice.D20Roll.build(rollConfig, dialogConfig, messageConfig);
+    const rolls = await CONFIG.Dice.D20Roll.buildConfigure(rollConfig, dialogConfig, messageConfig);
+    await CONFIG.Dice.D20Roll.buildEvaluate(rolls, rollConfig, messageConfig);
     if ( !rolls.length ) return null;
-    if ( messageConfig.document ) {
-      const flags = {};
-      for ( const key of ["ammunition", "attackMode", "mastery"] ) {
-        if ( !rolls[0].options[key] ) continue;
-        foundry.utils.setProperty(flags, `dnd5e.roll.${key}`, rolls[0].options[key]);
-      }
-      if ( !foundry.utils.isEmpty(flags) ) messageConfig.document.update(flags);
+    for ( const key of ["ammunition", "attackMode", "mastery"] ) {
+      if ( !rolls[0].options[key] ) continue;
+      foundry.utils.setProperty(messageConfig.data, `flags.dnd5e.roll.${key}`, rolls[0].options[key]);
     }
+    await CONFIG.Dice.D20Roll.buildPost(rolls, rollConfig, messageConfig);
 
     const flags = {};
     let ammoUpdate = null;


### PR DESCRIPTION
Splits the `build` method on `BasicRoll` into three parts:
1. `buildConfigure`: Applies keybindings, calls the `preRoll` hook, displays the configuration dialog, and calls the `postRollConfiguration` hook.
2. `buildEvaluate`: Evalutes the rolls if `evaluate` is `true`.
3. `buildPost`: Sets the `originatingMessage` flag and posts a message to chat.

The `build` method now calls these three methods in turn.

This process now also adjust `config.hookNames` to incude the empty value rather than using a local variable so the final hook names can be used elsewhere, and saves the created chat message into the message configuration so it can be referenced after the fact.

Closes #4751