### PR TITLE
[#4955] Add option to apply advancement steps automatically

### DIFF
--- a/module/applications/advancement/advancement-flow.mjs
+++ b/module/applications/advancement/advancement-flow.mjs
@@ -110,6 +110,16 @@ export default class AdvancementFlow extends FormApplication {
 
   /* -------------------------------------------- */
 
+  /**
+   * Retrieve automatic application data from the advancement, if supported.
+   * @returns {object|false}  Data to pass to the apply method, or `false` if advancement requirers user intervention.
+   */
+  getAutomaticApplicationValue() {
+    return this.advancement.automaticApplicationValue(this.level);
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   async _updateObject(event, formData) {
     await this.advancement.apply(this.level, formData);

--- a/module/documents/advancement/advancement.mjs
+++ b/module/documents/advancement/advancement.mjs
@@ -323,6 +323,18 @@ export default class Advancement extends BaseAdvancement {
    */
   async apply(level, data) { }
 
+
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieves the data to pass to the apply method in order to apply this advancement automatically, if possible.
+   * @param {number} level    Level being advanced.
+   * @returns {object|false}  Data to pass to the apply method, or `false` if advancement requirers user intervention.
+   */
+  automaticApplicationValue(level) {
+    return false;
+  }
+
   /* -------------------------------------------- */
 
   /**
@@ -361,6 +373,6 @@ export default class Advancement extends BaseAdvancement {
       _id: id ?? foundry.utils.randomID(),
       "flags.dnd5e.sourceId": uuid,
       "flags.dnd5e.advancementOrigin": `${this.item.id}.${this.id}`
-    }, {keepId: true}).toObject();
+    }, { keepId: true }).toObject();
   }
 }

--- a/module/documents/advancement/hit-points.mjs
+++ b/module/documents/advancement/hit-points.mjs
@@ -165,6 +165,15 @@ export default class HitPointsAdvancement extends Advancement {
 
   /* -------------------------------------------- */
 
+  /** @override */
+  automaticApplicationValue(level) {
+    if ( (level === 1) && this.item.isOriginalClass ) return { [level]: "max" };
+    if ( this.value[level - 1] === "avg" ) return { [level]: "avg" };
+    return false;
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   restore(level, data) {
     this.apply(level, data);

--- a/module/documents/advancement/item-grant.mjs
+++ b/module/documents/advancement/item-grant.mjs
@@ -113,6 +113,16 @@ export default class ItemGrantAdvancement extends Advancement {
 
   /* -------------------------------------------- */
 
+  /** @override */
+  automaticApplicationValue(level) {
+    if ( this.configuration.optional
+      || (this.configuration.spell?.ability?.size > 1)
+      || this.configuration.items.some(i => i.optional) ) return false;
+    return Object.fromEntries(this.configuration.items.map(({ uuid }) => [uuid, true]));
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   restore(level, data) {
     const updates = {};

--- a/module/documents/advancement/scale-value.mjs
+++ b/module/documents/advancement/scale-value.mjs
@@ -98,4 +98,12 @@ export default class ScaleValueAdvancement extends Advancement {
     return true;
   }
 
+  /* -------------------------------------------- */
+  /*  Application Methods                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  automaticApplicationValue(level) {
+    return {};
+  }
 }

--- a/module/documents/advancement/size.mjs
+++ b/module/documents/advancement/size.mjs
@@ -79,8 +79,16 @@ export default class SizeAdvancement extends Advancement {
 
   /** @inheritDoc */
   async apply(level, data) {
-    this.actor.updateSource({"system.traits.size": data.size ?? "med"});
+    this.actor.updateSource({ "system.traits.size": data.size ?? this.configuration.sizes.first() ?? "med" });
     this.updateSource({ value: data });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  automaticApplicationValue(level) {
+    if ( this.configuration.sizes > 1 ) return false;
+    return this.configuration.sizes.first() ?? "med";
   }
 
   /* -------------------------------------------- */

--- a/module/documents/advancement/trait.mjs
+++ b/module/documents/advancement/trait.mjs
@@ -120,6 +120,16 @@ export default class TraitAdvancement extends Advancement {
 
   /* -------------------------------------------- */
 
+  /** @override */
+  automaticApplicationValue(level) {
+    // TODO: Ideally this would be able to detect situations where choices are automatically fulfilled because
+    // they only have one valid option, but that is an async process and cannot be called from within `render`
+    if ( this.configuration.choices.length || this.configuration.allowReplacements ) return false;
+    return { chosen: Array.from(this.configuration.grants) };
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   async restore(level, data) {
     this.apply(level, data);


### PR DESCRIPTION
Adds a `automaticApplication` option to the `AdvancementManager` that tells it to no display the UI for advancement steps if they can be applied without user intervention.

To support automatic application the `Advancement` API has a new method: `automaticApplicationValue`. This method takes the level to be applied and returns the data object to pass to the `apply` method if automatic application is possible, otherwise it returns `false`. Since this method returns `false` by default, only advancement types that opt-in to it will get the new behavior.

Closes #4955