### PR TITLE
[#4631, #4569] Add compendium source where applicable.

### DIFF
--- a/module/documents/advancement/advancement.mjs
+++ b/module/documents/advancement/advancement.mjs
@@ -355,8 +355,10 @@ export default class Advancement extends BaseAdvancement {
   async createItemData(uuid, id) {
     const source = await fromUuid(uuid);
     if ( !source ) return null;
+    const { _stats } = game.items.fromCompendium(source);
     return source.clone({
       _id: id ?? foundry.utils.randomID(),
+      _stats: _stats,
       "flags.dnd5e.sourceId": uuid,
       "flags.dnd5e.advancementOrigin": `${this.item.id}.${this.id}`
     }, {keepId: true}).toObject();

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1501,7 +1501,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       let newItemData = transformAll ? await transformAll(item, o) : item;
       if ( transformFirst && (depth === 0) ) newItemData = await transformFirst(newItemData, o);
       if ( !newItemData ) return;
-      if ( newItemData instanceof Item ) newItemData = newItemData.toObject();
+      if ( newItemData instanceof Item ) newItemData = game.items.fromCompendium(newItemData, {
+        clearSort: false, keepId: true, clearOwnership: false
+      });
       foundry.utils.mergeObject(newItemData, {"system.container": containerId} );
       if ( !keepId ) newItemData._id = foundry.utils.randomID();
 


### PR DESCRIPTION
Closes #4631.
Closes #4569.

Was surprised to learn that `fromCompendium` adds `_stats.compendiumSource` even if the item is not from a compendium so this *could* be simplified by just using the `uuid` of the given item but I decided not go that route since it seems misaligned with core behavior, at the very least.