### PR TITLE
Improve consistency of Item Sheet display

### DIFF
--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -168,6 +168,7 @@
     align-items: center;
     gap: 4px;
 
+    &:has(input[type=checkbox]:disabled, dnd5e-checkbox[disabled]) { cursor: default; }
     > span { line-height: calc(var(--form-field-height) + 1px); }
   }
 
@@ -408,7 +409,7 @@
 
   select {
     height: var(--form-field-height);
-    cursor: pointer;
+    &:not(:disabled) { cursor: pointer; }
   }
 
   :is(document-tags, multi-select) .tags.input-element-tags .tag {
@@ -418,6 +419,12 @@
     background: var(--dnd5e-background-card);
     border-radius: 3px;
     &:hover a { text-shadow: 0 0 6px var(--color-shadow-primary); }
+  }
+
+  :is(document-tags, multi-select):has(select:disabled) .tags.input-element-tags .tag {
+    cursor: default;
+    a { cursor: default; }
+    &:hover a { text-shadow: none; }
   }
 
   multi-select.hidden-tags .tags.input-element-tags { display: none; }
@@ -474,7 +481,7 @@
   dnd5e-checkbox {
     &[disabled]:not([checked]) {
       --checkbox-border-color: var(--color-text-light-6);
-      --checkbox-empty-color: var(--color-text-light-6);
+      --checkbox-empty-color: transparent;
     }
   }
 

--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -2,6 +2,7 @@ import * as Trait from "../../documents/actor/trait.mjs";
 import { formatNumber, simplifyBonus, splitSemicolons, staticID } from "../../utils.mjs";
 import Tabs5e from "../tabs.mjs";
 import DocumentSheetV2Mixin from "../mixins/sheet-v2-mixin.mjs";
+import ItemSheet5e2 from "../item/item-sheet-2.mjs";
 
 /**
  * Adds common V2 Actor sheet functionality.
@@ -593,8 +594,9 @@ export default function ActorSheetV2Mixin(Base) {
       const item = this.actor.items.get(itemId);
 
       switch ( action ) {
-        case "edit": item?.sheet.render(true); break;
         case "delete": item?.deleteDialog(); break;
+        case "edit": item?.sheet.render(true, { mode: ItemSheet5e2.MODES.EDIT }); break;
+        case "view": item?.sheet.render(true, { mode: ItemSheet5e2.MODES.PLAY }); break;
       }
     }
 

--- a/module/applications/components/checkbox.mjs
+++ b/module/applications/components/checkbox.mjs
@@ -40,6 +40,8 @@ export default class CheckboxElement extends AdoptedStyleSheetMixin(
       aspect-ratio: 1;
     }
 
+    :host(:disabled) { cursor: default; }
+
     :host > div {
       width: 100%;
       height: 100%;

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -2,6 +2,7 @@ import Item5e from "../../documents/item.mjs";
 import {parseInputDelta} from "../../utils.mjs";
 import CurrencyManager from "../currency-manager.mjs";
 import ContextMenu5e from "../context-menu.mjs";
+import ItemSheet5e2 from "../item/item-sheet-2.mjs";
 
 /**
  * Custom element that handles displaying actor & container inventories.
@@ -424,8 +425,9 @@ export default class InventoryElement extends HTMLElement {
       case "duplicate":
         return item.clone({name: game.i18n.format("DOCUMENT.CopyOf", {name: item.name})}, {save: true});
       case "edit":
+        return item.sheet.render(true, { mode: ItemSheet5e2.MODES.EDIT });
       case "view":
-        return item.sheet.render(true);
+        return item.sheet.render(true, { mode: ItemSheet5e2.MODES.PLAY });
       case "equip":
         return item.update({"system.equipped": !item.system.equipped});
       case "expand":

--- a/module/applications/item/item-compendium.mjs
+++ b/module/applications/item/item-compendium.mjs
@@ -1,4 +1,5 @@
 import Item5e from "../../documents/item.mjs";
+import ItemSheet5e2 from "./item-sheet-2.mjs";
 
 /**
  * Compendium with added support for item containers.
@@ -45,5 +46,14 @@ export default class ItemCompendium5e extends Compendium {
 
     // Let parent method perform sorting
     super._handleDroppedEntry(target, item.toDragData());
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _onClickEntryName(event) {
+    const { entryId } = event.target.closest("[data-entry-id]")?.dataset ?? {};
+    const item = await this.collection.getDocument?.(entryId);
+    item?.sheet.render(true, { mode: this.collection.locked ? ItemSheet5e2.MODES.PLAY : ItemSheet5e2.MODES.EDIT });
   }
 }

--- a/module/applications/item/item-directory.mjs
+++ b/module/applications/item/item-directory.mjs
@@ -1,4 +1,5 @@
 import Item5e from "../../documents/item.mjs";
+import ItemSheet5e2 from "./item-sheet-2.mjs";
 
 /**
  * Items sidebar with added support for item containers.
@@ -23,5 +24,14 @@ export default class ItemDirectory5e extends ItemDirectory {
 
     // Let parent method perform sorting
     super._handleDroppedEntry(target, item.toDragData());
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _onClickEntryName(event) {
+    const { entryId } = event.target.closest("[data-entry-id]")?.dataset ?? {};
+    const item = this.collection.get(entryId);
+    item?.sheet.render(true, { mode: ItemSheet5e2.MODES.EDIT });
   }
 }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -262,17 +262,18 @@ export default class ItemSheet5e extends ItemSheet {
 
   /**
    * Get the base weapons and tools based on the selected type.
+   * @param {object} [context]        Sheet preparation context.
    * @returns {Promise<object|null>}  Object with base items for this type formatted for selectOptions.
    * @protected
    */
