### PR TITLE
[#2359, #4799] Add new turn chat message

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -131,6 +131,7 @@ Hooks.once("init", function() {
   // Hook up system data types
   CONFIG.ActiveEffect.dataModels = dataModels.activeEffect.config;
   CONFIG.Actor.dataModels = dataModels.actor.config;
+  CONFIG.ChatMessage.dataModels = dataModels.chatMessage.config;
   CONFIG.Item.dataModels = dataModels.item.config;
   CONFIG.JournalEntryPage.dataModels = dataModels.journal.config;
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -18,6 +18,10 @@
 "TYPES.ActiveEffect.enchantment": "Enchantment",
 "TYPES.ActiveEffect.enchantmentPl": "Enchantments",
 
+"TYPES.ChatMessage": {
+  "turn": "Combat Turn Message"
+},
+
 "TYPES.Item.background": "Background",
 "TYPES.Item.backgroundPl": "Backgrounds",
 "TYPES.Item.container": "Container",
@@ -745,6 +749,13 @@
 "DND5E.ChatContextSelectHit": "Select Hit Targets",
 "DND5E.ChatContextSelectMiss": "Select Missed Targets",
 "DND5E.ChatFlavor": "Chat Message Flavor",
+
+"DND5E.CHATMESSAGE": {
+  "TURN": {
+    "NoCombat": "Combat has ended!",
+    "Recovery": "Recovery"
+  }
+},
 
 "DND5E.CHECK": {
   "Title": "Check",

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -771,3 +771,16 @@ enchantment-application {
     }
   }
 }
+
+/* ---------------------------------- */
+/*  Turn Cards                        */
+/* ---------------------------------- */
+
+.chat-card.turn-card {
+  .deltas ul {
+    li {
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+}

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -777,6 +777,10 @@ enchantment-application {
 /* ---------------------------------- */
 
 .chat-card.turn-card {
+  section > strong:first-child {
+    display: block;
+    margin-block-start: 1em;
+  }
   .deltas ul {
     li {
       display: flex;

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -1,10 +1,12 @@
 export {default as SystemDataModel, ActorDataModel, ItemDataModel, SparseDataModel} from "./abstract.mjs";
 export * as fields from "./fields/_module.mjs";
 
+export * as abstract from "./abstract/_module.mjs";
 export * as activeEffect from "./active-effect/_module.mjs";
 export * as activity from "./activity/_module.mjs";
 export * as actor from "./actor/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";
+export * as chatMessage from "./chat-message/_module.mjs";
 export * as collection from "./collection/_module.mjs";
 export * as item from "./item/_module.mjs";
 export * as journal from "./journal/_module.mjs";

--- a/module/data/abstract/_module.mjs
+++ b/module/data/abstract/_module.mjs
@@ -1,0 +1,1 @@
+export {default as ChatMessageDataModel} from "./chat-message-data-model.mjs";

--- a/module/data/abstract/chat-message-data-model.mjs
+++ b/module/data/abstract/chat-message-data-model.mjs
@@ -1,0 +1,122 @@
+/**
+ * @typedef {object} ChatMessageDataModelMetadata
+ * @property {Record<string, ApplicationClickAction>} actions  Default click actions for buttons on the message.
+ * @property {string} template                                 Template to use when rendering this message.
+ */
+
+/**
+ * Abstract base class to add some shared functionality to all of the system's custom chat message types.
+ * @abstract
+ */
+export default class ChatMessageDataModel extends foundry.abstract.DataModel {
+
+  /**
+   * Metadata for this chat message type.
+   * @type {ChatMessageDataModelMetadata}
+   */
+  static metadata = Object.freeze({
+    actions: {},
+    template: ""
+  });
+
+  get metadata() {
+    return this.constructor.metadata;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Template to use when rendering this message.
+   * @type {string}
+   */
+  get template() {
+    return this.metadata.template;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /**
+   * Perform any changes to the chat message's element before displaying in the list.
+   * @param {HTMLElement} element  Element representing the entire chat message.
+   */
+  async getHTML(element) {
+    const rendered = await this.render();
+    if ( rendered ) element.querySelector(".message-content").innerHTML = rendered;
+    this.parent._enrichChatCard(element);
+
+    const click = this.#onClick.bind(this);
+    element.addEventListener("click", click);
+    element.addEventListener("contextmenu", click);
+    this._onRender(element);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Render the contents of this chat message.
+   * @returns {string}
+   */
+  async render() {
+    if ( !this.template ) return "";
+    return renderTemplate(this.template, await this._prepareContext());
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare application rendering context data for a given render request.
+   * @returns {Promise<ApplicationRenderContext>}   Context data for the render operation.
+   * @protected
+   */
+  async _prepareContext() {
+    return {};
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Actions taken after the message has been rendered.
+   * @param {HTMLElement} element
+   * @protected
+   */
+  _onRender(element) {}
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle click events within the card.
+   * @param {PointerEvent} event  Triggering pointer event.
+   */
+  #onClick(event) {
+    const target = event.target.closest("[data-action]");
+    if ( target ) {
+      const action = target.dataset.action;
+      let handler = this.metadata.actions[action];
+      if ( handler ) {
+        let buttons = [0];
+        if ( typeof handler === "object" ) {
+          buttons = handler.buttons;
+          handler = handler.handler;
+        }
+        if ( buttons.includes(event.button) ) handler?.call(this, event, target);
+      } else {
+        this._onClickAction(event, target);
+      }
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * A generic event handler for action clicks which can be extended by subclasses, called if no action is found in
+   * the actions list in the message type's metadata.
+   * @param {PointerEvent} event  Triggering pointer event.
+   * @param {HTMLElement} target  Button with [data-action] defined.
+   * @protected
+   */
+  _onClickAction(event, target) {}
+}

--- a/module/data/abstract/chat-message-data-model.mjs
+++ b/module/data/abstract/chat-message-data-model.mjs
@@ -8,7 +8,7 @@
  * Abstract base class to add some shared functionality to all of the system's custom chat message types.
  * @abstract
  */
-export default class ChatMessageDataModel extends foundry.abstract.DataModel {
+export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel {
 
   /**
    * Metadata for this chat message type.
@@ -40,9 +40,10 @@ export default class ChatMessageDataModel extends foundry.abstract.DataModel {
   /**
    * Perform any changes to the chat message's element before displaying in the list.
    * @param {HTMLElement} element  Element representing the entire chat message.
+   * @param {object} options       Options forwarded to the render function.
    */
-  async getHTML(element) {
-    const rendered = await this.render();
+  async getHTML(element, options) {
+    const rendered = await this.render(options);
     if ( rendered ) element.querySelector(".message-content").innerHTML = rendered;
     this.parent._enrichChatCard(element);
 
@@ -56,21 +57,23 @@ export default class ChatMessageDataModel extends foundry.abstract.DataModel {
 
   /**
    * Render the contents of this chat message.
-   * @returns {string}
+   * @param {object} options  Rendering options.
+   * @returns {Promise<string>}
    */
-  async render() {
+  async render(options) {
     if ( !this.template ) return "";
-    return renderTemplate(this.template, await this._prepareContext());
+    return renderTemplate(this.template, await this._prepareContext(options));
   }
 
   /* -------------------------------------------- */
 
   /**
    * Prepare application rendering context data for a given render request.
+   * @param {object} options  Rendering options.
    * @returns {Promise<ApplicationRenderContext>}   Context data for the render operation.
    * @protected
    */
-  async _prepareContext() {
+  async _prepareContext(options) {
     return {};
   }
 

--- a/module/data/chat-message/_module.mjs
+++ b/module/data/chat-message/_module.mjs
@@ -1,0 +1,10 @@
+import TurnMessageData from "./turn-message-data.mjs";
+
+export {
+  TurnMessageData
+};
+export {default as ActorDeltasField, IndividualDeltaField} from "./fields/deltas-field.mjs";
+
+export const config = {
+  turn: TurnMessageData
+};

--- a/module/data/chat-message/_module.mjs
+++ b/module/data/chat-message/_module.mjs
@@ -3,7 +3,7 @@ import TurnMessageData from "./turn-message-data.mjs";
 export {
   TurnMessageData
 };
-export {default as ActorDeltasField, IndividualDeltaField} from "./fields/deltas-field.mjs";
+export * as fields from "./fields/_module.mjs";
 
 export const config = {
   turn: TurnMessageData

--- a/module/data/chat-message/fields/_module.mjs
+++ b/module/data/chat-message/fields/_module.mjs
@@ -1,0 +1,1 @@
+export * from "./deltas-field.mjs";

--- a/module/data/chat-message/fields/deltas-field.mjs
+++ b/module/data/chat-message/fields/deltas-field.mjs
@@ -1,0 +1,80 @@
+import MappingField from "../../fields/mapping-field.mjs";
+
+const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * @typedef ActorDeltasData
+ * @property {IndividualDeltaData[]} actor                 Changes for the actor.
+ * @property {Record<string, IndividualDeltaData[]>} item  Changes for each item grouped by ID.
+ */
+
+/**
+ * A field for storing deltas made to an actor or embedded items.
+ */
+export default class ActorDeltasField extends SchemaField {
+  constructor() {
+    super({
+      actor: new ArrayField(new IndividualDeltaField()),
+      item: new MappingField(new ArrayField(new IndividualDeltaField()))
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Calculate delta information for an actor document from the given updates.
+   * @param {Actor5e} actor                              Actor for which to calculate the deltas.
+   * @param {{ actor: object, item: object[] }} updates  Updates to apply to the actor and contained items.
+   * @returns {ActorDeltasData}
+   */
+  static getDeltas(actor, updates) {
+    return {
+      actor: IndividualDeltaField.getDeltas(actor, updates.actor),
+      item: updates.item.reduce((obj, { _id, ...changes }) => {
+        const deltas = IndividualDeltaField.getDeltas(actor.items.get(_id), changes);
+        if ( deltas.length ) obj[_id] = deltas;
+        return obj;
+      }, {})
+    };
+  }
+}
+
+/**
+ * @typedef IndividualDeltaData
+ * @property {number} delta    The change in the specified field.
+ * @property {string} keyPath  Path to the changed field on the document.
+ */
+
+/**
+ * A field that stores a delta for an individual property on an actor or item.
+ */
+export class IndividualDeltaField extends SchemaField {
+  constructor() {
+    super({ delta: new NumberField(), keyPath: new StringField() });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Calculate delta information for a document from the given updates.
+   * @param {DataModel} dataModel      Document for which to calculate the deltas.
+   * @param {object} updates           Updates that are to be applied.
+   * @returns {IndividualDeltaData[]}
+   */
+  static getDeltas(dataModel, updates) {
+    updates = foundry.utils.flattenObject(updates);
+    const deltas = [];
+    for ( const [keyPath, value] of Object.entries(updates) ) {
+      let currentValue;
+      if ( keyPath.startsWith("system.activities") ) {
+        const [id, ...kp] = keyPath.slice(18).split(".");
+        currentValue = foundry.utils.getProperty(dataModel.system.activities?.get(id) ?? {}, kp.join("."));
+      }
+      else currentValue = foundry.utils.getProperty(dataModel, keyPath);
+
+      const delta = value - currentValue;
+      if ( delta && !Number.isNaN(delta) ) deltas.push({ keyPath, delta });
+    }
+    return deltas;
+  }
+}

--- a/module/data/chat-message/fields/deltas-field.mjs
+++ b/module/data/chat-message/fields/deltas-field.mjs
@@ -11,7 +11,7 @@ const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.field
 /**
  * A field for storing deltas made to an actor or embedded items.
  */
-export default class ActorDeltasField extends SchemaField {
+export class ActorDeltasField extends SchemaField {
   constructor() {
     super({
       actor: new ArrayField(new IndividualDeltaField()),

--- a/module/data/chat-message/turn-message-data.mjs
+++ b/module/data/chat-message/turn-message-data.mjs
@@ -1,0 +1,109 @@
+import { formatNumber, getHumanReadableAttributeLabel } from "../../utils.mjs";
+import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+import ActorDeltasField from "./fields/deltas-field.mjs";
+
+const { DocumentIdField, SchemaField, SetField, StringField } = foundry.data.fields;
+
+/**
+ * @typedef {import("./fields/deltas-field.mjs").ActorDeltasData} ActorDeltasData
+ */
+
+/**
+ * Data stored in a combat turn chat message.
+ *
+ * @property {ActorDeltasData} deltas   Actor/item recovery from this turn change.
+ * @property {object} origin
+ * @property {string} origin.combat     ID of the triggering combat.
+ * @property {string} origin.combatant  ID of the relevant combatant within the combat.
+ * @property {Set<string>} periods      Combat state change that triggered this message.
+ */
+export default class TurnMessageData extends ChatMessageDataModel {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {
+      deltas: new ActorDeltasField(),
+      origin: new SchemaField({
+        combat: new DocumentIdField({ nullable: false, required: true }),
+        combatant: new DocumentIdField({ nullable: false, required: true })
+      }),
+      trigger: new SetField(new StringField())
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    template: "systems/dnd5e/templates/chat/turn-card.hbs"
+  }, { inplace: false }));
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The actor belonging to the combatant.
+   * @type {Actor5e}
+   */
+  get actor() {
+    return this.combatant?.actor;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The combat during which this message was triggered.
+   * @type {Combat5e}
+   */
+  get combat() {
+    return game.combats.get(this.origin.combat);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The combatant to whom this message applies.
+   * @type {Combatant5e}
+   */
+  get combatant() {
+    return this.combat?.combatants.get(this.origin.combatant);
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext() {
+    const context = {
+      actor: this.actor,
+      combat: this.combat,
+      combatant: this.combatant
+    };
+    if ( !context.actor ) return context;
+
+    const processDelta = (doc, delta) => {
+      const type = doc instanceof Actor ? "actor" : "item";
+      return {
+        type,
+        delta: formatNumber(delta.delta, { signDisplay: "always" }),
+        document: doc,
+        label: getHumanReadableAttributeLabel(delta.keyPath, { [type]: doc }) ?? delta.keyPath
+        // TODO: If any rolls were performed for recovery, associate with delta
+      };
+    };
+
+    context.deltas = [
+      ...this.deltas.actor.map(d => processDelta(this.actor, d)),
+      ...Object.entries(this.deltas.item).map(([id, deltas]) =>
+        deltas.map(d => processDelta(this.actor.items.get(id), d))
+      ).flat()
+    ];
+    return context;
+  }
+}

--- a/module/data/chat-message/turn-message-data.mjs
+++ b/module/data/chat-message/turn-message-data.mjs
@@ -1,11 +1,11 @@
 import { formatNumber, getHumanReadableAttributeLabel } from "../../utils.mjs";
 import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
-import ActorDeltasField from "./fields/deltas-field.mjs";
+import { ActorDeltasField } from "./fields/deltas-field.mjs";
 
 const { DocumentIdField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
- * @typedef {import("./fields/deltas-field.mjs").ActorDeltasData} ActorDeltasData
+ * @import { ActorDeltasData } from "./fields/deltas-field.mjs";
  */
 
 /**
@@ -79,7 +79,7 @@ export default class TurnMessageData extends ChatMessageDataModel {
   /* -------------------------------------------- */
 
   /** @override */
-  async _prepareContext() {
+  async _prepareContext(options) {
     const context = {
       actor: this.actor,
       combat: this.combat,
@@ -100,9 +100,9 @@ export default class TurnMessageData extends ChatMessageDataModel {
 
     context.deltas = [
       ...this.deltas.actor.map(d => processDelta(this.actor, d)),
-      ...Object.entries(this.deltas.item).map(([id, deltas]) =>
+      ...Object.entries(this.deltas.item).flatMap(([id, deltas]) =>
         deltas.map(d => processDelta(this.actor.items.get(id), d))
-      ).flat()
+      )
     ];
     return context;
   }

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -41,6 +41,7 @@ export default class ChatMessage5e extends ChatMessage {
 
   /** @inheritDoc */
   get isRoll() {
+    if ( (this.system?.isRoll !== undefined) ) return this.system.isRoll;
     return super.isRoll && !this.flags.dnd5e?.rest;
   }
 
@@ -100,8 +101,14 @@ export default class ChatMessage5e extends ChatMessage {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async getHTML(...args) {
+  async getHTML() {
     const html = await super.getHTML();
+    const element = (html instanceof HTMLElement) ? html : html[0];
+
+    if ( foundry.utils.getType(this.system?.getHTML) === "function" ) {
+      await this.system.getHTML(element);
+      return html;
+    }
 
     this._displayChatActionButtons(html);
     this._highlightCriticalSuccessFailure(html);
@@ -109,10 +116,10 @@ export default class ChatMessage5e extends ChatMessage {
       html.find(".description.collapsible").each((i, el) => el.classList.add("collapsed"));
     }
 
-    this._enrichChatCard(html[0]);
-    this._collapseTrays(html[0]);
-    this._activateActivityListeners(html[0]);
-    dnd5e.bastion._activateChatListeners(this, html[0]);
+    this._enrichChatCard(element);
+    this._collapseTrays(element);
+    this._activateActivityListeners(element);
+    dnd5e.bastion._activateChatListeners(this, element);
 
     /**
      * A hook event that fires after dnd5e-specific chat message modifications have completed.
@@ -121,7 +128,7 @@ export default class ChatMessage5e extends ChatMessage {
      * @param {ChatMessage5e} message  Chat message being rendered.
      * @param {HTMLElement} html       HTML contents of the message.
      */
-    Hooks.callAll("dnd5e.renderChatMessage", this, html[0]);
+    Hooks.callAll("dnd5e.renderChatMessage", this, element);
 
     return html;
   }

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -41,7 +41,7 @@ export default class ChatMessage5e extends ChatMessage {
 
   /** @inheritDoc */
   get isRoll() {
-    if ( (this.system?.isRoll !== undefined) ) return this.system.isRoll;
+    if ( this.system?.isRoll !== undefined ) return this.system.isRoll;
     return super.isRoll && !this.flags.dnd5e?.rest;
   }
 
@@ -101,12 +101,12 @@ export default class ChatMessage5e extends ChatMessage {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async getHTML() {
-    const html = await super.getHTML();
+  async getHTML(options={}) {
+    const html = await super.getHTML(options);
     const element = (html instanceof HTMLElement) ? html : html[0];
 
     if ( foundry.utils.getType(this.system?.getHTML) === "function" ) {
-      await this.system.getHTML(element);
+      await this.system.getHTML(element, options);
       return html;
     }
 

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -1,7 +1,58 @@
+import ActorDeltasField from "../data/chat-message/fields/deltas-field.mjs";
+
+/**
+ * @typedef {import("../data/chat-message/fields/deltas-field.mjs").ActorDeltasData} ActorDeltasData
+ */
+
 /**
  * Custom combatant with custom initiative roll handling.
  */
 export default class Combatant5e extends Combatant {
+  /**
+   * Create a chat message representing actor changes and displaying possible actions for this turn.
+   * @param {object} [data={}]
+   * @param {ActorDeltasData} [data.deltas]
+   * @param {string[]} [data.periods]
+   * @returns {ChatMessage5e|void}
+   */
+  async createTurnMessage({ deltas, periods }={}) {
+    const messageConfig = {
+      create: false,
+      data: {
+        speaker: ChatMessage.getSpeaker({ actor: this.actor, token: this.token }),
+        system: {
+          deltas, periods,
+          origin: {
+            combat: this.combat.id,
+            combatant: this.id
+          }
+        },
+        type: "turn",
+        whisper: game.users.filter(u => this.actor.testUserPermission(game.user, "OWNER"))
+      }
+    };
+
+    if ( !foundry.utils.isEmpty(messageConfig.data.system.deltas?.actor)
+      || !foundry.utils.isEmpty(messageConfig.data.system.deltas?.item) ) messageConfig.create = true;
+    // TODO: Also create message if actor has items with relevant activation type
+    // when implementing https://github.com/foundryvtt/dnd5e/issues/4861
+
+    /**
+     * A hook event that fires before a combat state change chat message is created.
+     * @function dnd5e.preCreateCombatMessage
+     * @memberof hookEvents
+     * @param {Combatant5e} combatant         Combatant for which the message will be created.
+     * @param {object} messageConfig
+     * @param {boolean} messageConfig.create  Should the chat message be posted?
+     * @param {object} messageConfig.data     Data for the created chat message.
+     */
+    Hooks.callAll("dnd5e.preCreateCombatMessage", this, messageConfig);
+
+    if ( messageConfig.create ) return ChatMessage.implementation.create(messageConfig.data);
+  }
+
+  /* -------------------------------------------- */
+
   /** @override */
   getInitiativeRoll(formula) {
     if ( !this.actor ) return new CONFIG.Dice.D20Roll(formula ?? "1d20", {});
@@ -43,20 +94,22 @@ export default class Combatant5e extends Combatant {
      */
     if ( Hooks.call("dnd5e.combatRecovery", this, periods, updates) === false ) return;
 
+    const deltas = ActorDeltasField.getDeltas(this.actor, updates);
+
     if ( !foundry.utils.isEmpty(updates.actor) ) await this.actor.update(updates.actor);
     if ( updates.item.length ) await this.actor.updateEmbeddedDocuments("Item", updates.item);
 
-    // TODO: Consider adding a chat message indicating what was recovered with a "Revert" button
-    // Not sure if this should be GM-only or whispered to the owners of the actor
+    const message = await this.createTurnMessage({ deltas, periods: Array.from(periods) });
 
     /**
      * A hook event that fires after combat-related recovery changes have been applied.
      * @function dnd5e.postCombatRecovery
      * @memberof hookEvents
-     * @param {Combatant5e} combatant  Combatant that is being recovered.
-     * @param {Set<string>} periods    Periods that were recovered.
+     * @param {Combatant5e} combatant       Combatant that is being recovered.
+     * @param {Set<string>} periods         Periods that were recovered.
+     * @param {ChatMessage5e|void} message  Chat message created, if any.
      */
-    Hooks.callAll("dnd5e.postCombatRecovery", this, periods);
+    Hooks.callAll("dnd5e.postCombatRecovery", this, periods, message);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -1,7 +1,7 @@
-import ActorDeltasField from "../data/chat-message/fields/deltas-field.mjs";
+import { ActorDeltasField } from "../data/chat-message/fields/deltas-field.mjs";
 
 /**
- * @typedef {import("../data/chat-message/fields/deltas-field.mjs").ActorDeltasData} ActorDeltasData
+ * @import { ActorDeltasData } from "../data/chat-message/fields/deltas-field.mjs";
  */
 
 /**

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -921,6 +921,8 @@ const _attributeLabelCache = new Map();
  * @returns {string|void}
  */
 export function getHumanReadableAttributeLabel(attr, { actor }={}) {
+  if ( attr.startsWith("system.") ) attr = attr.slice(7);
+
   // Check any actor-specific names first.
   if ( attr.startsWith("resources.") && actor ) {
     const key = attr.replace(/\.value$/, "");

--- a/system.json
+++ b/system.json
@@ -41,6 +41,9 @@
         "htmlFields": ["description.full", "description.summary"]
       }
     },
+    "ChatMessage": {
+      "turn": {}
+    },
     "Item": {
       "weapon": {
         "htmlFields": ["description.value", "description.chat", "unidentified.description"]

--- a/templates/chat/turn-card.hbs
+++ b/templates/chat/turn-card.hbs
@@ -1,0 +1,26 @@
+<div class="dnd5e2 chat-card turn-card">
+    {{#if actor}}
+
+    {{!-- Deltas --}}
+    {{#if deltas.length}}
+    <section class="deltas">
+        <h5 class="roboto-condensed-upper">{{ localize "DND5E.CHATMESSAGE.TURN.Recovery" }}</h5>
+        <ul class="unlist">
+            {{#each deltas}}
+            <li class="delta-{{ type }}">
+                <span class="label">{{ label }}</span>
+                <span class="value">{{ delta }}</span>
+            </li>
+            {{/each}}
+        </ul>
+        <!-- TODO: Add button to revert changes -->
+    </section>
+    {{/if}}
+
+    {{!-- Actions --}}
+    <!-- TODO: Add actions when implementing https://github.com/foundryvtt/dnd5e/issues/4861 -->
+
+    {{else}}
+    <p>{{ localize "DND5E.CHATMESSAGE.TURN.NoCombat" }}</p>
+    {{/if}}
+</div>

--- a/templates/chat/turn-card.hbs
+++ b/templates/chat/turn-card.hbs
@@ -4,7 +4,7 @@
     {{!-- Deltas --}}
     {{#if deltas.length}}
     <section class="deltas">
-        <h5 class="roboto-condensed-upper">{{ localize "DND5E.CHATMESSAGE.TURN.Recovery" }}</h5>
+        <strong class="roboto-condensed-upper">{{ localize "DND5E.CHATMESSAGE.TURN.Recovery" }}</strong>
         <ul class="unlist">
             {{#each deltas}}
             <li class="delta-{{ type }}">


### PR DESCRIPTION
Introduces a new chat message type for communicating combat recovery information and offering combat-related controls. At this point the message just displays a summary of recovery changes that occured at the start of combat, the start of a turn, or the end of a turn.

<img width="299" alt="Turn Change Chat Message" src="https://github.com/user-attachments/assets/d55bdac6-3c58-42d5-81f7-1baf341f9bae" />

This introduces a new `turn` chat message type which stores information on the relevant combatant, what kind of combat change event triggered the message, and deltas for any changes made to the actor or their items.