### PR TITLE
[#3798] Add limited uses labels for NPC stat block actions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2566,6 +2566,8 @@
 "DND5E.ReactionAbbr": "R",
 "DND5E.ReactionPl": "Reactions",
 "DND5E.Recharge": "Recharge",
+"DND5E.RechargeLong": "Recharge after a Long Rest",
+"DND5E.RechargeShort": "Recharge after a Short or Long Rest",
 "DND5E.Recovery": "Recovery",
 "DND5E.RecoveryFormula": "Recovery Formula",
 "DND5E.RequiredMaterials": "Required Materials",

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -46,7 +46,7 @@ const {
  * @property {TargetField} target
  * @property {boolean} target.override           Override target values inferred from item.
  * @property {boolean} target.prompt             Should the player be prompted to place the template?
- * @property {UsesField} uses                    Uses available to this activity.
+ * @property {UsesData} uses                     Uses available to this activity.
  */
 export default class BaseActivityData extends foundry.abstract.DataModel {
 

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -315,7 +315,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * Calculate updates to activity or item uses.
    * @param {ActivityUseConfiguration} config  Configuration data for the activity usage.
    * @param {object} options
-   * @param {UsesField} options.uses           Uses data to consume.
+   * @param {UsesData} options.uses            Uses data to consume.
    * @param {string} options.type              Type label to be used in warning messages.
    * @param {BasicRoll[]} options.rolls        Rolls performed as part of the usages.
    * @returns {{ spent: number, quantity: number }|null}

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -576,13 +576,15 @@ export default class NPCData extends CreatureTemplate {
 
     for ( const item of this.parent.items ) {
       if ( !["feat", "weapon"].includes(item.type) ) continue;
-      const category = item.system.activities.contents[0]?.activation.type ?? "trait";
+      const category = item.system.activities?.contents[0]?.activation.type ?? "trait";
       if ( category in context.actionSections ) {
         const description = (await TextEditor.enrichHTML(item.system.description.value, {
           secrets: false, rollData: item.getRollData(), relativeTo: item
         })).replace(/^\s*<p>/g, "").replace(/<\/p>\s*$/g, "");
-        // TODO: Add standard uses to item names (e.g. `Recharge 5-6`, `1/day`, etc.)
-        context.actionSections[category].actions.push({ name: item.name, description, sort: item.sort });
+        const uses = item.system.uses.label || item.system.activities?.contents[0]?.uses.label;
+        context.actionSections[category].actions.push({
+          name: uses ? `${item.name} (${uses})` : item.name, description, sort: item.sort
+        });
       }
     }
     for ( const key of Object.keys(context.actionSections) ) {

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -7,6 +7,7 @@ import UsesField from "../../shared/uses-field.mjs";
  * Data model template for items with activities.
  *
  * @property {ActivityCollection} activities  Activities on this item.
+ * @property {UsesData} uses                  Item's limited uses & recovery.
  * @mixin
  */
 export default class ActivitiesTemplate extends SystemDataModel {


### PR DESCRIPTION
During data preparation for the uses field generates a label that matches the style of the NPC stat blocks, whihc is then used when embedding them. This will use the item uses if available and fall back to the activity uses otherwise. Any uses recovery that isn't normally used for NPCs will not get a label.