### PR TITLE
[#3695] Adjust ASI advancement in modern rules to be feat-first

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -248,6 +248,7 @@
     },
     "Details": "Improvement Details",
     "Feat": {
+      "ASIName": "Ability Score Improvement Feat",
       "Hint": "Drop a feat here to choose one instead of an ability score improvement."
     },
     "FIELDS": {
@@ -4434,7 +4435,7 @@
   "Normal": "Normal (max carrying capacity)",
   "Variant": "Variant (encumbered & heavily encumbered)"
 },
-"SETTINGS.5eFeatsL": "Allow players to choose a feat rather than taking an ability score improvement during class advancement.",
+"SETTINGS.5eFeatsL": "Allow players to choose a feat rather than taking an ability score improvement during class advancement when using the Legacy rules.",
 "SETTINGS.5eFeatsN": "Allow Feats",
 "SETTINGS.5eHonorL": "Enable the use of the optional Honor ability score. Requires the world to be reloaded.",
 "SETTINGS.5eHonorN": "Honor Ability Score",

--- a/less/v1/advancement.less
+++ b/less/v1/advancement.less
@@ -199,13 +199,9 @@
     }
     .drop-area {
       padding-block: 0.5em;
-      h4 {
-        margin: 0;
-        font-size: var(--font-size-16);
-      }
-      a.item-control {
-        flex: 0;
-      }
+      align-items: center;
+      .name { font-size: var(--font-size-16); }
+      .item-control { flex: 0; }
     }
     .drop-area.empty {
       padding-block: 1em;

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -122,7 +122,10 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
     const input = event.currentTarget;
     if ( input.name === "asi-selected" ) {
       if ( input.checked ) this.feat = { isASI: true };
-      else this.feat = null;
+      else {
+        if ( this.feat?.isASI ) this.assignments = {};
+        this.feat = null;
+      }
     } else {
       const key = input.closest("[data-score]").dataset.score;
       if ( isNaN(input.valueAsNumber) ) this.assignments[key] = 0;

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -22,6 +22,11 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  static _customElements = super._customElements.concat(["dnd5e-checkbox"]);
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       dragDrop: [{ dropSelector: "form" }],
@@ -37,6 +42,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
     this.assignments = this.retainedData.assignments ?? {};
     const featUuid = Object.values(this.retainedData.feat ?? {})[0];
     if ( featUuid ) this.feat = await fromUuid(featUuid);
+    else if ( !foundry.utils.isEmpty(this.assignments) ) this.feat = { isASI: true };
   }
 
   /* -------------------------------------------- */
@@ -55,6 +61,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
 
     const formatter = new Intl.NumberFormat(game.i18n.lang, { signDisplay: "always" });
 
+    const lockImprovement = this.feat && !this.feat.isASI;
     const abilities = Object.entries(CONFIG.DND5E.abilities).reduce((obj, [key, data]) => {
       if ( !this.advancement.canImprove(key) ) return obj;
       const ability = this.advancement.actor.system.abilities[key];
@@ -71,26 +78,29 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
         initial: ability.value + fixed,
         delta: (value - ability.value) ? formatter.format(value - ability.value) : null,
         showDelta: true,
-        isDisabled: !!this.feat,
+        isDisabled: lockImprovement,
         isLocked: !!locked || (ability.value >= ability.max),
-        canIncrease: (value < max) && ((fixed + assignment) < points.cap) && !locked && !this.feat,
-        canDecrease: (value > (ability.value + fixed)) && !locked && !this.feat
+        canIncrease: (value < max) && ((fixed + assignment) < points.cap) && !locked && !lockImprovement,
+        canDecrease: (value > (ability.value + fixed)) && !locked && !lockImprovement
       };
       return obj;
     }, {});
 
+    const modernRules = game.settings.get("dnd5e", "rulesVersion") === "modern";
     const pluralRules = new Intl.PluralRules(game.i18n.lang);
     return foundry.utils.mergeObject(super.getData(), {
-      abilities, points,
+      abilities, lockImprovement, points,
       feat: this.feat,
-      staticIncrease: !this.advancement.configuration.points,
       pointCap: game.i18n.format(
-        `DND5E.ADVANCEMENT.AbilityScoreImprovement.CapDisplay.${pluralRules.select(points.cap)}`, {points: points.cap}
+        `DND5E.ADVANCEMENT.AbilityScoreImprovement.CapDisplay.${pluralRules.select(points.cap)}`, { points: points.cap }
       ),
       pointsRemaining: game.i18n.format(
         `DND5E.ADVANCEMENT.AbilityScoreImprovement.PointsRemaining.${pluralRules.select(points.available)}`,
         {points: points.available}
-      )
+      ),
+      showASIFeat: modernRules && this.advancement.allowFeat && !lockImprovement,
+      showImprovement: !modernRules || !this.advancement.allowFeat || this.feat?.isASI,
+      staticIncrease: !this.advancement.configuration.points
     });
   }
 
