### PR TITLE
[#3695] Allow feats to define the abilities they can improve

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1908,6 +1908,33 @@
 "DND5E.FavoriteRemove": "Remove Favorite",
 "DND5E.Favorites": "Favorites",
 "DND5E.FeatureActionRecharge": "Action Recharge",
+
+"DND5E.FEATURE": {
+  "FIELDS": {
+    "asi": {
+      "label": "Ability Score Increase",
+      "abilities": {
+        "label": "Allowed Abilities"
+      },
+      "maximum": {
+        "label": "Maximum Score"
+      }
+    },
+    "prerequisites": {
+      "label": "Prerequisites"
+    },
+    "properties": {
+      "label": "Feature Properties"
+    },
+    "requirements": {
+      "label": "Requirements"
+    },
+    "type": {
+      "label": "Feature Type"
+    }
+  }
+},
+
 "DND5E.Feature": {
   "Background": "Background Feature",
   "Class": {

--- a/module/applications/actor/config/hit-points-config.mjs
+++ b/module/applications/actor/config/hit-points-config.mjs
@@ -69,7 +69,6 @@ export default class HitPointsConfig extends BaseConfigSheet {
         .filter(e => e.mode === CONST.ACTIVE_EFFECT_MODES.ADD)
         .map(e => ({ ...e, anchor: e.document.toAnchor().outerHTML}));
     }
-    console.log(context.effects);
 
     context.levels = this.document.system.details?.level ?? 0;
     context.levelMultiplier = `

--- a/module/data/advancement/ability-score-improvement.mjs
+++ b/module/data/advancement/ability-score-improvement.mjs
@@ -32,7 +32,6 @@ export class AbilityScoreImprovementConfigurationData extends foundry.abstract.D
 /**
  * Data model for the Ability Score Improvement advancement value.
  *
- * @property {string} type             When on a class, whether the player chose ASI or a Feat.
  * @property {Object<string, number>}  Points assigned to individual scores.
  * @property {Object<string, string>}  Feat that was selected.
  */
@@ -40,7 +39,6 @@ export class AbilityScoreImprovementValueData extends SparseDataModel {
   /** @inheritDoc */
   static defineSchema() {
     return {
-      type: new StringField({ required: true, initial: "asi", choices: ["asi", "feat"] }),
       assignments: new MappingField(new NumberField({
         nullable: false, integer: true
       }), { required: false, initial: undefined }),

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -13,6 +13,9 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
  * @mixes ItemDescriptionTemplate
  * @mixes ItemTypeTemplate
  *
+ * @property {object} asi
+ * @property {Set<string>} asi.abilities            Abilities that can be improved by this feat.
+ * @property {number} asi.maximum                   Maximum ability score to which the ability can be increased.
  * @property {object} enchant
  * @property {string} enchant.max                   Maximum number of items that can have this enchantment.
  * @property {string} enchant.period                Frequency at which the enchantment can be swapped.
@@ -30,25 +33,27 @@ export default class FeatData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.ENCHANTMENT", "DND5E.Prerequisites", "DND5E.SOURCE"];
+  static LOCALIZATION_PREFIXES = ["DND5E.FEATURE", "DND5E.ENCHANTMENT", "DND5E.Prerequisites", "DND5E.SOURCE"];
 
   /* -------------------------------------------- */
 
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
+      asi: new SchemaField({
+        abilities: new SetField(new StringField()),
+        maximum: new NumberField({ positive: true, integer: true, initial: () => CONFIG.DND5E.maxAbilityScore })
+      }),
       enchant: new SchemaField({
-        max: new FormulaField({deterministic: true}),
+        max: new FormulaField({ deterministic: true }),
         period: new StringField()
       }),
-      type: new ItemTypeField({baseItem: false}, {label: "DND5E.ItemFeatureType"}),
       prerequisites: new SchemaField({
-        level: new NumberField({integer: true, min: 0})
+        level: new NumberField({ integer: true, min: 0 })
       }),
-      properties: new SetField(new StringField(), {
-        label: "DND5E.ItemFeatureProperties"
-      }),
-      requirements: new StringField({required: true, nullable: true, label: "DND5E.Requirements"})
+      properties: new SetField(new StringField()),
+      requirements: new StringField({ required: true, nullable: true }),
+      type: new ItemTypeField({ baseItem: false })
     });
   }
 
@@ -161,6 +166,8 @@ export default class FeatData extends ItemDataModel.mixin(
         placeholder: "DND5E.Requirements" }
     ];
     context.parts = ["dnd5e.details-feat", "dnd5e.field-uses"];
+    context.showAbilityScoreIncrease = this.type.value === "feat";
+    context.abilityOptions = Object.entries(CONFIG.DND5E.abilities).map(([value, { label }]) => ({ value, label }));
   }
 
   /* -------------------------------------------- */

--- a/templates/advancement/ability-score-improvement-flow.hbs
+++ b/templates/advancement/ability-score-improvement-flow.hbs
@@ -2,15 +2,11 @@
     <h3>{{{ this.title }}}</h3>
     {{#if advancement.hint}}<p>{{ advancement.hint }}</p>{{/if}}
 
-    <ul class="ability-scores {{#if feat}}disabled{{/if}}">
+    <ul class="ability-scores">
         {{#unless staticIncrease}}
         <label>
-            {{#if feat}}
-            {{ localize "DND5E.ADVANCEMENT.AbilityScoreImprovement.LockedHint" }}
-            {{else}}
             {{ pointsRemaining }}
-            {{#if advancement.configuration.cap}}<p class="cap">{{ pointCap }}</p>{{/if}}
-            {{/if}}
+            {{#if pointCap}}<p class="cap">{{ pointCap }}</p>{{/if}}
         </label>
         {{/unless}}
         {{#each abilities}}

--- a/templates/items/details/details-feat.hbs
+++ b/templates/items/details/details-feat.hbs
@@ -21,6 +21,18 @@
                  input=inputs.createMultiCheckboxInput stacked=true classes="checkbox-grid checkbox-grid-3" }}
 </fieldset>
 
+{{#if showAbilityScoreIncrease}}
+<fieldset>
+    <legend>{{ localize "DND5E.FEATURE.FIELDS.asi.label" }}</legend>
+
+    {{!-- Allowed Abilities --}}
+    {{ formField fields.asi.fields.abilities value=source.asi.abilities options=abilityOptions labelAttr="label" }}
+
+    {{!-- Maximum Score --}}
+    {{ formField fields.asi.fields.maximum value=source.asi.maximum }}
+</fieldset>
+{{/if}}
+
 {{#if system.isEnchantmentSource}}
 <fieldset>
     <legend>{{ localize "DND5E.ENCHANTMENT.Label" }}</legend>


### PR DESCRIPTION
Adds the ability for feats to define a set of abilities that can be improved as part of taking the feat, as well as a maximum for that improvement regardless of the maximum set on the actor.

When a feat is selected as part of ability score improvement and an ability is specified, the player will now have the option of selecting an ability to improve according to what the feat specifies.

<img width="996" alt="Feat ASI Support" src="https://github.com/user-attachments/assets/f62c11d0-efa6-4e1f-8692-ed3dcbfb2147" />

This integrates nicely with the existing advancement workflow, but it has the limitation that these ability score increases through feats are only available through the normal advancement. If a feat is granted to a player outside of the normal leveling process (such as an epic boon feat at level 20) then they will have to apply the ability score increase manually.

Closes #3695