### PR TITLE
[#4744] Add "Advance Bastion Turn" option to group long rest dialog

### DIFF
--- a/module/applications/actor/rest/long-rest-dialog.mjs
+++ b/module/applications/actor/rest/long-rest-dialog.mjs
@@ -1,5 +1,7 @@
 import BaseRestDialog from "./base-rest-dialog.mjs";
 
+const { BooleanField } = foundry.data.fields;
+
 /**
  * Dialog for configuring a long rest.
  */
@@ -21,6 +23,25 @@ export default class LongRestDialog extends BaseRestDialog {
       template: "systems/dnd5e/templates/actors/rest/long-rest.hbs"
     }
   };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+
+    const { enabled } = game.settings.get("dnd5e", "bastionConfiguration");
+    if ( game.user.isGM && context.isGroup && enabled ) context.fields.unshift({
+      field: new BooleanField({ label: game.i18n.localize("DND5E.Bastion.Action.BastionTurn") }),
+      input: context.inputs.createCheckboxInput,
+      name: "advanceBastionTurn",
+      value: context.config.advanceBastionTurn
+    });
+
+    return context;
+  }
 
   /* -------------------------------------------- */
   /*  Factory Methods                             */

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -275,7 +275,7 @@ export default class GroupActor extends ActorDataModel.mixin(CurrencyTemplate) {
       results.set(
         member.actor,
         await member.actor[config.type === "short" ? "shortRest" : "longRest"]({
-          ...config, dialog: false, advanceTime: false
+          ...config, dialog: false, advanceBastionTurn: false, advanceTime: false
         }) ?? null
       );
     }
@@ -291,6 +291,10 @@ export default class GroupActor extends ActorDataModel.mixin(CurrencyTemplate) {
      * @param {Map<Actor5e, RestResult|null>} result  Details on the rests completed.
      */
     Hooks.callAll("dnd5e.groupRestCompleted", this.parent, results);
+
+    if ( config.advanceBastionTurn && game.user.isGM && game.settings.get("dnd5e", "bastionConfiguration").enabled ) {
+      await dnd5e.bastion.advanceAllBastions();
+    }
 
     return false;
   }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2457,16 +2457,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * Configuration options for a rest.
    *
    * @typedef {object} RestConfiguration
-   * @property {string} type               Type of rest to perform.
-   * @property {boolean} dialog            Present a dialog window which allows for rolling hit dice as part of the
-   *                                       Short Rest and selecting whether a new day has occurred.
-   * @property {boolean} chat              Should a chat message be created to summarize the results of the rest?
-   * @property {number} duration           Amount of time passed during the rest in minutes.
-   * @property {boolean} newDay            Does this rest carry over to a new day?
-   * @property {boolean} [advanceTime]     Should the game clock be advanced by the rest duration?
-   * @property {boolean} [autoHD]          Should hit dice be spent automatically during a short rest?
-   * @property {number} [autoHDThreshold]  How many hit points should be missing before hit dice are
-   *                                       automatically spent during a short rest.
+   * @property {string} type                   Type of rest to perform.
+   * @property {boolean} dialog                Present a dialog window which allows for rolling hit dice as part of the
+   *                                           Short Rest and selecting whether a new day has occurred.
+   * @property {boolean} chat                  Should a chat message be created to summarize the results of the rest?
+   * @property {number} duration               Amount of time passed during the rest in minutes.
+   * @property {boolean} newDay                Does this rest carry over to a new day?
+   * @property {boolean} [advanceBastionTurn]  Should a bastion turn be advanced for all players?
+   * @property {boolean} [advanceTime]         Should the game clock be advanced by the rest duration?
+   * @property {boolean} [autoHD]              Should hit dice be spent automatically during a short rest?
+   * @property {number} [autoHDThreshold]      How many hit points should be missing before hit dice are
+   *                                           automatically spent during a short rest.
    */
 
   /**
@@ -2477,10 +2478,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @property {object} deltas
    * @property {number} deltas.hitPoints  Hit points recovered during the rest.
    * @property {number} deltas.hitDice    Hit dice recovered or spent during the rest.
-   * @property {object} updateData        Updates applied to the actor.
-   * @property {object[]} updateItems     Updates applied to actor's items.
    * @property {boolean} newDay           Whether a new day occurred during the rest.
    * @property {Roll[]} rolls             Any rolls that occurred during the rest process, not including hit dice.
+   * @property {object} updateData        Updates applied to the actor.
+   * @property {object[]} updateItems     Updates applied to actor's items.
    */
 
   /* -------------------------------------------- */
@@ -2650,6 +2651,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * @param {RestConfiguration} config  Configuration data for that occurred.
      */
     Hooks.callAll("dnd5e.restCompleted", this, result, config);
+
+    if ( config.advanceBastionTurn && game.user.isGM && game.settings.get("dnd5e", "bastionConfiguration").enabled
+      && this.itemTypes.facility.length ) await dnd5e.bastion.advanceAllFacilities(this);
 
     // Return data summarizing the rest effects
     return result;


### PR DESCRIPTION
Adds the "Advance Bastion Turn" button to the long rest dialog so long as it is a group rest and bastions are enabled.

Right now this advances bastion turns for all actors, not just those in the group, but perhaps that should change.

<img width="396" alt="Screenshot 2025-01-10 at 14 07 35" src="https://github.com/user-attachments/assets/8980c82f-dae3-43e2-a988-18a0cce57578" />

The normal actor rest also supports the `advanceBastionTurn` config option which advances turn for a specific actor, but it isn't exposed in the UI yet.

Closes #4744