### PR TITLE
[#4861] Add combat activation types that display in turn message

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -160,17 +160,27 @@
     }
   },
   "Category": {
+    "Combat": "Combat",
+    "Monster": "Monster",
     "Standard": "Standard",
     "Time": "Time",
-    "Monster": "Monster",
     "Vehicle": "Vehicle"
   },
   "Type": {
+    "Encounter": {
+      "Label": "Start of Encounter"
+    },
     "Legendary": {
       "Counted": {
         "one": "{number} legendary action",
         "other": "{number} legendary actions"
       }
+    },
+    "TurnEnd": {
+      "Label": "End of Turn"
+    },
+    "TurnStart": {
+      "Label": "Start of Turn"
     }
   },
   "Warning": {
@@ -753,7 +763,8 @@
 
 "DND5E.CHATMESSAGE": {
   "TURN": {
-    "NoCombat": "Combat has ended!",
+    "Activities": "Activities",
+    "NoCombatant": "Combatant no longer exists!",
     "Recovery": "Recovery"
   }
 },

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -292,6 +292,7 @@
   }
 
   .pill-lg {
+    --gold-icon-size: 32px;
     background: var(--dnd5e-background-card);
     border: var(--dnd5e-border-gold);
     border-radius: 5px;
@@ -311,11 +312,6 @@
       display: grid;
       place-content: center;
       opacity: .25;
-    }
-
-    .gold-icon {
-      width: 32px;
-      height: 32px;
     }
 
     .name { flex: 1; }
