### PR TITLE
Fix warnings migrations

### DIFF
--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -179,7 +179,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
 
     const charged = source.recharge?.charged;
 
-    if (  (source.recharge?.value !== null) && (charged !== undefined) && !source.uses?.max ) {
+    if ( (source.recharge?.value !== null) && (charged !== undefined) && !source.uses?.max ) {
       source.uses ??= {};
       source.uses.spent = charged ? 0 : 1;
       source.uses.max = "1";

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -187,8 +187,8 @@ export default class ActivitiesTemplate extends SystemDataModel {
 
     if ( foundry.utils.getType(source?.uses?.recovery) !== "string" ) return;
 
-    // If period is charges, set the recovery type to formula
-    if (source?.uses?.per === "charges" ) {
+    // If period is charges, set the recovery type to `formula`
+    if ( source.uses?.per === "charges" ) {
       if ( source.uses.recovery ) {
         source.uses.recovery = [{ period: "lr", type: "formula", formula: source.uses.recovery }];
       } else if (hasSourceUses) {

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -169,6 +169,8 @@ export default class ActivitiesTemplate extends SystemDataModel {
     // Remove any old ternary operators from uses to prevent errors
     let maxIncludesIsAFunction = source?.uses && typeof (source?.uses?.max?.includes) === "function";
 
+    if (maxIncludesIsAFunction source?.uses?.max?.includes(" ? ") ) source.uses.max = "";
+
     for ( const activity of Object.values(source.activities ?? {}) ) {
       if (maxIncludesIsAFunction && activity?.uses?.max?.includes(" ? ") )
       {

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -208,7 +208,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
     }
     // Otherwise, check to see if recharge is set
     else if ( source.recharge?.value ) {
-      source?.uses?.recovery = [{ period: "recharge", formula: source.recharge.value }];
+      source.uses.recovery = [{ period: "recharge", formula: source.recharge.value }];
     }
     // Prevent a string value for uses recovery from being cleaned into a default recovery entry
     else if ( source.uses?.recovery === "" ) {

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -167,8 +167,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
    */
   static #migrateUses(source) {
     // Remove any old ternary operators from uses to prevent errors
-    let hasSourceUses = source.uses;
-    let maxIncludesIsAFunction = hasSourceUses && typeof (source.uses?.max?.includes) === "function";
+    let maxIncludesIsAFunction = source?.uses && typeof (source?.uses?.max?.includes) === "function";
 
     for ( const activity of Object.values(source.activities ?? {}) ) {
       if (maxIncludesIsAFunction && activity?.uses?.max?.includes(" ? ") )
@@ -177,48 +176,48 @@ export default class ActivitiesTemplate extends SystemDataModel {
       }
     }
 
-    if ( Array.isArray(source.uses?.recovery) )
+    if ( Array.isArray(source?.uses?.recovery) )
     {
       return;
     }
 
     const charged = source.recharge?.charged;
 
-    if (hasSourceUses && (source.recharge?.value !== null) && (charged !== undefined) && !source.uses?.max ) {
+    if (  (source.recharge?.value !== null) && (charged !== undefined) && !source.uses?.max ) {
       source.uses ??= {};
       source.uses.spent = charged ? 0 : 1;
       source.uses.max = "1";
     }
 
-    if ( hasSourceUses && foundry.utils.getType(source.uses?.recovery) !== "string" )
+    if (  foundry.utils.getType(source?.uses?.recovery) !== "string" )
     {
       return;
     }
 
     // If period is charges, set the recovery type to formula
-    if (hasSourceUses && source.uses.per === "charges" ) {
-      if ( hasSourceUses && source.uses.recovery ) {
+    if (source?.uses?.per === "charges" ) {
+      if ( source.uses.recovery ) {
         source.uses.recovery = [{ period: "lr", type: "formula", formula: source.uses.recovery }];
       } else if (hasSourceUses) {
         delete source.uses.recovery;
       }
     }
     // If period is not blank, set an appropriate recovery type
-    else if (hasSourceUses && source.uses.per ) {
-      if ( CONFIG.DND5E.limitedUsePeriods[source.uses.per]?.formula && source.uses.recovery ) {
-        source.uses.recovery = [{ period: source.uses.per, type: "formula", formula: source.uses.recovery }];
+    else if (source?.uses?.per ) {
+      if ( CONFIG.DND5E.limitedUsePeriods[source?.uses?.per]?.formula && source?.uses?.recovery ) {
+        source?.uses?.recovery = [{ period: source?.uses?.per, type: "formula", formula: source?.uses?.recovery }];
       }
       else {
-        source.uses.recovery = [{ period: source.uses.per, type: "recoverAll" }];
+        source?.uses?.recovery = [{ period: source?.uses?.per, type: "recoverAll" }];
       }
     }
     // Otherwise, check to see if recharge is set
-    else if (hasSourceUses && source.recharge?.value ) {
-      source.uses.recovery = [{ period: "recharge", formula: source.recharge.value }];
+    else if ( source.recharge?.value ) {
+      source?.uses?.recovery = [{ period: "recharge", formula: source.recharge.value }];
     }
     // Prevent a string value for uses recovery from being cleaned into a default recovery entry
-    else if (hasSourceUses && source.uses?.recovery === "" ) {
-      delete source.uses.recovery;
+    else if (source?.uses?.recovery === "" ) {
+      delete source?.uses.recovery;
     }
   }
 

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -169,7 +169,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
     // Remove any old ternary operators from uses to prevent errors
     let maxIncludesIsAFunction = source?.uses && typeof (source?.uses?.max?.includes) === "function";
 
-    if (maxIncludesIsAFunction source?.uses?.max?.includes(" ? ") ) source.uses.max = "";
+    if (maxIncludesIsAFunction && source?.uses?.max?.includes(" ? ") ) source.uses.max = "";
 
     for ( const activity of Object.values(source.activities ?? {}) ) {
       if (maxIncludesIsAFunction && activity?.uses?.max?.includes(" ? ") )

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -189,19 +189,19 @@ export default class ActivitiesTemplate extends SystemDataModel {
     if ( source.uses?.per === "charges" ) {
       if ( source.uses.recovery ) {
         source.uses.recovery = [{ period: "lr", type: "formula", formula: source.uses.recovery }];
-      } else if (hasSourceUses) {
+      } else if (source.uses) {
         delete source.uses.recovery;
       }
     }
     // If period is not blank, set an appropriate recovery type
     else if (source?.uses?.per ) {
       if ( CONFIG.DND5E.limitedUsePeriods[source?.uses?.per]?.formula && source?.uses?.recovery ) {
-        if(source?.uses)
+        if(source.uses)
         {
           source.uses.recovery = [{ period: source?.uses?.per, type: "formula", formula: source?.uses?.recovery }];
         }
       }
-      else if(source?.uses)
+      else if(source.uses)
       {
         source.uses.recovery = [{ period: source?.uses?.per, type: "recoverAll" }];
       }

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -178,10 +178,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
       }
     }
 
-    if ( Array.isArray(source?.uses?.recovery) )
-    {
-      return;
-    }
+    if ( Array.isArray(source?.uses?.recovery) ) return;
 
     const charged = source.recharge?.charged;
 

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -185,10 +185,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
       source.uses.max = "1";
     }
 
-    if (  foundry.utils.getType(source?.uses?.recovery) !== "string" )
-    {
-      return;
-    }
+    if ( foundry.utils.getType(source?.uses?.recovery) !== "string" ) return;
 
     // If period is charges, set the recovery type to formula
     if (source?.uses?.per === "charges" ) {

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -172,10 +172,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
     if (maxIncludesIsAFunction && source?.uses?.max?.includes(" ? ") ) source.uses.max = "";
 
     for ( const activity of Object.values(source.activities ?? {}) ) {
-      if (maxIncludesIsAFunction && activity?.uses?.max?.includes(" ? ") )
-      {
-        activity.uses.max = "";
-      }
+      if ( activity?.uses?.max?.includes?.(" ? ") ) activity.uses.max = "";
     }
 
     if ( Array.isArray(source?.uses?.recovery) ) return;

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -205,10 +205,14 @@ export default class ActivitiesTemplate extends SystemDataModel {
     // If period is not blank, set an appropriate recovery type
     else if (source?.uses?.per ) {
       if ( CONFIG.DND5E.limitedUsePeriods[source?.uses?.per]?.formula && source?.uses?.recovery ) {
-        source?.uses?.recovery = [{ period: source?.uses?.per, type: "formula", formula: source?.uses?.recovery }];
+        if(source?.uses)
+        {
+          source.uses.recovery = [{ period: source?.uses?.per, type: "formula", formula: source?.uses?.recovery }];
+        }
       }
-      else {
-        source?.uses?.recovery = [{ period: source?.uses?.per, type: "recoverAll" }];
+      else if(source?.uses)
+      {
+        source.uses.recovery = [{ period: source?.uses?.per, type: "recoverAll" }];
       }
     }
     // Otherwise, check to see if recharge is set
@@ -217,7 +221,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
     }
     // Prevent a string value for uses recovery from being cleaned into a default recovery entry
     else if (source?.uses?.recovery === "" ) {
-      delete source?.uses.recovery;
+      delete source.uses.recovery;
     }
   }
 

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -213,7 +213,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
       source?.uses?.recovery = [{ period: "recharge", formula: source.recharge.value }];
     }
     // Prevent a string value for uses recovery from being cleaned into a default recovery entry
-    else if (source?.uses?.recovery === "" ) {
+    else if ( source.uses?.recovery === "" ) {
       delete source.uses.recovery;
     }
   }

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -167,9 +167,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
    */
   static #migrateUses(source) {
     // Remove any old ternary operators from uses to prevent errors
-    let maxIncludesIsAFunction = source?.uses && typeof (source?.uses?.max?.includes) === "function";
-
-    if (maxIncludesIsAFunction && source?.uses?.max?.includes(" ? ") ) source.uses.max = "";
+    if ( source.uses?.max?.includes?.(" ? ") ) source.uses.max = "";
 
     for ( const activity of Object.values(source.activities ?? {}) ) {
       if ( activity?.uses?.max?.includes?.(" ? ") ) activity.uses.max = "";

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -187,27 +187,24 @@ export default class ActivitiesTemplate extends SystemDataModel {
     if ( source.uses?.per === "charges" ) {
       if ( source.uses.recovery ) {
         source.uses.recovery = [{ period: "lr", type: "formula", formula: source.uses.recovery }];
-      } else if (source.uses) {
+      } else if ( source.uses ) {
         delete source.uses.recovery;
       }
     }
+
     // If period is not blank, set an appropriate recovery type
-    else if (source.uses?.per ) {
+    else if ( source.uses?.per ) {
       if ( CONFIG.DND5E.limitedUsePeriods[source.uses?.per]?.formula && source.uses?.recovery ) {
-        if(source.uses)
-        {
-          source.uses.recovery = [{ period: source?.uses?.per, type: "formula", formula: source?.uses?.recovery }];
-        }
+        source.uses.recovery = [{ period: source?.uses?.per, type: "formula", formula: source?.uses?.recovery }];
       }
-      else if(source.uses)
-      {
-        source.uses.recovery = [{ period: source.uses?.per, type: "recoverAll" }];
-      }
+      else if ( source.uses ) source.uses.recovery = [{ period: source.uses?.per, type: "recoverAll" }];
     }
+
     // Otherwise, check to see if recharge is set
     else if ( source.recharge?.value ) {
       source.uses.recovery = [{ period: "recharge", formula: source.recharge.value }];
     }
+
     // Prevent a string value for uses recovery from being cleaned into a default recovery entry
     else if ( source.uses?.recovery === "" ) {
       delete source.uses.recovery;

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -202,7 +202,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
       }
       else if(source.uses)
       {
-        source.uses.recovery = [{ period: source?.uses?.per, type: "recoverAll" }];
+        source.uses.recovery = [{ period: source.uses?.per, type: "recoverAll" }];
       }
     }
     

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -172,7 +172,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
       if ( activity?.uses?.max?.includes?.(" ? ") ) activity.uses.max = "";
     }
 
-    if ( Array.isArray(source?.uses?.recovery) ) return;
+    if ( Array.isArray(source.uses?.recovery) ) return;
 
     const charged = source.recharge?.charged;
     if ( (source.recharge?.value !== null) && (charged !== undefined) && !source.uses?.max ) {

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -168,7 +168,6 @@ export default class ActivitiesTemplate extends SystemDataModel {
   static #migrateUses(source) {
     // Remove any old ternary operators from uses to prevent errors
     if ( source.uses?.max?.includes?.(" ? ") ) source.uses.max = "";
-
     for ( const activity of Object.values(source.activities ?? {}) ) {
       if ( activity?.uses?.max?.includes?.(" ? ") ) activity.uses.max = "";
     }
@@ -176,14 +175,13 @@ export default class ActivitiesTemplate extends SystemDataModel {
     if ( Array.isArray(source?.uses?.recovery) ) return;
 
     const charged = source.recharge?.charged;
-
     if ( (source.recharge?.value !== null) && (charged !== undefined) && !source.uses?.max ) {
       source.uses ??= {};
       source.uses.spent = charged ? 0 : 1;
       source.uses.max = "1";
     }
 
-    if ( foundry.utils.getType(source?.uses?.recovery) !== "string" ) return;
+    if ( foundry.utils.getType(source.uses?.recovery) !== "string" ) return;
 
     // If period is charges, set the recovery type to `formula`
     if ( source.uses?.per === "charges" ) {
@@ -193,9 +191,10 @@ export default class ActivitiesTemplate extends SystemDataModel {
         delete source.uses.recovery;
       }
     }
+
     // If period is not blank, set an appropriate recovery type
-    else if (source?.uses?.per ) {
-      if ( CONFIG.DND5E.limitedUsePeriods[source?.uses?.per]?.formula && source?.uses?.recovery ) {
+    else if (source.uses?.per ) {
+      if ( CONFIG.DND5E.limitedUsePeriods[source.uses?.per]?.formula && source.uses?.recovery ) {
         if(source.uses)
         {
           source.uses.recovery = [{ period: source?.uses?.per, type: "formula", formula: source?.uses?.recovery }];
@@ -206,10 +205,12 @@ export default class ActivitiesTemplate extends SystemDataModel {
         source.uses.recovery = [{ period: source?.uses?.per, type: "recoverAll" }];
       }
     }
+    
     // Otherwise, check to see if recharge is set
     else if ( source.recharge?.value ) {
       source.uses.recovery = [{ period: "recharge", formula: source.recharge.value }];
     }
+    
     // Prevent a string value for uses recovery from being cleaned into a default recovery entry
     else if ( source.uses?.recovery === "" ) {
       delete source.uses.recovery;

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -187,15 +187,15 @@ export default class ActivitiesTemplate extends SystemDataModel {
     if ( source.uses?.per === "charges" ) {
       if ( source.uses.recovery ) {
         source.uses.recovery = [{ period: "lr", type: "formula", formula: source.uses.recovery }];
-      } else if ( source.uses ) {
+      } else {
         delete source.uses.recovery;
       }
     }
 
     // If period is not blank, set an appropriate recovery type
     else if ( source.uses?.per ) {
-      if ( CONFIG.DND5E.limitedUsePeriods[source.uses?.per]?.formula && source.uses?.recovery ) {
-        source.uses.recovery = [{ period: source?.uses?.per, type: "formula", formula: source?.uses?.recovery }];
+      if ( CONFIG.DND5E.limitedUsePeriods[source.uses.per]?.formula && source.uses?.recovery ) {
+        source.uses.recovery = [{ period: source.uses.per, type: "formula", formula: source.uses.recovery }];
       }
       else if ( source.uses ) source.uses.recovery = [{ period: source.uses?.per, type: "recoverAll" }];
     }

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -194,10 +194,10 @@ export default class ActivitiesTemplate extends SystemDataModel {
 
     // If period is not blank, set an appropriate recovery type
     else if ( source.uses?.per ) {
-      if ( CONFIG.DND5E.limitedUsePeriods[source.uses.per]?.formula && source.uses?.recovery ) {
+      if ( CONFIG.DND5E.limitedUsePeriods[source.uses.per]?.formula && source.uses.recovery ) {
         source.uses.recovery = [{ period: source.uses.per, type: "formula", formula: source.uses.recovery }];
       }
-      else if ( source.uses ) source.uses.recovery = [{ period: source.uses?.per, type: "recoverAll" }];
+      else source.uses.recovery = [{ period: source.uses.per, type: "recoverAll" }];
     }
 
     // Otherwise, check to see if recharge is set

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -191,7 +191,6 @@ export default class ActivitiesTemplate extends SystemDataModel {
         delete source.uses.recovery;
       }
     }
-
     // If period is not blank, set an appropriate recovery type
     else if (source.uses?.per ) {
       if ( CONFIG.DND5E.limitedUsePeriods[source.uses?.per]?.formula && source.uses?.recovery ) {
@@ -205,12 +204,10 @@ export default class ActivitiesTemplate extends SystemDataModel {
         source.uses.recovery = [{ period: source.uses?.per, type: "recoverAll" }];
       }
     }
-    
     // Otherwise, check to see if recharge is set
     else if ( source.recharge?.value ) {
       source.uses.recovery = [{ period: "recharge", formula: source.recharge.value }];
     }
-    
     // Prevent a string value for uses recovery from being cleaned into a default recovery entry
     else if ( source.uses?.recovery === "" ) {
       delete source.uses.recovery;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dnd5e",
+  "name": "dnd5edfix",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dnd5ed",
+  "name": "dnd5e",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dnd5edfix",
+  "name": "dnd5ed",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
This fix a possible lot warnings in old campaigns.  The warning is:

`TypeError: Failed data migration for FeatData: source.uses?.max?.includes is not a function at #migrateUses (activities.mjs:170:28) at ActivitiesTemplate.migrateActivities (activities.mjs:159:36) at FeatData._migrateData (feat.mjs:174:24) at FeatData.migrateData (abstract.mjs:240:10) at FeatData.migrateDataSafe (foundry-esm.js:10695:14) at TypeDataField.migrateSource (foundry-esm.js:9837:22) at  (...)`

This warning is caused because a possible null pointer in some objects. What I did is check if the object is null before use. 