### PR TITLE
[#3788] Add enhanced rest chat message with recovery info

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -20,6 +20,7 @@
 "TYPES.ActiveEffect.enchantmentPl": "Enchantments",
 
 "TYPES.ChatMessage": {
+  "rest": "Rest Message",
   "turn": "Combat Turn Message"
 },
 
@@ -849,10 +850,12 @@
 "DND5E.ChatFlavor": "Chat Message Flavor",
 
 "DND5E.CHATMESSAGE": {
+  "Deltas": {
+    "Recovery": "Recovery"
+  },
   "TURN": {
     "Activities": "Activities",
-    "NoCombatant": "Combatant no longer exists!",
-    "Recovery": "Recovery"
+    "NoCombatant": "Combatant no longer exists!"
   }
 },
 

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -777,10 +777,10 @@ enchantment-application {
 }
 
 /* ---------------------------------- */
-/*  Turn Cards                        */
+/*  Rest & Turn Cards                 */
 /* ---------------------------------- */
 
-.chat-card.turn-card {
+.dnd5e2.chat-card {
   section > strong:first-child {
     display: block;
     margin-block-start: 1em;

--- a/module/data/chat-message/_module.mjs
+++ b/module/data/chat-message/_module.mjs
@@ -1,3 +1,4 @@
+import RestMessageData from "./rest-message-data.mjs";
 import TurnMessageData from "./turn-message-data.mjs";
 
 export {
@@ -6,5 +7,6 @@ export {
 export * as fields from "./fields/_module.mjs";
 
 export const config = {
+  rest: RestMessageData,
   turn: TurnMessageData
 };

--- a/module/data/chat-message/fields/deltas-field.mjs
+++ b/module/data/chat-message/fields/deltas-field.mjs
@@ -1,3 +1,4 @@
+import { formatNumber, getHumanReadableAttributeLabel } from "../../../utils.mjs";
 import MappingField from "../../fields/mapping-field.mjs";
 
 const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
@@ -6,6 +7,14 @@ const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.field
  * @typedef ActorDeltasData
  * @property {IndividualDeltaData[]} actor                 Changes for the actor.
  * @property {Record<string, IndividualDeltaData[]>} item  Changes for each item grouped by ID.
+ */
+
+/**
+ * @typedef DeltaDisplayContext
+ * @property {string} type              Type of document to which the delta applies.
+ * @property {string} delta             The formatted numeric change.
+ * @property {Actor5e|Item5e} document  The document to which the delta applies.
+ * @property {string} label             The formatted label for the attribute.
  */
 
 /**
@@ -36,6 +45,23 @@ export class ActorDeltasField extends SchemaField {
         return obj;
       }, {})
     };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare deltas for display in a chat message.
+   * @this {ActorDeltasData}
+   * @param {Actor5e} actor  Actor to which this delta applies.
+   * @returns {DeltaDisplayContext[]}
+   */
+  static processDeltas(actor) {
+    return [
+      ...this.actor.map(d => IndividualDeltaField.processDelta.call(d, actor)),
+      ...Object.entries(this.item).flatMap(([id, deltas]) =>
+        deltas.map(d => IndividualDeltaField.processDelta.call(d, actor.items.get(id)))
+      )
+    ];
   }
 }
 
@@ -76,5 +102,25 @@ export class IndividualDeltaField extends SchemaField {
       if ( delta && !Number.isNaN(delta) ) deltas.push({ keyPath, delta });
     }
     return deltas;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare a delta for display in a chat message.
+   * @this {IndividualDeltaData}
+   * @param {Actor5e|Item5e} doc  Actor or item to which this delta applies.
+   * @returns {DeltaDisplayContext}
+   */
+  static processDelta(doc) {
+    const type = doc instanceof Actor ? "actor" : "item";
+    const value = this.keyPath.endsWith(".spent") ? -this.delta : this.delta;
+    return {
+      type,
+      delta: formatNumber(value, { signDisplay: "always" }),
+      document: doc,
+      label: getHumanReadableAttributeLabel(this.keyPath, { [type]: doc }) ?? this.keyPath
+      // TODO: If any rolls were performed for recovery, associate with delta
+    };
   }
 }

--- a/module/data/chat-message/rest-message-data.mjs
+++ b/module/data/chat-message/rest-message-data.mjs
@@ -1,0 +1,66 @@
+import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+import { ActorDeltasField } from "./fields/deltas-field.mjs";
+
+const { StringField } = foundry.data.fields;
+
+/**
+ * @import { ActorDeltasData } from "./fields/deltas-field.mjs";
+ */
+
+/**
+ * Data stored in a rest chat message.
+ *
+ * @property {ActorDeltasData} deltas  Actor/item recovery from this turn change.
+ * @property {string} type             Type of rest performed.
+ */
+export default class RestMessageData extends ChatMessageDataModel {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {
+      deltas: new ActorDeltasField(),
+      type: new StringField()
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    template: "systems/dnd5e/templates/chat/rest-card.hbs"
+  }, { inplace: false }));
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The actor for the chat message.
+   * @type {Actor5e}
+   */
+  get actor() {
+    return this.parent.getAssociatedActor();
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext() {
+    const context = {
+      actor: this.actor,
+      content: await TextEditor.enrichHTML(this.parent.content, { rollData: this.parent.getRollData() })
+    };
+
+    if ( context.actor?.isOwner ) {
+      context.deltas = ActorDeltasField.processDeltas.call(this.deltas, this.actor);
+    }
+
+    return context;
+  }
+}

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1075,7 +1075,8 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   let name;
   let type = "actor";
 
-  const getSchemaLabel = (attr, type) => {
+  const getSchemaLabel = (attr, type, doc) => {
+    if ( doc ) return doc.system.schema.getField(attr)?.label;
     for ( const model of Object.values(CONFIG[type].dataModels) ) {
       const field = model.schema.getField(attr);
       if ( field ) return field.label;
@@ -1101,7 +1102,18 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
     if ( _attributeLabelCache.item.has(attr) ) label = _attributeLabelCache.item.get(attr);
     else if ( attr === "hd.spent" ) label = "DND5E.HitDice";
     else if ( attr === "uses.spent" ) label = "DND5E.Uses";
-    else label = getSchemaLabel(attr, "Item");
+    else label = getSchemaLabel(attr, "Item", item);
+  }
+
+  // Derived fields.
+  else if ( attr === "attributes.init.total" ) label = "DND5E.InitiativeBonus";
+  else if ( (attr === "attributes.ac.value") || (attr === "attributes.ac.flat") ) label = "DND5E.ArmorClass";
+  else if ( attr === "attributes.spelldc" ) label = "DND5E.SpellDC";
+
+  // Abilities.
+  else if ( attr.startsWith("abilities.") ) {
+    const [, key] = attr.split(".");
+    label = game.i18n.format("DND5E.AbilityScoreL", { ability: CONFIG.DND5E.abilities[key].label });
   }
 
   // Skills.
@@ -1128,7 +1140,7 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   }
 
   // Attempt to find the attribute in a data model.
-  if ( !label ) label = getSchemaLabel(attr, "Actor");
+  if ( !label ) label = getSchemaLabel(attr, "Actor", actor);
 
   if ( label ) {
     label = game.i18n.localize(label);

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -711,6 +711,9 @@ export async function preloadHandlebarsTemplates() {
     "systems/dnd5e/templates/actors/parts/columns/column-roll.hbs",
     "systems/dnd5e/templates/actors/parts/columns/column-uses.hbs",
 
+    // Chat Message Partials
+    "systems/dnd5e/templates/chat/parts/card-deltas.hbs",
+
     // Item Sheet Partials
     "systems/dnd5e/templates/items/details/details-background.hbs",
     "systems/dnd5e/templates/items/details/details-class.hbs",
@@ -1028,18 +1031,24 @@ function _localizeObject(obj, keys) {
 
 /**
  * A cache of already-fetched labels for faster lookup.
- * @type {Map<string, string>}
+ * @type {Record<string, Map<string, string>>}
  */
-const _attributeLabelCache = new Map();
+const _attributeLabelCache = {
+  activity: new Map(),
+  actor: new Map(),
+  item: new Map()
+};
 
 /**
- * Convert an attribute path to a human-readable label.
+ * Convert an attribute path to a human-readable label. Assumes paths are on an actor unless an reference item
+ * is provided.
  * @param {string} attr              The attribute path.
  * @param {object} [options]
  * @param {Actor5e} [options.actor]  An optional reference actor.
+ * @param {Item5e} [options.item]    An optional reference item.
  * @returns {string|void}
  */
-export function getHumanReadableAttributeLabel(attr, { actor }={}) {
+export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   if ( attr.startsWith("system.") ) attr = attr.slice(7);
 
   // Check any actor-specific names first.
@@ -1061,18 +1070,38 @@ export function getHumanReadableAttributeLabel(attr, { actor }={}) {
   }
 
   // Check if the attribute is already in cache.
-  let label = _attributeLabelCache.get(attr);
+  let label = item ? null : _attributeLabelCache.actor.get(attr);
   if ( label ) return label;
+  let name;
+  let type = "actor";
 
-  // Derived fields.
-  if ( attr === "attributes.init.total" ) label = "DND5E.InitiativeBonus";
-  else if ( (attr === "attributes.ac.value") || (attr === "attributes.ac.flat") ) label = "DND5E.ArmorClass";
-  else if ( attr === "attributes.spelldc" ) label = "DND5E.SpellDC";
+  const getSchemaLabel = (attr, type) => {
+    for ( const model of Object.values(CONFIG[type].dataModels) ) {
+      const field = model.schema.getField(attr);
+      if ( field ) return field.label;
+    }
+  };
 
-  // Abilities.
-  else if ( attr.startsWith("abilities.") ) {
-    const [, key] = attr.split(".");
-    label = game.i18n.format("DND5E.AbilityScoreL", { ability: CONFIG.DND5E.abilities[key].label });
+  // Activity labels
+  if ( item && attr.startsWith("activities.") ) {
+    let [, activityId, ...keyPath] = attr;
+    const activity = item.system.activities?.get(activityId);
+    if ( !activity ) return attr;
+    attr = keyPath.join(".");
+    name = `${item.name}: ${activity.name}`;
+    type = "activity";
+    if ( _attributeLabelCache.activity.has(attr) ) label = _attributeLabelCache.activity.get(attr);
+    else if ( attr === "uses.spent" ) label = "DND5E.Uses";
+  }
+
+  // Item labels
+  else if ( item ) {
+    name = item.name;
+    type = "item";
+    if ( _attributeLabelCache.item.has(attr) ) label = _attributeLabelCache.item.get(attr);
+    else if ( attr === "hd.spent" ) label = "DND5E.HitDice";
+    else if ( attr === "uses.spent" ) label = "DND5E.Uses";
+    else label = getSchemaLabel(attr, "Item");
   }
 
   // Skills.
@@ -1086,7 +1115,7 @@ export function getHumanReadableAttributeLabel(attr, { actor }={}) {
     const [, key] = attr.split(".");
     if ( !/spell\d+/.test(key) ) label = `DND5E.SpellSlots${key.capitalize()}`;
     else {
-      const plurals = new Intl.PluralRules(game.i18n.lang, {type: "ordinal"});
+      const plurals = new Intl.PluralRules(game.i18n.lang, { type: "ordinal" });
       const level = Number(key.slice(5));
       label = game.i18n.format(`DND5E.SpellSlotsN.${plurals.select(level)}`, { n: level });
     }
@@ -1099,20 +1128,12 @@ export function getHumanReadableAttributeLabel(attr, { actor }={}) {
   }
 
   // Attempt to find the attribute in a data model.
-  if ( !label ) {
-    const { CharacterData, NPCData, VehicleData, GroupData } = dnd5e.dataModels.actor;
-    for ( const model of [CharacterData, NPCData, VehicleData, GroupData] ) {
-      const field = model.schema.getField(attr);
-      if ( field ) {
-        label = field.label;
-        break;
-      }
-    }
-  }
+  if ( !label ) label = getSchemaLabel(attr, "Actor");
 
   if ( label ) {
     label = game.i18n.localize(label);
-    _attributeLabelCache.set(attr, label);
+    _attributeLabelCache[type].set(attr, label);
+    if ( name ) label = `${name} ${label}`;
   }
 
   return label;

--- a/system.json
+++ b/system.json
@@ -42,6 +42,7 @@
       }
     },
     "ChatMessage": {
+      "rest": {},
       "turn": {}
     },
     "Item": {

--- a/templates/chat/parts/card-deltas.hbs
+++ b/templates/chat/parts/card-deltas.hbs
@@ -1,0 +1,12 @@
+<section class="deltas">
+    <strong class="roboto-condensed-upper">{{ localize "DND5E.CHATMESSAGE.Deltas.Recovery" }}</strong>
+    <ul class="unlist">
+        {{#each deltas}}
+        <li class="delta-{{ type }}">
+            <span class="label">{{ label }}</span>
+            <span class="value">{{ delta }}</span>
+        </li>
+        {{/each}}
+    </ul>
+    <!-- TODO: Add button to revert changes -->
+</section>

--- a/templates/chat/rest-card.hbs
+++ b/templates/chat/rest-card.hbs
@@ -1,0 +1,10 @@
+<div class="dnd5e2 chat-card rest-card">
+    {{{ content }}}
+
+    {{#if actor}}
+
+    {{!-- Deltas --}}
+    {{#if deltas.length}}{{> "dnd5e.card-deltas" }}{{/if}}
+
+    {{/if}}
+</div>

--- a/templates/chat/turn-card.hbs
+++ b/templates/chat/turn-card.hbs
@@ -2,20 +2,7 @@
     {{#if actor}}
 
     {{!-- Deltas --}}
-    {{#if deltas.length}}
-    <section class="deltas">
-        <strong class="roboto-condensed-upper">{{ localize "DND5E.CHATMESSAGE.TURN.Recovery" }}</strong>
-        <ul class="unlist">
-            {{#each deltas}}
-            <li class="delta-{{ type }}">
-                <span class="label">{{ label }}</span>
-                <span class="value">{{ delta }}</span>
-            </li>
-            {{/each}}
-        </ul>
-        <!-- TODO: Add button to revert changes -->
-    </section>
-    {{/if}}
+    {{#if deltas.length}}{{> "dnd5e.card-deltas" }}{{/if}}
 
     {{!-- Actions --}}
     {{#if activities.length}}


### PR DESCRIPTION
Adds a new `rest` chat message type that matches the `turn` type and displays more information on the resources recovered during the rest including item uses and spell slots.

<img width="303" alt="Rest Chat Card" src="https://github.com/user-attachments/assets/cd3187be-8304-4669-bbcd-8daa82c748c3" />

Expands `getHumanReadableAttributeLabel` with support for fetching labels for activity & item attributes.

Closes #3788