### PR TITLE
[#4973] Add auto-generated ASI description to class journals

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -269,6 +269,11 @@
         "increase": "Increase Points"
       }
     },
+    "Journal": {
+      "DescriptionLegacy": "<p>When you reach {firstLevelOrdinal} level, and again at {otherLevelsOrdinal} level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can’t increase an ability score above {maxAbilityScore} using this feature.</p><p>Using the optional feats rule, you can forgo taking this feature to take a feat of your choice instead.</p>",
+      "DescriptionModern": "<p>You gain the Ability Score Improvement feat or another feat of your choice for which you qualify. You gain this feature again at {class} levels {otherLevels}.</p>",
+      "Name": "Ability Score Improvement"
+    },
     "LockedHint": "Scores cannot be modified with a feat selected.",
     "PointsRemaining": {
       "one": "{points} Point Remaining",
@@ -2551,6 +2556,14 @@
 
 "DND5E.Number": "Number",
 "DND5E.OtherFormula": "Other Formula",
+
+"DND5E.ORDINAL": {
+  "one": "{number}st",
+  "two": "{number}nd",
+  "few": "{number}rd",
+  "other": "{number}th"
+},
+
 "DND5E.PactMagic": "Pact Magic",
 "DND5E.Passive": "Passive",
 "DND5E.PassivePerception": "Passive Perception",

--- a/module/applications/journal/class-page-sheet.mjs
+++ b/module/applications/journal/class-page-sheet.mjs
@@ -408,7 +408,7 @@ export default class JournalClassPageSheet extends JournalPageSheet {
       const document = await fromUuid(f.uuid);
       if ( document?.type !== "feat" ) return null;
       return {
-        document,
+        document, level,
         name: modernStyle ? game.i18n.format("JOURNALENTRYPAGE.DND5E.Class.Features.Name", {
           name: document.name, level: formatNumber(level)
         }) : document.name,
@@ -419,13 +419,38 @@ export default class JournalClassPageSheet extends JournalPageSheet {
     };
 
     let features = [];
-    const itemGrants = Array.from(item.advancement.byType.ItemGrant ?? []).sort((lhs, rhs) => lhs.level - rhs.level);
+    const itemGrants = Array.from(item.advancement.byType.ItemGrant ?? []);
     for ( const advancement of itemGrants ) {
       if ( !!advancement.configuration.optional !== optional ) continue;
       features.push(...advancement.configuration.items.map(f => prepareFeature(f, advancement.level)));
     }
+
+    const asiLevels = (item.advancement.byType.AbilityScoreImprovement ?? []).map(a => a.level).sort((a, b) => a - b);
+    if ( asiLevels.length ) {
+      const [firstLevel, ...otherLevels] = asiLevels;
+      const name = game.i18n.localize("DND5E.ADVANCEMENT.AbilityScoreImprovement.Journal.Name");
+      features.push({
+        description: game.i18n.format(
+          `DND5E.ADVANCEMENT.AbilityScoreImprovement.Journal.Description${modernStyle ? "Modern" : "Legacy"}`,
+          {
+            class: item.name,
+            firstLevel: formatNumber(firstLevel),
+            firstLevelOrdinal: formatNumber(firstLevel, { ordinal: true }),
+            maxAbilityScore: formatNumber(CONFIG.DND5E.maxAbilityScore),
+            otherLevels: game.i18n.getListFormatter({ style: "long" }).format(otherLevels.map(l => formatNumber(l))),
+            otherLevelsOrdinal: game.i18n.getListFormatter({ style: "long" })
+              .format(otherLevels.map(l => formatNumber(l, { ordinal: true })))
+          }
+        ),
+        level: asiLevels[0],
+        name: modernStyle ? game.i18n.format("JOURNALENTRYPAGE.DND5E.Class.Features.Name", {
+          name: name, level: formatNumber(firstLevel)
+        }) : name
+      });
+    }
+
     features = await Promise.all(features);
-    return features.filter(f => f);
+    return features.filter(f => f).sort((lhs, rhs) => lhs.level - rhs.level);
   }
 
   /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -47,12 +47,14 @@ export function formatModifier(mod) {
  * @param {number} value    The value to format.
  * @param {object} options  Options forwarded to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat}
  * @param {boolean} [options.numerals]  Format the number as roman numerals.
+ * @param {boolean} [options.ordinal]   Use ordinal formatting.
  * @param {boolean} [options.words]     Write out number as full word, if possible.
  * @returns {string}
  */
-export function formatNumber(value, { numerals, words, ...options }={}) {
+export function formatNumber(value, { numerals, ordinal, words, ...options }={}) {
   if ( words && game.i18n.has(`DND5E.NUMBER.${value}`, false) ) return game.i18n.localize(`DND5E.NUMBER.${value}`);
   if ( numerals ) return _formatNumberAsNumerals(value);
+  if ( ordinal ) return _formatNumberAsOrdinal(value, options);
   const formatter = new Intl.NumberFormat(game.i18n.lang, options);
   return formatter.format(value);
 }
@@ -79,6 +81,20 @@ function _formatNumberAsNumerals(n) {
     out += numeral.repeat(quotient);
   }
   return out;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Format a number using an ordinal format.
+ * @param {number} n        The number to format.
+ * @param {object} options  Options forwarded to `formatNumber`.
+ * @returns {string}
+ */
+function _formatNumberAsOrdinal(n, options={}) {
+  const pr = getPluralRules({ type: "ordinal" }).select(n);
+  const number = formatNumber(n, options);
+  return game.i18n.has(`DND5E.ORDINAL.${pr}`) ? game.i18n.format(`DND5E.ORDINAL.${pr}`, { number }) : number;
 }
 
 /* -------------------------------------------- */


### PR DESCRIPTION
Adds an "Ability Score Improvement" description to class journal pages using either the 2014 or 2024 rules text with the proper levels filled.

<img width="651" alt="Screenshot 2025-01-07 at 11 44 00" src="https://github.com/user-attachments/assets/532eb593-62c7-4385-9fbb-1bf16a7c20a2" />
<img width="643" alt="Screenshot 2025-01-07 at 11 44 14" src="https://github.com/user-attachments/assets/da9e18d9-633e-4e06-93f6-7ffc52c29241" />


Closes #4973