### PR TITLE
[#4819, #4993] Add activity macros, pass event to item macros

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -482,7 +482,7 @@ Hooks.once("i18nInit", () => {
 Hooks.once("ready", function() {
   // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
   Hooks.on("hotbarDrop", (bar, data, slot) => {
-    if ( ["Item", "ActiveEffect"].includes(data.type) ) {
+    if ( ["ActiveEffect", "Activity", "Item"].includes(data.type) ) {
       documents.macro.create5eMacro(data, slot);
       return false;
     }

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -394,41 +394,9 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
 
   /* -------------------------------------------- */
 
-  /**
-   * Handling beginning a drag-drop operation on an Activity.
-   * @param {DragEvent} event  The originating drag event.
-   * @protected
-   */
-  _onDragActivity(event) {
-    const { itemId } = event.target.closest("[data-item-id]").dataset;
-    const { activityId } = event.target.closest("[data-activity-id]").dataset;
-    const activity = this.actor.items.get(itemId)?.system.activities?.get(activityId);
-    if ( activity ) event.dataTransfer.setData("text/plain", JSON.stringify(activity.toDragData()));
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Handle beginning a drag-drop operation on an Item.
-   * @param {DragEvent} event  The originating drag event.
-   * @protected
-   */
-  _onDragItem(event) {
-    const { itemId } = event.target.closest("[data-item-id]").dataset;
-    const item = this.actor.items.get(itemId);
-    if ( item ) event.dataTransfer.setData("text/plain", JSON.stringify(item.toDragData()));
-  }
-
-  /* -------------------------------------------- */
-
   /** @inheritDoc */
   _onDragStart(event) {
-    // Add another deferred deactivation to catch the second pointerenter event that seems to be fired on Firefox.
-    requestAnimationFrame(() => game.tooltip.deactivate());
-    game.tooltip.deactivate();
-
     const modes = CONFIG.DND5E.spellPreparationModes;
-
     const { key } = event.target.closest("[data-key]")?.dataset ?? {};
     const { level, preparationMode } = event.target.closest("[data-level]")?.dataset ?? {};
     const isSlots = event.target.closest("[data-favorite-id]") || event.target.classList.contains("spell-header");
@@ -436,13 +404,12 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     if ( key in CONFIG.DND5E.skills ) type = "skill";
     else if ( key in CONFIG.DND5E.tools ) type = "tool";
     else if ( modes[preparationMode]?.upcast && (level !== "0") && isSlots ) type = "slots";
-    if ( !type ) {
-      if ( event.target.matches("[data-item-id] > .item-row") ) return this._onDragItem(event);
-      else if ( event.target.matches("[data-item-id] [data-activity-id], [data-item-id][data-activity-id]") ) {
-        return this._onDragActivity(event);
-      }
-      return super._onDragStart(event);
-    }
+    if ( !type ) return super._onDragStart(event);
+
+    // Add another deferred deactivation to catch the second pointerenter event that seems to be fired on Firefox.
+    requestAnimationFrame(() => game.tooltip.deactivate());
+    game.tooltip.deactivate();
+
     const dragData = { dnd5e: { action: "favorite", type } };
     if ( type === "slots" ) dragData.dnd5e.id = (preparationMode === "prepared") ? `spell${level}` : preparationMode;
     else dragData.dnd5e.id = key;

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -14,7 +14,11 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
       height: 700,
       resizable: true,
       scrollY: [".sheet-body"],
-      tabs: [{ navSelector: ".tabs", contentSelector: ".tab-body", initial: "features" }]
+      tabs: [{ navSelector: ".tabs", contentSelector: ".tab-body", initial: "features" }],
+      dragDrop: [
+        { dragSelector: ".item-list .item > .item-row", dropSelector: null },
+        { dragSelector: ".item-list .item .activity-row", dropSelector: null }
+      ]
     });
   }
 

--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -604,6 +604,48 @@ export default function ActorSheetV2Mixin(Base) {
     /* -------------------------------------------- */
 
     /**
+     * Handling beginning a drag-drop operation on an Activity.
+     * @param {DragEvent} event  The originating drag event.
+     * @protected
+     */
+    _onDragActivity(event) {
+      const { itemId } = event.target.closest("[data-item-id]").dataset;
+      const { activityId } = event.target.closest("[data-activity-id]").dataset;
+      const activity = this.actor.items.get(itemId)?.system.activities?.get(activityId);
+      if ( activity ) event.dataTransfer.setData("text/plain", JSON.stringify(activity.toDragData()));
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Handle beginning a drag-drop operation on an Item.
+     * @param {DragEvent} event  The originating drag event.
+     * @protected
+     */
+    _onDragItem(event) {
+      const { itemId } = event.target.closest("[data-item-id]").dataset;
+      const item = this.actor.items.get(itemId);
+      if ( item ) event.dataTransfer.setData("text/plain", JSON.stringify(item.toDragData()));
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    _onDragStart(event) {
+      // Add another deferred deactivation to catch the second pointerenter event that seems to be fired on Firefox.
+      requestAnimationFrame(() => game.tooltip.deactivate());
+      game.tooltip.deactivate();
+
+      if ( event.target.matches("[data-item-id] > .item-row") ) return this._onDragItem(event);
+      else if ( event.target.matches("[data-item-id] [data-activity-id], [data-item-id][data-activity-id]") ) {
+        return this._onDragActivity(event);
+      }
+      return super._onDragStart(event);
+    }
+
+    /* -------------------------------------------- */
+
+    /**
      * Handle performing some action on an owned Item.
      * @param {PointerEvent} event  The triggering event.
      * @protected

--- a/module/documents/macro.mjs
+++ b/module/documents/macro.mjs
@@ -7,30 +7,44 @@
 export async function create5eMacro(dropData, slot) {
   const macroData = { type: "script", scope: "actor" };
   switch ( dropData.type ) {
+    case "Activity":
+      const activity = await fromUuid(dropData.uuid);
+      if ( !activity ) {
+        ui.notifications.warn("MACRO.5eUnownedWarn", { localize: true });
+        return null;
+      }
+      foundry.utils.mergeObject(macroData, {
+        name: `${activity.item.name}: ${activity.name}`,
+        img: activity.img,
+        command: `dnd5e.documents.macro.rollItem("${activity.item._source.name}", { activityName: "${
+          activity._source.name}", event });`,
+        flags: { "dnd5e.itemMacro": true }
+      });
+      break;
     case "Item":
       const itemData = await Item.implementation.fromDropData(dropData);
       if ( !itemData ) {
-        ui.notifications.warn("MACRO.5eUnownedWarn", {localize: true});
+        ui.notifications.warn("MACRO.5eUnownedWarn", { localize: true });
         return null;
       }
       foundry.utils.mergeObject(macroData, {
         name: itemData.name,
         img: itemData.img,
-        command: `dnd5e.documents.macro.rollItem("${itemData._source.name}")`,
-        flags: {"dnd5e.itemMacro": true}
+        command: `dnd5e.documents.macro.rollItem("${itemData._source.name}", { event })`,
+        flags: { "dnd5e.itemMacro": true }
       });
       break;
     case "ActiveEffect":
       const effectData = await ActiveEffect.implementation.fromDropData(dropData);
       if ( !effectData ) {
-        ui.notifications.warn("MACRO.5eUnownedWarn", {localize: true});
+        ui.notifications.warn("MACRO.5eUnownedWarn", { localize: true });
         return null;
       }
       foundry.utils.mergeObject(macroData, {
         name: effectData.name,
         img: effectData.img,
         command: `dnd5e.documents.macro.toggleEffect("${effectData.name}")`,
-        flags: {"dnd5e.effectMacro": true}
+        flags: { "dnd5e.effectMacro": true }
       });
       break;
     default:
@@ -84,12 +98,13 @@ function getMacroTarget(name, documentType) {
  * @param {string} itemName                Name of the item on the selected actor to trigger.
  * @param {object} [options={}]
  * @param {string} [options.activityName]  Name of a specific activity on the item to trigger.
+ * @param {Event} [options.event]          The triggering event.
  * @returns {Promise<ChatMessage|object>}  Usage result.
  */
-export function rollItem(itemName, { activityName }={}) {
+export function rollItem(itemName, { activityName, event }={}) {
   let target = getMacroTarget(itemName, "Item");
   if ( activityName ) target = target?.system.activities?.getName(activityName);
-  return target?.use({ legacy: false });
+  return target?.use({ event, legacy: false });
 }
 
 /* -------------------------------------------- */
@@ -101,5 +116,5 @@ export function rollItem(itemName, { activityName }={}) {
  */
 export function toggleEffect(effectName) {
   const effect = getMacroTarget(effectName, "ActiveEffect");
-  return effect?.update({disabled: !effect.disabled});
+  return effect?.update({ disabled: !effect.disabled });
 }


### PR DESCRIPTION
Adds the ability to drag specific activities into the macro bar and create a macro for them using the `activityName` functionality already supported in `rollItem`. This required some changes to drag & drop on NPC sheets so that activities can be dragged on their own like on the PC sheets.

Also passes the event in to item macros so that keyboard modifiers can be used when activating them.

Closes #4819
Closes #4993