### PR TITLE
[#4787] More informative roll dialog titles

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2814,7 +2814,7 @@
 "DND5E.SkillSlt": "Sleight of Hand",
 "DND5E.SkillSte": "Stealth",
 "DND5E.SkillSur": "Survival",
-"DND5E.SkillPromptTitle": "{skill} Skill Check",
+"DND5E.SkillPromptTitle": "{ability} ({skill}) Check",
 "DND5E.SkillConfigureTitle": "Configure {skill}",
 "DND5E.SkillConfigure": "Configure Skill",
 "DND5E.SkillsConfig": "Configure Skills",

--- a/module/applications/dice/skill-tool-configuration-dialog.mjs
+++ b/module/applications/dice/skill-tool-configuration-dialog.mjs
@@ -37,14 +37,13 @@ export default class SkillToolRollConfigurationDialog extends D20RollConfigurati
   /** @inheritDoc */
   _onChangeForm(formConfig, event) {
     super._onChangeForm(formConfig, event);
-    if ( this.config.skill && event.target?.name === "ability" ) {
+    if ( this.config.skill && (event.target?.name === "ability") ) {
       const skillLabel = CONFIG.DND5E.skills[this.config.skill]?.label ?? "";
       const ability = event.target.value ?? this.config.ability;
       const abilityLabel = CONFIG.DND5E.abilities[ability]?.label ?? "";
-      foundry.utils.setProperty(this.message, "data.flavor", game.i18n.format("DND5E.SkillPromptTitle", { skill: skillLabel, ability: abilityLabel }));
-      this._updateFrame({
-        window: { title: this.message.data.flavor }
-      });
+      const flavor = game.i18n.format("DND5E.SkillPromptTitle", { skill: skillLabel, ability: abilityLabel });
+      foundry.utils.setProperty(this.message, "data.flavor", flavor);
+      this._updateFrame({ window: { title: flavor } });
     }
   }
 }

--- a/module/applications/dice/skill-tool-configuration-dialog.mjs
+++ b/module/applications/dice/skill-tool-configuration-dialog.mjs
@@ -29,4 +29,22 @@ export default class SkillToolRollConfigurationDialog extends D20RollConfigurati
     });
     return context;
   }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onChangeForm(formConfig, event) {
+    super._onChangeForm(formConfig, event);
+    if ( this.config.skill && event.target?.name === "ability" ) {
+      const skillLabel = CONFIG.DND5E.skills[this.config.skill]?.label ?? "";
+      const ability = event.target.value ?? this.config.ability;
+      const abilityLabel = CONFIG.DND5E.abilities[ability]?.label ?? "";
+      foundry.utils.setProperty(this.message, "data.flavor", game.i18n.format("DND5E.SkillPromptTitle", { skill: skillLabel, ability: abilityLabel }));
+      this._updateFrame({
+        window: { title: this.message.data.flavor }
+      });
+    }
+  }
 }

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -152,8 +152,8 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
           left: window.innerWidth - 710
         },
         window: {
-          title: `${this.item.name} - ${game.i18n.localize("DND5E.AttackRoll")}`,
-          subtitle: "DND5E.RollConfiguration.Title",
+          title: game.i18n.localize("DND5E.AttackRoll"),
+          subtitle: this.item.name,
           icon: this.item.img
         }
       }

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -150,6 +150,11 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
         position: {
           top: config.event ? config.event.clientY - 80 : null,
           left: window.innerWidth - 710
+        },
+        window: {
+          title: `${this.item.name} - ${game.i18n.localize("DND5E.AttackRoll")}`,
+          subtitle: "DND5E.RollConfiguration.Title",
+          icon: this.item.img
         }
       }
     }, dialog);

