### PR TITLE
Display activity uses on spells tab for spells from Cast activity

### DIFF
--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -428,6 +428,12 @@ export default function ActorSheetV2Mixin(Base) {
       ctx.activities = item.system.activities
         ?.filter(a => !item.getFlag("dnd5e", "riders.activity")?.includes(a.id))
         ?.map(this._prepareActivity.bind(this));
+
+      // Linked Uses
+      const cachedFor = fromUuidSync(item.flags.dnd5e?.cachedFor, { relative: this.actor, strict: false });
+      if ( cachedFor ) ctx.linkedUses = cachedFor.consumption?.targets.find(t => t.type === "activityUses")
+        ? cachedFor.uses : cachedFor.consumption?.targets.find(t => t.type === "itemUses")
+          ? cachedFor.item.system.uses : null;
     }
 
     /* -------------------------------------------- */

--- a/templates/actors/tabs/creature-spells.hbs
+++ b/templates/actors/tabs/creature-spells.hbs
@@ -216,12 +216,17 @@
                         </div>
 
                         {{!-- Spell Uses --}}
-                        <div class="item-detail item-uses spell-uses {{#unless ctx.hasUses}}empty{{/unless}}">
+                        <div class="item-detail item-uses spell-uses
+                             {{#unless (or ctx.hasUses ctx.linkedUses)}}empty{{/unless}}">
                             {{#if ctx.hasUses}}
                             <input type="text" value="{{ item.system.uses.value }}" placeholder="0" data-dtype="Number"
                                    data-name="system.uses.value" inputmode="numeric" pattern="[+=\-]?\d*">
                             <span class="separator">&sol;</span>
                             <span class="max">{{ item.system.uses.max }}</span>
+                            {{else if ctx.linkedUses}}
+                            <span class="value">{{ ctx.linkedUses.value }}</span>
+                            <span class="separator">&sol;</span>
+                            <span class="max">{{ ctx.linkedUses.max }}</span>
                             {{/if}}
                         </div>
 


### PR DESCRIPTION
Displays the number of remaining uses/total uses on the spells tab for spells derived from the Cast activity. It will display activity uses first if activity consumption is set, and then it will display item uses if item consumption is set.