### PR TITLE
Allow natural weapons to make ranged attacks without "thrown"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -547,6 +547,7 @@
     "Label": "Attack Mode",
     "Offhand": "Offhand",
     "OneHanded": "One-Handed",
+    "Ranged": "Ranged",
     "Thrown": "Thrown",
     "ThrownOffhand": "Offhand Throw",
     "TwoHanded": "Two-Handed"

--- a/module/applications/activity/attack-sheet.mjs
+++ b/module/applications/activity/attack-sheet.mjs
@@ -77,10 +77,12 @@ export default class AttackSheet extends ActivitySheet {
 
     context.attackTypeOptions = Object.entries(CONFIG.DND5E.attackTypes)
       .map(([value, config]) => ({ value, label: config.label }));
-    if ( this.item.system.attackType ) context.attackTypeOptions.unshift({
+    if ( this.item.system.validAttackTypes?.size ) context.attackTypeOptions.unshift({
       value: "",
       label: game.i18n.format("DND5E.DefaultSpecific", {
-        default: CONFIG.DND5E.attackTypes[this.item.system.attackType].label.toLowerCase()
+        default: game.i18n.getListFormatter({ type: "disjunction" }).format(
+          Array.from(this.item.system.validAttackTypes).map(t => CONFIG.DND5E.attackTypes[t].label.toLowerCase())
+        )
       })
     });
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2833,6 +2833,9 @@ DND5E.attackModes = Object.seal({
   offhand: {
     label: "DND5E.ATTACK.Mode.Offhand"
   },
+  ranged: {
+    label: "DND5E.ATTACK.Mode.Ranged"
+  },
   thrown: {
     label: "DND5E.ATTACK.Mode.Thrown"
   },

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -649,6 +649,19 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Retrieve the action type reflecting changes based on the provided attack mode.
+   * @param {string} [attackMode=""]
+   * @returns {string}
+   */
+  getActionType(attackMode="") {
+    let actionType = this.actionType;
+    if ( (actionType === "mwak") && (attackMode?.startsWith("thrown") || (attackMode === "ranged")) ) return "rwak";
+    return actionType;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Get the roll parts used to create the damage rolls.
    * @param {Partial<DamageRollProcessConfiguration>} [config={}]
    * @returns {DamageRollProcessConfiguration}
@@ -683,8 +696,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     const data = { ...rollData };
 
     if ( index === 0 ) {
-      let actionType = this.actionType;
-      if ( (actionType === "mwak") && rollConfig.attackMode?.startsWith("thrown") ) actionType = "rwak";
+      const actionType = this.getActionType(rollConfig.attackMode);
       const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.bonuses.${actionType}.damage`);
       if ( bonus && (parseInt(bonus) !== 0) ) parts.push(bonus);
     }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -175,7 +175,8 @@ export default class WeaponData extends ItemDataModel.mixin(
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migrateReach(source) {
-    if ( !source.properties || !source.range?.value || !source.type?.value || source.range?.reach ) return;
+    if ( !source.properties || !source.range?.value || !source.type?.value
+      || (source.range?.reach !== undefined) ) return;
     if ( (CONFIG.DND5E.weaponTypeMap[source.type.value] !== "melee") || source.properties.includes("thr") ) return;
     // Range of `0` or greater than `10` is always included, and so is range longer than `5` without reach property
     if ( (source.range.value === 0) || (source.range.value > 10)
@@ -351,6 +352,11 @@ export default class WeaponData extends ItemDataModel.mixin(
       });
     }
 
+    else if ( !this.attackType && this.range.value ) {
+      if ( modes.length ) modes.push({ rule: true });
+      modes.push({ value: "ranged", label: CONFIG.DND5E.attackModes.ranged.label });
+    }
+
     return modes;
   }
 
@@ -508,6 +514,21 @@ export default class WeaponData extends ItemDataModel.mixin(
     const improvised = (this.type.value === "improv") && !!actor.getFlag("dnd5e", "tavernBrawlerFeat");
     const isProficient = natural || improvised || actorProfs.has(itemProf) || actorProfs.has(this.type.baseItem);
     return Number(isProficient);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Attack types that can be used with this item by default.
+   * @type {Set<string>}
+   */
+  get validAttackTypes() {
+    const types = new Set();
+    const attackType = this.attackType;
+    if ( (attackType === "melee") || (attackType === null) ) types.add("melee");
+    if ( (attackType === "ranged") || this.properties.has("thr")
+      || ((attackType === null) && this.range.value) ) types.add("ranged");
+    return types;
   }
 
   /* -------------------------------------------- */

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -188,7 +188,7 @@ async function enrichAttack(config, label, options) {
   config.type = "attack";
   if ( label ) return createRollLink(label, config);
 
-  let displayFormula = simplifyRollFormula(config.formula);
+  let displayFormula = simplifyRollFormula(config.formula) || "+0";
   if ( !displayFormula.startsWith("+") && !displayFormula.startsWith("-") ) displayFormula = `+${displayFormula}`;
 
   const span = document.createElement("span");


### PR DESCRIPTION
Reworks how activities fetch their list of available attack types so they can display "Default (melee or ranged)" in the attack activity dialog if relevant (such as thrown melee weapons).

Adjust how that list of valid attack types is generated to that natural weapons can have ranged attacks so long as they have a range value. To ensure modifiers are properly supported this adds a new attack mode of "Ranged" for natural weapons that don't have the thrown property.

Fixes a bug with extra melee critical damage dice being applied even when the weapon is thrown.

Also fixes a bug causing the "reach" migration to be applied when switching weapon modes.