### PR TITLE
[#4215] Ensure exhaustion speed reduction matches movement units

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3388,7 +3388,9 @@ DND5E.consumableResources = [
  *                                 but acts as a status effect?
  * @property {number} [levels]     The number of levels of exhaustion an actor can obtain.
  * @property {{ rolls: number, speed: number }} [reduction]  Amount D20 Tests & Speed are reduced per exhaustion level
- *                                                           when using the modern rules.
+ *                                                           when using the modern rules. Speed reduction is measured
+ *                                                           in the default imperial units and converted to metric
+ *                                                           if necessary.
  */
 
 /**

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -3,7 +3,7 @@ import MovementField from "../../shared/movement-field.mjs";
 import SensesField from "../../shared/senses-field.mjs";
 import ActiveEffect5e from "../../../documents/active-effect.mjs";
 import RollConfigField from "../../shared/roll-config-field.mjs";
-import { convertWeight, simplifyBonus } from "../../../utils.mjs";
+import { convertLength, convertWeight, simplifyBonus } from "../../../utils.mjs";
 
 const { NumberField, SchemaField, StringField } = foundry.data.fields;
 
@@ -267,8 +267,9 @@ export default class AttributesFields {
     const exceedingCarryingCapacity = statuses.has("exceedingCarryingCapacity");
     const crawl = this.parent.hasConditionEffect("crawl");
     const units = this.attributes.movement.units;
-    const reduction = game.settings.get("dnd5e", "rulesVersion") === "modern"
+    let reduction = game.settings.get("dnd5e", "rulesVersion") === "modern"
       ? this.attributes.exhaustion * (CONFIG.DND5E.conditionTypes.exhaustion?.reduction?.speed ?? 0) : 0;
+    reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, units);
     for ( const type in CONFIG.DND5E.movementTypes ) {
       let speed = Math.max(0, this.attributes.movement[type] - reduction);
       if ( noMovement || (crawl && (type !== "walk")) ) speed = 0;

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -502,20 +502,53 @@ export function getSceneTargets() {
 /* -------------------------------------------- */
 
 /**
+ * Convert the provided length to another unit.
+ * @param {number} value                   The length being converted.
+ * @param {string} from                    The initial units.
+ * @param {string} to                      The final units.
+ * @param {object} [options={}]
+ * @param {boolean} [options.strict=true]  Throw an error if either unit isn't found.
+ * @returns {number}
+ */
+export function convertLength(value, from, to, { strict=true }={}) {
+  const message = unit => `Length unit ${unit} not defined in CONFIG.DND5E.movementUnits`;
+  return _convertSystemUnits(value, from, to, CONFIG.DND5E.movementUnits, { message, strict });
+}
+
+/* -------------------------------------------- */
+
+/**
  * Convert the provided weight to another unit.
- * @param {number} value  The weight being converted.
- * @param {string} from   The initial units.
- * @param {string} to     The final units.
+ * @param {number} value                   The weight being converted.
+ * @param {string} from                    The initial units.
+ * @param {string} to                      The final units.
+ * @param {object} [options={}]
+ * @param {boolean} [options.strict=true]  Throw an error if either unit isn't found.
  * @returns {number}      Weight in the specified units.
  */
-export function convertWeight(value, from, to) {
-  if ( from === to ) return value;
+export function convertWeight(value, from, to, { strict=true }={}) {
   const message = unit => `Weight unit ${unit} not defined in CONFIG.DND5E.weightUnits`;
-  if ( !CONFIG.DND5E.weightUnits[from] ) throw new Error(message(from));
-  if ( !CONFIG.DND5E.weightUnits[to] ) throw new Error(message(to));
-  return value
-    * CONFIG.DND5E.weightUnits[from].conversion
-    / CONFIG.DND5E.weightUnits[to].conversion;
+  return _convertSystemUnits(value, from, to, CONFIG.DND5E.weightUnits, { message, strict });
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Convert from one unit to another using one of core's built-in unit types.
+ * @param {number} value                                Value to display.
+ * @param {string} from                                 The initial unit.
+ * @param {string} to                                   The final unit.
+ * @param {UnitConfiguration} config                    Configuration data for the unit.
+ * @param {object} options
+ * @param {function(string): string} [options.message]  Method used to produce the error message if unit not found.
+ * @param {boolean} [options.strict]                    Throw an error if either unit isn't found.
+ * @returns {string}
+ */
+function _convertSystemUnits(value, from, to, config, { message, strict }) {
+  if ( from === to ) return value;
+  if ( strict && !config[from] ) throw new Error(errorMessage(from));
+  if ( strict && !config[to] ) throw new Error(errorMessage(to));
+  return value * (config[from].conversion ?? 1) / (config[to].conversion ?? 1);
 }
 
 /* -------------------------------------------- */


### PR DESCRIPTION
When applying exhaustion speed reduction to an actor, this ensures that the reduction matches the units defined on the actor. This uses a new `convertLength` method for converting the value defined in config from the default imperial units (e.g. `ft`) into whatever units are used for the actor.

Closes #4215