### PR TITLE
[#4924] Change `parseInt` to `Number`

### DIFF
--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -686,7 +686,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       let actionType = this.actionType;
       if ( (actionType === "mwak") && rollConfig.attackMode?.startsWith("thrown") ) actionType = "rwak";
       const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.bonuses.${actionType}.damage`);
-      if ( bonus && (parseInt(bonus) !== 0) ) parts.push(bonus);
+      if ( bonus && (Number(bonus) !== 0) ) parts.push(bonus);
     }
 
     const lastType = this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`);

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -686,7 +686,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       let actionType = this.actionType;
       if ( (actionType === "mwak") && rollConfig.attackMode?.startsWith("thrown") ) actionType = "rwak";
       const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.bonuses.${actionType}.damage`);
-      if ( bonus && (Number(bonus) !== 0) ) parts.push(bonus);
+      if ( bonus && !/^0+$/.test(bonus) ) parts.push(bonus);
     }
 
     const lastType = this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`);


### PR DESCRIPTION
Currently the system uses `parseInt`, which means a bonus such as `0 + 123` gets ignored because `parseInt("0 + 123")` is `0`.

iirc there was a reason we had this small validation step so I changed it for `Number` instead, but it would otherwise seem to me that we could just change to `bonus !== "0"`.