-  async _getItemBaseTypes() {
+  async _getItemBaseTypes(context) {
     const baseIds = this.item.type === "equipment" ? {
       ...CONFIG.DND5E.armorIds,
       ...CONFIG.DND5E.shieldIds
     } : CONFIG.DND5E[`${this.item.type}Ids`];
     if ( baseIds === undefined ) return null;
 
-    const baseType = this.item.system.type.value;
+    const baseType = context?.source.type.value ?? this.item.system.type.value;
 
     const items = {};
     for ( const [name, id] of Object.entries(baseIds) ) {

--- a/module/applications/item/sheet-v2-mixin.mjs
+++ b/module/applications/item/sheet-v2-mixin.mjs
@@ -111,7 +111,6 @@ export default function ItemSheetV2Mixin(Base) {
         user: game.user,
 
         // Physical items
-        baseItems: await this._getItemBaseTypes(),
         isPhysical: "quantity" in this.item.system,
 
         // Identified state
@@ -135,6 +134,9 @@ export default function ItemSheetV2Mixin(Base) {
       const { description, identified, schema, unidentified, validProperties } = this.item.system;
       context.fields = schema.fields;
       if ( !context.editable ) context.source = context.system;
+
+      // Physical items
+      context.baseItems = await this._getItemBaseTypes(context);
 
       // Set some default collapsed states on first open.
       if ( foundry.utils.isEmpty(this._collapsed) ) Object.assign(this._collapsed, {

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -52,6 +52,20 @@ export default function DocumentSheetV2Mixin(Base) {
     /* -------------------------------------------- */
 
     /** @inheritDoc */
+    async _render(force, { mode, ...options }={}) {
+      if ( mode && (mode !== this._mode) ) {
+        this._mode = mode;
+        if ( this.rendered ) {
+          const toggle = this.element[0].querySelector(".window-header .mode-slider");
+          toggle.checked = this._mode === this.constructor.MODES.EDIT;
+        }
+      }
+      return super._render(force, options);
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
     async _renderOuter() {
       const html = await super._renderOuter();
       const header = html[0].querySelector(".window-header");

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -37,10 +37,10 @@ export default function DocumentSheetV2Mixin(Base) {
 
     /**
      * The mode the sheet is currently in.
-     * @type {ActorSheetV2.MODES}
+     * @type {ActorSheetV2.MODES|null}
      * @protected
      */
-    _mode = this.constructor.MODES.PLAY;
+    _mode = null;
 
     /* -------------------------------------------- */
 
@@ -53,8 +53,8 @@ export default function DocumentSheetV2Mixin(Base) {
 
     /** @inheritDoc */
     async _render(force, { mode, ...options }={}) {
-      if ( mode && (mode !== this._mode) ) {
-        this._mode = mode;
+      if ( !this._mode ) {
+        this._mode = mode ?? this.constructor.MODES.PLAY;
         if ( this.rendered ) {
           const toggle = this.element[0].querySelector(".window-header .mode-slider");
           toggle.checked = this._mode === this.constructor.MODES.EDIT;

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -173,7 +173,10 @@ export default class ConsumableData extends ItemDataModel.mixin(
       ...this.physicalItemSheetFields
     ];
     context.damageTypes = Object.entries(CONFIG.DND5E.damageTypes).map(([value, { label }]) => {
-      return { value, label, selected: context.source.damage.base.types.includes(value) };
+      return {
+        value, label,
+        selected: context.source.damage.base.types.includes?.(value) ?? context.source.damage.base.types.has(value)
+      };
     });
     context.denominationOptions = [
       { value: "", label: "" },

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -270,7 +270,10 @@ export default class WeaponData extends ItemDataModel.mixin(
 
     // Damage
     context.damageTypes = Object.entries(CONFIG.DND5E.damageTypes).map(([value, { label }]) => {
-      return { value, label, selected: context.source.damage.base.types.includes(value) };
+      return {
+        value, label,
+        selected: context.source.damage.base.types.includes?.(value) ?? context.source.damage.base.types.has(value)
+      };
     });
     const makeDenominationOptions = placeholder => [
       { value: "", label: placeholder ? `d${placeholder}` : "" },

--- a/templates/actors/parts/actor-classes.hbs
+++ b/templates/actors/parts/actor-classes.hbs
@@ -4,11 +4,11 @@
     {{#dnd5e-itemContext cls as |ctx|}}
     <div class="class pill-lg" data-item-id="{{ cls.id }}" style="--underlay: url('{{ ctx.prefixedImage }}');">
         <div class="icons {{#if cls.subclass}}subclass{{/if}}">
-            <img class="gold-icon item-tooltip" src="{{ cls.img }}" alt="{{ cls.name }}" data-action="edit"
+            <img class="gold-icon item-tooltip" src="{{ cls.img }}" alt="{{ cls.name }}" data-action="view"
                  data-item-id="{{ cls.id }}">
             {{#if cls.subclass}}
             <img class="gold-icon item-tooltip" src="{{ cls.subclass.img }}" alt="{{ cls.subclass.name }}"
-                 data-action="edit" data-item-id="{{ cls.subclass.id }}">
+                 data-action="view" data-item-id="{{ cls.subclass.id }}">
             {{else if ctx.needsSubclass}}
             <a class="gold-icon subclass-icon" data-action="findItem" data-item-type="subclass"
                data-class-identifier="{{ cls.identifier }}" data-tooltip="DND5E.SubclassAdd"

--- a/templates/actors/tabs/character-details.hbs
+++ b/templates/actors/tabs/character-details.hbs
@@ -127,7 +127,7 @@
                 </div>
                 {{/with}}
                 {{#if race}}
-                <div class="pill-lg texture race item-tooltip" data-action="edit"
+                <div class="pill-lg texture race item-tooltip" data-action="view"
                      data-item-id="{{ system.details.race.id }}"
                      aria-label="{{#if actor.isOwner}}{{ localize "DND5E.ItemEdit" }}{{else}}{{ localize "DND5E.ItemView" }}{{/if}}">
                     {{#if system.details.race.img}}
@@ -156,7 +156,7 @@
                 </div>
                 {{/if}}
                 {{#if background}}
-                <div class="pill-lg texture background item-tooltip" data-action="edit"
+                <div class="pill-lg texture background item-tooltip" data-action="view"
                      data-item-id="{{ system.details.background.id }}"
                      aria-label="{{#if actor.isOwner}}{{ localize "DND5E.ItemEdit" }}{{else}}{{ localize "DND5E.ItemView" }}{{/if}}">
                     {{#if system.details.background.img}}

--- a/templates/shared/inventory2.hbs
+++ b/templates/shared/inventory2.hbs
@@ -46,7 +46,7 @@
         <ul class="containers unlist">
             {{#each containers}}
             <li class="container" data-item-id="{{ id }}">
-                <a class="item-action" data-action="edit" data-tooltip="{{ name }}" aria-label="{{ name }}">
+                <a class="item-action" data-action="view" data-tooltip="{{ name }}" aria-label="{{ name }}">
                     {{#dnd5e-itemContext this as |ctx|}}
                     {{#with ctx.capacity}}
                     <div class="meter progress" role="meter" aria-valuemin="0" aria-valuenow="{{ pct }}"
@@ -147,7 +147,7 @@
 
                         {{!-- Item Name --}}
                         <div class="item-name item-action item-tooltip {{ @root.rollableClass }}" role="button"
-                             data-action="{{#if (eq item.type "container")}}edit{{else}}use{{/if}}"
+                             data-action="{{#if (eq item.type "container")}}view{{else}}use{{/if}}"
                              aria-label="{{ item.name }}">
                             {{#if ctx.concentration}}
                             <i class="concentration fas fa-arrow-rotate-left fa-spin fa-spin-reverse"


### PR DESCRIPTION
- Closes #4381 
- Closes #4809 
- Closes #4364 

This brings the Item sheet in-line with the V2 Actor sheet in terms of consistency around editability in Edit vs. Play mode. Form fields are now disabled in Play mode, and will now show any enchanted values, where before it was not possible to see them. Switching the sheet to edit mode will make the fields editable, with their source values displayed, avoiding the issue of potentially persisting enchantment-modified values, or making changes that do not visually update due to being enchantment-modified.

The sheets will now default to opening in Edit mode also, where appropriate, as most contexts where the Item sheet is opened imply editability (e.g. the right-click context menu on Actor sheets is labelled 'edit', and opening an Item from the sidebar is assumed for editing purposes). Contexts where the Item is not editable, such as a locked compendium, or when viewing an Item on an Actor with Observer permissions, the sheet will display in Play mode as Edit mode is not available in those contexts.

I've also improved a few areas of styling that were not displaying correctly in a disabled context.

![image](https://github.com/user-attachments/assets/de9b5842-8b1d-48c1-983a-5e7b8d2d8d5b)

![image](https://github.com/user-attachments/assets/c12ba238-7a6b-4363-91a6-0e11c088a14a)
