### PR TITLE
[#3667] Add grouping to initiative tracker

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -561,6 +561,8 @@ Hooks.on("renderJournalPageSheet", applications.journal.JournalSheet5e.onRenderJ
 
 Hooks.on("targetToken", canvas.Token5e.onTargetToken);
 
+Hooks.on("renderCombatTracker", (app, html, data) => app.renderGroups(html instanceof HTMLElement ? html : html[0]));
+
 Hooks.on("preCreateScene", (doc, createData, options, userId) => {
   // Set default grid units based on metric length setting
   const units = utils.defaultUnits("length");

--- a/lang/en.json
+++ b/lang/en.json
@@ -1071,6 +1071,21 @@
 "DND5E.ClassOriginal": "Original Class",
 "DND5E.ClassSaves": "Saving Throws",
 "DND5E.Confirm": "Confirm",
+
+"DND5E.COMBAT": {
+  "Group": {
+    "ActiveCount": "{current} of {combatants}",
+    "Title": "{name} Group"
+  }
+},
+
+"DND5E.COMBATANT": {
+  "Counted": {
+    "one": "{number} combatant",
+    "other": "{number} combatants"
+  }
+},
+
 "DND5E.CompendiumBrowser": {
   "Title": "Compendium Browser",
   "Action": {

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1708,6 +1708,28 @@ dialog.dnd5e2.application {
 }
 
 /* ---------------------------------- */
+/*  Combat Tracker                    */
+/* ---------------------------------- */
+
+.combat-sidebar {
+  .combatant-group {
+    .fa-chevron-down { transition: transform 250ms ease; }
+    &.collapsed .fa-chevron-down { transform: rotate(-90deg); }
+
+    &.active::after { transition: border-color 250ms ease; }
+    &.active:not(.collapsed)::after { border-color: color-mix(in oklab, var(--color-border-highlight), transparent); }
+
+    .group-header { cursor: pointer; }
+    .group-numbers {
+      flex: 0 0 20px;
+      color: var(--color-text-light-5);
+      font-size: var(--font-size-12);
+      line-height: 20px;
+    }
+  }
+}
+
+/* ---------------------------------- */
 /*  Context Menus                     */
 /* ---------------------------------- */
 

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -231,20 +231,6 @@
     }
   }
 
-  .collapsible {
-    &.collapsed {
-      .fa-caret-down { transform: rotate(-90deg); }
-      .collapsible-content { grid-template-rows: 0fr; }
-    }
-    .fa-caret-down { transition: transform 250ms ease; }
-    .collapsible-content {
-      display: grid;
-      grid-template-rows: 1fr;
-      transition: grid-template-rows 250ms ease;
-      > .wrapper { overflow: hidden; }
-    }
-  }
-
   .unlist {
     list-style: none;
     padding: 0;
@@ -1708,6 +1694,24 @@ dialog.dnd5e2.application {
 }
 
 /* ---------------------------------- */
+/*  Collapsible Content               */
+/* ---------------------------------- */
+
+.dnd5e2 .collapsible, .collapsible.dnd5e2-collapsible {
+  &.collapsed {
+    .fa-caret-down { transform: rotate(-90deg); }
+    .collapsible-content { grid-template-rows: 0fr; }
+  }
+  .fa-caret-down { transition: transform 250ms ease; }
+  .collapsible-content {
+    display: grid;
+    grid-template-rows: 1fr;
+    transition: grid-template-rows 250ms ease;
+    > .wrapper { overflow: hidden; }
+  }
+}
+
+/* ---------------------------------- */
 /*  Combat Tracker                    */
 /* ---------------------------------- */
 
@@ -1716,7 +1720,7 @@ dialog.dnd5e2.application {
     .fa-chevron-down { transition: transform 250ms ease; }
     &.collapsed .fa-chevron-down { transform: rotate(-90deg); }
 
-    &.active::after { transition: border-color 250ms ease; }
+    &.active::after, &.active::before { transition: border-color 250ms ease; }
     &.active:not(.collapsed)::after { border-color: color-mix(in oklab, var(--color-border-highlight), transparent); }
 
     .group-header { cursor: pointer; }
@@ -1726,6 +1730,15 @@ dialog.dnd5e2.application {
       font-size: var(--font-size-12);
       line-height: 20px;
     }
+  }
+
+  /* V13 Syles */
+  .combat-tracker {
+    .combatant-group {
+      display: block;
+      &.active:not(.collapsed)::before { border-color: color-mix(in oklab, var(--color-warm-2), transparent); }
+    }
+    .group-children { padding: 0; }
   }
 }
 

--- a/module/applications/combat/combat-tracker.mjs
+++ b/module/applications/combat/combat-tracker.mjs
@@ -58,7 +58,7 @@ export default class CombatTracker5e extends CombatTracker {
       if ( !children.length ) continue;
       const groupContainer = document.createElement("li");
       groupContainer.classList.add("combatant", "combatant-group", "collapsible", "dnd5e2-collapsible");
-      if ( !V13 ) groupContainer.classlist.add("directory-item");
+      if ( !V13 ) groupContainer.classList.add("directory-item");
       if ( !expanded ) groupContainer.classList.add("collapsed");
 
       // Determine the count
@@ -82,9 +82,7 @@ export default class CombatTracker5e extends CombatTracker {
         <div class="group-header flexrow">
           <img class="token-image" alt="${img.alt}" src="${img.src || img.dataset.src}">
           <div class="token-name flexcol">
-            <${V13 ? "strong" : "h4"} class="name">
-              ${game.i18n.format("DND5E.COMBAT.Group.Title", { name })}
-            </${V13 ? "strong" : "h4"}>
+            <${V13 ? "strong" : "h4"} class="name"></${V13 ? "strong" : "h4"}>
             <div class="group-numbers">${count}</div>
           </div>
           <div class="token-initiative">
@@ -98,6 +96,7 @@ export default class CombatTracker5e extends CombatTracker {
         </div>
       `;
       groupContainer.dataset.groupKey = key;
+      groupContainer.querySelector(".name").innerText = game.i18n.format("DND5E.COMBAT.Group.Title", { name });
       children[0].before(groupContainer);
       groupContainer.querySelector(".group-children").replaceChildren(...children);
       groupContainer.addEventListener("click", event => {

--- a/module/applications/combat/combat-tracker.mjs
+++ b/module/applications/combat/combat-tracker.mjs
@@ -1,10 +1,18 @@
-import { formatNumber } from "../../utils.mjs";
+import ContextMenu5e from "../context-menu.mjs";
+import { formatNumber, getPluralRules } from "../../utils.mjs";
+
+/**
+ * @typedef {object} CombatGroupData
+ * @property {boolean} expanded
+ */
 
 /**
  * An extension of the base CombatTracker class to provide some 5e-specific functionality.
  * @extends {CombatTracker}
  */
 export default class CombatTracker5e extends CombatTracker {
+
+  /** @inheritDoc */
   async getData(options={}) {
     const context = await super.getData(options);
     context.turns.forEach(turn => {
@@ -22,5 +30,81 @@ export default class CombatTracker5e extends CombatTracker {
     const combatant = this.viewed.combatants.get(combatantId);
     if ( (btn.dataset.control === "rollInitiative") && combatant?.actor ) return combatant.actor.rollInitiativeDialog();
     return super._onCombatantControl(event);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  _contextMenu(html) {
+    if ( !(html instanceof HTMLElement) ) html = html[0];
+    new ContextMenu5e(
+      html.querySelector(".directory-list"), ".directory-item:not(.combatant-group)", this._getEntryContextOptions()
+    );
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Adjust initiative tracker to group combatants.
+   * @param {HTMLElement} html  The combat tracker being rendered.
+   */
+  renderGroups(html) {
+    if ( !this.viewed ) return;
+    const groups = this.viewed.createGroups();
+    const list = html.querySelector(".directory-list");
+    list.classList.add("dnd5e2");
+    for ( const [key, { combatants, expanded }] of groups.entries() ) {
+      const children = list.querySelectorAll(Array.from(combatants).map(c => `[data-combatant-id="${c.id}"]`).join(", "));
+      if ( !children.length ) continue;
+      const groupContainer = document.createElement("li");
+      groupContainer.classList.add("combatant", "combatant-group", "directory-item", "collapsible");
+      if ( !expanded ) groupContainer.classList.add("collapsed");
+
+      // Determine the count
+      let activeEntry;
+      for ( const [index, element] of children.entries() ) {
+        if ( element.classList.contains("active") ) activeEntry = index;
+      }
+      let count = game.i18n.format(`DND5E.COMBATANT.Counted.${getPluralRules().select(children.length)}`, {
+        number: formatNumber(children.length)
+      });
+      if ( activeEntry !== undefined ) {
+        groupContainer.classList.add("active");
+        count = game.i18n.format("DND5E.COMBAT.Group.ActiveCount", {
+          combatants: count, current: formatNumber(activeEntry + 1)
+        });
+      }
+
+      const name = combatants[0].token.baseActor.prototypeToken.name;
+      const img = children[0].querySelector("img");
+      groupContainer.innerHTML = `
+        <div class="group-header flexrow">
+          <img class="token-image" alt="${img.alt}" src="${img.src || img.dataset.src}">
+          <div class="token-name flexcol">
+            <h4>
+              ${game.i18n.format("DND5E.COMBAT.Group.Title", { name })}
+            </h4>
+            <div class="group-numbers">${count}</div>
+          </div>
+          <div class="token-initiative">
+            <i class="fa-solid fa-chevron-down fa-fw" inert></i>
+          </div>
+        </div>
+        <div class="collapsible-content">
+          <div class="wrapper">
+            <ol class="group-children directory-list"></ol>
+          </div>
+        </div>
+      `;
+      groupContainer.dataset.groupKey = key;
+      children[0].before(groupContainer);
+      groupContainer.querySelector(".group-children").replaceChildren(...children);
+      groupContainer.addEventListener("click", event => {
+        if ( event.target.closest(".collapsible-content") ) return;
+        if ( groupContainer.classList.contains("collapsed") ) this.viewed.expandedGroups.add(key);
+        else this.viewed.expandedGroups.delete(key);
+        groupContainer.classList.toggle("collapsed");
+      });
+    }
   }
 }

--- a/module/applications/combat/combat-tracker.mjs
+++ b/module/applications/combat/combat-tracker.mjs
@@ -51,13 +51,14 @@ export default class CombatTracker5e extends CombatTracker {
   renderGroups(html) {
     if ( !this.viewed ) return;
     const groups = this.viewed.createGroups();
-    const list = html.querySelector(".directory-list");
-    list.classList.add("dnd5e2");
+    const V13 = game.release.generation >= 13;
+    const list = html.querySelector(".directory-list, .combat-tracker");
     for ( const [key, { combatants, expanded }] of groups.entries() ) {
       const children = list.querySelectorAll(Array.from(combatants).map(c => `[data-combatant-id="${c.id}"]`).join(", "));
       if ( !children.length ) continue;
       const groupContainer = document.createElement("li");
-      groupContainer.classList.add("combatant", "combatant-group", "directory-item", "collapsible");
+      groupContainer.classList.add("combatant", "combatant-group", "collapsible", "dnd5e2-collapsible");
+      if ( !V13 ) groupContainer.classlist.add("directory-item");
       if ( !expanded ) groupContainer.classList.add("collapsed");
 
       // Determine the count
@@ -81,9 +82,9 @@ export default class CombatTracker5e extends CombatTracker {
         <div class="group-header flexrow">
           <img class="token-image" alt="${img.alt}" src="${img.src || img.dataset.src}">
           <div class="token-name flexcol">
-            <h4>
+            <${V13 ? "strong" : "h4"} class="name">
               ${game.i18n.format("DND5E.COMBAT.Group.Title", { name })}
-            </h4>
+            </${V13 ? "strong" : "h4"}>
             <div class="group-numbers">${count}</div>
           </div>
           <div class="token-initiative">
@@ -92,7 +93,7 @@ export default class CombatTracker5e extends CombatTracker {
         </div>
         <div class="collapsible-content">
           <div class="wrapper">
-            <ol class="group-children directory-list"></ol>
+            <ol class="group-children ${V13 ? "" : "directory-list"}"></ol>
           </div>
         </div>
       `;

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -3,6 +3,20 @@
  */
 export default class Combat5e extends Combat {
 
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Expansion state for groups within this combat.
+   * @type {Set<string>}
+   */
+  expandedGroups = new Set();
+
+  /* -------------------------------------------- */
+  /*  Methods                                     */
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   async startCombat() {
     await super.startCombat();
@@ -26,6 +40,23 @@ export default class Combat5e extends Combat {
     await super.rollInitiative(ids, options);
     for ( const id of ids ) await this._recoverUses({ initiative: this.combatants.get(id) });
     return this;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _sortCombatants(a, b) {
+    // Initiative takes top priority
+    if ( a.initiative !== b.initiative ) return super._sortCombatants(a, b);
+
+    // Separate out combatants with different base actors
+    if ( !a.token?.baseActor || !b.token?.baseActor || (a.token?.baseActor !== b.token?.baseActor) ) {
+      const name = c => `${c.token?.baseActor?.name ?? ""}.${c.token?.baseActor?.id ?? ""}`;
+      return name(a).localeCompare(name(b), game.i18n.lang);
+    }
+
+    // Otherwise sort based on combatant name
+    return a.name.localeCompare(b.name, game.i18n.lang);
   }
 
   /* -------------------------------------------- */
@@ -67,6 +98,28 @@ export default class Combat5e extends Combat {
 
   /* -------------------------------------------- */
   /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Determine which group each combatant should be added to, or if a new group should be created.
+   * @returns {Map<string, { combatants: Combatant5e[], expanded: boolean }>}
+   */
+  createGroups() {
+    const groups = new Map();
+    for ( const combatant of this.combatants ) {
+      const key = combatant.getGroupingKey();
+      if ( key === null ) continue;
+      if ( !groups.has(key) ) groups.set(key, { combatants: [], expanded: this.expandedGroups.has(key) });
+      groups.get(key).combatants.push(combatant);
+    }
+
+    for ( const [key, { combatants }] of groups.entries() ) {
+      if ( combatants.length <= 1 ) groups.delete(key);
+    }
+
+    return groups;
+  }
+
   /* -------------------------------------------- */
 
   /**

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -61,6 +61,17 @@ export default class Combatant5e extends Combatant {
 
   /* -------------------------------------------- */
 
+  /**
+   * Key for the group to which this combatant should belong, or `null` if it can't be grouped.
+   * @returns {boolean|null}
+   */
+  getGroupingKey() {
+    if ( !this.token?.baseActor || (this.initiative === null) ) return null;
+    return `${Math.floor(this.initiative).paddedString(4)}:${this.token.baseActor.id}`;
+  }
+
+  /* -------------------------------------------- */
+
   /** @override */
   getInitiativeRoll(formula) {
     if ( !this.actor ) return new CONFIG.Dice.D20Roll(formula ?? "1d20", {});

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -66,8 +66,8 @@ export default class Combatant5e extends Combatant {
    * @returns {boolean|null}
    */
   getGroupingKey() {
-    if ( !this.token?.baseActor || (this.initiative === null) ) return null;
-    return `${Math.floor(this.initiative).paddedString(4)}:${this.token.baseActor.id}`;
+    if ( this.token?.actorLink || !this.token?.baseActor || (this.initiative === null) ) return null;
+    return `${Math.floor(this.initiative).paddedString(4)}:${this.token.disposition}:${this.token.baseActor.id}`;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Adds automatic grouping to the initiative tracker. This will group any combatants with the same initiative and the same base actor into a group.

<img width="308" alt="Combat Groups - Collapsed" src="https://github.com/user-attachments/assets/5ff4c72b-0e3d-4590-9952-7e1c9bd52882" />
<img width="310" alt="Combat Groups - Expanded" src="https://github.com/user-attachments/assets/9fe72e1a-e41e-479c-ab46-3459d31b0c39" />

Groups are displayed as collapsible sections in the combat tracker that use the name from the base actor's prototype token. It lists the number of combatants in the group, and when one of the group members is active it displays how far through the group that actor is.

Currently only offers the one grouping mode, but could be expanded in the future to support different grouping such as splitting it into "friendly" and "hostile" groups.

Also works in V13:

<img width="307" alt="Screenshot 2024-12-20 at 12 26 37" src="https://github.com/user-attachments/assets/86ddbfa7-5904-4e54-a749-295deb4c4bba" />

Closes #3667