### PR TITLE
Add advantage modes to `abilities` objects

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -113,6 +113,7 @@ export default class CharacterData extends CreatureTemplate {
           })
         }, { label: "DND5E.HitPoints" }),
         death: new RollConfigField({
+          ability: false,
           success: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveSuccesses"
           }),

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -104,6 +104,7 @@ export default class NPCData extends CreatureTemplate {
           formula: new FormulaField({required: true, label: "DND5E.HPFormula"})
         }, {label: "DND5E.HitPoints"}),
         death: new RollConfigField({
+          ability: false,
           success: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveSuccesses"
           }),

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -144,7 +144,7 @@ export default class AttributesFields {
     const abilityId = concentration.ability || CONFIG.DND5E.defaultAbilities.concentration;
     const ability = this.abilities?.[abilityId] || {};
     const bonus = simplifyBonus(concentration.bonuses.save, rollData);
-    concentration.save = (ability.save ?? 0) + bonus;
+    concentration.save = (ability.save?.value ?? 0) + bonus;
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -163,9 +163,8 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
 
       // Deprecations.
       abl.save.toString = function() {
-        foundry.utils.logCompatibilityWarning("The 'abilities.<ability>.save' property is now stored in 'abilities.<ability>.save.value'.", {
-          since: "4.2", until: "4.5"
-        });
+        foundry.utils.logCompatibilityWarning("The 'abilities.<ability>.save' property is now stored in "
+          + "'abilities.<ability>.save.value'.", { since: "4.3", until: "4.5" });
         return abl.save.value;
       };
     }

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -16,8 +16,8 @@ const { NumberField, SchemaField } = foundry.data.fields;
  * @property {object} bonuses        Bonuses that modify ability checks and saves.
  * @property {string} bonuses.check  Numeric or dice bonus to ability checks.
  * @property {string} bonuses.save   Numeric or dice bonus to ability saving throws.
