### PR TITLE
Show ability-mod-using bonuses on sheet

### DIFF
--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -130,13 +130,14 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
   prepareAbilities({ rollData={}, originalSaves }={}) {
     const flags = this.parent.flags.dnd5e ?? {};
     const { prof = 0, ac } = this.attributes ?? {};
+    for ( const abl of Object.values(this.abilities) ) {
+      if ( flags.diamondSoul ) abl.proficient = 1;  // Diamond Soul is proficient in all saves
+      abl.mod = Math.floor((abl.value - 10) / 2);
+    }
     const checkBonus = simplifyBonus(this.bonuses?.abilities?.check, rollData);
     const saveBonus = simplifyBonus(this.bonuses?.abilities?.save, rollData);
     const dcBonus = simplifyBonus(this.bonuses?.spell?.dc, rollData);
     for ( const [id, abl] of Object.entries(this.abilities) ) {
-      if ( flags.diamondSoul ) abl.proficient = 1;  // Diamond Soul is proficient in all saves
-      abl.mod = Math.floor((abl.value - 10) / 2);
-
       abl.checkProf = this.calculateAbilityCheckProficiency(0, id);
       const saveBonusAbl = simplifyBonus(abl.bonuses?.save, rollData);
 

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -130,14 +130,13 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
   prepareAbilities({ rollData={}, originalSaves }={}) {
     const flags = this.parent.flags.dnd5e ?? {};
     const { prof = 0, ac } = this.attributes ?? {};
-    for ( const abl of Object.values(this.abilities) ) {
-      if ( flags.diamondSoul ) abl.proficient = 1;  // Diamond Soul is proficient in all saves
-      abl.mod = Math.floor((abl.value - 10) / 2);
-    }
+    Object.values(this.abilities).forEach(a => a.mod = Math.floor((a.value - 10) / 2));
     const checkBonus = simplifyBonus(this.bonuses?.abilities?.check, rollData);
     const saveBonus = simplifyBonus(this.bonuses?.abilities?.save, rollData);
     const dcBonus = simplifyBonus(this.bonuses?.spell?.dc, rollData);
     for ( const [id, abl] of Object.entries(this.abilities) ) {
+      if ( flags.diamondSoul ) abl.proficient = 1;  // Diamond Soul is proficient in all saves
+
       abl.checkProf = this.calculateAbilityCheckProficiency(0, id);
       const saveBonusAbl = simplifyBonus(abl.bonuses?.save, rollData);
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -295,7 +295,7 @@ export function simplifyBonus(bonus, data={}) {
   if ( Number.isNumeric(bonus) ) return Number(bonus);
   try {
     const roll = new Roll(bonus, data);
-    return roll.evaluateSync({strict: false}).total;
+    return roll.isDeterministic ? roll.evaluateSync().total : 0;
   } catch(error) {
     console.error(error);
     return 0;

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -295,7 +295,7 @@ export function simplifyBonus(bonus, data={}) {
   if ( Number.isNumeric(bonus) ) return Number(bonus);
   try {
     const roll = new Roll(bonus, data);
-    return roll.isDeterministic ? roll.evaluateSync().total : 0;
+    return roll.evaluateSync({strict: false}).total;
   } catch(error) {
     console.error(error);
     return 0;


### PR DESCRIPTION
By ~~changing `simplifyBonus` to always return the total of the deterministic terms, (and~~ moving `mod` calculation prior to any bonus determination ~~)~~, something like `system.bonuses.abilities.save | Add | @abilities.cha.mod` will actually display the appropriate bonus on the sheet. ~~All non-deterministic terms are ignored still for sheet display.~~

Update: Changing `simplifyBonus` is actually not necessary for the _main_ functionality of this change, which is to have ability mod bonuses show up on the sheet. It may still be a worthwhile change, but not as part of this PR.