### PR TITLE
[#2568, #3355] Add activity linking for attack & damage enrichers

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2720,6 +2720,31 @@ preLocalize("attackClassifications", { key: "label" });
 /* -------------------------------------------- */
 
 /**
+ * Attack modes available for weapons.
+ * @enum {string}
+ */
+DND5E.attackModes = Object.seal({
+  oneHanded: {
+    label: "DND5E.ATTACK.Mode.OneHanded"
+  },
+  twoHanded: {
+    label: "DND5E.ATTACK.Mode.TwoHanded"
+  },
+  offhand: {
+    label: "DND5E.ATTACK.Mode.Offhand"
+  },
+  thrown: {
+    label: "DND5E.ATTACK.Mode.Thrown"
+  },
+  "thrown-offhand": {
+    label: "DND5E.ATTACK.Mode.ThrownOffhand"
+  }
+});
+preLocalize("attackModes", { key: "label" });
+
+/* -------------------------------------------- */
+
+/**
  * Types of attacks based on range.
  * @enum {{ label: string }}
  */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -325,12 +325,12 @@ export default class WeaponData extends ItemDataModel.mixin(
     if ( !(this.properties.has("thr") && (this.attackType === "ranged")) ) {
       // Weapons without the "Two-Handed" property or with the "Versatile" property will have One-Handed attack
       if ( this.isVersatile || !this.properties.has("two") ) modes.push({
-        value: "oneHanded", label: game.i18n.localize("DND5E.ATTACK.Mode.OneHanded")
+        value: "oneHanded", label: CONFIG.DND5E.attackModes.oneHanded.label
       });
 
       // Weapons with the "Two-Handed" property or with the "Versatile" property will have Two-Handed attack
       if ( this.isVersatile || this.properties.has("two") ) modes.push({
-        value: "twoHanded", label: game.i18n.localize("DND5E.ATTACK.Mode.TwoHanded")
+        value: "twoHanded", label: CONFIG.DND5E.attackModes.twoHanded.label
       });
     }
 
@@ -340,17 +340,17 @@ export default class WeaponData extends ItemDataModel.mixin(
     // Weapons with the "Light" property will have Offhand attack
     // If player has the "Enhanced Dual Wielding" flag, then allow any melee weapon without the "Two-Handed" property
     if ( isLight ) modes.push({
-      value: "offhand", label: game.i18n.localize("DND5E.ATTACK.Mode.Offhand")
+      value: "offhand", label: CONFIG.DND5E.attackModes.offhand.label
     });
 
     // Weapons with the "Thrown" property will have Thrown attack
     if ( this.properties.has("thr") ) {
       if ( modes.length ) modes.push({ rule: true });
-      modes.push({ value: "thrown", label: game.i18n.localize("DND5E.ATTACK.Mode.Thrown") });
+      modes.push({ value: "thrown", label: CONFIG.DND5E.attackModes.thrown.label });
 
       // Weapons with the "Thrown" & "Light" properties will have an Offhand Throw attack
       if ( isLight ) modes.push({
-        value: "thrown-offhand", label: game.i18n.localize("DND5E.ATTACK.Mode.ThrownOffhand")
+        value: "thrown-offhand", label: CONFIG.DND5E.attackModes["thrown-offhand"].label
       });
     }
 


### PR DESCRIPTION
Adds the ability for attack and damgae enrichers to be linked to a specific activity, allowing them to fetch their formulas and any other information directly from that activity and to roll that activity when clicked, rather than using the generic rolling.

This can be done in two ways, either by explicitly stating the activity ID: `[[/attack activity=RLQlsLo5InKHZadn]]`, or by not specifiying a formula and letting the system find the first matching activity: `[[/attack]]` or `[[/damage average]]`.

This also adds support for specifying the attack mode in the enricher. For attack enrichers this just controls what attack mode is selected in the dialog by default (or used if the dialog is bypassed), and for damage enrichers this adjusts the damage formula if it changes based on the attack mode (so versatile weapons can contain enrichers for one-handed and two-handed damage.

Closes #2568
Closes #3355