### PR TITLE
Replace formula data when applying effects or enchantments

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2682,6 +2682,10 @@
           "priority": {
             "label": "Priority"
           },
+          "replacement": {
+            "label": "Replacement",
+            "hint": "Configure whether roll data properties in the Value are replaced prior to application, and using whose data."
+          },
           "type": {
             "label": "Type"
           },
@@ -2719,6 +2723,11 @@
   },
   "Label": "Available Effects",
   "New": "New Effect",
+  "Replacement": {
+    "NoChange": "No Change",
+    "Origin": "Origin",
+    "Target": "Target"
+  },
   "RIDER": {
     "Activity": "Enchantment Rider Activity",
     "Effect": "Enchantment Rider Effect",

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -311,6 +311,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     const originActor = this.chatMessage.getAssociatedActor();
     const concentration = originActor?.effects.get(this.chatMessage.system.concentration);
     const item = this.chatMessage.getAssociatedItem();
+    const activity = this.chatMessage.getAssociatedActivity({ scaled: true });
     const origin = concentration ?? (effect.inCompendium && item ? item : effect);
     if ( !game.user.isGM && !actor.isOwner ) {
       throw new Error(_loc("DND5E.EFFECT.Application.Warning.Ownership"));
@@ -330,7 +331,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     // its own.
     let durationOverride = {};
     if ( !Number.isFinite(effect.duration.value) && effect.expirySupportsDuration() ) {
-      const effectDuration = this.chatMessage.getAssociatedActivity({ scaled: true })?.duration.getEffectData();
+      const effectDuration = activity?.duration.getEffectData();
       if ( !foundry.utils.isEmpty(effectDuration) ) durationOverride = { duration: effectDuration };
     }
 
@@ -366,7 +367,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
 
     effectData.system.changes = await ActiveEffect5e.forApplication(
       effectData.system.changes,
-      item ?? originActor,
+      activity ?? item ?? originActor,
       actor
     );
 

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -1,3 +1,4 @@
+import ActiveEffect5e from "../../documents/active-effect.mjs";
 import { convertTime, formatTime, loadingTooltip } from "../../utils.mjs";
 import ChatTrayElement from "./chat-tray-element.mjs";
 import TargetedApplicationMixin from "./targeted-application-mixin.mjs";
@@ -291,7 +292,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
    * @protected
    */
   async _applyEffectToActor(effect, actor) {
-    const { action, data } = this._prepareEffectData(effect, actor);
+    const { action, data } = await this._prepareEffectData(effect, actor);
     if ( action === "update" ) return actor.effects.get(data._id).update(data);
     return ActiveEffect.implementation.create(data, { parent: actor });
   }
@@ -300,13 +301,13 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
 
   /**
    * Prepare the data for applying an Active Effect to an Actor.
-   * @param {ActiveEffect5e} effect                         The effect to apply.
-   * @param {Actor5e} actor                                 The actor.
-   * @returns {{ action: "create"|"update", data: object }} The effect data and the operation required to apply it.
-   * @throws {Error}                                        If the effect could not be applied.
+   * @param {ActiveEffect5e} effect  The effect to apply.
+   * @param {Actor5e} actor          The actor.
+   * @returns {Promise<{ action: "create"|"update", data: object }>}
+   * @throws {Error}
    * @protected
    */
-  _prepareEffectData(effect, actor) {
+  async _prepareEffectData(effect, actor) {
     const originActor = this.chatMessage.getAssociatedActor();
     const concentration = originActor?.effects.get(this.chatMessage.system.concentration);
     const item = this.chatMessage.getAssociatedItem();
@@ -363,22 +364,11 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       }
     }, effectFlags);
 
-    const originData = (item ?? originActor)?.getRollData() ?? {};
-    const targetData = actor.getRollData();
-
-    for ( const change of effectData.system.changes ) {
-      // TODO: Needs better evaluation since it can be JSON containing strings.
-      if ( typeof change.value !== "string" ) continue;
-
-      switch ( change.replacement ) {
-        case "target":
-          change.value = Roll.replaceFormulaData(change.value, targetData);
-          break;
-        case "origin":
-          change.value = Roll.replaceFormulaData(change.value, originData);
-          break;
-      }
-    }
+    effectData.system.changes = await ActiveEffect5e.forApplication(
+      effectData.system.changes,
+      item ?? originActor,
+      actor
+    );
 
     return { action: "create", data: effectData };
   }