- * @property {RollConfigFieldData} check    Properties related to ability checks.
- * @property {RollConfigFieldData} save     Properties related to ability saving throws.
+ * @property {RollConfigData} check    Properties related to ability checks.
+ * @property {RollConfigData} save     Properties related to ability saving throws.
  */
 
 /**

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -16,16 +16,8 @@ const { NumberField, SchemaField } = foundry.data.fields;
  * @property {object} bonuses        Bonuses that modify ability checks and saves.
  * @property {string} bonuses.check  Numeric or dice bonus to ability checks.
  * @property {string} bonuses.save   Numeric or dice bonus to ability saving throws.
- * @property {object} check          Properties related to ability checks.
- * @property {object} check.roll
- * @property {number} check.roll.mode   The advantage mode of ability checks.
- * @property {number} check.roll.min    The minimum that can be rolled on the d20.
- * @property {number} check.roll.max    The maximum that can be rolled on the d20.
- * @property {object} save              Properties related to ability saving throws.
- * @property {object} save.roll
- * @property {number} save.roll.mode    The advantage mode of ability saving throws.
- * @property {number} save.roll.min     The minimum that can be rolled on the d20.
- * @property {number} save.roll.max     The maximum that can be rolled on the d20.
+ * @property {RollConfigFieldData} check    Properties related to ability checks.
+ * @property {RollConfigFieldData} save     Properties related to ability saving throws.
  */
 
 /**
@@ -53,9 +45,8 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
           check: new FormulaField({ required: true, label: "DND5E.AbilityCheckBonus" }),
           save: new FormulaField({ required: true, label: "DND5E.SaveBonus" })
         }, { label: "DND5E.AbilityBonuses" }),
-        save: new RollConfigField({
-          ability: false
-        })
+        check: new RollConfigField({ ability: false }),
+        save: new RollConfigField({ ability: false })
       }), {
         initialKeys: CONFIG.DND5E.abilities, initialValue: this._initialAbilityValue.bind(this),
         initialKeysOnly: true, label: "DND5E.Abilities"

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -3,7 +3,7 @@ import AdvantageModeField from "../fields/advantage-mode-field.mjs";
 const { StringField, NumberField, SchemaField } = foundry.data.fields;
 
 /**
- * @typedef {object} RollConfigFieldData
+ * @typedef {object} RollConfigData
  * @property {string} [ability]  Default ability associated with this roll.
  * @property {object} roll
  * @property {number} roll.min   Minimum number on the die rolled.
@@ -18,6 +18,11 @@ export default class RollConfigField extends foundry.data.fields.SchemaField {
   constructor({roll={}, ability="", ...fields}={}, options={}) {
     const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
     fields = {
+      ability: ( ability === false ) ? null : new StringField({
+        required: true,
+        initial: ability,
+        label: "DND5E.AbilityModifier"
+      }),
       roll: new SchemaField({
         min: new NumberField({...opts, label: "DND5E.ROLL.Range.Minimum"}),
         max: new NumberField({...opts, label: "DND5E.ROLL.Range.Maximum"}),
@@ -26,13 +31,7 @@ export default class RollConfigField extends foundry.data.fields.SchemaField {
       }),
       ...fields
     };
-    if ( ability !== false ) {
-      fields.ability = new StringField({
-        required: true,
-        initial: ability,
-        label: "DND5E.AbilityModifier"
-      });
-    }
+    Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);
     super(fields, options);
   }
 }

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -3,7 +3,7 @@ import AdvantageModeField from "../fields/advantage-mode-field.mjs";
 const { StringField, NumberField, SchemaField } = foundry.data.fields;
 
 /**
- * @typedef {object} RollConfigData
+ * @typedef {object} RollConfigFieldData
  * @property {string} [ability]  Default ability associated with this roll.
  * @property {object} roll
  * @property {number} roll.min   Minimum number on the die rolled.

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -4,7 +4,7 @@ const { StringField, NumberField, SchemaField } = foundry.data.fields;
 
 /**
  * @typedef {object} RollConfigData
- * @property {string} ability   Default ability associated with this roll.
+ * @property {string} [ability]  Default ability associated with this roll.
  * @property {object} roll
  * @property {number} roll.min   Minimum number on the die rolled.
  * @property {number} roll.max   Maximum number on the die rolled.
@@ -18,7 +18,6 @@ export default class RollConfigField extends foundry.data.fields.SchemaField {
   constructor({roll={}, ability="", ...fields}={}, options={}) {
     const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
     fields = {
-      ability: new StringField({required: true, initial: ability, label: "DND5E.AbilityModifier"}),
       roll: new SchemaField({
         min: new NumberField({...opts, label: "DND5E.ROLL.Range.Minimum"}),
         max: new NumberField({...opts, label: "DND5E.ROLL.Range.Maximum"}),
@@ -27,6 +26,13 @@ export default class RollConfigField extends foundry.data.fields.SchemaField {
       }),
       ...fields
     };
+    if ( ability !== false ) {
+      fields.ability = new StringField({
+        required: true,
+        initial: ability,
+        label: "DND5E.AbilityModifier"
+      });
+    }
     super(fields, options);
   }
 }

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -18,7 +18,7 @@ export default class RollConfigField extends foundry.data.fields.SchemaField {
   constructor({roll={}, ability="", ...fields}={}, options={}) {
     const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
     fields = {
-      ability: ( ability === false ) ? null : new StringField({
+      ability: (ability === false) ? null : new StringField({
         required: true,
         initial: ability,
         label: "DND5E.AbilityModifier"

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -171,7 +171,7 @@
                             {{{ability.icon}}}
                         </a>
                         <span class="ability-save" data-tooltip="DND5E.SavingThrow">
-                            {{numberFormat ability.save decimals=0 sign=true}}
+                            {{numberFormat ability.save.value decimals=0 sign=true}}
                         </span>
                     </div>
                     <a class="config-button" data-action="ability"

--- a/templates/actors/npc-sheet-2.hbs
+++ b/templates/actors/npc-sheet-2.hbs
@@ -297,7 +297,7 @@
                                            data-tooltip="{{ hover }}" aria-label="{{ localize hover }}"
                                            value="{{#if @root.editable}}{{ baseProf }}{{else}}{{ proficient }}{{/if}}"
                                            {{ disabled (not @root.editable) }}></proficiency-cycle>
-                        <span class="save">{{ dnd5e-formatModifier save }}</span>
+                        <span class="save">{{ dnd5e-formatModifier save.value }}</span>
                         <i class="fas fa-shield-heart" inert></i>
                     </div>
                 </div>

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -143,7 +143,7 @@
                             {{{ability.icon}}}
                         </a>
                         <span class="ability-save" data-tooltip="DND5E.SavingThrow">
-                            {{numberFormat ability.save decimals=0 sign=true}}
+                            {{numberFormat ability.save.value decimals=0 sign=true}}
                         </span>
                     </div>
                     <a class="config-button" data-action="ability"

--- a/templates/actors/tabs/character-details.hbs
+++ b/templates/actors/tabs/character-details.hbs
@@ -34,7 +34,7 @@
         {{/if}}
         <a class="name saving-throw full {{ @root.rollableClass }}">{{ label }}</a>
         <a class="name saving-throw abbr {{ @root.rollableClass }}">{{ abbr }}</a>
-        <div class="bonus">{{ dnd5e-formatModifier save }}</div>
+        <div class="bonus">{{ dnd5e-formatModifier save.value }}</div>
         {{#if @root.editable}}
         <a class="config-button" data-action="ability" data-tooltip="{{ config }}" aria-label="{{ localize config }}">
             <i class="fas fa-cog"></i>


### PR DESCRIPTION
(Built on top of #4890.)

Adds `system.abilities.<abilityId>.check.roll` and `.save.roll` objects.

Moves the derived `abilities.<abilityId>.save` value into `.check/.save.value` with a `toString` method for the deprecation period.

(Also removes the `ability` property from the `attributes.death` object.)

TODO:
- [ ] Add the roll mode and min/max stuff to ability configs.
- [ ] Hook up actually using the data in rolls.