### PR TITLE
Adds a new "Resist" button beneath saving throws that have been

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2373,7 +2373,7 @@
 
 "DND5E.LegendaryResistance": {
   "Action": {
-    "Resist": "Resist"
+    "Resist": "Legendary Resistance"
   },
   "Label": "Legendary Resistance",
   "Max": "Maximum Legendary Resistances",
@@ -2384,7 +2384,7 @@
     "other": "{n}th Legendary Resistance"
   },
   "Remaining": "Remaining Legendary Resistances",
-  "Resisted": "Resisted"
+  "Resisted": "Used Legendary Resistance"
 },
 
 "DND5E.Level": "Level",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2358,21 +2358,35 @@
 "DND5E.LanguagesTerran": "Terran",
 "DND5E.LanguagesThievesCant": "Thieves' Cant",
 "DND5E.LanguagesUndercommon": "Undercommon",
-"DND5E.LegAct": "Legendary Actions",
-"DND5E.LegActN.one": "1st Legendary Action",
-"DND5E.LegActN.two": "2nd Legendary Action",
-"DND5E.LegActN.few": "3rd Legendary Action",
-"DND5E.LegActN.other": "{n}th Legendary Action",
-"DND5E.LegActMax": "Maximum Legendary Actions",
-"DND5E.LegActRemaining": "Remaining Legendary Actions",
-"DND5E.LegendaryActionLabel": "Legendary Action",
-"DND5E.LegRes": "Legendary Resistance",
-"DND5E.LegResN.one": "1st Legendary Resistance",
-"DND5E.LegResN.two": "2nd Legendary Resistance",
-"DND5E.LegResN.few": "3rd Legendary Resistance",
-"DND5E.LegResN.other": "{n}th Legendary Resistance",
-"DND5E.LegResMax": "Maximum Legendary Resistances",
-"DND5E.LegResRemaining": "Remaining Legendary Resistances",
+
+"DND5E.LegendaryAction": {
+  "Label": "Legendary Action",
+  "Max": "Maximum Legendary Actions",
+  "Ordinal": {
+    "one": "{n}st Legendary Action",
+    "two": "{n}nd Legendary Action",
+    "few": "{n}rd Legendary Action",
+    "other": "{n}th Legendary Action"
+  },
+  "Remaining": "Remaining Legendary Actions"
+},
+
+"DND5E.LegendaryResistance": {
+  "Action": {
+    "Resist": "Resist"
+  },
+  "Label": "Legendary Resistance",
+  "Max": "Maximum Legendary Resistances",
+  "Ordinal": {
+    "one": "{n}st Legendary Resistance",
+    "two": "{n}nd Legendary Resistance",
+    "few": "{n}rd Legendary Resistance",
+    "other": "{n}th Legendary Resistance"
+  },
+  "Remaining": "Remaining Legendary Resistances",
+  "Resisted": "Resisted"
+},
+
 "DND5E.Level": "Level",
 "DND5E.LevelPl": "Levels",
 "DND5E.LevelActionDecrease": "Level Down",
@@ -2605,7 +2619,8 @@
     "Maximum": "Maximum Roll",
     "Minimum": "Minimum Roll"
   },
-  "Section": "{label} Rolls"
+  "Section": "{label} Rolls",
+  "Status": "Status"
 },
 
 "DND5E.Roll": "Roll",

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -446,6 +446,10 @@
   }
 }
 
