### PR TITLE
[#4800] Add visibility to check & save activities

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1471,6 +1471,10 @@
           "label": "DC Formula",
           "hint": "Custom formula or flat value for defining the check DC."
         }
+      },
+      "visible": {
+        "label": "Visible to All",
+        "hint": "Display the rolling button in chat for all players."
       }
     }
   },
@@ -3814,6 +3818,10 @@
         },
         "CustomFormula": "Custom Formula",
         "DefaultFormula": "8 + @mod + @prof"
+      },
+      "visible": {
+        "label": "Visible to All",
+        "hint": "Display the rolling button in chat for all players."
       }
     }
   },

--- a/module/applications/activity/check-sheet.mjs
+++ b/module/applications/activity/check-sheet.mjs
@@ -67,4 +67,17 @@ export default class CheckSheet extends ActivitySheet {
 
     return context;
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareIdentityContext(context) {
+    context = await super._prepareIdentityContext(context);
+    context.behaviorFields.push({
+      field: context.fields.check.fields.visible,
+      value: context.source.check.visible,
+      input: context.inputs.createCheckboxInput
+    });
+    return context;
+  }
 }

--- a/module/applications/activity/save-sheet.mjs
+++ b/module/applications/activity/save-sheet.mjs
@@ -63,4 +63,17 @@ export default class SaveSheet extends ActivitySheet {
 
     return context;
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareIdentityContext(context) {
+    context = await super._prepareIdentityContext(context);
+    context.behaviorFields.push({
+      field: context.fields.save.fields.visible,
+      value: context.source.save.visible,
+      input: context.inputs.createCheckboxInput
+    });
+    return context;
+  }
 }

--- a/module/applications/activity/utility-sheet.mjs
+++ b/module/applications/activity/utility-sheet.mjs
@@ -32,6 +32,10 @@ export default class UtilitySheet extends ActivitySheet {
       field: context.fields.roll.fields.prompt,
       value: context.source.roll.prompt,
       input: context.inputs.createCheckboxInput
+    }, {
+      field: context.fields.roll.fields.visible,
+      value: context.source.roll.visible,
+      input: context.inputs.createCheckboxInput
     });
     return context;
   }

--- a/module/data/activity/_types.mjs
+++ b/module/data/activity/_types.mjs
@@ -83,6 +83,7 @@
  * @property {object} check.dc
  * @property {string} check.dc.calculation   Method or ability used to calculate the difficulty class of the check.
  * @property {string} check.dc.formula       Custom DC formula or flat value.
+ * @property {boolean} check.visible         Should this check be displayed to all players?
  */
 
 /**
@@ -143,6 +144,7 @@
  * @property {object} save.dc
  * @property {string} save.dc.calculation           Method or ability used to calculate the difficulty class.
  * @property {string} save.dc.formula               Custom DC formula or flat value.
+ * @property {boolean} save.visible                 Should this check be displayed to all players?
  */
 
 /**

--- a/module/data/activity/_types.mjs
+++ b/module/data/activity/_types.mjs
@@ -144,7 +144,7 @@
  * @property {object} save.dc
  * @property {string} save.dc.calculation           Method or ability used to calculate the difficulty class.
  * @property {string} save.dc.formula               Custom DC formula or flat value.
- * @property {boolean} save.visible                 Should this check be displayed to all players?
+ * @property {boolean} save.visible                 Should this save be displayed to all players?
  */
 
 /**

--- a/module/data/activity/check-data.mjs
+++ b/module/data/activity/check-data.mjs
@@ -2,7 +2,7 @@ import { simplifyBonus } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
-const { SchemaField, SetField, StringField } = foundry.data.fields;
+const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { CheckActivityData } from "./_types.mjs";
@@ -24,7 +24,8 @@ export default class BaseCheckActivityData extends BaseActivityData {
         dc: new SchemaField({
           calculation: new StringField(),
           formula: new FormulaField({ deterministic: true })
-        })
+        }),
+        visible: new BooleanField({ initial: true })
       })
     };
   }

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -32,7 +32,8 @@ export default class BaseSaveActivityData extends BaseActivityData {
         dc: new SchemaField({
           calculation: new StringField({ initial: "initial" }),
           formula: new FormulaField({ deterministic: true })
-        })
+        }),
+        visible: new BooleanField({ initial: true })
       })
     };
   }

--- a/module/documents/activity/check.mjs
+++ b/module/documents/activity/check.mjs
@@ -46,7 +46,7 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
       const ability = CONFIG.DND5E.abilities[abilityKey]?.label;
       const checkType = (associated in CONFIG.DND5E.skills) ? "skill"
         : (associated in CONFIG.DND5E.tools) ? "tool": "ability";
-      const dataset = { ability: abilityKey, action: "rollCheck", visibility: "all" };
+      const dataset = { ability: abilityKey, action: "rollCheck", visibility: this.check.visible ? "all" : undefined };
       if ( dc ) dataset.dc = dc;
       if ( checkType !== "ability" ) dataset[checkType] = associated;
 

--- a/module/documents/activity/save.mjs
+++ b/module/documents/activity/save.mjs
@@ -54,7 +54,7 @@ export default class SaveActivity extends ActivityMixin(BaseSaveActivityData) {
           dc,
           ability: abilityId,
           action: "rollSave",
-          visibility: "all"
+          visibility: this.save.visible ? "all" : undefined
         }
       });
     }

--- a/templates/activity/utility-effect.hbs
+++ b/templates/activity/utility-effect.hbs
@@ -4,6 +4,5 @@
         <legend>{{ localize "DND5E.UTILITY.FIELDS.roll.label" }}</legend>
         {{ formField fields.roll.fields.name value=source.roll.name }}
         {{ formField fields.roll.fields.formula value=source.roll.formula }}
-        {{ formField fields.roll.fields.visible value=source.roll.visible input=inputs.createCheckboxInput }}
     </fieldset>
 </section>


### PR DESCRIPTION
Adds a "Visible to All" option to `CheckActivity` & `SaveActivity` to match the option currently on `UtilityActivity`. This allows checks and save that are only visible to the person activing the item, rather than to all players.

This also modifies how the behavior fields on the identity tab of activity sheets are rendered to avoid having to replace the whole template just to add a single field.

Closes #4800