@@ -402,7 +392,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       const updates = [];
       for ( const effect of effects ) {
         try {
-          const operation = this._prepareEffectData(effect, actor);
+          const operation = await this._prepareEffectData(effect, actor);
           (operation.action === "create" ? data : updates).push(operation.data);
         } catch ( err ) {
           Hooks.onError("EffectApplicationElement._prepareEffectData", err, { notify: "warn", log: "warn" });

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -307,7 +307,8 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
    * @protected
    */
   _prepareEffectData(effect, actor) {
-    const concentration = this.chatMessage.getAssociatedActor()?.effects.get(this.chatMessage.system.concentration);
+    const originActor = this.chatMessage.getAssociatedActor();
+    const concentration = originActor?.effects.get(this.chatMessage.system.concentration);
     const item = this.chatMessage.getAssociatedItem();
     const origin = concentration ?? (effect.inCompendium && item ? item : effect);
     if ( !game.user.isGM && !actor.isOwner ) {
@@ -350,7 +351,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     }
 
     // Otherwise, create a new effect on the target
-    return { action: "create", data: foundry.utils.mergeObject({
+    const effectData = foundry.utils.mergeObject({
       ...effect.toObject(),
       ...durationOverride,
       disabled: false,
@@ -360,7 +361,26 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
         [effect.inCompendium ? "compendiumSource" : "duplicateSource"]: effect.uuid,
         [effect.inCompendium ? "duplicateSource" : "compendiumSource"]: null
       }
-    }, effectFlags) };
+    }, effectFlags);
+
+    const originData = (item ?? originActor)?.getRollData() ?? {};
+    const targetData = actor.getRollData();
+
+    for ( const change of effectData.system.changes ) {
+      // TODO: Needs better evaluation since it can be JSON containing strings.
+      if ( typeof change.value !== "string" ) continue;
+
+      switch ( change.replacement ) {
+        case "target":
+          change.value = Roll.replaceFormulaData(change.value, targetData);
+          break;
+        case "origin":
+          change.value = Roll.replaceFormulaData(change.value, originData);
+          break;
+      }
+    }
+
+    return { action: "create", data: effectData };
   }
 
   /* -------------------------------------------- */

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -17,6 +17,7 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
     const schema = super.defineSchema();
     schema.changes.element.extendFields({
       _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
+      conditions: new FiltersField(),
       replacement: new StringField({
         required: true,
         blank: true,
@@ -24,8 +25,7 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
           origin: "DND5E.EFFECT.Replacement.Origin",
           target: "DND5E.EFFECT.Replacement.Target"
         }
-      }),
-      conditions: new FiltersField()
+      })
     });
     return schema;
   }

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -1,7 +1,7 @@
 import { getHumanReadableAttributeLabel } from "../../utils.mjs";
 import FiltersField from "../fields/filters-field.mjs";
 
-const { DocumentIdField } = foundry.data.fields;
+const { DocumentIdField, StringField } = foundry.data.fields;
 
 /**
  * Abstract base class to add some shared functionality to all of the system's custom active effect types.
@@ -17,6 +17,14 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
     const schema = super.defineSchema();
     schema.changes.element.extendFields({
       _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
+      replacement: new StringField({
+        required: true,
+        blank: true,
+        choices: {
+          origin: "DND5E.EFFECT.Replacement.Origin",
+          target: "DND5E.EFFECT.Replacement.Target"
+        }
+      }),
       conditions: new FiltersField()
     });
     return schema;

--- a/module/data/region-behavior/apply-active-effect.mjs
+++ b/module/data/region-behavior/apply-active-effect.mjs
@@ -62,7 +62,7 @@ export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.
     if ( !actor || !this.#evaluateConditions(token) ) return;
     const resumeMovement = movement ? token.pauseMovement() : undefined;
     const effects = await Promise.all(this.effects.map(fromUuid));
-    const toCreate = this.#getEffectsToCreate(actor, effects);
+    const toCreate = await this.#getEffectsToCreate(actor, effects);
     if ( toCreate.length ) await actor.createEmbeddedDocuments("ActiveEffect", toCreate);
     await resumeMovement?.();
   }
@@ -125,7 +125,7 @@ export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.
         });
       }
       if ( !this.#evaluateConditions(token) ) continue;
-      const toCreate = this.#getEffectsToCreate(actor, effects);
+      const toCreate = await this.#getEffectsToCreate(actor, effects);
       if ( toCreate.length ) {
         operations.push({
           action: "create",
@@ -142,11 +142,12 @@ export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.
 
   /**
    * Get Active Effects that should be created for the Actor.
-   * @param {Actor54} actor            The actor the Active Effects should be created for.
-   * @param {ActiveEffect5e]} effects  The effects the Active Effects are created from.
-   * @returns {ActiveEffectData[]}     The data of Active Effects that should be created.
+   * @param {Actor5e} actor                  The actor the Active Effects should be created for.
+   * @param {ActiveEffect5e[]} effects       The effects the Active Effects are created from.
+   * @returns {Promise<ActiveEffectData[]>}  The data of Active Effects that should be created.
    */
