### PR TITLE
Socket framework proof of concept

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -25,6 +25,7 @@ import {default as registry} from "./module/registry.mjs";
 import * as utils from "./module/utils.mjs";
 import {ModuleArt} from "./module/module-art.mjs";
 import registerModuleData from "./module/module-registration.mjs";
+import Sockets5e from "./module/sockets.mjs";
 import Tooltips5e from "./module/tooltips.mjs";
 
 /* -------------------------------------------- */
@@ -88,6 +89,9 @@ Hooks.once("init", function() {
 
   // Configure bastions
   game.dnd5e.bastion = new documents.Bastion();
+
+  // Configure sockets
+  game.dnd5e.sockets = new Sockets5e();
 
   // Configure tooltips
   game.dnd5e.tooltips = new Tooltips5e();

--- a/module/sockets.mjs
+++ b/module/sockets.mjs
@@ -1,0 +1,67 @@
+import sockets from "./sockets/_module.mjs";
+
+/**
+ * @typedef {object} SocketEventConfig
+ * @property {string} event           The unique socket event name.
+ * @property {Function} initiate      A function used to initiate the socket event.
+ * @property {Function} finalize      A function that finalizes the socket event as the valid user(s).
+ */
+
+export default class Sockets5e {
+  constructor() {
+    game.socket.on("system.dnd5e", this.#handleSocket.bind(this));
+    for (const config of sockets) this.#register(config);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Store event configurations.
+   * @type {Map<string, SocketEventConfig>}
+   */
+  #events = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Register a sovket event config.
+   * @param {SocketEventConfig} config
+   */
+  #register(config) {
+    this.#events.set(config.event, config);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle the socket event for the correct user(s).
+   * @param {object} data              Socket data.
+   * @param {boolean} [data._emit]     Internally used parameter for whether this was initiated or emitted.
+   * @returns {*}
+   */
+  #handleSocket({ _emit, ...data }) {
+    if ( !data.userIds.includes(game.user.id) ) {
+      if (!_emit) game.socket.emit("system.dnd5e", { ...data, _emit: true });
+      else return;
+    }
+
+    const config = this.#events.get(data.event);
+    if ( config ) return config.finalize(data);
+
+    throw new Error(`'${data.event}' is not a valid socket event action!`);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Initiate a given event, which may or may not be emitted.
+   * @param {string} event      The event name.
+   * @param {any[]} args        Function parameters for the handler.
+   */
+  initiate(event, ...args) {
+    const config = this.#events.get(event);
+    if ( !config ) return;
+    const data = config.initiate(...args);
+    this.#handleSocket(data);
+  }
+}

--- a/module/sockets/_module.mjs
+++ b/module/sockets/_module.mjs
@@ -1,0 +1,5 @@
+import GrantEffect from "./grant-effect.mjs";
+
+export default [
+  GrantEffect
+];

--- a/module/sockets/grant-effect.mjs
+++ b/module/sockets/grant-effect.mjs
@@ -1,0 +1,68 @@
+/**
+ * @typedef {object} GrantEffectConfig
+ * @property {string} event           The event name.
+ * @property {string} actor           The uuid of the actor to receive the effect.
+ * @property {object} effectData      Data used to create the effect.
+ * @property {string[]} userIds       The ids of the users that should perform the operation.
+ */
+
+/**
+ * Name of this socket event.
+ * @type {string}
+ */
+const eventName = "grantEffect";
+
+/* -------------------------------------------- */
+
+/**
+ * Grant the effect to a given actor.
+ * @param {GrantEffectConfig} data
+ */
+async function grantEffect(data) {
+  const actor = await fromUuid(data.actor);
+  if ( actor?.documentName !== "Actor" ) return;
+  getDocumentClass("ActiveEffect").create(data.effectData, { parent: actor });
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Initiate the socket event.
+ * @param {Actor5e} actor                 The actor to receive the effect.
+ * @param {ActiveEffecet5e} effect        The effect to be duplicated onto the actor.
+ * @returns {GrantEffectConfig|void}      The event data.
+ */
+function initiate(actor, effect) {
+  if ( (actor?.documentName !== "Actor") || (effect?.documentName !== "ActiveEffect") ) {
+    throw new Error("You must supply both an actor and effect instance for this operation.");
+  }
+
+  // Get a valid user to perform the operation.
+  // TODO: improve in v13
+  const userId = actor.isOwner ? game.user.id : game.users.find(user => {
+    return user.active && actor.testUserPermission(user, "OWNER");
+  })?.id;
+
+  if (!userId) {
+    // TODO: add to i18n
+    ui.notifications.error("DND5E.SOCKETS.GrantEffect.Warning.MissingUser", { localize: true });
+    return;
+  }
+
+  const data = {
+    event: eventName,
+    userIds: [userId],
+    actor: actor.uuid,
+    effectData: effect.toObject()
+  };
+
+  return data;
+}
+
+/* -------------------------------------------- */
+
+export default {
+  event: eventName,
+  initiate: initiate,
+  finalize: grantEffect
+};


### PR DESCRIPTION
Added a new class, `Sockets5e`, available in `game.dnd5e.sockets`. It registers socket configurations, each with `event`, `initiate`, and `finalize`.

We can then call `game.dnd5e.sockets.initiate(eventName, ...args)`, which initiates a specific function, and then - if needed - emits to other clients.

The `initiate` method in the socket config is used to set up the data given a few parameters.

The `finalize` method in the socket config is calling the relevant function under the assumption that the user calling it is meant to do so.

This PR includes a sample setup with a "grantEffect" configuration, which allows a user to create an effect on an actor they may or may not be owner of.