### PR TITLE
[#3695] Add ASI Advancement support to feature items

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4150,7 +4150,7 @@ const _ALL_ITEM_TYPES = ["background", "class", "race", "subclass"];
 DND5E.advancementTypes = {
   AbilityScoreImprovement: {
     documentClass: advancement.AbilityScoreImprovementAdvancement,
-    validItemTypes: new Set(["background", "class", "race"])
+    validItemTypes: new Set(["background", "class", "race", "feat"])
   },
   HitPoints: {
     documentClass: advancement.HitPointsAdvancement,

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -1,11 +1,12 @@
 import { ItemDataModel } from "../abstract.mjs";
+import AdvancementField from "../fields/advancement-field.mjs";
+import FormulaField from "../fields/formula-field.mjs";
 import ActivitiesTemplate from "./templates/activities.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ItemTypeTemplate from "./templates/item-type.mjs";
 import ItemTypeField from "./fields/item-type-field.mjs";
-import { FormulaField } from "../fields/_module.mjs";
 
-const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * Data definition for Feature items.
@@ -13,6 +14,7 @@ const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundr
  * @mixes ItemDescriptionTemplate
  * @mixes ItemTypeTemplate
  *
+ * @property {Advancement[]}                        Advancement objects for this feature.
  * @property {object} enchant
  * @property {string} enchant.max                   Maximum number of items that can have this enchantment.
  * @property {string} enchant.period                Frequency at which the enchantment can be swapped.
@@ -38,6 +40,7 @@ export default class FeatData extends ItemDataModel.mixin(
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
+      advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" }),
       enchant: new SchemaField({
         max: new FormulaField({ deterministic: true }),
         period: new StringField()


### PR DESCRIPTION
Adds advancement data to `feature` items and allows them to use the `ASIAdvancement`. Holding off on more advancement types until more testing has been performed to ensure granting items will work properly.

<img width="511" alt="Advancement on Feat" src="https://github.com/user-attachments/assets/ae3e6344-6be0-4d28-96c8-59fca955f4d0" />

Closes #3695