### PR TITLE
[#3214, #4738] Add combat-related usage recovery periods

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3716,9 +3716,6 @@
       "Dusk": {
         "Label": "Dusk"
       },
-      "Encounter": {
-        "Label": "Encounter"
-      },
       "Initiative": {
         "Label": "Initiative"
       },

--- a/lang/en.json
+++ b/lang/en.json
@@ -1614,6 +1614,12 @@
     "Entry": "{item} on <em>{actor}</em>"
   },
   "Label": "Enchantment",
+  "Period": {
+    "AtWill": "At Will",
+    "LongRest": "Long Rest",
+    "Never": "Never",
+    "ShortRest": "Short Rest"
+  },
   "Warning": {
     "NotOnActor": "Enchantments can only be added to items, not directly to actors.",
     "Override": "This value is being modified by an Enchantment and cannot be edited. Disable the enchantment in the effects tab to edit it."
@@ -3657,20 +3663,8 @@
 "DND5E.UsesMax": "Maximum Uses",
 "DND5E.UsesPeriod": "Recovery Period",
 "DND5E.UsesPeriods": {
-  "AtWill": "At Will",
   "Charges": "Charges",
-  "ChargesAbbreviation": "Charges",
-  "Dawn": "Dawn",
-  "DawnAbbreviation": "Dawn",
-  "Day": "Day",
-  "DayAbbreviation": "Day",
-  "Dusk": "Dusk",
-  "DuskAbbreviation": "Dusk",
-  "Lr": "Long Rest",
-  "LrAbbreviation": "LR",
-  "Never": "Never",
-  "Sr": "Short Rest",
-  "SrAbbreviation": "SR"
+  "ChargesAbbreviation": "Charges"
 },
 
 "DND5E.USES": {
@@ -3710,10 +3704,50 @@
       "Create": "Create Recovery Profile",
       "Delete": "Delete Recovery Profile"
     },
+    "Combat": "Combat",
+    "Never": "Never",
+    "Period": {
+      "Dawn": {
+        "Label": "Dawn"
+      },
+      "Day": {
+        "Label": "Day"
+      },
+      "Dusk": {
+        "Label": "Dusk"
+      },
+      "Encounter": {
+        "Label": "Encounter"
+      },
+      "Initiative": {
+        "Label": "Initiative"
+      },
+      "LongRest": {
+        "Label": "Long Rest",
+        "Abbreviation": "LR"
+      },
+      "ShortRest": {
+        "Label": "Short Rest",
+        "Abbreviation": "SR"
+      },
+      "Turn": {
+        "Label": "Turn"
+      },
+      "TurnEnd": {
+        "Label": "Round (end of turn)",
+        "Abbreviation": "Turn Start"
+      },
+      "TurnStart": {
+        "Label": "Round (start of turn)",
+        "Abbreviation": "Turn End"
+      }
+    },
     "Recharge": {
       "Label": "Recharge",
       "Range": "Recharge {range}"
     },
+    "Special": "Special",
+    "Time": "Time",
     "Type": {
       "Formula": "Custom Formula",
       "LoseAll": "Lose All Uses",

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -267,14 +267,7 @@ export default class ActivitySheet extends Application5e {
     context.showScaling = !this.activity.isSpell;
 
     // Uses recovery
-    context.recoveryPeriods = [
-      ...Object.entries(CONFIG.DND5E.limitedUsePeriods)
-        .filter(([, config]) => !config.deprecated)
-        .map(([value, config]) => ({
-          value, label: config.label, group: game.i18n.localize("DND5E.DurationTime")
-        })),
-      { value: "recharge", label: game.i18n.localize("DND5E.USES.Recovery.Recharge.Label") }
-    ];
+    context.recoveryPeriods = CONFIG.DND5E.limitedUsePeriods.recoveryOptions;
     context.recoveryTypes = [
       { value: "recoverAll", label: game.i18n.localize("DND5E.USES.Recovery.Type.RecoverAll") },
       { value: "loseAll", label: game.i18n.localize("DND5E.USES.Recovery.Type.LoseAll") },

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -116,12 +116,7 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
     // Limited Uses
     context.data = { uses: context.source.uses };
     context.hasLimitedUses = this.item.system.hasLimitedUses;
-    context.recoveryPeriods = [
-      ...Object.entries(CONFIG.DND5E.limitedUsePeriods)
-        .filter(([, { deprecated }]) => !deprecated)
-        .map(([value, { label }]) => ({ value, label, group: "DND5E.DurationTime" })),
-      { value: "recharge", label: "DND5E.USES.Recovery.Recharge.Label" }
-    ];
+    context.recoveryPeriods = CONFIG.DND5E.limitedUsePeriods.recoveryOptions;
     context.recoveryTypes = [
       { value: "recoverAll", label: "DND5E.USES.Recovery.Type.RecoverAll" },
       { value: "loseAll", label: "DND5E.USES.Recovery.Type.LoseAll" },

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1403,9 +1403,10 @@ preLocalize("itemRarity");
  * Configuration data for limited use periods.
  *
  * @typedef {object} LimitedUsePeriodConfiguration
- * @property {string} label           Localized label.
- * @property {string} abbreviation    Shorthand form of the label.
- * @property {boolean} [formula]      Whether this limited use period restores charges via formula.
+ * @property {string} label                Localized label.
+ * @property {string}  abbreviation        Shorthand form of the label.
+ * @property {"combat"|"special"} [group]  Grouping if outside the normal "time" group.
+ * @property {boolean} [formula]           Whether this limited use period restores charges via formula.
  */
 
 /**
@@ -1414,17 +1415,18 @@ preLocalize("itemRarity");
  */
 DND5E.limitedUsePeriods = {
   lr: {
-    label: "DND5E.UsesPeriods.Lr",
-    abbreviation: "DND5E.UsesPeriods.LrAbbreviation"
+    label: "DND5E.USES.Recovery.Period.LongRest.Label",
+    abbreviation: "DND5E.USES.Recovery.Period.LongRest.Abbreviation"
   },
   sr: {
-    label: "DND5E.UsesPeriods.Sr",
-    abbreviation: "DND5E.UsesPeriods.SrAbbreviation"
+    label: "DND5E.USES.Recovery.Period.ShortRest.Label",
+    abbreviation: "DND5E.USES.Recovery.Period.ShortRest.Abbreviation"
   },
   day: {
-    label: "DND5E.UsesPeriods.Day",
-    abbreviation: "DND5E.UsesPeriods.DayAbbreviation"
+    label: "DND5E.USES.Recovery.Period.Day.Label",
+    abbreviation: "DND5E.USES.Recovery.Period.Day.Label"
   },
+  // TODO: Remove with DnD5e 4.4
   charges: {
     label: "DND5E.UsesPeriods.Charges",
     abbreviation: "DND5E.UsesPeriods.ChargesAbbreviation",
@@ -1432,17 +1434,55 @@ DND5E.limitedUsePeriods = {
     deprecated: true
   },
   dawn: {
-    label: "DND5E.UsesPeriods.Dawn",
-    abbreviation: "DND5E.UsesPeriods.DawnAbbreviation",
+    label: "DND5E.USES.Recovery.Period.Dawn.Label",
+    abbreviation: "DND5E.USES.Recovery.Period.Dawn.Label",
     formula: true
   },
   dusk: {
-    label: "DND5E.UsesPeriods.Dusk",
-    abbreviation: "DND5E.UsesPeriods.DuskAbbreviation",
+    label: "DND5E.USES.Recovery.Period.Dusk.Label",
+    abbreviation: "DND5E.USES.Recovery.Period.Dusk.Label",
     formula: true
+  },
+  initiative: {
+    label: "DND5E.USES.Recovery.Period.Initiative.Label",
+    abbreviation: "DND5E.USES.Recovery.Period.Initiative.Label",
+    type: "special"
+  },
+  encounter: {
+    label: "DND5E.USES.Recovery.Period.Encounter.Label",
+    abbreviation: "DND5E.USES.Recovery.Period.Encounter.Label",
+    type: "combat"
+  },
+  turnStart: {
+    label: "DND5E.USES.Recovery.Period.TurnStart.Label",
+    abbreviation: "DND5E.USES.Recovery.Period.TurnStart.Abbreviation",
+    type: "combat"
+  },
+  turnEnd: {
+    label: "DND5E.USES.Recovery.Period.TurnEnd.Label",
+    abbreviation: "DND5E.USES.Recovery.Period.TurnEnd.Abbreviation",
+    type: "combat"
+  },
+  turn: {
+    label: "DND5E.USES.Recovery.Period.Turn.Label",
+    abbreviation: "DND5E.USES.Recovery.Period.Turn.Label",
+    type: "combat"
   }
 };
 preLocalize("limitedUsePeriods", { keys: ["label", "abbreviation"] });
+
+Object.defineProperty(DND5E.limitedUsePeriods, "recoveryOptions", {
+  get() {
+    return [
+      ...Object.entries(CONFIG.DND5E.limitedUsePeriods)
+        .filter(([, config]) => !config.deprecated)
+        .map(([value, { label, type }]) => ({
+          value, label, group: game.i18n.localize(`DND5E.USES.Recovery.${type?.capitalize() ?? "Time"}`)
+        })),
+      { value: "recharge", label: game.i18n.localize("DND5E.USES.Recovery.Recharge.Label") }
+    ];
+  }
+});
 
 /* -------------------------------------------- */
 
@@ -1452,13 +1492,13 @@ preLocalize("limitedUsePeriods", { keys: ["label", "abbreviation"] });
  */
 DND5E.enchantmentPeriods = {
   sr: {
-    label: "DND5E.UsesPeriods.Sr"
+    label: "DND5E.ENCHANTMENT.Period.ShortRest"
   },
   lr: {
-    label: "DND5E.UsesPeriods.Lr"
+    label: "DND5E.ENCHANTMENT.Period.LongRest"
   },
   atwill: {
-    label: "DND5E.UsesPeriods.AtWill"
+    label: "DND5E.ENCHANTMENT.Period.AtWill"
   }
 };
 preLocalize("enchantmentPeriods", { key: "label" });

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1448,11 +1448,6 @@ DND5E.limitedUsePeriods = {
     abbreviation: "DND5E.USES.Recovery.Period.Initiative.Label",
     type: "special"
   },
-  encounter: {
-    label: "DND5E.USES.Recovery.Period.Encounter.Label",
-    abbreviation: "DND5E.USES.Recovery.Period.Encounter.Label",
-    type: "combat"
-  },
   turnStart: {
     label: "DND5E.USES.Recovery.Period.TurnStart.Label",
     abbreviation: "DND5E.USES.Recovery.Period.TurnStart.Abbreviation",

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -396,10 +396,10 @@ export class ActorDataModel extends SystemDataModel {
 
   /**
    * Reset combat-related uses.
-   * @param {string[]} periods                 Which recovery periods should be considered.
-   * @param {{ actor: {}, item: [] }} updates  Updates to perform on the actor and containing items.
+   * @param {string[]} periods               Which recovery periods should be considered.
+   * @param {CombatRecoveryResults} results  Updates to perform on the actor and containing items.
    */
-  async recoverCombatUses(periods, updates) {}
+  async recoverCombatUses(periods, results) {}
 }
 
 /* -------------------------------------------- */

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -69,7 +69,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    */
   get combatOnly() {
     let recovery;
-    switch (this.type) {
+    switch ( this.type ) {
       case "activityUses":
         recovery = this.activity.uses.recovery;
         break;

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -63,6 +63,27 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Should this consumption only be performed during initiative? This will return `true` if consuming activity or item
+   * uses and those uses only recover on "combat" periods.
+   * @type {boolean}
+   */
+  get combatOnly() {
+    let recovery;
+    switch (this.type) {
+      case "activityUses":
+        recovery = this.activity.uses.recovery;
+        break;
+      case "itemUses":
+        recovery = (this.target ? this.actor?.items.get(this.target) : this.item)?.system.uses.recovery;
+        break;
+      default: return false;
+    }
+    return recovery?.every(r => CONFIG.DND5E.limitedUsePeriods[r.period]?.type === "combat") ?? false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Item to which this consumption target's activity belongs.
    * @type {Item5e}
    */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -423,10 +423,10 @@ export default class NPCData extends CreatureTemplate {
   /* -------------------------------------------- */
 
   /** @override */
-  async recoverCombatUses(periods, updates) {
+  async recoverCombatUses(periods, results) {
     // Reset legendary actions at the start of a combat encounter or at the end of the creature's turn
     if ( this.resources.legact.max && (periods.includes("encounter") || periods.includes("turnEnd")) ) {
-      updates.actor["system.resources.legact.value"] = this.resources.legact.max;
+      results.actor["system.resources.legact.value"] = this.resources.legact.max;
     }
   }
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -850,7 +850,7 @@ export default function ActivityMixin(Base) {
      */
     _requiresConfigurationDialog(config) {
       const checkObject = obj => (foundry.utils.getType(obj) === "Object")
-        && Object.values(obj).some(v => v === true || v?.length > 0);
+        && Object.values(obj).some(v => v === true || v?.length);
       return config.concentration?.begin === true
         || checkObject(config.create)
         || ((checkObject(config.consume) || (config.cause?.resources === true)) && config.hasConsumption)

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -625,7 +625,9 @@ export default function ActivityMixin(Base) {
         const hasSpellSlotConsumption = this.requiresSpellSlot && this.consumption.spellSlot;
         config.consume ??= {};
         config.consume.action ??= hasActionConsumption;
-        config.consume.resources ??= hasResourceConsumption;
+        config.consume.resources ??= Array.from(this.consumption.targets.entries())
+          .filter(([, target]) => !target.combatOnly || this.actor.inCombat)
+          .map(([index]) => index);
         config.consume.spellSlot ??= !linked && hasSpellSlotConsumption;
         config.hasConsumption = hasActionConsumption || hasResourceConsumption || hasLinkedConsumption
           || (!linked && hasSpellSlotConsumption);
@@ -847,7 +849,8 @@ export default function ActivityMixin(Base) {
      * @protected
      */
     _requiresConfigurationDialog(config) {
-      const checkObject = obj => (foundry.utils.getType(obj) === "Object") && Object.values(obj).some(v => v);
+      const checkObject = obj => (foundry.utils.getType(obj) === "Object")
+        && Object.values(obj).some(v => v === true || v?.length > 0);
       return config.concentration?.begin === true
         || checkObject(config.create)
         || ((checkObject(config.consume) || (config.cause?.resources === true)) && config.hasConsumption)

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -11,6 +11,24 @@ export default class Combat5e extends Combat {
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async endCombat() {
+    await super.endCombat();
+    this._recoverUses({ encounter: true, turn: true, turnEnd: true, turnStart: true });
+    return this;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async rollInitiative(ids, options={}) {
+    await super.rollInitiative(ids, options);
+    for ( const id of ids ) await this._recoverUses({ initiative: this.combatants.get(id) });
+    return this;
+  }
+
+  /* -------------------------------------------- */
   /*  Socket Event Handlers                       */
   /* -------------------------------------------- */
 
@@ -44,7 +62,7 @@ export default class Combat5e extends Combat {
   /** @inheritDoc */
   async _onStartTurn(combatant) {
     await super._onStartTurn(combatant);
-    this._recoverUses({ turnStart: combatant });
+    this._recoverUses({ turn: true, turnStart: combatant });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -15,7 +15,7 @@ export default class Combat5e extends Combat {
   /** @inheritDoc */
   async endCombat() {
     await super.endCombat();
-    this._recoverUses({ encounter: true, turn: true, turnEnd: true, turnStart: true });
+    this._recoverUses({ turn: true, turnEnd: true, turnStart: true });
     return this;
   }
 

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -111,7 +111,7 @@ export default class Combatant5e extends Combatant {
      */
     if ( Hooks.call("dnd5e.combatRecovery", this, periods, results) === false ) return;
 
-    const deltas = ActorDeltasField.getDeltas(this.actor, updates);
+    const deltas = ActorDeltasField.getDeltas(this.actor, results);
 
     if ( !foundry.utils.isEmpty(results.actor) ) await this.actor.update(results.actor);
     if ( results.item.length ) await this.actor.updateEmbeddedDocuments("Item", results.item);

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -6,6 +6,13 @@ import { ActorDeltasField } from "../data/chat-message/fields/deltas-field.mjs";
  */
 
 /**
+ * @typedef CombatRecoveryResults
+ * @property {object} actor       Updates to be applied to the actor.
+ * @property {object[]} item      Updates to be applied to the actor's items.
+ * @property {BasicRoll[]} rolls  Any recovery rolls performed.
+ */
+
+/**
  * Custom combatant with custom initiative roll handling.
  */
 export default class Combatant5e extends Combatant {
@@ -77,28 +84,37 @@ export default class Combatant5e extends Combatant {
      */
     if ( Hooks.call("dnd5e.preCombatRecovery", this, periods) === false ) return;
 
-    const updates = { actor: {}, item: [] };
-    await this.actor?.system.recoverCombatUses?.(periods, updates);
+    const results = { actor: {}, item: [], rolls: [] };
+    await this.actor?.system.recoverCombatUses?.(periods, results);
 
-    // TODO: If https://github.com/foundryvtt/dnd5e/issues/3214 is implemented, this is where
-    // item/activity uses with combat related recovery can be recovered
+    for ( const item of this.actor?.items ?? [] ) {
+      if ( foundry.utils.getType(item.system.recoverUses) !== "function" ) continue;
+      const rollData = item.getRollData();
+      const { updates, rolls } = await item.system.recoverUses(Array.from(periods), rollData);
+      if ( !foundry.utils.isEmpty(updates) ) {
+        const updateTarget = results.item.find(i => i._id === item.id);
+        if ( updateTarget ) foundry.utils.mergeObject(updateTarget, updates);
+        else results.item.push({ _id: item.id, ...updates });
+      }
+      results.rolls.push(...rolls);
+    }
 
     /**
      * A hook event that fires after combat-related recovery changes have been prepared, but before they have been
      * applied to the actor.
      * @function dnd5e.combatRecovery
      * @memberof hookEvents
-     * @param {Combatant5e} combatant                      Combatant that is being recovered.
-     * @param {string[]} periods                           Periods that were recovered.
-     * @param {{ actor: object, item: object[] }} updates  Update that will be applied to the actor and its items.
+     * @param {Combatant5e} combatant          Combatant that is being recovered.
+     * @param {string[]} periods               Periods that were recovered.
+     * @param {CombatRecoveryResults} results  Update that will be applied to the actor and its items.
      * @returns {boolean}  Explicitly return `false` to prevent updates from being performed.
      */
-    if ( Hooks.call("dnd5e.combatRecovery", this, periods, updates) === false ) return;
+    if ( Hooks.call("dnd5e.combatRecovery", this, periods, results) === false ) return;
 
     const deltas = ActorDeltasField.getDeltas(this.actor, updates);
 
-    if ( !foundry.utils.isEmpty(updates.actor) ) await this.actor.update(updates.actor);
-    if ( updates.item.length ) await this.actor.updateEmbeddedDocuments("Item", updates.item);
+    if ( !foundry.utils.isEmpty(results.actor) ) await this.actor.update(results.actor);
+    if ( results.item.length ) await this.actor.updateEmbeddedDocuments("Item", results.item);
 
     const message = await this.createTurnMessage({ deltas, periods });
 

--- a/templates/items/details/details-feat.hbs
+++ b/templates/items/details/details-feat.hbs
@@ -32,7 +32,7 @@
 
     {{!-- Enchantment Replacement --}}
     {{ formField fields.enchant.fields.period value=source.enchant.period localize=true
-                 choices=config.enchantmentPeriods labelAttr="label" blank="DND5E.UsesPeriods.Never"
+                 choices=config.enchantmentPeriods labelAttr="label" blank="DND5E.ENCHANTMENT.Period.Never"
                  label="DND5E.ENCHANTMENT.FIELDS.enchantment.items.period.label"
                  hint="DND5E.ENCHANTMENT.FIELDS.enchantment.items.period.hint" }}
 </fieldset>

--- a/templates/items/feat.hbs
+++ b/templates/items/feat.hbs
@@ -96,7 +96,7 @@
                 <label>{{ localize "DND5E.ENCHANTMENT.FIELDS.enchantment.items.period.label" }}</label>
                 <select name="system.enchantment.items.period">
                     {{ selectOptions config.enchantmentPeriods selected=system.enchantment.items.period
-                                     labelAttr="label" blank=(localize "DND5E.UsesPeriods.Never") }}
+                                     labelAttr="label" blank=(localize "DND5E.ENCHANTMENT.Period.Never") }}
                 </select>
                 <p class="hint">{{ localize "DND5E.ENCHANTMENT.FIELDS.enchantment.items.period.hint" }}</p>
             </div>

--- a/templates/shared/fields/field-uses.hbs
+++ b/templates/shared/fields/field-uses.hbs
@@ -61,7 +61,7 @@
         </div>
     </div>
     {{else}}
-    <div class="empty">{{ localize "DND5E.UsesPeriods.Never" }}</div>
+    <div class="empty">{{ localize "DND5E.USES.Recovery.Never" }}</div>
     {{/each}}
 </fieldset>
 {{/if}}


### PR DESCRIPTION
Introduces five new uses recover periods relating to combat:
- `encounter`: Recovered at the start of combat
- `turnStart` & `turnEnd`: Recovered once per round at the start or end of a specific combatant's turn
- `turn`: Recovered at the start of all combatant's turns
- `initiative`: Recovered when an actor rolls initiative

First first four (but not `initiative`) are special "combat" recovery types, which changes their behavior outside combat in two ways:

1. They are automatically recovered at the end of combat
2. They will not be consumed by default if combat isn't occuring

The second point means that if an activity is consuming item or activity uses and the only recovery periods are combat periods, then the consumption button will be unchecked by default.

Closes #3214
Closes #4738