+.dice-roll + .chat-card {
+  margin-block-start: .375rem;
+}
+
 .chat-sidebar:not([data-gm-user]) .card-header[data-concealed] {
   .summary { cursor: inherit; }
   .fa-chevron-down, .details { display: none; }

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -249,7 +249,7 @@ export default class ActivityUsageDialog extends Dialog5e {
       context.fields.push({
         field: new BooleanField({
           label: game.i18n.format("DND5E.CONSUMPTION.Type.Action.Prompt", {
-            type: game.i18n.localize("DND5E.LegAct")
+            type: game.i18n.localize("DND5E.LegendaryAction.Label")
           }),
           hint: game.i18n.format("DND5E.CONSUMPTION.Type.Action.PromptHint", {
             available: game.i18n.format(

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -118,14 +118,14 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     ["legact", "legres"].forEach(res => {
       const { max, value } = resources[res];
       context[res] = Array.fromRange(max, 1).map(n => {
-        const i18n = res === "legact" ? "LegAct" : "LegRes";
+        const i18n = res === "legact" ? "LegendaryAction" : "LegendaryResistance";
         const filled = value >= n;
         const classes = ["pip"];
         if ( filled ) classes.push("filled");
         return {
           n, filled,
-          tooltip: `DND5E.${i18n}`,
-          label: game.i18n.format(`DND5E.${i18n}N.${plurals.select(n)}`, { n }),
+          tooltip: `DND5E.${i18n}.Label`,
+          label: game.i18n.format(`DND5E.${i18n}.Ordinal.${plurals.select(n)}`, { n }),
           classes: classes.join(" ")
         };
       });

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -420,7 +420,7 @@ export default class NPCData extends CreatureTemplate {
   /* -------------------------------------------- */
 
   /**
-   * Spent a legendary resistance to change a failed saving throw into a success.
+   * Spend a legendary resistance to change a failed saving throw into a success.
    * @param {ChatMessage5e} message  The chat message containing the failed save.
    */
   async resistSave(message) {

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -127,20 +127,22 @@ export default class NPCData extends CreatureTemplate {
       resources: new SchemaField({
         legact: new SchemaField({
           value: new NumberField({
-            required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.LegActRemaining"
+            required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.LegendaryAction.Remaining"
           }),
           max: new NumberField({
-            required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.LegActMax"
+            required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.LegendaryAction.Max"
           })
-        }, {label: "DND5E.LegAct"}),
+        }, {label: "DND5E.LegendaryAction.Label"}),
         legres: new SchemaField({
           value: new NumberField({
-            required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.LegResRemaining"
+            required: true, nullable: false, integer: true, min: 0, initial: 0,
+            label: "DND5E.LegendaryResistance.Remaining"
           }),
           max: new NumberField({
-            required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.LegResMax"
+            required: true, nullable: false, integer: true, min: 0, initial: 0,
+            label: "DND5E.LegendaryResistance.Max"
           })
-        }, {label: "DND5E.LegRes"}),
+        }, {label: "DND5E.LegendaryResistance.Label"}),
         lair: new SchemaField({
           value: new BooleanField({required: true, label: "DND5E.LairAct"}),
           initiative: new NumberField({
@@ -413,6 +415,20 @@ export default class NPCData extends CreatureTemplate {
     if ( this.resources.legact.max && (periods.has("encounter") || periods.has("turnEnd")) ) {
       updates.actor["system.resources.legact.value"] = this.resources.legact.max;
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Spent a legendary resistance to change a failed saving throw into a success.
+   * @param {ChatMessage5e} message  The chat message containing the failed save.
+   */
+  async resistSave(message) {
+    if ( this.resources.legres.value === 0 ) throw new Error("No legendary resistances remaining.");
+    if ( message.flags.dnd5e?.roll?.type !== "save" ) throw new Error("Chat message must contain a save roll.");
+    if ( message.flags.dnd5e?.roll?.forceSuccess ) throw new Error("Save has already been resisted.");
+    await this.parent.update({ "system.resources.legres.value": this.resources.legres.value - 1 });
+    await message.setFlag("dnd5e", "roll.forceSuccess", true);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -741,7 +741,7 @@ export default function ActivityMixin(Base) {
           else if ( count > legendary.value ) message = "DND5E.ACTIVATION.Warning.NotEnoughActions";
           if ( message ) {
             const err = new ConsumptionError(game.i18n.format(message, {
-              type: game.i18n.localize("DND5E.LegAct"),
+              type: game.i18n.localize("DND5E.LegendaryAction.Label"),
               required: formatNumber(count),
               available: formatNumber(legendary.value)
             }));

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -619,7 +619,7 @@ export default class ChatMessage5e extends ChatMessage {
     `);
 
     // Otherwise if actor has legendary resistances remaining, display resist button
-    else if ( (actor.system.resources.legres.value > 0) && actor.isOwner ) {
+    else if ( actor.system.resources.legres.value && actor.isOwner ) {
       content.insertAdjacentHTML("beforeend", `
         <div class="card-buttons">
           <button type="button">

--- a/templates/actors/npc-sheet-2.hbs
+++ b/templates/actors/npc-sheet-2.hbs
@@ -315,11 +315,11 @@
                 <div class="legendary">
                     {{#if editable}}
                     <label class="legact">
-                        <span class="label roboto-upper">{{ localize "DND5E.LegAct" }}</span>
+                        <span class="label roboto-upper">{{ localize "DND5E.LegendaryAction.Label" }}</span>
                         {{ numberInput source.resources.legact.max name="system.resources.legact.max" step=1 min=0 }}
                     </label>
                     <label class="legres">
-                        <span class="label roboto-upper">{{ localize "DND5E.LegRes" }}</span>
+                        <span class="label roboto-upper">{{ localize "DND5E.LegendaryResistance.Label" }}</span>
                         {{ numberInput source.resources.legres.max name="system.resources.legres.max" step=1 min=0 }}
                     </label>
                     <label class="lair">
@@ -330,7 +330,7 @@
                     {{else}}
                     {{#if system.resources.legact.max}}
                     <div class="legact">
-                        <span class="label roboto-upper">{{ localize "DND5E.LegAct" }}</span>
+                        <span class="label roboto-upper">{{ localize "DND5E.LegendaryAction.Label" }}</span>
                         <div class="pips" data-prop="system.resources.legact.value">
                             {{#each legact}}
                                 {{> pip }}
@@ -340,7 +340,7 @@
                     {{/if}}
                     {{#if system.resources.legres.max}}
                     <div class="legres">
-                        <span class="label roboto-upper">{{ localize "DND5E.LegRes" }}</span>
+                        <span class="label roboto-upper">{{ localize "DND5E.LegendaryResistance.Label" }}</span>
                         <div class="pips" data-prop="system.resources.legres.value">
                             {{#each legres}}
                                 {{> pip }}

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -187,22 +187,22 @@
                 {{!-- Legendary Actions --}}
                 <div class="counters">
                     <div class="counter flexrow legendary">
-                        <h4>{{ localize "DND5E.LegAct" }}</h4>
+                        <h4>{{ localize "DND5E.LegendaryAction.Label" }}</h4>
                         <div class="counter-value">
                             <input name="system.resources.legact.value" type="text" step="any"
                                    value="{{system.resources.legact.value}}" placeholder="0"
-                                   data-tooltip="DND5E.LegActRemaining" data-dtype="Number">
+                                   data-tooltip="DND5E.LegendaryAction.Remaining" data-dtype="Number">
                             <span class="sep">/</span>
                             {{numberInput system.resources.legact.max name="system.resources.legact.max" min=0 step=1
                                           placeholder=0}}
                         </div>
                     </div>
                     <div class="counter flexrow legendary">
-                        <h4>{{ localize "DND5E.LegRes" }}</h4>
+                        <h4>{{ localize "DND5E.LegendaryResistance.Label" }}</h4>
                         <div class="counter-value">
                             <input name="system.resources.legres.value" type="text" step="any"
                                    value="{{system.resources.legres.value}}" placeholder="0"
-                                   data-tooltip="DND5E.LegResRemaining" data-dtype="Number">
+                                   data-tooltip="DND5E.LegendaryResistance.Remaining" data-dtype="Number">
                             <span class="sep">/</span>
                             {{numberInput system.resources.legres.max name="system.resources.legres.max" min=0 step=1
                                           placeholder=0}}


### PR DESCRIPTION
failed by an NPC so long as that NPC has remaining legendary resistances. If a save has been resisted, it is displayed as a successful roll and an indicator is displayed beneath.

<img width="316" alt="Legendary Resist" src="https://github.com/user-attachments/assets/63b9b49c-b036-4a16-9f9d-bbda636e68af" />

Closes #4863