@@ -406,6 +402,10 @@
   }
 
   .gold-icon {
+    block-size: var(--gold-icon-size);
+    inline-size: var(--gold-icon-size);
+    flex: 0 0 var(--gold-icon-size);
+
     border: 2px solid var(--dnd5e-color-gold);
     box-shadow: 0 0 4px var(--dnd5e-shadow-45);
     border-radius: 0;

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -785,6 +785,14 @@ enchantment-application {
     display: block;
     margin-block-start: 1em;
   }
+  .activities ul {
+    margin-block-start: 8px;
+    li {
+      --gold-icon-size: 32px;
+      gap: 8px;
+      button { flex: .5 0; }
+    }
+  }
   .deltas ul {
     li {
       display: flex;

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -787,10 +787,13 @@ enchantment-application {
   }
   .activities ul {
     margin-block-start: 8px;
+
     li {
       --gold-icon-size: 32px;
       gap: 8px;
     }
+
+    a.rollable:hover .subtitle { text-shadow: none; }
   }
   .deltas ul {
     li {

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -790,7 +790,6 @@ enchantment-application {
     li {
       --gold-icon-size: 32px;
       gap: 8px;
-      button { flex: .5 0; }
     }
   }
   .deltas ul {

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -67,8 +67,9 @@ export default class ActorSheet5eNPC extends ActorSheet5e {
       ctx.canToggle = false;
       ctx.totalWeight = item.system.totalWeight?.toNearest(0.1);
       // Item grouping
-      ctx.group = item.system.properties?.has("trait") ? "passive"
-        : item.system.activities?.contents[0]?.activation.type || "passive";
+      const isPassive = item.system.properties?.has("trait")
+        || CONFIG.DND5E.activityActivationTypes[item.system.activities?.contents[0]?.activation.type]?.passive;
+      ctx.group = isPassive ? "passive" : item.system.activities?.contents[0]?.activation.type || "passive";
       ctx.ungroup = "feat";
       if ( item.type === "weapon" ) ctx.ungroup = "weapon";
       if ( ctx.group === "passive" ) ctx.ungroup = "passive";

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -933,9 +933,10 @@ preLocalize("abilityActivationTypes");
 
 /**
  * @typedef {ActivityActivationTypeConfig}
- * @property {string} label            Localized label for the activation type.
- * @property {string} [group]          Localized label for the presentational group.
- * @property {boolean} [scalar=false]  Does this activation type have a numeric value attached?
+ * @property {string} label             Localized label for the activation type.
+ * @property {string} [group]           Localized label for the presentational group.
+ * @property {boolean} [passive=false]  Classify this item as a passive feature on NPC sheets.
+ * @property {boolean} [scalar=false]   Does this activation type have a numeric value attached?
  */
 
 /**
@@ -972,15 +973,18 @@ DND5E.activityActivationTypes = {
   },
   encounter: {
     label: "DND5E.ACTIVATION.Type.Encounter.Label",
-    group: "DND5E.ACTIVATION.Category.Combat"
+    group: "DND5E.ACTIVATION.Category.Combat",
+    passive: true
   },
   turnStart: {
     label: "DND5E.ACTIVATION.Type.TurnStart.Label",
-    group: "DND5E.ACTIVATION.Category.Combat"
+    group: "DND5E.ACTIVATION.Category.Combat",
+    passive: true
   },
   turnEnd: {
     label: "DND5E.ACTIVATION.Type.TurnEnd.Label",
-    group: "DND5E.ACTIVATION.Category.Combat"
+    group: "DND5E.ACTIVATION.Category.Combat",
+    passive: true
   },
   legendary: {
     label: "DND5E.LegendaryAction.Label",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -970,6 +970,18 @@ DND5E.activityActivationTypes = {
     group: "DND5E.ACTIVATION.Category.Time",
     scalar: true
   },
+  encounter: {
+    label: "DND5E.ACTIVATION.Type.Encounter.Label",
+    group: "DND5E.ACTIVATION.Category.Combat"
+  },
+  turnStart: {
+    label: "DND5E.ACTIVATION.Type.TurnStart.Label",
+    group: "DND5E.ACTIVATION.Category.Combat"
+  },
+  turnEnd: {
+    label: "DND5E.ACTIVATION.Type.TurnEnd.Label",
+    group: "DND5E.ACTIVATION.Category.Combat"
+  },
   legendary: {
     label: "DND5E.LegendaryAction.Label",
     group: "DND5E.ACTIVATION.Category.Monster",

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -396,7 +396,7 @@ export class ActorDataModel extends SystemDataModel {
 
   /**
    * Reset combat-related uses.
-   * @param {Set<string>} periods              Which recovery periods should be considered.
+   * @param {string[]} periods                 Which recovery periods should be considered.
    * @param {{ actor: {}, item: [] }} updates  Updates to perform on the actor and containing items.
    */
   async recoverCombatUses(periods, updates) {}

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -424,7 +424,7 @@ export default class NPCData extends CreatureTemplate {
   /** @override */
   async recoverCombatUses(periods, updates) {
     // Reset legendary actions at the start of a combat encounter or at the end of the creature's turn
-    if ( this.resources.legact.max && (periods.has("encounter") || periods.has("turnEnd")) ) {
+    if ( this.resources.legact.max && (periods.includes("encounter") || periods.includes("turnEnd")) ) {
       updates.actor["system.resources.legact.value"] = this.resources.legact.max;
     }
   }

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -7,41 +7,44 @@ export default class Combat5e extends Combat {
   async startCombat() {
     await super.startCombat();
     this._recoverUses({ encounter: true });
-    this.combatant?.refreshDynamicRing();
     return this;
+  }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onUpdate(changed, options, userId) {
+    super._onUpdate(changed, options, userId);
+    if ( this.current.combatantId !== this.previous.combatantId ) {
+      this.combatants.get(this.previous.combatantId)?.refreshDynamicRing();
+      this.combatants.get(this.current.combatantId)?.refreshDynamicRing();
+    }
   }
 
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async nextTurn() {
-    const previous = this.combatant;
-    await super.nextTurn();
-    this._recoverUses({ turnEnd: previous, turnStart: this.combatant });
-    if ( previous && (previous !== this.combatant) ) previous.refreshDynamicRing();
-    this.combatant?.refreshDynamicRing();
-    return this;
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    this.combatants.get(this.current.combatantId)?.refreshDynamicRing();
   }
 
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async previousTurn() {
-    const previous = this.combatant;
-    await super.previousTurn();
-    if ( previous && (previous !== this.combatant) ) previous.refreshDynamicRing();
-    this.combatant?.refreshDynamicRing();
-    return this;
+  async _onEndTurn(combatant) {
+    await super._onEndTurn(combatant);
+    this._recoverUses({ turnEnd: combatant });
   }
 
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async endCombat() {
-    const previous = this.combatant;
-    await super.endCombat();
-    previous?.refreshDynamicRing();
-    return this;
+  async _onStartTurn(combatant) {
+    await super._onStartTurn(combatant);
+    this._recoverUses({ turnStart: combatant });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -57,7 +57,7 @@ export default class Combat5e extends Combat {
   async _recoverUses(types) {
     for ( const combatant of this.combatants ) {
       const periods = Object.entries(types).filter(([, v]) => (v === true) || (v === combatant)).map(([k]) => k);
-      if ( periods.length ) await combatant.recoverCombatUses(new Set(periods));
+      if ( periods.length ) await combatant.recoverCombatUses(periods);
     }
   }
 }

--- a/templates/chat/turn-card.hbs
+++ b/templates/chat/turn-card.hbs
@@ -25,13 +25,12 @@
             {{#each activities}}
             <li class="activity flexrow item-tooltip" data-activity-uuid="{{ uuid }}" data-item-uuid="{{ item.uuid }}">
                 <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
-                <span class="name-stacked">
-                    <span class="title">{{ item.name }}</span>
-                    <span class="subtitle">{{ name }}</span>
-                </span>
-                <button type="button" data-action="use">
-                    {{ localize "DND5E.Use" }}
-                </button>
+                <a class="rollable" data-action="use">
+                    <span class="name-stacked">
+                        <span class="title">{{ item.name }}</span>
+                        <span class="subtitle">{{ name }}</span>
+                    </span>
+                </a>
             </li>
             {{/each}}
         </ul>

--- a/templates/chat/turn-card.hbs
+++ b/templates/chat/turn-card.hbs
@@ -18,9 +18,27 @@
     {{/if}}
 
     {{!-- Actions --}}
-    <!-- TODO: Add actions when implementing https://github.com/foundryvtt/dnd5e/issues/4861 -->
+    {{#if activities.length}}
+    <section class="activities">
+        <strong class="roboto-condensed-upper">{{ localize "DND5E.CHATMESSAGE.TURN.Activities" }}</strong>
+        <ul class="unlist">
+            {{#each activities}}
+            <li class="activity flexrow item-tooltip" data-activity-uuid="{{ uuid }}" data-item-uuid="{{ item.uuid }}">
+                <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
+                <span class="name-stacked">
+                    <span class="title">{{ item.name }}</span>
+                    <span class="subtitle">{{ name }}</span>
+                </span>
+                <button type="button" data-action="use">
+                    {{ localize "DND5E.Use" }}
+                </button>
+            </li>
+            {{/each}}
+        </ul>
+    </section>
+    {{/if}}
 
     {{else}}
-    <p>{{ localize "DND5E.CHATMESSAGE.TURN.NoCombat" }}</p>
+    <p>{{ localize "DND5E.CHATMESSAGE.TURN.NoCombatant" }}</p>
     {{/if}}
 </div>


### PR DESCRIPTION
Adds three new activation types in a new "Combat" section: "Start of Encounter", "Start of Turn", and "End of Turn". These activation types will display in the combat chat message with a "Use" button to be easily activated. They also have a tooltip to display the full item description on hover.

The turn chat message stores relative UUIDs of the activiations in its data model to avoid having to check all of the actor's items every time the chat message is rendered.

Closes #4861