### PR TITLE
Allow for "spellcasting" as the chosen ability in enrichers

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4462,6 +4462,10 @@ Object.defineProperty(DND5E, "enrichmentLookup", {
       addFullKeys("abilities");
       addFullKeys("skills");
       addFullKeys("spellSchools");
+
+      _enrichmentLookup.abilities.spellcasting = {
+        label: game.i18n.localize("DND5E.Spellcasting")
+      };
     }
     return _enrichmentLookup;
   },

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -937,8 +937,8 @@ function createPassiveTag(label, dataset) {
  * @returns {string}
  */
 export function createRollLabel(config) {
-  const { label: ability, abbreviation } = CONFIG.DND5E.abilities[config.ability] ?? {};
-  const skill = CONFIG.DND5E.skills[config.skill]?.label;
+  const { label: ability, abbreviation } = CONFIG.DND5E.enrichmentLookup.abilities[config.ability] ?? {};
+  const skill = CONFIG.DND5E.enrichmentLookup.skills[config.skill]?.label;
   const toolUUID = CONFIG.DND5E.enrichmentLookup.tools[config.tool];
   const tool = toolUUID ? Trait.getBaseItem(toolUUID, { indexOnly: true })?.name : null;
   const longSuffix = config.format === "long" ? "Long" : "Short";
@@ -1114,6 +1114,7 @@ async function rollAction(event) {
       }
 
       for ( const actor of actors ) {
+        if ( ability === "spellcasting" ) options.ability = actor.system.attributes?.spellcasting;
         switch ( type ) {
           case "check":
             await actor.rollAbilityCheck(options);

--- a/module/tooltips.mjs
+++ b/module/tooltips.mjs
@@ -126,12 +126,13 @@ export default class Tooltips5e {
     const abilityConfig = CONFIG.DND5E.abilities[ability ?? skillConfig.ability];
 
     let label;
+    const abilityLabel = ability === "spellcasting" ? game.i18n.localize("DND5E.Spellcasting") : abilityConfig.label;
     if ( skillConfig ) {
-      label = game.i18n.format("DND5E.SkillPassiveSpecificHint", { skill: skillConfig.label, ability: abilityConfig.label });
+      label = game.i18n.format("DND5E.SkillPassiveSpecificHint", { skill: skillConfig.label, ability: abilityLabel });
     } else {
       // If no skill was provided, we're doing a passive ability check.
       // This isn't technically a thing in the rules, but we can support it anyway if people want to use it.
-      label = game.i18n.format("DND5E.SkillPassiveHint", { skill: abilityConfig.label });
+      label = game.i18n.format("DND5E.SkillPassiveHint", { skill: abilityLabel });
     }
 
     const party = game.settings.get("dnd5e", "primaryParty")?.actor;
@@ -143,17 +144,18 @@ export default class Tooltips5e {
     const context = { label, party: [] };
     for ( const member of party.system.members ) {
       const systemData = member.actor?.system;
+      const abi = ability === "spellcasting" ? member.actor?.system.attributes?.spellcasting : ability;
       let passive;
-      if ( skill && (!ability || (ability === skillConfig.ability)) ) {
+      if ( skill && (!abi || (abi === skillConfig.ability)) ) {
         // Default passive skill check
         passive = systemData?.skills?.[skill]?.passive;
       } else if ( skill ) {
         // Passive ability check with custom ability
-        const customSkillData = member.actor?._prepareSkill(skill, { ability });
+        const customSkillData = member.actor?._prepareSkill(skill, { ability: abi });
         passive = customSkillData.passive;
       } else {
         // Passive ability check
-        const abilityMod = systemData?.abilities?.[ability]?.mod;
+        const abilityMod = systemData?.abilities?.[abi]?.mod;
         if ( abilityMod !== undefined ) passive = 10 + abilityMod;
       }
 


### PR DESCRIPTION
We had a use case for a lot of "make a saving throw with your spellcasting ability" in adventures.

![image](https://github.com/user-attachments/assets/b3df85bf-7aad-461d-b3fd-543595048fe1)
