### PR TITLE
Avoid crash when getting scene targets when canvas is disabled

### DIFF
--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -492,7 +492,7 @@ export function getTargetDescriptors() {
  * @returns {Token5e[]}
  */
 export function getSceneTargets() {
-  let targets = canvas.tokens.controlled.filter(t => t.actor);
+  let targets = canvas.tokens?.controlled.filter(t => t.actor) ?? [];
   if ( !targets.length && game.user.character ) targets = game.user.character.getActiveTokens();
   return targets;
 }


### PR DESCRIPTION
Repro:

- Disable canvas in Foundry settings
- Use a "save" activity from an actor's sheet
- Click the "DC \<X\> \<Y\> Saving Throw" button in the resulting chat card