### PR TITLE
[#4851] Add option to override casting ability in `CastActivity`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -675,6 +675,10 @@
   "FIELDS": {
     "spell": {
       "label": "Casting Details",
+      "ability": {
+        "label": "Casting Ability",
+        "hint": "Ability to override the creature's normal spellcasting ability."
+      },
       "challenge": {
         "attack": {
           "label": "Attack Bonus",

--- a/module/applications/activity/cast-sheet.mjs
+++ b/module/applications/activity/cast-sheet.mjs
@@ -56,6 +56,11 @@ export default class CastSheet extends ActivitySheet {
         .map(([value, label]) => ({ value, label }));
     }
 
+    context.abilityOptions = [
+      { value: "", label: game.i18n.localize("DND5E.Spellcasting") },
+      { rule: true },
+      ...Object.entries(CONFIG.DND5E.abilities).map(([value, { label }]) => ({ value, label }))
+    ];
     context.propertyOptions = Array.from(CONFIG.DND5E.validProperties.spell).map(value => ({
       value, label: CONFIG.DND5E.itemProperties[value]?.label ?? ""
     }));

--- a/module/data/activity/cast-data.mjs
+++ b/module/data/activity/cast-data.mjs
@@ -6,6 +6,7 @@ const { BooleanField, DocumentUUIDField, NumberField, SchemaField, SetField, Str
  * Data model for a Cast activity.
  *
  * @property {object} spell
+ * @property {string} spell.ability              Ability to override default spellcasting ability.
  * @property {object} spell.challenge
  * @property {number} spell.challenge.attack     Flat to hit bonus in place of the spell's normal attack bonus.
  * @property {number} spell.challenge.save       Flat DC to use in place of the spell's normal save DC.
@@ -23,6 +24,7 @@ export default class CastActivityData extends BaseActivityData {
     return {
       ...schema,
       spell: new SchemaField({
+        ability: new StringField(),
         challenge: new SchemaField({
           attack: new NumberField(),
           save: new NumberField(),

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -150,6 +150,11 @@ export default class CastActivity extends ActivityMixin(CastActivityData) {
       changes.push({ key: `system.${type}`, mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: JSON.stringify(data) });
     }
 
+    // Set the casting ability
+    if ( this.spell.ability ) changes.push({
+      key: "system.ability", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: this.spell.ability
+    });
+
     // Remove ignored properties
     for ( const property of this.spell.properties ) {
       changes.push({ key: "system.properties", mode: CONST.ACTIVE_EFFECT_MODES.ADD, value: `-${property}` });

--- a/templates/activity/parts/cast-details.hbs
+++ b/templates/activity/parts/cast-details.hbs
@@ -1,5 +1,6 @@
 <fieldset>
     <legend>{{ localize "DND5E.CAST.FIELDS.spell.label" }}</legend>
+    {{ formField fields.spell.fields.ability value=source.spell.ability options=abilityOptions }}
     {{#if levelOptions}}
     {{ formField fields.spell.fields.level value=source.spell.level options=levelOptions }}
     {{/if}}


### PR DESCRIPTION
Adds a spellcasting ability override to the cast activity that then sets `system.ability` in the spell enchantment.

Closes #4851