### PR TITLE
[#4859] Add option to use lookup enricher on activity

### DIFF
--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -653,10 +653,17 @@ async function enrichDamage(configs, label, options) {
  * @returns {HTMLElement|null}         An HTML element if the lookup could be built, otherwise null.
  *
  * @example Include a creature's name in its description:
- * ```[[lookup @name]]``
+ * ```[[lookup @name]]```
  * becomes
  * ```html
  * <span class="lookup-value">Adult Black Dragon</span>
+ * ```
+ *
+ * @example Lookup a property within an activity:
+ * ```[[lookup @target.template.size activity=dnd5eactivity000]]```
+ * becomes
+ * ```html
+ * <span class="lookup-value">120</span>
  * ```
  */
 function enrichLookup(config, fallback, options) {
@@ -669,12 +676,18 @@ function enrichLookup(config, fallback, options) {
     else if ( value.startsWith("@") ) keyPath ??= value;
   }
 
+  let activity = options.relativeTo?.system.activities?.get(config.activity);
+  if ( config.activity && !activity ) {
+    console.warn(`Activity not found when enriching ${config._input}.`);
+    return null;
+  }
+
   if ( !keyPath ) {
     console.warn(`Lookup path must be defined to enrich ${config._input}.`);
     return null;
   }
 
-  const data = options.rollData ?? options.relativeTo?.getRollData();
+  const data = activity ? activity.getRollData().activity : options.rollData ?? options.relativeTo?.getRollData();
   let value = foundry.utils.getProperty(data, keyPath.substring(1)) ?? fallback;
   if ( value && style ) {
     if ( style === "capitalize" ) value = value.capitalize();


### PR DESCRIPTION
Adds an `activity` option to the lookup enricher that takes an activity ID and allows for grabbing roll data directly from an activity on an item, rather than from the item's roll data:

```
[[lookup @target.template.size activity=dnd5eactivity000]]
```

Closes #4859