### PR TITLE
[#4876] Add support for modifier keys during drag operations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -69,7 +69,6 @@
     "no-obj-calls": "warn",
     "no-octal": "warn",
     "no-octal-escape": "warn",
-    "no-promise-executor-return": "warn",
     "no-proto": "warn",
     "no-regex-spaces": "warn",
     "no-script-url": "warn",

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -18,6 +18,7 @@ import * as canvas from "./module/canvas/_module.mjs";
 import * as dataModels from "./module/data/_module.mjs";
 import * as dice from "./module/dice/_module.mjs";
 import * as documents from "./module/documents/_module.mjs";
+import DragDrop5e from "./module/drag-drop.mjs";
 import * as enrichers from "./module/enrichers.mjs";
 import * as Filter from "./module/filter.mjs";
 import * as migrations from "./module/migration.mjs";
@@ -44,6 +45,8 @@ globalThis.dnd5e = {
   registry,
   utils
 };
+
+DragDrop = DragDrop5e;
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */

--- a/lang/en.json
+++ b/lang/en.json
@@ -4513,6 +4513,8 @@
   }
 },
 
+"KEYBINDINGS.DND5E.DragCopy": "Force Copy when Dragging Document",
+"KEYBINDINGS.DND5E.DragMove": "Force Move when Dragging Document",
 "KEYBINDINGS.DND5E.SkipDialogNormal": "Skip Dialog",
 "KEYBINDINGS.DND5E.SkipDialogAdvantage": "Skip Dialog (roll with Advantage/Critical)",
 "KEYBINDINGS.DND5E.SkipDialogDisadvantage": "Skip Dialog (roll with Disadvantage)",

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1802,3 +1802,9 @@ dialog.dnd5e2.application {
 
   > i { display: none; }
 }
+
+/* ---------------------------------- */
+/*  Keybindings                       */
+/* ---------------------------------- */
+
+#keybindings [data-tab="system"] .control.conflicts { display: none; }

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -32,6 +32,10 @@ import TreasureConfig from "./config/treasure-config.mjs";
 import WeaponsConfig from "./config/weapons-config.mjs";
 
 /**
+ * @typedef {import("../../drag-drop.mjs").DropEffectValue} DropEffectValue
+ */
+
+/**
  * Extend the basic ActorSheet class to suppose system-specific logic and functionality.
  * @abstract
  */
@@ -943,16 +947,17 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
 
   /** @override */
   async _onDropItem(event, data) {
-    if ( !this.actor.isOwner ) return false;
+    const behavior = this._dropBehavior(event, data);
+    if ( !this.actor.isOwner || (behavior === "none") ) return false;
     const item = await Item.implementation.fromDropData(data);
 
     // Handle moving out of container & item sorting
-    if ( this.actor.uuid === item.parent?.uuid ) {
-      if ( item.system.container !== null ) await item.update({"system.container": null});
+    if ( (behavior === "move") && (this.actor.uuid === item.parent?.uuid) ) {
+      if ( item.system.container !== null ) await item.update({ "system.container": null });
       return this._onSortItem(event, item.toObject());
     }
 
-    return this._onDropItemCreate(item, event);
+    return this._onDropItemCreate(item, event, behavior);
   }
 
   /* -------------------------------------------- */
@@ -975,10 +980,11 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
    * Handle the final creation of dropped Item data on the Actor.
    * @param {Item5e[]|Item5e} itemData     The item or items requested for creation.
    * @param {DragEvent} event              The concluding DragEvent which provided the drop data.
+   * @param {DropEffectValue} behavior     The specific drop behavior.
    * @returns {Promise<Item5e[]>}
    * @protected
    */
-  async _onDropItemCreate(itemData, event) {
+  async _onDropItemCreate(itemData, event, behavior) {
     let items = itemData instanceof Array ? itemData : [itemData];
     const itemsWithoutAdvancement = items.filter(i => !i.system.advancement?.length);
     const multipleAdvancements = (items.length - itemsWithoutAdvancement.length) > 1;
@@ -998,7 +1004,9 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
         return this._onDropSingleItem(item, event);
       }
     });
