### PR TITLE
[#4840] Switch custom elements to extend `AbstractFormInputElement`

### DIFF
--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -492,7 +492,6 @@ export default function ActorSheetV2Mixin(Base) {
     activateListeners(html) {
       super.activateListeners(html);
       html.find(".pips[data-prop]").on("click", this._onTogglePip.bind(this));
-      html.find("proficiency-cycle").on("change", this._onChangeInput.bind(this));
       html.find(".rollable:is(.saving-throw, .ability-check)").on("click", this._onRollAbility.bind(this));
       html.find(".sidebar-collapser").on("click", this._onToggleSidebar.bind(this));
       html.find("[data-item-id][data-action]").on("click", this._onItemAction.bind(this));

--- a/module/applications/components/checkbox.mjs
+++ b/module/applications/components/checkbox.mjs
@@ -13,13 +13,20 @@ export default class CheckboxElement extends AdoptedStyleSheetMixin(
     this._internals.role = "checkbox";
     this._value = this.getAttribute("value");
     this.#defaultValue = this._value;
-    this.#shadowRoot = this.attachShadow({ mode: "closed" });
+    if ( this.constructor.useShadowRoot ) this.#shadowRoot = this.attachShadow({ mode: "closed" });
   }
 
   /* -------------------------------------------- */
 
   /** @override */
   static tagName = "dnd5e-checkbox";
+
+  /* -------------------------------------------- */
+
+  /**
+   * Should a show root be created for this element?
+   */
+  static useShadowRoot = true;
 
   /* -------------------------------------------- */
 
@@ -155,7 +162,6 @@ export default class CheckboxElement extends AdoptedStyleSheetMixin(
 
   /** @override */
   connectedCallback() {
-    this._controller = new AbortController();
     this._adoptStyleSheet(this._getStyleSheet());
     const elements = this._buildElements();
     this.#shadowRoot.replaceChildren(...elements);
@@ -213,9 +219,17 @@ export default class CheckboxElement extends AdoptedStyleSheetMixin(
 
   /** @override */
   _activateListeners() {
-    const { signal } = this._controller;
+    const { signal } = this._controller = new AbortController();
     this.addEventListener("click", this._onClick.bind(this), { signal });
     this.addEventListener("keydown", event => event.key === " " ? this._onClick(event) : null, { signal });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _refresh() {
+    super._refresh();
+    this._internals.ariaChecked = `${this.hasAttribute("checked")}`;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/slide-toggle.mjs
+++ b/module/applications/components/slide-toggle.mjs
@@ -1,87 +1,28 @@
+import CheckboxElement from "./checkbox.mjs";
+
 /**
  * A custom HTML element that represents a checkbox-like input that is displayed as a slide toggle.
  * @fires change
  */
-export default class SlideToggleElement extends HTMLElement {
-  /** @override */
-  static formAssociated = true;
-
+export default class SlideToggleElement extends CheckboxElement {
   /** @inheritDoc */
   constructor() {
     super();
-    this.#internals = this.attachInternals();
-    this.#internals.role = "switch";
-    this.#internals.ariaChecked = this.hasAttribute("checked") ? "true" : "false";
-  }
-
-  /**
-   * The custom element's form and accessibility internals.
-   * @type {ElementInternals}
-   */
-  #internals;
-
-  /**
-   * The form this element belongs to, if any.
-   * @type {HTMLFormElement}
-   */
-  get form() {
-    return this.#internals.form;
+    this._internals.role = "switch";
   }
 
   /* -------------------------------------------- */
 
-  /**
-   * The name of the toggle.
-   * @type {string}
-   */
-  get name() {
-    return this.getAttribute("name");
-  }
-
-  set name(value) {
-    this.setAttribute("name", value);
-  }
+  /** @override */
+  static tagName = "slide-toggle";
 
   /* -------------------------------------------- */
 
-  /**
-   * Whether the slide toggle is toggled on.
-   * @type {boolean}
-   */
-  get checked() {
-    return this.hasAttribute("checked");
-  }
-
-  set checked(value) {
-    if ( typeof value !== "boolean" ) throw new Error("Slide toggle checked state must be a boolean.");
-    this.toggleAttribute("checked", value);
-    this.#internals.ariaChecked = `${value}`;
-  }
+  /** @override */
+  static useShadowRoot = false;
 
   /* -------------------------------------------- */
-
-  /**
-   * The value of the input as it appears in form data.
-   * @type {string}
-   */
-  get value() {
-    return this.getAttribute("value") || "on";
-  }
-
-  set value(value) {
-    this.setAttribute("value", value);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Masquerade as a checkbox input.
-   * @type {string}
-   */
-  get type() {
-    return "checkbox";
-  }
-
+  /*  Element Lifecycle                           */
   /* -------------------------------------------- */
 
   /**
@@ -89,8 +30,8 @@ export default class SlideToggleElement extends HTMLElement {
    * @inheritDoc
    */
   connectedCallback() {
-    this.replaceChildren();
-    this.append(...this._buildElements());
+    this.replaceChildren(...this._buildElements());
+    this._refresh();
     this._activateListeners();
   }
 
@@ -108,35 +49,5 @@ export default class SlideToggleElement extends HTMLElement {
     thumb.classList.add("slide-toggle-thumb");
     track.append(thumb);
     return [track];
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Guard against adding event listeners more than once.
-   * @type {boolean}
-   */
-  #listenersAdded = false;
-
-  /**
-   * Activate event listeners.
-   * @protected
-   */
-  _activateListeners() {
-    if ( this.#listenersAdded ) return;
-    this.addEventListener("click", this._onToggle.bind(this));
-    this.#listenersAdded = true;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Handle toggling the control.
-   * @param {PointerEvent} event  The triggering event.
-   * @protected
-   */
-  _onToggle(event) {
-    this.checked = !this.checked;
-    this.dispatchEvent(new Event("change"));
   }
 }

--- a/module/applications/item/sheet-v2-mixin.mjs
+++ b/module/applications/item/sheet-v2-mixin.mjs
@@ -35,9 +35,6 @@ export default function ItemSheetV2Mixin(Base) {
       inventory: { name: "", properties: new Set() }
     };
 
-    /** @inheritDoc */
-    static _customElements = super._customElements.concat(["dnd5e-checkbox"]);
-
     /* -------------------------------------------- */
     /*  Rendering                                   */
     /* -------------------------------------------- */

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -43,6 +43,11 @@ export default function DocumentSheetV2Mixin(Base) {
     _mode = this.constructor.MODES.PLAY;
 
     /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    static _customElements = super._customElements.concat(["dnd5e-checkbox", "proficiency-cycle", "slide-toggle"]);
+
+    /* -------------------------------------------- */
     /*  Rendering                                   */
     /* -------------------------------------------- */
 


### PR DESCRIPTION
Modifies `ProficiencyCycleElement` to extend core's form input element directly, and modify `SlideToggleElement` to inherit from `CheckboxElement` and take advantage of most of its code.

Also ensures all three elements are registered with AppV1 actor and item sheets for form submission.

Closes #4840