-  #getEffectsToCreate(actor, effects) {
+  async #getEffectsToCreate(actor, effects) {
+    const origin = await fromUuid(this.region.getFlag("dnd5e", "activity"));
     const toCreate = [];
     for ( const effect of effects ) {
       if ( !effect ) continue;
@@ -161,6 +162,7 @@ export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.
       }
       data._stats.exportSource = null;
       data.origin = this.behavior.uuid;
+      data.system.changes = await ActiveEffect.implementation.forApplication(data.system.changes, origin, actor);
       toCreate.push(data);
     }
     return toCreate;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -529,16 +529,16 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /**
    * Convert roll data properties in change data.
-   * @param {object[]} changes        Effect change data in json-serializable format.
-   * @param {*} origin                The origin of the effect to be applied.
-   * @param {Actor5e|Item5e} target   The target of the effect to be applied.
-   * @returns {Promise<object[]>}     A promise that resolves to the modified change data.
+   * @param {object[]} changes         Effect change data in json-serializable format.
+   * @param {*} [origin]               The origin of the effect to be applied.
+   * @param {Actor5e|Item5e} [target]  The target of the effect to be applied.
+   * @returns {Promise<object[]>}      A promise that resolves to the modified change data.
    */
   static async forApplication(changes, origin, target) {
     const oData = origin?.getRollData() ?? {};
     const tData = target?.getRollData() ?? {};
 
-    changes = foundry.utils.deepClone(changes);
+    changes = foundry.utils.deepClone(changes ?? []);
     for ( const change of changes ) {
       // TODO: Evaluate properties in objects, as this may be valid json.
       if ( typeof change.value !== "string" ) continue;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -525,6 +525,38 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     return super._applyChangeUpgrade(actor, change, current, delta, changes);
   }
 
+  /* -------------------------------------------- */
+
+  /**
+   * Convert roll data properties in change data.
+   * @param {object[]} changes        Effect change data in json-serializable format.
+   * @param {*} origin                The origin of the effect to be applied.
+   * @param {Actor5e|Item5e} target   The target of the effect to be applied.
+   * @returns {Promise<object[]>}     A promise that resolves to the modified change data.
+   */
+  static async forApplication(changes, origin, target) {
+    const oData = origin?.getRollData() ?? {};
+    const tData = target?.getRollData() ?? {};
+
+    changes = foundry.utils.deepClone(changes);
+    for ( const change of changes ) {
+      // TODO: Evaluate properties in objects, as this may be valid json.
+      if ( typeof change.value !== "string" ) continue;
+
+      // TODO: Evaluate dice formulas.
+      switch ( change.replacement ) {
+        case "origin":
+          change.value = Roll.replaceFormulaData(change.value, oData);
+          break;
+        case "target":
+          change.value = Roll.replaceFormulaData(change.value, tData);
+          break;
+      }
+    }
+
+    return changes;
+  }
+
   /* --------------------------------------------- */
 
   /**

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -205,7 +205,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
       [item] = await Item5e.createDocuments(toCreate, { keepId: true, parent: actor });
     }
 
-    const enchantment = await ActiveEffect5e.create(enchantmentData, {
+    const enchantment = await ActiveEffect.implementation.create(enchantmentData, {
       parent: item, keepId: true, keepOrigin: true, chatMessageOrigin: chatMessage?.id
     });
 

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -176,6 +176,22 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
     if ( concentration ) flags.dependentOn = concentration.uuid;
     const enchantmentData = effect.clone({ origin: this.uuid, "flags.dnd5e": flags }).toObject();
 
+    const originData = this.getRollData();
+    const targetData = item.getRollData();
+    for (const change of enchantmentData.system.changes) {
+      // TODO: Needs better evaluation since it can be JSON containing strings.
+      if ( typeof change.value !== "string" ) continue;
+
+      switch ( change.replacement ) {
+        case "target":
+          change.value = Roll.replaceFormulaData(change.value, targetData);
+          break;
+        case "origin":
+          change.value = Roll.replaceFormulaData(change.value, originData);
+          break;
+      }
+    }
+
     /**
      * Hook that fires before an enchantment is applied to an item.
      * @function dnd5e.preApplyEnchantment

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -3,6 +3,7 @@ import EnchantUsageDialog from "../../applications/activity/enchant-usage-dialog
 import BaseEnchantActivityData from "../../data/activity/enchant-data.mjs";
 import Item5e from "../../documents/item.mjs";
 import { getSceneTargets } from "../../utils.mjs";
+import ActiveEffect5e from "../active-effect.mjs";
 import ActivityMixin from "./mixin.mjs";
 
 /**
@@ -175,22 +176,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
     const flags = { enchantmentProfile: profileId };
     if ( concentration ) flags.dependentOn = concentration.uuid;
     const enchantmentData = effect.clone({ origin: this.uuid, "flags.dnd5e": flags }).toObject();
-
-    const originData = this.getRollData();
-    const targetData = item.getRollData();
-    for (const change of enchantmentData.system.changes) {
-      // TODO: Needs better evaluation since it can be JSON containing strings.
-      if ( typeof change.value !== "string" ) continue;
-
-      switch ( change.replacement ) {
-        case "target":
-          change.value = Roll.replaceFormulaData(change.value, targetData);
-          break;
-        case "origin":
-          change.value = Roll.replaceFormulaData(change.value, originData);
-          break;
-      }
-    }
+    enchantmentData.system.changes = await ActiveEffect5e.forApplication(enchantmentData.system.changes, this, item);
 
     /**
      * Hook that fires before an enchantment is applied to an item.
@@ -219,7 +205,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
       [item] = await Item5e.createDocuments(toCreate, { keepId: true, parent: actor });
     }
 
-    const enchantment = await ActiveEffect.create(enchantmentData, {
+    const enchantment = await ActiveEffect5e.create(enchantmentData, {
       parent: item, keepId: true, keepOrigin: true, chatMessageOrigin: chatMessage?.id
     });
 

--- a/templates/effects/change-config.hbs
+++ b/templates/effects/change-config.hbs
@@ -6,6 +6,8 @@
     {{ formField fields.value name=(concat prefix "value") value=source.value elementType="input" rootId=partId }}
     {{ formField fields.priority name=(concat prefix "priority") value=source.priority
                  placeholder=defaultPriority rootId=partId }}
+    {{ formField fields.replacement name=(concat prefix "replacement") value=source.replacement
+                 blank="DND5E.EFFECT.Replacement.NoChange" localize=true rootId=partId }}
     {{#if fields.conditions}}
     {{ formField fields.conditions name=(concat prefix "conditions") value=source.conditions rootId=partId }}
     {{/if}}


### PR DESCRIPTION
Adds a string field `replacement` to change data in the base active effects.

- If `"target"`, the target's (item or actor) roll data is used to replace roll data properties in the `change.value` field.
- If `"origin"`, the origin item / activity / actor's roll data is used.
- If blank, no change is made.

TODO:
- [x] Add these options in the effect config.
- [x] Consider whether the option should be in the data model instead; perhaps a data model for the `base` type, which the `enchantment` type could then extend.
- [ ] Add option to not replace roll data at all, preventing the core replacement taking place. (see #7256).
- [ ] Add an option to evaluate dice formulas.

Some notes:

While I did consider placing this in `_preCreate`, it isn't possible to determine if the creation of the effect was due to just wanting to copy from one item/actor to another during data entry or to grant the item/actor the effect.

Closes #4437.
Closes #3809.
Closes #4465.