### PR TITLE
[#2094] Move actor data preparation into data models

### DIFF
--- a/module/applications/activity/attack-sheet.mjs
+++ b/module/applications/activity/attack-sheet.mjs
@@ -1,4 +1,3 @@
-import { safePropertyExists } from "../../utils.mjs";
 import ActivitySheet from "./activity-sheet.mjs";
 
 /**

--- a/module/applications/advancement/advancement-selection.mjs
+++ b/module/applications/advancement/advancement-selection.mjs
@@ -1,5 +1,3 @@
-import Advancement from "../../documents/advancement/advancement.mjs";
-
 /**
  * Presents a list of advancement types to create when clicking the new advancement button.
  * Once a type is selected, this hands the process over to the advancement's individual editing interface.

--- a/module/applications/token-config.mjs
+++ b/module/applications/token-config.mjs
@@ -1,4 +1,3 @@
-import TokenDocument5e from "../documents/token.mjs";
 import { getHumanReadableAttributeLabel } from "../utils.mjs";
 
 /**

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -375,6 +375,33 @@ export class ActorDataModel extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /**
+   * Data preparation steps to perform after item data has been prepared, but before active effects are applied.
+   */
+  prepareEmbeddedData() {
+    this._prepareScaleValues();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Derive any values that have been scaled by the Advancement system.
+   * Mutates the value of the `system.scale` object.
+   * @protected
+   */
+  _prepareScaleValues() {
+    this.scale = this.parent.items.reduce((scale, item) => {
+      if ( CONFIG.DND5E.advancementTypes.ScaleValue.validItemTypes.has(item.type) ) {
+        scale[item.identifier] = item.scaleValues;
+      }
+      return scale;
+    }, {});
+  }
+
+  /* -------------------------------------------- */
   /*  Helpers                                     */
   /* -------------------------------------------- */
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -31,10 +31,6 @@ const {
  * System data definition for Characters.
  *
  * @property {object} attributes
- * @property {object} attributes.ac
- * @property {number} attributes.ac.flat                  Flat value used for flat or natural armor calculation.
- * @property {string} attributes.ac.calc                  Name of one of the built-in formulas to use.
- * @property {string} attributes.ac.formula               Custom formula to use.
  * @property {object} attributes.hp
  * @property {number} attributes.hp.value                 Current hit points.
  * @property {number} attributes.hp.max                   Override for maximum HP.
@@ -97,11 +93,6 @@ export default class CharacterData extends CreatureTemplate {
       attributes: new SchemaField({
         ...AttributesFields.common,
         ...AttributesFields.creature,
-        ac: new SchemaField({
-          flat: new NumberField({ integer: true, min: 0, label: "DND5E.ArmorClassFlat" }),
-          calc: new StringField({ initial: "default", label: "DND5E.ArmorClassCalculation" }),
-          formula: new FormulaField({ deterministic: true, label: "DND5E.ArmorClassFormula" })
-        }, { label: "DND5E.ArmorClass" }),
         hp: new SchemaField({
           value: new NumberField({
             nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.HitPointsCurrent"
@@ -238,6 +229,7 @@ export default class CharacterData extends CreatureTemplate {
    * Prepare movement & senses values derived from race item.
    */
   prepareEmbeddedData() {
+    super.prepareEmbeddedData();
     if ( this.details.race instanceof Item ) {
       AttributesFields.prepareRace.call(this, this.details.race);
       this.details.type = this.details.race.system.type;
@@ -257,13 +249,19 @@ export default class CharacterData extends CreatureTemplate {
    */
   prepareDerivedData() {
     const rollData = this.parent.getRollData({ deterministic: true });
-    const { originalSaves } = this.parent.getOriginalStats();
+    const { originalSaves, originalSkills } = this.parent.getOriginalStats();
 
     this.prepareAbilities({ rollData, originalSaves });
+    this.prepareSkills({ rollData, originalSkills });
+    this.prepareTools({ rollData });
+    AttributesFields.prepareArmorClass.call(this, rollData);
+    AttributesFields.prepareConcentration.call(this, rollData);
     AttributesFields.prepareEncumbrance.call(this, rollData);
     AttributesFields.prepareExhaustionLevel.call(this);
+    AttributesFields.prepareInitiative.call(this, rollData);
     AttributesFields.prepareMovement.call(this);
     AttributesFields.prepareConcentration.call(this, rollData);
+    AttributesFields.prepareSpellcastingAbility.call(this);
     TraitsFields.prepareLanguages.call(this);
     TraitsFields.prepareResistImmune.call(this);
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -23,10 +23,6 @@ const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringFiel
  * System data definition for NPCs.
  *
  * @property {object} attributes
- * @property {object} attributes.ac
- * @property {number} attributes.ac.flat         Flat value used for flat or natural armor calculation.
- * @property {string} attributes.ac.calc         Name of one of the built-in formulas to use.
- * @property {string} attributes.ac.formula      Custom formula to use.
  * @property {object} attributes.hd
  * @property {number} attributes.hd.spent        Number of hit dice spent.
  * @property {object} attributes.hp
@@ -95,11 +91,6 @@ export default class NPCData extends CreatureTemplate {
       attributes: new SchemaField({
         ...AttributesFields.common,
         ...AttributesFields.creature,
-        ac: new SchemaField({
-          flat: new NumberField({integer: true, min: 0, label: "DND5E.ArmorClassFlat"}),
-          calc: new StringField({initial: "default", label: "DND5E.ArmorClassCalculation"}),
-          formula: new FormulaField({deterministic: true, label: "DND5E.ArmorClassFormula"})
-        }, {label: "DND5E.ArmorClass"}),
         hd: new SchemaField({
           spent: new NumberField({integer: true, min: 0, initial: 0})
         }, {label: "DND5E.HitDice"}),
@@ -383,6 +374,7 @@ export default class NPCData extends CreatureTemplate {
    * Prepare movement & senses values derived from race item.
    */
   prepareEmbeddedData() {
+    super.prepareEmbeddedData();
     if ( this.details.race instanceof Item ) {
       AttributesFields.prepareRace.call(this, this.details.race, { force: true });
       this.details.type = this.details.race.system.type;
@@ -398,13 +390,18 @@ export default class NPCData extends CreatureTemplate {
   /** @inheritDoc */
   prepareDerivedData() {
     const rollData = this.parent.getRollData({ deterministic: true });
-    const { originalSaves } = this.parent.getOriginalStats();
+    const { originalSaves, originalSkills } = this.parent.getOriginalStats();
 
     this.prepareAbilities({ rollData, originalSaves });
+    this.prepareSkills({ rollData, originalSkills });
+    this.prepareTools({ rollData });
+    AttributesFields.prepareArmorClass.call(this, rollData);
+    AttributesFields.prepareConcentration.call(this, rollData);
     AttributesFields.prepareEncumbrance.call(this, rollData);
     AttributesFields.prepareExhaustionLevel.call(this);
+    AttributesFields.prepareInitiative.call(this, rollData);
     AttributesFields.prepareMovement.call(this);
-    AttributesFields.prepareConcentration.call(this, rollData);
+    AttributesFields.prepareSpellcastingAbility.call(this);
     SourceField.prepareData.call(this.source, this.parent._stats?.compendiumSource ?? this.parent.uuid);
     TraitsFields.prepareLanguages.call(this);
     TraitsFields.prepareResistImmune.call(this);

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -167,9 +167,8 @@ export default class AttributesFields {
     }
 
     // Identify Equipped Items
-    const armorTypes = new Set(Object.keys(CONFIG.DND5E.armorTypes));
     const { armors, shields } = this.parent.itemTypes.equipment.reduce((obj, equip) => {
-      if ( !equip.system.equipped || !armorTypes.has(equip.system.type.value) ) return obj;
+      if ( !equip.system.equipped || !(equip.system.type.value in CONFIG.DND5E.armorTypes)) return obj;
       if ( equip.system.type.value === "shield" ) obj.shields.push(equip);
       else obj.armors.push(equip);
       return obj;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -1,34 +1,58 @@
+import ActiveEffect5e from "../../../documents/active-effect.mjs";
+import Proficiency from "../../../documents/actor/proficiency.mjs";
+import { convertLength, convertWeight, replaceFormulaData, simplifyBonus } from "../../../utils.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 import MovementField from "../../shared/movement-field.mjs";
-import SensesField from "../../shared/senses-field.mjs";
-import ActiveEffect5e from "../../../documents/active-effect.mjs";
 import RollConfigField from "../../shared/roll-config-field.mjs";
-import { convertLength, convertWeight, simplifyBonus } from "../../../utils.mjs";
+import SensesField from "../../shared/senses-field.mjs";
 
 const { NumberField, SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * @import { MovementData } from "../../shared/movement-field.mjs"
+ * @import { RollConfigData } from "../../shared/roll-config-field.mjs"
+ * @import { SensesData } from "../../shared/senses-field.mjs"
+ */
+
+/**
+ * @typedef {object} ArmorClassData
+ * @property {string} calc     Name of one of the built-in formulas to use.
+ * @property {number} flat     Flat value used for flat or natural armor calculation.
+ * @property {string} formula  Custom formula to use.
+ */
 
 /**
  * Shared contents of the attributes schema between various actor types.
  */
 export default class AttributesFields {
   /**
+   * Armor class fields shared between characters, NPCs, and vehicles.
+   *
+   * @type {ArmorClassData}
+   */
+  static get armorClass() {
+    return {
+      calc: new StringField({ initial: "default", label: "DND5E.ArmorClassCalculation" }),
+      flat: new NumberField({ integer: true, min: 0, label: "DND5E.ArmorClassFlat" }),
+      formula: new FormulaField({ deterministic: true, label: "DND5E.ArmorClassFormula" })
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Fields shared between characters, NPCs, and vehicles.
    *
    * @type {object}
-   * @property {object} init
+   * @property {ArmorClassData} ac       Armor class configuration.
+   * @property {RollConfigData} init
    * @property {string} init.ability     The ability used for initiative rolls.
    * @property {string} init.bonus       The bonus provided to initiative rolls.
-   * @property {object} movement
-   * @property {number} movement.burrow  Actor burrowing speed.
-   * @property {number} movement.climb   Actor climbing speed.
-   * @property {number} movement.fly     Actor flying speed.
-   * @property {number} movement.swim    Actor swimming speed.
-   * @property {number} movement.walk    Actor walking speed.
-   * @property {string} movement.units   Movement used to measure the various speeds.
-   * @property {boolean} movement.hover  Is this flying creature able to hover in place.
+   * @property {MovementData} movement
    */
   static get common() {
     return {
+      ac: new SchemaField(this.armorClass, { label: "DND5E.ArmorClass" }),
       init: new RollConfigField({
         ability: "",
         bonus: new FormulaField({ required: true, label: "DND5E.InitiativeBonus" })
@@ -44,26 +68,17 @@ export default class AttributesFields {
    *
    * @type {object}
    * @property {object} attunement
-   * @property {number} attunement.max          Maximum number of attuned items.
-   * @property {object} senses
-   * @property {number} senses.darkvision       Creature's darkvision range.
-   * @property {number} senses.blindsight       Creature's blindsight range.
-   * @property {number} senses.tremorsense      Creature's tremorsense range.
-   * @property {number} senses.truesight        Creature's truesight range.
-   * @property {string} senses.units            Distance units used to measure senses.
-   * @property {string} senses.special          Description of any special senses or restrictions.
-   * @property {string} spellcasting            Primary spellcasting ability.
-   * @property {number} exhaustion              Creature's exhaustion level.
-   * @property {object} concentration
-   * @property {string} concentration.ability   The ability used for concentration saving throws.
-   * @property {string} concentration.bonus     The bonus provided to concentration saving throws.
-   * @property {number} concentration.limit     The amount of items this actor can concentrate on.
-   * @property {object} concentration.roll
-   * @property {number} concentration.roll.min  The minimum the d20 can roll.
-   * @property {number} concentration.roll.max  The maximum the d20 can roll.
-   * @property {number} concentration.roll.mode The default advantage mode for this actor's concentration saving throws.
+   * @property {number} attunement.max              Maximum number of attuned items.
+   * @property {SensesData} senses
+   * @property {string} spellcasting                Primary spellcasting ability.
+   * @property {number} exhaustion                  Creature's exhaustion level.
+   * @property {RollConfigData} concentration
+   * @property {string} concentration.ability       The ability used for concentration saving throws.
+   * @property {object} concentration.bonuses
+   * @property {string} concentration.bonuses.save  The bonus provided to concentration saving throws.
+   * @property {number} concentration.limit         The amount of items this actor can concentrate on.
    * @property {object} loyalty
-   * @property {number} loyalty.value           The creature's loyalty score.
+   * @property {number} loyalty.value               The creature's loyalty score.
    */
   static get creature() {
     return {
@@ -129,12 +144,96 @@ export default class AttributesFields {
    */
   static prepareBaseEncumbrance() {
     const encumbrance = this.attributes.encumbrance ??= {};
-    encumbrance.multipliers = {
-      encumbered: "1", heavilyEncumbered: "1", maximum: "1", overall: "1"
-    };
-    encumbrance.bonuses = {
-      encumbered: "", heavilyEncumbered: "", maximum: "", overall: ""
-    };
+    encumbrance.multipliers = { encumbered: "1", heavilyEncumbered: "1", maximum: "1", overall: "1" };
+    encumbrance.bonuses = { encumbered: "", heavilyEncumbered: "", maximum: "", overall: "" };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare a character's AC value from their equipped armor and shield.
+   * @this {CharacterData|NPCData|VehicleData}
+   * @param {object} rollData  The Actor's roll data.
+   */
+  static prepareArmorClass(rollData) {
+    const ac = this.attributes.ac;
+
+    // Apply automatic migrations for older data structures
+    let cfg = CONFIG.DND5E.armorClasses[ac.calc];
+    if ( !cfg ) {
+      ac.calc = "flat";
+      if ( Number.isNumeric(ac.value) ) ac.flat = Number(ac.value);
+      cfg = CONFIG.DND5E.armorClasses.flat;
+    }
+
+    // Identify Equipped Items
+    const armorTypes = new Set(Object.keys(CONFIG.DND5E.armorTypes));
+    const { armors, shields } = this.parent.itemTypes.equipment.reduce((obj, equip) => {
+      if ( !equip.system.equipped || !armorTypes.has(equip.system.type.value) ) return obj;
+      if ( equip.system.type.value === "shield" ) obj.shields.push(equip);
+      else obj.armors.push(equip);
+      return obj;
+    }, { armors: [], shields: [] });
+
+    // Determine base AC
+    switch ( ac.calc ) {
+
+      // Flat AC (no additional bonuses)
+      case "flat":
+        ac.value = Number(ac.flat);
+        return;
+
+      // Natural AC (includes bonuses)
+      case "natural":
+        ac.base = Number(ac.flat);
+        break;
+
+      default:
+        let formula = ac.calc === "custom" ? ac.formula : cfg.formula;
+        if ( armors.length ) {
+          if ( armors.length > 1 ) this.parent._preparationWarnings.push({
+            message: game.i18n.localize("DND5E.WarnMultipleArmor"), type: "warning"
+          });
+          const armorData = armors[0].system.armor;
+          const isHeavy = armors[0].system.type.value === "heavy";
+          ac.armor = armorData.value ?? ac.armor;
+          ac.dex = isHeavy ? 0 : Math.min(armorData.dex ?? Infinity, this.abilities.dex?.mod ?? 0);
+          ac.equippedArmor = armors[0];
+        }
+        else ac.dex = this.abilities.dex?.mod ?? 0;
+
+        rollData.attributes.ac = ac;
+        try {
+          const replaced = replaceFormulaData(formula, rollData, {
+            actor: this, missing: null, property: game.i18n.localize("DND5E.ArmorClass")
+          });
+          ac.base = replaced ? new Roll(replaced).evaluateSync().total : 0;
+        } catch(err) {
+          this.parent._preparationWarnings.push({
+            message: game.i18n.format("DND5E.WarnBadACFormula", { formula }), link: "armor", type: "error"
+          });
+          const replaced = Roll.replaceFormulaData(CONFIG.DND5E.armorClasses.default.formula, rollData);
+          ac.base = new Roll(replaced).evaluateSync().total;
+        }
+        break;
+    }
+
+    // Equipped Shield
+    if ( shields.length ) {
+      if ( shields.length > 1 ) this.parent._preparationWarnings.push({
+        message: game.i18n.localize("DND5E.WarnMultipleShields"), type: "warning"
+      });
+      ac.shield = shields[0].system.armor.value ?? 0;
+      ac.equippedShield = shields[0];
+    }
+
+    // Compute cover.
+    ac.cover = Math.max(ac.cover, this.parent.coverBonus);
+
+    // Compute total AC and return
+    ac.min = simplifyBonus(ac.min, rollData);
+    ac.bonus = simplifyBonus(ac.bonus, rollData);
+    ac.value = Math.max(ac.min, ac.base + ac.shield + ac.bonus + ac.cover);
   }
 
   /* -------------------------------------------- */
@@ -260,6 +359,40 @@ export default class AttributesFields {
   /* -------------------------------------------- */
 
   /**
+   * Prepare the initiative data for an actor.
+   * @this {CharacterData|NPCData|VehicleData}
+   * @param {object} rollData  The Actor's roll data.
+   */
+  static prepareInitiative(rollData) {
+    const init = this.attributes.init ??= {};
+    const flags = this.parent.flags.dnd5e ?? {};
+    const globalCheckBonus = simplifyBonus(this.bonuses?.abilities?.check, rollData);
+
+    // Compute initiative modifier
+    const abilityId = init.ability || CONFIG.DND5E.defaultAbilities.initiative;
+    const ability = this.abilities?.[abilityId] || {};
+    init.mod = ability.mod ?? 0;
+
+    // Initiative proficiency
+    const isLegacy = game.settings.get("dnd5e", "rulesVersion") === "legacy";
+    const prof = this.attributes.prof ?? 0;
+    const joat = flags.jackOfAllTrades && isLegacy;
+    const ra = this.parent._isRemarkableAthlete(abilityId);
+    const alert = flags.initiativeAlert && !isLegacy;
+    init.prof = new Proficiency(prof, alert ? 1 : (joat || ra) ? 0.5 : 0, !ra);
+
+    // Total initiative includes all numeric terms
+    const initBonus = simplifyBonus(init.bonus, rollData);
+    const abilityBonus = simplifyBonus(ability.bonuses?.check, rollData);
+    init.total = init.mod + initBonus + abilityBonus + globalCheckBonus
+      + (flags.initiativeAlert && isLegacy ? 5 : 0)
+      + (Number.isNumeric(init.prof.term) ? init.prof.flat : 0);
+    init.score = 10 + init.total;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Modify movement speeds taking exhaustion and any other conditions into account.
    * @this {CharacterData|NPCData}
    */
@@ -319,5 +452,17 @@ export default class AttributesFields {
     this.attributes.senses.special = [this.attributes.senses.special, race.system.senses.special].filterJoin(";");
     if ( force && race.system.senses.units ) this.attributes.senses.units = race.system.senses.units;
     else this.attributes.senses.units ??= race.system.senses.units;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare spellcasting DC & modifier.
+   * @this {CharacterData|NPCData}
+   */
+  static prepareSpellcastingAbility() {
+    const spellcastingAbility = this.abilities[this.attributes.spellcasting];
+    this.attributes.spelldc = spellcastingAbility ? spellcastingAbility.dc : 8 + this.attributes.prof;
+    this.attributes.spellmod = spellcastingAbility ? spellcastingAbility.mod : 0;
   }
 }

--- a/module/data/actor/templates/traits.mjs
+++ b/module/data/actor/templates/traits.mjs
@@ -166,10 +166,14 @@ export default class TraitsField {
   /* -------------------------------------------- */
 
   /**
-   * Modify resistances and immunities for the petrified condition.
-   * @this {CharacterData|NPCData}
+   * Prepare condition immunities & petrified condition.
+   * @this {CharacterData|NPCData|VehicleData}
    */
   static prepareResistImmune() {
+    // Apply condition immunities
+    for ( const condition of this.traits.ci.value ) this.parent.statuses.delete(condition);
+
+    // Apply petrified condition
     if ( this.parent.hasConditionEffect("petrification") ) {
       this.traits.dr.custom = game.i18n.localize("DND5E.DamageAll");
       Object.keys(CONFIG.DND5E.damageTypes).forEach(type => this.traits.dr.value.add(type));

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -1,4 +1,3 @@
-import FormulaField from "../fields/formula-field.mjs";
 import SourceField from "../shared/source-field.mjs";
 import DamageTraitField from "./fields/damage-trait-field.mjs";
 import SimpleTraitField from "./fields/simple-trait-field.mjs";
@@ -10,14 +9,16 @@ import TraitsFields from "./templates/traits.mjs";
 const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
+ * @import { SourceData } from "../shared/source-field.mjs"
+ * @import { ArmorClassData } from "./templates/attributes.mjs"
+ */
+
+/**
  * System data definition for Vehicles.
  *
  * @property {string} vehicleType                      Type of vehicle as defined in `DND5E.vehicleTypes`.
  * @property {object} attributes
- * @property {object} attributes.ac
- * @property {number} attributes.ac.flat               Flat value used for flat or natural armor calculation.
- * @property {string} attributes.ac.calc               Name of one of the built-in formulas to use.
- * @property {string} attributes.ac.formula            Custom formula to use.
+ * @property {ArmorClassData} attributes.ac
  * @property {string} attributes.ac.motionless         Changes to vehicle AC when not moving.
  * @property {object} attributes.hp
  * @property {number} attributes.hp.value              Current hit points.
@@ -67,9 +68,7 @@ export default class VehicleData extends CommonTemplate {
       attributes: new SchemaField({
         ...AttributesFields.common,
         ac: new SchemaField({
-          flat: new NumberField({ integer: true, min: 0, label: "DND5E.ArmorClassFlat" }),
-          calc: new StringField({ initial: "default", label: "DND5E.ArmorClassCalculation" }),
-          formula: new FormulaField({ deterministic: true, label: "DND5E.ArmorClassFormula" }),
+          ...AttributesFields.armorClass,
           motionless: new StringField({ required: true, label: "DND5E.ArmorClassMotionless" })
         }, { label: "DND5E.ArmorClass" }),
         hp: new SchemaField({
@@ -177,11 +176,14 @@ export default class VehicleData extends CommonTemplate {
     const { originalSaves } = this.parent.getOriginalStats();
 
     this.prepareAbilities({ rollData, originalSaves });
+    AttributesFields.prepareArmorClass.call(this, rollData);
     AttributesFields.prepareEncumbrance.call(this, rollData, { validateItem: item =>
       (item.flags.dnd5e?.vehicleCargo === true) || !["weapon", "equipment"].includes(item.type)
     });
     AttributesFields.prepareHitPoints.call(this, this.attributes.hp);
+    AttributesFields.prepareInitiative.call(this, rollData);
     SourceField.prepareData.call(this.source, this.parent._stats?.compendiumSource ?? this.parent.uuid);
+    TraitsFields.prepareResistImmune.call(this);
   }
 }
 

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -1,6 +1,6 @@
 import { ItemDataModel } from "../../abstract.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
-import {default as EnchantmentField, EnchantmentData} from "../fields/enchantment-field.mjs";
+import EnchantmentField from "../fields/enchantment-field.mjs";
 import SummonsField from "../fields/summons-field.mjs";
 
 const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;

--- a/module/data/shared/movement-field.mjs
+++ b/module/data/shared/movement-field.mjs
@@ -1,6 +1,17 @@
 const { BooleanField, NumberField, StringField } = foundry.data.fields;
 
 /**
+ * @typedef {object} MovementData
+ * @property {number} burrow  Actor burrowing speed.
+ * @property {number} climb   Actor climbing speed.
+ * @property {number} fly     Actor flying speed.
+ * @property {number} swim    Actor swimming speed.
+ * @property {number} walk    Actor walking speed.
+ * @property {string} units   Movement used to measure the various speeds.
+ * @property {boolean} hover  This flying creature able to hover in place.
+ */
+
+/**
  * Field for storing movement data.
  */
 export default class MovementField extends foundry.data.fields.SchemaField {

--- a/module/data/shared/senses-field.mjs
+++ b/module/data/shared/senses-field.mjs
@@ -1,6 +1,16 @@
 const { NumberField, StringField } = foundry.data.fields;
 
 /**
+ * @typedef {object} SensesData
+ * @property {number} darkvision       Creature's darkvision range.
+ * @property {number} blindsight       Creature's blindsight range.
+ * @property {number} tremorsense      Creature's tremorsense range.
+ * @property {number} truesight        Creature's truesight range.
+ * @property {string} units            Distance units used to measure senses.
+ * @property {string} special          Description of any special senses or restrictions.
+ */
+
+/**
  * Field for storing senses data.
  */
 export default class SensesField extends foundry.data.fields.SchemaField {

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -1,4 +1,3 @@
-import { SummonsData } from "../data/item/fields/summons-field.mjs";
 import SystemFlagsMixin from "./mixins/flags.mjs";
 
 /**


### PR DESCRIPTION
Moves skill, tool, armor class, initiative, spellcasting ability, condition immunity, and scale value preparation into data models. This leaves only spellcasting preparation in the main actor class.