--- a/module/documents/activity/heal.mjs
+++ b/module/documents/activity/heal.mjs
@@ -36,7 +36,7 @@ export default class HealActivity extends ActivityMixin(HealActivityData) {
 
   /** @override */
   get damageFlavor() {
-    return game.i18n.localize("DND5E.Healing");
+    return game.i18n.localize("DND5E.HealingRoll");
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1039,7 +1039,6 @@ export default function ActivityMixin(Base) {
       rollConfig.hookNames = [...(config.hookNames ?? []), "damage"];
       rollConfig.subject = this;
 
-      const titleFlavor = game.i18n.localize(`DND5E.${this.type === "heal" ? "Healing" : "Damage"}Roll`);
       const dialogConfig = foundry.utils.mergeObject({
         options: {
           position: {
@@ -1048,8 +1047,8 @@ export default function ActivityMixin(Base) {
             left: window.innerWidth - 710
           },
           window: {
-            title: `${this.item.name} - ${titleFlavor}`,
-            subtitle: "DND5E.RollConfiguration.Title",
+            title: game.i18n.localize(`DND5E.${this.type === "heal" ? "Healing" : "Damage"}Roll`),
+            subtitle: this.item.name,
             icon: this.item.img
           }
         }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1047,7 +1047,7 @@ export default function ActivityMixin(Base) {
             left: window.innerWidth - 710
           },
           window: {
-            title: game.i18n.localize(`DND5E.${this.type === "heal" ? "Healing" : "Damage"}Roll`),
+            title: this.damageFlavor,
             subtitle: this.item.name,
             icon: this.item.img
           }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1039,12 +1039,18 @@ export default function ActivityMixin(Base) {
       rollConfig.hookNames = [...(config.hookNames ?? []), "damage"];
       rollConfig.subject = this;
 
+      const titleFlavor = game.i18n.localize(`DND5E.${this.type === "heal" ? "Healing" : "Damage"}Roll`);
       const dialogConfig = foundry.utils.mergeObject({
         options: {
           position: {
             width: 400,
             top: config.event ? config.event.clientY - 80 : null,
             left: window.innerWidth - 710
+          },
+          window: {
+            title: `${this.item.name} - ${titleFlavor}`,
+            subtitle: "DND5E.RollConfiguration.Title",
+            icon: this.item.img
           }
         }
       }, dialog);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1348,10 +1348,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   async rollSkill(config={}, dialog={}, message={}) {
     const skillLabel = CONFIG.DND5E.skills[config.skill]?.label ?? "";
+    const ability = this.system.skills[config.skill]?.ability ?? CONFIG.DND5E.skills[config.skill]?.ability ?? "";
+    const abilityLabel = CONFIG.DND5E.abilities[ability]?.label ?? "";
     const dialogConfig = foundry.utils.mergeObject({
       options: {
         window: {
-          title: game.i18n.format("DND5E.SkillPromptTitle", { skill: skillLabel }),
+          title: game.i18n.format("DND5E.SkillPromptTitle", { skill: skillLabel, ability: abilityLabel }),
           subtitle: this.name
         }
       }
@@ -1458,6 +1460,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       }
     }, dialog);
 
+    const abilityLabel = CONFIG.DND5E.abilities[relevant?.ability ?? skillConfig?.ability ?? ""]?.label;
+
     const messageConfig = foundry.utils.mergeObject({
       create: true,
       data: {
@@ -1470,7 +1474,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
             }
           }
         },
-        flavor: type === "skill" ? game.i18n.format("DND5E.SkillPromptTitle", { skill: skillConfig.label })
+        flavor: type === "skill" ? game.i18n.format("DND5E.SkillPromptTitle", { skill: skillConfig.label, ability: abilityLabel })
           : game.i18n.format("DND5E.ToolPromptTitle", { tool: Trait.keyLabel(config.tool, { trait: "tool" }) ?? "" }),
         speaker: ChatMessage.getSpeaker({ actor: this })
       }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1347,7 +1347,16 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<D20Roll[]|null>}                          A Promise which resolves to the created Roll instance.
    */
   async rollSkill(config={}, dialog={}, message={}) {
-    return this.#rollSkillTool("skill", config, dialog, message);
+    const skillLabel = CONFIG.DND5E.skills[config.skill]?.label ?? "";
+    const dialogConfig = foundry.utils.mergeObject({
+      options: {
+        window: {
+          title: `${game.i18n.format("DND5E.SkillPromptTitle", { skill: skillLabel })}: ${this.name}`,
+          subtitle: "DND5E.RollConfiguration.Title"
+        }
+      }
+    }, dialog);
+    return this.#rollSkillTool("skill", config, dialogConfig, message);
   }
 
   /* -------------------------------------------- */
@@ -1360,7 +1369,16 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<D20Roll[]|null>}                          A Promise which resolves to the created Roll instance.
    */
   async rollToolCheck(config={}, dialog={}, message={}) {
-    return this.#rollSkillTool("tool", config, dialog, message);
+    const toolLabel = Trait.keyLabel(config.tool, { trait: "tool" }) ?? "";
+    const dialogConfig = foundry.utils.mergeObject({
+      options: {
+        window: {
+          title: `${game.i18n.format("DND5E.ToolPromptTitle", { tool: toolLabel })}: ${this.name}`,
+          subtitle: "DND5E.RollConfiguration.Title"
+        }
+      }
+    }, dialog);
+    return this.#rollSkillTool("tool", config, dialogConfig, message);
   }
 
   /* -------------------------------------------- */
@@ -1584,7 +1602,16 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<D20Roll[]|null>}                        A Promise which resolves to the created Roll instance.
    */
   async rollAbilityCheck(config={}, dialog={}, message={}) {
-    return this.#rollD20Test("check", config, dialog, message);
+    const abilityLabel = CONFIG.DND5E.abilities[config.ability]?.label ?? "";
+    const dialogConfig = foundry.utils.mergeObject({
+      options: {
+        window: {
+          title: `${game.i18n.format("DND5E.AbilityPromptTitle", { ability: abilityLabel })}: ${this.name}`,
+          subtitle: "DND5E.RollConfiguration.Title"
+        }
+      }
+    }, dialog);
+    return this.#rollD20Test("check", config, dialogConfig, message);
   }
 
   /**
@@ -1612,7 +1639,16 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<D20Roll[]|null>}                        A Promise which resolves to the created Roll instances.
    */
   async rollSavingThrow(config={}, dialog={}, message={}) {
-    return this.#rollD20Test("save", config, dialog, message);
+    const abilityLabel = CONFIG.DND5E.abilities[config.ability]?.label ?? "";
+    const dialogConfig = foundry.utils.mergeObject({
+      options: {
+        window: {
+          title: `${game.i18n.format("DND5E.SavePromptTitle", { ability: abilityLabel })}: ${this.name}`,
+          subtitle: "DND5E.RollConfiguration.Title"
+        }
+      }
+    }, dialog);
+    return this.#rollD20Test("save", config, dialogConfig, message);
   }
 
   /**

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1639,7 +1639,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<D20Roll[]|null>}                        A Promise which resolves to the created Roll instances.
    */
   async rollSavingThrow(config={}, dialog={}, message={}) {
-    const abilityLabel = config.isConcentration ? game.i18n.localize("DND5E.Concentration") : CONFIG.DND5E.abilities[config.ability]?.label ?? "";
+    const abilityLabel = CONFIG.DND5E.abilities[config.ability]?.label ?? "";
     const dialogConfig = foundry.utils.mergeObject({
       options: {
         window: {
@@ -2011,7 +2011,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     rollConfig.hookNames = [...(config.hookNames ?? []), "concentration"];
     rollConfig.rolls = [{ parts, data, options }].concat(config.rolls ?? []);
 
-    const dialogConfig = foundry.utils.deepClone(dialog);
+    const dialogConfig = foundry.utils.mergeObject({
+      options: {
+        window: {
+          title: game.i18n.format("DND5E.SavePromptTitle", { ability: game.i18n.localize("DND5E.Concentration") })
+        }
+      }
+    }, dialog);
 
     const messageConfig = foundry.utils.deepClone(message);
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1474,7 +1474,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
             }
           }
         },
-        flavor: type === "skill" ? game.i18n.format("DND5E.SkillPromptTitle", { skill: skillConfig.label, ability: abilityLabel })
+        flavor: type === "skill"
+          ? game.i18n.format("DND5E.SkillPromptTitle", { skill: skillConfig.label, ability: abilityLabel })
           : game.i18n.format("DND5E.ToolPromptTitle", { tool: Trait.keyLabel(config.tool, { trait: "tool" }) ?? "" }),
         speaker: ChatMessage.getSpeaker({ actor: this })
       }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1639,7 +1639,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<D20Roll[]|null>}                        A Promise which resolves to the created Roll instances.
    */
   async rollSavingThrow(config={}, dialog={}, message={}) {
-    const abilityLabel = CONFIG.DND5E.abilities[config.ability]?.label ?? "";
+    const abilityLabel = config.isConcentration ? game.i18n.localize("DND5E.Concentration") : CONFIG.DND5E.abilities[config.ability]?.label ?? "";
     const dialogConfig = foundry.utils.mergeObject({
       options: {
         window: {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1351,8 +1351,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const dialogConfig = foundry.utils.mergeObject({
       options: {
         window: {
-          title: `${game.i18n.format("DND5E.SkillPromptTitle", { skill: skillLabel })}: ${this.name}`,
-          subtitle: "DND5E.RollConfiguration.Title"
+          title: game.i18n.format("DND5E.SkillPromptTitle", { skill: skillLabel }),
+          subtitle: this.name
         }
       }
     }, dialog);
@@ -1373,8 +1373,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const dialogConfig = foundry.utils.mergeObject({
       options: {
         window: {
-          title: `${game.i18n.format("DND5E.ToolPromptTitle", { tool: toolLabel })}: ${this.name}`,
-          subtitle: "DND5E.RollConfiguration.Title"
+          title: game.i18n.format("DND5E.ToolPromptTitle", { tool: toolLabel }),
+          subtitle: this.name
         }
       }
     }, dialog);
@@ -1606,8 +1606,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const dialogConfig = foundry.utils.mergeObject({
       options: {
         window: {
-          title: `${game.i18n.format("DND5E.AbilityPromptTitle", { ability: abilityLabel })}: ${this.name}`,
-          subtitle: "DND5E.RollConfiguration.Title"
+          title: game.i18n.format("DND5E.AbilityPromptTitle", { ability: abilityLabel }),
+          subtitle: this.name
         }
       }
     }, dialog);
@@ -1643,8 +1643,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const dialogConfig = foundry.utils.mergeObject({
       options: {
         window: {
-          title: `${game.i18n.format("DND5E.SavePromptTitle", { ability: abilityLabel })}: ${this.name}`,
-          subtitle: "DND5E.RollConfiguration.Title"
+          title: game.i18n.format("DND5E.SavePromptTitle", { ability: abilityLabel }),
+          subtitle: this.name
         }
       }
     }, dialog);

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -307,7 +307,11 @@ export default class ChatMessage5e extends ChatMessage {
     if ( this.isContentVisible && item && roll ) {
       const isCritical = (roll.type === "damage") && this.rolls[0]?.isCritical;
       const subtitle = roll.type === "damage"
-        ? isCritical ? game.i18n.localize("DND5E.CriticalHit") : game.i18n.localize("DND5E.DamageRoll")
+        ? isCritical
+          ? game.i18n.localize("DND5E.CriticalHit") 
+          : activity.type === "heal"
+            ? game.i18n.localize("DND5E.HealingRoll")
+            : game.i18n.localize("DND5E.DamageRoll")
         : roll.type === "attack"
           ? (activity?.getActionLabel(roll.attackMode) ?? "")
           : (item.system.type?.label ?? game.i18n.localize(CONFIG.Item.typeLabels[item.type]));

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -309,9 +309,7 @@ export default class ChatMessage5e extends ChatMessage {
       const subtitle = roll.type === "damage"
         ? isCritical
           ? game.i18n.localize("DND5E.CriticalHit") 
-          : activity.type === "heal"
-            ? game.i18n.localize("DND5E.HealingRoll")
-            : game.i18n.localize("DND5E.DamageRoll")
+          : activity?.damageFlavor ?? game.i18n.localize("DND5E.DamageRoll")
         : roll.type === "attack"
           ? (activity?.getActionLabel(roll.attackMode) ?? "")
           : (item.system.type?.label ?? game.i18n.localize(CONFIG.Item.typeLabels[item.type]));


### PR DESCRIPTION
Closes #4787 
Also added a check when putting the subtitle for an activity use in a chat card whether the activity was a heal-type, if so display "Healing Roll" instead of "Damage Roll."
Attack Roll:
![image](https://github.com/user-attachments/assets/164978c7-fc9b-48f1-ac32-b963df0637a2)
Damage Roll:
![image](https://github.com/user-attachments/assets/dea83df0-20ae-4c24-bcdc-5cfebbf6e47c)
Skill Check:
![image](https://github.com/user-attachments/assets/d2e25dfa-fa00-4651-b4bc-e481278aad87)
Ability Check: 
![image](https://github.com/user-attachments/assets/8fb24a10-c002-489a-aebe-bae9500ffacf)
Saving Throw:
![image](https://github.com/user-attachments/assets/37c21e17-cc7c-4073-a6d1-8017652a1745)
Tool Check:
![image](https://github.com/user-attachments/assets/43b49afb-5ee9-447d-a05d-5302a321ed7c)
Fixed subtitle for a heal activity:
![image](https://github.com/user-attachments/assets/30c73076-80f1-46d4-89bb-412e7843d080)

Haven't tested much with super long item/actor names. Might make sense to put them as subtitles instead of titles. 