### PR TITLE
[#4384, #4828] Adds plural targets, add target to attack enricher

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -448,7 +448,11 @@ Hooks.once("i18nInit", () => {
         LanguagesExotic: game.i18n.localize("DND5E.LanguagesExoticLegacy"),
         LongRestHint: game.i18n.localize("DND5E.LongRestHintLegacy"),
         LongRestHintGroup: game.i18n.localize("DND5E.LongRestHintGroupLegacy"),
-        TargetRadius: game.i18n.localize("DND5E.TargetRadiusLegacy"),
+        "TARGET.Type.Emanation": foundry.utils.mergeObject(
+          _fallback.DND5E?.TARGET?.Type?.Radius ?? {},
+          translations.DND5E?.TARGET?.Type?.Radius ?? {},
+          { inplace: false }
+        ),
         TraitArmorPlural: foundry.utils.mergeObject(
           _fallback.DND5E?.TraitArmorLegacyPlural ?? {},
           translations.DND5E?.TraitArmorLegacyPlural ?? {},

--- a/lang/en.json
+++ b/lang/en.json
@@ -3268,7 +3268,7 @@
     "CreatureOrObject": {
       "Label": "Creature or Object",
       "Counted": {
-        "any": "any creature or objects",
+        "any": "any creatures or objects",
         "every": "every creature or object",
         "one": "{number} creature or object",
         "other": "{number} creatures or objects"

--- a/lang/en.json
+++ b/lang/en.json
@@ -2445,6 +2445,18 @@
   }
 },
 
+"DND5E.NUMBER": {
+  "1": "one",
+  "2": "two",
+  "3": "three",
+  "4": "four",
+  "5": "five",
+  "6": "six",
+  "7": "seven",
+  "8": "eight",
+  "9": "nine"
+},
+
 "DND5E.Number": "Number",
 "DND5E.OtherFormula": "Other Formula",
 "DND5E.PactMagic": "Pact Magic",
@@ -3146,6 +3158,13 @@
 "DND5E.Suppressed": "Suppressed",
 
 "DND5E.TARGET": {
+  "Action": {
+    "PlaceTemplate": "Place Measured Template"
+  },
+  "Count": {
+    "Any": "Any",
+    "Every": "Every"
+  },
   "FIELDS": {
     "target": {
       "label": "Targeting",
@@ -3209,8 +3228,156 @@
       }
     }
   },
-  "Action": {
-    "PlaceTemplate": "Place Measured Template"
+  "Formatted": "{count} {type}",
+  "Type": {
+    "Ally": {
+      "Label": "Ally",
+      "Counted": {
+        "any": "any allies",
+        "every": "every ally",
+        "one": "{number} ally",
+        "other": "{number} allies"
+      }
+    },
+    "Any": {
+      "Label": "Any"
+    },
+    "Circle": {
+      "Label": "Circle",
+      "Counted": {
+        "one": "{number} circle",
+        "other": "{number} circles"
+      }
+    },
+    "Cone": {
+      "Label": "Cone",
+      "Counted": {
+        "one": "{number} cone",
+        "other": "{number} cones"
+      }
+    },
+    "Creature": {
+      "Label": "Creature",
+      "Counted": {
+        "any": "any creatures",
+        "every": "every creature",
+        "one": "{number} creature",
+        "other": "{number} creatures"
+      }
+    },
+    "CreatureOrObject": {
+      "Label": "Creature or Object",
+      "Counted": {
+        "any": "any creature or objects",
+        "every": "every creature or object",
+        "one": "{number} creature or object",
+        "other": "{number} creatures or objects"
+      }
+    },
+    "Cube": {
+      "Label": "Cube",
+      "Counted": {
+        "one": "{number} cube",
+        "other": "{number} cubes"
+      }
+    },
+    "Cylinder": {
+      "Label": "Cylinder",
+      "Counted": {
+        "one": "{number} cylinder",
+        "other": "{number} cylinders"
+      }
+    },
+    "Emanation": {
+      "Label": "Emanation",
+      "Counted": {
+        "one": "{number} emanation",
+        "other": "{number} emanations"
+      }
+    },
+    "Enemy": {
+      "Label": "Enemy",
+      "Counted": {
+        "any": "any enemies",
+        "every": "every enemy",
+        "one": "{number} enemy",
+        "other": "{number} enemies"
+      }
+    },
+    "Line": {
+      "Label": "Line",
+      "Counted": {
+        "one": "{number} line",
+        "other": "{number} lines"
+      }
+    },
+    "Object": {
+      "Label": "Object",
+      "Counted": {
+        "any": "any objects",
+        "every": "every object",
+        "one": "{number} object",
+        "other": "{number} objects"
+      }
+    },
+    "Radius": {
+      "Label": "Radius",
+      "Counted": {
+        "one": "{number} radius",
+        "other": "{number} radii"
+      }
+    },
+    "Self": {
+      "Label": "Self"
+    },
+    "Sphere": {
+      "Label": "Sphere",
+      "Counted": {
+        "one": "{number} sphere",
+        "other": "{number} spheres"
+      }
+    },
+    "Space": {
+      "Label": "Space",
+      "Counted": {
+        "any": "any spaces",
+        "every": "every space",
+        "one": "{number} space",
+        "other": "{number} spaces"
+      }
+    },
+    "Square": {
+      "Label": "Square",
+      "Counted": {
+        "one": "{number} square",
+        "other": "{number} squares"
+      }
+    },
+    "Target": {
+      "Label": "Target",
+      "Counted": {
+        "any": "any targets",
+        "every": "every target",
+        "one": "{number} target",
+        "other": "{number} targets"
+      }
+    },
+    "Wall": {
+      "Label": "Wall",
+      "Counted": {
+        "one": "{number} wall",
+        "other": "{number} walls"
+      }
+    },
+    "WillingCreature": {
+      "Label": "Willing Creature",
+      "Counted": {
+        "any": "any willing creatures",
+        "every": "every willing creature",
+        "one": "{number} willing creature",
+        "other": "{number} willing creatures"
+      }
+    }
   },
   "Warning": {
     "PlaceTemplate": "Failed to place measured template."
@@ -3219,32 +3386,12 @@
 
 "DND5E.Target": "Target",
 "DND5E.TargetPl": "Targets",
-"DND5E.TargetAlly": "Ally",
-"DND5E.TargetAny": "Any",
-"DND5E.TargetCircle": "Circle",
-"DND5E.TargetCone": "Cone",
-"DND5E.TargetCreature": "Creature",
-"DND5E.TargetCreatureOrObject": "Creature or Object",
-"DND5E.TargetCube": "Cube",
-"DND5E.TargetCylinder": "Cylinder",
-"DND5E.TargetEnemy": "Enemy",
-"DND5E.TargetEvery": "Every",
-"DND5E.TargetLine": "Line",
-"DND5E.TargetObject": "Object",
-"DND5E.TargetRadius": "Emanation",
-"DND5E.TargetRadiusLegacy": "Radius",
-"DND5E.TargetSelf": "Self",
-"DND5E.TargetSpace": "Space",
-"DND5E.TargetSphere": "Sphere",
-"DND5E.TargetSquare": "Square",
 "DND5E.TargetType": "Target Type",
 "DND5E.TargetTypeArea": "Area",
 "DND5E.TargetTypeIndividual": "Individual",
 "DND5E.TargetUnits": "Area of Effect Units",
 "DND5E.TargetValue": "Target Length or Count",
-"DND5E.TargetWall": "Wall",
 "DND5E.TargetWidth": "Line Width",
-"DND5E.TargetWilling": "Willing Creature",
 "DND5E.TemplatePrompt": "Template Prompt",
 "DND5E.TemplatePromptTooltip": "If unchecked, the prompt for placing a Measured Template will be suppressed.",
 "DND5E.Temp": "Temp",

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -218,7 +218,7 @@ export default class ActivitySheet extends Application5e {
       { value: "", label: game.i18n.localize("DND5E.NoneActionLabel") }
     ];
     context.affectsPlaceholder = game.i18n.localize(
-      `DND5E.Target${context.data.target?.template?.type ? "Every" : "Any"}`
+      `DND5E.TARGET.Count.${context.data.target?.template?.type ? "Every" : "Any"}`
     );
     context.durationUnits = [
       { value: "inst", label: game.i18n.localize("DND5E.TimeInst") },

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -74,15 +74,16 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
 
     // Targets
     context.targetTypes = [
-      ...Object.entries(CONFIG.DND5E.individualTargetTypes).map(([value, label]) => {
+      ...Object.entries(CONFIG.DND5E.individualTargetTypes).map(([value, { label }]) => {
         return { value, label, group: "DND5E.TargetTypeIndividual" };
       }),
       ...Object.entries(CONFIG.DND5E.areaTargetTypes).map(([value, { label }]) => {
         return { value, label, group: "DND5E.TargetTypeArea" };
       })
     ];
-    context.scalarTarget = !["", "self", "any"].includes(target?.affects?.type);
-    context.affectsPlaceholder = game.i18n.localize(`DND5E.Target${target?.template?.type ? "Every" : "Any"}`);
+    context.scalarTarget = target?.affects?.type
+      && (CONFIG.DND5E.individualTargetTypes[target.affects.type]?.scalar !== false);
+    context.affectsPlaceholder = game.i18n.localize(`DND5E.TARGET.Count.${target?.template?.type ? "Every" : "Any"}`);
 
     // Range
     context.rangeTypes = [

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2589,7 +2589,7 @@ DND5E.individualTargetTypes = {
   },
   any: {
     label: "DND5E.TARGET.Type.Any.Label",
-    scalar: false
+    counted: "DND5E.TARGET.Type.Target.Counted"
   },
   willing: {
     label: "DND5E.TARGET.Type.WillingCreature.Label",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2548,21 +2548,56 @@ preLocalize("encumbrance.effects", { key: "name" });
 /* -------------------------------------------- */
 
 /**
+ * @typedef {object} IndividualTargetDefinition
+ * @property {string} label           Localized label for this type.
+ * @property {string} [counted]       Localization path for counted plural forms. Only necessary for scalar types.
+ * @property {boolean} [scalar=true]  Can this target take an associated numeric value?
+ */
+
+/**
  * Targeting types that apply to one or more distinct targets.
- * @enum {string}
+ * @enum {IndividualTargetDefinition}
  */
 DND5E.individualTargetTypes = {
-  self: "DND5E.TargetSelf",
-  ally: "DND5E.TargetAlly",
-  enemy: "DND5E.TargetEnemy",
-  creature: "DND5E.TargetCreature",
-  object: "DND5E.TargetObject",
-  space: "DND5E.TargetSpace",
-  creatureOrObject: "DND5E.TargetCreatureOrObject",
-  any: "DND5E.TargetAny",
-  willing: "DND5E.TargetWilling"
+  self: {
+    label: "DND5E.TARGET.Type.Self.Label",
+    scalar: false
+  },
+  ally: {
+    label: "DND5E.TARGET.Type.Ally.Label",
+    counted: "DND5E.TARGET.Type.Ally.Counted"
+  },
+  enemy: {
+    label: "DND5E.TARGET.Type.Enemy.Label",
+    counted: "DND5E.TARGET.Type.Enemy.Counted"
+  },
+  creature: {
+    label: "DND5E.TARGET.Type.Creature.Label",
+    counted: "DND5E.TARGET.Type.Creature.Counted"
+  },
+  object: {
+    label: "DND5E.TARGET.Type.Object.Label",
+    counted: "DND5E.TARGET.Type.Object.Counted"
+  },
+  space: {
+    label: "DND5E.TARGET.Type.Space.Label",
+    counted: "DND5E.TARGET.Type.Space.Counted"
+  },
+  creatureOrObject: {
+    label: "DND5E.TARGET.Type.CreatureOrObject.Label",
+    counted: "DND5E.TARGET.Type.CreatureOrObject.Counted"
+  },
+  any: {
+    label: "DND5E.TARGET.Type.Any.Label",
+    scalar: false
+  },
+  willing: {
+    label: "DND5E.TARGET.Type.WillingCreature.Label",
+    counted: "DND5E.TARGET.Type.WillingCreature.Counted"
+  }
 };
-preLocalize("individualTargetTypes");
+patchConfig("individualTargetTypes", "label", { from: "DnD5e 4.2", until: "DnD5e 4.4" });
+preLocalize("individualTargetTypes", { key: "label" });
 
 /* -------------------------------------------- */
 
@@ -2571,6 +2606,7 @@ preLocalize("individualTargetTypes");
  *
  * @typedef {object} AreaTargetDefinition
  * @property {string} label        Localized label for this type.
+ * @property {string} counted      Localization path for counted plural forms.
  * @property {string} template     Type of `MeasuredTemplate` create for this target type.
  * @property {string} [reference]  Reference to a rule page describing this area of effect.
  * @property {string[]} [sizes]    List of available sizes for this template. Options are chosen from the list:
@@ -2585,57 +2621,66 @@ preLocalize("individualTargetTypes");
  */
 DND5E.areaTargetTypes = {
   circle: {
-    label: "DND5E.TargetCircle",
+    label: "DND5E.TARGET.Type.Circle.Label",
+    counted: "DND5E.TARGET.Type.Circle.Counted",
     template: "circle",
     sizes: ["radius"]
   },
   cone: {
-    label: "DND5E.TargetCone",
+    label: "DND5E.TARGET.Type.Cone.Label",
+    counted: "DND5E.TARGET.Type.Cone.Counted",
     template: "cone",
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.DqqAOr5JnX71OCOw",
     sizes: ["length"],
     standard: true
   },
   cube: {
-    label: "DND5E.TargetCube",
+    label: "DND5E.TARGET.Type.Cube.Label",
+    counted: "DND5E.TARGET.Type.Cube.Counted",
     template: "rect",
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.dRfDIwuaHmUQ06uA",
     sizes: ["width"],
     standard: true
   },
   cylinder: {
-    label: "DND5E.TargetCylinder",
+    label: "DND5E.TARGET.Type.Cylinder.Label",
+    counted: "DND5E.TARGET.Type.Cylinder.Counted",
     template: "circle",
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.jZFp4R7tXsIqkiG3",
     sizes: ["radius", "height"],
     standard: true
   },
   line: {
-    label: "DND5E.TargetLine",
+    label: "DND5E.TARGET.Type.Line.Label",
+    counted: "DND5E.TARGET.Type.Line.Counted",
     template: "ray",
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.6DOoBgg7okm9gBc6",
     sizes: ["length", "width"],
     standard: true
   },
   radius: {
-    label: "DND5E.TargetRadius",
+    label: "DND5E.TARGET.Type.Emanation.Label",
+    counted: "DND5E.TARGET.Type.Emanation.Counted",
     template: "circle",
     standard: true
   },
   sphere: {
-    label: "DND5E.TargetSphere",
+    label: "DND5E.TARGET.Type.Sphere.Label",
+    counted: "DND5E.TARGET.Type.Sphere.Counted",
     template: "circle",
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.npdEWb2egUPnB5Fa",
     sizes: ["radius"],
     standard: true
   },
   square: {
-    label: "DND5E.TargetSquare",
+    label: "DND5E.TARGET.Type.Square.Label",
+    counted: "DND5E.TARGET.Type.Square.Counted",
     template: "rect",
     sizes: ["width"]
   },
   wall: {
-    label: "DND5E.TargetWall",
+    label: "DND5E.TARGET.Type.Wall.Label",
+    counted: "DND5E.TARGET.Type.Wall.Counted",
     template: "ray",
     sizes: ["length", "thickness", "height"]
   }
@@ -2661,7 +2706,7 @@ Object.defineProperty(DND5E, "areaTargetOptions", {
  * @enum {string}
  */
 DND5E.targetTypes = {
-  ...DND5E.individualTargetTypes,
+  ...Object.fromEntries(Object.entries(DND5E.individualTargetTypes).map(([k, v]) => [k, v.label])),
   ...Object.fromEntries(Object.entries(DND5E.areaTargetTypes).map(([k, v]) => [k, v.label]))
 };
 preLocalize("targetTypes", { sort: true });

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -43,7 +43,7 @@ const {
  * @property {EffectApplicationData[]} effects   Linked effects that can be applied.
  * @property {object} range
  * @property {boolean} range.override            Override range values inferred from item.
- * @property {TargetField} target
+ * @property {TargetData} target
  * @property {boolean} target.override           Override target values inferred from item.
  * @property {boolean} target.prompt             Should the player be prompted to place the template?
  * @property {UsesData} uses                     Uses available to this activity.

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -1,11 +1,10 @@
-import { formatDistance, prepareFormulaValue } from "../../utils.mjs";
+import { formatDistance, formatNumber, getPluralRules, prepareFormulaValue } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { BooleanField, SchemaField, StringField } = foundry.data.fields;
 
 /**
- * Field for storing target data.
- *
+ * @typedef {object} TargetData
  * @property {object} template
  * @property {string} template.count        Number of templates created.
  * @property {boolean} template.contiguous  Must all created areas be connected to one another?
@@ -19,6 +18,10 @@ const { BooleanField, SchemaField, StringField } = foundry.data.fields;
  * @property {string} affects.type          Type of targets that can be affected (e.g. creatures, objects, spaces).
  * @property {boolean} affects.choice       When targeting an area, can the user choose who it affects?
  * @property {string} affects.special       Description of special targeting.
+ */
+
+/**
+ * Field for storing target data.
  */
 export default class TargetField extends SchemaField {
   constructor(fields={}, options={}) {
@@ -54,7 +57,8 @@ export default class TargetField extends SchemaField {
    * @param {object} [labels]  Object in which to insert generated labels.
    */
   static prepareData(rollData, labels) {
-    this.target.affects.scalar = !["", "self", "any"].includes(this.target.affects.type);
+    this.target.affects.scalar = this.target.affects.type
+      && (CONFIG.DND5E.individualTargetTypes[this.target.affects.type]?.scalar !== false);
     if ( this.target.affects.scalar ) {
       prepareFormulaValue(this, "target.affects.count", "DND5E.TARGET.FIELDS.target.affects.count.label", rollData);
     } else this.target.affects.count = null;
@@ -76,26 +80,37 @@ export default class TargetField extends SchemaField {
       this.target.template.height = null;
     }
 
-    if ( labels ) {
+    const pr = getPluralRules();
+
+    // Generate the template label
+    const templateConfig = CONFIG.DND5E.areaTargetTypes[this.target.template.type];
+    if ( templateConfig ) {
       const parts = [];
+      if ( this.target.template.count > 1 ) parts.push(`${this.target.template.count} ×`);
+      if ( this.target.template.units in CONFIG.DND5E.movementUnits ) {
+        parts.push(formatDistance(this.target.template.size, this.target.template.units));
+      }
+      this.target.template.label = game.i18n.format(
+        `${templateConfig.counted}.${pr.select(this.target.template.count || 1)}`, { number: parts.filterJoin(" ") }
+      ).trim().capitalize();
+    } else this.target.template.label = "";
 
-      if ( this.target.template.type ) {
-        if ( this.target.template.count > 1 ) parts.push(`${this.target.template.count} ×`);
-        if ( this.target.template.units in CONFIG.DND5E.movementUnits ) {
-          parts.push(formatDistance(this.target.template.size, this.target.template.units));
-        } else {
-          parts.push(this.target.template.size);
+    // Generate the affects label
+    const affectsConfig = CONFIG.DND5E.individualTargetTypes[this.target.affects.type];
+    this.target.affects.labels = {
+      sheet: affectsConfig?.counted ? game.i18n.format(
+        `${affectsConfig.counted}.${this.target.affects.count ? pr.select(this.target.affects.count) : "other"}`, {
+          number: this.target.affects.count ? formatNumber(this.target.affects.count)
+            : game.i18n.localize(`DND5E.TARGET.Count.${this.target.template.type ? "Every" : "Any"}`)
         }
-        parts.push(CONFIG.DND5E.areaTargetTypes[this.target.template.type]?.label);
-      }
+      ).trim().capitalize() : (affectsConfig?.label ?? ""),
+      statblock: game.i18n.format(
+        `${affectsConfig?.counted ?? "DND5E.TARGET.Type.Target.Counted"}.${pr.select(this.target.affects.count || 1)}`,
+        { number: formatNumber(this.target.affects.count || 1, { spellOut: true }) }
+      )
+    };
 
-      else if ( this.target.affects.type ) {
-        if ( this.target.affects.scalar ) parts.push(this.target.affects.count);
-        parts.push(CONFIG.DND5E.individualTargetTypes[this.target.affects.type]);
-      }
-
-      labels.target = parts.filterJoin(" ");
-    }
+    if ( labels ) labels.target = this.target.template.label || this.target.affects.labels.sheet;
   }
 
   /* -------------------------------------------- */

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -106,7 +106,7 @@ export default class TargetField extends SchemaField {
       ).trim().capitalize() : (affectsConfig?.label ?? ""),
       statblock: game.i18n.format(
         `${affectsConfig?.counted ?? "DND5E.TARGET.Type.Target.Counted"}.${pr.select(this.target.affects.count || 1)}`,
-        { number: formatNumber(this.target.affects.count || 1, { spellOut: true }) }
+        { number: formatNumber(this.target.affects.count || 1, { words: true }) }
       )
     };
 

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -205,8 +205,7 @@ async function enrichAttack(config, label, options) {
       classification: CONFIG.DND5E.attackClassifications[activity?.attack.type.classification]?.label ?? ""
     }).trim();
     const parts = [span.outerHTML, activity?.getRangeLabel(config.attackMode)];
-
-    // TODO: Add targeting information (e.g. "one target") according to 2014 rules
+    if ( config._rules === "2014" ) parts.push(activity?.target?.affects.labels?.statblock);
 
     const full = document.createElement("span");
     full.className = "attack-extended";

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -46,10 +46,12 @@ export function formatModifier(mod) {
  * A helper for using Intl.NumberFormat within handlebars.
  * @param {number} value    The value to format.
  * @param {object} options  Options forwarded to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat}
+ * @param {boolean} [options.spellOut]  Spell out number as full word, if possible.
  * @param {boolean} [options.numerals]  Format the number as roman numerals.
  * @returns {string}
  */
-export function formatNumber(value, { numerals, ...options }={}) {
+export function formatNumber(value, { spellOut, numerals, ...options }={}) {
+  if ( spellOut && game.i18n.has(`DND5E.NUMBER.${value}`, false) ) return game.i18n.localize(`DND5E.NUMBER.${value}`);
   if ( numerals ) return _formatNumberAsNumerals(value);
   const formatter = new Intl.NumberFormat(game.i18n.lang, options);
   return formatter.format(value);

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -46,12 +46,12 @@ export function formatModifier(mod) {
  * A helper for using Intl.NumberFormat within handlebars.
  * @param {number} value    The value to format.
  * @param {object} options  Options forwarded to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat}
- * @param {boolean} [options.spellOut]  Spell out number as full word, if possible.
  * @param {boolean} [options.numerals]  Format the number as roman numerals.
+ * @param {boolean} [options.words]     Write out number as full word, if possible.
  * @returns {string}
  */
-export function formatNumber(value, { spellOut, numerals, ...options }={}) {
-  if ( spellOut && game.i18n.has(`DND5E.NUMBER.${value}`, false) ) return game.i18n.localize(`DND5E.NUMBER.${value}`);
+export function formatNumber(value, { numerals, words, ...options }={}) {
+  if ( words && game.i18n.has(`DND5E.NUMBER.${value}`, false) ) return game.i18n.localize(`DND5E.NUMBER.${value}`);
   if ( numerals ) return _formatNumberAsNumerals(value);
   const formatter = new Intl.NumberFormat(game.i18n.lang, options);
   return formatter.format(value);

--- a/templates/items/parts/item-activation.hbs
+++ b/templates/items/parts/item-activation.hbs
@@ -49,7 +49,7 @@
             {{#select system.target.type}}
                  <option value="">{{localize "DND5E.None"}}</option>
                  <optgroup label="{{localize 'DND5E.TargetTypeIndividual'}}">
-                     {{selectOptions config.individualTargetTypes}}
+                     {{selectOptions config.individualTargetTypes labelAttr="label"}}
                  </optgroup>
                  <optgroup label="{{localize 'DND5E.TargetTypeArea'}}">
                      {{selectOptions config.areaTargetTypes labelAttr="label"}}

--- a/templates/shared/fields/field-targets.hbs
+++ b/templates/shared/fields/field-targets.hbs
@@ -18,7 +18,7 @@
 
             {{!-- Type --}}
             {{ formField fields.affects.fields.type value=data.affects.type label="DND5E.Type" localize=true hint=false
-                         choices=CONFIG.individualTargetTypes classes="label-top" }}
+                         choices=CONFIG.individualTargetTypes labelAttr="label" classes="label-top" }}
         </div>
 
         {{!-- Special --}}


### PR DESCRIPTION
Adds the targeting information to the extended attack enricher when using the 2014 rules (e.g. "one target"). Two additional localization features were added to support this.

First, `formatNumber` now takes the `spellOut` option which will attempt to write the number out if the current language provides a written form (e.g. `one` instead of `1`). The does not fall back to the default language, so a language where this doesn't make sense can simply not provide the appropriate localization keys and it will just use the numeric form instead. For English this is set up to spell out the numbers 1–9 only.

Second, the targeting localization was modified to include counted plural localizations so now the system will be able to display "2 creatures" rather than "2 creature" when it displays target labels. This change required changing the `individualTargetTypes` config entry to contain objects.

Closes #4384
Closes #4828