### PR TITLE
Add parameter for preventing subsequent actions

### DIFF
--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -157,7 +157,7 @@ export default function ActivityMixin(Base) {
      *                                                 scaling is not allowed.
      * @property {object} spell
      * @property {number} spell.slot                   The spell slot to consume.
-     * @property {boolean} [triggerSubsequentActions]  If explicitly false, subsequent actions will not be triggered.
+     * @property {boolean} [subsequentActions=true]    Trigger subsequent actions defined by this activity.
      * @property {object} [cause]
      * @property {string} [cause.activity]             Relative UUID to the activity that caused this one to be used.
      *                                                 Activity must be on the same actor as this one.
@@ -322,7 +322,7 @@ export default function ActivityMixin(Base) {
       }
 
       // Trigger any primary action provided by this activity
-      if ( usageConfig.triggerSubsequentActions !== false ) {
+      if ( usageConfig.subsequentActions !== false ) {
         activity._triggerSubsequentActions(usageConfig, results);
       }
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -157,6 +157,7 @@ export default function ActivityMixin(Base) {
      *                                                 scaling is not allowed.
      * @property {object} spell
      * @property {number} spell.slot                   The spell slot to consume.
+     * @property {boolean} [triggerSubsequentActions]  If explicitly false, subsequent actions will not be triggered.
      * @property {object} [cause]
      * @property {string} [cause.activity]             Relative UUID to the activity that caused this one to be used.
      *                                                 Activity must be on the same actor as this one.
@@ -321,7 +322,9 @@ export default function ActivityMixin(Base) {
       }
 
       // Trigger any primary action provided by this activity
-      activity._triggerSubsequentActions(usageConfig, results);
+      if ( usageConfig.triggerSubsequentActions !== false ) {
+        activity._triggerSubsequentActions(usageConfig, results);
+      }
 
       return results;
     }


### PR DESCRIPTION
I had a use case for just getting the return of the usage without the follow-up actions.

Note: I considered `followup` as the name for the property but did not want to clash with a possible future feature. Open to suggestions, however.