### PR TITLE
[#4846] Add "Passive Trait" property to features for group control

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2289,6 +2289,7 @@
     "Special": "Special",
     "StealthDisadvantage": "Stealth Disadvantage",
     "Thrown": "Thrown",
+    "Trait": "Passive Trait",
     "TwoHanded": "Two-Handed",
     "Versatile": "Versatile",
     "Verbal": "Verbal",

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -178,7 +178,7 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
         hasActions: false, dataset: {type: "feat"} }
     };
     for ( const feat of feats ) {
-      if ( feat.system.activities?.size ) {
+      if ( feat.system.activities?.size && !feat.system.properties?.has("trait") ) {
         features.active.items.push(feat);
         context.itemContext[feat.id].ungroup = "active";
       }

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -67,7 +67,8 @@ export default class ActorSheet5eNPC extends ActorSheet5e {
       ctx.canToggle = false;
       ctx.totalWeight = item.system.totalWeight?.toNearest(0.1);
       // Item grouping
-      ctx.group = item.system.activities?.contents[0]?.activation.type || "passive";
+      ctx.group = item.system.properties?.has("trait") ? "passive"
+        : item.system.activities?.contents[0]?.activation.type || "passive";
       ctx.ungroup = "feat";
       if ( item.type === "weapon" ) ctx.ungroup = "weapon";
       if ( ctx.group === "passive" ) ctx.ungroup = "passive";

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1897,6 +1897,9 @@ DND5E.itemProperties = {
   thr: {
     label: "DND5E.Item.Property.Thrown"
   },
+  trait: {
+    label: "DND5E.Item.Property.Trait"
+  },
   two: {
     label: "DND5E.Item.Property.TwoHanded"
   },
@@ -1935,7 +1938,8 @@ DND5E.validProperties = {
     "stealthDisadvantage"
   ]),
   feat: new Set([
-    "mgc"
+    "mgc",
+    "trait"
   ]),
   loot: new Set([
     "mgc"

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -576,7 +576,8 @@ export default class NPCData extends CreatureTemplate {
 
     for ( const item of this.parent.items ) {
       if ( !["feat", "weapon"].includes(item.type) ) continue;
-      const category = item.system.activities?.contents[0]?.activation.type ?? "trait";
+      const category = item.system.properties.has("trait") ? "trait"
+        : (item.system.activities?.contents[0]?.activation?.type ?? "trait");
       if ( category in context.actionSections ) {
         const description = (await TextEditor.enrichHTML(item.system.description.value, {
           secrets: false, rollData: item.getRollData(), relativeTo: item


### PR DESCRIPTION
Adds a new trait for feature items that controls whether that feature is considered passive for grouping on PC & NPC sheets and on NPC stat blocks. When checked, the feature will always be treated as a passive feature regardless of the activities it has.

Closes #4846