### PR TITLE
[#3798, #4644] Add "All Languages", group primordial languages

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2331,6 +2331,7 @@
 "DND5E.LairActionInitiative": "Lair Action Initiative Count",
 
 "DND5E.Language": {
+  "All": "All Languages",
   "Label": "Language",
   "Category": {
     "Exotic": "Exotic Languages",

--- a/module/applications/actor/config/traits-config.mjs
+++ b/module/applications/actor/config/traits-config.mjs
@@ -72,7 +72,7 @@ export default class TraitsConfig extends BaseConfigSheet {
     context.choices = await Trait.choices(this.options.trait, { chosen });
     context.fields = Trait.actorFields(this.document, this.options.trait);
 
-    // Handle custom weapons not in a top-level category
+    // Handle custom traits not in a top-level category
     const other = {
       label: this.otherLabel,
       children: new SelectChoices(),
@@ -83,7 +83,7 @@ export default class TraitsConfig extends BaseConfigSheet {
       other.children[key] = choice;
       delete context.choices[key];
     }
-    if ( !foundry.utils.isEmpty(other.children) ) context.choices.other = other;
+    if ( !foundry.utils.isEmpty(other.children) ) context.choices.OTHER = other;
     this._processChoices(context.data, context.choices);
 
     return context;
@@ -102,7 +102,7 @@ export default class TraitsConfig extends BaseConfigSheet {
   _processChoices(data, choices, categoryChosen=false) {
     for ( const [key, choice] of Object.entries(choices) ) {
       this._processChoice(data, key, choice, categoryChosen);
-      if ( choice.children ) this._processChoices(data, choice.children, choice.chosen);
+      if ( choice.children ) this._processChoices(data, choice.children, choice.chosen && (key !== "OTHER"));
     }
   }
 
@@ -117,7 +117,7 @@ export default class TraitsConfig extends BaseConfigSheet {
    * @protected
    */
   _processChoice(data, key, choice, categoryChosen=false) {
-    if ( categoryChosen ) {
+    if ( (data.value.includes("ALL") && (key !== "ALL")) || categoryChosen ) {
       choice.chosen = true;
       choice.disabled = true;
     }

--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -263,7 +263,7 @@ export default function ActorSheetV2Mixin(Base) {
 
       // Handle languages
       const languages = this.actor.system.traits?.languages?.labels;
-      if ( languages?.dialects?.length ) traits.languages = languages.dialects.map(label => ({ label }));
+      if ( languages?.languages?.length ) traits.languages = languages.languages.map(label => ({ label }));
       for ( const [key, { label }] of Object.entries(CONFIG.DND5E.communicationTypes) ) {
         const data = this.actor.system.traits?.languages?.communication?.[key];
         if ( !data?.value ) continue;

--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -207,7 +207,7 @@ export default function ActorSheetV2Mixin(Base) {
     _prepareTraits() {
       const traits = {};
       for ( const [trait, config] of Object.entries(CONFIG.DND5E.traits) ) {
-        if ( trait === "dm" ) continue;
+        if ( ["dm", "languages"].includes(trait) ) continue;
         const key = config.actorKeyPath ?? `system.traits.${trait}`;
         const data = foundry.utils.deepClone(foundry.utils.getProperty(this.actor, key));
         if ( !data ) continue;
@@ -261,7 +261,9 @@ export default function ActorSheetV2Mixin(Base) {
         if ( values.length ) traits.dm = values;
       }
 
-      // Display ranged communication
+      // Handle languages
+      const languages = this.actor.system.traits?.languages?.labels;
+      if ( languages?.dialects?.length ) traits.languages = languages.dialects.map(label => ({ label }));
       for ( const [key, { label }] of Object.entries(CONFIG.DND5E.communicationTypes) ) {
         const data = this.actor.system.traits?.languages?.communication?.[key];
         if ( !data?.value ) continue;

--- a/module/applications/advancement/trait-config.mjs
+++ b/module/applications/advancement/trait-config.mjs
@@ -127,7 +127,7 @@ export default class TraitConfig extends AdvancementConfig {
 
     // Handle selecting & disabling category children when a category is selected
     for ( const checkbox of html[0].querySelectorAll(".trait-selector input:checked") ) {
-      const toCheck = checkbox.name.endsWith("*")
+      const toCheck = (checkbox.name.endsWith("*") || checkbox.name.endsWith("ALL"))
         ? checkbox.closest("ol").querySelectorAll(`input:not([name="${checkbox.name}"])`)
         : checkbox.closest("li").querySelector("ol")?.querySelectorAll("input");
       toCheck?.forEach(i => i.checked = i.disabled = true);

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3665,6 +3665,7 @@ DND5E.bloodied = {
 DND5E.languages = {
   standard: {
     label: "DND5E.Language.Category.Standard",
+    selectable: false,
     children: {
       common: "DND5E.Language.Language.Common",
       draconic: "DND5E.Language.Language.Draconic",
@@ -3680,6 +3681,7 @@ DND5E.languages = {
   },
   exotic: {
     label: "DND5E.Language.Category.Rare",
+    selectable: false,
     children: {
       aarakocra: "DND5E.Language.Language.Aarakocra",
       abyssal: "DND5E.Language.Language.Abyssal",
@@ -3770,6 +3772,8 @@ DND5E.epicBoonInterval = 30000;
  * @property {string} labels.title         Localization key for the trait name.
  * @property {string} labels.localization  Prefix for a localization key that can be used to generate various
  *                                         plural variants of the trait type.
+ * @property {string} [labels.all]         Localization to use for the "all" option for this trait. If not provided,
+ *                                         then no all option will be available.
  * @property {string} icon                 Path to the icon used to represent this trait.
  * @property {string} [actorKeyPath]       If the trait doesn't directly map to an entry as `traits.[key]`, where is
  *                                         this trait's data stored on the actor?
@@ -3815,7 +3819,8 @@ DND5E.traits = {
   languages: {
     labels: {
       title: "DND5E.Languages",
-      localization: "DND5E.TraitLanguagesPlural"
+      localization: "DND5E.TraitLanguagesPlural",
+      all: "DND5E.Language.All"
     },
     icon: "icons/skills/social/diplomacy-peace-alliance.webp"
   },
@@ -3894,7 +3899,7 @@ DND5E.traits = {
     configKey: "conditionTypes"
   }
 };
-preLocalize("traits", { key: "labels.title" });
+preLocalize("traits", { keys: ["labels.title", "labels.all"] });
 
 /* -------------------------------------------- */
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -259,6 +259,7 @@ export default class CharacterData extends CreatureTemplate {
     AttributesFields.prepareExhaustionLevel.call(this);
     AttributesFields.prepareMovement.call(this);
     AttributesFields.prepareConcentration.call(this, rollData);
+    TraitsFields.prepareLanguages.call(this);
     TraitsFields.prepareResistImmune.call(this);
 
     // Hit Points

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -361,6 +361,7 @@ export default class NPCData extends CreatureTemplate {
     AttributesFields.prepareMovement.call(this);
     AttributesFields.prepareConcentration.call(this, rollData);
     SourceField.prepareData.call(this.source, this.parent._stats?.compendiumSource ?? this.parent.uuid);
+    TraitsFields.prepareLanguages.call(this);
     TraitsFields.prepareResistImmune.call(this);
 
     // Hit Dice
@@ -529,11 +530,8 @@ export default class NPCData extends CreatureTemplate {
 
         // Languages (e.g. `Common, Draconic`)
         languages: [
-          prepareTrait(this.traits.languages, "languages"),
-          ...Object.entries(CONFIG.DND5E.communicationTypes).map(([key, { label }]) => {
-            const data = this.traits.languages.communication[key];
-            return data?.value ? `${label} ${formatDistance(data.value, data.units)}`.toLowerCase() : null;
-          })
+          formatter.format(this.traits.languages.labels.dialects),
+          formatter.format(this.traits.languages.labels.ranged)
         ].filterJoin("; ") || game.i18n.localize("None"),
 
         // Senses (e.g. `Blindsight 60 ft., Darkvision 120 ft.; Passive Perception 27`)

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -530,7 +530,7 @@ export default class NPCData extends CreatureTemplate {
 
         // Languages (e.g. `Common, Draconic`)
         languages: [
-          formatter.format(this.traits.languages.labels.dialects),
+          formatter.format(this.traits.languages.labels.languages),
           formatter.format(this.traits.languages.labels.ranged)
         ].filterJoin("; ") || game.i18n.localize("None"),
 

--- a/module/data/actor/templates/traits.mjs
+++ b/module/data/actor/templates/traits.mjs
@@ -129,20 +129,20 @@ export default class TraitsField {
    */
   static prepareLanguages() {
     const languages = this.traits.languages;
-    const labels = languages.labels = { dialects: [], ranged: [] };
+    const labels = languages.labels = { languages: [], ranged: [] };
 
-    if ( languages.value.has("ALL") ) labels.dialects.push(game.i18n.localize("DND5E.Language.All"));
+    if ( languages.value.has("ALL") ) labels.languages.push(game.i18n.localize("DND5E.Language.All"));
     else {
       const processCategory = (key, data, group) => {
         // If key is within languages, don't bother with children
-        if ( languages.value.has(key) ) (group?.children ?? labels.dialects).push(data.label ?? data);
+        if ( languages.value.has(key) ) (group?.children ?? labels.languages).push(data.label ?? data);
 
         // Display children as part of this group (e.g. "Primordial (Ignan)")
         else if ( data.children ) {
           const topLevel = group === undefined;
           group ??= { label: data.label, children: [] };
           Object.entries(data.children).forEach(([k, d]) => processCategory(k, d, group));
-          if ( topLevel && group.children.length ) labels.dialects.push(
+          if ( topLevel && group.children.length ) labels.languages.push(
             `${data.label} (${game.i18n.getListFormatter({ type: "unit" }).format(group.children)})`
           );
         }
@@ -154,7 +154,7 @@ export default class TraitsField {
       }
     }
 
-    labels.dialects.push(...splitSemicolons(languages.custom));
+    labels.languages.push(...splitSemicolons(languages.custom));
 
     for ( const [key, { label }] of Object.entries(CONFIG.DND5E.communicationTypes) ) {
       const data = languages.communication?.[key];

--- a/module/documents/actor/trait.mjs
+++ b/module/documents/actor/trait.mjs
@@ -189,6 +189,12 @@ export async function choices(trait, { chosen=new Set(), prefixed=false, any=fal
   const categoryData = await categories(trait);
 
   let result = {};
+
+  if ( traitConfig.labels?.all && !any ) {
+    const key = prefixed ? `${trait}:ALL` : "ALL";
+    result[key] = { label: traitConfig.labels.all, chosen: chosen.has(key), sorting: false };
+  }
+
   if ( prefixed && any ) {
     const key = `${trait}:*`;
     result[key] = {
@@ -203,7 +209,8 @@ export async function choices(trait, { chosen=new Set(), prefixed=false, any=fal
     if ( prefixed ) key = `${prefix}:${key}`;
     result[key] = {
       label: game.i18n.localize(label),
-      chosen: chosen.has(key),
+      chosen: data.selectable !== false ? chosen.has(key) : false,
+      selectable: data.selectable !== false,
       sorting: topLevel ? traitConfig.sortCategories === true : true
     };
     if ( data.children ) {
@@ -410,8 +417,11 @@ export function keyLabel(key, config={}) {
   const lastKey = parts.pop();
   if ( !lastKey ) return categoryLabel;
 
+  // All (e.g. "All Languages")
+  if ( lastKey === "ALL" ) return traitConfig.labels?.all ?? key;
+
   // Wildcards (e.g. "Artisan's Tools", "any Artisan's Tools", "any 2 Artisan's Tools", or "2 other Artisan's Tools")
-  if ( lastKey === "*" ) {
+  else if ( lastKey === "*" ) {
     let type;
     if ( parts.length ) {
       let category = traitData;

--- a/templates/apps/parts/trait-list.hbs
+++ b/templates/apps/parts/trait-list.hbs
@@ -2,8 +2,10 @@
     {{#each choices as |choice key|}}
     <li class="{{#if choice.category}}category{{/if}} {{#if choice.wildcard}}wildcard{{/if}}">
         <label class="checkbox">
+            {{#unless (eq selectable false)}}
             <input type="checkbox" name="{{#if ../prefix}}{{../prefix}}.{{/if}}{{key}}"
                    {{checked choice.chosen}} {{disabled choice.disabled}}>
+            {{/unless}}
             {{choice.label}}
         </label>
         {{#if choice.children}}

--- a/templates/apps/parts/traits-list.hbs
+++ b/templates/apps/parts/traits-list.hbs
@@ -1,5 +1,5 @@
 <ol class="unlist trait-list">
-    {{#if (and children topLevel (not otherGroup))}}
+    {{#if (and children selectable topLevel (not otherGroup))}}
     <li>
         <label class="name">{{ localize "DND5E.TraitAll" category=label }}</label>
         <div class="proficiency">


### PR DESCRIPTION
Adds an "All Languages" option. If selected, then only that option will show an all other language proficiencies will be hidden (custom languages and ranged communication will still be displayed as normal). This includes some broader changes that should work as the basis for adding this to other trait types (such as resistance to all damage).

Also modifies how the labels for languages are created to match modern stat blocks that display grouped languages next to the group name (e.g. "Primordial (Terran)"). This also handles some checks to prevent redundant information, such as if you have Primordial proficiency as well as Terran proficiency, it will only show the top-level group and not its children.