### PR TITLE
Add deletion dialog when multiple sources of the same status exists on the actor

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2584,6 +2584,10 @@
     "DeleteEffect": "Delete Effect",
     "DissociateEffect": "Dissociate Effect",
     "EditEffect": "Edit Effect",
+    "RemoveStatus": {
+      "all": "All Sources",
+      "label": "Source"
+    },
     "Search": "Search effects"
   },
   "Application": {
@@ -2630,9 +2634,7 @@
     "ChangeActive": "Change Active",
     "ChangeInactive": "Change Inactive",
     "DeleteDialog": {
-      "all": "All Sources",
       "hint": "You are under the effects of this condition from more than one source. Pick which effect to end.",
-      "label": "Source",
       "title": "Remove Effect"
     },
     "Inactive": "Inactive",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2630,6 +2630,7 @@
     "ChangeActive": "Change Active",
     "ChangeInactive": "Change Inactive",
     "DeleteDialog": {
+      "all": "All Sources",
       "hint": "You are under the effects of this condition from more than one source. Pick which effect to end.",
       "label": "Source",
       "title": "Remove Effect"

--- a/lang/en.json
+++ b/lang/en.json
@@ -2629,6 +2629,11 @@
   "Status": {
     "ChangeActive": "Change Active",
     "ChangeInactive": "Change Inactive",
+    "DeleteDialog": {
+      "hint": "You are under the effects of this condition from more than one source. Pick which effect to end.",
+      "label": "Source",
+      "title": "Remove Effect"
+    },
     "Inactive": "Inactive",
     "Passive": "Passive",
     "Temporary": "Temporary",

--- a/module/applications/hud/token-hud.mjs
+++ b/module/applications/hud/token-hud.mjs
@@ -15,6 +15,19 @@ export default class TokenHUD5e extends foundry.applications.hud.TokenHUD {
   /* -------------------------------------------------- */
 
   /** @inheritDoc */
+  _getStatusEffectChoices() {
+    const choices = super._getStatusEffectChoices();
+    for ( const status of Object.values(choices) ) {
+      if ( status.isActive || !this.actor?.statuses.has(status.id) ) continue;
+      status.isActive = true;
+      status.cssClass = ["active", status.cssClass].filterJoin(" ");
+    }
+    return choices;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritDoc */
   async _onRender(context, options) {
     await super._onRender(context, options);
     this.#adjustConditionIcons();
@@ -59,8 +72,9 @@ export default class TokenHUD5e extends foundry.applications.hud.TokenHUD {
 
     const id = target.dataset.statusId;
 
-    let resolved = false;
+    let resolved;
     if ( id === "concentrating" ) resolved = ActiveEffect5e._manageConcentration(event, this.actor);
+    else resolved = ActiveEffect5e._manageCondition(event, this.actor, id);
 
     if ( !resolved ) this.actor.toggleStatusEffect(id, {
       overlay: event.button === 2,

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -822,7 +822,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * Prompt the user to delete one of several conditions.
    * @param {Actor5e} actor                           The owner of the effects.
    * @param {string|Set<ActiveEffect5e>} effects      A set of effects, or the status to derive them from.
-   * @returns {Promise<ActiveEffect5e|null>}
+   * @returns {Promise<ActiveEffect5e[]|null>}
    */
   static async deleteConditionDialog(actor, effects) {
     if ( foundry.utils.getType(effects) === "string" ) {
@@ -830,23 +830,30 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     }
     if ( !effects.size ) return null;
 
-    const html = new foundry.data.fields.StringField({
+    const sources = Array.from(effects).sort((a, b) => a.name.localeCompare(b.name, game.i18n.lang));
+    const group = foundry.applications.fields.createFormGroup({
       label: game.i18n.localize("DND5E.EFFECT.Status.DeleteDialog.label"),
       hint: game.i18n.localize("DND5E.EFFECT.Status.DeleteDialog.hint"),
-      required: true,
-      choices: Object.fromEntries(Array.from(effects).map(effect => [effect.id, effect.name]))
-    }).toFormGroup({}, { name: "source", sort: true }).outerHTML;
+      input: foundry.applications.fields.createSelectInput({
+        name: "source",
+        options: [
+          { label: game.i18n.localize("DND5E.EFFECT.Status.DeleteDialog.all"), rule: true, value: "" },
+          ...sources.map(effect => ({ label: effect.name, value: effect.id }))
+        ]
+      })
+    }).outerHTML;
 
     return foundry.applications.api.DialogV2.prompt({
       rejectClose: false,
-      content: `<fieldset>${html}</fieldset>`,
+      content: `<fieldset>${group}</fieldset>`,
       window: { title: "DND5E.EFFECT.Status.DeleteDialog.title" },
       position: { width: 400 },
       ok: {
         label: "DND5E.Confirm",
-        callback: async function(event, button) {
+        callback: (event, button) => {
           const source = button.form.elements.source.value;
-          return actor.effects.get(source)?.delete();
+          const ids = source ? [source] : sources.map(effect => effect.id);
+          return actor.deleteEmbeddedDocuments("ActiveEffect", ids);
         }
       }
     });

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -1,4 +1,5 @@
 import CreateDocumentDialog from "../applications/create-document-dialog.mjs";
+import ConditionData from "../data/active-effect/condition.mjs";
 import FormulaField from "../data/fields/formula-field.mjs";
 import MappingField from "../data/fields/mapping-field.mjs";
 import { getHumanReadableAttributeLabel, parseOrString, staticID } from "../utils.mjs";
@@ -802,19 +803,17 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @param {PointerEvent} event        The triggering event.
    * @param {Actor5e} actor             The actor belonging to the token.
    * @param {string} status             The status condition.
+   * @returns {boolean}                 Whether the status was resolved via this method.
    */
   static _manageCondition(event, actor, status) {
+    if ( ConditionData.hasLevels(status) ) return false;
     const effects = new Set(actor.effects.filter(effect => effect.statuses.has(status)));
-    if ( !effects.size ) return;
-
+    if ( !effects.size ) return false;
     event.preventDefault();
     event.stopPropagation();
-
-    if ( effects.size > 1 ) {
-      ActiveEffect5e.deleteConditionDialog(actor, effects);
-    } else {
-      effects.first().delete();
-    }
+    if ( effects.size > 1 ) ActiveEffect5e.deleteConditionDialog(actor, effects);
+    else effects.first().delete();
+    return true;
   }
 
   /* -------------------------------------------- */
@@ -832,8 +831,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( !effects.size ) return null;
 
     const html = new foundry.data.fields.StringField({
-      label: game.i18n.localize("DND5E.CONDITIONS.DeleteDialog.label"),
-      hint: game.i18n.localize("DND5E.CONDITIONS.DeleteDialog.hint"),
+      label: game.i18n.localize("DND5E.EFFECT.Status.DeleteDialog.label"),
+      hint: game.i18n.localize("DND5E.EFFECT.Status.DeleteDialog.hint"),
       required: true,
       choices: Object.fromEntries(Array.from(effects).map(effect => [effect.id, effect.name]))
     }).toFormGroup({}, { name: "source", sort: true }).outerHTML;
@@ -841,13 +840,13 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     return foundry.applications.api.DialogV2.prompt({
       rejectClose: false,
       content: `<fieldset>${html}</fieldset>`,
-      window: { title: "DND5E.CONDITIONS.DeleteDialog.title" },
+      window: { title: "DND5E.EFFECT.Status.DeleteDialog.title" },
       position: { width: 400 },
       ok: {
         label: "DND5E.Confirm",
         callback: async function(event, button) {
           const source = button.form.elements.source.value;
-          return actor.effects.get(source).delete();
+          return actor.effects.get(source)?.delete();
         }
       }
     });

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -764,35 +764,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( effects.size < 1 ) return false;
     event.preventDefault();
     event.stopPropagation();
-    if ( effects.size === 1 ) {
-      actor.endConcentration(effects.first());
-      return true;
-    }
-    const choices = effects.reduce((acc, effect) => {
-      const data = effect.getFlag("dnd5e", "item");
-      acc[effect.id] = data?.name ?? actor.items.get(data?.id)?.name ?? _loc("DND5E.CONCENTRATION.NoSource");
-      return acc;
-    }, {});
-    const options = foundry.applications.handlebars.selectOptions(choices, { hash: { sort: true } });
-    const content = `
-    <p>${_loc("DND5E.CONCENTRATION.EndChoice")}</p>
-    <div class="form-group">
-      <label>${_loc("DND5E.SOURCE.FIELDS.source.label")}</label>
-      <div class="form-fields">
-        <select name="source">${options}</select>
-      </div>
-    </div>`;
-    foundry.applications.api.Dialog.prompt({
-      content,
-      window: { title: _loc("DND5E.Concentration") },
-      ok: {
-        label: _loc("DND5E.Confirm"),
-        callback: (event, button, dialog) => {
-          const source = new foundry.applications.ux.FormDataExtended(button.form).object.source;
-          if ( source ) actor.endConcentration(source);
-        }
-      }
-    });
+    if ( effects.size === 1 ) actor.endConcentration(effects.first());
+    else ActiveEffect5e.endConcentrationDialog(actor, effects);
     return true;
   }
 
@@ -829,16 +802,55 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       effects = new Set(actor.effects.filter(effect => effect.statuses.has(effects)));
     }
     if ( !effects.size ) return null;
+    const choices = Object.fromEntries(Array.from(effects).map(effect => [effect.id, effect.name]));
+    const source = await ActiveEffect5e.#promptRemoveSource({
+      choices, hint: "DND5E.EFFECT.Status.DeleteDialog.hint", title: "DND5E.EFFECT.Status.DeleteDialog.title"
+    });
+    if ( source === null ) return null;
+    return actor.deleteEmbeddedDocuments("ActiveEffect", source ? [source] : Object.keys(choices));
+  }
 
-    const sources = Array.from(effects).sort((a, b) => a.name.localeCompare(b.name, game.i18n.lang));
+  /* -------------------------------------------- */
+
+  /**
+   * Prompt the user to end concentration on one source, or all of them.
+   * @param {Actor5e} actor                       The concentrating actor.
+   * @param {Collection<ActiveEffect5e>} effects  The active concentration effects.
+   * @returns {Promise<ActiveEffect5e[]|null>}    The effects concentration was ended on, or null if dismissed.
+   */
+  static async endConcentrationDialog(actor, effects) {
+    const choices = effects.reduce((acc, effect) => {
+      const data = effect.getFlag("dnd5e", "item");
+      acc[effect.id] = data?.name ?? actor.items.get(data?.id)?.name ?? _loc("DND5E.CONCENTRATION.NoSource");
+      return acc;
+    }, {});
+    const source = await ActiveEffect5e.#promptRemoveSource({
+      choices, hint: "DND5E.CONCENTRATION.EndChoice", title: "DND5E.Concentration"
+    });
+    if ( source === null ) return null;
+    return actor.endConcentration(source || undefined);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prompt the user to pick one of several sources of an effect, or all of them.
+   * @param {object} config
+   * @param {Record<string, string>} config.choices  Mapping of option value to display label.
+   * @param {string} config.hint                     Localization key for the hint describing the choice.
+   * @param {string} config.title                    Localization key for the dialog title.
+   * @returns {Promise<string|null>}                 The selected value ("" for all sources), or null if dismissed.
+   */
+  static #promptRemoveSource({ choices, hint, title }) {
+    const sources = Object.entries(choices).sort((a, b) => a[1].localeCompare(b[1], game.i18n.lang));
     const group = foundry.applications.fields.createFormGroup({
-      label: game.i18n.localize("DND5E.EFFECT.Status.DeleteDialog.label"),
-      hint: game.i18n.localize("DND5E.EFFECT.Status.DeleteDialog.hint"),
+      label: _loc("DND5E.EFFECT.Action.RemoveStatus.label"),
+      hint: _loc(hint),
       input: foundry.applications.fields.createSelectInput({
         name: "source",
         options: [
-          { label: game.i18n.localize("DND5E.EFFECT.Status.DeleteDialog.all"), rule: true, value: "" },
-          ...sources.map(effect => ({ label: effect.name, value: effect.id }))
+          { label: _loc("DND5E.EFFECT.Action.RemoveStatus.all"), rule: true, value: "" },
+          ...sources.map(([value, label]) => ({ label, value }))
         ]
       })
     }).outerHTML;
@@ -846,15 +858,11 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     return foundry.applications.api.DialogV2.prompt({
       rejectClose: false,
       content: `<fieldset>${group}</fieldset>`,
-      window: { title: "DND5E.EFFECT.Status.DeleteDialog.title" },
+      window: { title },
       position: { width: 400 },
       ok: {
         label: "DND5E.Confirm",
-        callback: (event, button) => {
-          const source = button.form.elements.source.value;
-          const ids = source ? [source] : sources.map(effect => effect.id);
-          return actor.deleteEmbeddedDocuments("ActiveEffect", ids);
-        }
+        callback: (event, button) => button.form.elements.source.value
       }
     });
   }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -798,6 +798,64 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /* -------------------------------------------- */
 
   /**
+   * Manage custom condition handling when interacting with the token HUD.
+   * @param {PointerEvent} event        The triggering event.
+   * @param {Actor5e} actor             The actor belonging to the token.
+   * @param {string} status             The status condition.
+   */
+  static _manageCondition(event, actor, status) {
+    const effects = new Set(actor.effects.filter(effect => effect.statuses.has(status)));
+    if ( !effects.size ) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    if ( effects.size > 1 ) {
+      ActiveEffect5e.deleteConditionDialog(actor, effects);
+    } else {
+      effects.first().delete();
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prompt the user to delete one of several conditions.
+   * @param {Actor5e} actor                           The owner of the effects.
+   * @param {string|Set<ActiveEffect5e>} effects      A set of effects, or the status to derive them from.
+   * @returns {Promise<ActiveEffect5e|null>}
+   */
+  static async deleteConditionDialog(actor, effects) {
+    if ( foundry.utils.getType(effects) === "string" ) {
+      effects = new Set(actor.effects.filter(effect => effect.statuses.has(effects)));
+    }
+    if ( !effects.size ) return null;
+
+    const html = new foundry.data.fields.StringField({
+      label: game.i18n.localize("DND5E.CONDITIONS.DeleteDialog.label"),
+      hint: game.i18n.localize("DND5E.CONDITIONS.DeleteDialog.hint"),
+      required: true,
+      choices: Object.fromEntries(Array.from(effects).map(effect => [effect.id, effect.name]))
+    }).toFormGroup({}, { name: "source", sort: true }).outerHTML;
+
+    return foundry.applications.api.DialogV2.prompt({
+      rejectClose: false,
+      content: `<fieldset>${html}</fieldset>`,
+      window: { title: "DND5E.CONDITIONS.DeleteDialog.title" },
+      position: { width: 400 },
+      ok: {
+        label: "DND5E.Confirm",
+        callback: async function(event, button) {
+          const source = button.form.elements.source.value;
+          return actor.effects.get(source).delete();
+        }
+      }
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Retrieve a list of dependent effects.
    * @returns {Array<ActiveEffect5e|Item5e>}
    */


### PR DESCRIPTION
- If more than one effect exists on the actor granting a `status`, when the user clicks the condition a prompt will appear similar to concentration.
- If the actor has an active ActiveEffect with a status, the given condition is highlighted on the token HUD regardless of it being the OG condition.

This PR also fixes errors being thrown on v13 re: exhaustion on the token HUD.

TODO:
- [ ] Rework concentration deletion dialog to use this same dialog.