### PR TITLE
[#4826] Rename "Utility" activity to "Use"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3445,10 +3445,10 @@
 },
 
 "DND5E.UTILITY": {
-  "Title": "Utility",
+  "Title": "Use",
   "FIELDS": {
     "roll": {
-      "label": "Utility Roll",
+      "label": "Roll",
       "formula": {
         "label": "Roll Formula",
         "hint": "Formula for an arbitrary roll."
@@ -3458,7 +3458,7 @@
         "hint": "Display name for the rolling button."
       },
       "prompt": {
-        "label": "Utility Roll Prompt",
+        "label": "Roll Prompt",
         "hint": "Should the roll configuration dialog be displayed when rolling?"
       },
       "visible": {


### PR DESCRIPTION
Renames `UtilityActivity` to use an imperative verb for its name to match the other activity types. Doesn't change the underlying type from `utility`.

Closes #4826