### PR TITLE
Track advantage modes

### DIFF
--- a/module/data/fields/_module.mjs
+++ b/module/data/fields/_module.mjs
@@ -1,6 +1,7 @@
 export * from "./activities-field.mjs";
-export {default as AdvancementField} from "./advancement-field.mjs";
 export {default as AdvancementDataField} from "./advancement-data-field.mjs";
+export {default as AdvancementField} from "./advancement-field.mjs";
+export {default as AdvantageModeField} from "./advantage-mode-field.mjs";
 export {default as FormulaField} from "./formula-field.mjs";
 export {default as IdentifierField} from "./identifier-field.mjs";
 export {default as LocalDocumentField} from "./local-document-field.mjs";

--- a/module/data/fields/advantage-mode-field.mjs
+++ b/module/data/fields/advantage-mode-field.mjs
@@ -1,0 +1,59 @@
+/**
+ * Subclass of NumberField that tracks the number of changes made to a roll mode.
+ */
+export default class AdvantageModeField extends foundry.data.fields.NumberField {
+  /** @inheritDoc */
+  static get _defaults() {
+    return foundry.utils.mergeObject(super._defaults, {
+      choices: [-1, 0, 1],
+      initial: 0,
+      label: "DND5E.AdvantageMode"
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Number of advantage modifications.
+   * @type {number}
+   */
+  #advantage;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Number of disadvantage modifications.
+   * @type {number}
+   */
+  #disadvantage;
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  initialize(value, model, options={}) {
+    this.#advantage = Number(value === 1);
+    this.#disadvantage = Number(value === -1);
+    return value;
+  }
+
+  /* -------------------------------------------- */
+  /*  Active Effect Integration                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  applyChange(value, model, change) {
+    const delta = this._castChangeDelta(change.value);
+    if ( change.mode === CONST.ACTIVE_EFFECT_MODES.CUSTOM ) {
+      return this._applyChangeCustom(value, delta, model, change);
+    }
+    switch (delta) {
+      case 1:
+        this.#advantage++;
+        break;
+      case -1:
+        this.#disadvantage++;
+        break;
+    }
+    return Math.sign(this.#advantage) - Math.sign(this.#disadvantage);
+  }
+}

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -1,3 +1,5 @@
+import AdvantageModeField from "../fields/advantage-mode-field.mjs";
+
 const { StringField, NumberField, SchemaField } = foundry.data.fields;
 
 /**
@@ -20,7 +22,7 @@ export default class RollConfigField extends foundry.data.fields.SchemaField {
       roll: new SchemaField({
         min: new NumberField({...opts, label: "DND5E.ROLL.Range.Minimum"}),
         max: new NumberField({...opts, label: "DND5E.ROLL.Range.Maximum"}),
-        mode: new NumberField({choices: [-1, 0, 1], initial: 0, label: "DND5E.AdvantageMode"}),
+        mode: new AdvantageModeField(),
         ...roll
       }),
       ...fields


### PR DESCRIPTION
Adds a new `AdvantageModeField` which tracks the number of effects that apply advantage and disadvantage. The final value is then either -1 if only disadvantages exist (including the initial value), 1 if only advantages exist (including initial value), otherwise 0 if there are both advantages and disadvantages (including initial value).

TODO: Add +5 (-5) to the skill's passive if the actor has advantage (disadvantage).