-    return Item5e.createDocuments(toCreate, {pack: this.actor.pack, parent: this.actor, keepId: true});
+    const created = await Item5e.createDocuments(toCreate, { pack: this.actor.pack, parent: this.actor, keepId: true });
+    if ( behavior === "move" ) items.forEach(i => fromUuid(i.uuid).then(d => d?.delete({ deleteContents: true })));
+    return created;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -32,7 +32,7 @@ import TreasureConfig from "./config/treasure-config.mjs";
 import WeaponsConfig from "./config/weapons-config.mjs";
 
 /**
- * @typedef {import("../../drag-drop.mjs").DropEffectValue} DropEffectValue
+ * @import { DropEffectValue } from "../../drag-drop.mjs"
  */
 
 /**

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -447,6 +447,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     if ( type === "slots" ) dragData.dnd5e.id = (preparationMode === "prepared") ? `spell${level}` : preparationMode;
     else dragData.dnd5e.id = key;
     event.dataTransfer.setData("application/json", JSON.stringify(dragData));
+    event.dataTransfer.effectAllowed = "link";
   }
 
   /* -------------------------------------------- */
@@ -616,6 +617,15 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
 
   /* -------------------------------------------- */
   /*  Favorites                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _defaultDropBehavior(event, data) {
+    if ( data.dnd5e?.action === "favorite" || (["Activity", "Item"].includes(data.type)
+      && event.target.closest(".favorites")) ) return "link";
+    return super._defaultDropBehavior(event, data);
+  }
+
   /* -------------------------------------------- */
 
   /** @inheritDoc */

--- a/module/applications/actor/sheet-mixin.mjs
+++ b/module/applications/actor/sheet-mixin.mjs
@@ -1,4 +1,5 @@
 import { parseInputDelta } from "../../utils.mjs";
+import DragDropApplicationMixin from "../mixins/drag-drop-mixin.mjs";
 
 /**
  * Mixin method for common uses between all actor sheets.
@@ -6,46 +7,79 @@ import { parseInputDelta } from "../../utils.mjs";
  * @returns {class}
  * @mixin
  */
