### PR TITLE
Extend rider conditions to generic effects

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -565,6 +565,8 @@ Hooks.on("getItemDirectoryEntryContext", documents.Item5e.addDirectoryContextOpt
 
 Hooks.on("renderJournalPageSheet", applications.journal.JournalSheet5e.onRenderJournalPageSheet);
 
+Hooks.on("renderActiveEffectConfig", documents.ActiveEffect5e.onRenderActiveEffectConfig);
+
 Hooks.on("targetToken", canvas.Token5e.onTargetToken);
 
 Hooks.on("renderCombatTracker", (app, html, data) => app.renderGroups(html instanceof HTMLElement ? html : html[0]));

--- a/lang/en.json
+++ b/lang/en.json
@@ -201,6 +201,7 @@
 "DND5E.ACTIVEEFFECT": {
   "FIELDS": {
     "statuses": {
+      "label": "Status Conditions",
       "hint": "While affected by this Active Effect, the target will be treated as having these additional status conditions."
     }
   }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1229,6 +1229,12 @@
 "DND5E.ConCharmed": "Charmed",
 "DND5E.ConDeafened": "Deafened",
 "DND5E.ConDiseased": "Diseased",
+"DND5E.CONDITIONS": {
+  "RiderConditions": {
+    "label": "Additional Effects",
+    "hint": "Configure additional conditions that will be applied when this effect is created on an actor."
+  }
+},
 "DND5E.ConExhaustion": "Exhaustion",
 "DND5E.ConFrightened": "Frightened",
 "DND5E.ConGrappled": "Grappled",

--- a/lang/en.json
+++ b/lang/en.json
@@ -198,6 +198,14 @@
   }
 },
 