@@ -110,13 +120,18 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
   _onChangeInput(event) {
     super._onChangeInput(event);
     const input = event.currentTarget;
-    const key = input.closest("[data-score]").dataset.score;
-    if ( isNaN(input.valueAsNumber) ) this.assignments[key] = 0;
-    else {
-      this.assignments[key] = Math.min(
-        Math.clamp(input.valueAsNumber, Number(input.min), Number(input.max)) - Number(input.dataset.initial),
-        (this.advancement.configuration.cap - (this.advancement.configuration.fixed[key] ?? 0)) ?? Infinity
-      );
+    if ( input.name === "asi-selected" ) {
+      if ( input.checked ) this.feat = { isASI: true };
+      else this.feat = null;
+    } else {
+      const key = input.closest("[data-score]").dataset.score;
+      if ( isNaN(input.valueAsNumber) ) this.assignments[key] = 0;
+      else {
+        this.assignments[key] = Math.min(
+          Math.clamp(input.valueAsNumber, Number(input.min), Number(input.max)) - Number(input.dataset.initial),
+          (this.advancement.configuration.cap - (this.advancement.configuration.fixed[key] ?? 0)) ?? Infinity
+        );
+      }
     }
     this.render();
   }
@@ -159,7 +174,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
   /** @inheritDoc */
   async _updateObject(event, formData) {
     await this.advancement.apply(this.level, {
-      type: this.feat ? "feat" : "asi",
+      type: (this.feat && !this.feat.isASI) ? "feat" : "asi",
       assignments: this.assignments,
       featUuid: this.feat?.uuid,
       retainedItems: this.retainedData?.retainedItems

--- a/module/documents/advancement/ability-score-improvement.mjs
+++ b/module/documents/advancement/ability-score-improvement.mjs
@@ -50,7 +50,8 @@ export default class AbilityScoreImprovementAdvancement extends Advancement {
    * @type {boolean}
    */
   get allowFeat() {
-    return (this.item.type === "class") && game.settings.get("dnd5e", "allowFeats");
+    return (this.item.type === "class") && (game.settings.get("dnd5e", "allowFeats")
+      || game.settings.get("dnd5e", "rulesVersion") === "modern");
   }
 
   /* -------------------------------------------- */

--- a/templates/advancement/ability-score-improvement-flow.hbs
+++ b/templates/advancement/ability-score-improvement-flow.hbs
@@ -2,10 +2,11 @@
     <h3>{{{ this.title }}}</h3>
     {{#if advancement.hint}}<p>{{ advancement.hint }}</p>{{/if}}
 
-    <ul class="ability-scores {{#if feat}}disabled{{/if}}">
+    {{#if showImprovement}}
+    <ul class="ability-scores {{#if lockImprovement}}disabled{{/if}}">
         {{#unless staticIncrease}}
         <label>
-            {{#if feat}}
+            {{#if lockImprovement}}
             {{ localize "DND5E.ADVANCEMENT.AbilityScoreImprovement.LockedHint" }}
             {{else}}
             {{ pointsRemaining }}
@@ -17,23 +18,33 @@
         {{> "dnd5e.advancement-ability-score-control" this canAdjust=(not @root.staticIncrease) }}
         {{/each}}
     </ul>
+    {{/if}}
 
     {{#if advancement.allowFeat}}
-        <h3>{{ localize "DND5E.Feature.Feat.Label" }}</h3>
+    {{#if showImprovement}}<h3>{{ localize "DND5E.Feature.Feat.Label" }}</h3>{{/if}}
 
-        <div class="item-name flexrow drop-area {{#unless feat}}empty{{/unless}}">
-            {{#if feat}}
-            <div class="item-image" style="background-image: url('{{ feat.img }}');"></div>
-            <h4>
-                <a data-uuid="{{ feat.uuid }}">{{ feat.name }}</a>
-            </h4>
-            <a class="item-control" data-action="delete" data-tooltip="DND5E.ItemDelete"
-               aria-label="{{ localize 'DND5E.ItemDelete' }}">
-                <i class="fas fa-trash" inert></i>
-            </a>
-            {{else}}
-            {{ localize "DND5E.ADVANCEMENT.AbilityScoreImprovement.Feat.Hint" }}
-            {{/if}}
-        </div>
+    {{#if showASIFeat}}
+    <div class="item-name flexrow drop-area dnd5e2">
+        <div class="item-image"
+             style="background-image: url('icons/skills/melee/weapons-crossed-swords-white-blue.webp');"></div>
+        <span class="name">{{ localize "DND5E.ADVANCEMENT.AbilityScoreImprovement.Feat.ASIName" }}</span>
+        <dnd5e-checkbox class="item-control" name="asi-selected" {{ checked feat.isASI }}></dnd5e-checkbox>
+    </div>
+    {{/if}}
+
+    {{#unless feat.isASI}}
+    <div class="item-name flexrow drop-area {{#unless feat}}empty{{/unless}}">
+        {{#if feat}}
+        <div class="item-image" style="background-image: url('{{ feat.img }}');"></div>
+        <a class="name" data-uuid="{{ feat.uuid }}">{{ feat.name }}</a>
+        <a class="item-control" data-action="delete" data-tooltip="DND5E.ItemDelete"
+           aria-label="{{ localize 'DND5E.ItemDelete' }}">
+            <i class="fas fa-trash" inert></i>
+        </a>
+        {{else}}
+        {{ localize "DND5E.ADVANCEMENT.AbilityScoreImprovement.Feat.Hint" }}
+        {{/if}}
+    </div>
+    {{/unless}}
     {{/if}}
 </form>


### PR DESCRIPTION
In the 2024 rules ability score improvement is presented as: "Take the Ability Score Improvmeent Feat or another feat". This adjusts the interface of the ASI advancement when using the modern rules to hide the ASI interface unless the "Ability Score Improvement Feat" is checked. This change will improve the experience of half-feats because they won't be presented with two ASI interfaces in a row.

<img width="477" alt="ASI 2024" src="https://github.com/user-attachments/assets/4b54bed2-f479-4311-9213-bf8ed9f1d76b" />

Also ignores the "Allow Feats" setting when using the 2024 rules because they are no longer an optional rule.