-export default Base => class extends Base {
-  /**
-   * Handle input changes to numeric form fields, allowing them to accept delta-typed inputs.
-   * @param {Event} event  Triggering event.
-   * @protected
-   */
-  _onChangeInputDelta(event) {
-    const input = event.target;
-    const target = this.actor.items.get(input.closest("[data-item-id]")?.dataset.itemId) ?? this.actor;
-    const { activityId } = input.closest("[data-activity-id]")?.dataset ?? {};
-    const activity = target?.system.activities?.get(activityId);
-    const result = parseInputDelta(input, activity ?? target);
-    if ( result !== undefined ) {
-      // Special case handling for Item uses.
-      if ( input.dataset.name === "system.uses.value" ) {
-        target.update({ "system.uses.spent": target.system.uses.max - result });
-      } else if ( activity && (input.dataset.name === "uses.value") ) {
-        target.updateActivity(activityId, { "uses.spent": activity.uses.max - result });
+export default function ActorSheetMixin(Base) {
+  return class ActorSheet extends DragDropApplicationMixin(Base) {
+
+    /**
+     * Handle input changes to numeric form fields, allowing them to accept delta-typed inputs.
+     * @param {Event} event  Triggering event.
+     * @protected
+     */
+    _onChangeInputDelta(event) {
+      const input = event.target;
+      const target = this.actor.items.get(input.closest("[data-item-id]")?.dataset.itemId) ?? this.actor;
+      const { activityId } = input.closest("[data-activity-id]")?.dataset ?? {};
+      const activity = target?.system.activities?.get(activityId);
+      const result = parseInputDelta(input, activity ?? target);
+      if ( result !== undefined ) {
+        // Special case handling for Item uses.
+        if ( input.dataset.name === "system.uses.value" ) {
+          target.update({ "system.uses.spent": target.system.uses.max - result });
+        } else if ( activity && (input.dataset.name === "uses.value") ) {
+          target.updateActivity(activityId, { "uses.spent": activity.uses.max - result });
+        }
+        else target.update({ [input.dataset.name]: result });
       }
-      else target.update({ [input.dataset.name]: result });
     }
-  }
 
-  /* -------------------------------------------- */
+    /* -------------------------------------------- */
 
-  /**
-   * Stack identical consumables when a new one is dropped rather than creating a duplicate item.
-   * @param {object} itemData                  The item data requested for creation.
-   * @param {object} [options={}]
-   * @param {string} [options.container=null]  ID of the container into which this item is being dropped.
-   * @returns {Promise<Item5e>|null}           If a duplicate was found, returns the adjusted item stack.
-   */
-  _onDropStackConsumables(itemData, { container=null }={}) {
-    const droppedSourceId = itemData._stats?.compendiumSource ?? itemData.flags.core?.sourceId;
-    if ( itemData.type !== "consumable" || !droppedSourceId ) return null;
-    const similarItem = this.actor.sourcedItems.get(droppedSourceId, { legacy: false })
-      ?.filter(i => (i.system.container === container) && (i.name === itemData.name))?.first();
-    if ( !similarItem ) return null;
-    return similarItem.update({
-      "system.quantity": similarItem.system.quantity + Math.max(itemData.system.quantity, 1)
-    });
-  }
-};
+    /**
+     * Stack identical consumables when a new one is dropped rather than creating a duplicate item.
+     * @param {object} itemData                  The item data requested for creation.
+     * @param {object} [options={}]
+     * @param {string} [options.container=null]  ID of the container into which this item is being dropped.
+     * @returns {Promise<Item5e>|null}           If a duplicate was found, returns the adjusted item stack.
+     */
+    _onDropStackConsumables(itemData, { container=null }={}) {
+      const droppedSourceId = itemData._stats?.compendiumSource ?? itemData.flags.core?.sourceId;
+      if ( itemData.type !== "consumable" || !droppedSourceId ) return null;
+      const similarItem = this.actor.sourcedItems.get(droppedSourceId, { legacy: false })
+        ?.filter(i => (i.system.container === container) && (i.name === itemData.name))?.first();
+      if ( !similarItem ) return null;
+      return similarItem.update({
+        "system.quantity": similarItem.system.quantity + Math.max(itemData.system.quantity, 1)
+      });
+    }
+
+    /* -------------------------------------------- */
+    /*  Drag & Drop                                 */
+    /* -------------------------------------------- */
+
+    /** @override */
+    _allowedDropBehaviors(event, data) {
+      if ( !data.uuid ) return new Set(["copy"]);
+      const allowed = new Set(["copy", "move"]);
+      const s = foundry.utils.parseUuid(data.uuid);
+      const t = foundry.utils.parseUuid(this.document.uuid);
+      const sCompendium = s.collection instanceof CompendiumCollection;
+      const tCompendium = t.collection instanceof CompendiumCollection;
+
+      // If either source or target are within a compendium, but not inside the same compendium, move not allowed
+      if ( (sCompendium || tCompendium) && (s.collection !== t.collection) ) allowed.delete("move");
+
+      return allowed;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    _defaultDropBehavior(event, data) {
+      if ( !data.uuid ) return "copy";
+      const d = foundry.utils.parseUuid(data.uuid);
+      const t = foundry.utils.parseUuid(this.document.uuid);
+      return (d.collection === t.collection) && (d.documentId === t.documentId) && (d.documentType === t.documentType)
+        ? "move" : "copy";
+    }
+  };
+}

--- a/module/applications/actor/sheet-mixin.mjs
+++ b/module/applications/actor/sheet-mixin.mjs
@@ -78,7 +78,7 @@ export default function ActorSheetMixin(Base) {
       if ( !data.uuid ) return "copy";
       const d = foundry.utils.parseUuid(data.uuid);
       const t = foundry.utils.parseUuid(this.document.uuid);
-      return (d.collection === t.collection) && (d.documentId === t.documentId) && (d.documentType === t.documentType)
+      return (d.collection === t.collection) && (d.primaryId === t.primaryId) && (d.primaryType === t.primaryType)
         ? "move" : "copy";
     }
   };

--- a/module/applications/actor/sheet-mixin.mjs
+++ b/module/applications/actor/sheet-mixin.mjs
@@ -78,8 +78,9 @@ export default function ActorSheetMixin(Base) {
       if ( !data.uuid ) return "copy";
       const d = foundry.utils.parseUuid(data.uuid);
       const t = foundry.utils.parseUuid(this.document.uuid);
-      return (d.collection === t.collection) && (d.primaryId === t.primaryId) && (d.primaryType === t.primaryType)
-        ? "move" : "copy";
+      const base = d.embedded?.length ? "document" : "primary";
+      return (d.collection === t.collection) && (d[`${base}Id`] === t[`${base}Id`])
+        && (d[`${base}Type`] === t[`${base}Type`]) ? "move" : "copy";
     }
   };
 }

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -153,10 +153,11 @@ export default class ContainerSheet extends ItemSheet5e {
    */
   async _onDropItem(event, data) {
     const item = await Item.implementation.fromDropData(data);
-    if ( !this.item.isOwner || !item ) return false;
+    const behavior = this._dropBehavior(event, data);
+    if ( !this.item.isOwner || !item || (behavior === "none") ) return false;
 
     // If item already exists in this container, just adjust its sorting
-    if ( item.system.container === this.item.id ) {
+    if ( (behavior === "move") && (item.system.container === this.item.id) ) {
       return this._onSortItem(event, item);
     }
 
@@ -168,8 +169,8 @@ export default class ContainerSheet extends ItemSheet5e {
     }
 
     // If item already exists in same DocumentCollection, just adjust its container property
-    if ( (item.actor === this.item.actor) && (item.pack === this.item.pack) ) {
-      return item.update({folder: this.item.folder, "system.container": this.item.id});
+    if ( (behavior === "move") && (item.actor === this.item.actor) && (item.pack === this.item.pack) ) {
+      return item.update({ folder: this.item.folder, "system.container": this.item.id });
     }
 
     // Otherwise, create a new item & contents in this context
@@ -178,7 +179,9 @@ export default class ContainerSheet extends ItemSheet5e {
       transformAll: (itemData, options) => this._onDropSingleItem(itemData, { ...options, event })
     });
     if ( this.item.folder ) toCreate.forEach(d => d.folder = this.item.folder.id);
-    return Item5e.createDocuments(toCreate, {pack: this.item.pack, parent: this.item.actor, keepId: true});
+    const created = Item5e.createDocuments(toCreate, { pack: this.item.pack, parent: this.item.actor, keepId: true });
+    if ( behavior === "move" ) item.delete({ deleteContents: true });
+    return created;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/item/item-directory.mjs
+++ b/module/applications/item/item-directory.mjs
@@ -1,22 +1,63 @@
 import Item5e from "../../documents/item.mjs";
+import DragDropApplicationMixin from "../mixins/drag-drop-mixin.mjs";
 import ItemSheet5e2 from "./item-sheet-2.mjs";
 
 /**
  * Items sidebar with added support for item containers.
  */
-export default class ItemDirectory5e extends ItemDirectory {
+export default class ItemDirectory5e extends DragDropApplicationMixin(ItemDirectory) {
+
+  /** @override */
+  _allowedDropBehaviors(event, data) {
+    const allowed = new Set(["copy"]);
+    if ( !data.uuid ) return allowed;
+    const s = foundry.utils.parseUuid(data.uuid);
+    if ( !(s.collection instanceof CompendiumCollection) ) allowed.add("move");
+    return allowed;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _defaultDropBehavior(event, data) {
+    if ( !data.uuid ) return "copy";
+    if ( data.type !== "Item" ) return "none";
+    return foundry.utils.parseUuid(data.uuid).collection === this.collection ? "move" : "copy";
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onDrop(event) {
+    const data = TextEditor.getDragEventData(event);
+    if ( !data.type ) return;
+    const target = event.target.closest(".directory-item") || null;
+
+    // Call the drop handler
+    switch ( data.type ) {
+      case "Folder":
+        return this._handleDroppedFolder(target, data);
+      case this.collection.documentName:
+        return this._handleDroppedEntry(target, data, event);
+    }
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
-  async _handleDroppedEntry(target, data) {
+  async _handleDroppedEntry(target, data, event) {
     // Obtain the dropped Document
+    const behavior = this._dropBehavior(event, data);
     let item = await this._getDroppedEntryFromData(data);
-    if ( !item ) return;
+    if ( (behavior === "none") || !item ) return;
 
     // Create item and its contents if it doesn't already exist here
-    if ( !this._entryAlreadyExists(item) ) {
+    if ( (behavior === "copy") || !this._entryAlreadyExists(item) ) {
       const toCreate = await Item5e.createWithContents([item]);
       const folder = target?.closest("[data-folder-id]")?.dataset.folderId;
       if ( folder ) toCreate.map(d => d.folder = folder);
       [item] = await Item5e.createDocuments(toCreate, {keepId: true});
+      if ( behavior === "move" ) fromUuid(data.uuid).then(d => d?.delete({ deleteContents: true }));
     }
 
     // Otherwise, if it is within a container, take it out

--- a/module/applications/mixins/drag-drop-mixin.mjs
+++ b/module/applications/mixins/drag-drop-mixin.mjs
@@ -1,3 +1,5 @@
+import { areKeysPressed } from "../../utils.mjs";
+
 /**
  * @typedef {import("../../drag-drop.mjs").DropEffectValue} DropEffectValue
  */
@@ -32,13 +34,9 @@ export default function DragDropApplicationMixin(Base) {
       let behavior = event.dataTransfer.dropEffect;
 
       if ( event.type === "dragover" ) {
-        behavior = this._defaultDropBehavior(event, data);
-
-        // An initial `dropEffect` of `copy` indicates that a modifier key is held down
-        if ( (event.type === "dragover") && (event.dataTransfer.dropEffect === "copy") ) {
-          if ( (behavior === "copy") && allowed.has("move") ) return "move";
-          else if ( (behavior === "move") && allowed.has("copy") ) return "copy";
-        }
+        if ( areKeysPressed(event, "dragMove") ) behavior = "move";
+        else if ( areKeysPressed(event, "dragCopy") ) behavior = "copy";
+        else behavior = this._defaultDropBehavior(event, data);
       }
 
       if ( (behavior !== "none") && !allowed.has(behavior) ) return allowed.first() ?? "none";

--- a/module/applications/mixins/drag-drop-mixin.mjs
+++ b/module/applications/mixins/drag-drop-mixin.mjs
@@ -1,7 +1,7 @@
 import { areKeysPressed } from "../../utils.mjs";
 
 /**
- * @typedef {import("../../drag-drop.mjs").DropEffectValue} DropEffectValue
+ * @import { DropEffectValue } from "../../drag-drop.mjs"
  */
 
 /**
@@ -28,7 +28,7 @@ export default function DragDropApplicationMixin(Base) {
      */
     _dropBehavior(event, data) {
       const allowed = this._allowedDropBehaviors(event, data);
-      let behavior = DragDrop.dropEffect ?? event.dataTransfer.dropEffect;
+      let behavior = DragDrop.dropEffect ?? event.dataTransfer?.dropEffect;
 
       if ( event.type === "dragover" ) {
         if ( areKeysPressed(event, "dragMove") ) behavior = "move";

--- a/module/applications/mixins/drag-drop-mixin.mjs
+++ b/module/applications/mixins/drag-drop-mixin.mjs
@@ -14,11 +14,8 @@ export default function DragDropApplicationMixin(Base) {
     /** @override */
     _onDragOver(event) {
       const data = DragDrop.getPayload(event);
-      if ( foundry.utils.getType(data) === "Object" ) {
-        event.dataTransfer.dropEffect = this._dropBehavior(event, data);
-      } else {
-        event.dataTransfer.dropEffect = "copy";
-      }
+      DragDrop.dropEffect = event.dataTransfer.dropEffect = (foundry.utils.getType(data) === "Object")
+        ? this._dropBehavior(event, data) : "copy";
     }
 
     /* -------------------------------------------- */
@@ -31,7 +28,7 @@ export default function DragDropApplicationMixin(Base) {
      */
     _dropBehavior(event, data) {
       const allowed = this._allowedDropBehaviors(event, data);
-      let behavior = event.dataTransfer.dropEffect;
+      let behavior = DragDrop.dropEffect ?? event.dataTransfer.dropEffect;
 
       if ( event.type === "dragover" ) {
         if ( areKeysPressed(event, "dragMove") ) behavior = "move";

--- a/module/applications/mixins/drag-drop-mixin.mjs
+++ b/module/applications/mixins/drag-drop-mixin.mjs
@@ -1,0 +1,74 @@
+/**
+ * @typedef {import("../../drag-drop.mjs").DropEffectValue} DropEffectValue
+ */
+
+/**
+ * Adds drop behavior functionality to all sheets.
+ * @param {typeof Application} Base  The base class being mixed.
+ * @returns {typeof DragDropApplication}
+ */
+export default function DragDropApplicationMixin(Base) {
+  return class DragDropApplication extends Base {
+    /** @override */
+    _onDragOver(event) {
+      const data = DragDrop.getPayload(event);
+      if ( foundry.utils.getType(data) === "Object" ) {
+        event.dataTransfer.dropEffect = this._dropBehavior(event, data);
+      } else {
+        event.dataTransfer.dropEffect = "copy";
+      }
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * The behavior for the dropped data.
+     * @param {DragEvent} event  The drag event.
+     * @param {object} data      The drag payload.
+     * @returns {DropEffectValue}
+     */
+    _dropBehavior(event, data) {
+      const allowed = this._allowedDropBehaviors(event, data);
+      let behavior = event.dataTransfer.dropEffect;
+
+      if ( event.type === "dragover" ) {
+        behavior = this._defaultDropBehavior(event, data);
+
+        // An initial `dropEffect` of `copy` indicates that a modifier key is held down
+        if ( (event.type === "dragover") && (event.dataTransfer.dropEffect === "copy") ) {
+          if ( (behavior === "copy") && allowed.has("move") ) return "move";
+          else if ( (behavior === "move") && allowed.has("copy") ) return "copy";
+        }
+      }
+
+      if ( (behavior !== "none") && !allowed.has(behavior) ) return allowed.first() ?? "none";
+      return behavior || "copy";
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Types of allowed drop behaviors based on the origin & target of a drag event.
+     * @param {DragEvent} event  The drag event.
+     * @param {object} data      The drag payload.
+     * @returns {Set<DropEffectValue>}
+     * @protected
+     */
+    _allowedDropBehaviors(event, data) {
+      return new Set();
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Determine the default drop behavior for the provided operation.
+     * @param {DragEvent} event  The drag event.
+     * @param {object} data      The drag payload.
+     * @returns {DropEffectValue}
+     * @protected
+     */
+    _defaultDropBehavior(event, data) {
+      return "copy";
+    }
+  };
+}

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -313,7 +313,7 @@ export default function DocumentSheetV2Mixin(Base) {
       if ( !data.uuid ) return "copy";
       const d = foundry.utils.parseUuid(data.uuid);
       const t = foundry.utils.parseUuid(this.document.uuid);
-      return (d.collection === t.collection) && (d.documentId === t.documentId) && (d.documentType === t.documentType)
+      return (d.collection === t.collection) && (d.primaryId === t.primaryId) && (d.primaryType === t.primaryType)
         ? "move" : "copy";
     }
 

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -278,7 +278,7 @@ export default function DocumentSheetV2Mixin(Base) {
         const content = await renderTemplate("systems/dnd5e/templates/items/parts/item-summary.hbs", context);
         summary.querySelectorAll(".item-summary").forEach(el => el.remove());
         summary.insertAdjacentHTML("beforeend", content);
-        await new Promise(resolve => { requestAnimationFrame(resolve); });
+        await new Promise(resolve => requestAnimationFrame(resolve));
         this._expanded.add(item.id);
       }
 

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -313,8 +313,9 @@ export default function DocumentSheetV2Mixin(Base) {
       if ( !data.uuid ) return "copy";
       const d = foundry.utils.parseUuid(data.uuid);
       const t = foundry.utils.parseUuid(this.document.uuid);
-      return (d.collection === t.collection) && (d.primaryId === t.primaryId) && (d.primaryType === t.primaryType)
-        ? "move" : "copy";
+      const base = d.embedded?.length ? "document" : "primary";
+      return (d.collection === t.collection) && (d[`${base}Id`] === t[`${base}Id`])
+        && (d[`${base}Type`] === t[`${base}Type`]) ? "move" : "copy";
     }
 
     /* -------------------------------------------- */

--- a/module/drag-drop.mjs
+++ b/module/drag-drop.mjs
@@ -10,6 +10,14 @@
 export default class DragDrop5e extends DragDrop {
 
   /**
+   * Drop effect used for current drag operation.
+   * @type {DropEffectValue}
+   */
+  static dropEffect = null;
+
+  /* -------------------------------------------- */
+
+  /**
    * Stored drag event payload.
    * @type {{ data: any, event: DragEvent }|null}
    */
@@ -39,7 +47,8 @@ export default class DragDrop5e extends DragDrop {
     await this.callback(event, "dragstart");
     if ( event.dataTransfer.items.length ) {
       event.stopPropagation();
-      const data = event.dataTransfer.getData("application/json") || event.dataTransfer.getData("text/plain");
+      let data = event.dataTransfer.getData("application/json") || event.dataTransfer.getData("text/plain");
+      try { data = JSON.parse(data); } catch(err) {}
       DragDrop5e.#payload = data ? { event, data } : null;
     } else {
       DragDrop5e.#payload = null;
@@ -55,6 +64,7 @@ export default class DragDrop5e extends DragDrop {
    */
   async _handleDragEnd(event) {
     await this.callback(event, "dragend");
+    DragDrop5e.dropEffect = null;
     DragDrop5e.#payload = null;
   }
 
@@ -67,10 +77,6 @@ export default class DragDrop5e extends DragDrop {
    */
   static getPayload(event) {
     if ( !DragDrop5e.#payload?.data ) return null;
-    try {
-      return JSON.parse(DragDrop5e.#payload.data);
-    } catch(err) {
-      return DragDrop5e.#payload.data;
-    }
+    return DragDrop5e.#payload.data;
   }
 }

--- a/module/drag-drop.mjs
+++ b/module/drag-drop.mjs
@@ -1,0 +1,76 @@
+/**
+ * Valid `dropEffect` value (see https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/dropEffect).
+ * @typedef {"copy"|"move"|"link"|"none"} DropEffectValue
+ */
+
+/**
+ * Extension of core's DragDrop class to provide additional information used by the system. Will replace core's
+ * version in the global namespace.
+ */
+export default class DragDrop5e extends DragDrop {
+
+  /**
+   * Stored drag event payload.
+   * @type {{ data: any, event: DragEvent }|null}
+   */
+  static #payload = null;
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  bind(html) {
+    super.bind(html);
+
+    // Add dragend event handler to the existing dragstart event
+    if ( this.can("dragstart", this.dragSelector) ) {
+      const draggables = html.querySelectorAll(this.dragSelector);
+      for ( const el of draggables ) {
+        el.ondragend = this._handleDragEnd.bind(this);
+      }
+    }
+
+    return this;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _handleDragStart(event) {
+    await this.callback(event, "dragstart");
+    if ( event.dataTransfer.items.length ) {
+      event.stopPropagation();
+      const data = event.dataTransfer.getData("application/json") || event.dataTransfer.getData("text/plain");
+      DragDrop5e.#payload = data ? { event, data } : null;
+    } else {
+      DragDrop5e.#payload = null;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle the end of a drag workflow
+   * @param {DragEvent} event   The drag event being handled
+   * @private
+   */
+  async _handleDragEnd(event) {
+    await this.callback(event, "dragend");
+    DragDrop5e.#payload = null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the data payload for the current drag event.
+   * @param {DragEvent} event
+   * @returns {object|string|null}
+   */
+  static getPayload(event) {
+    if ( !DragDrop5e.#payload?.data ) return null;
+    try {
+      return JSON.parse(DragDrop5e.#payload.data);
+    } catch(err) {
+      return DragDrop5e.#payload.data;
+    }
+  }
+}

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -21,6 +21,16 @@ export function registerSystemKeybindings() {
     name: "KEYBINDINGS.DND5E.SkipDialogDisadvantage",
     editable: [{ key: "ControlLeft" }, { key: "ControlRight" }, { key: "OsLeft" }, { key: "OsRight" }]
   });
+
+  game.keybindings.register("dnd5e", "dragCopy", {
+    name: "KEYBINDINGS.DND5E.DragCopy",
+    editable: [{ key: "ControlLeft" }, { key: "ControlRight" }, { key: "AltLeft" }, { key: "AltRight" }]
+  });
+
+  game.keybindings.register("dnd5e", "dragMove", {
+    name: "KEYBINDINGS.DND5E.DragMove",
+    editable: [{ key: "ShiftLeft" }, { key: "ShiftRight" }, { key: "OsLeft" }, { key: "OsRight" }]
+  });
 }
 
 /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -378,6 +378,18 @@ export function staticID(id) {
 /* -------------------------------------------- */
 
 /**
+ * Track which KeyboardEvent#code presses associate with each modifier.
+ * Added support for treating Meta separate from Control.
+ * @enum {string[]}
+ */
+const MODIFIER_CODES = {
+  Alt: KeyboardManager.MODIFIER_CODES.Alt,
+  Control: KeyboardManager.MODIFIER_CODES.Control.filter(k => k.startsWith("Control")),
+  Meta: KeyboardManager.MODIFIER_CODES.Control.filter(k => !k.startsWith("Control")),
+  Shift: KeyboardManager.MODIFIER_CODES.Shift
+};
+
+/**
  * Based on the provided event, determine if the keys are pressed to fulfill the specified keybinding.
  * @param {Event} event    Triggering event.
  * @param {string} action  Keybinding action within the `dnd5e` namespace.
@@ -388,11 +400,12 @@ export function areKeysPressed(event, action) {
   const activeModifiers = {};
   const addModifiers = (key, pressed) => {
     activeModifiers[key] = pressed;
-    KeyboardManager.MODIFIER_CODES[key].forEach(n => activeModifiers[n] = pressed);
+    MODIFIER_CODES[key].forEach(n => activeModifiers[n] = pressed);
   };
-  addModifiers(KeyboardManager.MODIFIER_KEYS.CONTROL, event.ctrlKey || event.metaKey);
-  addModifiers(KeyboardManager.MODIFIER_KEYS.SHIFT, event.shiftKey);
   addModifiers(KeyboardManager.MODIFIER_KEYS.ALT, event.altKey);
+  addModifiers(KeyboardManager.MODIFIER_KEYS.CONTROL, event.ctrlKey);
+  addModifiers("Meta", event.metaKey);
+  addModifiers(KeyboardManager.MODIFIER_KEYS.SHIFT, event.shiftKey);
   return game.keybindings.get("dnd5e", action).some(b => {
     if ( game.keyboard.downKeys.has(b.key) && b.modifiers.every(m => activeModifiers[m]) ) return true;
     if ( b.modifiers.length ) return false;

--- a/templates/shared/inventory2.hbs
+++ b/templates/shared/inventory2.hbs
@@ -54,7 +54,7 @@
                          style="--bar-percentage: {{ pct }}%"></div>
                     {{/with}}
                     {{/dnd5e-itemContext}}
-                    <img src="{{ img }}" alt="{{ name }}">
+                    <img src="{{ img }}" alt="{{ name }}" draggable="false">
                 </a>
             </li>
             {{/each}}


### PR DESCRIPTION
Adds the ability to use the OS-defined modifier key (usually Alt on Windows and Option on Mac) to toggle between the default drop behavior and the opposite behavior. So if dragging within the same actor this changes from the default move behaior to copy behavior and the opposite when dragging between different actors or to the sidebar.

Enabling this required access to the current drag payload during the `ondragover` event, so this extends the `DragDrop` class provided by core to store that information during the `ondragstart` event and adds a new handler for the `ondragend` event to clear the stored payload.

Currently this only covers dragging items, with some minor improvements to dragging favorites on the character sheet. This framework could be expanded in the future to support dragging actors into the bastion tab as well as dragging active effects, advancements, or activities.

Closes #4876