+"DND5E.ACTIVEEFFECT": {
+  "FIELDS": {
+    "statuses": {
+      "hint": "While affected by this Active Effect, the target will be treated as having these additional status conditions."
+    }
+  }
+},
+
 "DND5E.ACTIVITY": {
   "Action": {
     "Create": "Create Activity",
@@ -1231,8 +1239,8 @@
 "DND5E.ConDiseased": "Diseased",
 "DND5E.CONDITIONS": {
   "RiderConditions": {
-    "label": "Additional Effects",
-    "hint": "Configure additional conditions that will be applied when this effect is created on an actor."
+    "label": "Separate Status Conditions",
+    "hint": "When this Active Effect is applied, these additional status conditions will be applied separately."
   }
 },
 "DND5E.ConExhaustion": "Exhaustion",

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -40,6 +40,11 @@ export default class ActiveEffect5e extends ActiveEffect {
 
   /* -------------------------------------------- */
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [...super.LOCALIZATION_PREFIXES, "DND5E.ACTIVEEFFECT"];
+
+  /* -------------------------------------------- */
+
   /**
    * Is this effect an enchantment on an item that accepts enchantment?
    * @type {boolean}
@@ -644,6 +649,10 @@ export default class ActiveEffect5e extends ActiveEffect {
       options: CONFIG.statusEffects.map(se => ({ value: se.id, label: se.name }))
     }).outerHTML;
     html.querySelector("[data-tab=details] > .form-group:last-child").insertAdjacentHTML("afterend", element);
+
+    html.querySelector(".form-fields:has([name=statuses])").insertAdjacentHTML("afterend", `
+      <p class="hint">${app.document.schema.fields.statuses.hint}</p>`);
+    if ( game.release.generation < 13 ) app.setPosition();
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -639,8 +639,7 @@ export default class ActiveEffect5e extends ActiveEffect {
   static onRenderActiveEffectConfig(app, html) {
     // TODO: rebase once #4805 is merged.
     if ( game.release.generation < 13 ) html = html[0];
-    const element = new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {
-    }).toFormGroup({
+    const element = new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {}).toFormGroup({
       label: game.i18n.localize("DND5E.CONDITIONS.RiderConditions.label"),
       hint: game.i18n.localize("DND5E.CONDITIONS.RiderConditions.hint")
     }, {
@@ -650,9 +649,12 @@ export default class ActiveEffect5e extends ActiveEffect {
     }).outerHTML;
     html.querySelector("[data-tab=details] > .form-group:last-child").insertAdjacentHTML("afterend", element);
 
-    html.querySelector(".form-fields:has([name=statuses])").insertAdjacentHTML("afterend", `
-      <p class="hint">${app.document.schema.fields.statuses.hint}</p>`);
-    if ( game.release.generation < 13 ) app.setPosition();
+    if ( game.release.generation < 13 ) {
+      html.querySelector(".form-fields:has([name=statuses])").insertAdjacentHTML("afterend", `
+        <p class="hint">${app.document.schema.fields.statuses.hint}</p>
+      `);
+      app.setPosition();
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -337,23 +337,31 @@ export default class ActiveEffect5e extends ActiveEffect {
 
   /**
    * Create conditions that are applied separately from an effect.
-   * @returns {Promise<ActiveEffect5e[]|void>}      Created rider effects.
+   * @returns {Promise<ActiveEffect5e[]>}      Created rider effects.
    */
   async createRiderConditions() {
-    const riders = new Set(this.statuses.reduce((acc, status) => {
+    const riders = new Set();
+
+    for ( const status of this.getFlag("dnd5e", "riders.statuses") ?? [] ) {
+      riders.add(status);
+    }
+
+    for ( const status of this.statuses ) {
       const r = CONFIG.statusEffects.find(e => e.id === status)?.riders ?? [];
-      return acc.concat(r);
-    }, []));
-    if ( !riders.size ) return;
+      for ( const p of r ) riders.add(p);
+    }
+
+    if ( !riders.size ) return [];
 
     const createRider = async id => {
       const existing = this.parent.effects.get(staticID(`dnd5e${id}`));
       if ( existing ) return;
-      const effect = await ActiveEffect.implementation.fromStatusEffect(id);
-      return ActiveEffect.implementation.create(effect, { parent: this.parent, keepId: true });
+      const effect = await ActiveEffect5e.fromStatusEffect(id);
+      return effect.toObject();
     };
 
-    return Promise.all(Array.from(riders).map(createRider));
+    const effectData = await Promise.all(Array.from(riders).map(createRider));
+    return ActiveEffect5e.createDocuments(effectData.filter(_ => _), { keepId: true, parent: this.parent });
   }
 
   /* -------------------------------------------- */
@@ -614,6 +622,28 @@ export default class ActiveEffect5e extends ActiveEffect {
     Hooks.on("renderTokenHUD", this.onTokenHUDRender);
     document.addEventListener("click", this.onClickTokenHUD.bind(this), { capture: true });
     document.addEventListener("contextmenu", this.onClickTokenHUD.bind(this), { capture: true });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add modifications to the core ActiveEffect config.
+   * @param {ActiveEffectConfig} app   The ActiveEffect config.
+   * @param {jQuery|HTMLElement} html  The ActiveEffect config element.
+   */
+  static onRenderActiveEffectConfig(app, html) {
+    // TODO: rebase once #4805 is merged.
+    if ( game.release.generation < 13 ) html = html[0];
+    const element = new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {
+    }).toFormGroup({
+      label: game.i18n.localize("DND5E.CONDITIONS.RiderConditions.label"),
+      hint: game.i18n.localize("DND5E.CONDITIONS.RiderConditions.hint")
+    }, {
+      name: "flags.dnd5e.riders.statuses",
+      value: app.document.getFlag("dnd5e", "riders.statuses") ?? [],
+      options: CONFIG.statusEffects.map(se => ({ value: se.id, label: se.name }))
+    }).outerHTML;
+    html.querySelector("[data-tab=details] > .form-group:last-child").insertAdjacentHTML("afterend", element);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
When an effect granted to a target by some monster feature means that you also suffer from a given condition (eg "while slimed, you are also considered Poisoned"), that effect should simply have the given status. This use case is covered well enough and improved slightly by #4881.

The other case is being affected by a generic condition *in addition* - eg "you are slimed, and also knocked prone," where the two effects/conditions are independent; they are applied at the same time but can be removed at different times. This PR helps with that specific use case.

![image](https://github.com/user-attachments/assets/3128162a-4cd9-4130-a751-cb22dc88b057)
