### PR TITLE
[#3958] Add formatters for distance and weight units

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3360,6 +3360,76 @@
 "DND5E.Unidentified.Notice": "You must identify this item to learn its details.",
 "DND5E.Unidentified.Title": "Unidentified",
 "DND5E.Unidentified.Value": "???",
+
+"DND5E.UNITS": {
+  "DISTANCE": {
+    "Label": "Distance Units",
+    "Foot": {
+      "Label": "Feet",
+      "Abbreviation": "ft"
+    },
+    "Kilometer": {
+      "Label": "Kilometers",
+      "Abbreviation": "km"
+    },
+    "Meter": {
+      "Label": "Meters",
+      "Abbreviation": "m"
+    },
+    "Mile": {
+      "Label": "Miles",
+      "Abbreviation": "mi"
+    }
+  },
+  "WEIGHT": {
+    "Label": "Weight Units",
+    "Kilogram": {
+      "Label": "Kilogram",
+      "Abbreviation": "kg"
+    },
+    "Megagram": {
+      "Label": "Tonnes",
+      "Abbreviation": "t",
+      "Counted": {
+        "narrow": {
+          "one": "{number}t",
+          "other": "{number}t"
+        },
+        "short": {
+          "one": "{number} t",
+          "other": "{number} t"
+        },
+        "long": {
+          "one": "{number} tonne",
+          "other": "{number} tonnes"
+        }
+      }
+    },
+    "Pound": {
+      "Label": "Pounds",
+      "Abbreviation": "lb"
+    },
+    "Ton": {
+      "Label": "Tons",
+      "Abbreviation": "tn",
+      "Counted": {
+        "narrow": {
+          "one": "{number}tn",
+          "other": "{number}tn"
+        },
+        "short": {
+          "one": "{number} tn",
+          "other": "{number} tn"
+        },
+        "long": {
+          "one": "{number} ton",
+          "other": "{number} tons"
+        }
+      }
+    }
+  }
+},
+
 "DND5E.Unknown": "Unknown",
 "DND5E.Unlimited": "Unlimited",
 
@@ -3548,25 +3618,6 @@
 "DND5E.WeaponSimpleProficiency": "Simple",
 "DND5E.WeaponSimpleR": "Simple Ranged",
 "DND5E.Weight": "Weight",
-"DND5E.WeightUnit": {
-  "Label": "Weight Units",
-  "Kilograms": {
-    "Label": "Kilograms",
-    "Abbreviation": "kg"
-  },
-  "Megagrams": {
-    "Label": "Tonnes",
-    "Abbreviation": "t"
-  },
-  "Pounds": {
-    "Label": "Pounds",
-    "Abbreviation": "lb"
-  },
-  "Tons": {
-    "Label": "Tons",
-    "Abbreviation": "tn"
-  }
-},
 "DND5E.WhisperedTo": "Whispered to",
 "DND5E.Wiki": "Wiki",
 "DND5E.available": "available",

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -404,12 +404,10 @@
       /* Spell Range */
       .item-range {
         width: 50px;
-        display: flex;
-        gap: .1875rem;
+        display: block;
         align-self: center;
-        align-items: baseline;
 
-        .value { font-weight: bold; }
+        .integer { font-weight: bold; }
 
         .unit {
           color: var(--color-text-light-6);

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -230,7 +230,7 @@ export default class ActivitySheet extends Application5e {
     ];
     context.rangeUnits = [
       ...Object.entries(CONFIG.DND5E.rangeTypes).map(([value, label]) => ({ value, label })),
-      ...Object.entries(CONFIG.DND5E.movementUnits).map(([value, label]) => ({
+      ...Object.entries(CONFIG.DND5E.movementUnits).map(([value, { label }]) => ({
         value, label, group: game.i18n.localize("DND5E.RangeDistance")
       }))
     ];

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1,6 +1,6 @@
 import * as Trait from "../../documents/actor/trait.mjs";
 import Item5e from "../../documents/item.mjs";
-import { splitSemicolons } from "../../utils.mjs";
+import { formatDistance, splitSemicolons } from "../../utils.mjs";
 import EffectsElement from "../components/effects.mjs";
 import MovementSensesConfig from "../shared/movement-senses-config.mjs";
 import CreatureTypeConfig from "../shared/creature-type-config.mjs";
@@ -253,12 +253,13 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
 
     // Filter and sort speeds on their values
     speeds = speeds.filter(s => s[0]).sort((a, b) => b[0] - a[0]);
+    const units = movement.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
 
     // Case 1: Largest as primary
     if ( largestPrimary ) {
       let primary = speeds.shift();
       return {
-        primary: `${primary ? primary[1] : "0"} ${movement.units || Object.keys(CONFIG.DND5E.movementUnits)[0]}`,
+        primary: formatDistance(primary?.[1], units),
         special: speeds.map(s => s[1]).join(", ")
       };
     }
@@ -266,7 +267,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
     // Case 2: Walk as primary
     else {
       return {
-        primary: `${movement.walk || 0} ${movement.units || Object.keys(CONFIG.DND5E.movementUnits)[0]}`,
+        primary: formatDistance(movement.walk ?? 0, units),
         special: speeds.length ? speeds.map(s => s[1]).join(", ") : ""
       };
     }
@@ -283,10 +284,11 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
   _getSenses(systemData) {
     const senses = systemData.attributes.senses ?? {};
     const tags = {};
+    const units = senses.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
     for ( let [k, label] of Object.entries(CONFIG.DND5E.senses) ) {
       const v = senses[k] ?? 0;
       if ( v === 0 ) continue;
-      tags[k] = `${game.i18n.localize(label)} ${v} ${senses.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0]}`;
+      tags[k] = `${game.i18n.localize(label)} ${formatDistance(v, units)}`;
     }
     if ( senses.special ) splitSemicolons(senses.special).forEach((c, i) => tags[`custom${i + 1}`] = c);
     return tags;

--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -1,5 +1,5 @@
 import * as Trait from "../../documents/actor/trait.mjs";
-import { formatNumber, simplifyBonus, splitSemicolons, staticID } from "../../utils.mjs";
+import { formatDistance, formatNumber, simplifyBonus, splitSemicolons, staticID } from "../../utils.mjs";
 import Tabs5e from "../tabs.mjs";
 import DocumentSheetV2Mixin from "../mixins/sheet-v2-mixin.mjs";
 
@@ -337,7 +337,8 @@ export default function ActorSheetV2Mixin(Base) {
             ctx.range = {
               distance: true,
               value: system.range.value,
-              unit: game.i18n.localize(`DND5E.Dist${units.capitalize()}Abbr`)
+              unit: CONFIG.DND5E.movementUnits[units].abbreviation,
+              parts: formatDistance(system.range.value, units, { parts: true })
             };
           }
           else ctx.range = { distance: false };

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -87,7 +87,7 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
     // Range
     context.rangeTypes = [
       ...Object.entries(CONFIG.DND5E.rangeTypes).map(([value, label]) => ({ value, label })),
-      ...Object.entries(CONFIG.DND5E.movementUnits).map(([value, label]) => {
+      ...Object.entries(CONFIG.DND5E.movementUnits).map(([value, { label }]) => {
         return { value, label, group: "DND5E.RangeDistance" };
       })
     ];

--- a/module/applications/shared/movement-senses-config.mjs
+++ b/module/applications/shared/movement-senses-config.mjs
@@ -89,7 +89,7 @@ export default class MovementSensesConfig extends BaseConfigSheet {
     context.unitsOptions = [
       { value: "", label: game.i18n.format("DND5E.AutomaticValue", { value: automaticUnit }) },
       { rule: true },
-      ...Object.entries(CONFIG.DND5E.movementUnits).map(([value, label]) => ({ value, label }))
+      ...Object.entries(CONFIG.DND5E.movementUnits).map(([value, { label }]) => ({ value, label }))
     ];
 
     return context;

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2346,16 +2346,16 @@ preLocalize("movementTypes", { sort: true });
 
 /**
  * @typedef {object} UnitConfiguration
- * @property {string} label             Localized label for the unit.
- * @property {string} abbreviation      Localized abbreviation for the unit.
- * @property {number} conversion        Multiplier used to convert between various units.
- * @property {string} [counted]         Localization path for counted plural forms in various unit display modes.
- *                                      Only necessary if non-supported unit or using a non-standard name for a
- *                                      supported unit.
- * @property {string} [formattingUnit]  Unit formatting value as supported by javascript's internationalization system:
- *                                      https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers. Only
- *                                      required if the formatting name doesn't match the unit key.
- * @property {string} type              Whether this is an "imperial" or "metric" unit.
+ * @property {string} label              Localized label for the unit.
+ * @property {string} abbreviation       Localized abbreviation for the unit.
+ * @property {number} conversion         Multiplier used to convert between various units.
+ * @property {string} [counted]          Localization path for counted plural forms in various unit display modes.
+ *                                       Only necessary if non-supported unit or using a non-standard name for a
+ *                                       supported unit.
+ * @property {string} [formattingUnit]   Unit formatting value as supported by javascript's internationalization system:
+ *                                       https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers. Only
+ *                                       required if the formatting name doesn't match the unit key.
+ * @property {"imperial"|"metric"} type  Whether this is an "imperial" or "metric" unit.
  */
 
 /**
@@ -2381,14 +2381,14 @@ DND5E.movementUnits = {
   m: {
     label: "DND5E.UNITS.DISTANCE.Meter.Label",
     abbreviation: "DND5E.UNITS.DISTANCE.Meter.Abbreviation",
-    conversion: 3.281,
+    conversion: 10 / 3, // D&D uses a simplified 5ft -> 1.5m conversion.
     formattingUnit: "meter",
     type: "metric"
   },
   km: {
     label: "DND5E.UNITS.DISTANCE.Kilometer.Label",
     abbreviation: "DND5E.UNITS.DISTANCE.Kilometer.Abbreviation",
-    conversion: 3_281,
+    conversion: 10_000 / 3, // Matching simplified conversion
     formattingUnit: "kilometer",
     type: "metric"
   }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2345,17 +2345,56 @@ preLocalize("movementTypes", { sort: true });
 /* -------------------------------------------- */
 
 /**
+ * @typedef {object} UnitConfiguration
+ * @property {string} label             Localized label for the unit.
+ * @property {string} abbreviation      Localized abbreviation for the unit.
+ * @property {number} conversion        Multiplier used to convert between various units.
+ * @property {string} [counted]         Localization path for counted plural forms in various unit display modes.
+ *                                      Only necessary if non-supported unit or using a non-standard name for a
+ *                                      supported unit.
+ * @property {string} [formattingUnit]  Unit formatting value as supported by javascript's internationalization system:
+ *                                      https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers. Only
+ *                                      required if the formatting name doesn't match the unit key.
+ * @property {string} type              Whether this is an "imperial" or "metric" unit.
+ */
+
+/**
  * The valid units of measure for movement distances in the game system.
  * By default this uses the imperial units of feet and miles.
  * @enum {string}
  */
 DND5E.movementUnits = {
-  ft: "DND5E.DistFt",
-  mi: "DND5E.DistMi",
-  m: "DND5E.DistM",
-  km: "DND5E.DistKm"
+  ft: {
+    label: "DND5E.UNITS.DISTANCE.Foot.Label",
+    abbreviation: "DND5E.UNITS.DISTANCE.Foot.Abbreviation",
+    conversion: 1,
+    formattingUnit: "foot",
+    type: "imperial"
+  },
+  mi: {
+    label: "DND5E.UNITS.DISTANCE.Mile.Label",
+    abbreviation: "DND5E.UNITS.DISTANCE.Mile.Abbreviation",
+    conversion: 5_280,
+    formattingUnit: "mile",
+    type: "imperial"
+  },
+  m: {
+    label: "DND5E.UNITS.DISTANCE.Meter.Label",
+    abbreviation: "DND5E.UNITS.DISTANCE.Meter.Abbreviation",
+    conversion: 3.281,
+    formattingUnit: "meter",
+    type: "metric"
+  },
+  km: {
+    label: "DND5E.UNITS.DISTANCE.Kilometer.Label",
+    abbreviation: "DND5E.UNITS.DISTANCE.Kilometer.Abbreviation",
+    conversion: 3_281,
+    formattingUnit: "kilometer",
+    type: "metric"
+  }
 };
-preLocalize("movementUnits");
+patchConfig("movementUnits", "label", { since: "DnD5e 4.2", until: "DnD5e 4.4" });
+preLocalize("movementUnits", { keys: ["label", "abbreviation"] });
 
 /* -------------------------------------------- */
 
@@ -2379,7 +2418,7 @@ preLocalize("rangeTypes");
  * @enum {string}
  */
 DND5E.distanceUnits = {
-  ...DND5E.movementUnits,
+  ...Object.fromEntries(Object.entries(DND5E.movementUnits).map(([k, { label }]) => [k, label])),
   ...DND5E.rangeTypes
 };
 preLocalize("distanceUnits");
@@ -2387,41 +2426,35 @@ preLocalize("distanceUnits");
 /* -------------------------------------------- */
 
 /**
- * Configuration data for a weight unit.
- *
- * @typedef {object} WeightUnitConfiguration
- * @property {string} label         Localized label for the unit.
- * @property {string} abbreviation  Localized abbreviation for the unit.
- * @property {number} conversion    Number that by which this unit should be multiplied to arrive at a standard value.
- * @property {string} type          Whether this is an "imperial" or "metric" unit.
- */
-
-/**
  * The valid units for measurement of weight.
- * @enum {WeightUnitConfiguration}
+ * @enum {UnitConfiguration}
  */
 DND5E.weightUnits = {
   lb: {
-    label: "DND5E.WeightUnit.Pounds.Label",
-    abbreviation: "DND5E.WeightUnit.Pounds.Abbreviation",
+    label: "DND5E.UNITS.WEIGHT.Pound.Label",
+    abbreviation: "DND5E.UNITS.WEIGHT.Pound.Abbreviation",
     conversion: 1,
+    formattingUnit: "pound",
     type: "imperial"
   },
   tn: {
-    label: "DND5E.WeightUnit.Tons.Label",
-    abbreviation: "DND5E.WeightUnit.Tons.Abbreviation",
+    label: "DND5E.UNITS.WEIGHT.Ton.Label",
+    abbreviation: "DND5E.UNITS.WEIGHT.Ton.Abbreviation",
+    counted: "DND5E.UNITS.WEIGHT.Ton.Counted",
     conversion: 2000,
     type: "imperial"
   },
   kg: {
-    label: "DND5E.WeightUnit.Kilograms.Label",
-    abbreviation: "DND5E.WeightUnit.Kilograms.Abbreviation",
+    label: "DND5E.UNITS.WEIGHT.Kilogram.Label",
+    abbreviation: "DND5E.UNITS.WEIGHT.Kilogram.Abbreviation",
     conversion: 2.5,
+    formattingUnit: "kilogram",
     type: "metric"
   },
   Mg: {
-    label: "DND5E.WeightUnit.Megagrams.Label",
-    abbreviation: "DND5E.WeightUnit.Megagrams.Abbreviation",
+    label: "DND5E.UNITS.WEIGHT.Megagram.Label",
+    abbreviation: "DND5E.UNITS.WEIGHT.Megagram.Abbreviation",
+    counted: "DND5E.UNITS.WEIGHT.Megagram.Counted",
     conversion: 2500,
     type: "metric"
   }

--- a/module/data/advancement/scale-value.mjs
+++ b/module/data/advancement/scale-value.mjs
@@ -1,3 +1,4 @@
+import { formatDistance } from "../../utils.mjs";
 import IdentifierField from "../fields/identifier-field.mjs";
 import MappingField from "../fields/mapping-field.mjs";
 
@@ -333,7 +334,7 @@ export class ScaleValueTypeDistance extends ScaleValueTypeNumber {
 
   /** @inheritDoc */
   get display() {
-    return `${this.value} ${CONFIG.DND5E.movementUnits[this.parent.configuration.distance?.units || "ft"]}`;
+    return formatDistance(this.value, this.parent.configuration.distance?.units || "ft");
   }
 }
 

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -1,5 +1,5 @@
 import Actor5e from "../../documents/actor/actor.mjs";
-import { splitSemicolons } from "../../utils.mjs";
+import { formatDistance, splitSemicolons } from "../../utils.mjs";
 import { ItemDataModel } from "../abstract.mjs";
 import AdvancementField from "../fields/advancement-field.mjs";
 import { CreatureTypeField, MovementField, SensesField } from "../shared/_module.mjs";
@@ -71,10 +71,10 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
    * @returns {Object<string>}
    */
   get movementLabels() {
-    const units = CONFIG.DND5E.movementUnits[this.movement.units || Object.keys(CONFIG.DND5E.movementUnits)[0]];
+    const units = this.movement.units || Object.keys(CONFIG.DND5E.movementUnits)[0];
     return Object.entries(CONFIG.DND5E.movementTypes).reduce((obj, [k, label]) => {
       const value = this.movement[k];
-      if ( value ) obj[k] = `${label} ${value} ${units}`;
+      if ( value ) obj[k] = `${label} ${formatDistance(value, units)}`;
       return obj;
     }, {});
   }
@@ -86,10 +86,10 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
    * @returns {Object<string>}
    */
   get sensesLabels() {
-    const units = CONFIG.DND5E.movementUnits[this.senses.units || Object.keys(CONFIG.DND5E.movementUnits)[0]];
+    const units = this.senses.units || Object.keys(CONFIG.DND5E.movementUnits)[0];
     return Object.entries(CONFIG.DND5E.senses).reduce((arr, [k, label]) => {
       const value = this.senses[k];
-      if ( value ) arr.push(`${label} ${value} ${units}`);
+      if ( value ) arr.push(`${label} ${formatDistance(value, units)}`);
       return arr;
     }, []).concat(splitSemicolons(this.senses.special));
   }

--- a/module/data/item/templates/activated-effect.mjs
+++ b/module/data/item/templates/activated-effect.mjs
@@ -116,7 +116,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
       const target = [this.target.value];
       if ( this.hasAreaTarget ) {
         if ( this.target.units in CONFIG.DND5E.movementUnits ) {
-          target.push(game.i18n.localize(`DND5E.Dist${this.target.units.capitalize()}Abbr`));
+          target.push(CONFIG.DND5E.movementUnits[this.target.units].abbreviation);
         }
         else target.push(CONFIG.DND5E.distanceUnits[this.target.units]);
       }
@@ -127,7 +127,7 @@ export default class ActivatedEffectTemplate extends SystemDataModel {
     if ( this.isActive && this.range.units ) {
       const range = [this.range.value, this.range.long ? `/ ${this.range.long}` : null];
       if ( this.range.units in CONFIG.DND5E.movementUnits ) {
-        range.push(game.i18n.localize(`DND5E.Dist${this.range.units.capitalize()}Abbr`));
+        range.push(CONFIG.DND5E.movementUnits[this.range.units].abbreviation);
       }
       else range.push(CONFIG.DND5E.distanceUnits[this.range.units]);
       this.parent.labels.range = range.filterJoin(" ");

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -32,7 +32,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
           required: true, nullable: false, initial: 0, min: 0, label: "DND5E.Weight"
         }),
         units: new StringField({
-          required: true, label: "DND5E.WeightUnit.Label",
+          required: true, label: "DND5E.UNITS.WEIGHT.Label",
           initial: () => game.settings.get("dnd5e", "metricWeightUnits") ? "kg" : "lb"
         })
       }, {label: "DND5E.Weight"}),

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -1,4 +1,4 @@
-import { filteredKeys } from "../../utils.mjs";
+import { filteredKeys, formatDistance } from "../../utils.mjs";
 import { ItemDataModel } from "../abstract.mjs";
 import BaseActivityData from "../activity/base-activity.mjs";
 import DamageField from "../shared/damage-field.mjs";
@@ -219,13 +219,10 @@ export default class WeaponData extends ItemDataModel.mixin(
 
     const labels = this.parent.labels ??= {};
     if ( this.hasRange ) {
-      const parts = [
-        this.range.value,
-        this.range.long ? `/ ${this.range.long}` : null,
-        (this.range.units in CONFIG.DND5E.movementUnits)
-          ? game.i18n.localize(`DND5E.Dist${this.range.units.capitalize()}Abbr`) : null
-      ];
-      labels.range = parts.filterJoin(" ");
+      const units = this.range.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0];
+      const parts = [this.range.value, this.range.long !== this.range.value ? this.range.long : null].filter(_ => _);
+      parts.push(formatDistance(parts.pop(), units));
+      labels.range = parts.filterJoin("/");
     } else labels.range = game.i18n.localize("DND5E.None");
   }
 

--- a/module/data/shared/range-field.mjs
+++ b/module/data/shared/range-field.mjs
@@ -1,4 +1,4 @@
-import { prepareFormulaValue } from "../../utils.mjs";
+import { formatDistance, prepareFormulaValue } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { SchemaField, StringField } = foundry.data.fields;
@@ -38,17 +38,12 @@ export default class RangeField extends SchemaField {
     } else this.range.value = null;
 
     if ( labels && this.range.units ) {
-      const parts = [];
       if ( this.range.scalar && this.range.value ) {
-        parts.push(
-          this.range.value,
-          this.range.units in CONFIG.DND5E.movementUnits
-            ? game.i18n.localize(`DND5E.Dist${this.range.units.capitalize()}Abbr`) : null
-        );
+        labels.range = formatDistance(this.range.value, this.range.units);
+        labels.rangeParts = formatDistance(this.range.value, this.range.units, { parts: true });
       } else if ( !this.range.scalar ) {
-        parts.push(CONFIG.DND5E.distanceUnits[this.range.units]);
+        labels.range = CONFIG.DND5E.distanceUnits[this.range.units];
       }
-      labels.range = parts.filterJoin(" ");
     } else if ( labels ) labels.range = game.i18n.localize("DND5E.DistSelf");
   }
 }

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -1,4 +1,4 @@
-import { prepareFormulaValue } from "../../utils.mjs";
+import { formatDistance, prepareFormulaValue } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { BooleanField, SchemaField, StringField } = foundry.data.fields;
@@ -81,9 +81,10 @@ export default class TargetField extends SchemaField {
 
       if ( this.target.template.type ) {
         if ( this.target.template.count > 1 ) parts.push(`${this.target.template.count} ×`);
-        parts.push(this.target.template.size);
         if ( this.target.template.units in CONFIG.DND5E.movementUnits ) {
-          parts.push(game.i18n.localize(`DND5E.Dist${this.target.template.units.capitalize()}Abbr`));
+          parts.push(formatDistance(this.target.template.size, this.target.template.units));
+        } else {
+          parts.push(this.target.template.size);
         }
         parts.push(CONFIG.DND5E.areaTargetTypes[this.target.template.type]?.label);
       }

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -18,6 +18,19 @@ export function formatCR(value, { narrow=true }={}) {
 /* -------------------------------------------- */
 
 /**
+ * Form a number using the provided distance unit.
+ * @param {number} value         The distance to format.
+ * @param {string} unit          Distance unit as defined in `CONFIG.DND5E.movementUnits`.
+ * @param {object} [options={}]  Formatting options passed to `formatNumber`.
+ * @returns {string}
+ */
+export function formatDistance(value, unit, options={}) {
+  return _formatSystemUnits(value, unit, CONFIG.DND5E.movementUnits[unit], options);
+}
+
+/* -------------------------------------------- */
+
+/**
  * Format a modifier for display with its sign separate.
  * @param {number} mod  The modifier.
  * @returns {Handlebars.SafeString}
@@ -103,6 +116,60 @@ export function formatRange(min, max, options) {
  */
 export function formatText(value) {
   return new Handlebars.SafeString(value?.replaceAll("\n", "<br>") ?? "");
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Form a number using the provided weight unit.
+ * @param {number} value         The weight to format.
+ * @param {string} unit          Weight unit as defined in `CONFIG.DND5E.weightUnits`.
+ * @param {object} [options={}]  Formatting options passed to `formatNumber`.
+ * @returns {string}
+ */
+export function formatWeight(value, unit, options={}) {
+  return _formatSystemUnits(value, unit, CONFIG.DND5E.weightUnits[unit], options);
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Format a number using one of core's built-in unit types.
+ * @param {number} value                   Value to display.
+ * @param {string} unit                    Name of the unit to use.
+ * @param {UnitConfiguration} config       Configuration data for the unit.
+ * @param {object} [options={}]            Formatting options passed to `formatNumber`.
+ * @param {boolean} [options.parts=false]  Format to parts.
+ * @returns {string}
+ */
+function _formatSystemUnits(value, unit, config, { parts=false, ...options }={}) {
+  options.unitDisplay ??= "short";
+  if ( config?.counted ) {
+    const localizationKey = `${config.counted}.${options.unitDisplay}.${getPluralRules().select(value)}`;
+    return game.i18n.format(localizationKey, { number: formatNumber(value, options) });
+  }
+  return (parts ? formatNumberParts : formatNumber)(value, {
+    style: "unit", unit: config?.formattingUnit ?? unit, ...options
+  });
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Cached store of Intl.PluralRules instances.
+ * @type {Record<string, Intl.PluralRules>}
+ */
+const _pluralRules = {};
+
+/**
+ * Get a PluralRules object, fetching from cache if possible.
+ * @param {object} [options={}]
+ * @param {string} [options.type=cardinal]
+ * @returns {Intl.PluralRules}
+ */
+export function getPluralRules({ type="cardinal" }={}) {
+  _pluralRules[type] ??= new Intl.PluralRules(game.i18n.lang, { type });
+  return _pluralRules[type];
 }
 
 /* -------------------------------------------- */

--- a/templates/activity/columns/activity-column-range.hbs
+++ b/templates/activity/columns/activity-column-range.hbs
@@ -1,7 +1,6 @@
 <div class="item-detail item-range">
     {{#if range.scalar}}
-    <span class="value">{{ range.value }}</span>
-    <span class="unit">{{ range.units }}</span>
+    {{{ labels.rangeParts }}}
     {{else}}
     <span class="condensed">{{ labels.range }}</span>
     {{/if}}

--- a/templates/actors/tabs/creature-spells.hbs
+++ b/templates/actors/tabs/creature-spells.hbs
@@ -189,8 +189,7 @@
                         <div class="item-detail item-range {{#unless ctx.range}}empty{{/unless}}">
                             {{#if ctx.range}}
                             {{#if ctx.range.distance}}
-                            <span class="value">{{ ctx.range.value }}</span>
-                            <span class="unit">{{ ctx.range.unit }}</span>
+                            {{{ ctx.range.parts }}}
                             {{else}}
                             <span class="condensed">{{ item.labels.range }}</span>
                             {{/if}}

--- a/templates/advancement/scale-value-config.hbs
+++ b/templates/advancement/scale-value-config.hbs
@@ -9,7 +9,7 @@
                 </select>
                 {{#if (eq configuration.type "distance")}}
                 <select name="configuration.distance.units">
-                    {{selectOptions movementUnits selected=configuration.distance.units}}
+                    {{selectOptions movementUnits selected=configuration.distance.units labelAttr="label"}}
                 </select>
                 {{/if}}
             </div>


### PR DESCRIPTION
Adds two new utility methods, `formatDistance` and `formatWeight` that perform proper localized formatting of those two unit types. By default these use the standard javascript unit localization, but the config object can be used to override this or provide custom localization for units that javascript doesn't support (such as tons).