### PR TITLE
[#3240] Update SRD monsters to use chat descriptions

### DIFF
--- a/packs/_source/monsters/aberration/aboleth.json
+++ b/packs/_source/monsters/aberration/aboleth.json
@@ -613,8 +613,8 @@
       "img": "icons/magic/control/hypnosis-mesmerism-watch.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The aboleth targets one creature it can see within 30 ft. of it. The target must succeed on a  <strong>DC 14 Wisdom</strong> saving throw or be magically charmed by the aboleth until the aboleth dies or until it is on a different plane of existence from the target.</p>\n<p>The charmed target is under the aboleth's control and can't take reactions, and the aboleth and the target can communicate telepathically with each other over any distance.Whenever the charmed target takes damage, the target can repeat the saving throw. On a success, the effect ends. No more than once every 24 hours, the target can also repeat the saving throw when it is at least 1 mile away from the aboleth.</p>\n</section>\n<p>The target must make a <strong>Wisdom</strong> saving throw. Whenever the target takes damage, the target can repeat the saving throw. No more than once every 24 hours, the target can also repeat the saving throw when it is at least 1 mile away from the aboleth.</p>",
-          "chat": ""
+          "value": "<p>The aboleth targets one creature it can see within 30 ft. of it. The target must succeed on a  <strong>DC 14 Wisdom</strong> saving throw or be magically charmed by the aboleth until the aboleth dies or until it is on a different plane of existence from the target.</p><p>The charmed target is under the aboleth's control and can't take reactions, and the aboleth and the target can communicate telepathically with each other over any distance.Whenever the charmed target takes damage, the target can repeat the saving throw. On a success, the effect ends. No more than once every 24 hours, the target can also repeat the saving throw when it is at least 1 mile away from the aboleth.</p>",
+          "chat": "<p>The target must make a <strong>Wisdom</strong> saving throw. Whenever the target takes damage, the target can repeat the saving throw. No more than once every 24 hours, the target can also repeat the saving throw when it is at least 1 mile away from the aboleth.</p>"
         },
         "source": {
           "custom": "",
@@ -745,10 +745,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676971,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!shhHtE7b92PefCWB.Wpa7li8EJJJ7W3kA"
     },
@@ -964,8 +964,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The aboleth makes one tail attack.</p>\n</section>\n<p>The aboleth swipes its tail against its prey!</p>",
-          "chat": ""
+          "value": "<p>The aboleth makes one tail attack.</p>",
+          "chat": "<p>The aboleth swipes its tail against its prey!</p>"
         },
         "source": {
           "custom": "",
@@ -1113,10 +1113,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676971,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!shhHtE7b92PefCWB.nb2rVHLawik6EjMJ"
     },
@@ -1281,8 +1281,8 @@
       "img": "icons/magic/water/bubbles-air-water-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>While underwater, the aboleth is surrounded by transformative mucus. A creature that touches the aboleth or that hits it with a melee attack while within <strong>5 ft.</strong> of it must make a <strong>DC 14 Constitution saving throw</strong>. On a failure, the creature is diseased for 1d4 hours. The diseased creature can breathe only underwater.</p>\n</section>\n<p>While underwater, the aboleth is surrounded by transformative mucus. A creature that touches the aboleth or that hits it with a melee attack while within <strong>5 ft.</strong> of it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>While underwater, the aboleth is surrounded by transformative mucus. A creature that touches the aboleth or that hits it with a melee attack while within <strong>5 ft.</strong> of it must make a <strong>DC 14 Constitution saving throw</strong>. On a failure, the creature is diseased for 1d4 hours. The diseased creature can breathe only underwater.</p>",
+          "chat": "<p>While underwater, the aboleth is surrounded by transformative mucus. A creature that touches the aboleth or that hits it with a melee attack while within <strong>5 ft.</strong> of it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1462,10 +1462,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676971,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!shhHtE7b92PefCWB.dZWUNgKiLNxVg983"
     },
@@ -1535,8 +1535,8 @@
       "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>bludgeoning damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 14 Constitution</strong> saving throw or become diseased. The disease has no effect for 1 minute and can be removed by any magic that cures disease. After 1 minute, the diseased creature gains Tentacle Disease.</p>\n</section>\n<p>The Aboleth attacks with its Tentacle. If the target is a creature, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>bludgeoning damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 14 Constitution</strong> saving throw or become diseased. The disease has no effect for 1 minute and can be removed by any magic that cures disease. After 1 minute, the diseased creature gains Tentacle Disease.</p>",
+          "chat": "<p>The Aboleth attacks with its Tentacle. If the target is a creature, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1814,10 +1814,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676971,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!shhHtE7b92PefCWB.sgauK8Lyt8qxsxOH"
     },
@@ -1828,8 +1828,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee Weapon Attack: +9 to hit, reach 10 ft. one target. Hit: <strong>15 (3d6 + 5) <em>bludgeoning damage</em></strong>.</p>\n</section>\n<p>The Aboleth attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +9 to hit, reach 10 ft. one target. Hit: <strong>15 (3d6 + 5) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Aboleth attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -2018,10 +2018,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676971,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!shhHtE7b92PefCWB.FwOZEwx7MPDq8Igu"
     },
@@ -2091,8 +2091,8 @@
       "img": "icons/magic/acid/projectile-glowing-bubbles.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><strong>After 1 minute</strong>, the diseased creature's skin becomes translucent and slimy, the creature can't regain hit points unless it is underwater, and the disease can be removed only by heal or another disease-curing spell of 6th level or higher. When the creature is <strong>outside a body of water</strong>, it takes <strong>6 (1d12) acid damage every 10 minutes</strong> unless moisture is applied to the skin before 10 minutes have passed.</p>\n</section>\n<p>You feel a surging pain rushing through your body!</p>",
-          "chat": ""
+          "value": "<p><strong>After 1 minute</strong>, the diseased creature's skin becomes translucent and slimy, the creature can't regain hit points unless it is underwater, and the disease can be removed only by heal or another disease-curing spell of 6th level or higher. When the creature is <strong>outside a body of water</strong>, it takes <strong>6 (1d12) acid damage every 10 minutes</strong> unless moisture is applied to the skin before 10 minutes have passed.</p>",
+          "chat": "<p>You feel a surging pain rushing through your body!</p>"
         },
         "source": {
           "custom": "",
@@ -2221,10 +2221,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676971,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!shhHtE7b92PefCWB.Lnp6wFaKnkpuWJs2"
     },
@@ -2360,8 +2360,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2405,10 +2405,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676971,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!shhHtE7b92PefCWB.7GePgmNDyzzHHCKS"
     },
@@ -2419,8 +2419,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The aboleth can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The aboleth regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The aboleth can take 3 legendary actions.</p>",
-          "chat": ""
+          "value": "<p>The aboleth can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The aboleth regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The aboleth can take 3 legendary actions.</p>"
         },
         "source": {
           "custom": "",
@@ -2464,10 +2464,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676971,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!shhHtE7b92PefCWB.SHlQeobxHZU6iQ24"
     },

--- a/packs/_source/monsters/aberration/chuul.json
+++ b/packs/_source/monsters/aberration/chuul.json
@@ -619,8 +619,8 @@
       "img": "icons/commodities/claws/claw-pincer-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p>\n<p>The target is grappled (escape DC 14) if it is a Large or smaller creature and the chuul doesn't have two other creatures grappled.</p>\n</section>\n<p>The Chuul attacks with its Pincer. The target is grappled if it is a Large or smaller creature.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p><p>The target is grappled (escape DC 14) if it is a Large or smaller creature and the chuul doesn't have two other creatures grappled.</p>",
+          "chat": "<p>The Chuul attacks with its Pincer. The target is grappled if it is a Large or smaller creature.</p>"
         },
         "source": {
           "custom": "",
@@ -809,10 +809,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676563,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!P6qC8jB3pnEH0tIE.7lnXqe8AnWhtnQh7"
     },
@@ -823,8 +823,8 @@
       "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>One creature grappled by the chuul must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be poisoned for 1 minute.</p>\n<p>Until this poison ends, the target is paralyzed. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>One creature grappled by the chuul must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p>One creature grappled by the chuul must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be poisoned for 1 minute.</p><p>Until this poison ends, the target is paralyzed. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>One creature grappled by the chuul must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -939,10 +939,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676563,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!P6qC8jB3pnEH0tIE.XUzROtGqVZS61Ofm"
     },

--- a/packs/_source/monsters/aberration/cloaker.json
+++ b/packs/_source/monsters/aberration/cloaker.json
@@ -618,8 +618,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>, and if the target is Large or smaller, the cloaker attaches to it. </p><p>If the cloaker has advantage against the target, the cloaker attaches to the target's head, and the target is blinded and unable to breathe while the cloaker is attached. While attached, the cloaker can make this attack only against the target and has advantage on the attack roll. The cloaker can detach itself by spending 5 feet of its movement. A creature, including the target, can take its action to detach the cloaker by succeeding on a DC 16 Strength check.</p></section><p>The Cloaker attacks with its Bite. A creature, including the target, can take its action to detach the cloaker by succeeding on a Strength check.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>, and if the target is Large or smaller, the cloaker attaches to it. </p><p>If the cloaker has advantage against the target, the cloaker attaches to the target's head, and the target is blinded and unable to breathe while the cloaker is attached. While attached, the cloaker can make this attack only against the target and has advantage on the attack roll. The cloaker can detach itself by spending 5 feet of its movement. A creature, including the target, can take its action to detach the cloaker by succeeding on a DC 16 Strength check.</p>",
+          "chat": "<p>The Cloaker attacks with its Bite. A creature, including the target, can take its action to detach the cloaker by succeeding on a Strength check.</p>"
         },
         "source": {
           "custom": "",
@@ -810,10 +810,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676777,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!HPUO3weiwRQnql0d.afXMbT7smRaCJbhc"
     },
@@ -1126,8 +1126,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>.</p><p></p></section><p>The Cloaker attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Cloaker attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1314,10 +1314,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676777,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!HPUO3weiwRQnql0d.ZRvdvg8n7pQdJ1Mj"
     },
@@ -1328,8 +1328,8 @@
       "img": "icons/magic/death/projectile-skull-flaming-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature within 60 feet of the cloaker that can hear its moan and that isn't an aberration must succeed on a  <strong>DC 13 Wisdom</strong> saving throw or become frightened until the end of the cloaker's next turn. </p><p>If a creature's saving throw is successful, the creature is immune to the cloaker's moan for the next 24 hours.</p></section><p>Each creature within 60 feet of the cloaker that can hear its moan and that isn't an aberration must make a <strong>Wisdom</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>Each creature within 60 feet of the cloaker that can hear its moan and that isn't an aberration must succeed on a  <strong>DC 13 Wisdom</strong> saving throw or become frightened until the end of the cloaker's next turn. </p><p>If a creature's saving throw is successful, the creature is immune to the cloaker's moan for the next 24 hours.</p>",
+          "chat": "<p>Each creature within 60 feet of the cloaker that can hear its moan and that isn't an aberration must make a <strong>Wisdom</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1445,10 +1445,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676777,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!HPUO3weiwRQnql0d.Jiua0A8CFeKc7Zun"
     },

--- a/packs/_source/monsters/aberration/gibbering-mouther.json
+++ b/packs/_source/monsters/aberration/gibbering-mouther.json
@@ -617,8 +617,8 @@
       "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\" id=\"secret-jQ1KL6uenxwn1YYg\"><p>The ground in a <strong>10-foot radius</strong> around the mouther is doughlike difficult terrain.</p><p>Each creature that starts its turn in that area must succeed on a <strong>DC 10 Strength saving throw</strong> or have its speed reduced to 0 until the start of its next turn.</p></section><p>The ground in a <strong>10-foot radius</strong> around the mouther is doughlike difficult terrain. Make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The ground in a <strong>10-foot radius</strong> around the mouther is doughlike difficult terrain.</p><p>Each creature that starts its turn in that area must succeed on a <strong>DC 10 Strength saving throw</strong> or have its speed reduced to 0 until the start of its next turn.</p>",
+          "chat": "<p>The ground in a <strong>10-foot radius</strong> around the mouther is doughlike difficult terrain. Make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -733,10 +733,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676867,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8pX2JhWUpTNNRBVx.yxlzyXTpsEf4QiI9"
     },
@@ -747,8 +747,8 @@
       "img": "icons/skills/toxins/cup-goblet-poisoned-spilled.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The mouther babbles incoherently while it can see any creature and isn't incapacitated. Each creature that starts its turn <strong>within 20 feet</strong> of the mouther and can hear the gibbering must succeed on a <strong>DC 10 Wisdom saving throw</strong>. On a failure, the creature can't take reactions until the start of its next turn and rolls a d8 to determine what it does during its turn. </p><p>On a 1 to 4, the creature does nothing. On a 5 or 6, the creature takes no action or bonus action and uses all its movement to move in a randomly determined direction. On a 7 or 8, the creature makes a melee attack against a randomly determined creature within its reach or does nothing if it can't make such an attack.</p></section><p>The mouther babbles incoherently while it can see any creature. Each creature that starts its turn <strong>within 20 feet</strong> of the mouther and can hear the gibbering must succeed on a Wisdom saving throw.</p>",
-          "chat": ""
+          "value": "<p>The mouther babbles incoherently while it can see any creature and isn't incapacitated. Each creature that starts its turn <strong>within 20 feet</strong> of the mouther and can hear the gibbering must succeed on a <strong>DC 10 Wisdom saving throw</strong>. On a failure, the creature can't take reactions until the start of its next turn and rolls a d8 to determine what it does during its turn. </p><p>On a 1 to 4, the creature does nothing. On a 5 or 6, the creature takes no action or bonus action and uses all its movement to move in a randomly determined direction. On a 7 or 8, the creature makes a melee attack against a randomly determined creature within its reach or does nothing if it can't make such an attack.</p>",
+          "chat": "<p>The mouther babbles incoherently while it can see any creature. Each creature that starts its turn <strong>within 20 feet</strong> of the mouther and can hear the gibbering must succeed on a Wisdom saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -928,10 +928,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676867,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8pX2JhWUpTNNRBVx.SzwWnAgr25vDeHKu"
     },
@@ -1067,8 +1067,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>17 (5d6) <em>piercing damage</em></strong>. </p><p>If the target is Medium or smaller, it must succeed on a  <strong>DC 10 Strength</strong> saving throw or be knocked prone. If the target is killed by this damage, it is absorbed into the mouther.</p></section><p>The Gibbering Mouther attacks with its Bites. If the target is Medium or smaller, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>17 (5d6) <em>piercing damage</em></strong>. </p><p>If the target is Medium or smaller, it must succeed on a  <strong>DC 10 Strength</strong> saving throw or be knocked prone. If the target is killed by this damage, it is absorbed into the mouther.</p>",
+          "chat": "<p>The Gibbering Mouther attacks with its Bites. If the target is Medium or smaller, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -1344,10 +1344,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676867,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8pX2JhWUpTNNRBVx.lfUDtJ8hdeULQzqa"
     },
@@ -1358,8 +1358,8 @@
       "img": "icons/magic/nature/root-vine-thorned-fire-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The mouther spits a chemical glob at a point it can see within 15 feet of it. The glob explodes in a blinding flash of light on impact. </p><p>Each creature within 5 feet of the flash must succeed on a  <strong>DC 13 Dexterity</strong> saving throw or be blinded until the end of the mouther's next turn.</p></section><p>The mouther spits a chemical glob at a point it can see within 15 feet of it. The glob explodes in a blinding flash of light on impact. Each creature within 5 feet of the flash must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The mouther spits a chemical glob at a point it can see within 15 feet of it. The glob explodes in a blinding flash of light on impact. </p><p>Each creature within 5 feet of the flash must succeed on a  <strong>DC 13 Dexterity</strong> saving throw or be blinded until the end of the mouther's next turn.</p>",
+          "chat": "<p>The mouther spits a chemical glob at a point it can see within 15 feet of it. The glob explodes in a blinding flash of light on impact. Each creature within 5 feet of the flash must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1491,10 +1491,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676867,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8pX2JhWUpTNNRBVx.KQRvDGowc6ihejLu"
     }

--- a/packs/_source/monsters/aberration/otyugh.json
+++ b/packs/_source/monsters/aberration/otyugh.json
@@ -674,8 +674,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d8 + 3) <em>piercing damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 15 Constitution</strong> saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the target must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. The disease is cured on a success. The target dies if the disease reduces its hit point maximum to 0. This reduction to the target's hit point maximum lasts until the disease is cured.</p>\n</section>\n<p>The Otyugh attacks with its Bite. If the target is a creature, it must make a <strong>Constitution</strong> saving throw. Every 24 hours that elapse, the target must repeat the saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d8 + 3) <em>piercing damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 15 Constitution</strong> saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the target must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. The disease is cured on a success. The target dies if the disease reduces its hit point maximum to 0. This reduction to the target's hit point maximum lasts until the disease is cured.</p>",
+          "chat": "<p>The Otyugh attacks with its Bite. If the target is a creature, it must make a <strong>Constitution</strong> saving throw. Every 24 hours that elapse, the target must repeat the saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -955,10 +955,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676821,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jcZblJ6lqtW0ePxe.CCawltKiVU4Mup9i"
     },
@@ -969,8 +969,8 @@
       "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>bludgeoning damage</em></strong> plus <strong>4 (1d8) <em>piercing damage</em></strong>.</p><p>If the target is Medium or smaller, it is grappled (escape DC 13) and restrained until the grapple ends. The otyugh has two tentacles, each of which can grapple one target.</p></section><p>The Otyugh attacks with its Tentacle. If the target is Medium or smaller, it is grappled, and restrained until the grapple ends. The otyugh has two tentacles, each of which can grapple one target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>bludgeoning damage</em></strong> plus <strong>4 (1d8) <em>piercing damage</em></strong>.</p><p>If the target is Medium or smaller, it is grappled (escape DC 13) and restrained until the grapple ends. The otyugh has two tentacles, each of which can grapple one target.</p>",
+          "chat": "<p>The Otyugh attacks with its Tentacle. If the target is Medium or smaller, it is grappled, and restrained until the grapple ends. The otyugh has two tentacles, each of which can grapple one target.</p>"
         },
         "source": {
           "custom": "",
@@ -1177,10 +1177,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676821,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jcZblJ6lqtW0ePxe.BPYsBEkmZMcGYZDh"
     },
@@ -1191,8 +1191,8 @@
       "img": "icons/magic/death/undead-skeleton-deformed-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The otyugh slams creatures grappled by it into each other or a solid surface. Each creature must succeed on a  <strong>DC 14 Constitution</strong> saving throw or take <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong> and be stunned until the end of the otyugh's next turn. </p><p>On a successful save, the target takes half the <em>bludgeoning damage</em> and isn't stunned.</p></section><p>The otyugh slams creatures grappled by it into each other or a solid surface. Each creature must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The otyugh slams creatures grappled by it into each other or a solid surface. Each creature must succeed on a  <strong>DC 14 Constitution</strong> saving throw or take <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong> and be stunned until the end of the otyugh's next turn. </p><p>On a successful save, the target takes half the <em>bludgeoning damage</em> and isn't stunned.</p>",
+          "chat": "<p>The otyugh slams creatures grappled by it into each other or a solid surface. Each creature must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1421,10 +1421,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676821,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jcZblJ6lqtW0ePxe.9d1ZhvT1vIJsNnN1"
     },

--- a/packs/_source/monsters/beast/ape.json
+++ b/packs/_source/monsters/beast/ape.json
@@ -740,8 +740,8 @@
       "img": "icons/magic/fire/flame-burning-fist-strike.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Ape attacks with its Fist.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ape attacks with its Fist.</p>"
         },
         "source": {
           "custom": "",
@@ -928,10 +928,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676663,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!K5cKmPoFkpuOotis.jxC1VNaCf2VXlD6C"
     },
@@ -942,8 +942,8 @@
       "img": "icons/magic/earth/projectile-stone-ball-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +5 to hit, range 25/50 ft., one target. Hit: <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Ape attacks with its Rock.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +5 to hit, range 25/50 ft., one target. Hit: <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ape attacks with its Rock.</p>"
         },
         "source": {
           "custom": "",
@@ -1132,10 +1132,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676663,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!K5cKmPoFkpuOotis.NsTx3MUaYkEI2t8M"
     }

--- a/packs/_source/monsters/beast/axe-beak.json
+++ b/packs/_source/monsters/beast/axe-beak.json
@@ -615,8 +615,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>slashing damage</em></strong>.</p></section>\n<p>The Axe Beak attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Axe Beak attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -803,10 +803,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676455,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SXXvwaLBNuzBymp3.FsSMPLEC46UKCf7T"
     }

--- a/packs/_source/monsters/beast/baboon.json
+++ b/packs/_source/monsters/beast/baboon.json
@@ -674,8 +674,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: 1 (1d4 - 1) <em>piercing damage</em>.</p></section>\n<p>The Baboon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: 1 (1d4 - 1) <em>piercing damage</em>.</p>",
+          "chat": "<p>The Baboon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -866,10 +866,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676438,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!JW8bXggOMBx1S6tF.EXVZptAEHLscbODF"
     }

--- a/packs/_source/monsters/beast/badger.json
+++ b/packs/_source/monsters/beast/badger.json
@@ -800,8 +800,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p></section>\n<p>The Badger attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p>",
+          "chat": "<p>The Badger attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -992,10 +992,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676500,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oQvORD924obyPdCc.siQuRYBFdjgVrKlA"
     }

--- a/packs/_source/monsters/beast/bat.json
+++ b/packs/_source/monsters/beast/bat.json
@@ -729,8 +729,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit:<strong> 1 <em>piercing damage</em>.</strong></p></section>\n<p>The Bat attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit:<strong> 1 <em>piercing damage</em>.</strong></p>",
+          "chat": "<p>The Bat attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -921,10 +921,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676510,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qav2dvMIUiMQCCsy.N05hdQhXPTOHipkJ"
     }

--- a/packs/_source/monsters/beast/black-bear.json
+++ b/packs/_source/monsters/beast/black-bear.json
@@ -795,8 +795,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Black Bear attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Black Bear attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -987,10 +987,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676657,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!D5WjGwKskeUT8HXa.8VdhUFhUE9m12piC"
     },
@@ -1001,8 +1001,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>slashing damage</em></strong>.</p></section>\n<p>The Black Bear attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Black Bear attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1189,10 +1189,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676657,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!D5WjGwKskeUT8HXa.gaxofmkFqQG1zqK9"
     }

--- a/packs/_source/monsters/beast/blood-hawk.json
+++ b/packs/_source/monsters/beast/blood-hawk.json
@@ -859,8 +859,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Blood Hawk attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Blood Hawk attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -1049,10 +1049,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676419,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AJiJW7K957aJJCN6.Jt0l1S2jZWGIiXjE"
     }

--- a/packs/_source/monsters/beast/boar.json
+++ b/packs/_source/monsters/beast/boar.json
@@ -615,8 +615,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>slashing damage</em></strong>.</p></section>\n<p>The Boar attacks with its Tusk.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Boar attacks with its Tusk.</p>"
         },
         "source": {
           "custom": "",
@@ -803,10 +803,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676738,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lZR4lhNmYSf89s4Q.ypnf9maxKh66ucMe"
     },
@@ -817,8 +817,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra <strong>3 (1d6) <em>slashing damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 11 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes extra <em>slashing damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra <strong>3 (1d6) <em>slashing damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 11 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes extra <em>slashing damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -1037,10 +1037,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676738,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lZR4lhNmYSf89s4Q.TSmET06nE61H6HC2"
     },
@@ -1051,8 +1051,8 @@
       "img": "icons/magic/water/heart-ice-freeze.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the boar takes <strong>7 damage</strong> or less that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead. Recharges on a short or long rest.</p>\n</section>\n<p>If the boar takes damage that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead.</p>",
-          "chat": ""
+          "value": "<p>If the boar takes <strong>7 damage</strong> or less that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead. Recharges on a short or long rest.</p>",
+          "chat": "<p>If the boar takes damage that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead.</p>"
         },
         "source": {
           "custom": "",
@@ -1177,10 +1177,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676738,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lZR4lhNmYSf89s4Q.U66PTM15QvmkenvW"
     }

--- a/packs/_source/monsters/beast/brown-bear.json
+++ b/packs/_source/monsters/beast/brown-bear.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack: </em><strong>+6 to hit,</strong> <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d8 + 4) <em>piercing damage</em></strong>.</p>\n</section>\n<p>The Brown Bear attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack: </em><strong>+6 to hit,</strong> <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d8 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Brown Bear attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676701,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!omcDpBoB69esCXeM.tOPVA2liaPY9pwgO"
     },
@@ -821,8 +821,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack: </em><strong>+6 to hit</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>\n</section>\n<p>The Brown Bear attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack: </em><strong>+6 to hit</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Brown Bear attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1009,10 +1009,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676701,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!omcDpBoB69esCXeM.MozRn0kqcm5IG3WI"
     },

--- a/packs/_source/monsters/beast/camel.json
+++ b/packs/_source/monsters/beast/camel.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Camel attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Camel attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676431,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!FQMFuzzSh73d0Nrd.XY89jRSGIvqLmLmw"
     }

--- a/packs/_source/monsters/beast/cat.json
+++ b/packs/_source/monsters/beast/cat.json
@@ -615,8 +615,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>slashing damage</em>.</strong></p></section>\n<p>The Cat attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>slashing damage</em>.</strong></p>",
+          "chat": "<p>The Cat attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -803,10 +803,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676491,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hIf83RD3ZVW4Egfi.QEiTKu95xZ1ovW5K"
     },

--- a/packs/_source/monsters/beast/constrictor-snake.json
+++ b/packs/_source/monsters/beast/constrictor-snake.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Constrictor Snake attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Constrictor Snake attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676684,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UTuKdTah1DKfPwWe.hZOM2L6WMmk8QOfO"
     },
@@ -821,8 +821,8 @@
       "img": "icons/creatures/reptiles/serpent-horned-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>6 (1d8 + 2) <em>bludgeoning damage</em></strong>. The target is grappled (escape DC 14). Until this grapple ends, the creature is restrained, and the snake can't constrict another target.</p></section>\n<p>The Constrictor Snake attacks with its Constrict. The target is grappled. Until this grapple ends, the creature is restrained, and the snake can't constrict another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>6 (1d8 + 2) <em>bludgeoning damage</em></strong>. The target is grappled (escape DC 14). Until this grapple ends, the creature is restrained, and the snake can't constrict another target.</p>",
+          "chat": "<p>The Constrictor Snake attacks with its Constrict. The target is grappled. Until this grapple ends, the creature is restrained, and the snake can't constrict another target.</p>"
         },
         "source": {
           "custom": "",
@@ -1009,10 +1009,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676684,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UTuKdTah1DKfPwWe.haXdYCAfGXo0iVqC"
     }

--- a/packs/_source/monsters/beast/crab.json
+++ b/packs/_source/monsters/beast/crab.json
@@ -615,8 +615,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>bludgeoning damage</em>.</strong></p></section>\n<p>The Crab attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>bludgeoning damage</em>.</strong></p>",
+          "chat": "<p>The Crab attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -803,10 +803,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676411,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8RgUhb31VvjUNZU1.gvfgesIscW0VALbY"
     },

--- a/packs/_source/monsters/beast/crocodile.json
+++ b/packs/_source/monsters/beast/crocodile.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong>.</p>\n<p>The target is grappled (escape DC 12). Until this grapple ends, the target is restrained, and the crocodile can't bite another target.</p>\n</section>\n<p>The Crocodile attacks with its Bite. If successful, the target is grappled. Until this grapple ends, the target is restrained, and the crocodile can't bite another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong>.</p><p>The target is grappled (escape DC 12). Until this grapple ends, the target is restrained, and the crocodile can't bite another target.</p>",
+          "chat": "<p>The Crocodile attacks with its Bite. If successful, the target is grappled. Until this grapple ends, the target is restrained, and the crocodile can't bite another target.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676414,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8aCTKP5qaBPFOqxM.L0k8pFgKxxEEMEOY"
     },

--- a/packs/_source/monsters/beast/deer.json
+++ b/packs/_source/monsters/beast/deer.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>piercing damage</em></strong>.</p></section>\n<p>The Deer attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Deer attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676400,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!4EODJbmPlpnNGVR7.EyXnPvAdgwKZz6LT"
     }

--- a/packs/_source/monsters/beast/dire-wolf.json
+++ b/packs/_source/monsters/beast/dire-wolf.json
@@ -729,8 +729,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>The Dire Wolf attacks with its Bite. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>The Dire Wolf attacks with its Bite. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -1010,10 +1010,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676428,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EYiQZ3rFL25fEJY5.tx9xPDEQ8osJq6ZQ"
     }

--- a/packs/_source/monsters/beast/draft-horse.json
+++ b/packs/_source/monsters/beast/draft-horse.json
@@ -615,8 +615,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d4 + 4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Draft Horse attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d4 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Draft Horse attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676421,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Bupo3E9X5Ptx6XeT.dJyouOu3yDwHTXEX"
     }

--- a/packs/_source/monsters/beast/eagle.json
+++ b/packs/_source/monsters/beast/eagle.json
@@ -670,8 +670,8 @@
       "img": "icons/creatures/claws/claw-scaled-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>slashing damage</em></strong>.</p></section>\n<p>The Eagle attacks with its Talons.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Eagle attacks with its Talons.</p>"
         },
         "source": {
           "custom": "",
@@ -858,10 +858,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676426,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EI8w6XjzCZICkox9.FeybcW5pMzYjWRqq"
     }

--- a/packs/_source/monsters/beast/elephant.json
+++ b/packs/_source/monsters/beast/elephant.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/cougar-pounce-stalk-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the elephant moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a <strong>DC 12 Strength saving throw</strong> or be knocked prone. If the target is prone, the elephant can make one stomp attack against it as a bonus action.</p>\n</section>\n<p>If the elephant moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a Strength saving throw.</p>",
-          "chat": ""
+          "value": "<p>If the elephant moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a <strong>DC 12 Strength saving throw</strong> or be knocked prone. If the target is prone, the elephant can make one stomp attack against it as a bonus action.</p>",
+          "chat": "<p>If the elephant moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a Strength saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -798,10 +798,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676820,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jLPhaBnMtAbB5dp1.TtrZUBPjTrxKxoFn"
     },
@@ -812,8 +812,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>19 (3d8 + 6) <em>piercing damage</em></strong>.</p></section>\n<p>The Elephant attacks with its Gore.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>19 (3d8 + 6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Elephant attacks with its Gore.</p>"
         },
         "source": {
           "custom": "",
@@ -1000,10 +1000,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676820,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jLPhaBnMtAbB5dp1.r6mBkCtL5j6Y6sBr"
     },
@@ -1014,8 +1014,8 @@
       "img": "icons/creatures/abilities/cougar-pounce-stalk-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>22 (3d10 + 6) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Elephant attacks with its Stomp.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>22 (3d10 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Elephant attacks with its Stomp.</p>"
         },
         "source": {
           "custom": "",
@@ -1202,10 +1202,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676820,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jLPhaBnMtAbB5dp1.ZHBbc5K4n6sU17rC"
     }

--- a/packs/_source/monsters/beast/elk.json
+++ b/packs/_source/monsters/beast/elk.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra damage. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage.</p><p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra damage. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -831,10 +831,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676761,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!55PkbskG5iBZGrgR.slVyUWagsSZ5CXSh"
     },
@@ -845,8 +845,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Elk attacks with its Ram.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Elk attacks with its Ram.</p>"
         },
         "source": {
           "custom": "",
@@ -1033,10 +1033,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676761,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!55PkbskG5iBZGrgR.05Vs3AiPgtQkX84S"
     },
@@ -1047,8 +1047,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>8 (2d4 + 3) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Elk attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>8 (2d4 + 3) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Elk attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -1239,10 +1239,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676761,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!55PkbskG5iBZGrgR.FneLrX10GhkE2o4E"
     }

--- a/packs/_source/monsters/beast/flying-snake.json
+++ b/packs/_source/monsters/beast/flying-snake.json
@@ -674,8 +674,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em> </strong>plus <strong>7 (3d4) <em>poison damage</em></strong>.</p></section>\n<p>The Flying Snake attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em> </strong>plus <strong>7 (3d4) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Flying Snake attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -884,10 +884,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676453,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SMfgOsfPgf6rb01k.ITtDDLuoOyJbDQpA"
     }

--- a/packs/_source/monsters/beast/giant-ape.json
+++ b/packs/_source/monsters/beast/giant-ape.json
@@ -740,8 +740,8 @@
       "img": "icons/magic/fire/flame-burning-fist-strike.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>22 (3d10 + 6) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Giant Ape attacks with its Fist.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>22 (3d10 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Giant Ape attacks with its Fist.</p>"
         },
         "source": {
           "custom": "",
@@ -930,10 +930,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676644,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8MuL8xisavJW9bnw.N86NeUNsfvruyJGq"
     },
@@ -944,8 +944,8 @@
       "img": "icons/magic/earth/projectile-stone-ball-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +9 to hit, range 50/100 ft., one target. Hit: <strong>30 (7d6 + 6) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Giant Ape attacks with its Rock.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +9 to hit, range 50/100 ft., one target. Hit: <strong>30 (7d6 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Giant Ape attacks with its Rock.</p>"
         },
         "source": {
           "custom": "",
@@ -1134,10 +1134,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676644,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8MuL8xisavJW9bnw.CVDcFc8ZcjYVl1EV"
     }

--- a/packs/_source/monsters/beast/giant-badger.json
+++ b/packs/_source/monsters/beast/giant-badger.json
@@ -795,8 +795,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>.</p></section>\n<p>The Giant Badger attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Badger attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -987,10 +987,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676690,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cJGY1ZywUOo6heNR.NTUVjYVsAjweAj1R"
     },
@@ -1001,8 +1001,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (2d4 + 1) <em>slashing damage</em></strong>.</p></section>\n<p>The Giant Badger attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (2d4 + 1) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Badger attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1189,10 +1189,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676690,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cJGY1ZywUOo6heNR.BToZtvd0HCyQvoXC"
     }

--- a/packs/_source/monsters/beast/giant-bat.json
+++ b/packs/_source/monsters/beast/giant-bat.json
@@ -729,8 +729,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Giant Bat attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Bat attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -921,10 +921,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676456,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SoK7l5zJQKxTVgLL.r77BXFVYT1LuJCZs"
     }

--- a/packs/_source/monsters/beast/giant-boar.json
+++ b/packs/_source/monsters/beast/giant-boar.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra <strong>7 (2d6) <em>slashing damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes extra <em>slashing damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra <strong>7 (2d6) <em>slashing damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes extra <em>slashing damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -835,10 +835,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676726,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SsuCaF2fIEoDdFA3.1ArcmRCn5G0t6sOo"
     },
@@ -849,8 +849,8 @@
       "img": "icons/magic/water/heart-ice-freeze.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the boar <strong>takes 10 damage</strong> or less that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead. Recharges after a short or long rest.</p>\n</section>\n<p>If the boar takes damage that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead.</p>",
-          "chat": ""
+          "value": "<p>If the boar <strong>takes 10 damage</strong> or less that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead. Recharges after a short or long rest.</p>",
+          "chat": "<p>If the boar takes damage that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead.</p>"
         },
         "source": {
           "custom": "",
@@ -975,10 +975,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676726,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SsuCaF2fIEoDdFA3.byaGAd7ILpgsQ7Un"
     },
@@ -989,8 +989,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>.</p></section>\n<p>The Giant Boar attacks with its Tusk.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Boar attacks with its Tusk.</p>"
         },
         "source": {
           "custom": "",
@@ -1177,10 +1177,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676726,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SsuCaF2fIEoDdFA3.zHwaxxXcDz8AE8Bj"
     }

--- a/packs/_source/monsters/beast/giant-centipede.json
+++ b/packs/_source/monsters/beast/giant-centipede.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>\n<p>The target must succeed on a  <strong>DC 11 Constitution</strong> saving throw or take <strong>10 (3d6) <em>poison damage</em></strong>. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>\n</section>\n<p>The Giant Centipede attacks with its Bite. The target must succeed on a  <strong>DC 11 Constitution</strong> saving throw or take <em>poison damage</em>. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 11 Constitution</strong> saving throw or take <strong>10 (3d6) <em>poison damage</em></strong>. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>",
+          "chat": "<p>The Giant Centipede attacks with its Bite. The target must succeed on a  <strong>DC 11 Constitution</strong> saving throw or take <em>poison damage</em>. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>"
         },
         "source": {
           "custom": "",
@@ -898,10 +898,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676436,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Hn8FFLEzscgT7azz.8EvqvqLumOBhrjeD"
     }

--- a/packs/_source/monsters/beast/giant-constrictor-snake.json
+++ b/packs/_source/monsters/beast/giant-constrictor-snake.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>.</p></section>\n<p>The Giant Constrictor Snake attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Constrictor Snake attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -809,10 +809,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676669,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NpvwE1feOHyEqAbP.qB9j7Epq7UVkGWzY"
     },
@@ -823,8 +823,8 @@
       "img": "icons/creatures/reptiles/serpent-horned-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p>\n<p>The target is grappled (escape DC 16). Until this grapple ends, the creature is restrained, and the snake can't constrict another target.</p>\n</section>\n<p>The Giant Constrictor Snake attacks with its Constrict. The target is grappled. Until this grapple ends, the creature is restrained, and the snake can't constrict another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p><p>The target is grappled (escape DC 16). Until this grapple ends, the creature is restrained, and the snake can't constrict another target.</p>",
+          "chat": "<p>The Giant Constrictor Snake attacks with its Constrict. The target is grappled. Until this grapple ends, the creature is restrained, and the snake can't constrict another target.</p>"
         },
         "source": {
           "custom": "",
@@ -1011,10 +1011,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676669,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NpvwE1feOHyEqAbP.3FIKn37A037kPgzc"
     }

--- a/packs/_source/monsters/beast/giant-crab.json
+++ b/packs/_source/monsters/beast/giant-crab.json
@@ -674,8 +674,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>bludgeoning damage</em></strong>.</p>\n<p>The target is grappled (escape DC 11). The crab has two claws, each of which can grapple only one target.</p>\n</section>\n<p>The Giant Crab attacks with its Claw. The target is grappled.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>bludgeoning damage</em></strong>.</p><p>The target is grappled (escape DC 11). The crab has two claws, each of which can grapple only one target.</p>",
+          "chat": "<p>The Giant Crab attacks with its Claw. The target is grappled.</p>"
         },
         "source": {
           "custom": "",
@@ -862,10 +862,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676420,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AOJvmk1IchxNxQzP.7qDtYuaBNQ3zOnBC"
     }

--- a/packs/_source/monsters/beast/giant-crocodile.json
+++ b/packs/_source/monsters/beast/giant-crocodile.json
@@ -799,8 +799,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>21 (3d10 + 5) <em>piercing damage</em></strong>.</p>\n<p>The target is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the crocodile can't bite another target.</p>\n</section>\n<p>The Giant Crocodile attacks with its Bite. If successful, the target is grappled. Until this grapple ends, the target is restrained, and the crocodile can't bite another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>21 (3d10 + 5) <em>piercing damage</em></strong>.</p><p>The target is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the crocodile can't bite another target.</p>",
+          "chat": "<p>The Giant Crocodile attacks with its Bite. If successful, the target is grappled. Until this grapple ends, the target is restrained, and the crocodile can't bite another target.</p>"
         },
         "source": {
           "custom": "",
@@ -991,10 +991,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676637,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3YwmvDupMwycWNCO.u7eurp95tuW3tYGl"
     },
@@ -1005,8 +1005,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target <strong>not grappled by the crocodile</strong>. Hit: <strong>14 (2d8 + 5) <em>bludgeoning damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 16 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>The Giant Crocodile attacks with its Tail. If the target is a creature, it must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target <strong>not grappled by the crocodile</strong>. Hit: <strong>14 (2d8 + 5) <em>bludgeoning damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 16 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>The Giant Crocodile attacks with its Tail. If the target is a creature, it must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1284,10 +1284,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676637,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3YwmvDupMwycWNCO.VkCVMF2SvsuYWWYg"
     }

--- a/packs/_source/monsters/beast/giant-eagle.json
+++ b/packs/_source/monsters/beast/giant-eagle.json
@@ -795,8 +795,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p></section>\n<p>The Giant Eagle attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Eagle attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -985,10 +985,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676645,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!9bHoR8k5D2DKHaF3.vyI1tbobhrYMxj76"
     },
@@ -999,8 +999,8 @@
       "img": "icons/creatures/claws/claw-scaled-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>.</p></section>\n<p>The Giant Eagle attacks with its Talons.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Eagle attacks with its Talons.</p>"
         },
         "source": {
           "custom": "",
@@ -1189,10 +1189,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676645,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!9bHoR8k5D2DKHaF3.sh91NilUd5bUZyiG"
     }

--- a/packs/_source/monsters/beast/giant-elk.json
+++ b/packs/_source/monsters/beast/giant-elk.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 14 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra damage. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage.</p><p>If the target is a creature, it must succeed on a  <strong>DC 14 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra damage. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -831,10 +831,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676813,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hQt3qIahnB1Odb40.xSzDPptifNbKyf5N"
     },
@@ -845,8 +845,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>22 (4d8 + 4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Giant Elk attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>22 (4d8 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Giant Elk attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -1037,10 +1037,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676813,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hQt3qIahnB1Odb40.jDA6wujGF6L3tPBM"
     },
@@ -1051,8 +1051,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Giant Elk attacks with its Ram.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Giant Elk attacks with its Ram.</p>"
         },
         "source": {
           "custom": "",
@@ -1241,10 +1241,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676813,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hQt3qIahnB1Odb40.epOt7fzXcBz9Hf0i"
     }

--- a/packs/_source/monsters/beast/giant-fire-beetle.json
+++ b/packs/_source/monsters/beast/giant-fire-beetle.json
@@ -615,8 +615,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: 2 (1d6 - 1) <em>slashing damage</em>.</p></section>\n<p>The Giant Fire Beetle attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: 2 (1d6 - 1) <em>slashing damage</em>.</p>",
+          "chat": "<p>The Giant Fire Beetle attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676471,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Z0GiAv3bJxTjUfjM.ytajTMHqbOxc0BvA"
     },

--- a/packs/_source/monsters/beast/giant-frog.json
+++ b/packs/_source/monsters/beast/giant-frog.json
@@ -733,8 +733,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>.</p>\n<p>The target is grappled (escape DC 11). Until this grapple ends, the target is restrained, and the frog can't bite another target.</p>\n</section>\n<p>The Giant Frog attacks with its Bite. If successful, the target is grappled. Until this grapple ends, the target is restrained, and the frog can't bite another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>.</p><p>The target is grappled (escape DC 11). Until this grapple ends, the target is restrained, and the frog can't bite another target.</p>",
+          "chat": "<p>The Giant Frog attacks with its Bite. If successful, the target is grappled. Until this grapple ends, the target is restrained, and the frog can't bite another target.</p>"
         },
         "source": {
           "custom": "",
@@ -925,10 +925,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676595,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kSAi2KRonL4G4JpO.2y826IUSIAgmYf2c"
     },
@@ -939,8 +939,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-tongue-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The frog makes one bite attack against a Small or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends.</p>\n<p>The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the frog, and it takes <strong>5 (2d4) <em>acid damage</em></strong> at the start of each of the frog's turns. The frog can have only one target swallowed at a time. If the frog dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 ft. of movement, exiting prone.</p>\n</section>\n<p>The Giant Frog attacks with its Swallow.</p>",
-          "chat": ""
+          "value": "<p>The frog makes one bite attack against a Small or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends.</p><p>The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the frog, and it takes <strong>5 (2d4) <em>acid damage</em></strong> at the start of each of the frog's turns. The frog can have only one target swallowed at a time. If the frog dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 ft. of movement, exiting prone.</p>",
+          "chat": "<p>The Giant Frog attacks with its Swallow.</p>"
         },
         "source": {
           "custom": "",
@@ -1069,10 +1069,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676595,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kSAi2KRonL4G4JpO.37M4eUyS3kovXqdr"
     }

--- a/packs/_source/monsters/beast/giant-goat.json
+++ b/packs/_source/monsters/beast/giant-goat.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra <strong>5 (2d4) <em>bludgeoning damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes a extra <em>bludgeoning damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra <strong>5 (2d4) <em>bludgeoning damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes a extra <em>bludgeoning damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -835,10 +835,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676608,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rjqk7ToMD8sGr3n4.dBII3VhTvg43aTUI"
     },
@@ -908,8 +908,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (2d4 + 3) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Giant Goat attacks with its Ram.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (2d4 + 3) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Giant Goat attacks with its Ram.</p>"
         },
         "source": {
           "custom": "",
@@ -1096,10 +1096,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676608,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rjqk7ToMD8sGr3n4.t8cKnWGtgVCfhW5v"
     }

--- a/packs/_source/monsters/beast/giant-hyena.json
+++ b/packs/_source/monsters/beast/giant-hyena.json
@@ -740,8 +740,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>.</p></section>\n<p>The Giant Hyena attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Hyena attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -932,10 +932,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676474,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aAqfEHPiVbhMwZ6j.X9XQ405Nx5lHP20E"
     }

--- a/packs/_source/monsters/beast/giant-lizard.json
+++ b/packs/_source/monsters/beast/giant-lizard.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Giant Lizard attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Lizard attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676502,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pLzSh4dA517Tn73E.fLwfCY0GE5S7mMYv"
     }

--- a/packs/_source/monsters/beast/giant-octopus.json
+++ b/packs/_source/monsters/beast/giant-octopus.json
@@ -792,8 +792,8 @@
       "img": "icons/magic/unholy/orb-swirling-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>A 20-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action. Recharges after a Short or Long Rest.</p></section>\n<p>A 20-foot-radius cloud of ink extends all around the octopus if it is underwater.</p>",
-          "chat": ""
+          "value": "<p>A 20-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action. Recharges after a Short or Long Rest.</p>",
+          "chat": "<p>A 20-foot-radius cloud of ink extends all around the octopus if it is underwater.</p>"
         },
         "source": {
           "custom": "",
@@ -918,10 +918,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676607,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!p9Xnr820UAZBOIVN.HoGLXQIsF3riSu3X"
     },
@@ -932,8 +932,8 @@
       "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p>\n<p>If the target is a creature, it is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the octopus can't use its tentacles on another target.</p>\n</section>\n<p>The Giant Octopus attacks with its Tentacles. If the target is a creature, it is grappled. Until this grapple ends, the target is restrained, and the octopus can't use its tentacles on another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p><p>If the target is a creature, it is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the octopus can't use its tentacles on another target.</p>",
+          "chat": "<p>The Giant Octopus attacks with its Tentacles. If the target is a creature, it is grappled. Until this grapple ends, the target is restrained, and the octopus can't use its tentacles on another target.</p>"
         },
         "source": {
           "custom": "",
@@ -1126,10 +1126,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676607,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!p9Xnr820UAZBOIVN.yOZK7sWcCRFmuAxz"
     }

--- a/packs/_source/monsters/beast/giant-owl.json
+++ b/packs/_source/monsters/beast/giant-owl.json
@@ -729,8 +729,8 @@
       "img": "icons/creatures/claws/claw-scaled-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (2d6 + 1) <em>slashing damage</em></strong>.</p></section>\n<p>The Giant Owl attacks with its Talons.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (2d6 + 1) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Owl attacks with its Talons.</p>"
         },
         "source": {
           "custom": "",
@@ -917,10 +917,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676462,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VVXly3ue0i3YgGrB.6jw1NtpZQXIesO4Y"
     }

--- a/packs/_source/monsters/beast/giant-poisonous-snake.json
+++ b/packs/_source/monsters/beast/giant-poisonous-snake.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>6 (1d4 + 4) <em>piercing damage</em></strong>.</p>\n<p>The target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>10 (3d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The Giant Poisonous Snake attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>6 (1d4 + 4) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>10 (3d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Giant Poisonous Snake attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -899,10 +899,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676473,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZW39DE2zI3TXVYC9.GlOJaYXJFUP0Hd80"
     }

--- a/packs/_source/monsters/beast/giant-rat-diseased.json
+++ b/packs/_source/monsters/beast/giant-rat-diseased.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d4 + 2) <em>piercing damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 10 Constitution</strong> saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</p>\n</section>\n<p>The Giant Rat (Diseased) attacks with its Bite. If the target is a creature, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d4 + 2) <em>piercing damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 10 Constitution</strong> saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</p>",
+          "chat": "<p>The Giant Rat (Diseased) attacks with its Bite. If the target is a creature, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -898,10 +898,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676517,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!z0zvgcIugizwcuxJ.52m3BQ2wpXvT0jOM"
     },

--- a/packs/_source/monsters/beast/giant-rat.json
+++ b/packs/_source/monsters/beast/giant-rat.json
@@ -729,8 +729,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Giant Rat attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Rat attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -923,10 +923,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676505,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!q1YJIeIt6rK8fCKn.D98YkFEPQRdesZUW"
     }

--- a/packs/_source/monsters/beast/giant-scorpion.json
+++ b/packs/_source/monsters/beast/giant-scorpion.json
@@ -740,8 +740,8 @@
       "img": "icons/commodities/claws/claw-pincer-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>bludgeoning damage</em></strong>.</p>\n<p>The target is grappled (escape DC 12). The scorpion has two claws, each of which can grapple only one target.</p>\n</section>\n<p>The Giant Scorpion attacks with its Claw. The target is grappled.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>bludgeoning damage</em></strong>.</p><p>The target is grappled (escape DC 12). The scorpion has two claws, each of which can grapple only one target.</p>",
+          "chat": "<p>The Giant Scorpion attacks with its Claw. The target is grappled.</p>"
         },
         "source": {
           "custom": "",
@@ -928,10 +928,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676659,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GxgIVRX5GbVTifiF.OJ2b64O3e1nni21W"
     },
@@ -942,8 +942,8 @@
       "img": "icons/creatures/abilities/stinger-poison-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong>.</p>\n<p>The target must make a  <strong>DC 12 Constitution</strong> saving throw, taking <strong>22 (4d10) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The Giant Scorpion attacks with its Sting. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 12 Constitution</strong> saving throw, taking <strong>22 (4d10) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Giant Scorpion attacks with its Sting. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1285,10 +1285,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676659,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GxgIVRX5GbVTifiF.q6uVUHWyzht5OpwV"
     }

--- a/packs/_source/monsters/beast/giant-sea-horse.json
+++ b/packs/_source/monsters/beast/giant-sea-horse.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the sea horse moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra <strong>7 (2d6) <em>bludgeoning damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 11 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>If the sea horse moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes extra <em>bludgeoning damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the sea horse moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra <strong>7 (2d6) <em>bludgeoning damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 11 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>If the sea horse moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes extra <em>bludgeoning damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -835,10 +835,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676581,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!c9XDGsTJRy9HUaxQ.MB7KUNGnxz6mw1J5"
     },
@@ -908,8 +908,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Giant Sea Horse attacks with its Ram.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Giant Sea Horse attacks with its Ram.</p>"
         },
         "source": {
           "custom": "",
@@ -1096,10 +1096,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676581,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!c9XDGsTJRy9HUaxQ.tTZCmbeeSHXXFZGJ"
     }

--- a/packs/_source/monsters/beast/giant-shark.json
+++ b/packs/_source/monsters/beast/giant-shark.json
@@ -733,8 +733,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>22 (3d10 + 6) <em>piercing damage</em></strong>.</p></section>\n<p>The Giant Shark attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>22 (3d10 + 6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Shark attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -925,10 +925,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676445,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MWlwLlKXh8jUUxOL.fGIh2Vq3XhIzacIg"
     }

--- a/packs/_source/monsters/beast/giant-spider.json
+++ b/packs/_source/monsters/beast/giant-spider.json
@@ -792,8 +792,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p>\n<p>The target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>9 (2d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>\n</section>\n<p>The Giant Spider attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>9 (2d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>",
+          "chat": "<p>The Giant Spider attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1075,10 +1075,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676616,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!v99wOosUJjUgcUNF.SuRAERXystPvC7Ci"
     },
@@ -1089,8 +1089,8 @@
       "img": "icons/creatures/webs/web-spider-glowing-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +5 to hit, range 30/60 ft., one creature. Hit: The target is restrained by webbing.</p>\n<p>As an action, the restrained target can make a DC 12 Strength check, bursting the webbing on a success. The webbing can also be attacked and destroyed (AC 10; hp 5; vulnerability to <em>fire damage</em>; immunity to bludgeoning, poison, and <em>psychic damage</em>).</p>\n</section>\n<p>The target is restrained by webbing. As an action, the restrained target can make a Strength check, bursting the webbing on a success.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +5 to hit, range 30/60 ft., one creature. Hit: The target is restrained by webbing.</p><p>As an action, the restrained target can make a DC 12 Strength check, bursting the webbing on a success. The webbing can also be attacked and destroyed (AC 10; hp 5; vulnerability to <em>fire damage</em>; immunity to bludgeoning, poison, and <em>psychic damage</em>).</p>",
+          "chat": "<p>The target is restrained by webbing. As an action, the restrained target can make a Strength check, bursting the webbing on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1311,10 +1311,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676616,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!v99wOosUJjUgcUNF.g7e60AxXarlQ9xQC"
     }

--- a/packs/_source/monsters/beast/giant-toad.json
+++ b/packs/_source/monsters/beast/giant-toad.json
@@ -733,8 +733,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong> plus <strong>5 (1d10) <em>poison damage</em></strong>.</p>\n<p>The target is grappled (escape DC 13). Until this grapple ends, the target is restrained, and the toad can't bite another target.</p>\n</section>\n<p>The Giant Toad attacks with its Bite. The target is grappled. Until this grapple ends, the target is restrained, and the toad can't bite another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong> plus <strong>5 (1d10) <em>poison damage</em></strong>.</p><p>The target is grappled (escape DC 13). Until this grapple ends, the target is restrained, and the toad can't bite another target.</p>",
+          "chat": "<p>The Giant Toad attacks with its Bite. The target is grappled. Until this grapple ends, the target is restrained, and the toad can't bite another target.</p>"
         },
         "source": {
           "custom": "",
@@ -943,10 +943,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676549,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Ixo5shumxy4I9qyD.lYSWskOMRCVLyWLZ"
     },
@@ -957,8 +957,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-tongue-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The toad makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends.</p>\n<p>The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the toad, and it takes <strong>10 (3d6) <em>acid damage</em></strong> at the start of each of the toad's turns. The toad can have only one target swallowed at a time. If the toad dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 ft. of movement, exiting prone.</p>\n</section>\n<p>The Giant Toad attacks with its Swallow.</p>",
-          "chat": ""
+          "value": "<p>The toad makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends.</p><p>The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the toad, and it takes <strong>10 (3d6) <em>acid damage</em></strong> at the start of each of the toad's turns. The toad can have only one target swallowed at a time. If the toad dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 ft. of movement, exiting prone.</p>",
+          "chat": "<p>The Giant Toad attacks with its Swallow.</p>"
         },
         "source": {
           "custom": "",
@@ -1087,10 +1087,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676549,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Ixo5shumxy4I9qyD.6aBDwlIsxceFMXxL"
     }

--- a/packs/_source/monsters/beast/giant-vulture.json
+++ b/packs/_source/monsters/beast/giant-vulture.json
@@ -854,8 +854,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Giant Vulture attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Vulture attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -1044,10 +1044,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676641,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!4ZlUHt4xmB7GdPfk.t6TG4rgkOXBefYZQ"
     },
@@ -1058,8 +1058,8 @@
       "img": "icons/creatures/claws/claw-scaled-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d6 + 2) <em>slashing damage</em></strong>.</p></section>\n<p>The Giant Vulture attacks with its Talons.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d6 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Vulture attacks with its Talons.</p>"
         },
         "source": {
           "custom": "",
@@ -1248,10 +1248,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676641,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!4ZlUHt4xmB7GdPfk.AXKWmB2ZU1hebo5S"
     }

--- a/packs/_source/monsters/beast/giant-wasp.json
+++ b/packs/_source/monsters/beast/giant-wasp.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/fang-tooth-venomous.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>\n<p>The target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>10 (3d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>\n</section>\n<p>The Giant Wasp attacks with its Sting. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>10 (3d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>",
+          "chat": "<p>The Giant Wasp attacks with its Sting. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -894,10 +894,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676403,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!4tl0s2SnaLjkoDiI.L1TmhBXd2UrVxExn"
     }

--- a/packs/_source/monsters/beast/giant-weasel.json
+++ b/packs/_source/monsters/beast/giant-weasel.json
@@ -670,8 +670,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p></section>\n<p>The Giant Weasel attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Giant Weasel attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -864,10 +864,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676412,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8VXxqeBvN54rPh81.BrbVh5Sx3clXLHIi"
     }

--- a/packs/_source/monsters/beast/giant-wolf-spider.json
+++ b/packs/_source/monsters/beast/giant-wolf-spider.json
@@ -674,8 +674,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>.</p>\n<p>The target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>7 (2d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>\n</section>\n<p>The Giant Wolf Spider attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>7 (2d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>",
+          "chat": "<p>The Giant Wolf Spider attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -955,10 +955,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676483,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!f9JbhBfWucrY2eDA.Et0GP61ZnJkxxqvN"
     },

--- a/packs/_source/monsters/beast/goat.json
+++ b/packs/_source/monsters/beast/goat.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 10 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes a extra <em>bludgeoning damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 10 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes a extra <em>bludgeoning damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -818,10 +818,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676621,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!y8sRU8Ks2lcrGsaf.fmILoB0arLdodNGB"
     },
@@ -891,8 +891,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d4 + 1) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Goat attacks with its Ram.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d4 + 1) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Goat attacks with its Ram.</p>"
         },
         "source": {
           "custom": "",
@@ -1079,10 +1079,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676621,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!y8sRU8Ks2lcrGsaf.I3ioyE4CVHPLGGy7"
     }

--- a/packs/_source/monsters/beast/hawk.json
+++ b/packs/_source/monsters/beast/hawk.json
@@ -670,8 +670,8 @@
       "img": "icons/creatures/claws/claw-talons-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>slashing damage</em>.</strong></p></section>\n<p>The Hawk attacks with its Talons.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>slashing damage</em>.</strong></p>",
+          "chat": "<p>The Hawk attacks with its Talons.</p>"
         },
         "source": {
           "custom": "",
@@ -858,10 +858,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676486,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fnkPNfIpS62LqOu4.0Di3cqTRD7ot8ZCa"
     }

--- a/packs/_source/monsters/beast/hunter-shark.json
+++ b/packs/_source/monsters/beast/hunter-shark.json
@@ -733,8 +733,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>piercing damage</em></strong>.</p></section>\n<p>The Hunter Shark attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Hunter Shark attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -925,10 +925,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676515,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!siBUEAj4UVdaiH6p.KcQolnG6732GPN3o"
     }

--- a/packs/_source/monsters/beast/hyena.json
+++ b/packs/_source/monsters/beast/hyena.json
@@ -674,8 +674,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d6) <em>piercing damage</em></strong>.</p></section>\n<p>The Hyena attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Hyena attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -866,10 +866,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676475,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cDr1JtzEV26bP5Ym.gqMeY9GtWfBNt1bf"
     }

--- a/packs/_source/monsters/beast/jackal.json
+++ b/packs/_source/monsters/beast/jackal.json
@@ -729,8 +729,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: 1 (1d4 - 1) <em>piercing damage</em>.</p></section>\n<p>The Jackal attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: 1 (1d4 - 1) <em>piercing damage</em>.</p>",
+          "chat": "<p>The Jackal attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -921,10 +921,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676446,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MZYCPIVoBs918qGZ.ggHLjL39tb62Bwxy"
     }

--- a/packs/_source/monsters/beast/killer-whale.json
+++ b/packs/_source/monsters/beast/killer-whale.json
@@ -788,8 +788,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>21 (5d6 + 4) <em>piercing damage</em></strong>.</p></section>\n<p>The Killer Whale attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>21 (5d6 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Killer Whale attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -980,10 +980,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676478,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ciLSItjCpwT7nMmk.2JDxekOVx1NSUwuP"
     }

--- a/packs/_source/monsters/beast/lion.json
+++ b/packs/_source/monsters/beast/lion.json
@@ -729,8 +729,8 @@
       "img": "icons/creatures/claws/claw-talons-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the lion moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 13 Strength saving throw</strong> or be knocked prone.</p>\n<p>If the target is prone, the lion can make one bite attack against it as a bonus action.</p>\n</section>\n<p>If the lion moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>If the lion moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 13 Strength saving throw</strong> or be knocked prone.</p><p>If the target is prone, the lion can make one bite attack against it as a bonus action.</p>",
+          "chat": "<p>If the lion moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -912,10 +912,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676816,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hjhERRzafCiFFVLA.pQdtHaxlArSTjbqb"
     },
@@ -985,8 +985,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p></section>\n<p>The Lion attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Lion attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1177,10 +1177,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676816,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hjhERRzafCiFFVLA.gKj1TlVfDhLp5WIk"
     },
@@ -1191,8 +1191,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p></section>\n<p>The Lion attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Lion attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1381,10 +1381,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676816,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hjhERRzafCiFFVLA.CHIayoaCAZj0GBkM"
     }

--- a/packs/_source/monsters/beast/lizard.json
+++ b/packs/_source/monsters/beast/lizard.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p></section>\n<p>The Lizard attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p>",
+          "chat": "<p>The Lizard attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676437,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!I2x01hzOjVN4NUjf.AlO7NtMS64z0faPM"
     }

--- a/packs/_source/monsters/beast/mammoth.json
+++ b/packs/_source/monsters/beast/mammoth.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/cougar-pounce-stalk-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the mammoth moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a <strong>DC 18 Strength saving throw</strong> or be knocked prone. If the target is prone, the mammoth can make one stomp attack against it as a bonus action.</p>\n</section>\n<p>If the mammoth moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a Strength saving throw.</p>",
-          "chat": ""
+          "value": "<p>If the mammoth moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a <strong>DC 18 Strength saving throw</strong> or be knocked prone. If the target is prone, the mammoth can make one stomp attack against it as a bonus action.</p>",
+          "chat": "<p>If the mammoth moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a Strength saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -798,10 +798,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676786,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MiYRAIHwm9It1in8.4LYRJH02EsSnZUNc"
     },
@@ -812,8 +812,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>25 (4d8 + 7) <em>piercing damage</em></strong>.</p></section>\n<p>The Mammoth attacks with its Gore.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>25 (4d8 + 7) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Mammoth attacks with its Gore.</p>"
         },
         "source": {
           "custom": "",
@@ -1002,10 +1002,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676786,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MiYRAIHwm9It1in8.S7i3GTdoo6tyc2wL"
     },
@@ -1016,8 +1016,8 @@
       "img": "icons/creatures/abilities/cougar-pounce-stalk-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>29 (4d10 + 7) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Mammoth attacks with its Stomp.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>29 (4d10 + 7) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Mammoth attacks with its Stomp.</p>"
         },
         "source": {
           "custom": "",
@@ -1204,10 +1204,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676786,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MiYRAIHwm9It1in8.Hx541foatcQiMSZj"
     }

--- a/packs/_source/monsters/beast/mastiff.json
+++ b/packs/_source/monsters/beast/mastiff.json
@@ -670,8 +670,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 11 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>The Mastiff attacks with its Bite. If the target is a creature, it must succeed on a Strength saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 11 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>The Mastiff attacks with its Bite. If the target is a creature, it must succeed on a Strength saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -951,10 +951,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676468,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!YTpL2c3NO4sOn2UA.QLJgy1aF5ijBEp4K"
     }

--- a/packs/_source/monsters/beast/mule.json
+++ b/packs/_source/monsters/beast/mule.json
@@ -733,8 +733,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Mule attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Mule attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -925,10 +925,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676463,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Vk7uHVkJ5b26gaTh.Ou2VI9ORGu2JnZqj"
     }

--- a/packs/_source/monsters/beast/octopus.json
+++ b/packs/_source/monsters/beast/octopus.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>bludgeoning damage</em>.</strong></p><p>The target is grappled (escape DC 10). Until this grapple ends, the octopus can't use its tentacles on another target.</p></section><p>The Octopus attacks with its Tentacles. The target is grappled . Until this grapple ends, the octopus can't use its tentacles on another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>bludgeoning damage</em>.</strong></p><p>The target is grappled (escape DC 10). Until this grapple ends, the octopus can't use its tentacles on another target.</p>",
+          "chat": "<p>The Octopus attacks with its Tentacles. The target is grappled . Until this grapple ends, the octopus can't use its tentacles on another target.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676522,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3UUNbGiG2Yf1ZPxM.SLnyx0Ta2ksVM9QL"
     },
@@ -998,8 +998,8 @@
       "img": "icons/magic/unholy/orb-swirling-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>A 5-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action.</p><p></p></section><p>A 5-foot-radius cloud of ink extends all around the octopus if it is underwater.</p>",
-          "chat": ""
+          "value": "<p>A 5-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action.</p>",
+          "chat": "<p>A 5-foot-radius cloud of ink extends all around the octopus if it is underwater.</p>"
         },
         "source": {
           "custom": "",
@@ -1124,10 +1124,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676522,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3UUNbGiG2Yf1ZPxM.8qYBpaA8c3BuBujY"
     }

--- a/packs/_source/monsters/beast/owl.json
+++ b/packs/_source/monsters/beast/owl.json
@@ -729,8 +729,8 @@
       "img": "icons/creatures/claws/claw-scaled-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>slashing damage</em>.</strong></p><p></p></section><p>The Owl attacks with its Talons.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>slashing damage</em>.</strong></p>",
+          "chat": "<p>The Owl attacks with its Talons.</p>"
         },
         "source": {
           "custom": "",
@@ -917,10 +917,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676480,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!d0prpsGSAorDadec.c3NnWQRHnaBpqtbe"
     }

--- a/packs/_source/monsters/beast/panther.json
+++ b/packs/_source/monsters/beast/panther.json
@@ -670,8 +670,8 @@
       "img": "icons/creatures/claws/claw-talons-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the panther moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 12 Strength saving throw</strong> or be knocked prone. </p><p>If the target is prone, the panther can make one bite attack against it as a bonus action.</p></section><p>If the panther moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw. </p>",
-          "chat": ""
+          "value": "<p>If the panther moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 12 Strength saving throw</strong> or be knocked prone. </p><p>If the target is prone, the panther can make one bite attack against it as a bonus action.</p>",
+          "chat": "<p>If the panther moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw. </p>"
         },
         "source": {
           "custom": "",
@@ -853,10 +853,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676768,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AijNdqMurWxDxUSl.6UmjtTyihpEERg1I"
     },
@@ -867,8 +867,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Panther attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Panther attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1059,10 +1059,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676768,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AijNdqMurWxDxUSl.c7iYo6g3A6DP8V4w"
     },
@@ -1073,8 +1073,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>slashing damage</em></strong>.</p><p></p></section><p>The Panther attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Panther attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1261,10 +1261,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676768,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AijNdqMurWxDxUSl.t4bERcqBVDvjJ2gx"
     }

--- a/packs/_source/monsters/beast/plesiosaurus.json
+++ b/packs/_source/monsters/beast/plesiosaurus.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>14 (3d6 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Plesiosaurus attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>14 (3d6 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Plesiosaurus attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -809,10 +809,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676402,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!4OeZZguYgJcsZoM9.RbcK5H5JO9EnIiCA"
     },

--- a/packs/_source/monsters/beast/poisonous-snake.json
+++ b/packs/_source/monsters/beast/poisonous-snake.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p><p>The target must make a  <strong>DC 10 Constitution</strong> saving throw, taking <strong>5 (2d4) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The Poisonous Snake attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p><p>The target must make a  <strong>DC 10 Constitution</strong> saving throw, taking <strong>5 (2d4) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Poisonous Snake attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -896,10 +896,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676423,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!D5rwVIxmfFrdyyxT.obYv0JJqJiMTsoIF"
     }

--- a/packs/_source/monsters/beast/polar-bear.json
+++ b/packs/_source/monsters/beast/polar-bear.json
@@ -795,8 +795,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d8 + 5) <em>piercing damage</em></strong>.</p><p></p></section><p>The Polar Bear attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d8 + 5) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Polar Bear attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -987,10 +987,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676696,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hb6pjvdCNYmLLp8V.c8cisRQ7Ki3qiXgL"
     },
@@ -1001,8 +1001,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing damage</em></strong>.</p><p></p></section><p>The Polar Bear attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Polar Bear attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1189,10 +1189,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676696,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hb6pjvdCNYmLLp8V.jFBgpP0EO1Y2HRL0"
     }

--- a/packs/_source/monsters/beast/pony.json
+++ b/packs/_source/monsters/beast/pony.json
@@ -615,8 +615,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Pony attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Pony attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676449,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PHO4J98zK2p4KNyc.bDVZoB8Y0b3nkveO"
     }

--- a/packs/_source/monsters/beast/quipper.json
+++ b/packs/_source/monsters/beast/quipper.json
@@ -733,8 +733,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p><p></p></section><p>The Quipper attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p>",
+          "chat": "<p>The Quipper attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -925,10 +925,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676499,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nkyCGJ9wXeAZkyyz.0SJofXpPrHJsVXOy"
     }

--- a/packs/_source/monsters/beast/rat.json
+++ b/packs/_source/monsters/beast/rat.json
@@ -670,8 +670,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p></section>\n<p>The Rat attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p>",
+          "chat": "<p>The Rat attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -862,10 +862,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676503,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pozQUPTnLZW8epox.QpysqgoHq9LXsShc"
     }

--- a/packs/_source/monsters/beast/raven.json
+++ b/packs/_source/monsters/beast/raven.json
@@ -674,8 +674,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p></section>\n<p>The Raven attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p>",
+          "chat": "<p>The Raven attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -862,10 +862,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676444,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!LPdX5YLlwci0NDZx.p8JmuP7pndzbZVzj"
     }

--- a/packs/_source/monsters/beast/reef-shark.json
+++ b/packs/_source/monsters/beast/reef-shark.json
@@ -733,8 +733,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Reef Shark attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Reef Shark attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -925,10 +925,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676430,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!F0yILX4xKKt4dxKY.9xaHEynEl0adgcJ4"
     }

--- a/packs/_source/monsters/beast/rhinoceros.json
+++ b/packs/_source/monsters/beast/rhinoceros.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the rhinoceros moves at least 20 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra <strong>9 (2d8) <em>bludgeoning damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 15 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>If the rhinoceros moves at least 20 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes extra <em>bludgeoning damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the rhinoceros moves at least 20 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra <strong>9 (2d8) <em>bludgeoning damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 15 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>If the rhinoceros moves at least 20 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes extra <em>bludgeoning damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -835,10 +835,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676573,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SBCe2BSa6opTS5M4.e1ZjZT7dyExUSEOu"
     },
@@ -849,8 +849,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Rhinoceros attacks with its Gore.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Rhinoceros attacks with its Gore.</p>"
         },
         "source": {
           "custom": "",
@@ -1037,10 +1037,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676573,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SBCe2BSa6opTS5M4.uFv78t6CwySS1gio"
     }

--- a/packs/_source/monsters/beast/riding-horse.json
+++ b/packs/_source/monsters/beast/riding-horse.json
@@ -615,8 +615,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (2d4 + 3) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Riding Horse attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (2d4 + 3) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Riding Horse attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676512,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rz8UTUnFT87BsAFR.CwpmLFcikAet169F"
     }

--- a/packs/_source/monsters/beast/saber-toothed-tiger.json
+++ b/packs/_source/monsters/beast/saber-toothed-tiger.json
@@ -670,8 +670,8 @@
       "img": "icons/creatures/abilities/cougar-pounce-stalk-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the tiger moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 14 Strength saving throw</strong> or be knocked prone.</p>\n<p>If the target is prone, the lion can make one bite attack against it as a bonus action.</p>\n</section>\n<p>If the tiger moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>If the tiger moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 14 Strength saving throw</strong> or be knocked prone.</p><p>If the target is prone, the lion can make one bite attack against it as a bonus action.</p>",
+          "chat": "<p>If the tiger moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -853,10 +853,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676832,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!tYYoifu9teGLetVI.6f3yWYLcONtKe72e"
     },
@@ -867,8 +867,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (1d10 + 5) <em>piercing damage</em></strong>.</p></section>\n<p>The Saber-Toothed Tiger attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (1d10 + 5) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Saber-Toothed Tiger attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1059,10 +1059,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676832,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!tYYoifu9teGLetVI.npiswgaiGzupcEmw"
     },
@@ -1073,8 +1073,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing damage</em></strong>.</p></section>\n<p>The Saber-Toothed Tiger attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Saber-Toothed Tiger attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1263,10 +1263,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676832,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!tYYoifu9teGLetVI.I9zJprscDFYpwwJR"
     }

--- a/packs/_source/monsters/beast/scorpion.json
+++ b/packs/_source/monsters/beast/scorpion.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/stinger-poison-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit:<strong> 1 <em>piercing damage</em>.</strong></p>\n<p>The target must make a  <strong>DC 9 Constitution</strong> saving throw, taking <strong>4 (1d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The Scorpion attacks with its Sting. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit:<strong> 1 <em>piercing damage</em>.</strong></p><p>The target must make a  <strong>DC 9 Constitution</strong> saving throw, taking <strong>4 (1d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Scorpion attacks with its Sting. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -958,10 +958,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676467,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Y0vxQVF7w2P38FK2.ltue5DUb1SZfphHE"
     }

--- a/packs/_source/monsters/beast/spider.json
+++ b/packs/_source/monsters/beast/spider.json
@@ -674,8 +674,8 @@
       "img": "icons/creatures/abilities/fang-tooth-venomous.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit:<strong> 1 <em>piercing damage</em>.</strong></p><p>The target must succeed on a  <strong>DC 9 Constitution</strong> saving throw or take <strong>2 (1d4) <em>poison damage</em></strong>.</p></section><p>The Spider attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit:<strong> 1 <em>piercing damage</em>.</strong></p><p>The target must succeed on a  <strong>DC 9 Constitution</strong> saving throw or take <strong>2 (1d4) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Spider attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -971,10 +971,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676396,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!28gU50HtG8Kp7uIz.ysV0KgiPcJOYCdMh"
     },

--- a/packs/_source/monsters/beast/stirge.json
+++ b/packs/_source/monsters/beast/stirge.json
@@ -615,8 +615,8 @@
       "img": "icons/skills/wounds/blood-spurt-spray-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p><p>The stirge attaches to the target. While attached, the stirge doesn't attack. Instead, at the start of each of the stirge's turns, the target loses 5 (1d4 + 3) hit points due to blood loss.The stirge can detach itself by spending 5 feet of its movement. It does so after it drains 10 hit points of blood from the target or the target dies.</p></section><p>The Stirge attacks with its Blood Drain. A creature, including the target, can use its action to detach the stirge.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p><p>The stirge attaches to the target. While attached, the stirge doesn't attack. Instead, at the start of each of the stirge's turns, the target loses 5 (1d4 + 3) hit points due to blood loss.The stirge can detach itself by spending 5 feet of its movement. It does so after it drains 10 hit points of blood from the target or the target dies.</p>",
+          "chat": "<p>The Stirge attacks with its Blood Drain. A creature, including the target, can use its action to detach the stirge.</p>"
         },
         "source": {
           "custom": "",
@@ -802,10 +802,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676488,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gKRtiMNAjZiCVfwz.MEFgfFD6YUD9cE08"
     }

--- a/packs/_source/monsters/beast/swarm-of-bats.json
+++ b/packs/_source/monsters/beast/swarm-of-bats.json
@@ -628,8 +628,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>0 ft.,</strong> one creature in the swarm's space. Hit: <strong>5 (2d4) <em>piercing damage</em></strong>, or <strong>2 (1d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p></section>\n<p>The Swarm of Bats attacks with a flurry of Bites.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>0 ft.,</strong> one creature in the swarm's space. Hit: <strong>5 (2d4) <em>piercing damage</em></strong>, or <strong>2 (1d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p>",
+          "chat": "<p>The Swarm of Bats attacks with a flurry of Bites.</p>"
         },
         "source": {
           "custom": "",
@@ -815,10 +815,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676451,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PcZ0QjIG6bHpffp9.0NpX1YUDTXjgIm23"
     },

--- a/packs/_source/monsters/beast/swarm-of-beetles.json
+++ b/packs/_source/monsters/beast/swarm-of-beetles.json
@@ -687,8 +687,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4) <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p></section>\n<p>The Swarm of Beetles attacks with a flurry of Bites.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4) <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p>",
+          "chat": "<p>The Swarm of Beetles attacks with a flurry of Bites.</p>"
         },
         "source": {
           "custom": "",
@@ -876,10 +876,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676481,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!dZZFmG8LiBlgWi76.neEOya9BCR7VSH09"
     }

--- a/packs/_source/monsters/beast/swarm-of-centipedes.json
+++ b/packs/_source/monsters/beast/swarm-of-centipedes.json
@@ -687,8 +687,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4) <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p>\n<p>A creature reduced to 0 hit points by a swarm of centipedes is stable but poisoned for 1 hour, even after regaining hit points, and paralyzed while poisoned in this way.</p>\n</section>\n<p>The Swarm of Centipedes attacks with a flurry of Bites.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4) <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p><p>A creature reduced to 0 hit points by a swarm of centipedes is stable but poisoned for 1 hour, even after regaining hit points, and paralyzed while poisoned in this way.</p>",
+          "chat": "<p>The Swarm of Centipedes attacks with a flurry of Bites.</p>"
         },
         "source": {
           "custom": "",
@@ -876,10 +876,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676440,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KC4tYOolARhajP18.E6zkvUOJARx1t0nc"
     }

--- a/packs/_source/monsters/beast/swarm-of-insects.json
+++ b/packs/_source/monsters/beast/swarm-of-insects.json
@@ -687,8 +687,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4) <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p></section>\n<p>The Swarm of Insects attacks with a flurry of Bites.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4) <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p>",
+          "chat": "<p>The Swarm of Insects attacks with a flurry of Bites.</p>"
         },
         "source": {
           "custom": "",
@@ -876,10 +876,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676452,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!S0zDrv6lbnwWaz9E.1yXz3JunJtlQs6vV"
     }

--- a/packs/_source/monsters/beast/swarm-of-poisonous-snakes.json
+++ b/packs/_source/monsters/beast/swarm-of-poisonous-snakes.json
@@ -687,8 +687,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>0 ft.,</strong> one creature in the swarm's space. Hit: <strong>7 (2d6) <em>piercing damage</em></strong>, or <strong>3 (1d6) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p>\n<p>The target must make a  <strong>DC 10 Constitution</strong> saving throw, taking <strong>14 (4d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The Swarm of Poisonous Snakes attacks with a flurry of Bites. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>0 ft.,</strong> one creature in the swarm's space. Hit: <strong>7 (2d6) <em>piercing damage</em></strong>, or <strong>3 (1d6) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p><p>The target must make a  <strong>DC 10 Constitution</strong> saving throw, taking <strong>14 (4d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Swarm of Poisonous Snakes attacks with a flurry of Bites. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1029,10 +1029,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676466,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!XfQMBoTh892XSnCX.OyLoUiIl3p2j4p59"
     }

--- a/packs/_source/monsters/beast/swarm-of-quippers.json
+++ b/packs/_source/monsters/beast/swarm-of-quippers.json
@@ -805,8 +805,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>0 ft.,</strong> one creature in the swarm's space. Hit: <strong>14 (4d6) <em>piercing damage</em></strong>, or <strong>7 (2d6) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p></section>\n<p>The Swarm of Quippers attacks with a flurry of Bites.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>0 ft.,</strong> one creature in the swarm's space. Hit: <strong>14 (4d6) <em>piercing damage</em></strong>, or <strong>7 (2d6) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p>",
+          "chat": "<p>The Swarm of Quippers attacks with a flurry of Bites.</p>"
         },
         "source": {
           "custom": "",
@@ -994,10 +994,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676443,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KXG5XLIwKhn1V0Y5.hZiOYQNCqAFq0sD6"
     }

--- a/packs/_source/monsters/beast/swarm-of-rats.json
+++ b/packs/_source/monsters/beast/swarm-of-rats.json
@@ -742,8 +742,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>7 (2d6) <em>piercing damage</em></strong>, or <strong>3 (1d6) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p></section>\n<p>The Swarm of Rats attacks with a flurry of Bites.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>7 (2d6) <em>piercing damage</em></strong>, or <strong>3 (1d6) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p>",
+          "chat": "<p>The Swarm of Rats attacks with a flurry of Bites.</p>"
         },
         "source": {
           "custom": "",
@@ -931,10 +931,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676415,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8ihbbjkaOFTPbI73.ESv9NuVeZhnEW1ua"
     }

--- a/packs/_source/monsters/beast/swarm-of-ravens.json
+++ b/packs/_source/monsters/beast/swarm-of-ravens.json
@@ -687,8 +687,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target in the swarm's space. Hit: <strong>7 (2d6) <em>piercing damage</em></strong>, or <strong>3 (1d6) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p></section>\n<p>The Swarm of Ravens attacks with its Beaks.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target in the swarm's space. Hit: <strong>7 (2d6) <em>piercing damage</em></strong>, or <strong>3 (1d6) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p>",
+          "chat": "<p>The Swarm of Ravens attacks with its Beaks.</p>"
         },
         "source": {
           "custom": "",
@@ -877,10 +877,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676487,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!g40zN6xMye6bSS94.rQWSxwspySRtFst2"
     }

--- a/packs/_source/monsters/beast/swarm-of-spiders.json
+++ b/packs/_source/monsters/beast/swarm-of-spiders.json
@@ -687,8 +687,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4) <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p></section>\n<p>The Swarm of Spiders attacks with a flurry of Bites.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4) <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p>",
+          "chat": "<p>The Swarm of Spiders attacks with a flurry of Bites.</p>"
         },
         "source": {
           "custom": "",
@@ -876,10 +876,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676405,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!4udpeEneFSZK9NTB.qoIR278ckqhlVaNr"
     },

--- a/packs/_source/monsters/beast/swarm-of-wasps.json
+++ b/packs/_source/monsters/beast/swarm-of-wasps.json
@@ -687,8 +687,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4) <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p></section>\n<p>The Swarm of Wasps attacks with a flurry of Bites.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0 ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4) <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing damage</em></strong> if the swarm has half of its hit points or fewer.</p>",
+          "chat": "<p>The Swarm of Wasps attacks with a flurry of Bites.</p>"
         },
         "source": {
           "custom": "",
@@ -876,10 +876,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676469,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!YUaprnengdFDNG8P.bmjRGkZH4lnTX72M"
     }

--- a/packs/_source/monsters/beast/tiger.json
+++ b/packs/_source/monsters/beast/tiger.json
@@ -670,8 +670,8 @@
       "img": "icons/creatures/claws/claw-talons-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the tiger moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 13 Strength saving throw</strong> or be knocked prone.</p>\n<p>If the target is prone, the panther can make one bite attack against it as a bonus action.</p>\n</section>\n<p>If the tiger moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>If the tiger moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 13 Strength saving throw</strong> or be knocked prone.</p><p>If the target is prone, the panther can make one bite attack against it as a bonus action.</p>",
+          "chat": "<p>If the tiger moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -853,10 +853,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676775,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!FayqbnjBMszO6Pat.wklAUVakX97y0z2S"
     },
@@ -867,8 +867,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong>.</p></section>\n<p>The Tiger attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Tiger attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1059,10 +1059,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676775,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!FayqbnjBMszO6Pat.YypXtXEL61FqWYOP"
     },
@@ -1073,8 +1073,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>.</p></section>\n<p>The Tiger attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Tiger attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1263,10 +1263,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676775,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!FayqbnjBMszO6Pat.7GCnVtakQo6iZyn7"
     }

--- a/packs/_source/monsters/beast/triceratops.json
+++ b/packs/_source/monsters/beast/triceratops.json
@@ -615,8 +615,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>24 (4d8 + 6) <em>piercing damage</em></strong>.</p><p></p></section><p>The Triceratops attacks with its Gore.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>24 (4d8 + 6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Triceratops attacks with its Gore.</p>"
         },
         "source": {
           "custom": "",
@@ -802,10 +802,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676803,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!e5IQxSJO7ySEDdSH.h5lGnMKW65NWIi2W"
     },
@@ -816,8 +816,8 @@
       "img": "icons/creatures/abilities/cougar-pounce-stalk-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one prone creature. Hit: <strong>22 (3d10 + 6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Triceratops attacks with its Stomp.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one prone creature. Hit: <strong>22 (3d10 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Triceratops attacks with its Stomp.</p>"
         },
         "source": {
           "custom": "",
@@ -1003,10 +1003,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676803,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!e5IQxSJO7ySEDdSH.6UWSefP0BqnmYwAz"
     },
@@ -1017,8 +1017,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the triceratops moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a <strong>DC 13 Strength saving throw</strong> or be knocked prone. If the target is prone, the triceratops can make one stomp attack against it as a bonus action.</p></section><p>If the triceratops moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a Strength saving throw.</p>",
-          "chat": ""
+          "value": "<p>If the triceratops moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a <strong>DC 13 Strength saving throw</strong> or be knocked prone. If the target is prone, the triceratops can make one stomp attack against it as a bonus action.</p>",
+          "chat": "<p>If the triceratops moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a Strength saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1133,10 +1133,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676803,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!e5IQxSJO7ySEDdSH.4jztSrWQNxc4q55u"
     }

--- a/packs/_source/monsters/beast/tyrannosaurus-rex.json
+++ b/packs/_source/monsters/beast/tyrannosaurus-rex.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>33 (4d12 + 7) <em>piercing damage</em></strong>. </p><p>If the target is a Medium or smaller creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the tyrannosaurus can't bite another target.</p></section><p>The Tyrannosaurus Rex attacks with its Bite. If the target is a Medium or smaller creature, it is grappled. Until this grapple ends, the target is restrained, and the tyrannosaurus can't bite another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>33 (4d12 + 7) <em>piercing damage</em></strong>. </p><p>If the target is a Medium or smaller creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the tyrannosaurus can't bite another target.</p>",
+          "chat": "<p>The Tyrannosaurus Rex attacks with its Bite. If the target is a Medium or smaller creature, it is grappled. Until this grapple ends, the target is restrained, and the tyrannosaurus can't bite another target.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676662,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!HlddcPm4cWptj3ka.O8pEyHMhxCwROJ6O"
     },
@@ -946,8 +946,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>20 (3d8 + 7) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Tyrannosaurus Rex attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>20 (3d8 + 7) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Tyrannosaurus Rex attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1134,10 +1134,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676662,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!HlddcPm4cWptj3ka.jw9SyNUWRzgHe37B"
     }

--- a/packs/_source/monsters/beast/vulture.json
+++ b/packs/_source/monsters/beast/vulture.json
@@ -729,8 +729,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>piercing damage</em></strong>.</p></section>\n<p>The Vulture attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Vulture attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -917,10 +917,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676484,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fkJ8Z8zi2JtlcHh9.MnAKUayu6jCzzRsS"
     }

--- a/packs/_source/monsters/beast/warhorse.json
+++ b/packs/_source/monsters/beast/warhorse.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the horse moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a hooves attack on the same turn, that target must succeed on a <strong>DC 14 Strength saving throw</strong> or be knocked prone. If the target is prone, the horse can make another attack with its hooves against it as a bonus action.</p>\n</section>\n<p>If the horse moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a hooves attack on the same turn, that target must succeed on Strength saving throw.</p>",
-          "chat": ""
+          "value": "<p>If the horse moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a hooves attack on the same turn, that target must succeed on a <strong>DC 14 Strength saving throw</strong> or be knocked prone. If the target is prone, the horse can make another attack with its hooves against it as a bonus action.</p>",
+          "chat": "<p>If the horse moves at least <strong>20 ft.</strong> straight toward a creature and then hits it with a hooves attack on the same turn, that target must succeed on Strength saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -798,10 +798,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676574,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!T1xZTDCGuvMBSq8d.1KyNbDtLLrcA5lj0"
     },
@@ -812,8 +812,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Warhorse attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Warhorse attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -1004,10 +1004,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676574,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!T1xZTDCGuvMBSq8d.7MiLYgDyM2Rm3nEb"
     }

--- a/packs/_source/monsters/beast/weasel.json
+++ b/packs/_source/monsters/beast/weasel.json
@@ -670,8 +670,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit:<strong> 1 <em>piercing damage</em>.</strong></p></section>\n<p>The Weasel attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit:<strong> 1 <em>piercing damage</em>.</strong></p>",
+          "chat": "<p>The Weasel attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -862,10 +862,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676465,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!WOdeacKCYVhgLDuN.qQmFFG5fOGkUEeu2"
     }

--- a/packs/_source/monsters/beast/wolf.json
+++ b/packs/_source/monsters/beast/wolf.json
@@ -729,8 +729,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>piercing damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 11 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>The Wolf attacks with its Bite. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>piercing damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 11 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>The Wolf attacks with its Bite. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -1012,10 +1012,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676516,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!yawTeS8u2FCfzzZH.MuH5aMoKOyZanrFf"
     }

--- a/packs/_source/monsters/celestial/couatl.json
+++ b/packs/_source/monsters/celestial/couatl.json
@@ -624,8 +624,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>8 (1d6 + 5) <em>piercing damage</em></strong>.</p>\n<p>The target must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be poisoned for 24 hours. Until this poison ends, the target is unconscious. Another creature can use an action to shake the target awake.</p>\n</section>\n<p>The Couatl attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>8 (1d6 + 5) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be poisoned for 24 hours. Until this poison ends, the target is unconscious. Another creature can use an action to shake the target awake.</p>",
+          "chat": "<p>The Couatl attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -907,10 +907,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676688,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZaP1H91t4FzbRqR5.7M1OrMoMMTCEKxta"
     },
@@ -921,8 +921,8 @@
       "img": "icons/creatures/reptiles/serpent-horned-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one Medium or smaller creature. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p>\n<p>The target is grappled (escape DC 15). Until this grapple ends, the target is restrained, and the couatl can't constrict another target.</p>\n</section>\n<p>The Couatl attacks with its Constrict. The target is grappled. Until this grapple ends, the target is restrained, and the couatl can't constrict another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one Medium or smaller creature. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p><p>The target is grappled (escape DC 15). Until this grapple ends, the target is restrained, and the couatl can't constrict another target.</p>",
+          "chat": "<p>The Couatl attacks with its Constrict. The target is grappled. Until this grapple ends, the target is restrained, and the couatl can't constrict another target.</p>"
         },
         "source": {
           "custom": "",
@@ -1111,10 +1111,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676688,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZaP1H91t4FzbRqR5.8LkzioyaScFxfst7"
     },

--- a/packs/_source/monsters/celestial/deva.json
+++ b/packs/_source/monsters/celestial/deva.json
@@ -626,8 +626,8 @@
       "img": "icons/magic/fire/dagger-rune-enchant-flame-strong-blue-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The deva's weapon attacks are magical. When the deva hits with any weapon, the weapon deals an <strong>extra 4d8 <em>radiant damage</em></strong> (included in the attack).</p></section><p>The deva's weapon attacks are magical. When the deva hits with any weapon, the weapon deals extra <em>radiant damage</em> (included in the attack).</p>",
-          "chat": ""
+          "value": "<p>The deva's weapon attacks are magical. When the deva hits with any weapon, the weapon deals an <strong>extra 4d8 <em>radiant damage</em></strong> (included in the attack).</p>",
+          "chat": "<p>The deva's weapon attacks are magical. When the deva hits with any weapon, the weapon deals extra <em>radiant damage</em> (included in the attack).</p>"
         },
         "source": {
           "custom": "",
@@ -671,10 +671,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676597,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!m4H3hjamBNMH09S9.KRskTTMCEepXUPwU"
     },
@@ -1204,8 +1204,8 @@
       "img": "icons/weapons/maces/mace-round-spiked-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d6 + 4) <em>bludgeoning damage</em></strong> plus <strong>18 (4d8) <em>radiant damage</em></strong>.</p></section>\n<p>The Deva attacks with its Mace.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d6 + 4) <em>bludgeoning damage</em></strong> plus <strong>18 (4d8) <em>radiant damage</em></strong>.</p>",
+          "chat": "<p>The Deva attacks with its Mace.</p>"
         },
         "source": {
           "custom": "",
@@ -1414,10 +1414,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676597,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!m4H3hjamBNMH09S9.qADu4OS68yINJCnZ"
     },

--- a/packs/_source/monsters/celestial/pegasus.json
+++ b/packs/_source/monsters/celestial/pegasus.json
@@ -615,8 +615,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Pegasus attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Pegasus attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676427,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EIgAW1dWVPpyWLUh.1HxBbZFsegOJ0cgu"
     }

--- a/packs/_source/monsters/celestial/planetar.json
+++ b/packs/_source/monsters/celestial/planetar.json
@@ -626,8 +626,8 @@
       "img": "icons/magic/fire/dagger-rune-enchant-flame-strong-blue-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The planetar's weapon attacks are magical. When the planetar hits with any weapon, the weapon deals an <strong>extra 5d8 <em>radiant damage</em></strong> (included in the attack).</p></section><p>The planetar's weapon attacks are magical. When the planetar hits with any weapon, the weapon deals extra <em>radiant damage</em> (included in the attack).</p>",
-          "chat": ""
+          "value": "<p>The planetar's weapon attacks are magical. When the planetar hits with any weapon, the weapon deals an <strong>extra 5d8 <em>radiant damage</em></strong> (included in the attack).</p>",
+          "chat": "<p>The planetar's weapon attacks are magical. When the planetar hits with any weapon, the weapon deals extra <em>radiant damage</em> (included in the attack).</p>"
         },
         "source": {
           "custom": "",
@@ -671,10 +671,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676733,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!XEByBLeOkDgL3mrr.sDvx0IybgYa8Q4WG"
     },
@@ -1129,8 +1129,8 @@
       "img": "icons/weapons/swords/greatsword-guard-gem-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>21 (4d6 + 7) <em>slashing damage</em></strong> plus <strong>22 (5d8) <em>radiant damage</em></strong>.</p><p></p></section><p>The Planetar attacks with its Greatsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>21 (4d6 + 7) <em>slashing damage</em></strong> plus <strong>22 (5d8) <em>radiant damage</em></strong>.</p>",
+          "chat": "<p>The Planetar attacks with its Greatsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1342,10 +1342,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676733,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!XEByBLeOkDgL3mrr.BBLXs9hiUvtRaP16"
     },
@@ -1356,8 +1356,8 @@
       "img": "icons/magic/light/explosion-star-glow-blue-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p></p><p></p></section><p>The planetar touches another creature. The target magically regains 30 (6d8 + 3) hit points and is freed from any curse, disease, poison, blindness, or deafness.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<section class=\"secret\"><p></p></section><p>The planetar touches another creature. The target magically regains 30 (6d8 + 3) hit points and is freed from any curse, disease, poison, blindness, or deafness.</p>"
         },
         "source": {
           "custom": "",
@@ -1493,10 +1493,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676733,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!XEByBLeOkDgL3mrr.VJz6sW3vOJcEL4IS"
     },

--- a/packs/_source/monsters/celestial/solar.json
+++ b/packs/_source/monsters/celestial/solar.json
@@ -630,8 +630,8 @@
       "img": "icons/magic/fire/dagger-rune-enchant-flame-strong-blue-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The solar's weapon attacks are magical. When the solar hits with any weapon, the weapon deals an <strong>extra 6d8 <em>radiant damage</em></strong> (included in the attack).</p></section><p>The solar's weapon attacks are magical. When the solar hits with any weapon, the weapon deals extra <em>radiant damage</em> (included in the attack).</p>",
-          "chat": ""
+          "value": "<p>The solar's weapon attacks are magical. When the solar hits with any weapon, the weapon deals an <strong>extra 6d8 <em>radiant damage</em></strong> (included in the attack).</p>",
+          "chat": "<p>The solar's weapon attacks are magical. When the solar hits with any weapon, the weapon deals extra <em>radiant damage</em> (included in the attack).</p>"
         },
         "source": {
           "custom": "",
@@ -675,10 +675,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676969,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lOYt73eaJojBDxAV.zkNT86Xasjyzk8Df"
     },
@@ -748,8 +748,8 @@
       "img": "icons/weapons/swords/sword-runed-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The solar releases its greatsword to hover magically in an unoccupied space within <strong>5 ft.</strong> of it. If the solar can see the sword, the solar can mentally command it as a bonus action to fly up to <strong>50 ft.</strong> and either make one attack against a target or return to the solar's hands.</p><p>If the hovering sword is targeted by any effect, the solar is considered to be holding it. The hovering sword falls if the solar dies.</p></section><p>The solar releases its greatsword to hover magically in an unoccupied space within <strong>5 ft.</strong> of it. If the hovering sword is targeted by any effect, the solar is considered to be holding it. </p>",
-          "chat": ""
+          "value": "<p>The solar releases its greatsword to hover magically in an unoccupied space within <strong>5 ft.</strong> of it. If the solar can see the sword, the solar can mentally command it as a bonus action to fly up to <strong>50 ft.</strong> and either make one attack against a target or return to the solar's hands.</p><p>If the hovering sword is targeted by any effect, the solar is considered to be holding it. The hovering sword falls if the solar dies.</p>",
+          "chat": "<p>The solar releases its greatsword to hover magically in an unoccupied space within <strong>5 ft.</strong> of it. If the hovering sword is targeted by any effect, the solar is considered to be holding it. </p>"
         },
         "source": {
           "custom": "",
@@ -859,10 +859,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676969,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lOYt73eaJojBDxAV.N5YFwsrzGuUFrblp"
     },
@@ -1267,8 +1267,8 @@
       "img": "icons/weapons/swords/greatsword-guard-gem-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>22 (4d6 + 8) <em>slashing damage</em></strong> plus <strong>27 (6d8) <em>radiant damage</em></strong>.</p></section>\n<p>The Solar attacks with its Greatsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>22 (4d6 + 8) <em>slashing damage</em></strong> plus <strong>27 (6d8) <em>radiant damage</em></strong>.</p>",
+          "chat": "<p>The Solar attacks with its Greatsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1480,10 +1480,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676969,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lOYt73eaJojBDxAV.QssrfCioglFdfd8I"
     },
@@ -1494,8 +1494,8 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: <strong>15 (2d8 + 6) <em>piercing damage</em></strong> plus <strong>27 (6d8) <em>radiant damage</em></strong>.</p>\n<p>If the target is a creature that has 190 hit points or fewer, it must succeed on a  <strong>DC 15 Constitution</strong> saving throw or die.</p>\n</section>\n<p>The Solar attacks with its Slaying Longbow. If the target is a creature that has 190 hit points or fewer, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: <strong>15 (2d8 + 6) <em>piercing damage</em></strong> plus <strong>27 (6d8) <em>radiant damage</em></strong>.</p><p>If the target is a creature that has 190 hit points or fewer, it must succeed on a  <strong>DC 15 Constitution</strong> saving throw or die.</p>",
+          "chat": "<p>The Solar attacks with its Slaying Longbow. If the target is a creature that has 190 hit points or fewer, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1793,10 +1793,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676969,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lOYt73eaJojBDxAV.BSLTe0yfltAnguOT"
     },
@@ -1807,8 +1807,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The solar can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The solar regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The solar can take 3 legendary actions.</p>",
-          "chat": ""
+          "value": "<p>The solar can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The solar regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The solar can take 3 legendary actions.</p>"
         },
         "source": {
           "custom": "",
@@ -1852,10 +1852,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676969,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lOYt73eaJojBDxAV.sZjcCRCNcf6m4VoK"
     },
@@ -2002,8 +2002,8 @@
       "img": "icons/magic/light/explosion-star-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">The solar emits magical, divine energy. Each creature of its choice in a 10-foot radius must make a  <strong>DC 23 Dexterity</strong> saving throw, taking <strong>14 (4d6) <em>fire damage</em></strong> plus <strong>14 (4d6) <em>radiant damage</em></strong> on a failed save, or half as much damage on a successful one.</section>\n<p>The solar emits magical, divine energy. Each creature of its choice in a 10-foot radius must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<strong>DC 23 Dexterity</strong><strong>14 (4d6) <em>fire damage</em></strong><strong>14 (4d6) <em>radiant damage</em></strong>",
+          "chat": "<p>The solar emits magical, divine energy. Each creature of its choice in a 10-foot radius must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2274,10 +2274,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676969,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lOYt73eaJojBDxAV.hvLibxV3shPORnBB"
     },
@@ -2288,8 +2288,8 @@
       "img": "icons/magic/perception/third-eye-blue-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">The solar targets one creature it can see within 30 feet of it. If the target can see it, the target must succeed on a  <strong>DC 15 Constitution</strong> saving throw or be blinded until magic such as the lesser restoration spell removes the blindness.\n<p>The solar targets one creature it can see within 30 feet of it. If the target can see it, the target must make a <strong>Constitution</strong> saving throw.</p>\n</section>\n<p>The solar targets one creature it can see within 30 feet of it. If the target can see it, the target must succeed on a Constitution saving throw or be blinded.</p>",
-          "chat": ""
+          "value": "<strong>DC 15 Constitution</strong><p>The solar targets one creature it can see within 30 feet of it. If the target can see it, the target must make a <strong>Constitution</strong> saving throw.</p>",
+          "chat": "<p>The solar targets one creature it can see within 30 feet of it. If the target can see it, the target must succeed on a Constitution saving throw or be blinded.</p>"
         },
         "source": {
           "custom": "",
@@ -2491,10 +2491,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676969,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lOYt73eaJojBDxAV.iXcyU8grGuxZbkYJ"
     },
@@ -2564,8 +2564,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2609,10 +2609,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676969,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lOYt73eaJojBDxAV.wxR8cWGMfaaMKc1W"
     },

--- a/packs/_source/monsters/celestial/unicorn.json
+++ b/packs/_source/monsters/celestial/unicorn.json
@@ -625,8 +625,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the unicorn moves at least 20 ft. straight toward a target and then hits it with a horn attack on the same turn, the target takes an extra <strong>9 (2d8) <em>piercing damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 15 Strength</strong> saving throw or be knocked prone.</p></section><p>If the unicorn moves at least 20 ft. straight toward a target and then hits it with a horn attack on the same turn, the target takes extra <em>piercing damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the unicorn moves at least 20 ft. straight toward a target and then hits it with a horn attack on the same turn, the target takes an extra <strong>9 (2d8) <em>piercing damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 15 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>If the unicorn moves at least 20 ft. straight toward a target and then hits it with a horn attack on the same turn, the target takes extra <em>piercing damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -845,10 +845,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676958,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!G9PENY6nw0xRxCJW.iWDQPwdffkW06c2Y"
     },
@@ -1161,8 +1161,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee Weapon Attack: +7 to hit, reach 5 ft ., one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Unicorn attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +7 to hit, reach 5 ft ., one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Unicorn attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -1353,10 +1353,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676958,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!G9PENY6nw0xRxCJW.f7m44y4TqYYcunMj"
     },
@@ -1367,8 +1367,8 @@
       "img": "icons/commodities/bones/horn-simple-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee Weapon Attack: +7 to hit, reach 5 ft ., one target. Hit: <strong>8 (1d8 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Unicorn attacks with its Horn.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +7 to hit, reach 5 ft ., one target. Hit: <strong>8 (1d8 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Unicorn attacks with its Horn.</p>"
         },
         "source": {
           "custom": "",
@@ -1559,10 +1559,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676958,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!G9PENY6nw0xRxCJW.ORrGdhTLKLTKK3BH"
     },
@@ -1573,8 +1573,8 @@
       "img": "icons/magic/light/explosion-star-glow-blue-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p></p><p></p></section><p>The unicorn touches another creature with its horn. The target magically regains 11 (2d8 + 2) hit points. In addition, the touch removes all diseases and neutralizes all poisons afflicting the target.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<section class=\"secret\"><p></p></section><p>The unicorn touches another creature with its horn. The target magically regains 11 (2d8 + 2) hit points. In addition, the touch removes all diseases and neutralizes all poisons afflicting the target.</p>"
         },
         "source": {
           "custom": "",
@@ -1710,10 +1710,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676958,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!G9PENY6nw0xRxCJW.uCaHWOOBeJEyR1ay"
     },
@@ -1724,8 +1724,8 @@
       "img": "icons/magic/symbols/runes-star-pentagon-magenta.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p></p><p></p></section><p>The unicorn magically teleports itself and up to three willing creatures it can see within 5 ft. of it, along with any equipment they are wearing or carrying, to a location the unicorn is familiar with, up to 1 mile away.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<section class=\"secret\"><p></p></section><p>The unicorn magically teleports itself and up to three willing creatures it can see within 5 ft. of it, along with any equipment they are wearing or carrying, to a location the unicorn is familiar with, up to 1 mile away.</p>"
         },
         "source": {
           "custom": "",
@@ -1851,10 +1851,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676958,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!G9PENY6nw0xRxCJW.W5ceTePXIPlUuiEY"
     },
@@ -1865,8 +1865,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The unicorn can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The unicorn regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The unicorn can take 3 legendary actions.</p>",
-          "chat": ""
+          "value": "<p>The unicorn can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The unicorn regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The unicorn can take 3 legendary actions.</p>"
         },
         "source": {
           "custom": "",
@@ -1910,10 +1910,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676958,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!G9PENY6nw0xRxCJW.uGNhUMAmD8L5AD1M"
     },
@@ -1924,8 +1924,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -1969,10 +1969,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676958,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!G9PENY6nw0xRxCJW.A9f9DUM9Sh0qLYlF"
     },

--- a/packs/_source/monsters/construct/animated-armor.json
+++ b/packs/_source/monsters/construct/animated-armor.json
@@ -627,8 +627,8 @@
       "img": "icons/magic/lightning/orb-ball-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The armor is incapacitated while in the area of an antimagic field.</p>\n<p>If targeted by dispel magic, the armor must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for <strong>1 minute</strong>.</p>\n</section>\n<p>The armor is incapacitated while in the area of an antimagic field.</p>",
-          "chat": ""
+          "value": "<p>The armor is incapacitated while in the area of an antimagic field.</p><p>If targeted by dispel magic, the armor must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for <strong>1 minute</strong>.</p>",
+          "chat": "<p>The armor is incapacitated while in the area of an antimagic field.</p>"
         },
         "source": {
           "custom": "",
@@ -672,10 +672,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676583,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eORmAXuV5v3nWsQL.jlZrv208u9gYyh7I"
     },
@@ -870,8 +870,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Animated Armor makes a slam attack!</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Animated Armor makes a slam attack!</p>"
         },
         "source": {
           "custom": "",
@@ -1044,7 +1044,8 @@
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "slam"
+        "identifier": "slam",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -1058,10 +1059,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804704635,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eORmAXuV5v3nWsQL.vUqKQJ1GGWbKg6cX"
     }

--- a/packs/_source/monsters/construct/clay-golem.json
+++ b/packs/_source/monsters/construct/clay-golem.json
@@ -632,8 +632,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>16 (2d10 + 5) <em>bludgeoning damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 15 Constitution</strong> saving throw or have its hit point maximum reduced by an amount equal to the damage taken. The target dies if this attack reduces its hit point maximum to 0. The reduction lasts until removed by the greater restoration spell or other magic.</p>\n</section>\n<p>The Clay Golem attacks with its Slam. If the target is a creature, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>16 (2d10 + 5) <em>bludgeoning damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 15 Constitution</strong> saving throw or have its hit point maximum reduced by an amount equal to the damage taken. The target dies if this attack reduces its hit point maximum to 0. The reduction lasts until removed by the greater restoration spell or other magic.</p>",
+          "chat": "<p>The Clay Golem attacks with its Slam. If the target is a creature, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -909,10 +909,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676736,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!YOqhbf8WsX0jH9Fu.vEEJei0CNaNbfQ2w"
     },
@@ -923,8 +923,8 @@
       "img": "icons/skills/movement/feet-winged-boots-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Recharge 5-6.</p>\n</section>\n<p>Until the end of its next turn, the golem magically gains a +2 bonus to its AC, has advantage on Dexterity saving throws, and can use its slam attack as a bonus action.</p>",
-          "chat": ""
+          "value": "<p>Recharge 5-6.</p>",
+          "chat": "<p>Until the end of its next turn, the golem magically gains a +2 bonus to its AC, has advantage on Dexterity saving throws, and can use its slam attack as a bonus action.</p>"
         },
         "source": {
           "custom": "",
@@ -1050,10 +1050,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676736,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!YOqhbf8WsX0jH9Fu.GOADsI5dGE3ah0Vi"
     },
@@ -1123,8 +1123,8 @@
       "img": "icons/creatures/reptiles/lizard-mouth-glowing-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Whenever the golem starts its turn with <strong>60 hit points</strong> or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see.</p>\n<p>If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its<strong> hit points</strong>.</p>\n</section>\n<p>The golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself.</p>",
-          "chat": ""
+          "value": "<p>Whenever the golem starts its turn with <strong>60 hit points</strong> or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see.</p><p>If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its<strong> hit points</strong>.</p>",
+          "chat": "<p>The golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself.</p>"
         },
         "source": {
           "custom": "",
@@ -1234,10 +1234,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676736,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!YOqhbf8WsX0jH9Fu.K5xMZVNv8m2Pw87E"
     },

--- a/packs/_source/monsters/construct/flesh-golem.json
+++ b/packs/_source/monsters/construct/flesh-golem.json
@@ -631,8 +631,8 @@
       "img": "icons/creatures/reptiles/lizard-mouth-glowing-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Whenever the golem starts its turn with <strong>40 hit points</strong> or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. </p><p>If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its<strong> hit points</strong><strong>. T</strong>he golem's creator, if <strong>within 60 feet</strong> of the berserk golem, can try to calm it by speaking firmly and persuasively. The golem must be able to hear its creator, who must take an action to make a <strong>DC 15 Charisma (Persuasion) check</strong>. If the check succeeds, the golem ceases being berserk. If it takes damage while still at <strong>40 hit points</strong> or fewer, the golem might go berserk again.</p></section><p>The golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself.</p>",
-          "chat": ""
+          "value": "<p>Whenever the golem starts its turn with <strong>40 hit points</strong> or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. </p><p>If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its<strong> hit points</strong><strong>. T</strong>he golem's creator, if <strong>within 60 feet</strong> of the berserk golem, can try to calm it by speaking firmly and persuasively. The golem must be able to hear its creator, who must take an action to make a <strong>DC 15 Charisma (Persuasion) check</strong>. If the check succeeds, the golem ceases being berserk. If it takes damage while still at <strong>40 hit points</strong> or fewer, the golem might go berserk again.</p>",
+          "chat": "<p>The golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself.</p>"
         },
         "source": {
           "custom": "",
@@ -742,10 +742,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676718,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Hm4o2FgPZsdbXjLq.AwiZrSjLzs3aNC33"
     },
@@ -756,8 +756,8 @@
       "img": "icons/magic/fire/projectile-wave-arrow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the golem takes <strong><em>fire damage</em></strong>, it has<strong> disadvantage </strong>on attack rolls and ability checks until the end of its next turn.</p></section><p>If the golem takes <strong><em>fire damage</em></strong>, it has<strong> disadvantage </strong>on some rolls.</p>",
-          "chat": ""
+          "value": "<p>If the golem takes <strong><em>fire damage</em></strong>, it has<strong> disadvantage </strong>on attack rolls and ability checks until the end of its next turn.</p>",
+          "chat": "<p>If the golem takes <strong><em>fire damage</em></strong>, it has<strong> disadvantage </strong>on some rolls.</p>"
         },
         "source": {
           "custom": "",
@@ -801,10 +801,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676718,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Hm4o2FgPZsdbXjLq.Ee9WvQyqy1lRYtuj"
     },
@@ -1176,8 +1176,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Flesh Golem attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Flesh Golem attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -1364,10 +1364,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676718,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Hm4o2FgPZsdbXjLq.mjn0iMGrjGTOn42w"
     }

--- a/packs/_source/monsters/construct/flying-sword.json
+++ b/packs/_source/monsters/construct/flying-sword.json
@@ -626,8 +626,8 @@
       "img": "icons/magic/lightning/orb-ball-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The sword is incapacitated while in the area of an antimagic field. </p><p>If targeted by dispel magic, the sword must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for <strong>1 minute</strong>.</p></section><p>The sword is incapacitated while in the area of an antimagic field.</p>",
-          "chat": ""
+          "value": "<p>The sword is incapacitated while in the area of an antimagic field. </p><p>If targeted by dispel magic, the sword must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for <strong>1 minute</strong>.</p>",
+          "chat": "<p>The sword is incapacitated while in the area of an antimagic field.</p>"
         },
         "source": {
           "custom": "",
@@ -671,10 +671,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676541,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EqJUA3Z3181RSSFU.KFvtNOH2AMQIWRps"
     },
@@ -744,8 +744,8 @@
       "img": "icons/weapons/swords/greatsword-crossguard-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d8 + 1) <em>slashing damage</em></strong>.</p></section>\n<p>The Flying Sword attacks!</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d8 + 1) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Flying Sword attacks!</p>"
         },
         "source": {
           "custom": "",
@@ -938,10 +938,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676541,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EqJUA3Z3181RSSFU.D2cJQHQa8UQp99Wt"
     }

--- a/packs/_source/monsters/construct/homunculus.json
+++ b/packs/_source/monsters/construct/homunculus.json
@@ -620,8 +620,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit:<strong> 1 <em>piercing damage</em>.</strong></p><p>The target must succeed on a  <strong>DC 10 Constitution</strong> saving throw or be poisoned for 1 minute. If the saving throw fails by 5 or more, the target is instead poisoned for 5 (1d10) minutes and unconscious while poisoned in this way.</p></section><p>The Homunculus attacks with its Bite.The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit:<strong> 1 <em>piercing damage</em>.</strong></p><p>The target must succeed on a  <strong>DC 10 Constitution</strong> saving throw or be poisoned for 1 minute. If the saving throw fails by 5 or more, the target is instead poisoned for 5 (1d10) minutes and unconscious while poisoned in this way.</p>",
+          "chat": "<p>The Homunculus attacks with its Bite.The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -901,10 +901,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676472,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZQTCZfTV9ZoTjNCU.1uXv78I9YByiz6rV"
     },

--- a/packs/_source/monsters/construct/iron-golem.json
+++ b/packs/_source/monsters/construct/iron-golem.json
@@ -993,8 +993,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>20 (3d8 + 7) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Iron Golem attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>20 (3d8 + 7) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Iron Golem attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -1181,10 +1181,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676810,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!h98AuPfomEPcCibP.0z51jBlE4BoPaEQn"
     },
@@ -1195,8 +1195,8 @@
       "img": "icons/weapons/swords/sword-guard-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>23 (3d10 + 7) <em>slashing damage</em></strong>.</p><p></p></section><p>The Iron Golem attacks with its Sword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>23 (3d10 + 7) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Iron Golem attacks with its Sword.</p>"
         },
         "source": {
           "custom": "",
@@ -1385,10 +1385,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676810,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!h98AuPfomEPcCibP.pPThO0mEw9iMaJw7"
     },
@@ -1399,8 +1399,8 @@
       "img": "icons/creatures/reptiles/serpent-horned-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a  <strong>DC 19 Constitution</strong> saving throw, taking <strong>45 (10d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a  <strong>DC 19 Constitution</strong> saving throw, taking <strong>45 (10d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1549,10 +1549,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676810,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!h98AuPfomEPcCibP.x44GisqrxHYC5fov"
     }

--- a/packs/_source/monsters/construct/rug-of-smothering.json
+++ b/packs/_source/monsters/construct/rug-of-smothering.json
@@ -626,8 +626,8 @@
       "img": "icons/magic/lightning/orb-ball-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The rug is incapacitated while in the area of an antimagic field. </p><p>If targeted by dispel magic, the rug must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for <strong>1 minute</strong>.</p></section><p>The rug is incapacitated while in the area of an antimagic field. </p>",
-          "chat": ""
+          "value": "<p>The rug is incapacitated while in the area of an antimagic field. </p><p>If targeted by dispel magic, the rug must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for <strong>1 minute</strong>.</p>",
+          "chat": "<p>The rug is incapacitated while in the area of an antimagic field. </p>"
         },
         "source": {
           "custom": "",
@@ -671,10 +671,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676584,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!f6HaKROPIcBRmSd1.PGulBR18kfO768c7"
     },
@@ -803,8 +803,8 @@
       "img": "icons/magic/water/wave-water-explosion.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one Medium or smaller creature. Hit:</p>\n<p>The creature is grappled (escape DC 13). Until this grapple ends, the target is restrained, blinded, and at risk of suffocating, and the rug can't smother another target. In addition, at the start of each of the target's turns, the target takes <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p>\n</section>\n<p>The Rug of Smothering makes a smothering attack! The creature is grappled. Until this grapple ends, the target is restrained, blinded, and at risk of suffocating, and the rug can't smother another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one Medium or smaller creature. Hit:</p><p>The creature is grappled (escape DC 13). Until this grapple ends, the target is restrained, blinded, and at risk of suffocating, and the rug can't smother another target. In addition, at the start of each of the target's turns, the target takes <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Rug of Smothering makes a smothering attack! The creature is grappled. Until this grapple ends, the target is restrained, blinded, and at risk of suffocating, and the rug can't smother another target.</p>"
         },
         "source": {
           "custom": "",
@@ -991,10 +991,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676584,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!f6HaKROPIcBRmSd1.7p94WH1WPMhF1ZP9"
     }

--- a/packs/_source/monsters/construct/shield-guardian.json
+++ b/packs/_source/monsters/construct/shield-guardian.json
@@ -623,8 +623,8 @@
       "img": "icons/equipment/neck/choker-chain-thick-silver.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The shield guardian is magically bound to an amulet. As long as the guardian and its amulet are on the same plane of existence, the amulet's wearer can telepathically call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. </p><p>If the guardian is <strong>within 60 feet</strong> of the amulet's wearer, half of any damage the wearer takes (rounded up) is transferred to the guardian.</p></section><p>The shield guardian is magically bound to an amulet. </p>",
-          "chat": ""
+          "value": "<p>The shield guardian is magically bound to an amulet. As long as the guardian and its amulet are on the same plane of existence, the amulet's wearer can telepathically call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. </p><p>If the guardian is <strong>within 60 feet</strong> of the amulet's wearer, half of any damage the wearer takes (rounded up) is transferred to the guardian.</p>",
+          "chat": "<p>The shield guardian is magically bound to an amulet. </p>"
         },
         "source": {
           "custom": "",
@@ -668,10 +668,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676760,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!z85EsGS2GVWj46qE.mJoNsESU5X2lBKqn"
     },
@@ -682,8 +682,8 @@
       "img": "icons/skills/wounds/anatomy-organ-heart-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The shield guardian regains <strong>10 hit points</strong> at the start of its turn if it has at least <strong>1 hit point</strong>.</p></section><p>The shield guardian regains <strong>10 hit points</strong> at the start of its turn.</p>",
-          "chat": ""
+          "value": "<p>The shield guardian regains <strong>10 hit points</strong> at the start of its turn if it has at least <strong>1 hit point</strong>.</p>",
+          "chat": "<p>The shield guardian regains <strong>10 hit points</strong> at the start of its turn.</p>"
         },
         "source": {
           "custom": "",
@@ -804,10 +804,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676760,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!z85EsGS2GVWj46qE.vk0gd3buCPWGpyYF"
     },
@@ -1002,8 +1002,8 @@
       "img": "icons/magic/fire/flame-burning-fist-strike.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Shield Guardian attacks with its Fist.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Shield Guardian attacks with its Fist.</p>"
         },
         "source": {
           "custom": "",
@@ -1189,10 +1189,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676760,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!z85EsGS2GVWj46qE.r6GQ1TwNK7pinX0a"
     },

--- a/packs/_source/monsters/construct/stone-golem.json
+++ b/packs/_source/monsters/construct/stone-golem.json
@@ -933,8 +933,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>19 (3d8 + 6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Stone Golem attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>19 (3d8 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Stone Golem attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -1120,10 +1120,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676625,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!z3gSIXHHWYaHjfBT.DelAxHnRbNHC6OoV"
     },
@@ -1134,8 +1134,8 @@
       "img": "icons/tools/navigation/watch-simple-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The golem targets one or more creatures it can see within 10 ft. of it. Each target must make a  <strong>DC 17 Wisdom</strong> saving throw against this magic. </p><p>On a failed save, a target can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the target can take either an action or a bonus action on its turn, not both. These effects last for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p></section><p>The golem targets one or more creatures it can see within 10 ft. of it. Each target must make a <strong>Wisdom</strong> saving throw against this magic. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p>The golem targets one or more creatures it can see within 10 ft. of it. Each target must make a  <strong>DC 17 Wisdom</strong> saving throw against this magic. </p><p>On a failed save, a target can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the target can take either an action or a bonus action on its turn, not both. These effects last for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The golem targets one or more creatures it can see within 10 ft. of it. Each target must make a <strong>Wisdom</strong> saving throw against this magic. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1265,10 +1265,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676625,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!z3gSIXHHWYaHjfBT.9aTwUWuZQLhMxjcD"
     }

--- a/packs/_source/monsters/dragon/adult-black-dragon.json
+++ b/packs/_source/monsters/dragon/adult-black-dragon.json
@@ -741,8 +741,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>acid damage</em></strong>.</p><p></p></section><p>The Adult Black Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>acid damage</em></strong>.</p>",
+          "chat": "<p>The Adult Black Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -951,10 +951,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677017,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.amUUCouL69OK1GZU"
     },
@@ -965,8 +965,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p><p></p></section><p>The Adult Black Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Black Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1153,10 +1153,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677017,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.uXxifk618IakGfYG"
     },
@@ -1167,8 +1167,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Adult Black Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Adult Black Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1357,10 +1357,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677017,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.t9FrDQLVCU8x4obw"
     },
@@ -1371,8 +1371,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1489,10 +1489,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677017,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.A3azHlbNcHLRgogu"
     },
@@ -1697,8 +1697,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales acid in a 60-foot line that is 5 feet wide. </p><p>Each creature in that line must make a  <strong>DC 18 Dexterity</strong> saving throw, taking <strong>54 (12d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The dragon exhales acid in a 60-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales acid in a 60-foot line that is 5 feet wide. </p><p>Each creature in that line must make a  <strong>DC 18 Dexterity</strong> saving throw, taking <strong>54 (12d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales acid in a 60-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1843,10 +1843,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677017,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.6bromElr0abqNXJL"
     },
@@ -1857,8 +1857,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1902,10 +1902,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677017,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.tWGObm0RZMwSrQLU"
     },
@@ -1916,8 +1916,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section>\n<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em> <strong>+12 to hit</strong>, reach <strong>15 ft.</strong>, one target. Hit: <strong>16 (2d8+7) bludgeoning</strong> damage.</p>\n</section>\n</section>\n<p>The dragon slams its long tail against its foe!</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em> <strong>+12 to hit</strong>, reach <strong>15 ft.</strong>, one target. Hit: <strong>16 (2d8+7) bludgeoning</strong> damage.</p>",
+          "chat": "<section>\n\n</section>\n<p>The dragon slams its long tail against its foe!</p>"
         },
         "source": {
           "custom": "",
@@ -2094,10 +2094,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677017,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.LgqLdk3VQOVcO5UI"
     },
@@ -2108,8 +2108,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon beats its wings. <strong>Each creature within 10 feet </strong>of the dragon must succeed on a <strong>DC 19 Dexterity saving throw</strong> or take <strong>13 (2d6+6) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>\n</section>\n<p>The dragon beats its wings!</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. <strong>Each creature within 10 feet </strong>of the dragon must succeed on a <strong>DC 19 Dexterity saving throw</strong> or take <strong>13 (2d6+6) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>",
+          "chat": "<p>The dragon beats its wings!</p>"
         },
         "source": {
           "custom": "",
@@ -2316,10 +2316,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677017,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.kFPbmQZGCKfWRXpq"
     },
@@ -2330,8 +2330,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2437,10 +2437,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677017,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.RnqMV5Ur5n9S3wIt"
     },
@@ -2510,8 +2510,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2555,10 +2555,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677017,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!M4eX4Mu5IHCr3TMf.Wgu6mm84tNNWdiEH"
     }

--- a/packs/_source/monsters/dragon/adult-blue-dragon.json
+++ b/packs/_source/monsters/dragon/adult-blue-dragon.json
@@ -675,8 +675,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>18 (2d10 + 7) <em>piercing damage</em></strong> plus <strong>5 (1d10) <em>lightning damage</em></strong>.</p><p></p></section><p>The Adult Blue Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>18 (2d10 + 7) <em>piercing damage</em></strong> plus <strong>5 (1d10) <em>lightning damage</em></strong>.</p>",
+          "chat": "<p>The Adult Blue Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -885,10 +885,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677024,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.tz3vYeFf3GLouPGC"
     },
@@ -899,8 +899,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d6 + 7) <em>slashing damage</em></strong>.</p><p></p></section><p>The Adult Blue Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d6 + 7) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Blue Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1087,10 +1087,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677024,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.kYySllKlNPBsT7Ho"
     },
@@ -1101,8 +1101,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -1218,10 +1218,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677024,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.wpVgm5eOdM9j3C3N"
     },
@@ -1232,8 +1232,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is within <strong>120 ft.</strong> of the dragon and aware of it must succeed on a <strong>DC 17 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is within <strong>120 ft.</strong> of the dragon and aware of it must succeed on a <strong>DC 17 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1350,10 +1350,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677024,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.zMT1Uj814On8O1Hg"
     },
@@ -1364,8 +1364,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -1409,10 +1409,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677024,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.hTzGBPIQzZPRkUgt"
     },
@@ -1423,8 +1423,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1468,10 +1468,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677024,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.2yqNNNEOupSnZs0p"
     },
@@ -1617,8 +1617,8 @@
       "img": "icons/magic/lightning/bolt-strike-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales lightning in a 90-foot line that is 5 ft. wide. Each creature in that line must make a  <strong>DC 19 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales lightning in a 90-foot line that is 5 ft. wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales lightning in a 90-foot line that is 5 ft. wide. Each creature in that line must make a  <strong>DC 19 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales lightning in a 90-foot line that is 5 ft. wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1765,10 +1765,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677024,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.ZrmS45Tc7RieN0qd"
     },
@@ -1904,8 +1904,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>16 (2d8 + 7) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Adult Blue Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>16 (2d8 + 7) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Adult Blue Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -2092,10 +2092,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677024,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.JRgWoRDlExmKqNVa"
     },
@@ -2106,8 +2106,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section>\n<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em> <strong>+12 to hit</strong>, reach <strong>15 ft.</strong>, one target. Hit: <strong>16 (2d8+7) bludgeoning</strong> damage.</p>\n</section>\n</section>\n<p>The dragon slams its long tail against its foe!</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em> <strong>+12 to hit</strong>, reach <strong>15 ft.</strong>, one target. Hit: <strong>16 (2d8+7) bludgeoning</strong> damage.</p>",
+          "chat": "<section>\n\n</section>\n<p>The dragon slams its long tail against its foe!</p>"
         },
         "source": {
           "custom": "",
@@ -2284,10 +2284,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677024,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.ANMZzr2n2EpU41eg"
     },
@@ -2298,8 +2298,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 20 Dexterity saving throw</strong> or take <strong>14 (2d6+7) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>\n</section>\n<p>The dragon beats its wings!</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 20 Dexterity saving throw</strong> or take <strong>14 (2d6+7) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>",
+          "chat": "<p>The dragon beats its wings!</p>"
         },
         "source": {
           "custom": "",
@@ -2503,10 +2503,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677024,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!cGM3iVYTtCsYXjzO.GcUNB4m0NAPgP0Nx"
     }

--- a/packs/_source/monsters/dragon/adult-brass-dragon.json
+++ b/packs/_source/monsters/dragon/adult-brass-dragon.json
@@ -616,8 +616,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee Weapon Attack: +11 to hit, reach,.0 ft., one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong>.</p><p></p></section><p>The Adult Brass Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +11 to hit, reach,.0 ft., one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Brass Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -790,7 +790,8 @@
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "bite"
+        "identifier": "bite",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -808,10 +809,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804713007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.Rr34cx78OgioMSHH"
     },
@@ -822,8 +823,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Fire Breath.** The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 18 Dexterity</strong> saving throw, taking <strong>45 (13d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Fire Breath.** The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 18 Dexterity</strong> saving throw, taking <strong>45 (13d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -966,10 +967,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.HOTavLfsvvI26Ele"
     },
@@ -980,8 +981,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p><p></p></section><p>The Adult Brass Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Brass Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1168,10 +1169,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.Gx6DVWF7D9lzZjse"
     },
@@ -1182,8 +1183,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -1299,10 +1300,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.jM7XLTjt7QeJ8B7U"
     },
@@ -1313,8 +1314,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>.</p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>.</p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1430,10 +1431,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.cVkEgorVxYQJkS8M"
     },
@@ -1444,8 +1445,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1489,10 +1490,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.Mmn2SNmzahxtikN3"
     },
@@ -1763,8 +1764,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Adult Brass Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Adult Brass Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1951,10 +1952,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.rR1dMvZqWVQTgCVw"
     },
@@ -1965,8 +1966,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a tail attack.</p>\n</section>\n<p>The dragon slams its long tail against its foe!</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a tail attack.</p>",
+          "chat": "<p>The dragon slams its long tail against its foe!</p>"
         },
         "source": {
           "custom": "",
@@ -2160,10 +2161,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.StCQbn2czecQteRM"
     },
@@ -2174,8 +2175,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section>\n<section class=\"secret\">\n<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 19 Dexterity saving throw</strong> or take <strong>13 (2d6+6) bludgeoning</strong> damage and be <strong>knocked prone</strong>. The dragon can then <strong>fly up to half its flying speed.</strong></p>\n</section>\n</section>\n<p>The dragon beats its wings!</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 19 Dexterity saving throw</strong> or take <strong>13 (2d6+6) bludgeoning</strong> damage and be <strong>knocked prone</strong>. The dragon can then <strong>fly up to half its flying speed.</strong></p>",
+          "chat": "<section>\n\n</section>\n<p>The dragon beats its wings!</p>"
         },
         "source": {
           "custom": "",
@@ -2381,10 +2382,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.Ge1y4jlE3zGCsy6K"
     },
@@ -2395,8 +2396,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2440,10 +2441,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.37PM2SkkUbzzambk"
     },
@@ -2454,8 +2455,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Fire Breath.** The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 18 Dexterity</strong> saving throw, taking <strong>45 (13d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Sleep Breath.** The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 18 Constitution</strong> saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Fire Breath.** The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 18 Dexterity</strong> saving throw, taking <strong>45 (13d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Sleep Breath.** The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 18 Constitution</strong> saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -2581,10 +2582,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.asAmhLPOTnfZhb5I"
     },
@@ -2595,8 +2596,8 @@
       "img": "icons/magic/perception/third-eye-blue-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Sleep Breath.** The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 18 Constitution</strong> saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>\n</section>\n<p>The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Sleep Breath.** The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 18 Constitution</strong> saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>",
+          "chat": "<p>The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2721,10 +2722,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677035,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7vswgicsiMfS4ZTS.K7XKtsJS8WUoEE0u"
     },

--- a/packs/_source/monsters/dragon/adult-bronze-dragon.json
+++ b/packs/_source/monsters/dragon/adult-bronze-dragon.json
@@ -675,8 +675,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>18 (2d10 + 7) <em>piercing damage</em></strong>.</p><p></p></section><p>The Adult Bronze Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>18 (2d10 + 7) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Bronze Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -867,10 +867,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.zMFGBLVpXSZC1Vjm"
     },
@@ -1141,8 +1141,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d6 + 7) <em>slashing damage</em></strong>.</p><p></p></section><p>The Adult Bronze Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d6 + 7) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Bronze Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1329,10 +1329,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.P0ycd36lowML3rTc"
     },
@@ -1343,8 +1343,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>16 (2d8 + 7) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Adult Bronze Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>16 (2d8 + 7) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Adult Bronze Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1531,10 +1531,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.irNLCfkryOmVWf25"
     },
@@ -1545,8 +1545,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 17 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 17 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1662,10 +1662,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.m7dF0hheApwoJLpp"
     },
@@ -1801,8 +1801,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Lightning Breath.** The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 19 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 19 Strength</strong> saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Lightning Breath.** The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 19 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 19 Strength</strong> saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1928,10 +1928,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.ApCOq8kdcdR2lgPa"
     },
@@ -1942,8 +1942,8 @@
       "img": "icons/magic/lightning/bolt-strike-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Lightning Breath.** The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 19 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Lightning Breath.** The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 19 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2086,10 +2086,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.Irqf7lAff02Flboj"
     },
@@ -2100,8 +2100,8 @@
       "img": "icons/magic/air/air-wave-gust-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 19 Strength</strong> saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.</p>\n</section>\n<p>The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 19 Strength</strong> saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.</p>",
+          "chat": "<p>The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2226,10 +2226,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.TlmOXrpIxG13apJr"
     },
@@ -2240,8 +2240,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -2285,10 +2285,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.jwbM0YJCiaOuH9fv"
     },
@@ -2299,8 +2299,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2416,10 +2416,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.7UhgJ951z7hjLmBu"
     },
@@ -2430,8 +2430,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a tail attack.</p>\n</section>\n<p>The dragon slams its long tail against its foe!</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a tail attack.</p>",
+          "chat": "<p>The dragon slams its long tail against its foe!</p>"
         },
         "source": {
           "custom": "",
@@ -2608,10 +2608,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.JOKHSoiYvCINS119"
     },
@@ -2622,8 +2622,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 20 Dexterity saving throw</strong> or take <strong>16 (2d6+7) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon <strong>can then fly up to half its flying speed.</strong></p>\n</section>\n<p>The dragon beats its wings!</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 20 Dexterity saving throw</strong> or take <strong>16 (2d6+7) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon <strong>can then fly up to half its flying speed.</strong></p>",
+          "chat": "<p>The dragon beats its wings!</p>"
         },
         "source": {
           "custom": "",
@@ -2829,10 +2829,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.Ls6rBLfLiVx1xTaD"
     },
@@ -2843,8 +2843,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2888,10 +2888,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677042,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VCuG0Z3MrO8kfDU0.WoixfK4f9t5yZ9XN"
     },

--- a/packs/_source/monsters/dragon/adult-copper-dragon.json
+++ b/packs/_source/monsters/dragon/adult-copper-dragon.json
@@ -876,8 +876,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong>.</p><p></p></section><p>The Adult Copper Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Copper Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1068,10 +1068,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.jLzmwSFLsR0jhWHF"
     },
@@ -1082,8 +1082,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p><p></p></section><p>The Adult Copper Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Copper Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1270,10 +1270,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.rIzRUQvEexZL1wZx"
     },
@@ -1284,8 +1284,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Adult Copper Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Adult Copper Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1472,10 +1472,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.S1RmDd4fOJffOxAy"
     },
@@ -1486,8 +1486,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>.</p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>.</p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1603,10 +1603,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.3ovBwWW2b9S8LYId"
     },
@@ -1617,8 +1617,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Acid Breath.** The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 18 Dexterity</strong> saving throw, taking <strong>54 (12d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Slowing Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 18 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Acid Breath.** The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 18 Dexterity</strong> saving throw, taking <strong>54 (12d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Slowing Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 18 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1744,10 +1744,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.l9M8UzmizF3KRbEr"
     },
@@ -1758,8 +1758,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Acid Breath.** The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 18 Dexterity</strong> saving throw, taking <strong>54 (12d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Acid Breath.** The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 18 Dexterity</strong> saving throw, taking <strong>54 (12d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1902,10 +1902,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.AMOb6E3TENPVZzFu"
     },
@@ -1916,8 +1916,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Slowing Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 18 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>\n</section>\n<p>The dragon exhales gas in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Slowing Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 18 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>",
+          "chat": "<p>The dragon exhales gas in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2042,10 +2042,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.PMfemsI55IkO3buY"
     },
@@ -2056,8 +2056,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -2101,10 +2101,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.EuIDfrjxsngqBcnD"
     },
@@ -2115,8 +2115,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2232,10 +2232,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.WpLmLtkW78JzpUOu"
     },
@@ -2246,8 +2246,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a tail attack.</p>\n</section>\n<p>The dragon slams its long tail against its foe!</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a tail attack.</p>",
+          "chat": "<p>The dragon slams its long tail against its foe!</p>"
         },
         "source": {
           "custom": "",
@@ -2424,10 +2424,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.56yxRgRdOJvr3Hi3"
     },
@@ -2438,8 +2438,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 19 Dexterity saving throw</strong> or take <strong>13 (2d6+6) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>\n</section>\n<p>The dragon beats its wings!</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 19 Dexterity saving throw</strong> or take <strong>13 (2d6+6) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>",
+          "chat": "<p>The dragon beats its wings!</p>"
         },
         "source": {
           "custom": "",
@@ -2646,10 +2646,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.4Cf4U7JMFMCyjw7N"
     },
@@ -2660,8 +2660,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2705,10 +2705,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677046,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!irz834sqAxRihtSG.othdHNDe2JbOsBXv"
     },

--- a/packs/_source/monsters/dragon/adult-gold-dragon.json
+++ b/packs/_source/monsters/dragon/adult-gold-dragon.json
@@ -935,8 +935,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong>.</p><p></p></section><p>The Adult Gold Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Gold Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1127,10 +1127,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.tx5M41t7JlSuVQ9R"
     },
@@ -1141,8 +1141,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p><p></p></section><p>The Adult Gold Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Gold Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1329,10 +1329,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.ORrcO13EbgjVvNjA"
     },
@@ -1343,8 +1343,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Adult Gold Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Adult Gold Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1531,10 +1531,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.FXYoii0YU2Y7CqBa"
     },
@@ -1545,8 +1545,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 21 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 21 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1662,10 +1662,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.v92F1DGzRWSEMPxH"
     },
@@ -1676,8 +1676,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Fire Breath.** The dragon exhales fire in a 60-foot cone. Each creature in that area must make a  <strong>DC 21 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Weakening Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 21 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Fire Breath.** The dragon exhales fire in a 60-foot cone. Each creature in that area must make a  <strong>DC 21 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Weakening Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 21 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1803,10 +1803,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.GTmsKSKk8kTlQXkT"
     },
@@ -1817,8 +1817,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Fire Breath.** The dragon exhales fire in a 60-foot cone. Each creature in that area must make a  <strong>DC 21 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales fire in a 60-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Fire Breath.** The dragon exhales fire in a 60-foot cone. Each creature in that area must make a  <strong>DC 21 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in a 60-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1961,10 +1961,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.zoAkmBfD677QYuSh"
     },
@@ -1975,8 +1975,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Weakening Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 21 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon exhales gas in a 60-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Weakening Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 21 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon exhales gas in a 60-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2101,10 +2101,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.KfnqUfoAw7IVzVpy"
     },
@@ -2240,8 +2240,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -2285,10 +2285,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.RNFCtDcWoF0NAvl2"
     },
@@ -2299,8 +2299,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2416,10 +2416,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.QtK9Z8y5x78hUIxF"
     },
@@ -2430,8 +2430,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a tail attack.</p>\n</section>\n<p>The dragon slams its long tail against its foe!</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a tail attack.</p>",
+          "chat": "<p>The dragon slams its long tail against its foe!</p>"
         },
         "source": {
           "custom": "",
@@ -2608,10 +2608,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.FehkcXNr3EsmJMif"
     },
@@ -2622,8 +2622,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 22 Dexterity saving throw</strong> or take <strong>15 (2d6+8) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>\n</section>\n<p>The dragon beats its wings!</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 22 Dexterity saving throw</strong> or take <strong>15 (2d6+8) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>",
+          "chat": "<p>The dragon beats its wings!</p>"
         },
         "source": {
           "custom": "",
@@ -2826,10 +2826,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.G0aqIC7Haxea184o"
     },
@@ -2840,8 +2840,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2885,10 +2885,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677039,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MO382D2sxtAIuUC5.jAr1sQYarE6ySAbR"
     },

--- a/packs/_source/monsters/dragon/adult-green-dragon.json
+++ b/packs/_source/monsters/dragon/adult-green-dragon.json
@@ -937,8 +937,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>poison damage</em></strong>.</p></section>\n<p>The Adult Green Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Adult Green Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1147,10 +1147,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677013,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GP8JMSDugRxuLOD2.ZJR61a1mg2JHdHE0"
     },
@@ -1161,8 +1161,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p><p></p></section><p>The Adult Green Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Green Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1349,10 +1349,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677013,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GP8JMSDugRxuLOD2.I4ycwNCADZj1bun0"
     },
@@ -1363,8 +1363,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Adult Green Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Adult Green Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1551,10 +1551,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677013,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GP8JMSDugRxuLOD2.HwjAaKkl4iBsFB24"
     },
@@ -1565,8 +1565,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours .</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours .</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1682,10 +1682,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677013,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GP8JMSDugRxuLOD2.k9uTT39kBp2sDDUE"
     },
@@ -1696,8 +1696,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales poisonous gas in a 60-foot cone. Each creature in that area must make a  <strong>DC 18 Constitution</strong> saving throw, taking <strong>56 (16d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales poisonous gas in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales poisonous gas in a 60-foot cone. Each creature in that area must make a  <strong>DC 18 Constitution</strong> saving throw, taking <strong>56 (16d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales poisonous gas in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1846,10 +1846,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677013,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GP8JMSDugRxuLOD2.WAglSb6wsm8V1iCd"
     },
@@ -1860,8 +1860,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1905,10 +1905,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677013,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GP8JMSDugRxuLOD2.jls6tBzceKBhLIJ9"
     },
@@ -1919,8 +1919,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2036,10 +2036,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677013,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GP8JMSDugRxuLOD2.hj8x2cAmsCz65VMp"
     },
@@ -2050,8 +2050,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a tail attack.</p>\n</section>\n<p>The dragon slams its long tail against its foe!</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a tail attack.</p>",
+          "chat": "<p>The dragon slams its long tail against its foe!</p>"
         },
         "source": {
           "custom": "",
@@ -2228,10 +2228,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677013,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GP8JMSDugRxuLOD2.jp6U9gVAnEqYxjal"
     },
@@ -2242,8 +2242,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon beats its wings. Each creature within <strong>10 feet </strong>of the dragon must succeed on a <strong>DC 19 Dexterity saving throw</strong> or take <strong>15 (2d6+6) bludgeoning</strong> damage and be knocked prone. The dragon can then fly up to half its flying speed.</p>\n</section>\n<p>The dragon beats its wings!</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. Each creature within <strong>10 feet </strong>of the dragon must succeed on a <strong>DC 19 Dexterity saving throw</strong> or take <strong>15 (2d6+6) bludgeoning</strong> damage and be knocked prone. The dragon can then fly up to half its flying speed.</p>",
+          "chat": "<p>The dragon beats its wings!</p>"
         },
         "source": {
           "custom": "",
@@ -2450,10 +2450,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677013,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GP8JMSDugRxuLOD2.mjuHphDtsXPuLymt"
     },
@@ -2464,8 +2464,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2509,10 +2509,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677013,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GP8JMSDugRxuLOD2.N0yg5M0tfiYJqxjz"
     },

--- a/packs/_source/monsters/dragon/adult-red-dragon.json
+++ b/packs/_source/monsters/dragon/adult-red-dragon.json
@@ -876,8 +876,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours .</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours .</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -993,10 +993,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677020,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZyIBOoZZD0nDaO2s.ftqEpCKoioTST72K"
     },
@@ -1007,8 +1007,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales fire in a 60-foot cone. Each creature in that area must make a  <strong>DC 21 Dexterity</strong> saving throw, taking <strong>63 (18d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales fire in a 60-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales fire in a 60-foot cone. Each creature in that area must make a  <strong>DC 21 Dexterity</strong> saving throw, taking <strong>63 (18d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in a 60-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1157,10 +1157,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677020,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZyIBOoZZD0nDaO2s.tD8Vmsb4B5eqTOJA"
     },
@@ -1171,8 +1171,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>fire damage</em></strong>.</p><p></p></section><p>The Adult Red Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Adult Red Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1381,10 +1381,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677020,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZyIBOoZZD0nDaO2s.060hAjIEDdMDfVoE"
     },
@@ -1395,8 +1395,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p><p></p></section><p>The Adult Red Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Red Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1583,10 +1583,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677020,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZyIBOoZZD0nDaO2s.pzDFBmC7wfQsMJzw"
     },
@@ -1597,8 +1597,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Adult Red Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Adult Red Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1785,10 +1785,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677020,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZyIBOoZZD0nDaO2s.DF0doZR8pYSjsrme"
     },
@@ -1799,8 +1799,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1844,10 +1844,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677020,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZyIBOoZZD0nDaO2s.LESSs8CLEr1DEuLM"
     },
@@ -1858,8 +1858,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -1975,10 +1975,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677020,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZyIBOoZZD0nDaO2s.1PppVLNAsjADU0Za"
     },
@@ -1989,8 +1989,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a tail attack.</p>\n</section>\n<p>The dragon slams its long tail against its foe!</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a tail attack.</p>",
+          "chat": "<p>The dragon slams its long tail against its foe!</p>"
         },
         "source": {
           "custom": "",
@@ -2167,10 +2167,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677020,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZyIBOoZZD0nDaO2s.ut9yaZWaSkU7bT1h"
     },
@@ -2181,8 +2181,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 22 Dexterity saving throw</strong> or take <strong>15 (2d6+8) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>\n</section>\n<p>The dragon beats its wings!</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 22 Dexterity saving throw</strong> or take <strong>15 (2d6+8) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>",
+          "chat": "<p>The dragon beats its wings!</p>"
         },
         "source": {
           "custom": "",
@@ -2389,10 +2389,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677020,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZyIBOoZZD0nDaO2s.Q5JDbGOejqXyeaCj"
     },
@@ -2403,8 +2403,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2448,10 +2448,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677020,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZyIBOoZZD0nDaO2s.yCGYa27YqTLhQK0I"
     },

--- a/packs/_source/monsters/dragon/adult-silver-dragon.json
+++ b/packs/_source/monsters/dragon/adult-silver-dragon.json
@@ -876,8 +876,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong>.</p><p></p></section><p>The Adult Silver Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Silver Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1068,10 +1068,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.3WM5UpCTIb6fQaWA"
     },
@@ -1082,8 +1082,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p><p></p></section><p>The Adult Silver Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Adult Silver Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1270,10 +1270,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.nO1hKkZifzX3UJ2y"
     },
@@ -1284,8 +1284,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Adult Silver Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Adult Silver Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1472,10 +1472,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.v5TMyixZTtiw13d7"
     },
@@ -1486,8 +1486,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 18 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 18 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1604,10 +1604,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.F8gfPJkHrrlTwVUs"
     },
@@ -1618,8 +1618,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Cold Breath.** The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a  <strong>DC 20 Constitution</strong> saving throw, taking <strong>58 (13d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 20 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Cold Breath.** The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a  <strong>DC 20 Constitution</strong> saving throw, taking <strong>58 (13d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 20 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1745,10 +1745,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.3c1EZHdUBP4tiWfK"
     },
@@ -1759,8 +1759,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Cold Breath.** The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a  <strong>DC 20 Constitution</strong> saving throw, taking <strong>58 (13d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Cold Breath.** The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a  <strong>DC 20 Constitution</strong> saving throw, taking <strong>58 (13d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1903,10 +1903,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.MzyHKQpwLeUUgBW7"
     },
@@ -1917,8 +1917,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 20 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must succeed on a  <strong>DC 20 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2043,10 +2043,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.5Q60uuHW5kZGaopg"
     },
@@ -2182,8 +2182,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -2227,10 +2227,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.lslg4XVihVKQhwte"
     },
@@ -2241,8 +2241,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2348,10 +2348,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.uqanvb4CeQp0bdn3"
     },
@@ -2554,8 +2554,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 21 Dexterity saving throw</strong> or take <strong>15 (2d6+8) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>\n</section>\n<p>The dragon beats its wings! Each creature within 10 feet of the dragon must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 21 Dexterity saving throw</strong> or take <strong>15 (2d6+8) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>",
+          "chat": "<p>The dragon beats its wings! Each creature within 10 feet of the dragon must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2762,10 +2762,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.CdSoAS13rAlkBKI7"
     },
@@ -2776,8 +2776,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2821,10 +2821,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677027,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!geM2F7HvVGhtk3h4.W525tFlyOp18jFTJ"
     },

--- a/packs/_source/monsters/dragon/adult-white-dragon.json
+++ b/packs/_source/monsters/dragon/adult-white-dragon.json
@@ -675,8 +675,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>cold damage</em></strong>.</p><p></p></section><p>The Adult White Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>cold damage</em></strong>.</p>",
+          "chat": "<p>The Adult White Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -885,10 +885,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676996,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3uIursokd3KdZrW3.542eNLhAx7XYJErk"
     },
@@ -899,8 +899,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p><p></p></section><p>The Adult White Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Adult White Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1087,10 +1087,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676996,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3uIursokd3KdZrW3.FhUOX8awKhQrGBV0"
     },
@@ -1101,8 +1101,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a  <strong>DC 19 Constitution</strong> saving throw, taking <strong>54 (12d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a  <strong>DC 19 Constitution</strong> saving throw, taking <strong>54 (12d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1249,10 +1249,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676996,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3uIursokd3KdZrW3.lQ57BVbUiVe2tJcL"
     },
@@ -1263,8 +1263,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -1380,10 +1380,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676996,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3uIursokd3KdZrW3.CwDVyMam0aPSvRyx"
     },
@@ -1394,8 +1394,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is within <strong>120 ft.</strong> of the dragon and aware of it must succeed on a <strong>DC 14 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is within <strong>120 ft.</strong> of the dragon and aware of it must succeed on a <strong>DC 14 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1512,10 +1512,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676996,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3uIursokd3KdZrW3.nKX7IFrwLJsAsWXU"
     },
@@ -1585,8 +1585,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -1630,10 +1630,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676996,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3uIursokd3KdZrW3.6AiskuquLuemBSzo"
     },
@@ -1644,8 +1644,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1689,10 +1689,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676996,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3uIursokd3KdZrW3.7JtKHjp4ib2tL3Qu"
     },
@@ -1963,8 +1963,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Adult White Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Adult White Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -2151,10 +2151,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676996,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3uIursokd3KdZrW3.pwOLYvuj5c9fEQAH"
     },
@@ -2357,8 +2357,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 19 Dexterity saving throw</strong> or take <strong>13 (2d6+6) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>\n</section>\n<p>The dragon beats its wings!</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. <strong>Each creature within 10 feet of the dragon</strong> must succeed on a <strong>DC 19 Dexterity saving throw</strong> or take <strong>13 (2d6+6) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>",
+          "chat": "<p>The dragon beats its wings!</p>"
         },
         "source": {
           "custom": "",
@@ -2565,10 +2565,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676996,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3uIursokd3KdZrW3.dEBTjqEC02PwvqOV"
     }

--- a/packs/_source/monsters/dragon/ancient-black-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-black-dragon.json
@@ -935,8 +935,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee Weapon Attack:+ 15 to hit, reach 15 ft., one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong> plus <strong>9 (2d8) <em>acid damage</em></strong>.</p><p></p></section><p>The Ancient Black Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack:+ 15 to hit, reach 15 ft., one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong> plus <strong>9 (2d8) <em>acid damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Black Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1145,10 +1145,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676981,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qNdFhY3JOkCfhG3d.YauNxZeIeT4uDcTf"
     },
@@ -1159,8 +1159,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ancient Black Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Black Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1347,10 +1347,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676981,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qNdFhY3JOkCfhG3d.GQLQiLBrkoOiNc8q"
     },
@@ -1361,8 +1361,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee Weapon Attack: +15 to hit, reach 20 ft ., one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ancient Black Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +15 to hit, reach 20 ft ., one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Black Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1549,10 +1549,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676981,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qNdFhY3JOkCfhG3d.A5cRQsDF3Qih94rC"
     },
@@ -1563,8 +1563,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 19 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 19 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1681,10 +1681,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676981,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qNdFhY3JOkCfhG3d.M3VJyuM63OKH7JH0"
     },
@@ -1695,8 +1695,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales acid in a 90-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 22 Dexterity</strong> saving throw, taking <strong>67 (15d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>Each creature in that line must make a  <strong>DC 22 Dexterity</strong> saving throw, taking <strong>67 (15d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The dragon exhales acid in a 90-foot line that is 10 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales acid in a 90-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 22 Dexterity</strong> saving throw, taking <strong>67 (15d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>Each creature in that line must make a  <strong>DC 22 Dexterity</strong> saving throw, taking <strong>67 (15d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales acid in a 90-foot line that is 10 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1845,10 +1845,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676981,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qNdFhY3JOkCfhG3d.zDlCrWQVJgZFMfxY"
     },
@@ -1859,8 +1859,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1904,10 +1904,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676981,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qNdFhY3JOkCfhG3d.3ZEmD9O6eOtAfSzJ"
     },
@@ -1918,8 +1918,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2035,10 +2035,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676981,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qNdFhY3JOkCfhG3d.Ue0XiojtilVvKhH4"
     },
@@ -2460,8 +2460,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2505,10 +2505,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676981,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qNdFhY3JOkCfhG3d.84PHEVjYThsmbYxc"
     },

--- a/packs/_source/monsters/dragon/ancient-blue-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-blue-dragon.json
@@ -876,8 +876,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>20 (2d10 + 9) <em>piercing damage</em></strong> plus <strong>10 (2d10) <em>lightning damage</em></strong>.</p></section>\n<p>The Ancient Blue Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>20 (2d10 + 9) <em>piercing damage</em></strong> plus <strong>10 (2d10) <em>lightning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Blue Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1086,10 +1086,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676975,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.F29wEcjTlpKWcfO3"
     },
@@ -1100,8 +1100,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1145,10 +1145,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676975,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.uDd2aKkvwMwZfncQ"
     },
@@ -1159,8 +1159,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -1276,10 +1276,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676975,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.BOsuBiKE1Enpl4xl"
     },
@@ -1290,8 +1290,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -1335,10 +1335,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676975,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.BLj6WOTkgYmTEfj1"
     },
@@ -1349,8 +1349,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d6 + 9) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ancient Blue Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d6 + 9) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Blue Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1537,10 +1537,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676975,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.Hoc6KiovAZiBi5HV"
     },
@@ -1551,8 +1551,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 20 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 20 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1669,10 +1669,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676975,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.NhYVY7hHFu2YsFpN"
     },
@@ -1683,8 +1683,8 @@
       "img": "icons/magic/lightning/bolt-strike-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 23 Dexterity</strong> saving throw, taking <strong>88 (16d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 23 Dexterity</strong> saving throw, taking <strong>88 (16d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1829,10 +1829,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676975,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.834XVlRwHOXkE2rK"
     },
@@ -1843,8 +1843,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>18 (2d8 + 9) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ancient Blue Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>18 (2d8 + 9) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Blue Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -2031,10 +2031,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676975,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SNT0JNVSngUTsj4m.rwLwUWCVufdiKDaK"
     },

--- a/packs/_source/monsters/dragon/ancient-brass-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-brass-dragon.json
@@ -876,8 +876,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong>.</p><p></p></section><p>The Ancient Brass Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Brass Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1068,10 +1068,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pAuiNDr7nvpsW9nG.M8QrGIl4ESY4kh6A"
     },
@@ -1082,8 +1082,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ancient Brass Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Brass Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1270,10 +1270,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pAuiNDr7nvpsW9nG.Iy1UXphRvuXgybrn"
     },
@@ -1284,8 +1284,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 18 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>.</p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 18 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>.</p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1401,10 +1401,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pAuiNDr7nvpsW9nG.yJGmBczsD2hSQuzI"
     },
@@ -1415,8 +1415,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ancient Brass Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Brass Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1603,10 +1603,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pAuiNDr7nvpsW9nG.JjvNpMw6JP0A33yu"
     },
@@ -1617,8 +1617,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons:</p>\n<p>**Fire Breath.** The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 21 Dexterity</strong> saving throw, taking <strong>56 (16d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Sleep Breath.** The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 21 Constitution</strong> saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons:</p><p>**Fire Breath.** The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 21 Dexterity</strong> saving throw, taking <strong>56 (16d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Sleep Breath.** The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 21 Constitution</strong> saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1744,10 +1744,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pAuiNDr7nvpsW9nG.qmdYJXoLm52JeDEN"
     },
@@ -1758,8 +1758,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Fire Breath.** The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 21 Dexterity</strong> saving throw, taking <strong>56 (16d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales fire in a 90-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Fire Breath.** The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 21 Dexterity</strong> saving throw, taking <strong>56 (16d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in a 90-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1902,10 +1902,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pAuiNDr7nvpsW9nG.zM7nlV0WXlCeZj01"
     },
@@ -1916,8 +1916,8 @@
       "img": "icons/magic/perception/third-eye-blue-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Sleep Breath.** The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 21 Constitution</strong> saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>\n</section>\n<p>The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Sleep Breath.** The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 21 Constitution</strong> saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>",
+          "chat": "<p>The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2042,10 +2042,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pAuiNDr7nvpsW9nG.n1nya8bJgMqzsyfz"
     },
@@ -2181,8 +2181,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -2226,10 +2226,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pAuiNDr7nvpsW9nG.BgJf6V68k1OQMyWH"
     },
@@ -2240,8 +2240,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2357,10 +2357,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pAuiNDr7nvpsW9nG.FWLpSMrjPPegkAxX"
     },
@@ -2785,8 +2785,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2830,10 +2830,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677007,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pAuiNDr7nvpsW9nG.OY4mIiqSBDwjHjdj"
     },

--- a/packs/_source/monsters/dragon/ancient-bronze-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-bronze-dragon.json
@@ -935,8 +935,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>20 (2d10 + 9) <em>piercing damage</em></strong>.</p><p></p></section><p>The Ancient Bronze Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>20 (2d10 + 9) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Bronze Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1127,10 +1127,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676993,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!35Y64PEFFdvQS0ra.17bKqeydGVM0tR6p"
     },
@@ -1141,8 +1141,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d6 + 9) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ancient Bronze Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d6 + 9) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Bronze Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1329,10 +1329,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676993,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!35Y64PEFFdvQS0ra.qd5qScYvDjNbDERs"
     },
@@ -1343,8 +1343,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>18 (2d8 + 9) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ancient Bronze Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+16 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>18 (2d8 + 9) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Bronze Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1531,10 +1531,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676993,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!35Y64PEFFdvQS0ra.Vu2UkFmxzWB17KtN"
     },
@@ -1545,8 +1545,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 20 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 20 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1662,10 +1662,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676993,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!35Y64PEFFdvQS0ra.QUlBJuNL7JOevT7b"
     },
@@ -1676,8 +1676,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Lightning Breath.** The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 23 Dexterity</strong> saving throw, taking <strong>88 (16d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 23 Strength</strong> saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Lightning Breath.** The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 23 Dexterity</strong> saving throw, taking <strong>88 (16d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 23 Strength</strong> saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1803,10 +1803,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676993,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!35Y64PEFFdvQS0ra.oVxtfa5RF6ibpTIt"
     },
@@ -1817,8 +1817,8 @@
       "img": "icons/magic/lightning/bolt-strike-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Lightning Breath.** The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 23 Dexterity</strong> saving throw, taking <strong>88 (16d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Lightning Breath.** The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 23 Dexterity</strong> saving throw, taking <strong>88 (16d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1961,10 +1961,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676993,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!35Y64PEFFdvQS0ra.X15z14jf8Wmtjz2i"
     },
@@ -1975,8 +1975,8 @@
       "img": "icons/magic/air/air-wave-gust-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 23 Strength</strong> saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.</p>\n</section>\n<p>The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 23 Strength</strong> saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.</p>",
+          "chat": "<p>The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2101,10 +2101,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676993,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!35Y64PEFFdvQS0ra.e2kQ63WuGtictHXG"
     },
@@ -2240,8 +2240,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -2285,10 +2285,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676993,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!35Y64PEFFdvQS0ra.LxYk4BFUh3Qo9b9U"
     },
@@ -2712,8 +2712,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2829,10 +2829,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676993,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!35Y64PEFFdvQS0ra.b7ej3RkphhDGh617"
     },

--- a/packs/_source/monsters/dragon/ancient-copper-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-copper-dragon.json
@@ -675,8 +675,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -720,10 +720,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677010,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u0FWdplSOMTXGnN1.ztuakGSKlE6QF2MC"
     },
@@ -734,8 +734,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -779,10 +779,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677010,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u0FWdplSOMTXGnN1.hGGrGcyo6L62I2rM"
     },
@@ -928,8 +928,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong>.</p><p></p></section><p>The Ancient Copper Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Copper Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1120,10 +1120,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677010,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u0FWdplSOMTXGnN1.eCpXCLFLV7W22orV"
     },
@@ -1134,8 +1134,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ancient Copper Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Copper Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1322,10 +1322,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677010,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u0FWdplSOMTXGnN1.lsey8RJZiuByt97z"
     },
@@ -1336,8 +1336,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ancient Copper Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Copper Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1524,10 +1524,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677010,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u0FWdplSOMTXGnN1.SvpSnbfGzHw6dW0p"
     },
@@ -1538,8 +1538,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 19 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 19 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1655,10 +1655,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677010,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u0FWdplSOMTXGnN1.YkCurZ53A7ciRit3"
     },
@@ -1919,8 +1919,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2036,10 +2036,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677010,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u0FWdplSOMTXGnN1.O2pIuhKov4RccvzH"
     },
@@ -2464,8 +2464,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Acid Breath.** The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 22 Dexterity</strong> saving throw, taking <strong>63 (14d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Slowing Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 22 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Acid Breath.** The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 22 Dexterity</strong> saving throw, taking <strong>63 (14d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Slowing Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 22 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -2591,10 +2591,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677010,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u0FWdplSOMTXGnN1.TXjalusRqJTJKFCq"
     },
@@ -2605,8 +2605,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Acid Breath.** The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 22 Dexterity</strong> saving throw, taking <strong>63 (14d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Acid Breath.** The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a  <strong>DC 22 Dexterity</strong> saving throw, taking <strong>63 (14d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2749,10 +2749,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677010,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u0FWdplSOMTXGnN1.gWVU1Bt1WhK9lLEf"
     },
@@ -2763,8 +2763,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Slowing Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 22 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>\n</section>\n<p>The dragon exhales gas in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Slowing Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 22 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>",
+          "chat": "<p>The dragon exhales gas in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2889,10 +2889,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677010,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u0FWdplSOMTXGnN1.B8O16TZ5LWWKc4a4"
     }

--- a/packs/_source/monsters/dragon/ancient-gold-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-gold-dragon.json
@@ -675,8 +675,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -720,10 +720,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677003,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ckOF3vQrnjFnZIDU.xe5ziibjDPuvqO20"
     },
@@ -1053,8 +1053,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>21 (2d10 + 10) <em>piercing damage</em></strong>.</p><p></p></section><p>The Ancient Gold Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>21 (2d10 + 10) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Gold Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1245,10 +1245,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677003,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ckOF3vQrnjFnZIDU.BFbR0db4At8TQY91"
     },
@@ -1259,8 +1259,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d6 + 10) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ancient Gold Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d6 + 10) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Gold Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1445,10 +1445,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677003,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ckOF3vQrnjFnZIDU.iqduxJQPzhHPTJp2"
     },
@@ -1459,8 +1459,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>19 (2d8 + 10) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ancient Gold Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>19 (2d8 + 10) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Gold Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1647,10 +1647,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677003,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ckOF3vQrnjFnZIDU.5dpAWzBBJmkzgvGY"
     },
@@ -1661,8 +1661,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 24 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 24 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1778,10 +1778,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677003,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ckOF3vQrnjFnZIDU.ncKFI8v5vPO7kOFi"
     },
@@ -1792,8 +1792,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Fire Breath.** The dragon exhales fire in a 90-foot cone. Each creature in that area must make a  <strong>DC 24 Dexterity</strong> saving throw, taking <strong>71 (13d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Weakening Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 24 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Fire Breath.** The dragon exhales fire in a 90-foot cone. Each creature in that area must make a  <strong>DC 24 Dexterity</strong> saving throw, taking <strong>71 (13d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Weakening Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 24 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1903,10 +1903,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677003,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ckOF3vQrnjFnZIDU.j2nbvKIkKdNI32hU"
     },
@@ -1917,8 +1917,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Fire Breath.** The dragon exhales fire in a 90-foot cone. Each creature in that area must make a  <strong>DC 24 Dexterity</strong> saving throw, taking <strong>71 (13d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales fire in a 90-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Fire Breath.** The dragon exhales fire in a 90-foot cone. Each creature in that area must make a  <strong>DC 24 Dexterity</strong> saving throw, taking <strong>71 (13d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in a 90-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2061,10 +2061,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677003,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ckOF3vQrnjFnZIDU.zeRGidXXHkyRaA0g"
     },
@@ -2075,8 +2075,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Weakening Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 24 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon exhales gas in a 90-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Weakening Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a  <strong>DC 24 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon exhales gas in a 90-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2201,10 +2201,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677003,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ckOF3vQrnjFnZIDU.aOiuiILBGXCAei63"
     },
@@ -2215,8 +2215,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -2260,10 +2260,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677003,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ckOF3vQrnjFnZIDU.XRmYEohSc8WQkWYT"
     },
@@ -2274,8 +2274,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2391,10 +2391,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677003,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ckOF3vQrnjFnZIDU.MEN285wvE8ocd3E3"
     },

--- a/packs/_source/monsters/dragon/ancient-green-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-green-dragon.json
@@ -937,8 +937,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong> plus <strong>10 (3d6) <em>poison damage</em></strong>.</p><p></p></section><p>The Ancient Green Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong> plus <strong>10 (3d6) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Green Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1147,10 +1147,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676986,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zjqjcRWKDMc59Tnx.qq17e5u6Bey1aHqo"
     },
@@ -1161,8 +1161,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>22 (4d6 + 8) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ancient Green Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>22 (4d6 + 8) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Green Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1349,10 +1349,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676986,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zjqjcRWKDMc59Tnx.Ja5vvhGRJnCi9YGT"
     },
@@ -1363,8 +1363,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ancient Green Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+15 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Green Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1551,10 +1551,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676986,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zjqjcRWKDMc59Tnx.X1d4jzEXKYOuvEjT"
     },
@@ -1565,8 +1565,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 19 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 19 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1682,10 +1682,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676986,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zjqjcRWKDMc59Tnx.kZAndihX3RcDqN5P"
     },
@@ -1696,8 +1696,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a  <strong>DC 22 Constitution</strong> saving throw, taking <strong>77 (22d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a  <strong>DC 22 Constitution</strong> saving throw, taking <strong>77 (22d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1846,10 +1846,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676986,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zjqjcRWKDMc59Tnx.4Ntr5H946Prr6gC0"
     },
@@ -1860,8 +1860,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1905,10 +1905,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676986,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zjqjcRWKDMc59Tnx.6y5ZnqreJDNfNzBm"
     },
@@ -1919,8 +1919,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2036,10 +2036,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676986,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zjqjcRWKDMc59Tnx.JYKvD7WqfnM7mgru"
     },
@@ -2464,8 +2464,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2509,10 +2509,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676986,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zjqjcRWKDMc59Tnx.rjVthf9YEA81XZjL"
     },

--- a/packs/_source/monsters/dragon/ancient-red-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-red-dragon.json
@@ -616,8 +616,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>21 (2d10 + 10) <em>piercing damage</em></strong> plus <strong>14 (4d6) <em>fire damage</em></strong>.</p><p></p></section><p>The Ancient Red Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>21 (2d10 + 10) <em>piercing damage</em></strong> plus <strong>14 (4d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Red Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -826,10 +826,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676983,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.nOBAY4ulYbWMc8Pz"
     },
@@ -840,8 +840,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d6 + 10) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ancient Red Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d6 + 10) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Red Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1028,10 +1028,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676983,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.AheA06jKecElYrVt"
     },
@@ -1042,8 +1042,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>19 (2d8 + 10) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ancient Red Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>19 (2d8 + 10) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Red Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1230,10 +1230,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676983,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.EjnCigBWyq30VL4S"
     },
@@ -1244,8 +1244,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 21 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 21 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1362,10 +1362,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676983,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.LQKBexRS91dTMEKa"
     },
@@ -1376,8 +1376,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales fire in a 90-foot cone. Each creature in that area must make a  <strong>DC 24 Dexterity</strong> saving throw, taking <strong>91 (26d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales fire in a 90-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales fire in a 90-foot cone. Each creature in that area must make a  <strong>DC 24 Dexterity</strong> saving throw, taking <strong>91 (26d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in a 90-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1522,10 +1522,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676983,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.wUEVmK5TEnYsMuwJ"
     },
@@ -1796,8 +1796,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1841,10 +1841,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676983,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.diR3Lju2cmIwIOyG"
     },
@@ -2270,8 +2270,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2387,10 +2387,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676983,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.7WxDZHowVjqC4DfC"
     },
@@ -2401,8 +2401,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2446,10 +2446,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676983,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vFeFRlF2FOgf2HIL.H2ocal2ApylIiTPs"
     },

--- a/packs/_source/monsters/dragon/ancient-silver-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-silver-dragon.json
@@ -876,8 +876,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>21 (2d10 + 10) <em>piercing damage</em></strong>.</p><p></p></section><p>The Ancient Silver Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>21 (2d10 + 10) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Silver Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1068,10 +1068,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.YCbR7M5CKKCFWLvk"
     },
@@ -1082,8 +1082,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d6 + 10) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ancient Silver Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d6 + 10) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Silver Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1270,10 +1270,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.YHoeJdvSJaT3qblq"
     },
@@ -1284,8 +1284,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>19 (2d8 + 10) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ancient Silver Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>19 (2d8 + 10) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient Silver Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1472,10 +1472,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.VlNQwm636T7qIEoQ"
     },
@@ -1486,8 +1486,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 21 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 21 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1604,10 +1604,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.ohWgcdw603aWWXum"
     },
@@ -1618,8 +1618,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Cold Breath.** The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a  <strong>DC 24 Constitution</strong> saving throw, taking <strong>67 (15d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must succeed on a  <strong>DC 24 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Cold Breath.** The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a  <strong>DC 24 Constitution</strong> saving throw, taking <strong>67 (15d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must succeed on a  <strong>DC 24 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1745,10 +1745,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.oL7vyWwH6bvXyl95"
     },
@@ -1759,8 +1759,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Cold Breath.** The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a  <strong>DC 24 Constitution</strong> saving throw, taking <strong>67 (15d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Cold Breath.** The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a  <strong>DC 24 Constitution</strong> saving throw, taking <strong>67 (15d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1903,10 +1903,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.p6laYHKsnkMnfwtu"
     },
@@ -1917,8 +1917,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must succeed on a  <strong>DC 24 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must succeed on a  <strong>DC 24 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2043,10 +2043,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.TbcUwDfwFSYvMmwp"
     },
@@ -2182,8 +2182,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -2227,10 +2227,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.yAVNzttgGO1cHIlQ"
     },
@@ -2433,8 +2433,8 @@
       "img": "icons/creatures/abilities/wing-batlike-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon beats its wings. <strong>Each creature within 15 feet of the dragon</strong> must succeed on a <strong>DC 25 Dexterity saving throw</strong> or take <strong>17 (2d6+10) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>\n</section>\n<p>The dragon beats its wings! Each creature within 15 feet of the dragon must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon beats its wings. <strong>Each creature within 15 feet of the dragon</strong> must succeed on a <strong>DC 25 Dexterity saving throw</strong> or take <strong>17 (2d6+10) bludgeoning</strong> damage and be <strong>knocked prone.</strong> The dragon can then <strong>fly up to half its flying speed.</strong></p>",
+          "chat": "<p>The dragon beats its wings! Each creature within 15 feet of the dragon must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2640,10 +2640,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.saU6KEYGTm2SZ3jv"
     },
@@ -2654,8 +2654,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -2771,10 +2771,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.fu7gTjVI9Dk9J8tT"
     },
@@ -2785,8 +2785,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2830,10 +2830,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804677031,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gf9QbHdMAfvFtxcv.Pb87W9xoor7xP185"
     },

--- a/packs/_source/monsters/dragon/ancient-white-dragon.json
+++ b/packs/_source/monsters/dragon/ancient-white-dragon.json
@@ -616,8 +616,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong> plus <strong>9 (2d8) <em>cold damage</em></strong>.</p><p></p></section><p>The Ancient White Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>19 (2d10 + 8) <em>piercing damage</em></strong> plus <strong>9 (2d8) <em>cold damage</em></strong>.</p>",
+          "chat": "<p>The Ancient White Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -826,10 +826,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676978,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aTITHYYxthuZBPBn.NB88hf8oRtLwBolX"
     },
@@ -840,8 +840,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ancient White Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ancient White Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1028,10 +1028,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676978,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aTITHYYxthuZBPBn.Cz5xqvQ50f5zxuNY"
     },
@@ -1042,8 +1042,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a  <strong>DC 22 Constitution</strong> saving throw, taking 72 (l6d8) <em>cold damage</em> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a  <strong>DC 22 Constitution</strong> saving throw, taking 72 (l6d8) <em>cold damage</em> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1192,10 +1192,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676978,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aTITHYYxthuZBPBn.VtIk8lLDM4Qj3uOl"
     },
@@ -1206,8 +1206,8 @@
       "img": "icons/creatures/eyes/lizard-single-slit-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon makes a Wisdom (Perception) check.</p>\n</section>\n<p>The dragon watches its surrounding...</p>",
-          "chat": ""
+          "value": "<p>The dragon makes a Wisdom (Perception) check.</p>",
+          "chat": "<p>The dragon watches its surrounding...</p>"
         },
         "source": {
           "custom": "",
@@ -1323,10 +1323,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676978,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aTITHYYxthuZBPBn.2LAZaoPDRIvnHwtf"
     },
@@ -1337,8 +1337,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours .</p></section><p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a <strong>DC 16 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours .</p>",
+          "chat": "<p>Each creature of the dragon's choice that is <strong>within 120 feet</strong> of the dragon and aware of it must succeed on a Wisdom saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1454,10 +1454,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676978,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aTITHYYxthuZBPBn.sYtyFXYWqxWT1uUI"
     },
@@ -1527,8 +1527,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -1572,10 +1572,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676978,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aTITHYYxthuZBPBn.hixTmzxSmaFgXDMy"
     },
@@ -1586,8 +1586,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The dragon can take 3 legendary actions. </p>",
-          "chat": ""
+          "value": "<p>The dragon can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The dragon regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The dragon can take 3 legendary actions. </p>"
         },
         "source": {
           "custom": "",
@@ -1631,10 +1631,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676978,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aTITHYYxthuZBPBn.rtz0KAuj9DeBKT8A"
     },
@@ -1905,8 +1905,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ancient White Dragon attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>17 (2d8 + 8) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ancient White Dragon attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -2093,10 +2093,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676978,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aTITHYYxthuZBPBn.Q3Nd59qtQ5rsGs6c"
     },

--- a/packs/_source/monsters/dragon/black-dragon-wyrmling.json
+++ b/packs/_source/monsters/dragon/black-dragon-wyrmling.json
@@ -619,8 +619,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>22 (5d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>22 (5d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>22 (5d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>22 (5d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -769,10 +769,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676546,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!IZMbiAHqQpzPo0CX.ABS9Om2RejM5wrRF"
     },
@@ -842,8 +842,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong> plus <strong>2 (1d4) <em>acid damage</em></strong>.</p><p></p></section><p>The Black Dragon Wyrmling attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong> plus <strong>2 (1d4) <em>acid damage</em></strong>.</p>",
+          "chat": "<p>The Black Dragon Wyrmling attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1051,10 +1051,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676546,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!IZMbiAHqQpzPo0CX.dmLvn6VGNA20rMvC"
     }

--- a/packs/_source/monsters/dragon/blue-dragon-wyrmling.json
+++ b/packs/_source/monsters/dragon/blue-dragon-wyrmling.json
@@ -619,8 +619,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong> plus <strong>3 (1d6) <em>lightning damage</em></strong>.</p><p></p></section><p>The Blue Dragon Wyrmling attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong> plus <strong>3 (1d6) <em>lightning damage</em></strong>.</p>",
+          "chat": "<p>The Blue Dragon Wyrmling attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -829,10 +829,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676603,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!najtPRiHLR6buSWe.VkmpLaL0RYt8WrzR"
     },
@@ -843,8 +843,8 @@
       "img": "icons/magic/lightning/bolt-strike-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales lightning in a 30-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 12 Dexterity</strong> saving throw, taking <strong>22 (4d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales lightning in a 30-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales lightning in a 30-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 12 Dexterity</strong> saving throw, taking <strong>22 (4d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales lightning in a 30-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -993,10 +993,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676603,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!najtPRiHLR6buSWe.7LCUjJcHm3odI9C8"
     }

--- a/packs/_source/monsters/dragon/brass-dragon-wyrmling.json
+++ b/packs/_source/monsters/dragon/brass-dragon-wyrmling.json
@@ -619,8 +619,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Brass Dragon Wyrmling attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Brass Dragon Wyrmling attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -811,10 +811,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676872,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!azCbLQt5LAYwTI7U.K4qz0HVrX4JxcUvf"
     },
@@ -825,8 +825,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Fire Breath.** The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>14 (4d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Sleep Breath.** The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 11 Constitution</strong> saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Fire Breath.** The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>14 (4d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Sleep Breath.** The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 11 Constitution</strong> saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -952,10 +952,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676872,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!azCbLQt5LAYwTI7U.JmVLjWM4G6OOQxl4"
     },
@@ -966,8 +966,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Fire Breath.** The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>14 (4d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Fire Breath.** The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>14 (4d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1110,10 +1110,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676872,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!azCbLQt5LAYwTI7U.Z7rjC1RhE8VwXz4Z"
     },
@@ -1124,8 +1124,8 @@
       "img": "icons/magic/perception/third-eye-blue-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Sleep Breath.** The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 11 Constitution</strong> saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>\n</section>\n<p>The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Sleep Breath.** The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 11 Constitution</strong> saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>",
+          "chat": "<p>The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1250,10 +1250,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676872,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!azCbLQt5LAYwTI7U.z0g5kgBSkb9qHd6S"
     }

--- a/packs/_source/monsters/dragon/bronze-dragon-wyrmling.json
+++ b/packs/_source/monsters/dragon/bronze-dragon-wyrmling.json
@@ -678,8 +678,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Bronze Dragon Wyrmling attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Bronze Dragon Wyrmling attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -870,10 +870,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676876,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hY9ptpO5Xl2tfkcj.Vq0dUbodqBggQAVQ"
     },
@@ -884,8 +884,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Lightning Breath.** The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 12 Dexterity</strong> saving throw, taking <strong>16 (3d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 12 Strength</strong> saving throw. On a failed save, the creature is pushed 30 feet away from the dragon.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Lightning Breath.** The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 12 Dexterity</strong> saving throw, taking <strong>16 (3d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 12 Strength</strong> saving throw. On a failed save, the creature is pushed 30 feet away from the dragon.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1011,10 +1011,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676876,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hY9ptpO5Xl2tfkcj.Bl0NweDKcGjwVdPu"
     },
@@ -1025,8 +1025,8 @@
       "img": "icons/magic/lightning/bolt-strike-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Lightning Breath.** The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 12 Dexterity</strong> saving throw, taking <strong>16 (3d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p> The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Lightning Breath.** The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 12 Dexterity</strong> saving throw, taking <strong>16 (3d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p> The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1169,10 +1169,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676876,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hY9ptpO5Xl2tfkcj.QoYyaNGqsz935dS2"
     },
@@ -1183,8 +1183,8 @@
       "img": "icons/magic/air/air-wave-gust-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 12 Strength</strong> saving throw. On a failed save, the creature is pushed 30 feet away from the dragon.</p>\n</section>\n<p>The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 12 Strength</strong> saving throw. On a failed save, the creature is pushed 30 feet away from the dragon.</p>",
+          "chat": "<p>The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1309,10 +1309,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676876,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hY9ptpO5Xl2tfkcj.WT04ZQprU9op6Wny"
     }

--- a/packs/_source/monsters/dragon/copper-dragon-wyrmling.json
+++ b/packs/_source/monsters/dragon/copper-dragon-wyrmling.json
@@ -619,8 +619,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Copper Dragon Wyrmling attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Copper Dragon Wyrmling attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -811,10 +811,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676869,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AyvniEKtyroOe83p.BQZkHEsVvkPuGJKq"
     },
@@ -825,8 +825,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Acid Breath.** The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>18 (4d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Slowing Breath.** The dragon exhales gas in a 1 5-foot cone. Each creature in that area must succeed on a  <strong>DC 11 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Acid Breath.** The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>18 (4d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Slowing Breath.** The dragon exhales gas in a 1 5-foot cone. Each creature in that area must succeed on a  <strong>DC 11 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -952,10 +952,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676869,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AyvniEKtyroOe83p.6mcnEM9hUPlfUT9x"
     },
@@ -966,8 +966,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Acid Breath.** The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>18 (4d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Acid Breath.** The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>18 (4d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1110,10 +1110,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676869,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AyvniEKtyroOe83p.xwWjmumhVKXd0vQM"
     },
@@ -1124,8 +1124,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Slowing Breath.** The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 11 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>\n</section>\n<p>The dragon exhales gas in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Slowing Breath.** The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 11 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>",
+          "chat": "<p>The dragon exhales gas in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1250,10 +1250,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676869,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AyvniEKtyroOe83p.FNphFmvaLB9QD8Ta"
     }

--- a/packs/_source/monsters/dragon/dragon-turtle.json
+++ b/packs/_source/monsters/dragon/dragon-turtle.json
@@ -804,8 +804,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>26 (3d12 + 7) <em>piercing damage</em></strong>.</p><p></p></section><p>The Dragon Turtle attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>26 (3d12 + 7) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Dragon Turtle attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -996,10 +996,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676920,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ijsfYEDqSuwQXwNN.7QJr0VCtVk2wtZ78"
     },
@@ -1010,8 +1010,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d8 + 7) <em>slashing damage</em></strong>.</p><p></p></section><p>The Dragon Turtle attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d8 + 7) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Dragon Turtle attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1198,10 +1198,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676920,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ijsfYEDqSuwQXwNN.P4joxK4BwyYsPfJv"
     },
@@ -1212,8 +1212,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>26 (3d12 + 7) <em>bludgeoning damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 20 Strength</strong> saving throw or be pushed up to 10 feet away from the dragon turtle and knocked prone.</p></section><p>The Dragon Turtle attacks with its Tail. If the target is a creature, it must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>26 (3d12 + 7) <em>bludgeoning damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 20 Strength</strong> saving throw or be pushed up to 10 feet away from the dragon turtle and knocked prone.</p>",
+          "chat": "<p>The Dragon Turtle attacks with its Tail. If the target is a creature, it must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1489,10 +1489,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676920,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ijsfYEDqSuwQXwNN.zNDI1LvLKZ9Hi2Ew"
     },
@@ -1503,8 +1503,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon turtle exhales scalding steam in a 60-foot cone. Each creature in that area must make a  <strong>DC 18 Constitution</strong> saving throw, taking <strong>52 (15d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>Being underwater doesn't grant resistance against this damage.</p></section><p>The dragon turtle exhales scalding steam in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon turtle exhales scalding steam in a 60-foot cone. Each creature in that area must make a  <strong>DC 18 Constitution</strong> saving throw, taking <strong>52 (15d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>Being underwater doesn't grant resistance against this damage.</p>",
+          "chat": "<p>The dragon turtle exhales scalding steam in a 60-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1653,10 +1653,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676920,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ijsfYEDqSuwQXwNN.UjT93YD55B87gMqZ"
     }

--- a/packs/_source/monsters/dragon/gold-dragon-wyrmling.json
+++ b/packs/_source/monsters/dragon/gold-dragon-wyrmling.json
@@ -678,8 +678,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d10 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Gold Dragon Wyrmling attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d10 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Gold Dragon Wyrmling attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -870,10 +870,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676878,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!naSoHU9KbkgeNIwB.s90OWDANSrZ1ttWp"
     },
@@ -884,8 +884,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Fire Breath.** The dragon exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 13 Dexterity</strong> saving throw, taking <strong>22 (4d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Weakening Breath.** The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 13 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Fire Breath.** The dragon exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 13 Dexterity</strong> saving throw, taking <strong>22 (4d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Weakening Breath.** The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 13 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1011,10 +1011,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676878,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!naSoHU9KbkgeNIwB.JH4iOMWhpUPZneJN"
     },
@@ -1025,8 +1025,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Fire Breath.** The dragon exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 13 Dexterity</strong> saving throw, taking <strong>22 (4d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales fire in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Fire Breath.** The dragon exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 13 Dexterity</strong> saving throw, taking <strong>22 (4d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1169,10 +1169,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676878,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!naSoHU9KbkgeNIwB.XeFYvc5dR8YNRizI"
     },
@@ -1183,8 +1183,8 @@
       "img": "icons/magic/unholy/projectile-fireball-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Weakening Breath.** The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 13 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon exhales gas in a 15-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Weakening Breath.** The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 13 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon exhales gas in a 15-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1309,10 +1309,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676878,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!naSoHU9KbkgeNIwB.8mLdG3PPJsB8rrI3"
     }

--- a/packs/_source/monsters/dragon/green-dragon-wyrmling.json
+++ b/packs/_source/monsters/dragon/green-dragon-wyrmling.json
@@ -621,8 +621,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales poisonous gas in a 15-foot cone. Each creature in that area must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>21 (6d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales poisonous gas in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales poisonous gas in a 15-foot cone. Each creature in that area must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>21 (6d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales poisonous gas in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -771,10 +771,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676556,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KH6ZrUiUOKQCOlRH.pFFlq9KvfXzAxhU8"
     },
@@ -785,8 +785,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong> plus <strong>3 (1d6) <em>poison damage</em></strong>.</p><p></p></section><p>The Green Dragon Wyrmling attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong> plus <strong>3 (1d6) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Green Dragon Wyrmling attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -995,10 +995,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676556,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KH6ZrUiUOKQCOlRH.zii9P95YmeE6b4km"
     },

--- a/packs/_source/monsters/dragon/pseudodragon.json
+++ b/packs/_source/monsters/dragon/pseudodragon.json
@@ -791,8 +791,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Pseudodragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Pseudodragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -983,10 +983,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676693,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fkCNtbvPOMd7mipF.GJgN3Qy49XCaKmTc"
     },
@@ -997,8 +997,8 @@
       "img": "icons/creatures/abilities/fang-tooth-venomous.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 11 Constitution</strong> saving throw or become poisoned for 1 hour. If the saving throw fails by 5 or more, the target falls unconscious for the same duration, or until it takes damage or another creature uses an action to shake it awake.</p></section><p>The Pseudodragon attacks with its Sting. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 11 Constitution</strong> saving throw or become poisoned for 1 hour. If the saving throw fails by 5 or more, the target falls unconscious for the same duration, or until it takes damage or another creature uses an action to shake it awake.</p>",
+          "chat": "<p>The Pseudodragon attacks with its Sting. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1274,10 +1274,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676693,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fkCNtbvPOMd7mipF.MKFXRWP55I1bVlyD"
     }

--- a/packs/_source/monsters/dragon/red-dragon-wyrmling.json
+++ b/packs/_source/monsters/dragon/red-dragon-wyrmling.json
@@ -619,8 +619,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d10 + 4) <em>piercing damage</em></strong> plus <strong>3 (1d6) <em>fire damage</em></strong>.</p><p></p></section><p>The Red Dragon Wyrmling attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d10 + 4) <em>piercing damage</em></strong> plus <strong>3 (1d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Red Dragon Wyrmling attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -829,10 +829,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676627,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zgWkII3VoE4AHCND.iGge3BzjEfpSeaxP"
     },
@@ -843,8 +843,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 13 Dexterity</strong> saving throw, taking <strong>24 (7d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales fire in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 13 Dexterity</strong> saving throw, taking <strong>24 (7d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -993,10 +993,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676627,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zgWkII3VoE4AHCND.KVIjYSLZoYmdFwzS"
     }

--- a/packs/_source/monsters/dragon/silver-dragon-wyrmling.json
+++ b/packs/_source/monsters/dragon/silver-dragon-wyrmling.json
@@ -619,8 +619,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d10 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Silver Dragon Wyrmling attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d10 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Silver Dragon Wyrmling attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -811,10 +811,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676871,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J1QVPd8POvcPaqx4.x7uPzThV97uQxTun"
     },
@@ -825,8 +825,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Cold Breath.** The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a  <strong>DC 13 Constitution</strong> saving throw, taking <strong>18 (4d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Cold Breath.** The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a  <strong>DC 13 Constitution</strong> saving throw, taking <strong>18 (4d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -952,10 +952,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676871,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J1QVPd8POvcPaqx4.W386vxVMsDz3Gr9l"
     },
@@ -966,8 +966,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Cold Breath.** The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a  <strong>DC 13 Constitution</strong> saving throw, taking <strong>18 (4d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw</p>",
-          "chat": ""
+          "value": "<p>**Cold Breath.** The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a  <strong>DC 13 Constitution</strong> saving throw, taking <strong>18 (4d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw</p>"
         },
         "source": {
           "custom": "",
@@ -1110,10 +1110,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676871,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J1QVPd8POvcPaqx4.DRZQX4YLhabLlxIR"
     },
@@ -1124,8 +1124,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1250,10 +1250,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676871,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J1QVPd8POvcPaqx4.lq8qwetpVyoHKCyi"
     }

--- a/packs/_source/monsters/dragon/white-dragon-wyrmling.json
+++ b/packs/_source/monsters/dragon/white-dragon-wyrmling.json
@@ -619,8 +619,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong> plus <strong>2 (1d4) <em>cold damage</em></strong>.</p><p></p></section><p>The White Dragon Wyrmling attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong> plus <strong>2 (1d4) <em>cold damage</em></strong>.</p>",
+          "chat": "<p>The White Dragon Wyrmling attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -829,10 +829,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676618,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vc2TAgIuq4yInjbf.5fAK2gZdIiYxLNzK"
     },
@@ -843,8 +843,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales an icy blast of hail in a 15-foot cone. Each creature in that area must make a  <strong>DC 12 Constitution</strong> saving throw, taking <strong>22 (5d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales an icy blast of hail in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales an icy blast of hail in a 15-foot cone. Each creature in that area must make a  <strong>DC 12 Constitution</strong> saving throw, taking <strong>22 (5d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales an icy blast of hail in a 15-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -993,10 +993,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676618,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!vc2TAgIuq4yInjbf.8ZXdgzpI6WytT63w"
     }

--- a/packs/_source/monsters/dragon/wyvern.json
+++ b/packs/_source/monsters/dragon/wyvern.json
@@ -740,8 +740,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>.</p></section>\n<p>The Wyvern attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Wyvern attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -934,10 +934,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676846,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7198siHjPJf8g0cG.j1LTHxGLXWdnEbwq"
     },
@@ -948,8 +948,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p></section>\n<p>The Wyvern attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Wyvern attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1138,10 +1138,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676846,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7198siHjPJf8g0cG.Wa8BU72wRqyBCqkI"
     },
@@ -1152,8 +1152,8 @@
       "img": "icons/creatures/abilities/fang-tooth-venomous.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>.</p>\n<p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>24 (7d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The Wyvern attacks with its Stinger. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>24 (7d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Wyvern attacks with its Stinger. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1432,10 +1432,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676846,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7198siHjPJf8g0cG.HzLuzqlmtBSeSS4Q"
     }

--- a/packs/_source/monsters/dragon/young-black-dragon.json
+++ b/packs/_source/monsters/dragon/young-black-dragon.json
@@ -620,8 +620,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales acid in a 30-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>49 (11d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>49 (11d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The dragon exhales acid in a 30-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales acid in a 30-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>49 (11d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>49 (11d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales acid in a 30-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -770,10 +770,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676800,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bcapsJdIhY5WktpT.963t1Gp9Nsy3UY9D"
     },
@@ -843,8 +843,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>acid damage</em></strong>.</p><p></p></section><p>The Young Black Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>acid damage</em></strong>.</p>",
+          "chat": "<p>The Young Black Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1053,10 +1053,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676800,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bcapsJdIhY5WktpT.kuTDtAq2QL2Tmr4h"
     },
@@ -1067,8 +1067,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Young Black Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Young Black Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1255,10 +1255,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676800,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bcapsJdIhY5WktpT.gy0FMKec2tea9YI1"
     },

--- a/packs/_source/monsters/dragon/young-blue-dragon.json
+++ b/packs/_source/monsters/dragon/young-blue-dragon.json
@@ -620,8 +620,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d10 + 5) <em>piercing damage</em></strong> plus <strong>5 (1d10) <em>lightning damage</em></strong>.</p><p></p></section><p>The Young Blue Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d10 + 5) <em>piercing damage</em></strong> plus <strong>5 (1d10) <em>lightning damage</em></strong>.</p>",
+          "chat": "<p>The Young Blue Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -830,10 +830,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676828,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!mNijwXPMhwR7yYfc.42AGHJQzJZfUYxF9"
     },
@@ -844,8 +844,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing damage</em></strong>.</p><p></p></section><p>The Young Blue Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Young Blue Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1032,10 +1032,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676828,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!mNijwXPMhwR7yYfc.YSVencwrBzRdfm62"
     },
@@ -1046,8 +1046,8 @@
       "img": "icons/magic/lightning/bolt-strike-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales lightning in an 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 16 Dexterity</strong> saving throw, taking <strong>55 (10d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales lightning in an 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 16 Dexterity</strong> saving throw, taking <strong>55 (10d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1196,10 +1196,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676828,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!mNijwXPMhwR7yYfc.7XDStiwr5cRAODjk"
     },

--- a/packs/_source/monsters/dragon/young-brass-dragon.json
+++ b/packs/_source/monsters/dragon/young-brass-dragon.json
@@ -620,8 +620,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Young Brass Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Young Brass Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -812,10 +812,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676930,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!FzvZ6xl3U9GoL9ju.dYJy66Ftt58qpTUi"
     },
@@ -826,8 +826,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Fire Breath.** The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>42 (12d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Sleep Breath.** The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 14 Constitution</strong> saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Fire Breath.** The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>42 (12d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Sleep Breath.** The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 14 Constitution</strong> saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -953,10 +953,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676930,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!FzvZ6xl3U9GoL9ju.h8ocFdixa3iZVj0m"
     },
@@ -967,8 +967,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Fire Breath.** The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>42 (12d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Fire Breath.** The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>42 (12d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1111,10 +1111,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676930,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!FzvZ6xl3U9GoL9ju.oXGdDIdmBZe6g4Uo"
     },
@@ -1125,8 +1125,8 @@
       "img": "icons/magic/perception/third-eye-blue-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Sleep Breath.** The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 14 Constitution</strong> saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>\n</section>\n<p>The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Sleep Breath.** The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 14 Constitution</strong> saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.</p>",
+          "chat": "<p>The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1251,10 +1251,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676930,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!FzvZ6xl3U9GoL9ju.JPo2TKHFQ4pJKZqr"
     },
@@ -1265,8 +1265,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Young Brass Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Young Brass Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1453,10 +1453,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676930,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!FzvZ6xl3U9GoL9ju.YHom7FFObzrKEBLQ"
     },

--- a/packs/_source/monsters/dragon/young-bronze-dragon.json
+++ b/packs/_source/monsters/dragon/young-bronze-dragon.json
@@ -679,8 +679,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d10 + 5) <em>piercing damage</em></strong>.</p><p></p></section><p>The Young Bronze Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d10 + 5) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Young Bronze Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -871,10 +871,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676934,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NmQLj0zv4FmfuSan.22lf3TLPObmD4s6h"
     },
@@ -885,8 +885,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Lightning Breath.** The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 15 Dexterity</strong> saving throw, taking <strong>55 (10d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 15 Strength</strong> saving throw. On a failed save, the creature is pushed 40 feet away from the dragon.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Lightning Breath.** The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 15 Dexterity</strong> saving throw, taking <strong>55 (10d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 15 Strength</strong> saving throw. On a failed save, the creature is pushed 40 feet away from the dragon.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1012,10 +1012,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676934,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NmQLj0zv4FmfuSan.LMfwpBb1Pg7CLItO"
     },
@@ -1026,8 +1026,8 @@
       "img": "icons/magic/lightning/bolt-strike-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>*Lightning Breath.** The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 15 Dexterity</strong> saving throw, taking <strong>55 (10d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>*Lightning Breath.** The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 15 Dexterity</strong> saving throw, taking <strong>55 (10d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1170,10 +1170,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676934,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NmQLj0zv4FmfuSan.Eahi8ih9q0jF1XW2"
     },
@@ -1184,8 +1184,8 @@
       "img": "icons/magic/air/air-wave-gust-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 15 Strength</strong> saving throw. On a failed save, the creature is pushed 40 feet away from the dragon.</p>\n</section>\n<p>The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 15 Strength</strong> saving throw. On a failed save, the creature is pushed 40 feet away from the dragon.</p>",
+          "chat": "<p>The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1310,10 +1310,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676934,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NmQLj0zv4FmfuSan.h48EplFcKFZxJWjO"
     },
@@ -1324,8 +1324,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing damage</em></strong>.</p><p></p></section><p>The Young Bronze Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Young Bronze Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1512,10 +1512,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676934,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NmQLj0zv4FmfuSan.LGFPSpA0pvVpj3cF"
     },

--- a/packs/_source/monsters/dragon/young-copper-dragon.json
+++ b/packs/_source/monsters/dragon/young-copper-dragon.json
@@ -620,8 +620,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Young Copper Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Young Copper Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -812,10 +812,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676940,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qW8cBwg7ghCA4Cw6.Km7rUn5tu44KuVbz"
     },
@@ -826,8 +826,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Young Copper Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Young Copper Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1014,10 +1014,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676940,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qW8cBwg7ghCA4Cw6.DlxAB4bcOmBIn0UG"
     },
@@ -1028,8 +1028,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Acid Breath.** The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>40 (9d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Slowing Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 14 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Acid Breath.** The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>40 (9d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Slowing Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 14 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1155,10 +1155,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676940,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qW8cBwg7ghCA4Cw6.eKFnpVBhSSB91leK"
     },
@@ -1169,8 +1169,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Acid Breath.** The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>40 (9d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Acid Breath.** The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a  <strong>DC 14 Dexterity</strong> saving throw, taking <strong>40 (9d8) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1313,10 +1313,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676940,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qW8cBwg7ghCA4Cw6.HHLqWQuhYdWvo1Tj"
     },
@@ -1327,8 +1327,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Slowing Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 14 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>\n</section>\n<p>The dragon exhales gas in a 30-foot cone. Each creature in that area make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Slowing Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 14 Constitution</strong> saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.</p>",
+          "chat": "<p>The dragon exhales gas in a 30-foot cone. Each creature in that area make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1453,10 +1453,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676940,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qW8cBwg7ghCA4Cw6.jH7GlNkVX5D2chWY"
     },

--- a/packs/_source/monsters/dragon/young-gold-dragon.json
+++ b/packs/_source/monsters/dragon/young-gold-dragon.json
@@ -679,8 +679,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong>.</p><p></p></section><p>The Young Gold Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Young Gold Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -871,10 +871,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676936,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!QSytPah5WKoFJ1zt.IiZoBYBEjE5gGjeD"
     },
@@ -885,8 +885,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Fire Breath.** The dragon exhales fire in a 30-foot cone. Each creature in that area must make a  <strong>DC 17 Dexterity</strong> saving throw, taking <strong>55 (10d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Weakening Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 17 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Fire Breath.** The dragon exhales fire in a 30-foot cone. Each creature in that area must make a  <strong>DC 17 Dexterity</strong> saving throw, taking <strong>55 (10d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Weakening Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 17 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -1012,10 +1012,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676936,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!QSytPah5WKoFJ1zt.7lHaAZMjuTYZ6w6J"
     },
@@ -1026,8 +1026,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p><p></p></section><p>The Young Gold Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Young Gold Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1213,10 +1213,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676936,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!QSytPah5WKoFJ1zt.qRuJSlOzJITBzcjv"
     },
@@ -1352,8 +1352,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Fire Breath.** The dragon exhales fire in a 30-foot cone. Each creature in that area must make a  <strong>DC 17 Dexterity</strong> saving throw, taking <strong>55 (10d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales fire in a 30-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Fire Breath.** The dragon exhales fire in a 30-foot cone. Each creature in that area must make a  <strong>DC 17 Dexterity</strong> saving throw, taking <strong>55 (10d10) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in a 30-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1496,10 +1496,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676936,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!QSytPah5WKoFJ1zt.AedUiopUrkxaTl7S"
     },
@@ -1510,8 +1510,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Weakening Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 17 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon exhales gas in a 30-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Weakening Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 17 Strength</strong> saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon exhales gas in a 30-foot cone. Each creature in that area must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1636,10 +1636,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676936,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!QSytPah5WKoFJ1zt.0D1CWFdQeP5vpXLz"
     }

--- a/packs/_source/monsters/dragon/young-green-dragon.json
+++ b/packs/_source/monsters/dragon/young-green-dragon.json
@@ -681,8 +681,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>poison damage</em></strong>.</p><p></p></section><p>The Young Green Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Young Green Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -891,10 +891,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676765,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!85ahD1jEo9B3POaQ.0Ob35HZxhSF7p2ys"
     },
@@ -905,8 +905,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Young Green Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Young Green Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1093,10 +1093,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676765,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!85ahD1jEo9B3POaQ.WvvHslcDhMq7MD1s"
     },
@@ -1232,8 +1232,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales poisonous gas in a 30-foot cone. Each creature in that area must make a  <strong>DC 14 Constitution</strong> saving throw, taking <strong>42 (12d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales poisonous gas in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales poisonous gas in a 30-foot cone. Each creature in that area must make a  <strong>DC 14 Constitution</strong> saving throw, taking <strong>42 (12d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales poisonous gas in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1382,10 +1382,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676765,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!85ahD1jEo9B3POaQ.PIXokIK4tYPwua2G"
     }

--- a/packs/_source/monsters/dragon/young-red-dragon.json
+++ b/packs/_source/monsters/dragon/young-red-dragon.json
@@ -620,8 +620,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong> plus <strong>3 (1d6) <em>fire damage</em></strong>.</p><p></p></section><p>The Young Red Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong> plus <strong>3 (1d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Young Red Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -830,10 +830,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676830,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qrasJNDC7SGj7xzG.KuuOPjJ1YeTtjGbN"
     },
@@ -844,8 +844,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p><p></p></section><p>The Young Red Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Young Red Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1032,10 +1032,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676830,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qrasJNDC7SGj7xzG.3UHmbpT3v3FTlplI"
     },
@@ -1046,8 +1046,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales fire in a 30-foot cone. Each creature in that area must make a  <strong>DC 17 Dexterity</strong> saving throw, taking <strong>56 (16d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales fire in a 30-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales fire in a 30-foot cone. Each creature in that area must make a  <strong>DC 17 Dexterity</strong> saving throw, taking <strong>56 (16d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales fire in a 30-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1196,10 +1196,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676830,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qrasJNDC7SGj7xzG.nWjLJm6ErLvCUvun"
     },

--- a/packs/_source/monsters/dragon/young-silver-dragon.json
+++ b/packs/_source/monsters/dragon/young-silver-dragon.json
@@ -620,8 +620,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong>.</p><p></p></section><p>The Young Silver Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Young Silver Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -812,10 +812,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676938,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eykRfV85DQJoCkmc.qsfDO6B4wLP1UeKS"
     },
@@ -826,8 +826,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon uses one of the following breath weapons.</p>\n<p>**Cold Breath.** The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a  <strong>DC 17 Constitution</strong> saving throw, taking <strong>54 (12d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 17 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon breathes in!</p>",
-          "chat": ""
+          "value": "<p>The dragon uses one of the following breath weapons.</p><p>**Cold Breath.** The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a  <strong>DC 17 Constitution</strong> saving throw, taking <strong>54 (12d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 17 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon breathes in!</p>"
         },
         "source": {
           "custom": "",
@@ -953,10 +953,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676938,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eykRfV85DQJoCkmc.08bC5Aq3vPzJatVB"
     },
@@ -967,8 +967,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p><p></p></section><p>The Young Silver Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Young Silver Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1155,10 +1155,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676938,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eykRfV85DQJoCkmc.GvAgPChKDJLm64Za"
     },
@@ -1294,8 +1294,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Cold Breath.** The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a  <strong>DC 17 Constitution</strong> saving throw, taking <strong>54 (12d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Cold Breath.** The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a  <strong>DC 17 Constitution</strong> saving throw, taking <strong>54 (12d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1438,10 +1438,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676938,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eykRfV85DQJoCkmc.vuuyXwshegZEpoSb"
     },
@@ -1452,8 +1452,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 17 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>**Paralyzing Breath.** The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 17 Constitution</strong> saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1578,10 +1578,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676938,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eykRfV85DQJoCkmc.spr7KRotXDVgwIso"
     }

--- a/packs/_source/monsters/dragon/young-white-dragon.json
+++ b/packs/_source/monsters/dragon/young-white-dragon.json
@@ -620,8 +620,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>cold damage</em></strong>.</p><p></p></section><p>The Young White Dragon attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>cold damage</em></strong>.</p>",
+          "chat": "<p>The Young White Dragon attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -830,10 +830,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676834,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u1UQfHutP5eEKkjM.qFfEF7lLt2kH3RbA"
     },
@@ -844,8 +844,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Young White Dragon attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Young White Dragon attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1032,10 +1032,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676834,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u1UQfHutP5eEKkjM.d9xXEIYNNQjIMGF8"
     },
@@ -1046,8 +1046,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>45 (10d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>45 (10d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1192,10 +1192,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676834,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!u1UQfHutP5eEKkjM.78LbjdfWaZcAqVE7"
     },

--- a/packs/_source/monsters/elemental/air-elemental.json
+++ b/packs/_source/monsters/elemental/air-elemental.json
@@ -820,8 +820,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Air Elemental attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Air Elemental attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -1010,10 +1010,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676579,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!banHjKDMCegbUwYE.qzLZFBO75loU77TZ"
     },
@@ -1024,8 +1024,8 @@
       "img": "icons/magic/air/wind-tornado-cyclone-white.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Each creature in the elemental's space must make a  <strong>DC 13 Strength</strong> saving throw. On a failure, a target takes <strong>15 (3d8 + 2) <em>bludgeoning damage</em></strong> and is flung up 20 feet away from the elemental in a random direction and knocked prone.</p>\n<p>If a thrown target strikes an object, such as a wall or floor, the target takes <strong>3 (1d6) <em>bludgeoning damage</em></strong> for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a  <strong>DC 13 Dexterity</strong> saving throw or take the same damage and be knocked prone. If the saving throw is successful, the target takes half the <em>bludgeoning damage</em> and isn't flung away or knocked prone.</p>\n</section>\n<p>Each creature in the elemental's space must make a <strong>Strength</strong> saving throw. On a failure, a target is flung up 20 feet away from the elemental in a random direction and knocked prone. If the target is thrown at another creature, that creature must make a <strong>Dexterity</strong> saving throw or take the same damage and be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>Each creature in the elemental's space must make a  <strong>DC 13 Strength</strong> saving throw. On a failure, a target takes <strong>15 (3d8 + 2) <em>bludgeoning damage</em></strong> and is flung up 20 feet away from the elemental in a random direction and knocked prone.</p><p>If a thrown target strikes an object, such as a wall or floor, the target takes <strong>3 (1d6) <em>bludgeoning damage</em></strong> for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a  <strong>DC 13 Dexterity</strong> saving throw or take the same damage and be knocked prone. If the saving throw is successful, the target takes half the <em>bludgeoning damage</em> and isn't flung away or knocked prone.</p>",
+          "chat": "<p>Each creature in the elemental's space must make a <strong>Strength</strong> saving throw. On a failure, a target is flung up 20 feet away from the elemental in a random direction and knocked prone. If the target is thrown at another creature, that creature must make a <strong>Dexterity</strong> saving throw or take the same damage and be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -1268,10 +1268,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676579,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!banHjKDMCegbUwYE.PVdWTEQBuiAglD7l"
     }

--- a/packs/_source/monsters/elemental/azer.json
+++ b/packs/_source/monsters/elemental/azer.json
@@ -858,8 +858,8 @@
       "img": "icons/skills/melee/strike-sword-blood-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>When the azer hits with a metal melee weapon, it deals an extra <strong>3 (1d6) <em>fire damage</em></strong> (included in the attack).</p>\n</section>\n<p>When the azer hits with a metal melee weapon, it deals extra <em>fire damage</em> (included in the attack).</p>",
-          "chat": ""
+          "value": "<p>When the azer hits with a metal melee weapon, it deals an extra <strong>3 (1d6) <em>fire damage</em></strong> (included in the attack).</p>",
+          "chat": "<p>When the azer hits with a metal melee weapon, it deals extra <em>fire damage</em> (included in the attack).</p>"
         },
         "source": {
           "custom": "",
@@ -903,10 +903,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676547,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!IiEDPMWqBlzkggYD.WRygAnkpMeaqiw70"
     },
@@ -976,8 +976,8 @@
       "img": "icons/weapons/hammers/hammer-drilling-spiked.webp",
       "system": {
         "description": {
-          "value": "<section>\n<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>bludgeoning damage</em></strong>, or <strong>8 (1d10 + 3) <em>bludgeoning damage</em></strong> if used with two hands to make a melee attack, plus <strong>3 (1d6) <em>fire damage</em></strong>.</p>\n</section>\n</section>\n<p>A heavy metal hammer capable of being wielded with a single hand with a shield or in two hands to deliver crushing concussive blows.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>bludgeoning damage</em></strong>, or <strong>8 (1d10 + 3) <em>bludgeoning damage</em></strong> if used with two hands to make a melee attack, plus <strong>3 (1d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<section>\n\n</section>\n<p>A heavy metal hammer capable of being wielded with a single hand with a shield or in two hands to deliver crushing concussive blows.</p>"
         },
         "source": {
           "custom": "",
@@ -1188,10 +1188,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676547,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!IiEDPMWqBlzkggYD.YvzdCGQeCV1XOcUt"
     }

--- a/packs/_source/monsters/elemental/djinni.json
+++ b/packs/_source/monsters/elemental/djinni.json
@@ -863,8 +863,8 @@
       "img": "icons/weapons/swords/sword-katana.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing damage</em></strong> plus 3 (1d6) lightning or thunder damage (djinni's choice).</p><p></p></section><p>The Djinni attacks with its Scimitar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing damage</em></strong> plus 3 (1d6) lightning or thunder damage (djinni's choice).</p>",
+          "chat": "<p>The Djinni attacks with its Scimitar.</p>"
         },
         "source": {
           "custom": "",
@@ -1073,10 +1073,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676525,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5P1VGAZQwOilwZQf.DGP7lnAJT1cv8SA4"
     },
@@ -1087,8 +1087,8 @@
       "img": "icons/magic/air/wind-tornado-cyclone-white.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>A 5-foot-radius, 30-foot-tall cylinder of swirling air magically forms on a point the djinni can see within 120 feet of it. The whirlwind lasts as long as the djinni maintains concentration (as if concentrating on a spell).</p>\n<p>Any creature but the djinni that enters the whirlwind must succeed on a  <strong>DC 18 Strength</strong> saving throw or be restrained by it. The djinni can move the whirlwind up to 60 feet as an action, and creatures restrained by the whirlwind move with it. The whirlwind ends if the djinni loses sight of it.</p>\n<p>A creature can use its action to free a creature restrained by the whirlwind, including itself, by succeeding on a DC 18 Strength check. If the check succeeds, the creature is no longer restrained and moves to the nearest space outside the whirlwind.</p>\n</section>\n<p>A 5-foot-radius, 30-foot-tall cylinder of swirling air magically forms on a point the djinni can see within 120 feet of it. Any creature but the djinni that enters the whirlwind must make a <strong>Strength</strong> saving throw or be restrained by it. The djinni can move the whirlwind up to 60 feet as an action, and creatures restrained by the whirlwind move with it. A creature can use its action to free a creature restrained by the whirlwind, including itself, by succeeding on a Strength check. If the check succeeds, the creature is no longer restrained and moves to the nearest space outside the whirlwind.</p>",
-          "chat": ""
+          "value": "<p>A 5-foot-radius, 30-foot-tall cylinder of swirling air magically forms on a point the djinni can see within 120 feet of it. The whirlwind lasts as long as the djinni maintains concentration (as if concentrating on a spell).</p><p>Any creature but the djinni that enters the whirlwind must succeed on a  <strong>DC 18 Strength</strong> saving throw or be restrained by it. The djinni can move the whirlwind up to 60 feet as an action, and creatures restrained by the whirlwind move with it. The whirlwind ends if the djinni loses sight of it.</p><p>A creature can use its action to free a creature restrained by the whirlwind, including itself, by succeeding on a DC 18 Strength check. If the check succeeds, the creature is no longer restrained and moves to the nearest space outside the whirlwind.</p>",
+          "chat": "<p>A 5-foot-radius, 30-foot-tall cylinder of swirling air magically forms on a point the djinni can see within 120 feet of it. Any creature but the djinni that enters the whirlwind must make a <strong>Strength</strong> saving throw or be restrained by it. The djinni can move the whirlwind up to 60 feet as an action, and creatures restrained by the whirlwind move with it. A creature can use its action to free a creature restrained by the whirlwind, including itself, by succeeding on a Strength check. If the check succeeds, the creature is no longer restrained and moves to the nearest space outside the whirlwind.</p>"
         },
         "source": {
           "custom": "",
@@ -1204,10 +1204,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676525,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5P1VGAZQwOilwZQf.nE7YNnVM7srBcdfl"
     },

--- a/packs/_source/monsters/elemental/dust-mephit.json
+++ b/packs/_source/monsters/elemental/dust-mephit.json
@@ -624,8 +624,8 @@
       "img": "icons/magic/light/explosion-star-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>When the mephit dies, it explodes in a burst of dust. Each creature within <strong>5 ft.</strong> of it must then succeed on a <strong>DC 10 Constitution saving throw</strong> or be blinded for <strong>1 minute</strong>. A blinded creature can repeat the saving throw on each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>When the mephit dies, it explodes in a burst of dust. Each creature within <strong>5 ft.</strong> of it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>When the mephit dies, it explodes in a burst of dust. Each creature within <strong>5 ft.</strong> of it must then succeed on a <strong>DC 10 Constitution saving throw</strong> or be blinded for <strong>1 minute</strong>. A blinded creature can repeat the saving throw on each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>When the mephit dies, it explodes in a burst of dust. Each creature within <strong>5 ft.</strong> of it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -827,10 +827,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676711,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!BUCfQ7ihaXX75Vai.v3i1DaUS4Bkc8Ser"
     },
@@ -900,8 +900,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>slashing damage</em></strong>.</p>\n</section>\n<p>The Dust Mephit attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Dust Mephit attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1090,10 +1090,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676711,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!BUCfQ7ihaXX75Vai.lazTMrXNUpGCrKdR"
     },
@@ -1104,8 +1104,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The mephit exhales a 15-foot cone of blinding dust.</p>\n<p>Each creature in that area must succeed on a  <strong>DC 10 Dexterity</strong> saving throw or be blinded for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The mephit exhales a 15-foot cone of blinding dust. Each creature in that area must make a <strong>Dexterity</strong> saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>The mephit exhales a 15-foot cone of blinding dust.</p><p>Each creature in that area must succeed on a  <strong>DC 10 Dexterity</strong> saving throw or be blinded for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The mephit exhales a 15-foot cone of blinding dust. Each creature in that area must make a <strong>Dexterity</strong> saving throw. A creature can repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1343,10 +1343,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676711,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!BUCfQ7ihaXX75Vai.RTpPc5fs27dBqDuj"
     },

--- a/packs/_source/monsters/elemental/earth-elemental.json
+++ b/packs/_source/monsters/elemental/earth-elemental.json
@@ -876,8 +876,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Earth Elemental attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Earth Elemental attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -1066,10 +1066,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676514,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!sApYLZj9PTZ40wJr.2AD5aTLMPDmQFhGZ"
     }

--- a/packs/_source/monsters/elemental/efreeti.json
+++ b/packs/_source/monsters/elemental/efreeti.json
@@ -1020,8 +1020,8 @@
       "img": "icons/weapons/swords/sword-katana.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong> plus <strong>7 (2d6) <em>fire damage</em></strong>.</p><p></p></section><p>The Efreeti attacks with its Scimitar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d6 + 6) <em>slashing damage</em></strong> plus <strong>7 (2d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Efreeti attacks with its Scimitar.</p>"
         },
         "source": {
           "custom": "",
@@ -1233,10 +1233,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676668,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!LTomFUTBrkRi0Pj5.tR7JGJjIz6H1oerb"
     },
@@ -1247,8 +1247,8 @@
       "img": "icons/magic/fire/blast-jet-stream-splash.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Ranged Spell Attack:</em><strong>+7 to hit,</strong>, <strong>120 ft.,</strong> one target. Hit: <strong>17 (5d6) <em>fire damage</em></strong>.</p><p></p></section><p>The Efreeti attacks with its Hurl Flame.</p>",
-          "chat": ""
+          "value": "<p><em>Ranged Spell Attack:</em><strong>+7 to hit,</strong>, <strong>120 ft.,</strong> one target. Hit: <strong>17 (5d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Efreeti attacks with its Hurl Flame.</p>"
         },
         "source": {
           "custom": "",
@@ -1437,10 +1437,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676668,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!LTomFUTBrkRi0Pj5.9D7vAr8iJbSa4g5N"
     },

--- a/packs/_source/monsters/elemental/fire-elemental.json
+++ b/packs/_source/monsters/elemental/fire-elemental.json
@@ -635,8 +635,8 @@
       "img": "icons/magic/earth/lava-explosion-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The elemental can move through a space as narrow as 1 inch wide without squeezing. A creature that touches the elemental or hits it with a melee attack while within 5 ft. of it takes <strong>5 (1d10) <em>fire damage</em></strong>. </p><p>In addition, the elemental can enter a hostile creature's space and stop there. The first time it enters a creature's space on a turn, that creature takes <strong>5 (1d10) <em>fire damage</em></strong> and catches fire; until someone takes an action to douse the fire, the creature takes <strong>5 (1d10) <em>fire damage</em></strong> at the start of each of its turns.</p></section><p>A creature that touches the elemental or hits it with a melee attack while within 5 ft. of it takes <em>fire damage</em>. In addition, the elemental can enter a hostile creature's space and stop there. The first time it enters a creature's space on a turn, that creature takes <em>fire damage</em> and catches fire; until someone takes an action to douse the fire, the creature takes <em>fire damage</em> at the start of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>The elemental can move through a space as narrow as 1 inch wide without squeezing. A creature that touches the elemental or hits it with a melee attack while within 5 ft. of it takes <strong>5 (1d10) <em>fire damage</em></strong>. </p><p>In addition, the elemental can enter a hostile creature's space and stop there. The first time it enters a creature's space on a turn, that creature takes <strong>5 (1d10) <em>fire damage</em></strong> and catches fire; until someone takes an action to douse the fire, the creature takes <strong>5 (1d10) <em>fire damage</em></strong> at the start of each of its turns.</p>",
+          "chat": "<p>A creature that touches the elemental or hits it with a melee attack while within 5 ft. of it takes <em>fire damage</em>. In addition, the elemental can enter a hostile creature's space and stop there. The first time it enters a creature's space on a turn, that creature takes <em>fire damage</em> and catches fire; until someone takes an action to douse the fire, the creature takes <em>fire damage</em> at the start of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -765,10 +765,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676531,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8SMQl75HLjhuSeau.yud1cnEVQ9KxbmWc"
     },
@@ -1022,8 +1022,8 @@
       "img": "icons/magic/fire/flame-burning-fist-strike.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>fire damage</em></strong>. </p><p>If the target is a creature or a flammable object, it ignites. Until a creature takes an action to douse the fire, the target takes <strong>5 (1d10) <em>fire damage</em></strong> at the start of each of its turns.</p></section><p>The Fire Elemental attacks with its Touch. If the target is a creature or a flammable object, it ignites. Until a creature takes an action to douse the fire, the target takes <em>fire damage</em> at the start of each of its turns.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>fire damage</em></strong>. </p><p>If the target is a creature or a flammable object, it ignites. Until a creature takes an action to douse the fire, the target takes <strong>5 (1d10) <em>fire damage</em></strong> at the start of each of its turns.</p>",
+          "chat": "<p>The Fire Elemental attacks with its Touch. If the target is a creature or a flammable object, it ignites. Until a creature takes an action to douse the fire, the target takes <em>fire damage</em> at the start of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1276,10 +1276,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676531,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8SMQl75HLjhuSeau.fdt2FIirmBRCpRBm"
     }

--- a/packs/_source/monsters/elemental/gargoyle.json
+++ b/packs/_source/monsters/elemental/gargoyle.json
@@ -814,8 +814,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Gargoyle attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Gargoyle attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1006,10 +1006,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676629,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!0m8QyDN52qw9zzOM.A6GBvah75Y7fGjc5"
     },
@@ -1020,8 +1020,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>slashing damage</em></strong>.</p><p></p></section><p>The Gargoyle attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Gargoyle attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1208,10 +1208,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676629,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!0m8QyDN52qw9zzOM.ipJwA0j2zfzmq5GW"
     }

--- a/packs/_source/monsters/elemental/ice-mephit.json
+++ b/packs/_source/monsters/elemental/ice-mephit.json
@@ -626,8 +626,8 @@
       "img": "icons/magic/light/explosion-star-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>When the mephit dies, it explodes in a burst of jagged ice. </p><p>Each creature within 5 ft. of it must make a  <strong>DC 10 Dexterity</strong> saving throw, taking <strong>4 (1d8) <em>slashing damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>When the mephit dies, it explodes in a burst of jagged ice. Each creature within 5 ft. of it must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>When the mephit dies, it explodes in a burst of jagged ice. </p><p>Each creature within 5 ft. of it must make a  <strong>DC 10 Dexterity</strong> saving throw, taking <strong>4 (1d8) <em>slashing damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>When the mephit dies, it explodes in a burst of jagged ice. Each creature within 5 ft. of it must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -760,10 +760,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676714,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ESEm3fGUfSKjzVUc.D4cqlN9pDyQwRvWP"
     },
@@ -892,8 +892,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>3 (1d4 + 1) <em>slashing damage</em></strong> plus <strong>2 (1d4) <em>cold damage</em></strong>.</p><p></p></section><p>The Ice Mephit attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>3 (1d4 + 1) <em>slashing damage</em></strong> plus <strong>2 (1d4) <em>cold damage</em></strong>.</p>",
+          "chat": "<p>The Ice Mephit attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1098,10 +1098,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676714,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ESEm3fGUfSKjzVUc.YEZPqZegxKiGO0Gq"
     },
@@ -1112,8 +1112,8 @@
       "img": "icons/magic/air/wind-tornado-wall-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The mephit exhales a 15-foot cone of cold air. Each creature in that area must succeed on a  <strong>DC 10 Dexterity</strong> saving throw, taking <strong>5 (2d4) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The mephit exhales a 15-foot cone of cold air. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The mephit exhales a 15-foot cone of cold air. Each creature in that area must succeed on a  <strong>DC 10 Dexterity</strong> saving throw, taking <strong>5 (2d4) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The mephit exhales a 15-foot cone of cold air. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1262,10 +1262,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676714,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ESEm3fGUfSKjzVUc.1mD9NcCf8ZMQtsrU"
     },

--- a/packs/_source/monsters/elemental/invisible-stalker.json
+++ b/packs/_source/monsters/elemental/invisible-stalker.json
@@ -634,8 +634,8 @@
       "img": "icons/creatures/mammals/wolf-howl-moon-forest-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The stalker is given a quarry by its summoner. The stalker knows the direction and distance to its quarry as long as the two of them are on the same plane of existence. The stalker also knows the location of its summoner.</p></section><p>The stalker knows the direction and distance to its quarry as long as the two of them are on the same plane of existence. </p>",
-          "chat": ""
+          "value": "<p>The stalker is given a quarry by its summoner. The stalker knows the direction and distance to its quarry as long as the two of them are on the same plane of existence. The stalker also knows the location of its summoner.</p>",
+          "chat": "<p>The stalker knows the direction and distance to its quarry as long as the two of them are on the same plane of existence. </p>"
         },
         "source": {
           "custom": "",
@@ -679,10 +679,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676605,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oDspGxRQFBhE74L2.VdFnTF9MqUFF7KPQ"
     },
@@ -877,8 +877,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Invisible Stalker attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Invisible Stalker attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -1065,10 +1065,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676605,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oDspGxRQFBhE74L2.rpKiEPQVeOZTLwjf"
     }

--- a/packs/_source/monsters/elemental/magma-mephit.json
+++ b/packs/_source/monsters/elemental/magma-mephit.json
@@ -686,8 +686,8 @@
       "img": "icons/magic/light/explosion-star-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>When the mephit dies, it explodes in a burst of lava. Each creature within 5 ft. of it must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>7 (2d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>When the mephit dies, it explodes in a burst of lava. Each creature within 5 ft. of it must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>When the mephit dies, it explodes in a burst of lava. Each creature within 5 ft. of it must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>7 (2d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>When the mephit dies, it explodes in a burst of lava. Each creature within 5 ft. of it must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -820,10 +820,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676753,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oJCOB9X2BPsBkWW5.LpYrQPxHA10HPnkl"
     },
@@ -893,8 +893,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee Weapon Attack: +3 to hit, reach 5 ft ., one creature. Hit: <strong>3 (1d4 + 1) <em>slashing damage</em></strong> plus <strong>2 (1d4) <em>fire damage</em></strong>.</p><p></p></section><p>The Magma Mephit attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +3 to hit, reach 5 ft ., one creature. Hit: <strong>3 (1d4 + 1) <em>slashing damage</em></strong> plus <strong>2 (1d4) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Magma Mephit attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1099,10 +1099,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676753,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oJCOB9X2BPsBkWW5.BiAfcjq7C9Wf8R9b"
     },
@@ -1113,8 +1113,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The mephit exhales a 15-foot cone of fire. Each creature in that area must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>7 (2d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The mephit exhales a 15-foot cone of fire. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The mephit exhales a 15-foot cone of fire. Each creature in that area must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>7 (2d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The mephit exhales a 15-foot cone of fire. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1263,10 +1263,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676753,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oJCOB9X2BPsBkWW5.iXhbFt7gCj3FBM2r"
     },

--- a/packs/_source/monsters/elemental/magmin.json
+++ b/packs/_source/monsters/elemental/magmin.json
@@ -621,8 +621,8 @@
       "img": "icons/magic/light/explosion-star-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>When the magmin dies, it explodes in a burst of fire and magma. </p><p>Each creature within 10 ft. of it must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>7 (2d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one. Flammable objects that aren't being worn or carried in that area are ignited.</p></section><p>When the magmin dies, it explodes in a burst of fire and magma. Each creature within 10 ft. of it must make a <strong>Dexterity</strong> saving throw. Flammable objects that aren't being worn or carried in that area are ignited.</p>",
-          "chat": ""
+          "value": "<p>When the magmin dies, it explodes in a burst of fire and magma. </p><p>Each creature within 10 ft. of it must make a  <strong>DC 11 Dexterity</strong> saving throw, taking <strong>7 (2d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one. Flammable objects that aren't being worn or carried in that area are ignited.</p>",
+          "chat": "<p>When the magmin dies, it explodes in a burst of fire and magma. Each creature within 10 ft. of it must make a <strong>Dexterity</strong> saving throw. Flammable objects that aren't being worn or carried in that area are ignited.</p>"
         },
         "source": {
           "custom": "",
@@ -755,10 +755,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676529,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8MD1vRBTcgSXXk3u.0xdLfPJEHYwh8MIT"
     },
@@ -894,8 +894,8 @@
       "img": "icons/magic/fire/flame-burning-fist-strike.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d6) <em>fire damage</em></strong>. </p><p></p></section><p>The Magmin attacks with its Touch. If the target is a creature or a flammable object, it ignites. Until a target takes an action to douse the fire, the target takes <strong>3 (1d6) <em>fire damage</em></strong> at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d6) <em>fire damage</em></strong>. </p>",
+          "chat": "<p>The Magmin attacks with its Touch. If the target is a creature or a flammable object, it ignites. Until a target takes an action to douse the fire, the target takes <strong>3 (1d6) <em>fire damage</em></strong> at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1148,10 +1148,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676529,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8MD1vRBTcgSXXk3u.th3hfRWQ3PT9f3Gs"
     }

--- a/packs/_source/monsters/elemental/salamander.json
+++ b/packs/_source/monsters/elemental/salamander.json
@@ -627,8 +627,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-fire-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>A creature that touches the salamander or hits it with a melee attack while within 5 ft. of it takes <strong>7 (2d6) <em>fire damage</em></strong>.</p><p></p></section><p>A creature that touches the salamander or hits it with a melee attack while within 5 ft. of it takes <em>fire damage</em>.</p>",
-          "chat": ""
+          "value": "<p>A creature that touches the salamander or hits it with a melee attack while within 5 ft. of it takes <strong>7 (2d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>A creature that touches the salamander or hits it with a melee attack while within 5 ft. of it takes <em>fire damage</em>.</p>"
         },
         "source": {
           "custom": "",
@@ -757,10 +757,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676907,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!yVNPVJIBpQ2Mp3Xa.2n8ByeQNl7QkjNVA"
     },
@@ -771,8 +771,8 @@
       "img": "icons/skills/melee/strike-weapons-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Any metal melee weapon the salamander wields deals an extra <strong>3 (1d6) <em>fire damage</em></strong> on a hit (included in the attack).</p></section><p>Any metal melee weapon the salamander wields deals an extra <em>fire damage</em> on a hit (included in the attack).</p>",
-          "chat": ""
+          "value": "<p>Any metal melee weapon the salamander wields deals an extra <strong>3 (1d6) <em>fire damage</em></strong> on a hit (included in the attack).</p>",
+          "chat": "<p>Any metal melee weapon the salamander wields deals an extra <em>fire damage</em> on a hit (included in the attack).</p>"
         },
         "source": {
           "custom": "",
@@ -816,10 +816,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676907,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!yVNPVJIBpQ2Mp3Xa.2y0o9wGzCVoBBuDZ"
     },
@@ -955,8 +955,8 @@
       "img": "icons/magic/lightning/bolt-strike-smoke-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong> plus <strong>7 (2d6) <em>fire damage</em></strong>.</p><p>The target is grappled (escape DC 14). Until this grapple ends, the target is restrained, the salamander can automatically hit the target with its tail, and the salamander can't make tail attacks against other targets.</p></section><p>The Salamander attacks with its Tail. The target is grappled. Until this grapple ends, the target is restrained, the salamander can automatically hit the target with its tail, and the salamander can't make tail attacks against other targets.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong> plus <strong>7 (2d6) <em>fire damage</em></strong>.</p><p>The target is grappled (escape DC 14). Until this grapple ends, the target is restrained, the salamander can automatically hit the target with its tail, and the salamander can't make tail attacks against other targets.</p>",
+          "chat": "<p>The Salamander attacks with its Tail. The target is grappled. Until this grapple ends, the target is restrained, the salamander can automatically hit the target with its tail, and the salamander can't make tail attacks against other targets.</p>"
         },
         "source": {
           "custom": "",
@@ -1161,10 +1161,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676907,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!yVNPVJIBpQ2Mp3Xa.rvRy41yt9zowrAr1"
     },
@@ -1175,8 +1175,8 @@
       "img": "icons/magic/fire/projectile-arrow-fire-red-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20 ft./60 ft., one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>, or <strong>13 (2d8 + 4) <em>piercing damage</em></strong> if used with two hands to make a melee attack, plus <strong>3 (1d6) <em>fire damage</em></strong>.</p></section>\n<p>The Salamander attacks with its Spear.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20 ft./60 ft., one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>, or <strong>13 (2d8 + 4) <em>piercing damage</em></strong> if used with two hands to make a melee attack, plus <strong>3 (1d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Salamander attacks with its Spear.</p>"
         },
         "source": {
           "custom": "",
@@ -1388,10 +1388,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676907,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!yVNPVJIBpQ2Mp3Xa.SKwOsrThcwqMXCZv"
     }

--- a/packs/_source/monsters/elemental/steam-mephit.json
+++ b/packs/_source/monsters/elemental/steam-mephit.json
@@ -623,8 +623,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>2 (1d4) <em>slashing damage</em></strong> plus <strong>2 (1d4) <em>fire damage</em></strong>.</p><p></p></section><p>The Steam Mephit attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>2 (1d4) <em>slashing damage</em></strong> plus <strong>2 (1d4) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Steam Mephit attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -828,10 +828,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676728,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UthHOT7QfZfEIUue.QrN7UxINx4UCaPIC"
     },
@@ -842,8 +842,8 @@
       "img": "icons/magic/light/explosion-star-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>When the mephit dies, it explodes in a cloud of steam. </p><p>Each creature within 5 ft. of the mephit must succeed on a  <strong>DC 10 Dexterity</strong> saving throw or take <strong>4 (1d8) <em>fire damage</em></strong>.</p></section><p>When the mephit dies, it explodes in a cloud of steam. Each creature within 5 ft. of the mephit must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>When the mephit dies, it explodes in a cloud of steam. </p><p>Each creature within 5 ft. of the mephit must succeed on a  <strong>DC 10 Dexterity</strong> saving throw or take <strong>4 (1d8) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>When the mephit dies, it explodes in a cloud of steam. Each creature within 5 ft. of the mephit must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1082,10 +1082,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676728,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UthHOT7QfZfEIUue.QWi0q0cSzHEp8VqB"
     },
@@ -1155,8 +1155,8 @@
       "img": "icons/magic/air/wind-tornado-wall-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The mephit exhales a 15-foot cone of scalding steam. Each creature in that area must succeed on a  <strong>DC 10 Dexterity</strong> saving throw, taking <strong>4 (1d8) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The mephit exhales a 15-foot cone of scalding steam. Each creature in that area must succeed on a Dexterity saving throw.</p>",
-          "chat": ""
+          "value": "<p>The mephit exhales a 15-foot cone of scalding steam. Each creature in that area must succeed on a  <strong>DC 10 Dexterity</strong> saving throw, taking <strong>4 (1d8) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The mephit exhales a 15-foot cone of scalding steam. Each creature in that area must succeed on a Dexterity saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1305,10 +1305,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676728,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UthHOT7QfZfEIUue.RnLjEUZ0gBxcH2T3"
     },

--- a/packs/_source/monsters/elemental/water-elemental.json
+++ b/packs/_source/monsters/elemental/water-elemental.json
@@ -635,8 +635,8 @@
       "img": "icons/magic/water/ice-crystal-white.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the elemental takes <strong><em>cold damage</em></strong>, it partially freezes; its speed is reduced by <strong>20 ft.</strong> until the end of its next turn.</p></section><p>If the elemental takes <strong><em>cold damage</em></strong>, it partially freezes.</p>",
-          "chat": ""
+          "value": "<p>If the elemental takes <strong><em>cold damage</em></strong>, it partially freezes; its speed is reduced by <strong>20 ft.</strong> until the end of its next turn.</p>",
+          "chat": "<p>If the elemental takes <strong><em>cold damage</em></strong>, it partially freezes.</p>"
         },
         "source": {
           "custom": "",
@@ -680,10 +680,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676751,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!namJz755U1EhvEJa.sZcc3bwnRjaDV9BZ"
     },
@@ -878,8 +878,8 @@
       "img": "icons/magic/water/wave-water-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Water Elemental attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Water Elemental attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -1066,10 +1066,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676751,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!namJz755U1EhvEJa.7xDGPsWicxgP6feT"
     },
@@ -1080,8 +1080,8 @@
       "img": "icons/magic/water/vortex-water-whirlpool.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature in the elemental's space must make a  <strong>DC 15 Strength</strong> saving throw. On a failure, a target takes <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>. If it is Large or smaller, it is also grappled (escape DC 14). Until this grapple ends, the target is restrained and unable to breathe unless it can breathe water. </p><p>If the saving throw is successful, the target is pushed out of the elemental's space.The elemental can grapple one Large creature or up to two Medium or smaller creatures at one time. At the start of each of the elemental's turns, each target grappled by it takes <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>. A creature within 5 feet of the elemental can pull a creature or object out of it by taking an action to make a DC 14 Strength check and succeeding.</p></section><p>Each creature in the elemental's space must make a <strong>Strength</strong> saving throw. If it is Large or smaller, it is also grappled. Until this grapple ends, the target is restrained and unable to breathe unless it can breathe water. A creature within 5 feet of the elemental can pull a creature or object out of it by taking an action to make a Strength check and succeeding.</p>",
-          "chat": ""
+          "value": "<p>Each creature in the elemental's space must make a  <strong>DC 15 Strength</strong> saving throw. On a failure, a target takes <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>. If it is Large or smaller, it is also grappled (escape DC 14). Until this grapple ends, the target is restrained and unable to breathe unless it can breathe water. </p><p>If the saving throw is successful, the target is pushed out of the elemental's space.The elemental can grapple one Large creature or up to two Medium or smaller creatures at one time. At the start of each of the elemental's turns, each target grappled by it takes <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>. A creature within 5 feet of the elemental can pull a creature or object out of it by taking an action to make a DC 14 Strength check and succeeding.</p>",
+          "chat": "<p>Each creature in the elemental's space must make a <strong>Strength</strong> saving throw. If it is Large or smaller, it is also grappled. Until this grapple ends, the target is restrained and unable to breathe unless it can breathe water. A creature within 5 feet of the elemental can pull a creature or object out of it by taking an action to make a Strength check and succeeding.</p>"
         },
         "source": {
           "custom": "",
@@ -1230,10 +1230,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676751,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!namJz755U1EhvEJa.5XUFTldfE6mtRUfd"
     }

--- a/packs/_source/monsters/elemental/xorn.json
+++ b/packs/_source/monsters/elemental/xorn.json
@@ -623,8 +623,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (3d6 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Xorn attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (3d6 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Xorn attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -815,10 +815,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676635,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!2MZNHeOZweXAYbv1.ODAa1IROPs40MUI2"
     },
@@ -829,8 +829,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p><p></p></section><p>The Xorn attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Xorn attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1017,10 +1017,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676635,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!2MZNHeOZweXAYbv1.LRjB7lk0aa4TOd16"
     },

--- a/packs/_source/monsters/fey/blink-dog.json
+++ b/packs/_source/monsters/fey/blink-dog.json
@@ -670,8 +670,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>.</p></section>\n<p>The Blink Dog attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Blink Dog attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -862,10 +862,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676492,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jOANE6M0My6UJF4e.DcZYdK2iycSJzamK"
     },

--- a/packs/_source/monsters/fey/dryad.json
+++ b/packs/_source/monsters/fey/dryad.json
@@ -920,8 +920,8 @@
       "img": "icons/weapons/clubs/club-simple-barbed.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee Weapon Attack: +2 to hit (+6 to hit with shillelagh), reach 5 ft., one target. Hit: <strong>2 (1d4) <em>bludgeoning damage</em></strong>, or <strong>8 (1d8 + 4) <em>bludgeoning damage</em></strong> with shillelagh.</p>\n</section>\n<p>The Dryad attacks with its Club.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +2 to hit (+6 to hit with shillelagh), reach 5 ft., one target. Hit: <strong>2 (1d4) <em>bludgeoning damage</em></strong>, or <strong>8 (1d8 + 4) <em>bludgeoning damage</em></strong> with shillelagh.</p>",
+          "chat": "<p>The Dryad attacks with its Club.</p>"
         },
         "source": {
           "custom": "",
@@ -1114,10 +1114,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676559,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KOHVWl5RU9XBR8Jb.DNPx6Myd5rHTGu4a"
     },
@@ -1128,8 +1128,8 @@
       "img": "icons/consumables/plants/leaf-veins-glowing-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dryad targets one humanoid or beast that she can see within 30 feet of her. If the target can see the dryad, it must succeed on a  <strong>DC 14 Wisdom</strong> saving throw or be magically charmed.</p>\n<p>The charmed creature regards the dryad as a trusted friend to be heeded and protected. Although the target isn't under the dryad's control, it takes the dryad's requests or actions in the most favorable way it can.Each time the dryad or its allies do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the dryad dies, is on a different plane of existence from the target, or ends the effect as a bonus action. If a target's saving throw is successful, the target is immune to the dryad's Fey Charm for the next 24 hours.The dryad can have no more than one humanoid and up to three beasts charmed at a time.</p>\n</section>\n<p>The dryad targets one humanoid or beast that she can see within 30 feet of her. If the target can see the dryad, it must make a <strong>Wisdom</strong> saving throw. Each time the dryad or its allies do anything harmful to the target, it can repeat the saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dryad targets one humanoid or beast that she can see within 30 feet of her. If the target can see the dryad, it must succeed on a  <strong>DC 14 Wisdom</strong> saving throw or be magically charmed.</p><p>The charmed creature regards the dryad as a trusted friend to be heeded and protected. Although the target isn't under the dryad's control, it takes the dryad's requests or actions in the most favorable way it can.Each time the dryad or its allies do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the dryad dies, is on a different plane of existence from the target, or ends the effect as a bonus action. If a target's saving throw is successful, the target is immune to the dryad's Fey Charm for the next 24 hours.The dryad can have no more than one humanoid and up to three beasts charmed at a time.</p>",
+          "chat": "<p>The dryad targets one humanoid or beast that she can see within 30 feet of her. If the target can see the dryad, it must make a <strong>Wisdom</strong> saving throw. Each time the dryad or its allies do anything harmful to the target, it can repeat the saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1311,10 +1311,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676559,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KOHVWl5RU9XBR8Jb.OdzhvEDeD06BWsZS"
     },

--- a/packs/_source/monsters/fey/green-hag.json
+++ b/packs/_source/monsters/fey/green-hag.json
@@ -737,8 +737,8 @@
       "img": "icons/creatures/birds/corvid-flying-wings-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The hag can mimic animal sounds and humanoid voices. A creature that hears the sounds can tell they are imitations with a successful <strong>DC 14 Wisdom (Insight) check</strong>.</p></section><p>The hag can mimic animal sounds and humanoid voices. A creature that hears the sounds can tell they are imitations with a successful Wisdom (Insight) check.</p>",
-          "chat": ""
+          "value": "<p>The hag can mimic animal sounds and humanoid voices. A creature that hears the sounds can tell they are imitations with a successful <strong>DC 14 Wisdom (Insight) check</strong>.</p>",
+          "chat": "<p>The hag can mimic animal sounds and humanoid voices. A creature that hears the sounds can tell they are imitations with a successful Wisdom (Insight) check.</p>"
         },
         "source": {
           "custom": "",
@@ -782,10 +782,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676755,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!saq6WM959pKHuaqP.C2ZJ3Oe30dyU2o7E"
     },
@@ -796,8 +796,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Green Hag attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Green Hag attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -984,10 +984,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676755,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!saq6WM959pKHuaqP.gtixTr9i63RtsSCv"
     },
@@ -1123,8 +1123,8 @@
       "img": "icons/magic/perception/silhouette-stealth-shadow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The hag magically turns invisible until she attacks or casts a spell, or until her concentration ends (as if concentrating on a spell). While invisible, she leaves no physical evidence of her passage, so she can be tracked only by magic. Any equipment she wears or carries is invisible with her.</p><p></p></section><p>The hag magically turns invisible. Any equipment she wears or carries is invisible with her.</p>",
-          "chat": ""
+          "value": "<p>The hag magically turns invisible until she attacks or casts a spell, or until her concentration ends (as if concentrating on a spell). While invisible, she leaves no physical evidence of her passage, so she can be tracked only by magic. Any equipment she wears or carries is invisible with her.</p>",
+          "chat": "<p>The hag magically turns invisible. Any equipment she wears or carries is invisible with her.</p>"
         },
         "source": {
           "custom": "",
@@ -1234,10 +1234,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676755,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!saq6WM959pKHuaqP.Cdis1lnjFvqfoScV"
     },

--- a/packs/_source/monsters/fey/satyr.json
+++ b/packs/_source/monsters/fey/satyr.json
@@ -1187,8 +1187,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (2d4 + 1) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Satyr attacks with its Ram.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (2d4 + 1) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Satyr attacks with its Ram.</p>"
         },
         "source": {
           "custom": "",
@@ -1374,10 +1374,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676417,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8xhuJXYMnlQD7LF6.2btvWgv8WIkadZjh"
     }

--- a/packs/_source/monsters/fey/sea-hag.json
+++ b/packs/_source/monsters/fey/sea-hag.json
@@ -678,8 +678,8 @@
       "img": "icons/creatures/unholy/demon-winged-cyclops-drooling.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Any humanoid that starts its turn <strong>within 30 feet</strong> of the hag and can see the hag's true form must make a <strong>DC 11 Wisdom saving throw</strong>. On a failed save, the creature is frightened for <strong>1 minute</strong>. A creature can repeat the saving throw at the end of each of its turns, with<strong> disadvantage </strong>if the hag is within line of sight, ending the effect on itself on a success.</p>\n<p>If a creature's saving throw is successful or the effect ends for it, the creature is immune to the hag's Horrific Appearance for the next 24 hours<strong>. </strong>Unless the target is surprised or the revelation of the hag's true form is sudden, the target can avert its eyes and avoid making the initial saving throw. Until the start of its next turn, a creature that averts its eyes has<strong> disadvantage </strong>on attack rolls against the hag.</p>\n</section>\n<p>Any humanoid that starts its turn <strong>within 30 feet</strong> of the hag and can see the hag's true form must make a <strong>Wisdom</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>Any humanoid that starts its turn <strong>within 30 feet</strong> of the hag and can see the hag's true form must make a <strong>DC 11 Wisdom saving throw</strong>. On a failed save, the creature is frightened for <strong>1 minute</strong>. A creature can repeat the saving throw at the end of each of its turns, with<strong> disadvantage </strong>if the hag is within line of sight, ending the effect on itself on a success.</p><p>If a creature's saving throw is successful or the effect ends for it, the creature is immune to the hag's Horrific Appearance for the next 24 hours<strong>. </strong>Unless the target is surprised or the revelation of the hag's true form is sudden, the target can avert its eyes and avoid making the initial saving throw. Until the start of its next turn, a creature that averts its eyes has<strong> disadvantage </strong>on attack rolls against the hag.</p>",
+          "chat": "<p>Any humanoid that starts its turn <strong>within 30 feet</strong> of the hag and can see the hag's true form must make a <strong>Wisdom</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -796,10 +796,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676725,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!OQqybZoMeDFn5AFD.XeAyeJsNjKZKPWEN"
     },
@@ -810,8 +810,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>.</p><p></p></section><p>The Sea Hag attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Sea Hag attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -998,10 +998,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676725,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!OQqybZoMeDFn5AFD.a75Ba80yp6Y28AJQ"
     },
@@ -1012,8 +1012,8 @@
       "img": "icons/magic/death/skull-humanoid-worn-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The hag targets one frightened creature she can see within 30 ft. of her. If the target can see the hag, it must succeed on a  <strong>DC 11 Wisdom</strong> saving throw against this magic or drop to 0 hit points.</p><p></p></section><p>The hag targets one frightened creature she can see within 30 ft. of her. If the target can see the hag, it must make a <strong>Wisdom</strong> saving throw against this magic.</p>",
-          "chat": ""
+          "value": "<p>The hag targets one frightened creature she can see within 30 ft. of her. If the target can see the hag, it must succeed on a  <strong>DC 11 Wisdom</strong> saving throw against this magic or drop to 0 hit points.</p>",
+          "chat": "<p>The hag targets one frightened creature she can see within 30 ft. of her. If the target can see the hag, it must make a <strong>Wisdom</strong> saving throw against this magic.</p>"
         },
         "source": {
           "custom": "",
@@ -1130,10 +1130,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676725,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!OQqybZoMeDFn5AFD.7AGmP2dRLYmORUX7"
     },

--- a/packs/_source/monsters/fey/sprite.json
+++ b/packs/_source/monsters/fey/sprite.json
@@ -706,8 +706,8 @@
       "img": "icons/weapons/bows/shortbow-recurve.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +6 to hit, range 40/160 ft., one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p><p></p></section><p>The Sprite attacks with its Shortbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +6 to hit, range 40/160 ft., one target. Hit:<strong> 1 <em>piercing damage</em>.</strong></p>",
+          "chat": "<p>The Sprite attacks with its Shortbow.</p>"
         },
         "source": {
           "custom": "",
@@ -987,10 +987,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676890,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MUpBNDoJEr09bLaO.YN8cO9SCNOIFJcmw"
     },
@@ -1001,8 +1001,8 @@
       "img": "icons/weapons/swords/greatsword-crossguard-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>slashing damage</em>.</strong></p><p></p></section><p>The Sprite attacks with its Longsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit:<strong> 1 <em>slashing damage</em>.</strong></p>",
+          "chat": "<p>The Sprite attacks with its Longsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1192,10 +1192,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676890,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MUpBNDoJEr09bLaO.mT8SL7VHsG6qY5G7"
     },
@@ -1206,8 +1206,8 @@
       "img": "icons/creatures/webs/webthin-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The sprite magically turns invisible until it attacks or casts a spell, or until its concentration ends (as if concentrating on a spell). Any equipment the sprite wears or carries is invisible with it.</p><p></p></section><p>The sprite magically turns invisible. Any equipment the sprite wears or carries is invisible with it.</p>",
-          "chat": ""
+          "value": "<p>The sprite magically turns invisible until it attacks or casts a spell, or until its concentration ends (as if concentrating on a spell). Any equipment the sprite wears or carries is invisible with it.</p>",
+          "chat": "<p>The sprite magically turns invisible. Any equipment the sprite wears or carries is invisible with it.</p>"
         },
         "source": {
           "custom": "",
@@ -1317,10 +1317,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676890,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MUpBNDoJEr09bLaO.qLd01BTjVwH6NUfH"
     },
@@ -1331,8 +1331,8 @@
       "img": "icons/magic/control/hypnosis-mesmerism-eye.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The sprite touches a creature and magically knows the creature's current emotional state. </p><p>If the target fails a  <strong>DC 10 Charisma</strong> saving throw, the sprite also knows the creature's alignment. Celestials, fiends, and undead automatically fail the saving throw.</p></section><p>The sprite touches a creature. target must make a <strong>Charisma</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The sprite touches a creature and magically knows the creature's current emotional state. </p><p>If the target fails a  <strong>DC 10 Charisma</strong> saving throw, the sprite also knows the creature's alignment. Celestials, fiends, and undead automatically fail the saving throw.</p>",
+          "chat": "<p>The sprite touches a creature. target must make a <strong>Charisma</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1448,10 +1448,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676890,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MUpBNDoJEr09bLaO.qJHrH8Q3q1JB5xe5"
     }

--- a/packs/_source/monsters/fiend/balor.json
+++ b/packs/_source/monsters/fiend/balor.json
@@ -628,8 +628,8 @@
       "img": "icons/magic/fire/explosion-fireball-large-red-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>When the balor dies, it explodes, and each creature within 30 feet of it must make a  <strong>DC 20 Dexterity</strong> saving throw, taking <strong>70 (20d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>The explosion ignites flammable objects in that area that aren't being worn or carried, and it destroys the balor's weapons.</p>\n</section>\n<p>When the balor dies, it explodes, and each creature within 30 feet of it must make a <strong>Dexterity</strong> saving throw. The explosion ignites flammable objects in that area that aren't being worn or carried, and it destroys the balor's weapons.</p>",
-          "chat": ""
+          "value": "<p>When the balor dies, it explodes, and each creature within 30 feet of it must make a  <strong>DC 20 Dexterity</strong> saving throw, taking <strong>70 (20d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>The explosion ignites flammable objects in that area that aren't being worn or carried, and it destroys the balor's weapons.</p>",
+          "chat": "<p>When the balor dies, it explodes, and each creature within 30 feet of it must make a <strong>Dexterity</strong> saving throw. The explosion ignites flammable objects in that area that aren't being worn or carried, and it destroys the balor's weapons.</p>"
         },
         "source": {
           "custom": "",
@@ -762,10 +762,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676903,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!uZ8NrRenwYZ4qNf6.nzkZgDrDq0RwWUao"
     },
@@ -776,8 +776,8 @@
       "img": "icons/magic/air/fog-gas-smoke-swirling-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>At the start of each of the balor's turns, each creature within 5 feet of it takes <strong>10 (3d6) <em>fire damage</em></strong>, and flammable objects in the aura that aren't being worn or carried ignite.</p>\n<p>A creature that touches the balor or hits it with a melee attack while within 5 feet of it takes <strong>10 (3d6) <em>fire damage</em></strong>.</p>\n</section>\n<p>At the start of each of the balor's turns, each creature within 5 feet of it takes <em>fire damage</em>, and flammable objects in the aura that aren't being worn or carried ignite. A creature that touches the balor or hits it with a melee attack while within 5 feet of it takes <em>fire damage</em>.</p>",
-          "chat": ""
+          "value": "<p>At the start of each of the balor's turns, each creature within 5 feet of it takes <strong>10 (3d6) <em>fire damage</em></strong>, and flammable objects in the aura that aren't being worn or carried ignite.</p><p>A creature that touches the balor or hits it with a melee attack while within 5 feet of it takes <strong>10 (3d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>At the start of each of the balor's turns, each creature within 5 feet of it takes <em>fire damage</em>, and flammable objects in the aura that aren't being worn or carried ignite. A creature that touches the balor or hits it with a melee attack while within 5 feet of it takes <em>fire damage</em>.</p>"
         },
         "source": {
           "custom": "",
@@ -906,10 +906,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676903,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!uZ8NrRenwYZ4qNf6.FWSzSLqeIDq7meXC"
     },
@@ -1289,8 +1289,8 @@
       "img": "icons/weapons/swords/greatsword-crossguard-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>21 (3d8 + 8) <em>slashing damage</em></strong> plus <strong>13 (3d8) <em>lightning damage</em></strong>.</p>\n<p>If the balor scores a critical hit, it rolls damage dice three times, instead of twice.</p>\n</section>\n<p>The Balor attacks with its Longsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>21 (3d8 + 8) <em>slashing damage</em></strong> plus <strong>13 (3d8) <em>lightning damage</em></strong>.</p><p>If the balor scores a critical hit, it rolls damage dice three times, instead of twice.</p>",
+          "chat": "<p>The Balor attacks with its Longsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1502,10 +1502,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676903,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!uZ8NrRenwYZ4qNf6.6ZAh5TkiXwQMUfDB"
     },
@@ -1516,8 +1516,8 @@
       "img": "icons/weapons/misc/whip-red-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>30 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong> plus <strong>10 (3d6) <em>fire damage</em></strong>.</p>\n<p>The target must succeed on a  <strong>DC 20 Strength</strong> saving throw or be pulled up to 25 feet toward the balor.</p>\n</section>\n<p>The Balor attacks with its Whip. The target must make a <strong>Strength</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>30 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>slashing damage</em></strong> plus <strong>10 (3d6) <em>fire damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 20 Strength</strong> saving throw or be pulled up to 25 feet toward the balor.</p>",
+          "chat": "<p>The Balor attacks with its Whip. The target must make a <strong>Strength</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1818,10 +1818,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676903,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!uZ8NrRenwYZ4qNf6.1oGgJQB1ItqyKoZ5"
     }

--- a/packs/_source/monsters/fiend/barbed-devil.json
+++ b/packs/_source/monsters/fiend/barbed-devil.json
@@ -1011,8 +1011,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee Weapon Attack: +6 to hit, reach 5 ft ., one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p></section>\n<p>The Barbed Devil attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +6 to hit, reach 5 ft ., one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Barbed Devil attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1201,10 +1201,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676857,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!sLdpiuaZF8lujJQy.pya9jchjLkwMedEr"
     },
@@ -1215,8 +1215,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>.</p></section>\n<p>The Barbed Devil attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Barbed Devil attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1403,10 +1403,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676857,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!sLdpiuaZF8lujJQy.mlWql992zSZ6hvl6"
     },
@@ -1417,8 +1417,8 @@
       "img": "icons/magic/fire/blast-jet-stream-splash.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Ranged Spell Attack:</em><strong>+5 to hit,</strong>, <strong>150 ft.,</strong> one target. Hit: <strong>10 (3d6) <em>fire damage</em></strong>.</p>\n<p>If the target is a flammable object that isn't being worn or carried, it also catches fire.</p>\n</section>\n<p>The Barbed Devil attacks with its Hurl Flame. If the target is a flammable object that isn't being worn or carried, it also catches fire.</p>",
-          "chat": ""
+          "value": "<p><em>Ranged Spell Attack:</em><strong>+5 to hit,</strong>, <strong>150 ft.,</strong> one target. Hit: <strong>10 (3d6) <em>fire damage</em></strong>.</p><p>If the target is a flammable object that isn't being worn or carried, it also catches fire.</p>",
+          "chat": "<p>The Barbed Devil attacks with its Hurl Flame. If the target is a flammable object that isn't being worn or carried, it also catches fire.</p>"
         },
         "source": {
           "custom": "",
@@ -1607,10 +1607,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676857,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!sLdpiuaZF8lujJQy.syCZDlwGoyT1GvJv"
     }

--- a/packs/_source/monsters/fiend/bearded-devil.json
+++ b/packs/_source/monsters/fiend/bearded-devil.json
@@ -803,8 +803,8 @@
       "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>\n<p>The target must succeed on a  <strong>DC 12 Constitution</strong> saving throw or be poisoned for 1 minute. While poisoned in this way, the target can't regain hit points. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The Bearded Devil attacks with its Beard. The target must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 12 Constitution</strong> saving throw or be poisoned for 1 minute. While poisoned in this way, the target can't regain hit points. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The Bearded Devil attacks with its Beard. The target must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1080,10 +1080,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676649,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!9ggQBmAKXraOtz7S.ndwCjJFBLTujojCl"
     },
@@ -1094,8 +1094,8 @@
       "img": "icons/weapons/polearms/halberd-crescent-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>slashing damage</em></strong>.</p>\n<p>If the target is a creature other than an undead or a construct, it must succeed on a  <strong>DC 12 Constitution</strong> saving throw or lose 5 (1d10) hit points at the start of each of its turns due to an infernal wound.</p>\n<p>Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 5 (1d10). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing.</p>\n</section>\n<p>The Bearded Devil attacks with its Glaive. If the target is a creature other than an undead or a construct, it must make a <strong>Constitution</strong> saving throw. Any creature can take an action to stanch the wound with a successful Wisdom (Medicine) check.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>slashing damage</em></strong>.</p><p>If the target is a creature other than an undead or a construct, it must succeed on a  <strong>DC 12 Constitution</strong> saving throw or lose 5 (1d10) hit points at the start of each of its turns due to an infernal wound.</p><p>Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 5 (1d10). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing.</p>",
+          "chat": "<p>The Bearded Devil attacks with its Glaive. If the target is a creature other than an undead or a construct, it must make a <strong>Constitution</strong> saving throw. Any creature can take an action to stanch the wound with a successful Wisdom (Medicine) check.</p>"
         },
         "source": {
           "custom": "",
@@ -1445,10 +1445,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676649,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!9ggQBmAKXraOtz7S.RgZ4lGrNf9AaIyrG"
     },

--- a/packs/_source/monsters/fiend/bone-devil.json
+++ b/packs/_source/monsters/fiend/bone-devil.json
@@ -630,8 +630,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>8 (1d8 + 4) <em>slashing damage</em></strong>.</p></section>\n<p>The Bone Devil attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>8 (1d8 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Bone Devil attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -821,10 +821,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676651,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AnseLn7HwuP97grf.KjxsSFx9xv2HLtMX"
     },
@@ -835,8 +835,8 @@
       "img": "icons/creatures/abilities/fang-tooth-venomous.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>piercing damage</em></strong> plus <strong>17 (5d6) <em>poison damage</em></strong>.</p>\n<p>The target must succeed on a  <strong>DC 14 Constitution</strong> saving throw or become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success .</p>\n</section>\n<p>The Bone Devil attacks with its Sting. the target must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success .</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>piercing damage</em></strong> plus <strong>17 (5d6) <em>poison damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 14 Constitution</strong> saving throw or become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success .</p>",
+          "chat": "<p>The Bone Devil attacks with its Sting. the target must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success .</p>"
         },
         "source": {
           "custom": "",
@@ -1133,10 +1133,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676651,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!AnseLn7HwuP97grf.iFHGL8wlqBtZAdHr"
     },

--- a/packs/_source/monsters/fiend/chain-devil.json
+++ b/packs/_source/monsters/fiend/chain-devil.json
@@ -630,8 +630,8 @@
       "img": "icons/tools/fasteners/chain-steel-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>\n<p>The target is grappled (escape DC 14) if the devil isn't already grappling a creature. Until this grapple ends, the target is restrained and takes <strong>7 (2d6) <em>piercing damage</em></strong> at the start of each of its turns.</p>\n</section>\n<p>The Chain Devil attacks with its Chain. The target is grappled if the devil isn't already grappling a creature. Until this grapple ends, the target is restrained.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p><p>The target is grappled (escape DC 14) if the devil isn't already grappling a creature. Until this grapple ends, the target is restrained and takes <strong>7 (2d6) <em>piercing damage</em></strong> at the start of each of its turns.</p>",
+          "chat": "<p>The Chain Devil attacks with its Chain. The target is grappled if the devil isn't already grappling a creature. Until this grapple ends, the target is restrained.</p>"
         },
         "source": {
           "custom": "",
@@ -886,10 +886,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676721,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KtM6IV9I5l1MWUDk.9SWi4zPVGsMD5l2Y"
     },
@@ -900,8 +900,8 @@
       "img": "icons/magic/life/heart-shadow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>When a creature the devil can see starts its turn within 30 feet of the devil, the devil can create the illusion that it looks like one of the creature's departed loved ones or bitter enemies. If the creature can see the devil, it must succeed on a <strong> DC 14 Wisdom saving throw</strong> or be Frightened until the end of its turn.</p>\n</section>\n<p>The devil can create the illusion that it looks like one of the creature's departed loved ones or bitter enemies. make a <strong>Wisdom</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>When a creature the devil can see starts its turn within 30 feet of the devil, the devil can create the illusion that it looks like one of the creature's departed loved ones or bitter enemies. If the creature can see the devil, it must succeed on a <strong> DC 14 Wisdom saving throw</strong> or be Frightened until the end of its turn.</p>",
+          "chat": "<p>The devil can create the illusion that it looks like one of the creature's departed loved ones or bitter enemies. make a <strong>Wisdom</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1083,10 +1083,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676721,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KtM6IV9I5l1MWUDk.c8fbl1Kc5O3GNTus"
     },
@@ -1336,8 +1336,8 @@
       "img": "icons/equipment/neck/choker-chain-thin-gold.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Up to four chains the devil can see within 60 feet of it magically sprout razor-edged barbs and animate under the devil's control, provided that the chains aren't being worn or carried.</p>\n<p>Each animated chain is an object with AC 20, 20 hit points, resistance to <em>piercing damage</em>, and immunity to psychic and thunder damage. When the devil uses Multiattack on its turn, it can use each animated chain to make one additional chain attack. An animated chain can grapple one creature of its own but can't make attacks while grappling. An animated chain reverts to its inanimate state if reduced to 0 hit points or if the devil is incapacitated or dies.</p>\n</section>\n<p>Up to four chains the devil can see within 60 feet of it magically sprout razor-edged barbs and animate under the devil's control, provided that the chains aren't being worn or carried.</p>",
-          "chat": ""
+          "value": "<p>Up to four chains the devil can see within 60 feet of it magically sprout razor-edged barbs and animate under the devil's control, provided that the chains aren't being worn or carried.</p><p>Each animated chain is an object with AC 20, 20 hit points, resistance to <em>piercing damage</em>, and immunity to psychic and thunder damage. When the devil uses Multiattack on its turn, it can use each animated chain to make one additional chain attack. An animated chain can grapple one creature of its own but can't make attacks while grappling. An animated chain reverts to its inanimate state if reduced to 0 hit points or if the devil is incapacitated or dies.</p>",
+          "chat": "<p>Up to four chains the devil can see within 60 feet of it magically sprout razor-edged barbs and animate under the devil's control, provided that the chains aren't being worn or carried.</p>"
         },
         "source": {
           "custom": "",
@@ -1463,10 +1463,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676721,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KtM6IV9I5l1MWUDk.B9KJpn20n0tG4xit"
     }

--- a/packs/_source/monsters/fiend/dretch.json
+++ b/packs/_source/monsters/fiend/dretch.json
@@ -750,8 +750,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d6) <em>piercing damage</em></strong>.</p></section>\n<p>The Dretch attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Dretch attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -942,10 +942,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676823,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kz2fW9xb5CcvXLX4.2So9DIMKKgeGHVru"
     },
@@ -956,8 +956,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (2d4) <em>slashing damage</em></strong>.</p></section>\n<p>The Dretch attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (2d4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Dretch attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1144,10 +1144,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676823,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kz2fW9xb5CcvXLX4.5fa9Rdzy2YYpkAgS"
     },
@@ -1158,8 +1158,8 @@
       "img": "icons/magic/acid/projectile-glowing-bubbles.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>A 10-foot radius of disgusting green gas extends out from the dretch. The gas spreads around corners, and its area is lightly obscured. It lasts for 1 minute or until a strong wind disperses it.</p>\n<p>Any creature that starts its turn in that area must succeed on a  <strong>DC 11 Constitution</strong> saving throw or be poisoned until the start of its next turn. While poisoned in this way, the target can take either an action or a bonus action on its turn, not both, and can't take reactions. 1 use per day.</p>\n</section>\n<p>A 10-foot radius of disgusting green gas extends out from the dretch. The gas spreads around corners, and its area is lightly obscured. Any creature that starts its turn in that area must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>A 10-foot radius of disgusting green gas extends out from the dretch. The gas spreads around corners, and its area is lightly obscured. It lasts for 1 minute or until a strong wind disperses it.</p><p>Any creature that starts its turn in that area must succeed on a  <strong>DC 11 Constitution</strong> saving throw or be poisoned until the start of its next turn. While poisoned in this way, the target can take either an action or a bonus action on its turn, not both, and can't take reactions. 1 use per day.</p>",
+          "chat": "<p>A 10-foot radius of disgusting green gas extends out from the dretch. The gas spreads around corners, and its area is lightly obscured. Any creature that starts its turn in that area must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1289,10 +1289,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676823,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kz2fW9xb5CcvXLX4.JVbj7KABKYi3Z8U3"
     }

--- a/packs/_source/monsters/fiend/erinyes.json
+++ b/packs/_source/monsters/fiend/erinyes.json
@@ -630,8 +630,8 @@
       "img": "icons/weapons/axes/axe-battle-eyes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The erinyes's weapon attacks are magical and deal an extra <strong>13 (3d8) <em>poison damage</em></strong> on a hit (included in the attacks).</p>\n</section>\n<p>The erinyes's weapon attacks are magical and deal extra <em>poison damage</em> on a hit (included in the attacks).</p>",
-          "chat": ""
+          "value": "<p>The erinyes's weapon attacks are magical and deal an extra <strong>13 (3d8) <em>poison damage</em></strong> on a hit (included in the attacks).</p>",
+          "chat": "<p>The erinyes's weapon attacks are magical and deal extra <em>poison damage</em> on a hit (included in the attacks).</p>"
         },
         "source": {
           "custom": "",
@@ -675,10 +675,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676883,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3o2rQBqpzjIHmrBW.BeB04w7ftFRDaMQ6"
     },
@@ -689,8 +689,8 @@
       "img": "icons/weapons/swords/greatsword-crossguard-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d8 + 4) <em>slashing damage</em></strong>, or <strong>9 (1d10 + 4) <em>slashing damage</em></strong> if used with two hands, plus <strong>13 (3d8) <em>poison damage</em></strong>.</p><p></p></section><p>The Erinyes attacks with its Longsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d8 + 4) <em>slashing damage</em></strong>, or <strong>9 (1d10 + 4) <em>slashing damage</em></strong> if used with two hands, plus <strong>13 (3d8) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Erinyes attacks with its Longsword.</p>"
         },
         "source": {
           "custom": "",
@@ -901,10 +901,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676883,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3o2rQBqpzjIHmrBW.dvoOA7jzBnq2Lxza"
     },
@@ -915,8 +915,8 @@
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The erinyes adds 4 to its <strong>AC</strong> against one melee Attack that would hit it. To do so, the erinyes must see the attacker and be wielding a melee weapon.</p></section><p>The erinyes adds 4 to its <strong>AC</strong> against one melee Attack that would hit it.</p>",
-          "chat": ""
+          "value": "<p>The erinyes adds 4 to its <strong>AC</strong> against one melee Attack that would hit it. To do so, the erinyes must see the attacker and be wielding a melee weapon.</p>",
+          "chat": "<p>The erinyes adds 4 to its <strong>AC</strong> against one melee Attack that would hit it.</p>"
         },
         "source": {
           "custom": "",
@@ -1026,10 +1026,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676883,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3o2rQBqpzjIHmrBW.W7sEr3m8MBrzYq2v"
     },
@@ -1192,8 +1192,8 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong> plus <strong>13 (3d8) <em>poison damage</em></strong>.</p>\n<p>The target must succeed on a  <strong>DC 14 Constitution</strong> saving throw or be poisoned. The poison lasts until it is removed by the lesser restoration spell or similar magic.</p>\n</section>\n<p>The Erinyes attacks with its Longbow. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong> plus <strong>13 (3d8) <em>poison damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 14 Constitution</strong> saving throw or be poisoned. The poison lasts until it is removed by the lesser restoration spell or similar magic.</p>",
+          "chat": "<p>The Erinyes attacks with its Longbow. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1495,10 +1495,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676883,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3o2rQBqpzjIHmrBW.CElneYmOXIzyfv2a"
     },

--- a/packs/_source/monsters/fiend/glabrezu.json
+++ b/packs/_source/monsters/fiend/glabrezu.json
@@ -873,8 +873,8 @@
       "img": "icons/commodities/claws/claw-pincer-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d10 + 5) <em>bludgeoning damage</em></strong>. </p><p>If the target is a Medium or smaller creature, it is grappled (escape DC 15). The glabrezu has two pincers, each of which can grapple only one target.</p></section><p>The Glabrezu attacks with its Pincer. If the target is a Medium or smaller creature, it is grappled.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>16 (2d10 + 5) <em>bludgeoning damage</em></strong>. </p><p>If the target is a Medium or smaller creature, it is grappled (escape DC 15). The glabrezu has two pincers, each of which can grapple only one target.</p>",
+          "chat": "<p>The Glabrezu attacks with its Pincer. If the target is a Medium or smaller creature, it is grappled.</p>"
         },
         "source": {
           "custom": "",
@@ -1063,10 +1063,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676674,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!OGPHF4sCVOAi87TU.pEUD99mri5iDNGH7"
     },
@@ -1077,8 +1077,8 @@
       "img": "icons/magic/fire/flame-burning-fist-strike.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Glabrezu attacks with its Fist.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Glabrezu attacks with its Fist.</p>"
         },
         "source": {
           "custom": "",
@@ -1265,10 +1265,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676674,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!OGPHF4sCVOAi87TU.VGFZM2Zvp0NT5Yb9"
     },

--- a/packs/_source/monsters/fiend/hell-hound.json
+++ b/packs/_source/monsters/fiend/hell-hound.json
@@ -731,8 +731,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>fire damage</em></strong>.</p><p></p></section><p>The Hell Hound attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Hell Hound attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -941,10 +941,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676593,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!iSCL4Q82ivnYelzc.AnHeKid7zbyPKJg9"
     },
@@ -955,8 +955,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The hound exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 12 Dexterity</strong> saving throw, taking <strong>21 (6d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The hound exhales fire in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The hound exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 12 Dexterity</strong> saving throw, taking <strong>21 (6d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The hound exhales fire in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1105,10 +1105,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676593,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!iSCL4Q82ivnYelzc.gijcyepmnWeRu4HV"
     }

--- a/packs/_source/monsters/fiend/hezrou.json
+++ b/packs/_source/monsters/fiend/hezrou.json
@@ -690,8 +690,8 @@
       "img": "icons/magic/acid/projectile-glowing-bubbles.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Any creature that starts its turn <strong>within 10 feet</strong> of the hezrou must succeed on a <strong>DC 14 Constitution saving throw</strong> or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the hezrou's stench for 24 hours.</p></section><p>Any creature that starts its turn <strong>within 10 feet</strong> of the hezrou must succeed on a Constitution saving throw.</p>",
-          "chat": ""
+          "value": "<p>Any creature that starts its turn <strong>within 10 feet</strong> of the hezrou must succeed on a <strong>DC 14 Constitution saving throw</strong> or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the hezrou's stench for 24 hours.</p>",
+          "chat": "<p>Any creature that starts its turn <strong>within 10 feet</strong> of the hezrou must succeed on a Constitution saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -806,10 +806,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676806,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ec3lhsNv1ZRu7Qaq.0EcUwWcmWzFuiJyg"
     },
@@ -945,8 +945,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Hezrou attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Hezrou attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1137,10 +1137,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676806,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ec3lhsNv1ZRu7Qaq.UNNl5XqsXZuKOm69"
     },
@@ -1151,8 +1151,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Hezrou attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Hezrou attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1339,10 +1339,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676806,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ec3lhsNv1ZRu7Qaq.HEQqPUsmmNs178Mj"
     }

--- a/packs/_source/monsters/fiend/horned-devil.json
+++ b/packs/_source/monsters/fiend/horned-devil.json
@@ -630,8 +630,8 @@
       "img": "icons/tools/cooking/fork-steel-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>piercing damage</em></strong>.</p><p></p></section><p>The Horned Devil attacks with its Fork.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d8 + 6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Horned Devil attacks with its Fork.</p>"
         },
         "source": {
           "custom": "",
@@ -821,10 +821,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676850,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MADGs8pWMVyyFOf1.g8r9DZeHyfNzerHP"
     },
@@ -949,8 +949,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>10 (1d8 + 6) <em>piercing damage</em></strong>. </p><p>If the target is a creature other than an undead or a construct, it must succeed on a  <strong>DC 17 Constitution</strong> saving throw or lose 10 (3d6) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 10 (3d6). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing.</p></section><p>The Horned Devil attacks with its Tail. If the target is a creature other than an undead or a construct, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>10 (1d8 + 6) <em>piercing damage</em></strong>. </p><p>If the target is a creature other than an undead or a construct, it must succeed on a  <strong>DC 17 Constitution</strong> saving throw or lose 10 (3d6) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 10 (3d6). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing.</p>",
+          "chat": "<p>The Horned Devil attacks with its Tail. If the target is a creature other than an undead or a construct, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1294,10 +1294,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676850,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MADGs8pWMVyyFOf1.VpvOoT7mbR0XNZiL"
     },
@@ -1433,8 +1433,8 @@
       "img": "icons/magic/fire/blast-jet-stream-splash.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Ranged Spell Attack:</em><strong>+7 to hit,</strong>, <strong>150 ft.,</strong> one target. Hit: <strong>14 (4d6) <em>fire damage</em></strong>.</p>\n<p>If the target is a flammable object that isn't being worn or carried, it also catches fire.</p>\n</section>\n<p>The Horned Devil attacks with its Hurl Flame. If the target is a flammable object that isn't being worn or carried, it also catches fire.</p>",
-          "chat": ""
+          "value": "<p><em>Ranged Spell Attack:</em><strong>+7 to hit,</strong>, <strong>150 ft.,</strong> one target. Hit: <strong>14 (4d6) <em>fire damage</em></strong>.</p><p>If the target is a flammable object that isn't being worn or carried, it also catches fire.</p>",
+          "chat": "<p>The Horned Devil attacks with its Hurl Flame. If the target is a flammable object that isn't being worn or carried, it also catches fire.</p>"
         },
         "source": {
           "custom": "",
@@ -1621,10 +1621,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676850,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MADGs8pWMVyyFOf1.GFYzWSyeuW9O4a0I"
     }

--- a/packs/_source/monsters/fiend/ice-devil.json
+++ b/packs/_source/monsters/fiend/ice-devil.json
@@ -630,8 +630,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>piercing damage</em></strong> plus <strong>10 (3d6) <em>cold damage</em></strong>.</p><p></p></section><p>The Ice Devil attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>piercing damage</em></strong> plus <strong>10 (3d6) <em>cold damage</em></strong>.</p>",
+          "chat": "<p>The Ice Devil attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -840,10 +840,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676909,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1zzRQps9jZdLZGqI.DV4KS0OE541vGOtI"
     },
@@ -968,8 +968,8 @@
       "img": "icons/magic/water/barrier-ice-crystal-wall-jagged-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The devil magically forms an opaque wall of ice on a solid surface it can see within 60 feet of it. The wall is 1 foot thick and up to 30 feet long and 10 feet high, or it's a hemispherical dome up to 20 feet in diameter.</p>\n<p>When the wall appears, each creature in its space is pushed out of it by the shortest route. The creature chooses which side of the wall to end up on, unless the creature is incapacitated. The creature then makes a  <strong>DC 17 Dexterity</strong> saving throw, taking <strong>35 (10d6) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n<p>The wall lasts for 1 minute or until the devil is incapacitated or dies. The wall can be damaged and breached; each 10-foot section has AC 5, 30 hit points, vulnerability to <em>fire damage</em>, and immunity to acid, cold, necrotic, poison, and <em>psychic damage</em>. If a section is destroyed, it leaves behind a sheet of frigid air in the space the wall occupied. Whenever a creature finishes moving through the frigid air on a turn, willingly or otherwise, the creature must make a  <strong>DC 17 Constitution</strong> saving throw, taking <strong>17 (5d6) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one. The frigid air dissipates when the rest of the wall vanishes.</p>\n</section>\n<p>The devil magically forms an opaque wall of ice on a solid surface it can see within 60 feet of it. The wall is 1 foot thick and up to 30 feet long and 10 feet high, or it's a hemispherical dome up to 20 feet in diameter.When the wall appears, each creature in its space is pushed out of it by the shortest route. The creature chooses which side of the wall to end up on, unless the creature is incapacitated. The creature then makes a Dexterity saving throw.</p>\n<p>The wall can be damaged and breached. If a section is destroyed, it leaves behind a sheet of frigid air in the space the wall occupied. Whenever a creature finishes moving through the frigid air on a turn, willingly or otherwise, the creature must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The devil magically forms an opaque wall of ice on a solid surface it can see within 60 feet of it. The wall is 1 foot thick and up to 30 feet long and 10 feet high, or it's a hemispherical dome up to 20 feet in diameter.</p><p>When the wall appears, each creature in its space is pushed out of it by the shortest route. The creature chooses which side of the wall to end up on, unless the creature is incapacitated. The creature then makes a  <strong>DC 17 Dexterity</strong> saving throw, taking <strong>35 (10d6) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p>The wall lasts for 1 minute or until the devil is incapacitated or dies. The wall can be damaged and breached; each 10-foot section has AC 5, 30 hit points, vulnerability to <em>fire damage</em>, and immunity to acid, cold, necrotic, poison, and <em>psychic damage</em>. If a section is destroyed, it leaves behind a sheet of frigid air in the space the wall occupied. Whenever a creature finishes moving through the frigid air on a turn, willingly or otherwise, the creature must make a  <strong>DC 17 Constitution</strong> saving throw, taking <strong>17 (5d6) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one. The frigid air dissipates when the rest of the wall vanishes.</p>",
+          "chat": "<p>The devil magically forms an opaque wall of ice on a solid surface it can see within 60 feet of it. The wall is 1 foot thick and up to 30 feet long and 10 feet high, or it's a hemispherical dome up to 20 feet in diameter.When the wall appears, each creature in its space is pushed out of it by the shortest route. The creature chooses which side of the wall to end up on, unless the creature is incapacitated. The creature then makes a Dexterity saving throw.</p>\n<p>The wall can be damaged and breached. If a section is destroyed, it leaves behind a sheet of frigid air in the space the wall occupied. Whenever a creature finishes moving through the frigid air on a turn, willingly or otherwise, the creature must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1266,10 +1266,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676909,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1zzRQps9jZdLZGqI.nCTze3rZpWcTeuYQ"
     },
@@ -1280,8 +1280,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>bludgeoning damage</em></strong> plus <strong>10 (3d6) <em>cold damage</em></strong>.</p></section>\n<p>The Ice Devil attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>bludgeoning damage</em></strong> plus <strong>10 (3d6) <em>cold damage</em></strong>.</p>",
+          "chat": "<p>The Ice Devil attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -1488,10 +1488,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676909,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1zzRQps9jZdLZGqI.AQ551xglVn90BdwU"
     },
@@ -1502,8 +1502,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d4 + 5) <em>slashing damage</em></strong> plus <strong>10 (3d6) <em>cold damage</em></strong>.</p></section>\n<p>The Ice Devil attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d4 + 5) <em>slashing damage</em></strong> plus <strong>10 (3d6) <em>cold damage</em></strong>.</p>",
+          "chat": "<p>The Ice Devil attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1710,10 +1710,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676909,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1zzRQps9jZdLZGqI.E6iXljYXLdQyfk1l"
     },

--- a/packs/_source/monsters/fiend/imp.json
+++ b/packs/_source/monsters/fiend/imp.json
@@ -870,8 +870,8 @@
       "img": "icons/creatures/abilities/fang-tooth-venomous.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee Weapon Attack: +5 to hit, reach 5 ft ., one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p>\n<p>The target must make on a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>10 (3d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The Imp attacks with its Sting. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +5 to hit, reach 5 ft ., one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p><p>The target must make on a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>10 (3d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Imp attacks with its Sting. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1213,10 +1213,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676802,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!dLQiESMsfsXijD5c.64Swhse7QnbiLAbi"
     },
@@ -1227,8 +1227,8 @@
       "img": "icons/creatures/webs/webthin-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The imp magically turns invisible until it attacks, or until its concentration ends (as if concentrating on a spell). Any equipment the imp wears or carries is invisible with it.</p>\n</section>\n<p>The imp magically turns invisible. Any equipment the imp wears or carries is invisible with it.</p>",
-          "chat": ""
+          "value": "<p>The imp magically turns invisible until it attacks, or until its concentration ends (as if concentrating on a spell). Any equipment the imp wears or carries is invisible with it.</p>",
+          "chat": "<p>The imp magically turns invisible. Any equipment the imp wears or carries is invisible with it.</p>"
         },
         "source": {
           "custom": "",
@@ -1338,10 +1338,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676802,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!dLQiESMsfsXijD5c.mMdtSlNy6FuPju7p"
     },
@@ -1352,8 +1352,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>, and the target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>10 (3d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The Imp attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>, and the target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>10 (3d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Imp attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1695,10 +1695,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676802,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!dLQiESMsfsXijD5c.RZpYFJGNqA7L1bj1"
     }

--- a/packs/_source/monsters/fiend/lemure.json
+++ b/packs/_source/monsters/fiend/lemure.json
@@ -682,8 +682,8 @@
       "img": "icons/skills/wounds/anatomy-organ-heart-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>A lemure that dies in the Nine Hells sometimes comes back to comes back to life with all its<strong> hit points</strong> in 1d10 days unless it is killed by a good-aligned creature with a bless spell cast on that creature or its remains are sprinkled with holy water.</p>\n</section>\n<p>A lemure that dies in the Nine Hells sometimes comes back to life.</p>",
-          "chat": ""
+          "value": "<p>A lemure that dies in the Nine Hells sometimes comes back to comes back to life with all its<strong> hit points</strong> in 1d10 days unless it is killed by a good-aligned creature with a bless spell cast on that creature or its remains are sprinkled with holy water.</p>",
+          "chat": "<p>A lemure that dies in the Nine Hells sometimes comes back to life.</p>"
         },
         "source": {
           "custom": "",
@@ -793,10 +793,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676614,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!tubcO7kaQ4w0soxS.7gfe5c1qGIvai12V"
     },
@@ -807,8 +807,8 @@
       "img": "icons/magic/fire/flame-burning-fist-strike.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Lemure attacks with its Fist.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Lemure attacks with its Fist.</p>"
         },
         "source": {
           "custom": "",
@@ -995,10 +995,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676614,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!tubcO7kaQ4w0soxS.TypCj0S846TqsHzI"
     }

--- a/packs/_source/monsters/fiend/marilith.json
+++ b/packs/_source/monsters/fiend/marilith.json
@@ -932,8 +932,8 @@
       "img": "icons/weapons/swords/greatsword-crossguard-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Marilith attacks with its Longsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Marilith attacks with its Longsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1124,10 +1124,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676892,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!egsSDYbqoLCelb0J.VzPNwzlwJ7knJ9MC"
     },
@@ -1138,8 +1138,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>15 (2d10 + 4) <em>bludgeoning damage</em></strong>. </p><p>If the target is Medium or smaller, it is grappled (escape DC 19). Until this grapple ends, the target is restrained, the marilith can automatically hit the target with its tail, and the marilith can't make tail attacks against other targets.</p></section><p>The Marilith attacks with its Tail. If the target is Medium or smaller, it is grappled. Until this grapple ends, the target is restrained, the marilith can automatically hit the target with its tail, and the marilith can't make tail attacks against other targets.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>15 (2d10 + 4) <em>bludgeoning damage</em></strong>. </p><p>If the target is Medium or smaller, it is grappled (escape DC 19). Until this grapple ends, the target is restrained, the marilith can automatically hit the target with its tail, and the marilith can't make tail attacks against other targets.</p>",
+          "chat": "<p>The Marilith attacks with its Tail. If the target is Medium or smaller, it is grappled. Until this grapple ends, the target is restrained, the marilith can automatically hit the target with its tail, and the marilith can't make tail attacks against other targets.</p>"
         },
         "source": {
           "custom": "",
@@ -1328,10 +1328,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676892,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!egsSDYbqoLCelb0J.BoIambnHLbZXr85T"
     },
@@ -1342,8 +1342,8 @@
       "img": "icons/magic/symbols/runes-star-pentagon-magenta.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p></p><p></p></section><p>The marilith magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<section class=\"secret\"><p></p></section><p>The marilith magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see.</p>"
         },
         "source": {
           "custom": "",
@@ -1454,10 +1454,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676892,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!egsSDYbqoLCelb0J.EMJe4NIzUdNIQj9S"
     },
@@ -1468,8 +1468,8 @@
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The marlith adds 5 to its <strong>AC</strong> against one melee Attack that would hit it. To do so, the marlith must see the attacker and be wielding a melee weapon.</p></section><p>The marlith adds 5 to its <strong>AC</strong> against one melee Attack that would hit it.</p>",
-          "chat": ""
+          "value": "<p>The marlith adds 5 to its <strong>AC</strong> against one melee Attack that would hit it. To do so, the marlith must see the attacker and be wielding a melee weapon.</p>",
+          "chat": "<p>The marlith adds 5 to its <strong>AC</strong> against one melee Attack that would hit it.</p>"
         },
         "source": {
           "custom": "",
@@ -1579,10 +1579,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676892,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!egsSDYbqoLCelb0J.lS2o3QOZ2lxKyi0L"
     }

--- a/packs/_source/monsters/fiend/nalfeshnee.json
+++ b/packs/_source/monsters/fiend/nalfeshnee.json
@@ -814,8 +814,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>32 (5d10 + 5) <em>piercing damage</em></strong>.</p><p></p></section><p>The Nalfeshnee attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>32 (5d10 + 5) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Nalfeshnee attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1006,10 +1006,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676901,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rUg5JMnKNnZNBAq9.524dkWbpWUJKFaj2"
     },
@@ -1020,8 +1020,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (3d6 + 5) <em>slashing damage</em></strong>.</p><p></p></section><p>The Nalfeshnee attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (3d6 + 5) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Nalfeshnee attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1210,10 +1210,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676901,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rUg5JMnKNnZNBAq9.xhKo80CbyA57Kl1l"
     },
@@ -1224,8 +1224,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The nalfeshnee magically emits scintillating, multicolored light. Each creature within 15 feet of the nalfeshnee that can see the light must succeed on a  <strong>DC 15 Wisdom</strong> saving throw or be frightened for 1 minute. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the nalfeshnee's Horror Nimbus for the next 24 hours.</p></section><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the nalfeshnee's Horror Nimbus for the next 24 hours.</p>",
-          "chat": ""
+          "value": "<p>The nalfeshnee magically emits scintillating, multicolored light. Each creature within 15 feet of the nalfeshnee that can see the light must succeed on a  <strong>DC 15 Wisdom</strong> saving throw or be frightened for 1 minute. </p><p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the nalfeshnee's Horror Nimbus for the next 24 hours.</p>",
+          "chat": "<p>A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the nalfeshnee's Horror Nimbus for the next 24 hours.</p>"
         },
         "source": {
           "custom": "",
@@ -1356,10 +1356,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676901,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rUg5JMnKNnZNBAq9.RFPDYIhkmBW2B47S"
     },
@@ -1370,8 +1370,8 @@
       "img": "icons/magic/symbols/runes-star-pentagon-magenta.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p></p><p></p></section><p>The nalfeshnee magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<section class=\"secret\"><p></p></section><p>The nalfeshnee magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see.</p>"
         },
         "source": {
           "custom": "",
@@ -1482,10 +1482,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676901,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rUg5JMnKNnZNBAq9.zK5E9yD6BR0fZRBo"
     }

--- a/packs/_source/monsters/fiend/night-hag.json
+++ b/packs/_source/monsters/fiend/night-hag.json
@@ -985,8 +985,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Night Hag attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Night Hag attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1173,10 +1173,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676758,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!xvh2UOKv1bh03Gih.Um3cK4i4ZQSTqodb"
     },
@@ -1312,8 +1312,8 @@
       "img": "icons/magic/unholy/barrier-shield-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p></p><p></p></section><p>The hag magically enters the Ethereal Plane from the Material Plane, or vice versa. To do so, the hag must have a heartstone in her possession.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<section class=\"secret\"><p></p></section><p>The hag magically enters the Ethereal Plane from the Material Plane, or vice versa. To do so, the hag must have a heartstone in her possession.</p>"
         },
         "source": {
           "custom": "",
@@ -1423,10 +1423,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676758,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!xvh2UOKv1bh03Gih.0blKOND2AnsMsZa6"
     },
@@ -1437,8 +1437,8 @@
       "img": "icons/commodities/tech/smoke-bomb-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. A protection from evil and good spell cast on the target prevents this contact, as does a magic circle. </p><p>As long as the contact persists, the target has dreadful visions. If these visions last for at least 1 hour, the target gains no benefit from its rest, and its hit point maximum is reduced by 5 (1d10). If this effect reduces the target's hit point maximum to 0, the target dies, and if the target was evil, its soul is trapped in the hag's soul bag. The reduction to the target's hit point maximum lasts until removed by the greater restoration spell or similar magic.</p></section><p>While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. As long as the contact persists, the target has dreadful visions.</p>",
-          "chat": ""
+          "value": "<p>While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. A protection from evil and good spell cast on the target prevents this contact, as does a magic circle. </p><p>As long as the contact persists, the target has dreadful visions. If these visions last for at least 1 hour, the target gains no benefit from its rest, and its hit point maximum is reduced by 5 (1d10). If this effect reduces the target's hit point maximum to 0, the target dies, and if the target was evil, its soul is trapped in the hag's soul bag. The reduction to the target's hit point maximum lasts until removed by the greater restoration spell or similar magic.</p>",
+          "chat": "<p>While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. As long as the contact persists, the target has dreadful visions.</p>"
         },
         "source": {
           "custom": "",
@@ -1563,10 +1563,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676758,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!xvh2UOKv1bh03Gih.tYZggJHgAbixP5rs"
     },

--- a/packs/_source/monsters/fiend/nightmare.json
+++ b/packs/_source/monsters/fiend/nightmare.json
@@ -735,8 +735,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong> plus <strong>7 (2d6) <em>fire damage</em></strong>.</p><p></p></section><p>The Nightmare attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong> plus <strong>7 (2d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Nightmare attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -945,10 +945,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676527,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5SgVGhQBswgWRwsF.lzv29dS3tAUUuVlI"
     },
@@ -959,8 +959,8 @@
       "img": "icons/magic/lightning/orb-ball-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p></p><p></p></section><p>The nightmare and up to three willing creatures within 5 feet of it magically enter the Ethereal Plane from the Material Plane, or vice versa.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<section class=\"secret\"><p></p></section><p>The nightmare and up to three willing creatures within 5 feet of it magically enter the Ethereal Plane from the Material Plane, or vice versa.</p>"
         },
         "source": {
           "custom": "",
@@ -1070,10 +1070,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676527,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5SgVGhQBswgWRwsF.XtK73VCT1s8abvjs"
     }

--- a/packs/_source/monsters/fiend/pit-fiend.json
+++ b/packs/_source/monsters/fiend/pit-fiend.json
@@ -630,8 +630,8 @@
       "img": "icons/magic/water/elemental-water.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Any creature hostile to the pit fiend that starts its turn <strong>within 20 feet</strong> of the pit fiend must make a <strong>DC 21 Wisdom saving throw</strong>, unless the pit fiend is incapacitated. On a failed save, the creature is frightened until the start of its next turn. If a creature's saving throw is successful, the creature is immune to the pit fiend's Fear Aura for the next 24 hours.</p></section><p>Any creature hostile to the pit fiend that starts its turn <strong>within 20 feet</strong> of the pit fiend must make a <strong>Wisdom</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>Any creature hostile to the pit fiend that starts its turn <strong>within 20 feet</strong> of the pit fiend must make a <strong>DC 21 Wisdom saving throw</strong>, unless the pit fiend is incapacitated. On a failed save, the creature is frightened until the start of its next turn. If a creature's saving throw is successful, the creature is immune to the pit fiend's Fear Aura for the next 24 hours.</p>",
+          "chat": "<p>Any creature hostile to the pit fiend that starts its turn <strong>within 20 feet</strong> of the pit fiend must make a <strong>Wisdom</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -746,10 +746,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676943,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!RCv5y7iWlfNxkinx.wkqjn4bqhPIUUo7k"
     },
@@ -1062,8 +1062,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>22 (4d6 + 8) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 21 Constitution</strong> saving throw or become poisoned. While poisoned in this way, the target can't regain hit points, and it takes <strong>21 (6d6) <em>poison damage</em></strong> at the start of each of its turns. The poisoned target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p></section><p>The Pit Fiend attacks with its Bite. The target must succeed on a  <strong>DC 21 Constitution</strong> saving throw or become poisoned. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>22 (4d6 + 8) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 21 Constitution</strong> saving throw or become poisoned. While poisoned in this way, the target can't regain hit points, and it takes <strong>21 (6d6) <em>poison damage</em></strong> at the start of each of its turns. The poisoned target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The Pit Fiend attacks with its Bite. The target must succeed on a  <strong>DC 21 Constitution</strong> saving throw or become poisoned. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1409,10 +1409,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676943,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!RCv5y7iWlfNxkinx.GjIQl7UOQUtsrj2v"
     },
@@ -1423,8 +1423,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee Weapon Attack: +14 to hit, reach 10 ft. , one target. Hit: <strong>17 (2d8 + 8) <em>slashing damage</em></strong>.</p><p></p></section><p>The Pit Fiend attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +14 to hit, reach 10 ft. , one target. Hit: <strong>17 (2d8 + 8) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Pit Fiend attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1613,10 +1613,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676943,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!RCv5y7iWlfNxkinx.RkuPEGbAXHhxfNWJ"
     },
@@ -1627,8 +1627,8 @@
       "img": "icons/weapons/maces/mace-round-spiked-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>bludgeoning damage</em></strong> plus <strong>21 (6d6) <em>fire damage</em></strong>.</p><p></p></section><p>The Pit Fiend attacks with its Mace.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d6 + 8) <em>bludgeoning damage</em></strong> plus <strong>21 (6d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>The Pit Fiend attacks with its Mace.</p>"
         },
         "source": {
           "custom": "",
@@ -1839,10 +1839,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676943,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!RCv5y7iWlfNxkinx.gpjBebqxqbQA35st"
     },
@@ -1853,8 +1853,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>24 (3d10 + 8) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Pit Fiend attacks with its Tail.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>24 (3d10 + 8) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Pit Fiend attacks with its Tail.</p>"
         },
         "source": {
           "custom": "",
@@ -2043,10 +2043,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676943,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!RCv5y7iWlfNxkinx.Gh1DbMpJiaTlTwWp"
     },

--- a/packs/_source/monsters/fiend/quasit.json
+++ b/packs/_source/monsters/fiend/quasit.json
@@ -631,8 +631,8 @@
       "img": "icons/creatures/webs/webthin-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The quasit magically turns invisible until it attacks or uses Scare, or until its concentration ends (as if concentrating on a spell). Any equipment the quasit wears or carries is invisible with it.</p></section>\n<p>The quasit magically turns invisible. Any equipment the quasit wears or carries is invisible with it.</p>",
-          "chat": ""
+          "value": "<p>The quasit magically turns invisible until it attacks or uses Scare, or until its concentration ends (as if concentrating on a spell). Any equipment the quasit wears or carries is invisible with it.</p>",
+          "chat": "<p>The quasit magically turns invisible. Any equipment the quasit wears or carries is invisible with it.</p>"
         },
         "source": {
           "custom": "",
@@ -742,10 +742,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676874,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bwtkdzavdNHISgp4.MLfZqvhaJjB78YiT"
     },
@@ -756,8 +756,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee Weapon Attack: +4 to hit, reach 5 ft ., one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 10 Constitution</strong> saving throw or take <strong>5 (2d4) <em>poison damage</em></strong> and become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p></section><p>The Quasit attacks with its Claw. The target must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +4 to hit, reach 5 ft ., one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 10 Constitution</strong> saving throw or take <strong>5 (2d4) <em>poison damage</em></strong> and become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The Quasit attacks with its Claw. The target must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1099,10 +1099,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676874,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bwtkdzavdNHISgp4.ae0OI3obJqa4AS7U"
     },
@@ -1113,8 +1113,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The quasit can use its action to <strong>polymorph</strong> into a beast form that resembles a bat (speed <strong>10 ft.</strong> fly <strong>40 ft.</strong>), a centipede (<strong>40 ft.</strong>, climb <strong>40 ft.</strong>), or a toad (<strong>40 ft.</strong>, swim <strong>40 ft.</strong>), or back into its true form . Its statistics are the same in each form, except for the speed changes noted. </p><p>Any equipment it is wearing or carrying isn't transformed . It reverts to its true form if it dies.</p></section><p>The quasit can use its action to <strong>polymorph</strong> into a beast form or back into its true form. </p>",
-          "chat": ""
+          "value": "<p>The quasit can use its action to <strong>polymorph</strong> into a beast form that resembles a bat (speed <strong>10 ft.</strong> fly <strong>40 ft.</strong>), a centipede (<strong>40 ft.</strong>, climb <strong>40 ft.</strong>), or a toad (<strong>40 ft.</strong>, swim <strong>40 ft.</strong>), or back into its true form . Its statistics are the same in each form, except for the speed changes noted. </p><p>Any equipment it is wearing or carrying isn't transformed . It reverts to its true form if it dies.</p>",
+          "chat": "<p>The quasit can use its action to <strong>polymorph</strong> into a beast form or back into its true form. </p>"
         },
         "source": {
           "custom": "",
@@ -1224,10 +1224,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676874,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bwtkdzavdNHISgp4.e8rpvJJVWCN4HU7I"
     },
@@ -1297,8 +1297,8 @@
       "img": "icons/creatures/unholy/demon-winged-cyclops-drooling.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>One creature of the quasit's choice within 20 ft. of it must succeed on a  <strong>DC 10 Wisdom</strong> saving throw or be frightened for 1 minute. </p><p>The target can repeat the saving throw at the end of each of its turns, with disadvantage if the quasit is within line of sight, ending the effect on itself on a success.</p></section><p>One creature of the quasit's choice within 20 ft. of it must make a <strong>Wisdom</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, with disadvantage if the quasit is within line of sight, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p>One creature of the quasit's choice within 20 ft. of it must succeed on a  <strong>DC 10 Wisdom</strong> saving throw or be frightened for 1 minute. </p><p>The target can repeat the saving throw at the end of each of its turns, with disadvantage if the quasit is within line of sight, ending the effect on itself on a success.</p>",
+          "chat": "<p>One creature of the quasit's choice within 20 ft. of it must make a <strong>Wisdom</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, with disadvantage if the quasit is within line of sight, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1505,10 +1505,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676874,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bwtkdzavdNHISgp4.1YhP86rTuRIXKFi2"
     }

--- a/packs/_source/monsters/fiend/rakshasa.json
+++ b/packs/_source/monsters/fiend/rakshasa.json
@@ -867,8 +867,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d6 + 2) <em>slashing damage</em></strong>, and the target is cursed if it is a creature. </p><p>The magical curse takes effect whenever the target takes a short or long rest, filling the target's thoughts with horrible images and dreams. The cursed target gains no benefit from finishing a short or long rest. The curse lasts until it is lifted by a remove curse spell or similar magic.</p></section><p>The Rakshasa attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d6 + 2) <em>slashing damage</em></strong>, and the target is cursed if it is a creature. </p><p>The magical curse takes effect whenever the target takes a short or long rest, filling the target's thoughts with horrible images and dreams. The cursed target gains no benefit from finishing a short or long rest. The curse lasts until it is lifted by a remove curse spell or similar magic.</p>",
+          "chat": "<p>The Rakshasa attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1055,10 +1055,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676508,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qXzMsRTHEodqO8l2.pHBLWUN5VKEjSBh6"
     },

--- a/packs/_source/monsters/fiend/succubus-incubus.json
+++ b/packs/_source/monsters/fiend/succubus-incubus.json
@@ -684,8 +684,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The fiend can use its action to <strong>polymorph</strong> into a Small or Medium humanoid, or back into its true form. Without wings, the fiend loses its flying speed. Other than its size and speed, its statistics are the same in each form.</p><p>Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p></section><p>The fiend can use its action to <strong>polymorph</strong> into a humanoid, or back into its true form.</p>",
-          "chat": ""
+          "value": "<p>The fiend can use its action to <strong>polymorph</strong> into a Small or Medium humanoid, or back into its true form. Without wings, the fiend loses its flying speed. Other than its size and speed, its statistics are the same in each form.</p><p>Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p>",
+          "chat": "<p>The fiend can use its action to <strong>polymorph</strong> into a humanoid, or back into its true form.</p>"
         },
         "source": {
           "custom": "",
@@ -795,10 +795,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676927,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.ZVMVqd01HraMcenH"
     },
@@ -809,8 +809,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p><p></p></section><p>The Succubus/Incubus attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Succubus/Incubus attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -997,10 +997,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676927,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.oSlFzVMu0fdEfYt1"
     },
@@ -1011,8 +1011,8 @@
       "img": "icons/magic/air/wind-tornado-spiral-pink-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\" id=\"secret-JgJC4PuKfndwnA7h\"><p>One humanoid the fiend can see within 30 feet of it must make a <strong>DC 15</strong> <strong>Wisdom</strong> saving throw or be magically charmed for 1 day. The charmed target obeys the fiend's verbal or telepathic commands.</p><p>If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend's Charm for the next 24 hours.The fiend can have only one target charmed at a time. If it charms another, the effect on the previous target ends.</p></section><p>One humanoid the fiend can see within 30 feet of it must make a <strong>Wisdom</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>One humanoid the fiend can see within 30 feet of it must make a <strong>DC 15</strong> <strong>Wisdom</strong> saving throw or be magically charmed for 1 day. The charmed target obeys the fiend's verbal or telepathic commands.</p><p>If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend's Charm for the next 24 hours.The fiend can have only one target charmed at a time. If it charms another, the effect on the previous target ends.</p>",
+          "chat": "<p>One humanoid the fiend can see within 30 feet of it must make a <strong>Wisdom</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1129,10 +1129,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676927,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.2bFCfFfjRNmhyE8A"
     },
@@ -1143,8 +1143,8 @@
       "img": "icons/magic/air/wind-vortex-swirl-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The fiend kisses a creature charmed by it or a willing creature. The target must make a  <strong>DC 15 Constitution</strong> saving throw against this magic, taking <strong>32 (5d10 + 5) <em>psychic damage</em></strong> on a failed save, or half as much damage on a successful one. </p><p>The target's hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p></section><p>The target must make a <strong>Constitution</strong> saving throw against this magic.</p>",
-          "chat": ""
+          "value": "<p>The fiend kisses a creature charmed by it or a willing creature. The target must make a  <strong>DC 15 Constitution</strong> saving throw against this magic, taking <strong>32 (5d10 + 5) <em>psychic damage</em></strong> on a failed save, or half as much damage on a successful one. </p><p>The target's hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p>",
+          "chat": "<p>The target must make a <strong>Constitution</strong> saving throw against this magic.</p>"
         },
         "source": {
           "custom": "",
@@ -1276,10 +1276,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676927,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.eb0O9cQ8N6lovLyI"
     },
@@ -1290,8 +1290,8 @@
       "img": "icons/magic/unholy/barrier-shield-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p></p><p></p></section><p>The fiend magically enters the Ethereal Plane from the Material Plane, or vice versa.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<section class=\"secret\"><p></p></section><p>The fiend magically enters the Ethereal Plane from the Material Plane, or vice versa.</p>"
         },
         "source": {
           "custom": "",
@@ -1401,10 +1401,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676927,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.s1s5asgUorljP7SV"
     }

--- a/packs/_source/monsters/fiend/vrock.json
+++ b/packs/_source/monsters/fiend/vrock.json
@@ -814,8 +814,8 @@
       "img": "icons/commodities/bones/beak-hooked-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Vrock attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Vrock attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -1002,10 +1002,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676885,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6oc29m5uzzzb0pk3.JwAFMjU7vHDDL2Ib"
     },
@@ -1016,8 +1016,8 @@
       "img": "icons/creatures/claws/claw-scaled-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d10 + 3) <em>slashing damage</em></strong>.</p><p></p></section><p>The Vrock attacks with its Talons.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d10 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Vrock attacks with its Talons.</p>"
         },
         "source": {
           "custom": "",
@@ -1204,10 +1204,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676885,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6oc29m5uzzzb0pk3.H5JJE8uS39dTI3Vg"
     },
@@ -1218,8 +1218,8 @@
       "img": "icons/magic/earth/orb-stone-smoke-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must succeed on a  <strong>DC 14 Constitution</strong> saving throw or become poisoned. </p><p>While poisoned in this way, a target takes <strong>5 (1d10) <em>poison damage</em></strong> at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Emptying a vial of holy water on the target also ends the effect on it.</p></section><p>A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must make a <strong>Constitution</strong> saving throw. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p>A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must succeed on a  <strong>DC 14 Constitution</strong> saving throw or become poisoned. </p><p>While poisoned in this way, a target takes <strong>5 (1d10) <em>poison damage</em></strong> at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Emptying a vial of holy water on the target also ends the effect on it.</p>",
+          "chat": "<p>A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must make a <strong>Constitution</strong> saving throw. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1368,10 +1368,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676885,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6oc29m5uzzzb0pk3.eEVWpD5omMdUkWLu"
     },
@@ -1382,8 +1382,8 @@
       "img": "icons/skills/toxins/cup-goblet-poisoned-spilled.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The vrock emits a horrific screech. Each creature within 20 feet of it that can hear it and that isn't a demon must succeed on a  <strong>DC 14 Constitution</strong> saving throw or be stunned until the end of the vrock's next turn .</p><p></p></section><p>The vrock emits a horrific screech. Each creature within 20 feet of it that can hear it and that isn't a demon must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The vrock emits a horrific screech. Each creature within 20 feet of it that can hear it and that isn't a demon must succeed on a  <strong>DC 14 Constitution</strong> saving throw or be stunned until the end of the vrock's next turn .</p>",
+          "chat": "<p>The vrock emits a horrific screech. Each creature within 20 feet of it that can hear it and that isn't a demon must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1514,10 +1514,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676885,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6oc29m5uzzzb0pk3.Ijd3GKLRlMzwoSe1"
     }

--- a/packs/_source/monsters/giant/cloud-giant.json
+++ b/packs/_source/monsters/giant/cloud-giant.json
@@ -857,8 +857,8 @@
       "img": "icons/weapons/maces/mace-round-spiked-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>21 (3d8 + 8) <em>piercing damage</em></strong>.</p></section>\n<p>The Cloud Giant attacks with its Morningstar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>21 (3d8 + 8) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Cloud Giant attacks with its Morningstar.</p>"
         },
         "source": {
           "custom": "",
@@ -1051,10 +1051,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676653,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Aw2wmqGIatxe2ImI.Jr0CfxY8xuFT6hoa"
     },
@@ -1065,8 +1065,8 @@
       "img": "icons/magic/earth/projectile-stone-ball-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +12 to hit, range 60/240 ft., one target. Hit: <strong>30 (4d10 + 8) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Cloud Giant attacks with its Rock.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +12 to hit, range 60/240 ft., one target. Hit: <strong>30 (4d10 + 8) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Cloud Giant attacks with its Rock.</p>"
         },
         "source": {
           "custom": "",
@@ -1256,10 +1256,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676653,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Aw2wmqGIatxe2ImI.NXgSHbDNtVbxsItU"
     },

--- a/packs/_source/monsters/giant/ettin.json
+++ b/packs/_source/monsters/giant/ettin.json
@@ -861,8 +861,8 @@
       "img": "icons/weapons/polearms/halberd-crescent-engraved-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ettin attacks with its Battleaxe.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ettin attacks with its Battleaxe.</p>"
         },
         "source": {
           "custom": "",
@@ -1055,10 +1055,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676666,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KLCkHep28HBfdsky.T1QQrbvnvnM73eIe"
     },
@@ -1069,8 +1069,8 @@
       "img": "icons/weapons/maces/mace-round-spiked-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>piercing damage</em></strong>.</p><p></p></section><p>The Ettin attacks with its Morningstar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Ettin attacks with its Morningstar.</p>"
         },
         "source": {
           "custom": "",
@@ -1261,10 +1261,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676666,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KLCkHep28HBfdsky.5ri5zr7IJKsaZNF7"
     }

--- a/packs/_source/monsters/giant/fire-giant.json
+++ b/packs/_source/monsters/giant/fire-giant.json
@@ -837,8 +837,8 @@
       "img": "icons/weapons/swords/greatsword-guard-gem-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>28 (6d6 + 7) <em>slashing damage</em></strong>.</p><p></p></section><p>The Fire Giant attacks with its Greatsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>28 (6d6 + 7) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Fire Giant attacks with its Greatsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1033,10 +1033,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676639,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!45Z5kogZEhawX1Ey.c8b8jy3sM3Z8gxm0"
     },
@@ -1047,8 +1047,8 @@
       "img": "icons/magic/earth/projectile-stone-ball-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +11 to hit, range 60/240 ft., one target. Hit: <strong>29 (4d10 + 7) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Fire Giant attacks with its Rock.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +11 to hit, range 60/240 ft., one target. Hit: <strong>29 (4d10 + 7) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Fire Giant attacks with its Rock.</p>"
         },
         "source": {
           "custom": "",
@@ -1238,10 +1238,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676639,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!45Z5kogZEhawX1Ey.DgNvJ2F0HSMya3hp"
     }

--- a/packs/_source/monsters/giant/frost-giant.json
+++ b/packs/_source/monsters/giant/frost-giant.json
@@ -619,8 +619,8 @@
       "img": "icons/magic/earth/projectile-stone-ball-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +9 to hit, range 60/240 ft., one target. Hit: <strong>28 (4d10 + 6) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Frost Giant attacks with its Rock.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +9 to hit, range 60/240 ft., one target. Hit: <strong>28 (4d10 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Frost Giant attacks with its Rock.</p>"
         },
         "source": {
           "custom": "",
@@ -810,10 +810,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676655,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Buxe6dDK5Mw7kxe6.gCi538awNcOfcZf7"
     },
@@ -911,8 +911,8 @@
       "img": "icons/weapons/axes/axe-double.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>25 (3d12 + 6) <em>slashing damage</em></strong>.</p><p></p></section><p>The Frost Giant attacks with its Greataxe.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>25 (3d12 + 6) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Frost Giant attacks with its Greataxe.</p>"
         },
         "source": {
           "custom": "",
@@ -1106,10 +1106,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676655,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Buxe6dDK5Mw7kxe6.LVOGKiIm4UTD4fpj"
     },

--- a/packs/_source/monsters/giant/hill-giant.json
+++ b/packs/_source/monsters/giant/hill-giant.json
@@ -742,8 +742,8 @@
       "img": "icons/weapons/clubs/club-simple-barbed.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>18 (3d8 + 5) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Hill Giant attacks with its Greatclub.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>18 (3d8 + 5) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Hill Giant attacks with its Greatclub.</p>"
         },
         "source": {
           "custom": "",
@@ -936,10 +936,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676647,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!9g4N9sjyh8Ql46to.250gOq5bpqIHb7rw"
     },
@@ -950,8 +950,8 @@
       "img": "icons/magic/earth/projectile-stone-ball-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +8 to hit, range 60/240 ft., one target. Hit: <strong>21 (3d10 + 5) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Hill Giant attacks with its Rock.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +8 to hit, range 60/240 ft., one target. Hit: <strong>21 (3d10 + 5) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Hill Giant attacks with its Rock.</p>"
         },
         "source": {
           "custom": "",
@@ -1138,10 +1138,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676647,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!9g4N9sjyh8Ql46to.lpyNJHYnhFtpLgo9"
     }

--- a/packs/_source/monsters/giant/ogre.json
+++ b/packs/_source/monsters/giant/ogre.json
@@ -618,8 +618,8 @@
       "img": "icons/weapons/clubs/club-simple-barbed.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ogre attacks with its Greatclub.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ogre attacks with its Greatclub.</p>"
         },
         "source": {
           "custom": "",
@@ -812,10 +812,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676692,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eIGowKTkEBC9gUzx.1bqysUVTadmvi8nb"
     },
@@ -826,8 +826,8 @@
       "img": "icons/weapons/ammunition/arrows-bodkin-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Ogre attacks with its Javelin.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Ogre attacks with its Javelin.</p>"
         },
         "source": {
           "custom": "",
@@ -1021,10 +1021,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676692,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eIGowKTkEBC9gUzx.tXgnd9qKOE2b7Wis"
     },

--- a/packs/_source/monsters/giant/oni.json
+++ b/packs/_source/monsters/giant/oni.json
@@ -711,8 +711,8 @@
       "img": "icons/weapons/polearms/halberd-crescent-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>slashing damage</em></strong>, or <strong>9 (1d10 + 4) <em>slashing damage</em></strong> in Small or Medium form.</p><p></p></section><p>The Oni attacks with its Glaive.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>slashing damage</em></strong>, or <strong>9 (1d10 + 4) <em>slashing damage</em></strong> in Small or Medium form.</p>",
+          "chat": "<p>The Oni attacks with its Glaive.</p>"
         },
         "source": {
           "custom": "",
@@ -907,10 +907,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676784,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!L1w8yBkInMscfJ3F.FC0FNE8O4rnbth8s"
     },
@@ -921,8 +921,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d8 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Oni attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d8 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Oni attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1109,10 +1109,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676784,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!L1w8yBkInMscfJ3F.q7J7PERrJb2vxtlt"
     },
@@ -1307,8 +1307,8 @@
       "img": "icons/skills/wounds/anatomy-organ-heart-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The oni regains <strong>10 hit points</strong> at the start of its turn if it has at least <strong>1 hit point</strong>.</p></section><p>The oni regains <strong>10 hit points</strong> at the start of its turn.</p>",
-          "chat": ""
+          "value": "<p>The oni regains <strong>10 hit points</strong> at the start of its turn if it has at least <strong>1 hit point</strong>.</p>",
+          "chat": "<p>The oni regains <strong>10 hit points</strong> at the start of its turn.</p>"
         },
         "source": {
           "custom": "",
@@ -1429,10 +1429,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676784,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!L1w8yBkInMscfJ3F.8liUuXPhjNLKYMMx"
     },

--- a/packs/_source/monsters/giant/stone-giant.json
+++ b/packs/_source/monsters/giant/stone-giant.json
@@ -617,8 +617,8 @@
       "img": "icons/weapons/clubs/club-simple-barbed.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>19 (3d8 + 6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Stone Giant attacks with its Greatclub.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>19 (3d8 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Stone Giant attacks with its Greatclub.</p>"
         },
         "source": {
           "custom": "",
@@ -809,10 +809,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676793,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SOin81NWijHRvXFK.Tm2NY0eSI6InRcsa"
     },
@@ -948,8 +948,8 @@
       "img": "icons/magic/earth/projectile-stone-ball-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +9 to hit, range 60/240 ft., one target. Hit: <strong>28 (4d10 + 6) <em>bludgeoning damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 17 Strength</strong> saving throw or be knocked prone.</p></section><p>The Stone Giant attacks with its Rock. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +9 to hit, range 60/240 ft., one target. Hit: <strong>28 (4d10 + 6) <em>bludgeoning damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 17 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>The Stone Giant attacks with its Rock. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -1209,10 +1209,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676793,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SOin81NWijHRvXFK.eiNNUlTgJyVFcQkO"
     },
@@ -1223,8 +1223,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If a rock or similar object is hurled at the giant, the giant can, with a successful DC 10 Dexterity saving throw, catch the missile and take no <em>bludgeoning damage</em> from it.</p></section><p>If a rock or similar object is hurled at the giant, the giant can catch the missile and take no <em>bludgeoning damage</em> from it.</p>",
-          "chat": ""
+          "value": "<p>If a rock or similar object is hurled at the giant, the giant can, with a successful DC 10 Dexterity saving throw, catch the missile and take no <em>bludgeoning damage</em> from it.</p>",
+          "chat": "<p>If a rock or similar object is hurled at the giant, the giant can catch the missile and take no <em>bludgeoning damage</em> from it.</p>"
         },
         "source": {
           "custom": "",
@@ -1339,10 +1339,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676793,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SOin81NWijHRvXFK.HxKKuoyc6AYGLsIX"
     },

--- a/packs/_source/monsters/giant/storm-giant.json
+++ b/packs/_source/monsters/giant/storm-giant.json
@@ -775,8 +775,8 @@
       "img": "icons/weapons/swords/greatsword-guard-gem-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>30 (6d6 + 9) <em>slashing damage</em></strong>.</p><p></p></section><p>The Storm Giant attacks with its Greatsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+14 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>30 (6d6 + 9) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Storm Giant attacks with its Greatsword.</p>"
         },
         "source": {
           "custom": "",
@@ -967,10 +967,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676843,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!68bAMIpe4jvDeR9G.iwN0z7f5LF9AAbRJ"
     },
@@ -1040,8 +1040,8 @@
       "img": "icons/magic/lightning/bolt-forked-blue-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The giant hurls a magical lightning bolt at a point it can see within 500 feet of it. </p><p>Each creature within 10 feet of that point must make a  <strong>DC 17 Dexterity</strong> saving throw, taking <strong>54 (12d8) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The Storm Giant attacks with its Lightning Strike. Each creature within 10 feet of that point must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The giant hurls a magical lightning bolt at a point it can see within 500 feet of it. </p><p>Each creature within 10 feet of that point must make a  <strong>DC 17 Dexterity</strong> saving throw, taking <strong>54 (12d8) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Storm Giant attacks with its Lightning Strike. Each creature within 10 feet of that point must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1238,10 +1238,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676843,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!68bAMIpe4jvDeR9G.k0g8uqoYdJ4LVxcn"
     },
@@ -1377,8 +1377,8 @@
       "img": "icons/magic/earth/projectile-stone-ball-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +14 to hit, range 60/240 ft., one target. Hit: <strong>35 (4d12 + 9) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Storm Giant attacks with its Rock.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +14 to hit, range 60/240 ft., one target. Hit: <strong>35 (4d12 + 9) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Storm Giant attacks with its Rock.</p>"
         },
         "source": {
           "custom": "",
@@ -1566,10 +1566,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676843,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!68bAMIpe4jvDeR9G.bRdk2uZ6iTuNGUIL"
     },

--- a/packs/_source/monsters/giant/troll.json
+++ b/packs/_source/monsters/giant/troll.json
@@ -617,8 +617,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d6 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Troll attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d6 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Troll attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -809,10 +809,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676796,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZHAFrnCwCz17dmLc.R7DpgLP3aFNmAgOc"
     },
@@ -823,8 +823,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Troll attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Troll attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1011,10 +1011,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676796,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZHAFrnCwCz17dmLc.ahGwFmyt6nItUOAK"
     },
@@ -1205,8 +1205,8 @@
       "img": "icons/skills/wounds/anatomy-organ-heart-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The troll regains <strong>10 hit points</strong> at the start of its turn. If the troll takes <strong>acid</strong> or <strong><em>fire damage</em></strong>, this trait doesn't function at the start of the troll's next turn. The troll dies only if it starts its turn with <strong>0 hit points</strong> and doesn't regenerate.</p>\n</section>\n<p>The troll regains <strong>10 hit points</strong> at the start of its turn.</p>",
-          "chat": ""
+          "value": "<p>The troll regains <strong>10 hit points</strong> at the start of its turn. If the troll takes <strong>acid</strong> or <strong><em>fire damage</em></strong>, this trait doesn't function at the start of the troll's next turn. The troll dies only if it starts its turn with <strong>0 hit points</strong> and doesn't regenerate.</p>",
+          "chat": "<p>The troll regains <strong>10 hit points</strong> at the start of its turn.</p>"
         },
         "source": {
           "custom": "",
@@ -1327,10 +1327,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676796,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZHAFrnCwCz17dmLc.yWYB2iyRA61AjcVJ"
     }

--- a/packs/_source/monsters/humanoid/acolyte.json
+++ b/packs/_source/monsters/humanoid/acolyte.json
@@ -615,8 +615,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The acolyte is a 1st-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The acolyte has following cleric spells prepared:• Cantrips (at will): light, sacred flame, thaumaturgy• 1st level (3 slots): bless, cure wounds, sanctuary</p>\n</section>\n<p>The acolyte is a spellcaster. Its spellcasting ability is Wisdom.</p>",
-          "chat": ""
+          "value": "<p>The acolyte is a 1st-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The acolyte has following cleric spells prepared:• Cantrips (at will): light, sacred flame, thaumaturgy• 1st level (3 slots): bless, cure wounds, sanctuary</p>",
+          "chat": "<p>The acolyte is a spellcaster. Its spellcasting ability is Wisdom.</p>"
         },
         "source": {
           "custom": "",
@@ -660,10 +660,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676539,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!CHEUjiYrVM9X0vIT.38I6bGoguRRefN6W"
     },
@@ -674,8 +674,8 @@
       "img": "icons/weapons/clubs/club-simple-barbed.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Acolyte attacks with their Club.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Acolyte attacks with their Club.</p>"
         },
         "source": {
           "custom": "",
@@ -868,10 +868,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676539,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!CHEUjiYrVM9X0vIT.swpThURVHnaQRjfY"
     },

--- a/packs/_source/monsters/humanoid/archmage.json
+++ b/packs/_source/monsters/humanoid/archmage.json
@@ -615,8 +615,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The archmage is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The archmage can cast disguise self and invisibility at will and has the following wizard spells prepared:</p>\n<p>• <strong>Cantrips</strong> (at will): fire bolt, light, mage hand, prestidigitation, shocking grasp</p>\n<p>• <strong>1st level</strong> (4 slots): detect magic, identify, <strong>mage armor*</strong>, magic missile</p>\n<p>• <strong>2nd level</strong> (3 slots): detect thoughts, mirror image, misty step</p>\n<p>•<strong> 3rd leve</strong>l (3 slots): counterspell,fly, lightning bolt</p>\n<p>•<strong> 4th level </strong>(3 slots): banishment, fire shield,<strong> stoneskin*</strong></p>\n<p>•<strong> 5th level</strong> (3 slots): cone of cold, scrying, wall of force</p>\n<p>•<strong> 6th level </strong>(1 slot): globe of invulnerability</p>\n<p>•<strong> 7th level </strong>(1 slot): teleport</p>\n<p>• <strong>8th level</strong> (1 slot): <strong>mind blank*</strong></p>\n<p>• <strong>9th level </strong>(1 slot):<strong> time stop* </strong></p>\n<p><strong>*-The archmage casts these spells on itself before combat.</strong></p>\n</section>\n<p>The archmage is an spellcaster. Its spellcasting ability is Intelligence.</p>",
-          "chat": ""
+          "value": "<p>The archmage is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The archmage can cast disguise self and invisibility at will and has the following wizard spells prepared:</p><p>• <strong>Cantrips</strong> (at will): fire bolt, light, mage hand, prestidigitation, shocking grasp</p><p>• <strong>1st level</strong> (4 slots): detect magic, identify, <strong>mage armor*</strong>, magic missile</p><p>• <strong>2nd level</strong> (3 slots): detect thoughts, mirror image, misty step</p><p>•<strong> 3rd leve</strong>l (3 slots): counterspell,fly, lightning bolt</p><p>•<strong> 4th level </strong>(3 slots): banishment, fire shield,<strong> stoneskin*</strong></p><p>•<strong> 5th level</strong> (3 slots): cone of cold, scrying, wall of force</p><p>•<strong> 6th level </strong>(1 slot): globe of invulnerability</p><p>•<strong> 7th level </strong>(1 slot): teleport</p><p>• <strong>8th level</strong> (1 slot): <strong>mind blank*</strong></p><p>• <strong>9th level </strong>(1 slot):<strong> time stop* </strong></p><p><strong>*-The archmage casts these spells on itself before combat.</strong></p>",
+          "chat": "<p>The archmage is an spellcaster. Its spellcasting ability is Intelligence.</p>"
         },
         "source": {
           "custom": "",
@@ -660,10 +660,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676536,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!B7lBOr1AahNZs4a6.gSrKQbka5aLxlcJz"
     },
@@ -733,8 +733,8 @@
       "img": "icons/weapons/daggers/dagger-jeweled-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Archmage attacks with their Dagger.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Archmage attacks with their Dagger.</p>"
         },
         "source": {
           "custom": "",
@@ -929,10 +929,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676536,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!B7lBOr1AahNZs4a6.vgTunE3gLps5Q595"
     },

--- a/packs/_source/monsters/humanoid/assassin.json
+++ b/packs/_source/monsters/humanoid/assassin.json
@@ -829,8 +829,8 @@
       "img": "icons/skills/melee/blade-tip-chipped-blood-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">Once per turn.</section>\n<p>The assassin deals an extra 13 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 ft. of an ally of the assassin that isn't incapacitated and the assassin doesn't have disadvantage on the attack roll.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<p>The assassin deals an extra 13 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 ft. of an ally of the assassin that isn't incapacitated and the assassin doesn't have disadvantage on the attack roll.</p>"
         },
         "source": {
           "custom": "",
@@ -957,10 +957,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676773,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EMvcuOpu7ABCmBWi.EcECOhaJIpCtN2o7"
     },
@@ -1096,8 +1096,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p>\n<p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>24 (7d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The Assassin attacks with their Shortsword. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>24 (7d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Assassin attacks with their Shortsword. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1446,10 +1446,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676773,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EMvcuOpu7ABCmBWi.Kbg12IJ0YW79vP06"
     },
@@ -1460,8 +1460,8 @@
       "img": "icons/weapons/crossbows/crossbow-simple-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p>\n<p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>24 (7d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The Assassin attacks with its Light Crossbow. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>24 (7d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Assassin attacks with its Light Crossbow. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1811,10 +1811,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676773,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EMvcuOpu7ABCmBWi.rNQK7okIBNZ2zDvD"
     }

--- a/packs/_source/monsters/humanoid/bandit-captain.json
+++ b/packs/_source/monsters/humanoid/bandit-captain.json
@@ -831,8 +831,8 @@
       "img": "icons/weapons/swords/sword-katana.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p></section>\n<p>The Bandit Captain attacks with their Scimitar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Bandit Captain attacks with their Scimitar.</p>"
         },
         "source": {
           "custom": "",
@@ -1026,10 +1026,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676704,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rb7OJt822wIO52qY.tSPkVJScEndipsFU"
     },
@@ -1040,8 +1040,8 @@
       "img": "icons/weapons/daggers/dagger-jeweled-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p></section>\n<p>The Bandit Captain attacks with their Dagger.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Bandit Captain attacks with their Dagger.</p>"
         },
         "source": {
           "custom": "",
@@ -1236,10 +1236,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676704,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rb7OJt822wIO52qY.mBUKIzY6aUW5Fnlm"
     },

--- a/packs/_source/monsters/humanoid/bandit.json
+++ b/packs/_source/monsters/humanoid/bandit.json
@@ -615,8 +615,8 @@
       "img": "icons/weapons/swords/sword-katana.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>slashing damage</em></strong>.</p></section>\n<p>The Bandit attacks with their Scimitar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Bandit attacks with their Scimitar.</p>"
         },
         "source": {
           "custom": "",
@@ -810,10 +810,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676697,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!n4TEv7inVUkyZviN.4oIyAj7rN5JbTjDZ"
     },
@@ -824,8 +824,8 @@
       "img": "icons/weapons/crossbows/crossbow-simple-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +3 to hit, range 80 ft./320 ft., one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p></section>\n<p>The Bandit attacks with their Light Crossbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +3 to hit, range 80 ft./320 ft., one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Bandit attacks with their Light Crossbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1020,10 +1020,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676697,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!n4TEv7inVUkyZviN.hSxEhrT9CFdLG40m"
     },

--- a/packs/_source/monsters/humanoid/berserker.json
+++ b/packs/_source/monsters/humanoid/berserker.json
@@ -765,8 +765,8 @@
       "img": "icons/weapons/axes/axe-double.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d12 + 3) <em>slashing damage</em></strong>.</p></section>\n<p>The Berserker attacks with their Greataxe.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d12 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Berserker attacks with their Greataxe.</p>"
         },
         "source": {
           "custom": "",
@@ -960,10 +960,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676494,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kz1t6xeXVwODpYb2.RrHhFZOd6QT75V3W"
     }

--- a/packs/_source/monsters/humanoid/bugbear.json
+++ b/packs/_source/monsters/humanoid/bugbear.json
@@ -618,8 +618,8 @@
       "img": "icons/weapons/maces/mace-round-spiked-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d8 + 2) <em>piercing damage</em></strong>.</p>\n<p>NOTE: the stats of this weapon have changed reflecting it being wielded by a creature with the \"Brute\" feature.</p>\n</section>\n<p>The Bugbear attacks with its Morningstar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d8 + 2) <em>piercing damage</em></strong>.</p><p>NOTE: the stats of this weapon have changed reflecting it being wielded by a creature with the \"Brute\" feature.</p>",
+          "chat": "<p>The Bugbear attacks with its Morningstar.</p>"
         },
         "source": {
           "custom": "",
@@ -810,10 +810,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676677,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!QtJairF0h18BRhEM.0ZKRgrkQppv6MYIq"
     },
@@ -1209,8 +1209,8 @@
       "img": "icons/weapons/ammunition/arrows-bodkin-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: <strong>9 (2d6 + 2) <em>piercing damage</em></strong> in melee or <strong>5 (1d6 + 2) <em>piercing damage</em></strong> at range.</p><p></p></section><p>The Bugbear attacks with its Javelin.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: <strong>9 (2d6 + 2) <em>piercing damage</em></strong> in melee or <strong>5 (1d6 + 2) <em>piercing damage</em></strong> at range.</p>",
+          "chat": "<p>The Bugbear attacks with its Javelin.</p>"
         },
         "source": {
           "custom": "",
@@ -1404,10 +1404,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676677,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!QtJairF0h18BRhEM.xwZYlJUYOv2J044p"
     }

--- a/packs/_source/monsters/humanoid/commoner.json
+++ b/packs/_source/monsters/humanoid/commoner.json
@@ -615,8 +615,8 @@
       "img": "icons/weapons/clubs/club-simple-barbed.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Commoner attacks with their Club.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Commoner attacks with their Club.</p>"
         },
         "source": {
           "custom": "",
@@ -809,10 +809,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676457,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!SqZRuJ8lt2KGJBbq.HwktDnB8qdr0BYGZ"
     }

--- a/packs/_source/monsters/humanoid/cult-fanatic.json
+++ b/packs/_source/monsters/humanoid/cult-fanatic.json
@@ -765,8 +765,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The fanatic is a 4th-level spellcaster. Its spell casting ability is Wisdom (spell save DC 11, +3 to hit with spell attacks).</p>\n<p>The fanatic has the following cleric spells prepared:</p>\n<p><strong>Cantrips</strong> (at will): light, sacred flame, thaumaturgy</p>\n<p><strong>1st level </strong>(4 slots): command, inflict wounds, shield of faith</p>\n<p><strong> 2nd level </strong>(3 slots): hold person, spiritual weapon</p>\n</section>\n<p>The fanatic is a spellcaster. Its spell casting ability is Wisdom.</p>",
-          "chat": ""
+          "value": "<p>The fanatic is a 4th-level spellcaster. Its spell casting ability is Wisdom (spell save DC 11, +3 to hit with spell attacks).</p><p>The fanatic has the following cleric spells prepared:</p><p><strong>Cantrips</strong> (at will): light, sacred flame, thaumaturgy</p><p><strong>1st level </strong>(4 slots): command, inflict wounds, shield of faith</p><p><strong> 2nd level </strong>(3 slots): hold person, spiritual weapon</p>",
+          "chat": "<p>The fanatic is a spellcaster. Its spell casting ability is Wisdom.</p>"
         },
         "source": {
           "custom": "",
@@ -810,10 +810,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676612,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!tYfQIxCJT0WaaKmc.KRbUbk5AkQOabBhO"
     },
@@ -949,8 +949,8 @@
       "img": "icons/weapons/daggers/dagger-jeweled-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Cult Fanatic attacks with their Dagger.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Cult Fanatic attacks with their Dagger.</p>"
         },
         "source": {
           "custom": "",
@@ -1145,10 +1145,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676612,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!tYfQIxCJT0WaaKmc.zTX7ZTUkqUMSbGII"
     },

--- a/packs/_source/monsters/humanoid/cultist.json
+++ b/packs/_source/monsters/humanoid/cultist.json
@@ -765,8 +765,8 @@
       "img": "icons/weapons/swords/sword-katana.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d6 + 1) <em>slashing damage</em></strong>.</p></section>\n<p>The Cultist attacks with their Scimitar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d6 + 1) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Cultist attacks with their Scimitar.</p>"
         },
         "source": {
           "custom": "",
@@ -960,10 +960,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676511,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qkLNA1lKMMJpxuWg.dldXP9XwjVIdIj5U"
     }

--- a/packs/_source/monsters/humanoid/deep-gnome.json
+++ b/packs/_source/monsters/humanoid/deep-gnome.json
@@ -828,8 +828,8 @@
       "img": "icons/weapons/axes/pickaxe-double-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Deep Gnome (Svirfneblin) attacks with its War Pick.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Deep Gnome (Svirfneblin) attacks with its War Pick.</p>"
         },
         "source": {
           "custom": "",
@@ -1020,10 +1020,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676686,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZM1P6LoYSwMiIJN9.AqLTSMp6MlcNK666"
     },
@@ -1093,8 +1093,8 @@
       "img": "icons/weapons/ammunition/arrows-war-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>\n<p>The target must succeed on a  <strong>DC 12 Constitution</strong> saving throw or be poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>\n</section>\n<p>The Deep Gnome (Svirfneblin) attacks with its Poisoned Dart. The target must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 12 Constitution</strong> saving throw or be poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The Deep Gnome (Svirfneblin) attacks with its Poisoned Dart. The target must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1373,10 +1373,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676686,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZM1P6LoYSwMiIJN9.YuhirWYJsQfL6zo5"
     },

--- a/packs/_source/monsters/humanoid/drow.json
+++ b/packs/_source/monsters/humanoid/drow.json
@@ -795,8 +795,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Drow attacks with its Shortsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Drow attacks with its Shortsword.</p>"
         },
         "source": {
           "custom": "",
@@ -987,10 +987,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676633,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1vaBSMUfOy6JPJ14.G2nFsJdp1Q3gshyr"
     },
@@ -1001,8 +1001,8 @@
       "img": "icons/weapons/crossbows/crossbow-simple-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the target is also unconscious while poisoned in this way. The target wakes up if it takes damage or if another creature takes an action to shake it awake.</p></section><p>The Drow attacks with its Hand Crossbow. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the target is also unconscious while poisoned in this way. The target wakes up if it takes damage or if another creature takes an action to shake it awake.</p>",
+          "chat": "<p>The Drow attacks with its Hand Crossbow. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1282,10 +1282,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676633,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1vaBSMUfOy6JPJ14.LqnhZjRtRqhLIFTm"
     },

--- a/packs/_source/monsters/humanoid/druid.json
+++ b/packs/_source/monsters/humanoid/druid.json
@@ -618,8 +618,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The druid is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks).</p>\n<p>It has the following druid spells prepared:</p>\n<p><strong>Cantrips </strong>(at will): druidcraft, produce flame, shillelagh</p>\n<p><strong> 1st level</strong> (4 slots): entangle, longstrider, speak with animals, thunderwave</p>\n<p><strong>2nd level</strong> (3 slots): animal messenger, barkskin</p>\n</section>\n<p>The druid is a spellcaster. Its spellcasting ability is Wisdom.</p>",
-          "chat": ""
+          "value": "<p>The druid is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks).</p><p>It has the following druid spells prepared:</p><p><strong>Cantrips </strong>(at will): druidcraft, produce flame, shillelagh</p><p><strong> 1st level</strong> (4 slots): entangle, longstrider, speak with animals, thunderwave</p><p><strong>2nd level</strong> (3 slots): animal messenger, barkskin</p>",
+          "chat": "<p>The druid is a spellcaster. Its spellcasting ability is Wisdom.</p>"
         },
         "source": {
           "custom": "",
@@ -663,10 +663,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676552,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!K15Yl8JmB5iPircc.07sdy4qaaW4MaB8W"
     },
@@ -677,8 +677,8 @@
       "img": "icons/weapons/staves/staff-simple-gold.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee Weapon Attack: +2 to hit (+4 to hit with shillelagh), reach 5 ft., one target. Hit: <strong>3 (1d6) <em>bludgeoning damage</em></strong>, or <strong>6 (1d8 + 2) <em>bludgeoning damage</em></strong> with shillelagh or if wielded with two hands.</p></section>\n<p>The Druid attacks with its Quarterstaff.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +2 to hit (+4 to hit with shillelagh), reach 5 ft., one target. Hit: <strong>3 (1d6) <em>bludgeoning damage</em></strong>, or <strong>6 (1d8 + 2) <em>bludgeoning damage</em></strong> with shillelagh or if wielded with two hands.</p>",
+          "chat": "<p>The Druid attacks with its Quarterstaff.</p>"
         },
         "source": {
           "custom": "",
@@ -871,10 +871,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676552,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!K15Yl8JmB5iPircc.KUP8WEfLxlcY7K2x"
     },

--- a/packs/_source/monsters/humanoid/duergar.json
+++ b/packs/_source/monsters/humanoid/duergar.json
@@ -1062,8 +1062,8 @@
       "img": "icons/weapons/axes/pickaxe-double-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>, or <strong>11 (2d8 + 2) <em>piercing damage</em></strong> while enlarged.</p></section>\n<p>The Duergar attacks with its War Pick.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>, or <strong>11 (2d8 + 2) <em>piercing damage</em></strong> while enlarged.</p>",
+          "chat": "<p>The Duergar attacks with its War Pick.</p>"
         },
         "source": {
           "custom": "",
@@ -1255,10 +1255,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676818,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!iGBdQA3IuKsurcUy.tCtnqPPKQ9NxIDqd"
     },
@@ -1269,8 +1269,8 @@
       "img": "icons/weapons/ammunition/arrows-bodkin-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>, or <strong>9 (2d6 + 2) <em>piercing damage</em></strong> while enlarged.</p></section>\n<p>The Duergar attacks with its Javelin.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>, or <strong>9 (2d6 + 2) <em>piercing damage</em></strong> while enlarged.</p>",
+          "chat": "<p>The Duergar attacks with its Javelin.</p>"
         },
         "source": {
           "custom": "",
@@ -1463,10 +1463,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676818,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!iGBdQA3IuKsurcUy.fHe3YshNib2lsJ45"
     },
@@ -1477,8 +1477,8 @@
       "img": "icons/creatures/webs/webthin-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The duergar magically turns invisible until it attacks, casts a spell, or uses its Enlarge, or until its concentration is broken, up to 1 hour (as if concentrating on a spell).</p>\n</section>\n<p>The duergar magically turns invisible. Any equipment the duergar wears or carries is invisible with it.</p>",
-          "chat": ""
+          "value": "<p>The duergar magically turns invisible until it attacks, casts a spell, or uses its Enlarge, or until its concentration is broken, up to 1 hour (as if concentrating on a spell).</p>",
+          "chat": "<p>The duergar magically turns invisible. Any equipment the duergar wears or carries is invisible with it.</p>"
         },
         "source": {
           "custom": "",
@@ -1603,10 +1603,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676818,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!iGBdQA3IuKsurcUy.lUm5wbaBhfO54dlB"
     }

--- a/packs/_source/monsters/humanoid/gladiator.json
+++ b/packs/_source/monsters/humanoid/gladiator.json
@@ -1040,8 +1040,8 @@
       "img": "icons/weapons/polearms/spear-flared-worn-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. and range 20/60 ft., one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>, or <strong>13 (2d8 + 4) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p></section>\n<p>The Gladiator attacks with their Spear.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. and range 20/60 ft., one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>, or <strong>13 (2d8 + 4) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p>",
+          "chat": "<p>The Gladiator attacks with their Spear.</p>"
         },
         "source": {
           "custom": "",
@@ -1235,10 +1235,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676808,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fsPruAIDOg4tVrgb.eL15erXXE9EuXWSB"
     },
@@ -1249,8 +1249,8 @@
       "img": "icons/equipment/shield/buckler-wooden-boss-glowing-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>9 (2d4 + 4) <em>bludgeoning damage</em></strong>.</p>\n<p>If the target is a Medium or smaller creature, it must succeed on a  <strong>DC 15 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>The Gladiator attacks with their Shield Bash. If the target is a Medium or smaller creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>9 (2d4 + 4) <em>bludgeoning damage</em></strong>.</p><p>If the target is a Medium or smaller creature, it must succeed on a  <strong>DC 15 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>The Gladiator attacks with their Shield Bash. If the target is a Medium or smaller creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -1526,10 +1526,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676808,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fsPruAIDOg4tVrgb.GrUneCbXCYngdpjf"
     },
@@ -1540,8 +1540,8 @@
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The gladiator adds 3 to its <strong>AC</strong> against one melee Attack that would hit it. To do so, the gladiator must see the attacker and be wielding a melee weapon.</p>\n</section>\n<p>The gladiator adds 3 to its <strong>AC</strong> against one melee Attack that would hit it.</p>",
-          "chat": ""
+          "value": "<p>The gladiator adds 3 to its <strong>AC</strong> against one melee Attack that would hit it. To do so, the gladiator must see the attacker and be wielding a melee weapon.</p>",
+          "chat": "<p>The gladiator adds 3 to its <strong>AC</strong> against one melee Attack that would hit it.</p>"
         },
         "source": {
           "custom": "",
@@ -1651,10 +1651,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676808,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fsPruAIDOg4tVrgb.AwP14Hu6dPdnSbQt"
     }

--- a/packs/_source/monsters/humanoid/gnoll.json
+++ b/packs/_source/monsters/humanoid/gnoll.json
@@ -858,8 +858,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Gnoll attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Gnoll attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1050,10 +1050,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676854,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!R2GPY9BhRmmwZwkh.fVB2xcZ4wVwiqEYf"
     },
@@ -1064,8 +1064,8 @@
       "img": "icons/weapons/polearms/spear-flared-worn-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>, or <strong>6 (1d8 + 2) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p><p></p></section><p>The Gnoll attacks with its Spear.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>, or <strong>6 (1d8 + 2) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p>",
+          "chat": "<p>The Gnoll attacks with its Spear.</p>"
         },
         "source": {
           "custom": "",
@@ -1259,10 +1259,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676854,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!R2GPY9BhRmmwZwkh.lsZzJMqxUIjbczLM"
     },
@@ -1273,8 +1273,8 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p><p></p></section><p>The Gnoll attacks with its Longbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Gnoll attacks with its Longbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1469,10 +1469,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676854,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!R2GPY9BhRmmwZwkh.2Squ8wLvm5nSzA8w"
     }

--- a/packs/_source/monsters/humanoid/goblin.json
+++ b/packs/_source/monsters/humanoid/goblin.json
@@ -859,8 +859,8 @@
       "img": "icons/weapons/swords/sword-katana.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>slashing damage</em></strong>.</p></section>\n<p>The Goblin attacks with its Scimitar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Goblin attacks with its Scimitar.</p>"
         },
         "source": {
           "custom": "",
@@ -1054,10 +1054,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676681,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!TjWQOgI3A4UAl7lC.S6UTTLu0bEB32HNG"
     },
@@ -1068,8 +1068,8 @@
       "img": "icons/weapons/bows/shortbow-recurve.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Goblin attacks with its Shortbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Goblin attacks with its Shortbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1263,10 +1263,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676681,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!TjWQOgI3A4UAl7lC.YqS3dsIlpWb2Q2UI"
     }

--- a/packs/_source/monsters/humanoid/grimlock.json
+++ b/packs/_source/monsters/humanoid/grimlock.json
@@ -792,8 +792,8 @@
       "img": "icons/weapons/clubs/club-simple-barbed.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d4 + 3) <em>bludgeoning damage</em></strong> plus <strong>2 (1d4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Grimlock attacks with its Spiked Bone Club.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d4 + 3) <em>bludgeoning damage</em></strong> plus <strong>2 (1d4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Grimlock attacks with its Spiked Bone Club.</p>"
         },
         "source": {
           "custom": "",
@@ -998,10 +998,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676434,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GpeQYtlo8oGvGlkM.aEWZXCiyNusgb3Ro"
     }

--- a/packs/_source/monsters/humanoid/guard.json
+++ b/packs/_source/monsters/humanoid/guard.json
@@ -797,8 +797,8 @@
       "img": "icons/weapons/polearms/spear-flared-worn-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong> or <strong>5 (1d8 + 1) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p></section>\n<p>The Guard attacks with its Spear.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong> or <strong>5 (1d8 + 1) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p>",
+          "chat": "<p>The Guard attacks with its Spear.</p>"
         },
         "source": {
           "custom": "",
@@ -992,10 +992,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676425,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!E9CvDPDg5dFEpVjS.92uVNexE43Z8D18r"
     }

--- a/packs/_source/monsters/humanoid/half-red-dragon-veteran.json
+++ b/packs/_source/monsters/humanoid/half-red-dragon-veteran.json
@@ -838,8 +838,8 @@
       "img": "icons/weapons/swords/greatsword-crossguard-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>, or <strong>8 (1d10 + 3) <em>slashing damage</em></strong> if used with two hands.</p></section>\n<p>The Half-Red Dragon Veteran attacks with its Longsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>, or <strong>8 (1d10 + 3) <em>slashing damage</em></strong> if used with two hands.</p>",
+          "chat": "<p>The Half-Red Dragon Veteran attacks with its Longsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1032,10 +1032,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676911,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5TmstVMURpVtmNR3.93eWZ75LncoC5U8d"
     },
@@ -1046,8 +1046,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Half-Red Dragon Veteran attacks with its Shortsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Half-Red Dragon Veteran attacks with its Shortsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1241,10 +1241,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676911,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5TmstVMURpVtmNR3.pl7hO2z20EnTaPZt"
     },
@@ -1255,8 +1255,8 @@
       "img": "icons/weapons/crossbows/crossbow-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +3 to hit, range 100/400 ft., one target. Hit: <strong>6 (1d10 + 1) <em>piercing damage</em></strong>.</p><p></p></section><p>The Half-Red Dragon Veteran attacks with its Heavy Crossbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +3 to hit, range 100/400 ft., one target. Hit: <strong>6 (1d10 + 1) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Half-Red Dragon Veteran attacks with its Heavy Crossbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1452,10 +1452,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676911,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5TmstVMURpVtmNR3.Jt9HuwZdYUCmEH5q"
     },
@@ -1466,8 +1466,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The veteran exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 15 Dexterity</strong> saving throw, taking <strong>24 (7d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p><p></p></section><p>The veteran exhales fire in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The veteran exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 15 Dexterity</strong> saving throw, taking <strong>24 (7d6) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The veteran exhales fire in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1616,10 +1616,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676911,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5TmstVMURpVtmNR3.68Y4sNHbVetQN3wa"
     }

--- a/packs/_source/monsters/humanoid/hobgoblin.json
+++ b/packs/_source/monsters/humanoid/hobgoblin.json
@@ -618,8 +618,8 @@
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Once per turn, the hobgoblin can deal an extra 7 (2d6) damage to a creature it hits with a weapon attack if that creature is within 5 ft. of an ally of the hobgoblin that isn't incapacitated.</p><p></p></section><p>Once per turn, the hobgoblin can deal extra damage to a creature it hits with a weapon attack if that creature is within 5 ft. of an ally of the hobgoblin that isn't incapacitated.</p>",
-          "chat": ""
+          "value": "<p>Once per turn, the hobgoblin can deal an extra 7 (2d6) damage to a creature it hits with a weapon attack if that creature is within 5 ft. of an ally of the hobgoblin that isn't incapacitated.</p>",
+          "chat": "<p>Once per turn, the hobgoblin can deal extra damage to a creature it hits with a weapon attack if that creature is within 5 ft. of an ally of the hobgoblin that isn't incapacitated.</p>"
         },
         "source": {
           "custom": "",
@@ -746,10 +746,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676763,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6qnT52lZtZblgGw8.Y73kGtiKbGevpBCo"
     },
@@ -760,8 +760,8 @@
       "img": "icons/weapons/swords/greatsword-crossguard-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d8 + 1) <em>slashing damage</em></strong>, or <strong>6 (1d10 + 1) <em>slashing damage</em></strong> if used with two hands.</p>\n</section>\n<p>The Hobgoblin attacks with its Longsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d8 + 1) <em>slashing damage</em></strong>, or <strong>6 (1d10 + 1) <em>slashing damage</em></strong> if used with two hands.</p>",
+          "chat": "<p>The Hobgoblin attacks with its Longsword.</p>"
         },
         "source": {
           "custom": "",
@@ -954,10 +954,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676763,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6qnT52lZtZblgGw8.is4wHu9FG6SPackl"
     },
@@ -968,8 +968,8 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p>\n</section>\n<p>The Hobgoblin attacks with its Longbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Hobgoblin attacks with its Longbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1164,10 +1164,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676763,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6qnT52lZtZblgGw8.ahUVLSMfFY5mqJ66"
     },

--- a/packs/_source/monsters/humanoid/knight.json
+++ b/packs/_source/monsters/humanoid/knight.json
@@ -833,8 +833,8 @@
       "img": "icons/weapons/swords/greatsword-guard-gem-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>.</p></section>\n<p>The Knight attacks with its Greatsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Knight attacks with its Greatsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1028,10 +1028,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676771,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!D5UqYD1EnTrJaMTO.iPLa96izrYFiVtaO"
     },
@@ -1042,8 +1042,8 @@
       "img": "icons/weapons/crossbows/crossbow-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +2 to hit, range 100/400 ft., one target. Hit: <strong>5 (1d10) <em>piercing damage</em></strong>.</p></section>\n<p>The Knight attacks with its Heavy Crossbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +2 to hit, range 100/400 ft., one target. Hit: <strong>5 (1d10) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Knight attacks with its Heavy Crossbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1238,10 +1238,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676771,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!D5UqYD1EnTrJaMTO.m68xw5aGQ7awxfYf"
     },
@@ -1393,8 +1393,8 @@
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The knight adds 2 to its <strong>AC</strong> against one melee Attack that would hit it. To do so, the knight must see the attacker and be wielding a melee weapon.</p>\n</section>\n<p>The knight adds 2 to its <strong>AC</strong> against one melee Attack that would hit it.</p>",
-          "chat": ""
+          "value": "<p>The knight adds 2 to its <strong>AC</strong> against one melee Attack that would hit it. To do so, the knight must see the attacker and be wielding a melee weapon.</p>",
+          "chat": "<p>The knight adds 2 to its <strong>AC</strong> against one melee Attack that would hit it.</p>"
         },
         "source": {
           "custom": "",
@@ -1504,10 +1504,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676771,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!D5UqYD1EnTrJaMTO.AxY9pWHDr2M1SPCC"
     },

--- a/packs/_source/monsters/humanoid/kobold.json
+++ b/packs/_source/monsters/humanoid/kobold.json
@@ -736,8 +736,8 @@
       "img": "icons/weapons/daggers/dagger-jeweled-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Kobold attacks with its Dagger.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Kobold attacks with its Dagger.</p>"
         },
         "source": {
           "custom": "",
@@ -931,10 +931,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676642,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5ngbctIMeEnuC1p1.io78wguVwNy9VfZ4"
     },
@@ -945,8 +945,8 @@
       "img": "icons/weapons/slings/slingshot-wood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: <strong>4 (1d4 + 2) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Kobold attacks with its Sling.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: <strong>4 (1d4 + 2) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Kobold attacks with its Sling.</p>"
         },
         "source": {
           "custom": "",
@@ -1139,10 +1139,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676642,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5ngbctIMeEnuC1p1.0yHcZm2TzgOyt3fI"
     }

--- a/packs/_source/monsters/humanoid/lizardfolk.json
+++ b/packs/_source/monsters/humanoid/lizardfolk.json
@@ -801,8 +801,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Lizardfolk attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Lizardfolk attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -993,10 +993,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676925,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!57DofLgRQx16ARoc.9x43sdgtqX8bOdiy"
     },
@@ -1007,8 +1007,8 @@
       "img": "icons/weapons/clubs/club-simple-barbed.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Lizardfolk attacks with its Heavy Club.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Lizardfolk attacks with its Heavy Club.</p>"
         },
         "source": {
           "custom": "",
@@ -1195,10 +1195,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676925,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!57DofLgRQx16ARoc.9T0RdBc0Tvsj6wJW"
     },
@@ -1209,8 +1209,8 @@
       "img": "icons/weapons/ammunition/arrows-bodkin-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Lizardfolk attacks with its Javelin.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Lizardfolk attacks with its Javelin.</p>"
         },
         "source": {
           "custom": "",
@@ -1403,10 +1403,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676925,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!57DofLgRQx16ARoc.bPnovVAPXO7MdagI"
     },
@@ -1417,8 +1417,8 @@
       "img": "icons/equipment/shield/oval-wooden-boss-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Lizardfolk attacks with its Spiked Shield.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Lizardfolk attacks with its Spiked Shield.</p>"
         },
         "source": {
           "custom": "",
@@ -1605,10 +1605,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676925,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!57DofLgRQx16ARoc.kZJqCMW6SxV5C0nu"
     },

--- a/packs/_source/monsters/humanoid/mage.json
+++ b/packs/_source/monsters/humanoid/mage.json
@@ -615,8 +615,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The mage has the following wizard spells prepared:</p>\n<p>Cantrips (at will): fire bolt, light, mage hand, prestidigitation</p>\n<p>1st level (4 slots): detect magic, mage armor, magic missile, shield</p>\n<p>2nd level (3 slots): misty step, suggestion</p>\n<p>3rd level (3 slots): counterspell, fireball, fly</p>\n<p>4th level (3 slots): greater invisibility, ice storm</p>\n<p>5th level (1 slot): cone of cold</p>\n</section>\n<p>The mage is a spellcaster. Its spellcasting ability is Intelligence.</p>",
-          "chat": ""
+          "value": "<p>The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The mage has the following wizard spells prepared:</p><p>Cantrips (at will): fire bolt, light, mage hand, prestidigitation</p><p>1st level (4 slots): detect magic, mage armor, magic missile, shield</p><p>2nd level (3 slots): misty step, suggestion</p><p>3rd level (3 slots): counterspell, fireball, fly</p><p>4th level (3 slots): greater invisibility, ice storm</p><p>5th level (1 slot): cone of cold</p>",
+          "chat": "<p>The mage is a spellcaster. Its spellcasting ability is Intelligence.</p>"
         },
         "source": {
           "custom": "",
@@ -660,10 +660,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676601,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!mQnsXanewsPiV7QE.tbKbwgcprUBciliF"
     },
@@ -674,8 +674,8 @@
       "img": "icons/weapons/daggers/dagger-jeweled-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Mage attacks with its Dagger.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Mage attacks with its Dagger.</p>"
         },
         "source": {
           "custom": "",
@@ -870,10 +870,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676601,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!mQnsXanewsPiV7QE.LcMdsxbtVEhUDXju"
     },

--- a/packs/_source/monsters/humanoid/merfolk.json
+++ b/packs/_source/monsters/humanoid/merfolk.json
@@ -677,8 +677,8 @@
       "img": "icons/weapons/polearms/spear-flared-worn-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee or Ranged Weapon Attack: +2 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>3 (1d6) <em>piercing damage</em></strong>, or <strong>4 (1d8) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p><p></p></section><p>The Merfolk attacks with its Spear.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +2 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>3 (1d6) <em>piercing damage</em></strong>, or <strong>4 (1d8) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p>",
+          "chat": "<p>The Merfolk attacks with its Spear.</p>"
         },
         "source": {
           "custom": "",
@@ -872,10 +872,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676441,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KUpbXdn1XmHEeOPk.sN28gnBGF2TVdd53"
     }

--- a/packs/_source/monsters/humanoid/noble.json
+++ b/packs/_source/monsters/humanoid/noble.json
@@ -706,8 +706,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p><p></p></section><p>The Noble attacks with its Rapier.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Noble attacks with its Rapier.</p>"
         },
         "source": {
           "custom": "",
@@ -900,10 +900,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676544,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GlaCGcgIP6YjBjGc.f12lOXuMaI21HDrz"
     },
@@ -914,8 +914,8 @@
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The noble adds 2 to its <strong>AC</strong> against one melee Attack that would hit it. To do so, the noble must see the attacker and be wielding a melee weapon.</p></section><p>The noble adds 2 to its <strong>AC</strong> against one melee Attack that would hit it.</p>",
-          "chat": ""
+          "value": "<p>The noble adds 2 to its <strong>AC</strong> against one melee Attack that would hit it. To do so, the noble must see the attacker and be wielding a melee weapon.</p>",
+          "chat": "<p>The noble adds 2 to its <strong>AC</strong> against one melee Attack that would hit it.</p>"
         },
         "source": {
           "custom": "",
@@ -1025,10 +1025,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676544,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GlaCGcgIP6YjBjGc.HhLmdqeivyDnsemN"
     }

--- a/packs/_source/monsters/humanoid/orc.json
+++ b/packs/_source/monsters/humanoid/orc.json
@@ -834,8 +834,8 @@
       "img": "icons/weapons/axes/axe-double.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d12 + 3) <em>slashing damage</em></strong>.</p><p></p></section><p>The Orc attacks with its Greataxe.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d12 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Orc attacks with its Greataxe.</p>"
         },
         "source": {
           "custom": "",
@@ -1029,10 +1029,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676660,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!HB49mCOVBXwWeKWQ.bGmBlXrvTBQgPMBJ"
     },
@@ -1043,8 +1043,8 @@
       "img": "icons/weapons/ammunition/arrows-bodkin-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Orc attacks with its Javelin.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Orc attacks with its Javelin.</p>"
         },
         "source": {
           "custom": "",
@@ -1238,10 +1238,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676660,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!HB49mCOVBXwWeKWQ.SrRZ2hBUcaXZiRab"
     }

--- a/packs/_source/monsters/humanoid/priest.json
+++ b/packs/_source/monsters/humanoid/priest.json
@@ -765,8 +765,8 @@
       "img": "icons/magic/symbols/cog-shield-white-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra <strong>10 (3d6) <em>radiant damage</em></strong> to a target on a hit. </p><p>This benefit lasts until the end of the turn. If the priest expends a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each level above 1st.</p></section><p>As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra <em>radiant damage</em> to a target on a hit.</p>",
-          "chat": ""
+          "value": "<p>As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra <strong>10 (3d6) <em>radiant damage</em></strong> to a target on a hit. </p><p>This benefit lasts until the end of the turn. If the priest expends a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each level above 1st.</p>",
+          "chat": "<p>As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra <em>radiant damage</em> to a target on a hit.</p>"
         },
         "source": {
           "custom": "",
@@ -977,10 +977,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676566,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PVD5wRdyO7iCJPs1.9LzZrzdWIZpjFIGV"
     },
@@ -991,8 +991,8 @@
       "img": "icons/weapons/maces/mace-round-spiked-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Priest attacks with its Mace.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Priest attacks with its Mace.</p>"
         },
         "source": {
           "custom": "",
@@ -1181,10 +1181,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676566,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PVD5wRdyO7iCJPs1.B0jROhxuoqvfmz2B"
     },

--- a/packs/_source/monsters/humanoid/sahuagin.json
+++ b/packs/_source/monsters/humanoid/sahuagin.json
@@ -824,8 +824,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d4 + 1) <em>piercing damage</em></strong>.</p><p></p></section><p>The Sahuagin attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d4 + 1) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Sahuagin attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1015,10 +1015,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676825,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lyNBFmJdbh4NLRzz.NSdAR332o65ZE3hC"
     },
@@ -1088,8 +1088,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d4 + 1) <em>slashing damage</em></strong>.</p><p></p></section><p>The Sahuagin attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d4 + 1) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Sahuagin attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1275,10 +1275,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676825,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lyNBFmJdbh4NLRzz.VJlDAg21VwBOjbuR"
     },
@@ -1289,8 +1289,8 @@
       "img": "icons/environment/creatures/frog-spotted-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The sahuagin can breathe air and water, but it needs to be submerged at least once every 4 hours to avoid suffocating.</p></section><p>The sahuagin can breathe air and water.</p>",
-          "chat": ""
+          "value": "<p>The sahuagin can breathe air and water, but it needs to be submerged at least once every 4 hours to avoid suffocating.</p>",
+          "chat": "<p>The sahuagin can breathe air and water.</p>"
         },
         "source": {
           "custom": "",
@@ -1334,10 +1334,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676825,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!lyNBFmJdbh4NLRzz.lH49mvA2g5C44yM4"
     },

--- a/packs/_source/monsters/humanoid/scout.json
+++ b/packs/_source/monsters/humanoid/scout.json
@@ -886,8 +886,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Scout attacks with their Shortsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Scout attacks with their Shortsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1081,10 +1081,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676671,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!O3ABqI55Ir1du1Xa.YDoOa6D6QDoR2Htu"
     },
@@ -1095,8 +1095,8 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +4 to hit, ranged 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Scout attacks with their Longbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, ranged 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Scout attacks with their Longbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1291,10 +1291,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676671,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!O3ABqI55Ir1du1Xa.E2fYrhLigMeVH09l"
     }

--- a/packs/_source/monsters/humanoid/spy.json
+++ b/packs/_source/monsters/humanoid/spy.json
@@ -1009,8 +1009,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Spy attacks with their Shortsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Spy attacks with their Shortsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1204,10 +1204,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676631,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!13K3XK2A3wwxVKLD.BhYnUUBoU3ESkl1B"
     },
@@ -1218,8 +1218,8 @@
       "img": "icons/weapons/crossbows/crossbow-simple-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Spy attacks with their Hand Crossbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Spy attacks with their Hand Crossbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1413,10 +1413,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676631,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!13K3XK2A3wwxVKLD.q6pfCQyaPQSw2waZ"
     }

--- a/packs/_source/monsters/humanoid/thug.json
+++ b/packs/_source/monsters/humanoid/thug.json
@@ -890,8 +890,8 @@
       "img": "icons/weapons/crossbows/crossbow-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +2 to hit, range 100/400 ft., one target. Hit: <strong>5 (1d10) <em>piercing damage</em></strong>.</p></section>\n<p>The Thug attacks with their Heavy Crossbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +2 to hit, range 100/400 ft., one target. Hit: <strong>5 (1d10) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Thug attacks with their Heavy Crossbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1086,10 +1086,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676656,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Cy3A0rsNMPLZozam.9INT7D1zulhfsok7"
     },
@@ -1100,8 +1100,8 @@
       "img": "icons/weapons/maces/mace-round-spiked-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Thug attacks with their Mace.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Thug attacks with their Mace.</p>"
         },
         "source": {
           "custom": "",
@@ -1292,10 +1292,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676656,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Cy3A0rsNMPLZozam.6gRu9IFFkvxesFfK"
     }

--- a/packs/_source/monsters/humanoid/tribal-warrior.json
+++ b/packs/_source/monsters/humanoid/tribal-warrior.json
@@ -765,8 +765,8 @@
       "img": "icons/weapons/polearms/spear-flared-worn-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>, or <strong>5 (1d8 + 1) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p></section>\n<p>The Tribal Warrior attacks with their Spear.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>4 (1d6 + 1) <em>piercing damage</em></strong>, or <strong>5 (1d8 + 1) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p>",
+          "chat": "<p>The Tribal Warrior attacks with their Spear.</p>"
         },
         "source": {
           "custom": "",
@@ -960,10 +960,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676497,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nREPw9g94Bsb9sIl.KO6Ez3XWFM4iH4zB"
     }

--- a/packs/_source/monsters/humanoid/veteran.json
+++ b/packs/_source/monsters/humanoid/veteran.json
@@ -708,8 +708,8 @@
       "img": "icons/weapons/swords/greatsword-crossguard-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>, or <strong>8 (1d10 + 3) <em>slashing damage</em></strong> if used with two hands.</p></section>\n<p>The Veteran attacks with their Longsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>, or <strong>8 (1d10 + 3) <em>slashing damage</em></strong> if used with two hands.</p>",
+          "chat": "<p>The Veteran attacks with their Longsword.</p>"
         },
         "source": {
           "custom": "",
@@ -902,10 +902,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676848,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J8xjoG4Dxb8WkHtV.WaEunPCFG0EddNTt"
     },
@@ -1041,8 +1041,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Veteran attacks with its Shortsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Veteran attacks with its Shortsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1233,10 +1233,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676848,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J8xjoG4Dxb8WkHtV.cXf5q5xw30ICGxZg"
     },
@@ -1247,8 +1247,8 @@
       "img": "icons/weapons/crossbows/crossbow-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +3 to hit, range 100/400 ft., one target. Hit: <strong>6 (1d10 + 1) <em>piercing damage</em></strong>.</p><p></p></section><p>The Veteran attacks with its Heavy Crossbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +3 to hit, range 100/400 ft., one target. Hit: <strong>6 (1d10 + 1) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Veteran attacks with its Heavy Crossbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1442,10 +1442,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676848,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J8xjoG4Dxb8WkHtV.6jQ7YUixkwBq2Fh8"
     }

--- a/packs/_source/monsters/humanoid/werebear.json
+++ b/packs/_source/monsters/humanoid/werebear.json
@@ -624,8 +624,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The werebear can use its action to <strong>polymorph</strong> into a Large bear-humanoid hybrid or into a Large bear, or back into its true form, which is humanoid. </p><p>Its statistics, other than its size and AC, are the same in each form. Any equipment it. is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p></section><p>The werebear can use its action to <strong>polymorph</strong>, or return to its true form.</p>",
-          "chat": ""
+          "value": "<p>The werebear can use its action to <strong>polymorph</strong> into a Large bear-humanoid hybrid or into a Large bear, or back into its true form, which is humanoid. </p><p>Its statistics, other than its size and AC, are the same in each form. Any equipment it. is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p>",
+          "chat": "<p>The werebear can use its action to <strong>polymorph</strong>, or return to its true form.</p>"
         },
         "source": {
           "custom": "",
@@ -735,10 +735,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676923,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oRBnO5OHoOZzlCOr.D8QWBbYLFAT7uIiz"
     },
@@ -929,8 +929,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 14 Constitution</strong> saving throw or be cursed with were bear lycanthropy.</p></section><p>The Werebear attacks with its Bite. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>15 (2d10 + 4) <em>piercing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 14 Constitution</strong> saving throw or be cursed with were bear lycanthropy.</p>",
+          "chat": "<p>The Werebear attacks with its Bite. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1190,10 +1190,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676923,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oRBnO5OHoOZzlCOr.h9XO0f5Un3EhJqHm"
     },
@@ -1204,8 +1204,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Werebear attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Werebear attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1392,10 +1392,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676923,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oRBnO5OHoOZzlCOr.pEYcOjAF2fovrXRP"
     },
@@ -1406,8 +1406,8 @@
       "img": "icons/weapons/axes/axe-double.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (1d12 + 4) <em>slashing damage</em></strong>.</p>\n</section>\n<p>The Werebear attacks with its Greataxe.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (1d12 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Werebear attacks with its Greataxe.</p>"
         },
         "source": {
           "custom": "",
@@ -1597,10 +1597,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676923,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!oRBnO5OHoOZzlCOr.UeXfHUO5RZp72PIs"
     }

--- a/packs/_source/monsters/humanoid/wereboar.json
+++ b/packs/_source/monsters/humanoid/wereboar.json
@@ -624,8 +624,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the wereboar moves at least 15 feet straight toward a target and then hits it with its tusks on the same turn, the target takes an extra <strong>7 (2d6) <em>slashing damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p></section><p>If the wereboar moves at least 15 feet straight toward a target and then hits it with its tusks on the same turn, the target takes extra <em>slashing damage</em>. If the target is a creature, it must make aStrength saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the wereboar moves at least 15 feet straight toward a target and then hits it with its tusks on the same turn, the target takes an extra <strong>7 (2d6) <em>slashing damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>If the wereboar moves at least 15 feet straight toward a target and then hits it with its tusks on the same turn, the target takes extra <em>slashing damage</em>. If the target is a creature, it must make aStrength saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -822,10 +822,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676932,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J9hgSaZODGjrNl9B.TizBVS6hRuBa8JYY"
     },
@@ -957,8 +957,8 @@
       "img": "icons/magic/death/skull-horned-goat-pentagram-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the wereboar <strong>takes 14 damage</strong> or less that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead.</p></section><p>If the wereboar takes damage that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead.</p>",
-          "chat": ""
+          "value": "<p>If the wereboar <strong>takes 14 damage</strong> or less that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead.</p>",
+          "chat": "<p>If the wereboar takes damage that would reduce it to <strong>0 hit points</strong>, it is reduced to <strong>1 hit point</strong> instead.</p>"
         },
         "source": {
           "custom": "",
@@ -1007,10 +1007,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676932,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J9hgSaZODGjrNl9B.NwivB5zd15WhthVJ"
     },
@@ -1021,8 +1021,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The wereboar can use its action to <strong>polymorph</strong> into a boar-humanoid hybrid or into a boar, or back into its true form, which is humanoid. </p><p>Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p></section><p>The wereboar can use its action to <strong>polymorph</strong>, or return to its true form.</p>",
-          "chat": ""
+          "value": "<p>The wereboar can use its action to <strong>polymorph</strong> into a boar-humanoid hybrid or into a boar, or back into its true form, which is humanoid. </p><p>Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p>",
+          "chat": "<p>The wereboar can use its action to <strong>polymorph</strong>, or return to its true form.</p>"
         },
         "source": {
           "custom": "",
@@ -1132,10 +1132,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676932,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J9hgSaZODGjrNl9B.zzskoOXzAiMDZfbc"
     },
@@ -1146,8 +1146,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 12 Constitution</strong> saving throw or be cursed with wereboar lycanthropy.</p></section><p>The Wereboar attacks with its Tusks. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 12 Constitution</strong> saving throw or be cursed with wereboar lycanthropy.</p>",
+          "chat": "<p>The Wereboar attacks with its Tusks. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1407,10 +1407,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676932,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J9hgSaZODGjrNl9B.3TD2NpdjIDJxeLl9"
     },
@@ -1421,8 +1421,8 @@
       "img": "icons/weapons/maces/mace-spiked-wood-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p>\n</section>\n<p>The Wereboar attacks with its Maul.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Wereboar attacks with its Maul.</p>"
         },
         "source": {
           "custom": "",
@@ -1612,10 +1612,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676932,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!J9hgSaZODGjrNl9B.dtdXnvp5cptFkGPu"
     }

--- a/packs/_source/monsters/humanoid/wererat.json
+++ b/packs/_source/monsters/humanoid/wererat.json
@@ -624,8 +624,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The wererat can use its action to <strong>polymorph</strong> into a rat-humanoid hybrid or into a giant rat, or back into its true form, which is humanoid. </p><p>Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p></section><p>The wererat can use its action to <strong>polymorph</strong>, or return to its true form.</p>",
-          "chat": ""
+          "value": "<p>The wererat can use its action to <strong>polymorph</strong> into a rat-humanoid hybrid or into a giant rat, or back into its true form, which is humanoid. </p><p>Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p>",
+          "chat": "<p>The wererat can use its action to <strong>polymorph</strong>, or return to its true form.</p>"
         },
         "source": {
           "custom": "",
@@ -735,10 +735,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676916,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!CrnUJhTbkdZjCZsH.PhdUmTsYUeWSSDNN"
     },
@@ -925,8 +925,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 11 Constitution</strong> saving throw or be cursed with wererat lycanthropy.</p></section><p>The Wererat attacks with its Bite. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 11 Constitution</strong> saving throw or be cursed with wererat lycanthropy.</p>",
+          "chat": "<p>The Wererat attacks with its Bite. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1186,10 +1186,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676916,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!CrnUJhTbkdZjCZsH.ldz0yUpzhV9Xlhss"
     },
@@ -1200,8 +1200,8 @@
       "img": "icons/weapons/crossbows/crossbow-simple-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>\n</section>\n<p>The Wererat attacks with its Hand Crossbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Wererat attacks with its Hand Crossbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1392,10 +1392,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676916,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!CrnUJhTbkdZjCZsH.YJi7nfridP2LjdJs"
     },
@@ -1406,8 +1406,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>\n</section>\n<p>The Wererat attacks with its Shortsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Wererat attacks with its Shortsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1597,10 +1597,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676916,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!CrnUJhTbkdZjCZsH.wpyEts6pBAxoD0Gh"
     }

--- a/packs/_source/monsters/humanoid/weretiger.json
+++ b/packs/_source/monsters/humanoid/weretiger.json
@@ -624,8 +624,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The weretiger can use its action to <strong>polymorph</strong> into a tiger-humanoid hybrid or into a tiger, or back into its true form, which is humanoid. </p><p>Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p></section><p>The weretiger can use its action to <strong>polymorph</strong>, or return to its true form.</p>",
-          "chat": ""
+          "value": "<p>The weretiger can use its action to <strong>polymorph</strong> into a tiger-humanoid hybrid or into a tiger, or back into its true form, which is humanoid. </p><p>Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p>",
+          "chat": "<p>The weretiger can use its action to <strong>polymorph</strong>, or return to its true form.</p>"
         },
         "source": {
           "custom": "",
@@ -735,10 +735,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676953,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.EjU9p4Wh1U2wsnFK"
     },
@@ -804,8 +804,8 @@
       "img": "icons/creatures/abilities/cougar-pounce-stalk-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the weretiger moves at <strong>least 15 feet</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 14 Strength saving throw</strong> or be knocked prone. If the target is prone, the weretiger can make one bite attack against it as a bonus action.</p><p>If the target is prone, the panther can make one bite attack against it as a bonus action.</p></section><p>If the weretiger moves at <strong>least 15 feet</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the weretiger moves at <strong>least 15 feet</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 14 Strength saving throw</strong> or be knocked prone. If the target is prone, the weretiger can make one bite attack against it as a bonus action.</p><p>If the target is prone, the panther can make one bite attack against it as a bonus action.</p>",
+          "chat": "<p>If the weretiger moves at <strong>least 15 feet</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -983,10 +983,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676953,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.jW4qHQ761qRLeWM8"
     },
@@ -1118,8 +1118,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be cursed with weretiger lycanthropy.</p></section><p>The Weretiger attacks with its Bite. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be cursed with weretiger lycanthropy.</p>",
+          "chat": "<p>The Weretiger attacks with its Bite. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1379,10 +1379,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676953,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.FOkSL18gU0Sli5ZA"
     },
@@ -1393,8 +1393,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>.</p><p></p></section><p>The Weretiger attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Weretiger attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1581,10 +1581,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676953,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.HPmjVRKpG08bgohb"
     },
@@ -1595,8 +1595,8 @@
       "img": "icons/weapons/swords/sword-katana.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p>\n</section>\n<p>The Weretiger attacks with its Scimitar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Weretiger attacks with its Scimitar.</p>"
         },
         "source": {
           "custom": "",
@@ -1786,10 +1786,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676953,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.vtnEGCOptmp2bcqG"
     },
@@ -1800,8 +1800,8 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>\n</section>\n<p>The Weretiger attacks with its Longbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Weretiger attacks with its Longbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1992,10 +1992,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676953,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.onmNGMiE4AyvYxDQ"
     }

--- a/packs/_source/monsters/humanoid/werewolf.json
+++ b/packs/_source/monsters/humanoid/werewolf.json
@@ -624,8 +624,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 12 Constitution</strong> saving throw or be cursed with werewolf lycanthropy.</p></section><p>The Werewolf attacks with its Bite. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 12 Constitution</strong> saving throw or be cursed with werewolf lycanthropy.</p>",
+          "chat": "<p>The Werewolf attacks with its Bite. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -885,10 +885,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676915,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7tRhrxuknTpHpYcA.tWfR8uJNnQxpXgDw"
     },
@@ -1020,8 +1020,8 @@
       "img": "icons/weapons/polearms/spear-flared-worn-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>, or <strong>6 (1d8 + 2) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p>\n</section>\n<p>The Werewolf attacks with its Spear.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>, or <strong>6 (1d8 + 2) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p>",
+          "chat": "<p>The Werewolf attacks with its Spear.</p>"
         },
         "source": {
           "custom": "",
@@ -1211,10 +1211,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676915,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7tRhrxuknTpHpYcA.TiKtAuqd6urQ45Ds"
     },
@@ -1225,8 +1225,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>7 (2d4 + 2) <em>slashing damage</em></strong>.</p><p></p></section><p>The Werewolf attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>7 (2d4 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Werewolf attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1413,10 +1413,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676915,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7tRhrxuknTpHpYcA.36H4LGNMMEYS1Irm"
     },
@@ -1427,8 +1427,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The werewolf can use its action to <strong>polymorph</strong> into a wolf-humanoid hybrid or into a wolf, or back into its true form, which is humanoid. </p><p>Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p></section><p>The werewolf can use its action to <strong>polymorph</strong>, or return to its true form.</p>",
-          "chat": ""
+          "value": "<p>The werewolf can use its action to <strong>polymorph</strong> into a wolf-humanoid hybrid or into a wolf, or back into its true form, which is humanoid. </p><p>Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p>",
+          "chat": "<p>The werewolf can use its action to <strong>polymorph</strong>, or return to its true form.</p>"
         },
         "source": {
           "custom": "",
@@ -1538,10 +1538,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676915,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7tRhrxuknTpHpYcA.2kHNI1T4gg879fDv"
     },

--- a/packs/_source/monsters/monstrosity/androsphinx.json
+++ b/packs/_source/monsters/monstrosity/androsphinx.json
@@ -745,8 +745,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The sphinx is a 12th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following cleric spells prepared:</p>\n<p>• Cantrips (at will): sacred flame, spare the dying, thaumaturgy• 1st level (4 slots): command, detect evil and good, detect magic• 2nd level (3 slots): lesser restoration, zone of truth• 3rd level (3 slots): dispel magic, tongues• 4th level (3 slots): banishment, freedom of movement• 5th level (2 slots): flame strike, greater restoration• 6th level (1 slot): heroes' feast</p>\n</section>\n<p>The sphinx is a spellcaster. Its spellcasting ability is Wisdom.</p>",
-          "chat": ""
+          "value": "<p>The sphinx is a 12th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following cleric spells prepared:</p><p>• Cantrips (at will): sacred flame, spare the dying, thaumaturgy• 1st level (4 slots): command, detect evil and good, detect magic• 2nd level (3 slots): lesser restoration, zone of truth• 3rd level (3 slots): dispel magic, tongues• 4th level (3 slots): banishment, freedom of movement• 5th level (2 slots): flame strike, greater restoration• 6th level (1 slot): heroes' feast</p>",
+          "chat": "<p>The sphinx is a spellcaster. Its spellcasting ability is Wisdom.</p>"
         },
         "source": {
           "custom": "",
@@ -790,10 +790,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676749,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nEC1BRwM8Lx9hLXW.zXzGfPnSFJbfZ7oW"
     },
@@ -804,8 +804,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>slashing damage</em></strong>.</p></section>\n<p>The Androsphinx attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+12 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>17 (2d10 + 6) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Androsphinx attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -992,10 +992,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676749,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nEC1BRwM8Lx9hLXW.yotsIj19d5spOVGb"
     },
@@ -1131,8 +1131,8 @@
       "img": "icons/magic/sonic/scream-wail-shout-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The sphinx emits a magical roar. Each time it roars before finishing a long rest, the roar is louder and the effect is different, as detailed below. Each creature within 500 feet of the sphinx and able to hear the roar must make a saving throw.</p>\n<p>**First Roar.** Each creature that fails a  <strong>DC 18 Wisdom</strong> saving throw is frightened for 1 minute. A frightened creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.**Second Roar.** Each creature that fails a  <strong>DC 18 Wisdom</strong> saving throw is deafened and frightened for 1 minute. A frightened creature is paralyzed and can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.**Third Roar.** Each creature makes a  <strong>DC 18 Constitution</strong> saving throw. On a failed save, a creature takes 44 (8d10) thunder damage and is knocked prone. On a successful save, the creature takes half as much damage and isn't knocked prone.</p>\n</section>\n<p>The sphinx emits a magical roar. Each time it roars before finishing a long rest, the roar is louder and the effect is different. Each creature within 500 feet of the sphinx and able to hear the roar must make a saving throw.</p>",
-          "chat": ""
+          "value": "<p>The sphinx emits a magical roar. Each time it roars before finishing a long rest, the roar is louder and the effect is different, as detailed below. Each creature within 500 feet of the sphinx and able to hear the roar must make a saving throw.</p><p>**First Roar.** Each creature that fails a  <strong>DC 18 Wisdom</strong> saving throw is frightened for 1 minute. A frightened creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.**Second Roar.** Each creature that fails a  <strong>DC 18 Wisdom</strong> saving throw is deafened and frightened for 1 minute. A frightened creature is paralyzed and can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.**Third Roar.** Each creature makes a  <strong>DC 18 Constitution</strong> saving throw. On a failed save, a creature takes 44 (8d10) thunder damage and is knocked prone. On a successful save, the creature takes half as much damage and isn't knocked prone.</p>",
+          "chat": "<p>The sphinx emits a magical roar. Each time it roars before finishing a long rest, the roar is louder and the effect is different. Each creature within 500 feet of the sphinx and able to hear the roar must make a saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1258,10 +1258,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676749,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nEC1BRwM8Lx9hLXW.ez87kySQJgKUPT9L"
     },

--- a/packs/_source/monsters/monstrosity/ankheg.json
+++ b/packs/_source/monsters/monstrosity/ankheg.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong> plus <strong>3 (1d6) <em>acid damage</em></strong>.</p>\n<p>If the target is a Large or smaller creature, it is grappled (escape DC 13). Until this grapple ends, the ankheg can bite only the grappled creature and has advantage on attack rolls to do so.</p>\n</section>\n<p>The Ankheg attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong> plus <strong>3 (1d6) <em>acid damage</em></strong>.</p><p>If the target is a Large or smaller creature, it is grappled (escape DC 13). Until this grapple ends, the ankheg can bite only the grappled creature and has advantage on attack rolls to do so.</p>",
+          "chat": "<p>The Ankheg attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -825,10 +825,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676576,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Wcsjbl25uiUsyQwn.mGamlcdui038L6gU"
     },
@@ -839,8 +839,8 @@
       "img": "icons/magic/acid/projectile-smoke-glowing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The ankheg spits acid in a line that is 30 ft. long and 5 ft. wide, provided that it has no creature grappled.</p>\n<p>Each creature in that line must make a  <strong>DC 13 Dexterity</strong> saving throw, taking <strong>10 (3d6) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>The ankheg spits acid in a line that is 30 ft. long and 5 ft. wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The ankheg spits acid in a line that is 30 ft. long and 5 ft. wide, provided that it has no creature grappled.</p><p>Each creature in that line must make a  <strong>DC 13 Dexterity</strong> saving throw, taking <strong>10 (3d6) <em>acid damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The ankheg spits acid in a line that is 30 ft. long and 5 ft. wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -989,10 +989,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676576,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!Wcsjbl25uiUsyQwn.XZwZexkrBLOzLo1Q"
     }

--- a/packs/_source/monsters/monstrosity/basilisk.json
+++ b/packs/_source/monsters/monstrosity/basilisk.json
@@ -615,8 +615,8 @@
       "img": "icons/magic/control/hypnosis-mesmerism-eye.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a creature starts its turn within <strong>30 ft.</strong> of the basilisk and the two of them can see each other, the basilisk can force the creature to make a <strong>DC 12 Constitution saving throw</strong> if the basilisk isn't incapacitated. On a failed save, the creature magically begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified until freed by the greater restoration spell or other magic.</p>\n<p>A creature that isn't surprised can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the basilisk until the start of its next turn, when it can avert its eyes again. If it looks at the basilisk in the meantime, it must immediately make the save<strong>. I</strong>f the basilisk sees its reflection within <strong>30 ft.</strong> of it in bright light, it mistakes itself for a rival and targets itself with its gaze.</p>\n</section>\n<p>The basilisk can force the creature to make a <strong>Constitution</strong> saving throw. It must repeat the saving throw at the end of its next turn. A creature that isn't surprised can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the basilisk until the start of its next turn, when it can avert its eyes again. If it looks at the basilisk in the meantime, it must immediately make the save.</p>",
-          "chat": ""
+          "value": "<p>If a creature starts its turn within <strong>30 ft.</strong> of the basilisk and the two of them can see each other, the basilisk can force the creature to make a <strong>DC 12 Constitution saving throw</strong> if the basilisk isn't incapacitated. On a failed save, the creature magically begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified until freed by the greater restoration spell or other magic.</p><p>A creature that isn't surprised can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the basilisk until the start of its next turn, when it can avert its eyes again. If it looks at the basilisk in the meantime, it must immediately make the save<strong>. I</strong>f the basilisk sees its reflection within <strong>30 ft.</strong> of it in bright light, it mistakes itself for a rival and targets itself with its gaze.</p>",
+          "chat": "<p>The basilisk can force the creature to make a <strong>Constitution</strong> saving throw. It must repeat the saving throw at the end of its next turn. A creature that isn't surprised can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the basilisk until the start of its next turn, when it can avert its eyes again. If it looks at the basilisk in the meantime, it must immediately make the save.</p>"
         },
         "source": {
           "custom": "",
@@ -732,10 +732,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676591,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hqj2yXtgwt64v3Lj.bKBPawscKpixPeO0"
     },
@@ -746,8 +746,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>poison damage</em></strong>.</p></section>\n<p>The Basilisk attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Basilisk attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -956,10 +956,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676591,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hqj2yXtgwt64v3Lj.atyoFYgU32nJ9kPK"
     }

--- a/packs/_source/monsters/monstrosity/behir.json
+++ b/packs/_source/monsters/monstrosity/behir.json
@@ -744,8 +744,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>22 (3d10 + 6) <em>piercing damage</em></strong>.</p></section>\n<p>The Behir attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>22 (3d10 + 6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Behir attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -938,10 +938,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676905,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!x47ZnpHfYl0ptDM9.4fNbTxkAFYHxDdJX"
     },
@@ -952,8 +952,8 @@
       "img": "icons/creatures/reptiles/serpent-horned-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Melee Weapon Attack: +10 to hit, reach 5 ft., <strong>one Large or smaller creature</strong>. Hit: <strong>17 (2d10 + 6) <em>bludgeoning damage</em></strong> plus <strong>17 (2d10 + 6) <em>slashing damage</em></strong>.</p>\n<p>The target is grappled (escape DC 16) if the behir isn't already constricting a creature, and the target is restrained until this grapple ends.</p>\n</section>\n<p>The Behir attacks with its Constrict. The target is grappled if the Behir isn't already constricting a creature, and the target is restrained until this grapple ends.</p>",
-          "chat": ""
+          "value": "<p>Melee Weapon Attack: +10 to hit, reach 5 ft., <strong>one Large or smaller creature</strong>. Hit: <strong>17 (2d10 + 6) <em>bludgeoning damage</em></strong> plus <strong>17 (2d10 + 6) <em>slashing damage</em></strong>.</p><p>The target is grappled (escape DC 16) if the behir isn't already constricting a creature, and the target is restrained until this grapple ends.</p>",
+          "chat": "<p>The Behir attacks with its Constrict. The target is grappled if the Behir isn't already constricting a creature, and the target is restrained until this grapple ends.</p>"
         },
         "source": {
           "custom": "",
@@ -1158,10 +1158,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676905,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!x47ZnpHfYl0ptDM9.GCUh42hMUnKtxx8j"
     },
@@ -1172,8 +1172,8 @@
       "img": "icons/magic/lightning/bolt-strike-smoke-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The behir exhales a line of lightning that is 20 ft. long and 5 ft. wide. Each creature in that line must make a  <strong>DC 16 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section>\n<p>The behir exhales a line of lightning that is 20 ft. long and 5 ft. wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The behir exhales a line of lightning that is 20 ft. long and 5 ft. wide. Each creature in that line must make a  <strong>DC 16 Dexterity</strong> saving throw, taking <strong>66 (12d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The behir exhales a line of lightning that is 20 ft. long and 5 ft. wide. Each creature in that line must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1322,10 +1322,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676905,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!x47ZnpHfYl0ptDM9.gjce4R2feN2UH0YE"
     },
@@ -1336,8 +1336,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-tongue-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The behir makes one bite attack against a <strong>Medium or smaller target it is grappling</strong>. If the attack hits, the target is also swallowed, and the grapple ends. While swallowed, the target is blinded and restrained, it has total cover against attacks and other effects outside the behir, and it takes <strong>21 (6d6) <em>acid damage</em></strong> at the start of each of the behir's turns. A behir can have only one creature swallowed at a time.</p>\n<p>If the behir takes 30 damage or more on a single turn from the swallowed creature, the behir must succeed on a  <strong>DC 14 Constitution</strong> saving throw at the end of that turn or regurgitate the creature, which falls prone in a space within 10 ft. of the behir. If the behir dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 15 ft. of movement, exiting prone.</p>\n</section>\n<p>The Behir attacks with its Swallow.</p>",
-          "chat": ""
+          "value": "<p>The behir makes one bite attack against a <strong>Medium or smaller target it is grappling</strong>. If the attack hits, the target is also swallowed, and the grapple ends. While swallowed, the target is blinded and restrained, it has total cover against attacks and other effects outside the behir, and it takes <strong>21 (6d6) <em>acid damage</em></strong> at the start of each of the behir's turns. A behir can have only one creature swallowed at a time.</p><p>If the behir takes 30 damage or more on a single turn from the swallowed creature, the behir must succeed on a  <strong>DC 14 Constitution</strong> saving throw at the end of that turn or regurgitate the creature, which falls prone in a space within 10 ft. of the behir. If the behir dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 15 ft. of movement, exiting prone.</p>",
+          "chat": "<p>The Behir attacks with its Swallow.</p>"
         },
         "source": {
           "custom": "",
@@ -1466,10 +1466,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676905,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!x47ZnpHfYl0ptDM9.0QJeW80m89X0RLNz"
     }

--- a/packs/_source/monsters/monstrosity/bulette.json
+++ b/packs/_source/monsters/monstrosity/bulette.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>30 (4d12 + 4) <em>piercing damage</em></strong>.</p></section>\n<p>The Bulette attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>30 (4d12 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Bulette attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676520,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1ES45ODWg3pCrkzv.r4KUyv5cYwjHqNl3"
     },
@@ -880,8 +880,8 @@
       "img": "icons/magic/fire/projectile-wave-arrow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the bulette jumps at least 15 ft. as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures.</p>\n<p>Each of those creatures must succeed on a DC 16 Strength or Dexterity saving throw (target's choice) or be knocked prone and take <strong>14 (3d6 + 4) <em>bludgeoning damage</em></strong> plus <strong>14 (3d6 + 4) <em>slashing damage</em></strong>. On a successful save, the creature takes only half the damage, isn't knocked prone, and is pushed 5 ft. out of the bulette's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls prone in the bulette's space.</p>\n</section>\n<p>If the bulette jumps at least 15 ft. as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures. Each of those creatures must make a Strength or Dexterity saving throw (target's choice) or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the bulette jumps at least 15 ft. as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures.</p><p>Each of those creatures must succeed on a DC 16 Strength or Dexterity saving throw (target's choice) or be knocked prone and take <strong>14 (3d6 + 4) <em>bludgeoning damage</em></strong> plus <strong>14 (3d6 + 4) <em>slashing damage</em></strong>. On a successful save, the creature takes only half the damage, isn't knocked prone, and is pushed 5 ft. out of the bulette's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls prone in the bulette's space.</p>",
+          "chat": "<p>If the bulette jumps at least 15 ft. as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures. Each of those creatures must make a Strength or Dexterity saving throw (target's choice) or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -1134,10 +1134,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676520,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1ES45ODWg3pCrkzv.Keg9oouX6Vbl9tms"
     }

--- a/packs/_source/monsters/monstrosity/centaur.json
+++ b/packs/_source/monsters/monstrosity/centaur.json
@@ -618,8 +618,8 @@
       "img": "icons/weapons/polearms/halberd-crescent-stone-worn.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>9 (1d10 + 4) <em>piercing damage</em></strong>.</p></section>\n<p>The Centaur attacks with its Pike.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>9 (1d10 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Centaur attacks with its Pike.</p>"
         },
         "source": {
           "custom": "",
@@ -814,10 +814,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676912,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5kZNNWzZ6HrfKuWf.uhqyN44IRWXixgxU"
     },
@@ -828,8 +828,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Centaur attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Centaur attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -1020,10 +1020,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676912,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5kZNNWzZ6HrfKuWf.ICbiLFrPjwIfA1Nj"
     },
@@ -1034,8 +1034,8 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Centaur attacks with its Longbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Centaur attacks with its Longbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1230,10 +1230,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676912,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5kZNNWzZ6HrfKuWf.v7ForWMLPJp1u78X"
     },
@@ -1369,8 +1369,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the centaur moves at least 30 ft. straight toward a target and then hits it with a pike attack on the same turn, the target takes an extra <strong>10 (3d6) <em>piercing damage</em></strong>.</p></section>\n<p>If the centaur moves at least 30 ft. straight toward a target and then hits it with a pike attack on the same turn, the target takes extra <em>piercing damage</em>.</p>",
-          "chat": ""
+          "value": "<p>If the centaur moves at least 30 ft. straight toward a target and then hits it with a pike attack on the same turn, the target takes an extra <strong>10 (3d6) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>If the centaur moves at least 30 ft. straight toward a target and then hits it with a pike attack on the same turn, the target takes extra <em>piercing damage</em>.</p>"
         },
         "source": {
           "custom": "",
@@ -1500,10 +1500,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676912,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!5kZNNWzZ6HrfKuWf.4R48w4DH2CqCpmED"
     }

--- a/packs/_source/monsters/monstrosity/chimera.json
+++ b/packs/_source/monsters/monstrosity/chimera.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>.</p></section>\n<p>The Chimera attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Chimera attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676922,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kr6r8bhSehACPfZ8.dDrIfOa408VFGv4a"
     },
@@ -821,8 +821,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p></section>\n<p>The Chimera attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Chimera attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1009,10 +1009,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676922,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kr6r8bhSehACPfZ8.J98n5dL3pMkWGu69"
     },
@@ -1023,8 +1023,8 @@
       "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The dragon head exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 15 Dexterity</strong> saving throw, taking <strong>31 (7d8) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section>\n<p>The dragon head exhales fire in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The dragon head exhales fire in a 15-foot cone. Each creature in that area must make a  <strong>DC 15 Dexterity</strong> saving throw, taking <strong>31 (7d8) <em>fire damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The dragon head exhales fire in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1188,10 +1188,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676922,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kr6r8bhSehACPfZ8.c4fLDKOomwlaFcac"
     },
@@ -1327,8 +1327,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (1d12 + 4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Chimera attacks with its Horns.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (1d12 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Chimera attacks with its Horns.</p>"
         },
         "source": {
           "custom": "",
@@ -1515,10 +1515,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676922,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kr6r8bhSehACPfZ8.m5xGw7RgVRGTklJT"
     }

--- a/packs/_source/monsters/monstrosity/cockatrice.json
+++ b/packs/_source/monsters/monstrosity/cockatrice.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>3 (1d4 + 1) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 11 Constitution</strong> saving throw against being magically petrified. On a failed save, the creature begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified for 24 hours.</p></section><p>The Cockatrice attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw. On a failed save, it must repeat the saving throw at the end of its next turn.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>3 (1d4 + 1) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 11 Constitution</strong> saving throw against being magically petrified. On a failed save, the creature begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified for 24 hours.</p>",
+          "chat": "<p>The Cockatrice attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw. On a failed save, it must repeat the saving throw at the end of its next turn.</p>"
         },
         "source": {
           "custom": "",
@@ -898,10 +898,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676429,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EpYl7qifM5pq6W6B.gpxvIs8yjQ4awt4s"
     }

--- a/packs/_source/monsters/monstrosity/darkmantle.json
+++ b/packs/_source/monsters/monstrosity/darkmantle.json
@@ -733,8 +733,8 @@
       "img": "icons/magic/life/heart-shadow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong>.</p>\n<p>The darkmantle attaches to the target. If the target is Medium or smaller and the darkmantle has advantage on the attack roll, it attaches by engulfing the target's head, and the target is also blinded and unable to breathe while the darkmantle is attached in this way.</p>\n<p>While attached to the target, the darkmantle can attack no other creature except the target but has advantage on its attack rolls. The darkmantle's speed also becomes 0, it can't benefit from any bonus to its speed, and it moves with the target.</p>\n<p>A creature can detach the darkmantle by making a successful DC 13 Strength check as an action. On its turn, the darkmantle can detach itself from the target by using 5 feet of movement.</p>\n</section>\n<p>The darkmantle attacks with its Crush. The darkmantle attaches to the target. While attached to the target, the darkmantle can attack no other creature except the target but has advantage on its attack rolls. A creature can detach the darkmantle by making a successful Strength check as an action.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong>.</p><p>The darkmantle attaches to the target. If the target is Medium or smaller and the darkmantle has advantage on the attack roll, it attaches by engulfing the target's head, and the target is also blinded and unable to breathe while the darkmantle is attached in this way.</p><p>While attached to the target, the darkmantle can attack no other creature except the target but has advantage on its attack rolls. The darkmantle's speed also becomes 0, it can't benefit from any bonus to its speed, and it moves with the target.</p><p>A creature can detach the darkmantle by making a successful DC 13 Strength check as an action. On its turn, the darkmantle can detach itself from the target by using 5 feet of movement.</p>",
+          "chat": "<p>The darkmantle attacks with its Crush. The darkmantle attaches to the target. While attached to the target, the darkmantle can attack no other creature except the target but has advantage on its attack rolls. A creature can detach the darkmantle by making a successful Strength check as an action.</p>"
         },
         "source": {
           "custom": "",
@@ -1010,10 +1010,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676588,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!g7FSu2oU4YHPgWNA.DA34sS4nWGc4OTwm"
     },
@@ -1024,8 +1024,8 @@
       "img": "icons/magic/perception/eye-ringed-glow-angry-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>A 15-foot radius of magical darkness extends out from the darkmantle, moves with it, and spreads around corners. The darkness lasts as long as the darkmantle maintains concentration, up to 10 minutes (as if concentrating on a spell).</p>\n<p>Darkvision can't penetrate this darkness, and no natural light can illuminate it. If any of the darkness overlaps with an area of light created by a spell of 2nd level or lower, the spell creating the light is dispelled.</p>\n</section>\n<p>A 15-foot radius of magical darkness extends out from the darkmantle, moves with it, and spreads around corners. Darkvision can't penetrate this darkness, and no natural light can illuminate it.</p>",
-          "chat": ""
+          "value": "<p>A 15-foot radius of magical darkness extends out from the darkmantle, moves with it, and spreads around corners. The darkness lasts as long as the darkmantle maintains concentration, up to 10 minutes (as if concentrating on a spell).</p><p>Darkvision can't penetrate this darkness, and no natural light can illuminate it. If any of the darkness overlaps with an area of light created by a spell of 2nd level or lower, the spell creating the light is dispelled.</p>",
+          "chat": "<p>A 15-foot radius of magical darkness extends out from the darkmantle, moves with it, and spreads around corners. Darkvision can't penetrate this darkness, and no natural light can illuminate it.</p>"
         },
         "source": {
           "custom": "",
@@ -1150,10 +1150,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676588,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!g7FSu2oU4YHPgWNA.qzSE2ZiVMLKsWF4F"
     }

--- a/packs/_source/monsters/monstrosity/death-dog.json
+++ b/packs/_source/monsters/monstrosity/death-dog.json
@@ -615,8 +615,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 12 Constitution</strong> saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the creature must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. This reduction lasts until the disease is cured. The creature dies if the disease reduces its hit point maximum to 0.</p>\n</section>\n<p>The Death Dog attacks with its Bite. If the target is a creature, it must make a <strong>Constitution</strong> saving throw. Every 24 hours that elapse, the creature must repeat the saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 12 Constitution</strong> saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the creature must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. This reduction lasts until the disease is cured. The creature dies if the disease reduces its hit point maximum to 0.</p>",
+          "chat": "<p>The Death Dog attacks with its Bite. If the target is a creature, it must make a <strong>Constitution</strong> saving throw. Every 24 hours that elapse, the creature must repeat the saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -896,10 +896,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676448,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PH78NBdvoaszAb61.TKV9mS1lvqMAyCaB"
     },

--- a/packs/_source/monsters/monstrosity/doppelganger.json
+++ b/packs/_source/monsters/monstrosity/doppelganger.json
@@ -947,8 +947,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d6 + 4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Doppelganger attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d6 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Doppelganger attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -1137,10 +1137,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676742,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!mWbrPhcKOz6oLXMV.scZU8bs551DZRvgC"
     },
@@ -1151,8 +1151,8 @@
       "img": "icons/magic/control/hypnosis-mesmerism-watch.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The doppelganger magically reads the surface thoughts of one creature within 60 ft. of it. The effect can penetrate barriers, but 3 ft. of wood or dirt, 2 ft. of stone, 2 inches of metal, or a thin sheet of lead blocks it.</p>\n<p>While the target is in range, the doppelganger can continue reading its thoughts, as long as the doppelganger's concentration isn't broken (as if concentrating on a spell). While reading the target's mind, the doppelganger has advantage on Wisdom (Insight) and Charisma (Deception, Intimidation, and Persuasion) checks against the target.</p>\n</section>\n<p>The doppelganger magically reads the surface thoughts of one creature within 60 ft. of it.</p>",
-          "chat": ""
+          "value": "<p>The doppelganger magically reads the surface thoughts of one creature within 60 ft. of it. The effect can penetrate barriers, but 3 ft. of wood or dirt, 2 ft. of stone, 2 inches of metal, or a thin sheet of lead blocks it.</p><p>While the target is in range, the doppelganger can continue reading its thoughts, as long as the doppelganger's concentration isn't broken (as if concentrating on a spell). While reading the target's mind, the doppelganger has advantage on Wisdom (Insight) and Charisma (Deception, Intimidation, and Persuasion) checks against the target.</p>",
+          "chat": "<p>The doppelganger magically reads the surface thoughts of one creature within 60 ft. of it.</p>"
         },
         "source": {
           "custom": "",
@@ -1263,10 +1263,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676742,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!mWbrPhcKOz6oLXMV.YIoB9xCKEcrrPRt9"
     },
@@ -1277,8 +1277,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The doppelganger can use its action to <strong>polymorph</strong> into a Small or Medium humanoid it has seen, or back into its true form.</p><p>Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p></section><p>The doppelganger can use its action to <strong>polymorph</strong> into a Small or Medium humanoid it has seen, or back into its true form.</p>",
-          "chat": ""
+          "value": "<p>The doppelganger can use its action to <strong>polymorph</strong> into a Small or Medium humanoid it has seen, or back into its true form.</p><p>Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p>",
+          "chat": "<p>The doppelganger can use its action to <strong>polymorph</strong> into a Small or Medium humanoid it has seen, or back into its true form.</p>"
         },
         "source": {
           "custom": "",
@@ -1388,10 +1388,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676742,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!mWbrPhcKOz6oLXMV.cG4WdhcrTZt6rxUi"
     }

--- a/packs/_source/monsters/monstrosity/drider.json
+++ b/packs/_source/monsters/monstrosity/drider.json
@@ -1038,8 +1038,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>2 (1d4) <em>piercing damage</em></strong> plus <strong>9 (2d8) <em>poison damage</em></strong>.</p></section>\n<p>The Drider attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>2 (1d4) <em>piercing damage</em></strong> plus <strong>9 (2d8) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Drider attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1248,10 +1248,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676839,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1OQbxoZI5BtlB2ME.rUvv8Vnh7XbqbCLd"
     },
@@ -1262,8 +1262,8 @@
       "img": "icons/weapons/swords/greatsword-crossguard-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>, or <strong>8 (1d10 + 3) <em>slashing damage</em></strong> if used with two hands.</p></section>\n<p>The Drider attacks with its Longsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>, or <strong>8 (1d10 + 3) <em>slashing damage</em></strong> if used with two hands.</p>",
+          "chat": "<p>The Drider attacks with its Longsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1456,10 +1456,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676839,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1OQbxoZI5BtlB2ME.xqwxVn28J0zx8Y7H"
     },
@@ -1470,8 +1470,8 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>poison damage</em></strong>.</p></section>\n<p>The Drider attacks with its Longbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Drider attacks with its Longbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1684,10 +1684,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676839,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1OQbxoZI5BtlB2ME.3XAtYmmaED1rxaaE"
     },

--- a/packs/_source/monsters/monstrosity/ettercap.json
+++ b/packs/_source/monsters/monstrosity/ettercap.json
@@ -917,8 +917,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>poison damage</em></strong>. </p><p>The target must succeed on a  <strong>DC 11 Constitution</strong> saving throw or be poisoned for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p></section><p>The Ettercap attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>poison damage</em></strong>. </p><p>The target must succeed on a  <strong>DC 11 Constitution</strong> saving throw or be poisoned for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The Ettercap attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1127,10 +1127,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676798,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aKt7vFAS1J0x3FQm.qpUx52QbFUCSPSln"
     },
@@ -1141,8 +1141,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>slashing damage</em></strong>.</p><p></p></section><p>The Ettercap attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Ettercap attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1329,10 +1329,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676798,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aKt7vFAS1J0x3FQm.T8XMTiCIOQP4dYEp"
     },
@@ -1343,8 +1343,8 @@
       "img": "icons/creatures/webs/web-spider-glowing-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +4 to hit, range 30/60 ft., one Large or smaller creature. Hit: The creature is restrained by webbing. </p><p>As an action, the restrained creature can make a DC 11 Strength check, escaping from the webbing on a success. The effect ends if the webbing is destroyed. The webbing has AC 10, 5 hit points, is vulnerable to <em>fire damage</em> and immune to <em>bludgeoning damage</em>.</p></section><p>The creature is restrained by webbing. As an action, the restrained creature can make a Strength check, escaping from the webbing on a success. </p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 30/60 ft., one Large or smaller creature. Hit: The creature is restrained by webbing. </p><p>As an action, the restrained creature can make a DC 11 Strength check, escaping from the webbing on a success. The effect ends if the webbing is destroyed. The webbing has AC 10, 5 hit points, is vulnerable to <em>fire damage</em> and immune to <em>bludgeoning damage</em>.</p>",
+          "chat": "<p>The creature is restrained by webbing. As an action, the restrained creature can make a Strength check, escaping from the webbing on a success. </p>"
         },
         "source": {
           "custom": "",
@@ -1565,10 +1565,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676798,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!aKt7vFAS1J0x3FQm.Sv5UJkCfY00yfFOE"
     }

--- a/packs/_source/monsters/monstrosity/gorgon.json
+++ b/packs/_source/monsters/monstrosity/gorgon.json
@@ -617,8 +617,8 @@
       "img": "icons/creatures/abilities/cougar-pounce-stalk-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the gorgon moves at <strong>least 20 feet</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a <strong>DC 16 Strength saving throw</strong> or be knocked prone. If the target is prone, the gorgon can make one attack with its hooves against it as a bonus action.</p></section><p>If the gorgon moves at <strong>least 20 feet</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on Strength saving throw.</p>",
-          "chat": ""
+          "value": "<p>If the gorgon moves at <strong>least 20 feet</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a <strong>DC 16 Strength saving throw</strong> or be knocked prone. If the target is prone, the gorgon can make one attack with its hooves against it as a bonus action.</p>",
+          "chat": "<p>If the gorgon moves at <strong>least 20 feet</strong> straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on Strength saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -800,10 +800,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676895,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nZthq6WHLhcdu3te.zpzof99ziVJCU4hI"
     },
@@ -814,8 +814,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>18 (2d12 + 5) <em>piercing damage</em></strong>.</p><p></p></section><p>The Gorgon attacks with its Gore.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>18 (2d12 + 5) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Gorgon attacks with its Gore.</p>"
         },
         "source": {
           "custom": "",
@@ -1002,10 +1002,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676895,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nZthq6WHLhcdu3te.7DSbBzpS1e9lYxZx"
     },
@@ -1016,8 +1016,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>16 (2d10 + 5) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Gorgon attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>16 (2d10 + 5) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Gorgon attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -1208,10 +1208,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676895,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nZthq6WHLhcdu3te.O8oahxePfpHFYohz"
     },
@@ -1222,8 +1222,8 @@
       "img": "icons/magic/air/fog-gas-smoke-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The gorgon exhales petrifying gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 13 Constitution</strong> saving throw. </p><p>On a failed save, a target begins to turn to stone and is restrained. The restrained target must repeat the saving throw at the end of its next turn. On a success, the effect ends on the target. On a failure, the target is petrified until freed by the greater restoration spell or other magic.</p></section><p>The gorgon exhales petrifying gas in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw. </p>",
-          "chat": ""
+          "value": "<p>The gorgon exhales petrifying gas in a 30-foot cone. Each creature in that area must succeed on a  <strong>DC 13 Constitution</strong> saving throw. </p><p>On a failed save, a target begins to turn to stone and is restrained. The restrained target must repeat the saving throw at the end of its next turn. On a success, the effect ends on the target. On a failure, the target is petrified until freed by the greater restoration spell or other magic.</p>",
+          "chat": "<p>The gorgon exhales petrifying gas in a 30-foot cone. Each creature in that area must make a <strong>Constitution</strong> saving throw. </p>"
         },
         "source": {
           "custom": "",
@@ -1354,10 +1354,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676895,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nZthq6WHLhcdu3te.5tEnGK28Rd4nHnwM"
     }

--- a/packs/_source/monsters/monstrosity/grick.json
+++ b/packs/_source/monsters/monstrosity/grick.json
@@ -805,8 +805,8 @@
       "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d6 + 2) <em>slashing damage</em></strong>.</p><p></p></section><p>The Grick attacks with its Tentacles.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d6 + 2) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Grick attacks with its Tentacles.</p>"
         },
         "source": {
           "custom": "",
@@ -997,10 +997,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676705,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!tFJX45zj3QDc3Zli.tkVlxJxg4LBVJvuX"
     },
@@ -1011,8 +1011,8 @@
       "img": "icons/commodities/bones/beak-hooked-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Grick attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Grick attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -1199,10 +1199,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676705,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!tFJX45zj3QDc3Zli.AGLjE9RSCjg1vQ6R"
     }

--- a/packs/_source/monsters/monstrosity/griffon.json
+++ b/packs/_source/monsters/monstrosity/griffon.json
@@ -795,8 +795,8 @@
       "img": "icons/commodities/bones/beak-hooked-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d8 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Griffon attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d8 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Griffon attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -983,10 +983,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676694,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!h052EIIUmRwJum65.T2JS1VEL7U2s92Fj"
     },
@@ -997,8 +997,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Griffon attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Griffon attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1185,10 +1185,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676694,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!h052EIIUmRwJum65.ldVEDIAP2PHxLHsL"
     }

--- a/packs/_source/monsters/monstrosity/guardian-naga.json
+++ b/packs/_source/monsters/monstrosity/guardian-naga.json
@@ -623,8 +623,8 @@
       "img": "icons/magic/control/debuff-energy-hold-levitate-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If it dies, the naga returns to life in 1d6 days and regains all its<strong> hit points</strong>. </p><p>Only a wish spell can prevent this trait from functioning.</p></section><p>If it dies, the naga returns to life in 1d6 days and regains all its<strong> hit points</strong>.</p>",
-          "chat": ""
+          "value": "<p>If it dies, the naga returns to life in 1d6 days and regains all its<strong> hit points</strong>. </p><p>Only a wish spell can prevent this trait from functioning.</p>",
+          "chat": "<p>If it dies, the naga returns to life in 1d6 days and regains all its<strong> hit points</strong>.</p>"
         },
         "source": {
           "custom": "",
@@ -734,10 +734,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676888,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8ExSFCar5Lbhdo7u.GkVxLIsamEXICEeT"
     },
@@ -748,8 +748,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The naga is an 11th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following cleric spells prepared:</p>\n<p>Cantrips (at will): mending, sacred flame, thaumaturgy</p>\n<p>1st level (4 slots): command, cure wounds, shield of faith</p>\n<p>2nd level (3 slots): calm emotions, hold person</p>\n<p>3rd level (3 slots): bestow curse, clairvoyance</p>\n<p>4th level (3 slots): banishment, freedom of movement</p>\n<p>5th level (2 slots): flame strike, geas</p>\n<p>6th level (1 slot): true seeing</p>\n</section>\n<p>The naga is an spellcaster. Its spellcasting ability is Wisdom.</p>",
-          "chat": ""
+          "value": "<p>The naga is an 11th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following cleric spells prepared:</p><p>Cantrips (at will): mending, sacred flame, thaumaturgy</p><p>1st level (4 slots): command, cure wounds, shield of faith</p><p>2nd level (3 slots): calm emotions, hold person</p><p>3rd level (3 slots): bestow curse, clairvoyance</p><p>4th level (3 slots): banishment, freedom of movement</p><p>5th level (2 slots): flame strike, geas</p><p>6th level (1 slot): true seeing</p>",
+          "chat": "<p>The naga is an spellcaster. Its spellcasting ability is Wisdom.</p>"
         },
         "source": {
           "custom": "",
@@ -793,10 +793,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676888,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8ExSFCar5Lbhdo7u.wtPKdh22QAc93kgt"
     },
@@ -807,8 +807,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>8 (1d8 + 4) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>45 (10d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The Guardian Naga attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>8 (1d8 + 4) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>45 (10d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Guardian Naga attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1156,10 +1156,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676888,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8ExSFCar5Lbhdo7u.hQFQz2LiNGpxcRvw"
     },
@@ -1170,8 +1170,8 @@
       "img": "icons/magic/acid/dissolve-drip-droplet-smoke.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +8 to hit, range 15/30 ft., one creature. Hit: </p><p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>45 (10d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The Guardian Naga attacks with its Spit Poison. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +8 to hit, range 15/30 ft., one creature. Hit: </p><p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>45 (10d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Guardian Naga attacks with its Spit Poison. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1447,10 +1447,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676888,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8ExSFCar5Lbhdo7u.PtPZ5aBQPEfbbvla"
     },

--- a/packs/_source/monsters/monstrosity/gynosphinx.json
+++ b/packs/_source/monsters/monstrosity/gynosphinx.json
@@ -746,8 +746,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The sphinx is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following wizard spells prepared:</p>\n<p>Cantrips (at will): mage hand, minor illusion, prestidigitation</p>\n<p>1st level (4 slots): detect magic, identify, shield</p>\n<p>2nd level (3 slots): darkness, locate object, suggestion</p>\n<p>3rd level (3 slots): dispel magic, remove curse, tongues</p>\n<p>4th level (3 slots): banishment, greater invisibility</p>\n<p>5th level (1 slot): legend lore</p>\n</section>\n<p>The sphinx is a spellcaster. Its spellcasting ability is Intelligence.</p>",
-          "chat": ""
+          "value": "<p>The sphinx is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following wizard spells prepared:</p><p>Cantrips (at will): mage hand, minor illusion, prestidigitation</p><p>1st level (4 slots): detect magic, identify, shield</p><p>2nd level (3 slots): darkness, locate object, suggestion</p><p>3rd level (3 slots): dispel magic, remove curse, tongues</p><p>4th level (3 slots): banishment, greater invisibility</p><p>5th level (1 slot): legend lore</p>",
+          "chat": "<p>The sphinx is a spellcaster. Its spellcasting ability is Intelligence.</p>"
         },
         "source": {
           "custom": "",
@@ -791,10 +791,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676862,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6wbasdWWqtXeIAyD.kvyuqG5WztblcJXb"
     },
@@ -930,8 +930,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p></section>\n<p>The Gynosphinx attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Gynosphinx attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1118,10 +1118,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676862,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6wbasdWWqtXeIAyD.gVFZXBtgx450yiH7"
     },
@@ -1132,8 +1132,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The sphinx can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The sphinx regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The sphinx can take 3 legendary actions.</p>",
-          "chat": ""
+          "value": "<p>The sphinx can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The sphinx regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The sphinx can take 3 legendary actions.</p>"
         },
         "source": {
           "custom": "",
@@ -1177,10 +1177,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676862,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6wbasdWWqtXeIAyD.rH7NbL1u2RarHKKb"
     },
@@ -1250,8 +1250,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -1295,10 +1295,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676862,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!6wbasdWWqtXeIAyD.Sw2aAeas52cJ4uHZ"
     },

--- a/packs/_source/monsters/monstrosity/harpy.json
+++ b/packs/_source/monsters/monstrosity/harpy.json
@@ -742,8 +742,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (2d4 + 1) <em>slashing damage</em></strong>.</p><p></p></section><p>The Harpy attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (2d4 + 1) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Harpy attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -930,10 +930,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676769,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!CqQ6pXQA5WXZNOm3.WqD5jsrWCeNHoD9O"
     },
@@ -944,8 +944,8 @@
       "img": "icons/weapons/clubs/club-simple-barbed.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d4 + 1) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Harpy attacks with its Club.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d4 + 1) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Harpy attacks with its Club.</p>"
         },
         "source": {
           "custom": "",
@@ -1138,10 +1138,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676769,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!CqQ6pXQA5WXZNOm3.ywVQhULZvd4Jn51c"
     },
@@ -1152,8 +1152,8 @@
       "img": "icons/magic/air/wind-vortex-swirl-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The harpy sings a magical melody. Every humanoid and giant within 300 ft. of the harpy that can hear the song must succeed on a  <strong>DC 11 Wisdom</strong> saving throw or be charmed until the song ends. The harpy must take a bonus action on its subsequent turns to continue singing. It can stop singing at any time. The song ends if the harpy is incapacitated.</p>\n<p>While charmed by the harpy, a target is incapacitated and ignores the songs of other harpies. If the charmed target is more than 5 feet away from the harpy, the target must move on its turn toward the harpy by the most direct route, trying to get within 5 feet. It doesn't avoid opportunity attacks, but before moving into damaging terrain, such as lava or a pit, and whenever it takes damage from a source other than the harpy, the target can repeat the saving throw. A charmed target can also repeat the saving throw at the end of each of its turns. If the saving throw is successful, the effect ends on it.</p>\n<p>A target that successfully saves is immune to this harpy's song for the next 24 hours.</p>\n</section>\n<p>The harpy sings a magical melody. Every humanoid and giant within 300 ft. of the harpy that can hear the song must make a <strong>Wisdom</strong> saving throw. A creature can also repeat the saving throw at the end of each of its turns.</p>",
-          "chat": ""
+          "value": "<p>The harpy sings a magical melody. Every humanoid and giant within 300 ft. of the harpy that can hear the song must succeed on a  <strong>DC 11 Wisdom</strong> saving throw or be charmed until the song ends. The harpy must take a bonus action on its subsequent turns to continue singing. It can stop singing at any time. The song ends if the harpy is incapacitated.</p><p>While charmed by the harpy, a target is incapacitated and ignores the songs of other harpies. If the charmed target is more than 5 feet away from the harpy, the target must move on its turn toward the harpy by the most direct route, trying to get within 5 feet. It doesn't avoid opportunity attacks, but before moving into damaging terrain, such as lava or a pit, and whenever it takes damage from a source other than the harpy, the target can repeat the saving throw. A charmed target can also repeat the saving throw at the end of each of its turns. If the saving throw is successful, the effect ends on it.</p><p>A target that successfully saves is immune to this harpy's song for the next 24 hours.</p>",
+          "chat": "<p>The harpy sings a magical melody. Every humanoid and giant within 300 ft. of the harpy that can hear the song must make a <strong>Wisdom</strong> saving throw. A creature can also repeat the saving throw at the end of each of its turns.</p>"
         },
         "source": {
           "custom": "",
@@ -1268,10 +1268,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676769,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!CqQ6pXQA5WXZNOm3.QeobH0xuWk2yWmsb"
     }

--- a/packs/_source/monsters/monstrosity/hippogriff.json
+++ b/packs/_source/monsters/monstrosity/hippogriff.json
@@ -795,8 +795,8 @@
       "img": "icons/commodities/bones/beak-hooked-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Hippogriff attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Hippogriff attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -983,10 +983,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676680,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!T2PExQE84ZcIbAXz.CNurXa30GaCRT8MC"
     },
@@ -997,8 +997,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>.</p><p></p></section><p>The Hippogriff attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Hippogriff attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1185,10 +1185,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676680,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!T2PExQE84ZcIbAXz.pJN1LKPv23YgFC8w"
     }

--- a/packs/_source/monsters/monstrosity/hydra.json
+++ b/packs/_source/monsters/monstrosity/hydra.json
@@ -674,8 +674,8 @@
       "img": "icons/skills/melee/strike-sword-stabbed-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The hydra has five heads. While it has more than one head, the hydra has<strong> advantage </strong>on saving throws <strong>against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious</strong><strong>. </strong></p>\n<p>Whenever the hydra takes 25 or more damage in a single turn, one of its heads dies. If all its heads die, the hydra dies.</p>\n<p>At the end of its turn, it grows two heads for each of its heads that died since its last turn, unless it has taken <em>fire damage</em> since its last turn. The hydra regains <strong>10 hit points</strong> for each head regrown in this way.</p>\n</section>\n<p>The hydra has five heads. While it has more than one head, the hydra has<strong> advantage </strong>on saving throws <strong>against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious</strong>.</p>",
-          "chat": ""
+          "value": "<p>The hydra has five heads. While it has more than one head, the hydra has<strong> advantage </strong>on saving throws <strong>against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious</strong><strong>. </strong></p><p>Whenever the hydra takes 25 or more damage in a single turn, one of its heads dies. If all its heads die, the hydra dies.</p><p>At the end of its turn, it grows two heads for each of its heads that died since its last turn, unless it has taken <em>fire damage</em> since its last turn. The hydra regains <strong>10 hit points</strong> for each head regrown in this way.</p>",
+          "chat": "<p>The hydra has five heads. While it has more than one head, the hydra has<strong> advantage </strong>on saving throws <strong>against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious</strong>.</p>"
         },
         "source": {
           "custom": "",
@@ -719,10 +719,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676555,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!K4vsSlHqbBAHUDHY.fsAeJDaI0a6sBeFk"
     },
@@ -976,8 +976,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>10 (1d10 + 5) <em>piercing damage</em></strong>.</p><p></p></section><p>The Hydra attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>10 (1d10 + 5) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Hydra attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1170,10 +1170,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676555,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!K4vsSlHqbBAHUDHY.fYE4f0Oa2I0MetId"
     }

--- a/packs/_source/monsters/monstrosity/kraken.json
+++ b/packs/_source/monsters/monstrosity/kraken.json
@@ -684,8 +684,8 @@
       "img": "icons/skills/movement/feet-winged-boots-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The kraken ignores difficult terrain, and magical effects can't reduce its speed or cause it to be restrained. It can spend 5 feet of movement to escape from nonmagical restraints or being grappled.</p></section><p>The kraken ignores difficult terrain, and magical effects can't reduce its speed or cause it to be restrained. </p>",
-          "chat": ""
+          "value": "<p>The kraken ignores difficult terrain, and magical effects can't reduce its speed or cause it to be restrained. It can spend 5 feet of movement to escape from nonmagical restraints or being grappled.</p>",
+          "chat": "<p>The kraken ignores difficult terrain, and magical effects can't reduce its speed or cause it to be restrained. </p>"
         },
         "source": {
           "custom": "",
@@ -729,10 +729,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676965,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kVg37NlPcACAzjCT.uxrpcslS4BkraMVB"
     },
@@ -927,8 +927,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>23 (3d8 + 10) <em>piercing damage</em></strong>.</p>\n<p>If the target is a Large or smaller creature grappled by the kraken, that creature is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the kraken, and it takes <strong>42 (12d6) <em>acid damage</em></strong> at the start of each of the kraken's turns. If the kraken takes 50 damage or more on a single turn from a creature inside it, the kraken must succeed on a  <strong>DC 25 Constitution</strong> saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the kraken. If the kraken dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 15 feet of movement, exiting prone.</p>\n</section>\n<p>The Kraken attacks with its Bite. If the target is a Large or smaller creature grappled by the kraken, that creature is swallowed, and the grapple ends.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>23 (3d8 + 10) <em>piercing damage</em></strong>.</p><p>If the target is a Large or smaller creature grappled by the kraken, that creature is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the kraken, and it takes <strong>42 (12d6) <em>acid damage</em></strong> at the start of each of the kraken's turns. If the kraken takes 50 damage or more on a single turn from a creature inside it, the kraken must succeed on a  <strong>DC 25 Constitution</strong> saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the kraken. If the kraken dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 15 feet of movement, exiting prone.</p>",
+          "chat": "<p>The Kraken attacks with its Bite. If the target is a Large or smaller creature grappled by the kraken, that creature is swallowed, and the grapple ends.</p>"
         },
         "source": {
           "custom": "",
@@ -1185,10 +1185,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676965,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kVg37NlPcACAzjCT.r51OovswZTVF8Yna"
     },
@@ -1199,8 +1199,8 @@
       "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>30 ft.,</strong> one target. Hit: <strong>20 (3d6 + 10) <em>bludgeoning damage</em></strong>.</p>\n<p>The target is grappled (escape DC 18). Until this grapple ends, the target is restrained. The kraken has ten tentacles, each of which can grapple one target.</p>\n</section>\n<p>The Kraken attacks with its Tentacle. The target is grappled. Until this grapple ends, the target is restrained. The kraken has ten tentacles, each of which can grapple one target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+17 to hit,</strong>, <strong>30 ft.,</strong> one target. Hit: <strong>20 (3d6 + 10) <em>bludgeoning damage</em></strong>.</p><p>The target is grappled (escape DC 18). Until this grapple ends, the target is restrained. The kraken has ten tentacles, each of which can grapple one target.</p>",
+          "chat": "<p>The Kraken attacks with its Tentacle. The target is grappled. Until this grapple ends, the target is restrained. The kraken has ten tentacles, each of which can grapple one target.</p>"
         },
         "source": {
           "custom": "",
@@ -1389,10 +1389,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676965,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kVg37NlPcACAzjCT.lfg28JvVAru30yJ4"
     },
@@ -1403,8 +1403,8 @@
       "img": "icons/creatures/webs/webthin-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>One Large or smaller object held or creature grappled by the kraken is thrown up to 60 feet in a random direction and knocked prone. </p><p>If a thrown target strikes a solid surface, the target takes <strong>3 (1d6) <em>bludgeoning damage</em></strong> for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a  <strong>DC 18 Dexterity</strong> saving throw or take the same damage and be knocked prone.</p></section><p>One Large or smaller object held or creature grappled by the kraken is thrown up to 60 feet in a random direction and knocked prone. If the target is thrown at another creature, that creature must make a <strong>Dexterity</strong> saving throw or take the same damage and be knocked prone.</p>",
-          "chat": ""
+          "value": "<p>One Large or smaller object held or creature grappled by the kraken is thrown up to 60 feet in a random direction and knocked prone. </p><p>If a thrown target strikes a solid surface, the target takes <strong>3 (1d6) <em>bludgeoning damage</em></strong> for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a  <strong>DC 18 Dexterity</strong> saving throw or take the same damage and be knocked prone.</p>",
+          "chat": "<p>One Large or smaller object held or creature grappled by the kraken is thrown up to 60 feet in a random direction and knocked prone. If the target is thrown at another creature, that creature must make a <strong>Dexterity</strong> saving throw or take the same damage and be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -1534,10 +1534,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676965,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kVg37NlPcACAzjCT.bwwyMBn4QwiNd4SM"
     },
@@ -1548,8 +1548,8 @@
       "img": "icons/magic/lightning/bolts-forked-large-blue-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The kraken magically creates three bolts of lightning, each of which can strike a target the kraken can see within 120 feet of it. </p><p>A target must make a  <strong>DC 23 Dexterity</strong> saving throw, taking <strong>22 (4d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The kraken magically creates three bolts of lightning, each of which can strike a target the kraken can see within 120 feet of it. A target must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The kraken magically creates three bolts of lightning, each of which can strike a target the kraken can see within 120 feet of it. </p><p>A target must make a  <strong>DC 23 Dexterity</strong> saving throw, taking <strong>22 (4d10) <em>lightning damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The kraken magically creates three bolts of lightning, each of which can strike a target the kraken can see within 120 feet of it. A target must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1683,10 +1683,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676965,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kVg37NlPcACAzjCT.wVCkpBj5omvdfaMm"
     },
@@ -1697,8 +1697,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The kraken can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The kraken regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The kraken can take 3 legendary actions.</p>",
-          "chat": ""
+          "value": "<p>The kraken can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The kraken regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The kraken can take 3 legendary actions.</p>"
         },
         "source": {
           "custom": "",
@@ -1742,10 +1742,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676965,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kVg37NlPcACAzjCT.ojhTng7wa5ehcJz3"
     },
@@ -1756,8 +1756,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -1801,10 +1801,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676965,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kVg37NlPcACAzjCT.y6iT81UwIkojo6c5"
     },
@@ -2144,8 +2144,8 @@
       "img": "icons/magic/air/wind-vortex-swirl-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>While Underwater, the Kraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than the Kraken. Each creature other than the Kraken that ends its turn there must succeed on a  <strong>DC 23 Constitution</strong> saving throw, taking <strong>16 (3d10) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn.</p>\n</section>\n<p>The Kraken expels an ink cloud. The cloud spreads around corners, and that area is heavily obscured to creatures other than the Kraken. Each creature other than the Kraken that ends its turn there must succeed on a Constitution saving throw.</p>",
-          "chat": ""
+          "value": "<p>While Underwater, the Kraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than the Kraken. Each creature other than the Kraken that ends its turn there must succeed on a  <strong>DC 23 Constitution</strong> saving throw, taking <strong>16 (3d10) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn.</p>",
+          "chat": "<p>The Kraken expels an ink cloud. The cloud spreads around corners, and that area is heavily obscured to creatures other than the Kraken. Each creature other than the Kraken that ends its turn there must succeed on a Constitution saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2288,10 +2288,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676965,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kVg37NlPcACAzjCT.K0T5NDyi2n8Yt8Ts"
     }

--- a/packs/_source/monsters/monstrosity/lamia.json
+++ b/packs/_source/monsters/monstrosity/lamia.json
@@ -942,8 +942,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d10 + 3) <em>slashing damage</em></strong>.</p><p></p></section><p>The Lamia attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d10 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Lamia attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1130,10 +1130,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676789,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MnoL59nOOfYatAkQ.lqr5NeudKmKQfSpZ"
     },
@@ -1144,8 +1144,8 @@
       "img": "icons/weapons/daggers/dagger-jeweled-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Lamia attacks with its Dagger.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d4 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Lamia attacks with its Dagger.</p>"
         },
         "source": {
           "custom": "",
@@ -1339,10 +1339,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676789,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MnoL59nOOfYatAkQ.jMTZfqYRB58CwXyw"
     },
@@ -1353,8 +1353,8 @@
       "img": "icons/magic/nature/beam-hand-leaves-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Spell Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: The target is magically cursed for 1 hour. Until the curse ends, the target has disadvantage on Wisdom saving throws and all ability checks.</p><p></p></section><p>The target has disadvantage on Wisdom saving throws and all ability checks.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Spell Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: The target is magically cursed for 1 hour. Until the curse ends, the target has disadvantage on Wisdom saving throws and all ability checks.</p>",
+          "chat": "<p>The target has disadvantage on Wisdom saving throws and all ability checks.</p>"
         },
         "source": {
           "custom": "",
@@ -1478,10 +1478,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676789,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MnoL59nOOfYatAkQ.cd8MN5gJkmUn1RTE"
     },

--- a/packs/_source/monsters/monstrosity/manticore.json
+++ b/packs/_source/monsters/monstrosity/manticore.json
@@ -806,8 +806,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Manticore attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Manticore attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -998,10 +998,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676852,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MAoCGF5VkQwhmgvI.thSJXAlyfHGmVWN5"
     },
@@ -1012,8 +1012,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p><p></p></section><p>The Manticore attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Manticore attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1200,10 +1200,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676852,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MAoCGF5VkQwhmgvI.4WFf0M2tCPwiLPxG"
     },
@@ -1214,8 +1214,8 @@
       "img": "icons/commodities/bones/horn-worn-white.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +5 to hit, range 100/200 ft., one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Manticore attacks with its Tail Spike.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +5 to hit, range 100/200 ft., one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Manticore attacks with its Tail Spike.</p>"
         },
         "source": {
           "custom": "",
@@ -1417,10 +1417,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676852,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!MAoCGF5VkQwhmgvI.bYJjJPKhiDOTMlmS"
     }

--- a/packs/_source/monsters/monstrosity/medusa.json
+++ b/packs/_source/monsters/monstrosity/medusa.json
@@ -617,8 +617,8 @@
       "img": "icons/magic/control/hypnosis-mesmerism-eye.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>When a creature that can see the medusa's eyes starts its turn within <strong>30 ft.</strong> of the medusa, the medusa can force it to make a <strong>DC 14 Constitution saving throw</strong> if the medusa isn't incapacitated and can see the creature. If the saving throw fails by 5 or more, the creature is instantly petrified. Otherwise, a creature that fails the save begins to turn to stone and is restrained. The restrained creature must repeat the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the greater restoration spell or other magic.</p>\n<p>Unless surprised, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save<strong>. I</strong>f the medusa sees itself reflected on a polished surface within <strong>30 ft.</strong> of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze.</p>\n</section>\n<p>The medusa can force it to make a <strong>Constitution</strong> saving throw. The restrained creature must repeat the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the greater restoration spell or other magic. Unless surprised, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save. If the medusa sees itself reflected on a polished surface within <strong>30 ft.</strong> of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze.</p>",
-          "chat": ""
+          "value": "<p>When a creature that can see the medusa's eyes starts its turn within <strong>30 ft.</strong> of the medusa, the medusa can force it to make a <strong>DC 14 Constitution saving throw</strong> if the medusa isn't incapacitated and can see the creature. If the saving throw fails by 5 or more, the creature is instantly petrified. Otherwise, a creature that fails the save begins to turn to stone and is restrained. The restrained creature must repeat the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the greater restoration spell or other magic.</p><p>Unless surprised, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save<strong>. I</strong>f the medusa sees itself reflected on a polished surface within <strong>30 ft.</strong> of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze.</p>",
+          "chat": "<p>The medusa can force it to make a <strong>Constitution</strong> saving throw. The restrained creature must repeat the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the greater restoration spell or other magic. Unless surprised, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save. If the medusa sees itself reflected on a polished surface within <strong>30 ft.</strong> of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze.</p>"
         },
         "source": {
           "custom": "",
@@ -733,10 +733,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676918,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eiifqZwYGi71r2Yl.KmzlUGMXUhY2HubE"
     },
@@ -872,8 +872,8 @@
       "img": "icons/creatures/reptiles/serpent-horned-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong> plus <strong>14 (4d6) <em>poison damage</em></strong>.</p><p></p></section><p>The Medusa attacks with its Snake Hair.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong> plus <strong>14 (4d6) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Medusa attacks with its Snake Hair.</p>"
         },
         "source": {
           "custom": "",
@@ -1078,10 +1078,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676918,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eiifqZwYGi71r2Yl.1N53jrQmsZuhiREF"
     },
@@ -1092,8 +1092,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Medusa attacks with its Shortsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Medusa attacks with its Shortsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1287,10 +1287,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676918,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eiifqZwYGi71r2Yl.ixrzcEmkn9jaDOZ0"
     },
@@ -1301,8 +1301,8 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>poison damage</em></strong>.</p><p></p></section><p>The Medusa attacks with its Longbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>poison damage</em></strong>.</p>",
+          "chat": "<p>The Medusa attacks with its Longbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1514,10 +1514,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676918,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!eiifqZwYGi71r2Yl.4U98oe3Qr28BGbzG"
     }

--- a/packs/_source/monsters/monstrosity/merrow.json
+++ b/packs/_source/monsters/monstrosity/merrow.json
@@ -802,8 +802,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d8 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Merrow attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d8 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Merrow attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -994,10 +994,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676841,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1cwfYaACm5F0l4y3.doFYltsiw2Fgp5gn"
     },
@@ -1008,8 +1008,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d4 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Merrow attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d4 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Merrow attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1196,10 +1196,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676841,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1cwfYaACm5F0l4y3.bbB0SMNW3l2SHEz5"
     },
@@ -1210,8 +1210,8 @@
       "img": "icons/weapons/polearms/spear-flared-worn-grey.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>. </p><p>If the target is a Huge or smaller creature, it must succeed on a Strength contest against the merrow or be pulled up to 20 feet toward the merrow.</p></section><p>The Merrow attacks with its Harpoon. If the target is a Huge or smaller creature, it must make a Strength contest against the merrow or be pulled up to 20 feet toward the merrow.</p>",
-          "chat": ""
+          "value": "<p>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>. </p><p>If the target is a Huge or smaller creature, it must succeed on a Strength contest against the merrow or be pulled up to 20 feet toward the merrow.</p>",
+          "chat": "<p>The Merrow attacks with its Harpoon. If the target is a Huge or smaller creature, it must make a Strength contest against the merrow or be pulled up to 20 feet toward the merrow.</p>"
         },
         "source": {
           "custom": "",
@@ -1400,10 +1400,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676841,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!1cwfYaACm5F0l4y3.7XgQY1kwKPuoWX7t"
     }

--- a/packs/_source/monsters/monstrosity/mimic.json
+++ b/packs/_source/monsters/monstrosity/mimic.json
@@ -619,8 +619,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The mimic can use its action to <strong>polymorph</strong> into an object or back into its true, amorphous form. Its statistics are the same in each form. </p><p>Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p></section><p>The mimic can use its action to <strong>polymorph</strong> into an object or back into its true, amorphous form. </p>",
-          "chat": ""
+          "value": "<p>The mimic can use its action to <strong>polymorph</strong> into an object or back into its true, amorphous form. Its statistics are the same in each form. </p><p>Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</p>",
+          "chat": "<p>The mimic can use its action to <strong>polymorph</strong> into an object or back into its true, amorphous form. </p>"
         },
         "source": {
           "custom": "",
@@ -730,10 +730,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676894,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hx240PG5r5qpRet3.DOyBdRdgMxLm9BIh"
     },
@@ -744,8 +744,8 @@
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic is also grappled by it <strong>escape DC 13</strong>. Ability checks made to escape this grapple have disadvantage.</p></section><p>The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic is also grappled by it. Make an escape check, with disadvantage.</p>",
-          "chat": ""
+          "value": "<p>The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic is also grappled by it <strong>escape DC 13</strong>. Ability checks made to escape this grapple have disadvantage.</p>",
+          "chat": "<p>The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic is also grappled by it. Make an escape check, with disadvantage.</p>"
         },
         "source": {
           "custom": "",
@@ -785,10 +785,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676894,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hx240PG5r5qpRet3.aPL8wE2ARwh9JFeX"
     },
@@ -913,8 +913,8 @@
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>bludgeoning damage</em></strong>. </p><p>If the mimic is in object form, the target is subjected to its Adhesive trait.</p></section><p>The Mimic attacks with its Pseudopod.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>bludgeoning damage</em></strong>. </p><p>If the mimic is in object form, the target is subjected to its Adhesive trait.</p>",
+          "chat": "<p>The Mimic attacks with its Pseudopod.</p>"
         },
         "source": {
           "custom": "",
@@ -1101,10 +1101,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676894,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hx240PG5r5qpRet3.qHJyEXRC7oExTjES"
     },
@@ -1115,8 +1115,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>acid damage</em></strong>.</p><p></p></section><p>The Mimic attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong> plus <strong>4 (1d8) <em>acid damage</em></strong>.</p>",
+          "chat": "<p>The Mimic attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1325,10 +1325,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676894,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!hx240PG5r5qpRet3.HgNW3DcqMvGVXO7s"
     }

--- a/packs/_source/monsters/monstrosity/minotaur.json
+++ b/packs/_source/monsters/monstrosity/minotaur.json
@@ -617,8 +617,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the minotaur moves at least 10 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra <strong>9 (2d8) <em>piercing damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 14 Strength</strong> saving throw or be pushed up to 10 ft. away and knocked prone.</p></section><p>If the minotaur moves at least 10 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes extra <em>piercing damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be pushed up to 10 ft. away and knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the minotaur moves at least 10 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra <strong>9 (2d8) <em>piercing damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 14 Strength</strong> saving throw or be pushed up to 10 ft. away and knocked prone.</p>",
+          "chat": "<p>If the minotaur moves at least 10 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes extra <em>piercing damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be pushed up to 10 ft. away and knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -837,10 +837,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676897,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pOPQU4UnR27zA0jf.Z1aFAtAP0JJ02tPV"
     },
@@ -910,8 +910,8 @@
       "img": "icons/skills/social/intimidation-impressing.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p></p><p></p></section><p>At the start of its turn, the minotaur can gain advantage on all melee weapon attack rolls it makes during that turn, but attack rolls against it have advantage until the start of its next turn.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<section class=\"secret\"><p></p></section><p>At the start of its turn, the minotaur can gain advantage on all melee weapon attack rolls it makes during that turn, but attack rolls against it have advantage until the start of its next turn.</p>"
         },
         "source": {
           "custom": "",
@@ -955,10 +955,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676897,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pOPQU4UnR27zA0jf.i1CyGkejt1lDCHEu"
     },
@@ -969,8 +969,8 @@
       "img": "icons/weapons/axes/axe-double.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>17 (2d12 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Minotaur attacks with its Greataxe.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>17 (2d12 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Minotaur attacks with its Greataxe.</p>"
         },
         "source": {
           "custom": "",
@@ -1164,10 +1164,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676897,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pOPQU4UnR27zA0jf.lZ5YdCcXmEDR6vhb"
     },
@@ -1178,8 +1178,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Minotaur attacks with its Gore.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Minotaur attacks with its Gore.</p>"
         },
         "source": {
           "custom": "",
@@ -1366,10 +1366,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676897,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!pOPQU4UnR27zA0jf.zTqVT0QztTuMOv0e"
     }

--- a/packs/_source/monsters/monstrosity/owlbear.json
+++ b/packs/_source/monsters/monstrosity/owlbear.json
@@ -795,8 +795,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>10 (1d10 + 5) <em>piercing damage</em></strong>.</p><p></p></section><p>The Owlbear attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>10 (1d10 + 5) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Owlbear attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -983,10 +983,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676707,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zY3W5MG7FjssENf6.CwKQlVkFc2uJW0HL"
     },
@@ -997,8 +997,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>slashing damage</em></strong>.</p><p></p></section><p>The Owlbear attacks with its Claws.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Owlbear attacks with its Claws.</p>"
         },
         "source": {
           "custom": "",
@@ -1185,10 +1185,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676707,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zY3W5MG7FjssENf6.FpbBzMs3wu1NK3Zu"
     }

--- a/packs/_source/monsters/monstrosity/phase-spider.json
+++ b/packs/_source/monsters/monstrosity/phase-spider.json
@@ -858,8 +858,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>18 (4d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p></section><p>The Phase Spider attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>7 (1d10 + 2) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 11 Constitution</strong> saving throw, taking <strong>18 (4d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one. If the <em>poison damage</em> reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</p>",
+          "chat": "<p>The Phase Spider attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1205,10 +1205,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676496,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!llSG0Hi4eGlRlQ4o.2HPk5TdUTeEhD2eG"
     }

--- a/packs/_source/monsters/monstrosity/purple-worm.json
+++ b/packs/_source/monsters/monstrosity/purple-worm.json
@@ -799,8 +799,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>22 (3d8 + 9) <em>piercing damage</em></strong>. </p><p>If the target is a Large or smaller creature, it must succeed on a  <strong>DC 19 Dexterity</strong> saving throw or be swallowed by the worm. A swallowed creature is blinded and restrained, it has total cover against attacks and other effects outside the worm, and it takes <strong>21 (6d6) <em>acid damage</em></strong> at the start of each of the worm's turns.If the worm takes 30 damage or more on a single turn from a creature inside it, the worm must succeed on a  <strong>DC 21 Constitution</strong> saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the worm. If the worm dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 20 feet of movement, exiting prone.</p></section><p>The Purple Worm attacks with its Bite. If the target is a Large or smaller creature, it must make a <strong>Dexterity</strong> saving throw. </p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>22 (3d8 + 9) <em>piercing damage</em></strong>. </p><p>If the target is a Large or smaller creature, it must succeed on a  <strong>DC 19 Dexterity</strong> saving throw or be swallowed by the worm. A swallowed creature is blinded and restrained, it has total cover against attacks and other effects outside the worm, and it takes <strong>21 (6d6) <em>acid damage</em></strong> at the start of each of the worm's turns.If the worm takes 30 damage or more on a single turn from a creature inside it, the worm must succeed on a  <strong>DC 21 Constitution</strong> saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the worm. If the worm dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 20 feet of movement, exiting prone.</p>",
+          "chat": "<p>The Purple Worm attacks with its Bite. If the target is a Large or smaller creature, it must make a <strong>Dexterity</strong> saving throw. </p>"
         },
         "source": {
           "custom": "",
@@ -1148,10 +1148,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676676,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PtotS52HpHX596cZ.dlzFJ5UjbMAfJ6Sb"
     },
@@ -1162,8 +1162,8 @@
       "img": "icons/creatures/abilities/stinger-poison-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>19 (3d6 + 9) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 19 Constitution</strong> saving throw, taking <strong>42 (12d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The Purple Worm attacks with its Tail Stinger. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>19 (3d6 + 9) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 19 Constitution</strong> saving throw, taking <strong>42 (12d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Purple Worm attacks with its Tail Stinger. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1507,10 +1507,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676676,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PtotS52HpHX596cZ.yOjkK3f9jt2fYu3M"
     }

--- a/packs/_source/monsters/monstrosity/remorhaz.json
+++ b/packs/_source/monsters/monstrosity/remorhaz.json
@@ -618,8 +618,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-fire-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>40 (6d10 + 7) <em>piercing damage</em></strong> plus <strong>10 (3d6) <em>fire damage</em></strong>. </p><p>If the target is a creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the remorhaz can't bite another target.</p></section><p>The Remorhaz attacks with its Bite. If the target is a creature, it is grappled. Until this grapple ends, the target is restrained, and the remorhaz can't bite another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+11 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>40 (6d10 + 7) <em>piercing damage</em></strong> plus <strong>10 (3d6) <em>fire damage</em></strong>. </p><p>If the target is a creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the remorhaz can't bite another target.</p>",
+          "chat": "<p>The Remorhaz attacks with its Bite. If the target is a creature, it is grappled. Until this grapple ends, the target is restrained, and the remorhaz can't bite another target.</p>"
         },
         "source": {
           "custom": "",
@@ -830,10 +830,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676794,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VBzqw2rOUvTuNOPI.Qcgc4zckQ7c1Ky8t"
     },
@@ -844,8 +844,8 @@
       "img": "icons/magic/fire/flame-burning-campfire-rocks.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>A creature that touches the remorhaz or hits it with a melee attack while within 5 feet of it takes <strong>10 (3d6) <em>fire damage</em></strong>.</p><p></p></section><p>A creature that touches the remorhaz or hits it with a melee attack while within 5 feet of it takes <em>fire damage</em>.</p>",
-          "chat": ""
+          "value": "<p>A creature that touches the remorhaz or hits it with a melee attack while within 5 feet of it takes <strong>10 (3d6) <em>fire damage</em></strong>.</p>",
+          "chat": "<p>A creature that touches the remorhaz or hits it with a melee attack while within 5 feet of it takes <em>fire damage</em>.</p>"
         },
         "source": {
           "custom": "",
@@ -974,10 +974,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676794,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VBzqw2rOUvTuNOPI.usmJdksgWhPnjq94"
     },
@@ -988,8 +988,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The remorhaz makes one bite attack against a Medium or smaller creature it is grappling. </p><p>If the attack hits, that creature takes the bite's damage and is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the remorhaz, and it takes <strong>21 (6d6) <em>acid damage</em></strong> at the start of each of the remorhaz's turns.</p></section><p>The Remorhaz attacks with its Swallow.</p>",
-          "chat": ""
+          "value": "<p>The remorhaz makes one bite attack against a Medium or smaller creature it is grappling. </p><p>If the attack hits, that creature takes the bite's damage and is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the remorhaz, and it takes <strong>21 (6d6) <em>acid damage</em></strong> at the start of each of the remorhaz's turns.</p>",
+          "chat": "<p>The Remorhaz attacks with its Swallow.</p>"
         },
         "source": {
           "custom": "",
@@ -1185,10 +1185,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676794,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VBzqw2rOUvTuNOPI.kT6wF3F49uuWgP3h"
     }

--- a/packs/_source/monsters/monstrosity/roc.json
+++ b/packs/_source/monsters/monstrosity/roc.json
@@ -615,8 +615,8 @@
       "img": "icons/commodities/bones/beak-hooked-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>27 (4d8 + 9) <em>piercing damage</em></strong>.</p><p></p></section><p>The Roc attacks with its Beak.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>27 (4d8 + 9) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Roc attacks with its Beak.</p>"
         },
         "source": {
           "custom": "",
@@ -805,10 +805,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676702,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!p980augbCIdpK9ZX.PZWkwOa8C0Y2tSCR"
     },
@@ -999,8 +999,8 @@
       "img": "icons/creatures/claws/claw-scaled-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>23 (4d6 + 9) <em>slashing damage</em></strong>.</p><p>The target is grappled (escape DC 19). Until this grapple ends, the target is restrained, and the roc can't use its talons on another target.</p></section><p>The Roc attacks with its Talons. The target is grappled. Until this grapple ends, the target is restrained, and the roc can't use its talons on another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+13 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>23 (4d6 + 9) <em>slashing damage</em></strong>.</p><p>The target is grappled (escape DC 19). Until this grapple ends, the target is restrained, and the roc can't use its talons on another target.</p>",
+          "chat": "<p>The Roc attacks with its Talons. The target is grappled. Until this grapple ends, the target is restrained, and the roc can't use its talons on another target.</p>"
         },
         "source": {
           "custom": "",
@@ -1187,10 +1187,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676702,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!p980augbCIdpK9ZX.XMiiDwLIMYWFqxyv"
     }

--- a/packs/_source/monsters/monstrosity/roper.json
+++ b/packs/_source/monsters/monstrosity/roper.json
@@ -674,8 +674,8 @@
       "img": "icons/magic/nature/root-vine-entangle-foot-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The roper can have up to six tendrils at a time. Each tendril can be attacked (AC 20; <strong>10 hit points</strong>; immunity to poison and <em>psychic damage</em>). </p><p>Destroying a tendril deals no damage to the roper, which can extrude a replacement tendril on its next turn. A tendril can also be broken if a creature takes an action and succeeds on a <strong>DC 15 Strength check</strong> against it.</p></section><p>The roper can have up to six tendrils at a time. Each tendril can be attacked. A tendril can also be broken if a creature takes an action and succeeds on a Strength check against it.</p>",
-          "chat": ""
+          "value": "<p>The roper can have up to six tendrils at a time. Each tendril can be attacked (AC 20; <strong>10 hit points</strong>; immunity to poison and <em>psychic damage</em>). </p><p>Destroying a tendril deals no damage to the roper, which can extrude a replacement tendril on its next turn. A tendril can also be broken if a creature takes an action and succeeds on a <strong>DC 15 Strength check</strong> against it.</p>",
+          "chat": "<p>The roper can have up to six tendrils at a time. Each tendril can be attacked. A tendril can also be broken if a creature takes an action and succeeds on a Strength check against it.</p>"
         },
         "source": {
           "custom": "",
@@ -719,10 +719,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676899,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qZyLwdx7lj5d1wfD.hQLj7Zzuva4M9KzH"
     },
@@ -792,8 +792,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>22 (4d8 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Roper attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>22 (4d8 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Roper attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -984,10 +984,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676899,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qZyLwdx7lj5d1wfD.mBRjMwEitGrPDm5I"
     },
@@ -998,8 +998,8 @@
       "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>50 ft.,</strong> one target. Hit: The target is <strong>Grappled (escape DC 15)</strong>. Until the grapple ends, the target is Restrained and has <strong>disadvantage on Strength Checks and Strength Saving Throws</strong> , and the roper can't use the same tendril on another target.</p></section><p>The Roper attacks with its Tendril. The target is grappled. Until the grapple ends, the target is restrained and has <strong>disadvantage on Strength Checks and Strength Saving Throws</strong>.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>50 ft.,</strong> one target. Hit: The target is <strong>Grappled (escape DC 15)</strong>. Until the grapple ends, the target is Restrained and has <strong>disadvantage on Strength Checks and Strength Saving Throws</strong> , and the roper can't use the same tendril on another target.</p>",
+          "chat": "<p>The Roper attacks with its Tendril. The target is grappled. Until the grapple ends, the target is restrained and has <strong>disadvantage on Strength Checks and Strength Saving Throws</strong>.</p>"
         },
         "source": {
           "custom": "",
@@ -1180,10 +1180,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676899,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qZyLwdx7lj5d1wfD.bTiw89tDx64zTqDk"
     },
@@ -1194,8 +1194,8 @@
       "img": "icons/magic/control/sihouette-hold-beam-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p></p><p></p></section><p>The roper pulls each creature grappled by it up to 25 ft. straight toward it.</p>",
-          "chat": ""
+          "value": "",
+          "chat": "<section class=\"secret\"><p></p></section><p>The roper pulls each creature grappled by it up to 25 ft. straight toward it.</p>"
         },
         "source": {
           "custom": "",
@@ -1305,10 +1305,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676899,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qZyLwdx7lj5d1wfD.iGuyFLbKazqPCcXY"
     },

--- a/packs/_source/monsters/monstrosity/rust-monster.json
+++ b/packs/_source/monsters/monstrosity/rust-monster.json
@@ -674,8 +674,8 @@
       "img": "icons/skills/melee/blade-tip-chipped-blood-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Any nonmagical weapon made of metal that hits the rust monster corrodes. After <strong>dealing damage</strong>, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Non magical ammunition made of metal that hits the rust monster is destroyed after dealing damage.</p></section><p>Any nonmagical weapon made of metal that hits the rust monster corrodes. After <strong>dealing damage</strong>, the weapon takes a permanent and cumulative -1 penalty to damage rolls.</p>",
-          "chat": ""
+          "value": "<p>Any nonmagical weapon made of metal that hits the rust monster corrodes. After <strong>dealing damage</strong>, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Non magical ammunition made of metal that hits the rust monster is destroyed after dealing damage.</p>",
+          "chat": "<p>Any nonmagical weapon made of metal that hits the rust monster corrodes. After <strong>dealing damage</strong>, the weapon takes a permanent and cumulative -1 penalty to damage rolls.</p>"
         },
         "source": {
           "custom": "",
@@ -719,10 +719,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676730,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!WJsxqbHU28D64lWT.dobpPU4kb00zSkQt"
     },
@@ -733,8 +733,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p><p></p></section><p>The Rust Monster attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Rust Monster attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -925,10 +925,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676730,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!WJsxqbHU28D64lWT.ZFTo8KoUDrqeFg7l"
     },
@@ -939,8 +939,8 @@
       "img": "icons/magic/nature/tree-bare-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. </p><p>If the object is being worn or carried by a creature, the creature can make a  <strong>DC 11 Dexterity</strong> saving throw to avoid the rust monster's touch.If the object touched is either metal armor or a metal shield being worn or carried, its takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed. If the object touched is a held metal weapon, it rusts as described in the Rust Metal trait.</p></section><p>The rust monster corrodes a ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. </p>",
-          "chat": ""
+          "value": "<p>The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. </p><p>If the object is being worn or carried by a creature, the creature can make a  <strong>DC 11 Dexterity</strong> saving throw to avoid the rust monster's touch.If the object touched is either metal armor or a metal shield being worn or carried, its takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed. If the object touched is a held metal weapon, it rusts as described in the Rust Metal trait.</p>",
+          "chat": "<p>The rust monster corrodes a ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. </p>"
         },
         "source": {
           "custom": "",
@@ -1056,10 +1056,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676730,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!WJsxqbHU28D64lWT.yxwZ9AtLMKZ61sTz"
     }

--- a/packs/_source/monsters/monstrosity/spirit-naga.json
+++ b/packs/_source/monsters/monstrosity/spirit-naga.json
@@ -623,8 +623,8 @@
       "img": "icons/creatures/abilities/fang-tooth-venomous.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>7 (1d6 + 4) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 13 Constitution</strong> saving throw, taking <strong>31 (7d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p></section><p>The Spirit Naga attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>7 (1d6 + 4) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 13 Constitution</strong> saving throw, taking <strong>31 (7d8) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>The Spirit Naga attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -922,10 +922,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676709,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!BAT6ld8qJZetpycL.aap2fFb4b7uX3XAO"
     },
@@ -936,8 +936,8 @@
       "img": "icons/magic/control/debuff-energy-hold-levitate-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If it dies, the naga returns to life in 1d6 days and regains all its<strong> hit points</strong>. Only a wish spell can prevent this trait from functioning.</p></section><p>If it dies, the naga returns to life in 1d6 days and regains all its<strong> hit points</strong>.</p>",
-          "chat": ""
+          "value": "<p>If it dies, the naga returns to life in 1d6 days and regains all its<strong> hit points</strong>. Only a wish spell can prevent this trait from functioning.</p>",
+          "chat": "<p>If it dies, the naga returns to life in 1d6 days and regains all its<strong> hit points</strong>.</p>"
         },
         "source": {
           "custom": "",
@@ -981,10 +981,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676709,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!BAT6ld8qJZetpycL.WqOflwn1ubAMkGdQ"
     },
@@ -995,8 +995,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The naga is a 10th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following wizard spells prepared:</p>\n<p><strong>• Cantrips (at will)</strong>: mage hand, minor illusion, ray of frost</p>\n<p><strong>• 1st level (4 slots)</strong>: charm person, detect magic, sleep</p>\n<p><strong>• 2nd level (3 slots)</strong>: detect thoughts, hold person</p>\n<p><strong>• 3rd level (3 slots)</strong>: lightning bolt, water breathing</p>\n<p><strong>• 4th level (3 slots)</strong>: blight, dimension door</p>\n<p><strong>• 5th level (2 slots)</strong>: dominate person</p>\n</section>\n<p>The naga is a spellcaster. Its spellcasting ability is Intelligence and it needs only verbal components to cast its spells.</p>",
-          "chat": ""
+          "value": "<p>The naga is a 10th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following wizard spells prepared:</p><p><strong>• Cantrips (at will)</strong>: mage hand, minor illusion, ray of frost</p><p><strong>• 1st level (4 slots)</strong>: charm person, detect magic, sleep</p><p><strong>• 2nd level (3 slots)</strong>: detect thoughts, hold person</p><p><strong>• 3rd level (3 slots)</strong>: lightning bolt, water breathing</p><p><strong>• 4th level (3 slots)</strong>: blight, dimension door</p><p><strong>• 5th level (2 slots)</strong>: dominate person</p>",
+          "chat": "<p>The naga is a spellcaster. Its spellcasting ability is Intelligence and it needs only verbal components to cast its spells.</p>"
         },
         "source": {
           "custom": "",
@@ -1040,10 +1040,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676709,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!BAT6ld8qJZetpycL.Fla0ZsaY2HvXWqbR"
     },

--- a/packs/_source/monsters/monstrosity/tarrasque.json
+++ b/packs/_source/monsters/monstrosity/tarrasque.json
@@ -822,8 +822,8 @@
       "img": "icons/magic/defensive/shield-barrier-flaming-pentagon-purple-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Any time the tarrasque is targeted by a magic missile spell, a line spell, or a spell that requires a ranged attack roll, roll a d6. On a 1 to 5, the tarrasque is unaffected.</p><p>On a 6, the tarrasque is unaffected, and the effect is reflected back at the caster as though it originated from the tarrasque, turning the caster into the target.</p></section><p>The tarrasque is unaffected, and the effect is reflected back at the caster as though it originated from the tarrasque, turning the caster into the target.</p>",
-          "chat": ""
+          "value": "<p>Any time the tarrasque is targeted by a magic missile spell, a line spell, or a spell that requires a ranged attack roll, roll a d6. On a 1 to 5, the tarrasque is unaffected.</p><p>On a 6, the tarrasque is unaffected, and the effect is reflected back at the caster as though it originated from the tarrasque, turning the caster into the target.</p>",
+          "chat": "<p>The tarrasque is unaffected, and the effect is reflected back at the caster as though it originated from the tarrasque, turning the caster into the target.</p>"
         },
         "source": {
           "custom": "",
@@ -933,10 +933,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676998,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KCvt4FdOVJbuZ3T0.tE9TjxIMLnqDisjv"
     },
@@ -1131,8 +1131,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+19 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>36 (4d12 + 10) <em>piercing damage</em></strong>. </p><p>If the target is a creature, it is grappled (escape DC 20). Until this grapple ends, the target is restrained, and the tarrasque can't bite another target.</p></section><p>The Tarrasque attacks with its Bite. If the target is a creature, it is grappled. Until this grapple ends, the target is restrained, and the tarrasque can't bite another target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+19 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>36 (4d12 + 10) <em>piercing damage</em></strong>. </p><p>If the target is a creature, it is grappled (escape DC 20). Until this grapple ends, the target is restrained, and the tarrasque can't bite another target.</p>",
+          "chat": "<p>The Tarrasque attacks with its Bite. If the target is a creature, it is grappled. Until this grapple ends, the target is restrained, and the tarrasque can't bite another target.</p>"
         },
         "source": {
           "custom": "",
@@ -1325,10 +1325,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676998,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KCvt4FdOVJbuZ3T0.suUr7bJqBqE7xk2F"
     },
@@ -1339,8 +1339,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+19 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>28 (4d8 + 10) <em>slashing damage</em></strong>.</p><p></p></section><p>The Tarrasque attacks with its Claw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+19 to hit,</strong>, <strong>15 ft.,</strong> one target. Hit: <strong>28 (4d8 + 10) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Tarrasque attacks with its Claw.</p>"
         },
         "source": {
           "custom": "",
@@ -1529,10 +1529,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676998,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KCvt4FdOVJbuZ3T0.7DRko62ztr6FjZLA"
     },
@@ -1543,8 +1543,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+19 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>32 (4d10 + 10) <em>piercing damage</em></strong>.</p><p></p></section><p>The Tarrasque attacks with its Horns.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+19 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>32 (4d10 + 10) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Tarrasque attacks with its Horns.</p>"
         },
         "source": {
           "custom": "",
@@ -1733,10 +1733,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676998,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KCvt4FdOVJbuZ3T0.E1RZdzEY2qnG2jLn"
     },
@@ -1747,8 +1747,8 @@
       "img": "icons/skills/wounds/injury-pain-impaled-hand-blood.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+19 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>24 (4d6 + 10) <em>bludgeoning damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 20 Strength</strong> saving throw or be knocked prone.</p></section><p>The Tarrasque attacks with its Tail. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+19 to hit,</strong>, <strong>20 ft.,</strong> one target. Hit: <strong>24 (4d6 + 10) <em>bludgeoning damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 20 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>The Tarrasque attacks with its Tail. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -2026,10 +2026,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676998,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KCvt4FdOVJbuZ3T0.Lo4LU9FBxez1Nzqm"
     },
@@ -2040,8 +2040,8 @@
       "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each creature of the tarrasque's choice <strong>within 120 feet</strong> of it and aware of it must succeed on a <strong>DC 17 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>.</p><p>A creature can repeat the saving throw at the end of each of its turns, with<strong> disadvantage </strong>if the tarrasque is within line of sight, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the tarrasque's Frightful Presence for the next 24 hours.</p></section><p>Each creature of the tarrasque's choice <strong>within 120 feet</strong> of it and aware of it must succeed on a Wisdom saving throw.</p>",
-          "chat": ""
+          "value": "<p>Each creature of the tarrasque's choice <strong>within 120 feet</strong> of it and aware of it must succeed on a <strong>DC 17 Wisdom saving throw</strong> or become frightened for <strong>1 minute</strong>.</p><p>A creature can repeat the saving throw at the end of each of its turns, with<strong> disadvantage </strong>if the tarrasque is within line of sight, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the tarrasque's Frightful Presence for the next 24 hours.</p>",
+          "chat": "<p>Each creature of the tarrasque's choice <strong>within 120 feet</strong> of it and aware of it must succeed on a Wisdom saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -2157,10 +2157,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676998,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KCvt4FdOVJbuZ3T0.3mtn5D2GoD19WDVW"
     },
@@ -2171,8 +2171,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The tarrasque makes one bite attack against a Large or smaller creature it is grappling. If the attack hits, the target takes the bite's damage, the target is swallowed, and the grapple ends. </p><p>While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the tarrasque, and it takes <strong>56 (16d6) <em>acid damage</em></strong> at the start of each of the tarrasque's turns.If the tarrasque takes 60 damage or more on a single turn from a creature inside it, the tarrasque must succeed on a  <strong>DC 20 Constitution</strong> saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the tarrasque. If the tarrasque dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 30 feet of movement, exiting prone.</p></section><p>The Tarrasque attacks with its Swallow.</p>",
-          "chat": ""
+          "value": "<p>The tarrasque makes one bite attack against a Large or smaller creature it is grappling. If the attack hits, the target takes the bite's damage, the target is swallowed, and the grapple ends. </p><p>While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the tarrasque, and it takes <strong>56 (16d6) <em>acid damage</em></strong> at the start of each of the tarrasque's turns.If the tarrasque takes 60 damage or more on a single turn from a creature inside it, the tarrasque must succeed on a  <strong>DC 20 Constitution</strong> saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the tarrasque. If the tarrasque dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 30 feet of movement, exiting prone.</p>",
+          "chat": "<p>The Tarrasque attacks with its Swallow.</p>"
         },
         "source": {
           "custom": "",
@@ -2362,10 +2362,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676998,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KCvt4FdOVJbuZ3T0.7ycN6rrAEJQP3ZOs"
     },
@@ -2376,8 +2376,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2421,10 +2421,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676998,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KCvt4FdOVJbuZ3T0.9OZ6Zm76HXyRSKlP"
     },
@@ -2435,8 +2435,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The tarrasque can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The tarrasque regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The tarrasque can take 3 legendary actions.</p>",
-          "chat": ""
+          "value": "<p>The tarrasque can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The tarrasque regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The tarrasque can take 3 legendary actions.</p>"
         },
         "source": {
           "custom": "",
@@ -2480,10 +2480,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676998,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!KCvt4FdOVJbuZ3T0.sBnQiUt83GYUkKBw"
     },

--- a/packs/_source/monsters/monstrosity/winter-wolf.json
+++ b/packs/_source/monsters/monstrosity/winter-wolf.json
@@ -794,8 +794,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>. If the target is a creature, it must succeed on a <strong>DC 14 Strength saving throw</strong> or be knocked prone.</p>\n</section>\n<p>The Winter Wolf attacks with its Bite. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>. If the target is a creature, it must succeed on a <strong>DC 14 Strength saving throw</strong> or be knocked prone.</p>",
+          "chat": "<p>The Winter Wolf attacks with its Bite. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -1075,10 +1075,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676623,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!yGTh874etxUckmAf.5PmQuifZGbPWxAYz"
     },
@@ -1089,8 +1089,8 @@
       "img": "icons/creatures/abilities/dragon-ice-breath-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The wolf exhales a blast of freezing wind in a 15-foot cone. Each creature in that area must make a  <strong>DC 12 Dexterity</strong> saving throw, taking <strong>18 (4d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one. Recharge 5-6.</p></section>\n<p>The wolf exhales a blast of freezing wind in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The wolf exhales a blast of freezing wind in a 15-foot cone. Each creature in that area must make a  <strong>DC 12 Dexterity</strong> saving throw, taking <strong>18 (4d8) <em>cold damage</em></strong> on a failed save, or half as much damage on a successful one. Recharge 5-6.</p>",
+          "chat": "<p>The wolf exhales a blast of freezing wind in a 15-foot cone. Each creature in that area must make a <strong>Dexterity</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1369,10 +1369,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676623,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!yGTh874etxUckmAf.Rj3oSInoQMIfHrPc"
     }

--- a/packs/_source/monsters/monstrosity/worg.json
+++ b/packs/_source/monsters/monstrosity/worg.json
@@ -673,8 +673,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>.</p>\n<p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>\n</section>\n<p>The Worg attacks with its Bite. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 13 Strength</strong> saving throw or be knocked prone.</p>",
+          "chat": "<p>The Worg attacks with its Bite. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -954,10 +954,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676460,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VBkp2rGQKvMcCOus.UnONIXYgZcE3Jya0"
     }

--- a/packs/_source/monsters/ooze/black-pudding.json
+++ b/packs/_source/monsters/ooze/black-pudding.json
@@ -686,8 +686,8 @@
       "img": "icons/magic/earth/orb-stone-smoke-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>A creature that touches the pudding or hits it with a melee attack while within 5 feet of it takes <strong>4 (1d8) <em>acid damage</em></strong>. Any nonmagical weapon made of metal or wood that hits the pudding corrodes.</p>\n<p>After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal or wood that hits the pudding is destroyed after dealing damage. The pudding can eat through 2-inch-thick, nonmagical wood or metal in 1 round.</p>\n</section>\n<p>A creature that touches the pudding or hits it with a melee attack while within 5 feet of it takes <em>acid damage</em>. Any nonmagical weapon made of metal or wood that hits the pudding corrodes.</p>",
-          "chat": ""
+          "value": "<p>A creature that touches the pudding or hits it with a melee attack while within 5 feet of it takes <strong>4 (1d8) <em>acid damage</em></strong>. Any nonmagical weapon made of metal or wood that hits the pudding corrodes.</p><p>After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal or wood that hits the pudding is destroyed after dealing damage. The pudding can eat through 2-inch-thick, nonmagical wood or metal in 1 round.</p>",
+          "chat": "<p>A creature that touches the pudding or hits it with a melee attack while within 5 feet of it takes <em>acid damage</em>. Any nonmagical weapon made of metal or wood that hits the pudding corrodes.</p>"
         },
         "source": {
           "custom": "",
@@ -816,10 +816,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676723,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NwQpeeaMxAC3fRft.wvlDMuDDdk7peoPa"
     },
@@ -889,8 +889,8 @@
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong> plus <strong>18 (4d8) <em>acid damage</em></strong>.</p>\n<p>In addition, nonmagical armor worn by the target is partly dissolved and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10.</p>\n</section>\n<p>The Black Pudding attacks with its Pseudopod. In addition, nonmagical armor worn by the target is partly dissolved and takes a permanent and cumulative -1 penalty to the AC it offers.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong> plus <strong>18 (4d8) <em>acid damage</em></strong>.</p><p>In addition, nonmagical armor worn by the target is partly dissolved and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10.</p>",
+          "chat": "<p>The Black Pudding attacks with its Pseudopod. In addition, nonmagical armor worn by the target is partly dissolved and takes a permanent and cumulative -1 penalty to the AC it offers.</p>"
         },
         "source": {
           "custom": "",
@@ -1095,10 +1095,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676723,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NwQpeeaMxAC3fRft.v6ZspnPr8G5hApkL"
     },
@@ -1109,8 +1109,8 @@
       "img": "icons/creatures/slimes/slime-movement-pseudopod-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>When a pudding that is Medium or larger is subjected to lightning or <em>slashing damage</em>, it splits into two new puddings if it has at least 10 Hit Points. Each new pudding has Hit Points equal to half the original pudding's, rounded down. New puddings are one size smaller than the original pudding.</p>\n</section>\n<p>The pudding splits into two new puddings. New puddings are one size smaller than the original pudding.</p>",
-          "chat": ""
+          "value": "<p>When a pudding that is Medium or larger is subjected to lightning or <em>slashing damage</em>, it splits into two new puddings if it has at least 10 Hit Points. Each new pudding has Hit Points equal to half the original pudding's, rounded down. New puddings are one size smaller than the original pudding.</p>",
+          "chat": "<p>The pudding splits into two new puddings. New puddings are one size smaller than the original pudding.</p>"
         },
         "source": {
           "custom": "",
@@ -1220,10 +1220,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676723,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NwQpeeaMxAC3fRft.VcVWWSlfTBeXWh3T"
     }

--- a/packs/_source/monsters/ooze/gelatinous-cube.json
+++ b/packs/_source/monsters/ooze/gelatinous-cube.json
@@ -622,8 +622,8 @@
       "img": "icons/magic/water/barrier-ice-water-cube.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The cube takes up its entire space. Other creatures can enter the space, but a creature that does so is subjected to the cube's Engulf and has<strong> disadvantage </strong>on the saving throw<strong>. C</strong>reatures inside the cube can be seen but have total cover.</p><p>A creature <strong>within 5 feet</strong> of the cube can take an action to pull a creature or object out of the cube. Doing so requires a successful <strong>DC 12 Strength check</strong>, and the creature making the attempt takes <strong>10 (3d6) <em>acid damage</em></strong><strong>. T</strong>he cube can hold only one Large creature or up to four Medium or smaller creatures inside it at a time.</p></section><p>The cube takes up its entire space. Other creatures can enter the space, but a creature that does so is subjected to the cube's Engulf and has<strong> disadvantage </strong>on the saving throw<strong>. C</strong>reatures inside the cube can be seen but have total cover<strong>. A</strong> creature <strong>within 5 feet</strong> of the cube can take an action to pull a creature or object out of the cube. Doing so requires a successful Strength check.</p>",
-          "chat": ""
+          "value": "<p>The cube takes up its entire space. Other creatures can enter the space, but a creature that does so is subjected to the cube's Engulf and has<strong> disadvantage </strong>on the saving throw<strong>. C</strong>reatures inside the cube can be seen but have total cover.</p><p>A creature <strong>within 5 feet</strong> of the cube can take an action to pull a creature or object out of the cube. Doing so requires a successful <strong>DC 12 Strength check</strong>, and the creature making the attempt takes <strong>10 (3d6) <em>acid damage</em></strong><strong>. T</strong>he cube can hold only one Large creature or up to four Medium or smaller creatures inside it at a time.</p>",
+          "chat": "<p>The cube takes up its entire space. Other creatures can enter the space, but a creature that does so is subjected to the cube's Engulf and has<strong> disadvantage </strong>on the saving throw<strong>. C</strong>reatures inside the cube can be seen but have total cover<strong>. A</strong> creature <strong>within 5 feet</strong> of the cube can take an action to pull a creature or object out of the cube. Doing so requires a successful Strength check.</p>"
         },
         "source": {
           "custom": "",
@@ -667,10 +667,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676859,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3fzQVYQhXxCXRa2o.m8prrQUwqGwX6Jyk"
     },
@@ -681,8 +681,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Even when the cube is in plain sight, it takes a successful <strong>DC 15 Wisdom (Perception) check</strong> to spot a cube that has neither moved nor attacked. A creature that tries to enter the cube's space while unaware of the cube is surprised by the cube.</p></section><p>Even when the cube is in plain sight, it takes a successful Wisdom (Perception) check to spot a cube that has neither moved nor attacked. A creature that tries to enter the cube's space while unaware of the cube is surprised by the cube.</p>",
-          "chat": ""
+          "value": "<p>Even when the cube is in plain sight, it takes a successful <strong>DC 15 Wisdom (Perception) check</strong> to spot a cube that has neither moved nor attacked. A creature that tries to enter the cube's space while unaware of the cube is surprised by the cube.</p>",
+          "chat": "<p>Even when the cube is in plain sight, it takes a successful Wisdom (Perception) check to spot a cube that has neither moved nor attacked. A creature that tries to enter the cube's space while unaware of the cube is surprised by the cube.</p>"
         },
         "source": {
           "custom": "",
@@ -726,10 +726,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676859,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3fzQVYQhXxCXRa2o.ISZmp6ev081hhUxT"
     },
@@ -740,8 +740,8 @@
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>10 (3d6) <em>acid damage</em></strong>.</p><p></p></section><p>The Gelatinous Cube attacks with its Pseudopod.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>10 (3d6) <em>acid damage</em></strong>.</p>",
+          "chat": "<p>The Gelatinous Cube attacks with its Pseudopod.</p>"
         },
         "source": {
           "custom": "",
@@ -928,10 +928,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676859,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3fzQVYQhXxCXRa2o.t2KRGzsjV4Wwp0wj"
     },
@@ -942,8 +942,8 @@
       "img": "icons/magic/water/pseudopod-swirl-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The cube moves up to its speed. While doing so, it can enter Large or smaller creatures' spaces. Whenever the cube enters a creature's space, the creature must make a  <strong>DC 12 Dexterity</strong> saving throw.On a successful save, the creature can choose to be pushed 5 feet back or to the side of the cube. A creature that chooses not to be pushed suffers the consequences of a failed saving throw.</p><p>On a failed save, the cube enters the creature's space, and the creature takes <strong>10 (3d6) <em>acid damage</em></strong> and is engulfed. The engulfed creature can't breathe, is restrained, and takes <strong>21 (6d6) <em>acid damage</em></strong> at the start of each of the cube's turns. When the cube moves, the engulfed creature moves with it.An engulfed creature can try to escape by taking an action to make a DC 12 Strength check. On a success, the creature escapes and enters a space of its choice within 5 feet of the cube.</p></section><p>Whenever the cube enters a creature's space, the creature must make a <strong>Dexterity</strong> saving throw. On a successful save, the creature can choose to be pushed 5 feet back or to the side of the cube. A creature that chooses not to be pushed suffers the consequences of a failed saving throw.</p>",
-          "chat": ""
+          "value": "<p>The cube moves up to its speed. While doing so, it can enter Large or smaller creatures' spaces. Whenever the cube enters a creature's space, the creature must make a  <strong>DC 12 Dexterity</strong> saving throw.On a successful save, the creature can choose to be pushed 5 feet back or to the side of the cube. A creature that chooses not to be pushed suffers the consequences of a failed saving throw.</p><p>On a failed save, the cube enters the creature's space, and the creature takes <strong>10 (3d6) <em>acid damage</em></strong> and is engulfed. The engulfed creature can't breathe, is restrained, and takes <strong>21 (6d6) <em>acid damage</em></strong> at the start of each of the cube's turns. When the cube moves, the engulfed creature moves with it.An engulfed creature can try to escape by taking an action to make a DC 12 Strength check. On a success, the creature escapes and enters a space of its choice within 5 feet of the cube.</p>",
+          "chat": "<p>Whenever the cube enters a creature's space, the creature must make a <strong>Dexterity</strong> saving throw. On a successful save, the creature can choose to be pushed 5 feet back or to the side of the cube. A creature that chooses not to be pushed suffers the consequences of a failed saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1141,10 +1141,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676859,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!3fzQVYQhXxCXRa2o.6PuULfBzy5vpBSFI"
     }

--- a/packs/_source/monsters/ooze/gray-ooze.json
+++ b/packs/_source/monsters/ooze/gray-ooze.json
@@ -685,8 +685,8 @@
       "img": "icons/magic/earth/orb-stone-smoke-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Any nonmagical weapon made of metal that hits the ooze corrodes. After <strong>dealing damage</strong>, the weapon takes a permanent and cumulative -1 penalty to damage rolls.</p>\n<p>If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal that hits the ooze is destroyed after dealing damage. The ooze can eat through 2-inch-thick, nonmagical metal in 1 round.</p>\n</section>\n<p>The ooze corrodes metal.</p>",
-          "chat": ""
+          "value": "<p>Any nonmagical weapon made of metal that hits the ooze corrodes. After <strong>dealing damage</strong>, the weapon takes a permanent and cumulative -1 penalty to damage rolls.</p><p>If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal that hits the ooze is destroyed after dealing damage. The ooze can eat through 2-inch-thick, nonmagical metal in 1 round.</p>",
+          "chat": "<p>The ooze corrodes metal.</p>"
         },
         "source": {
           "custom": "",
@@ -730,10 +730,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676586,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fqbFYtbtkrL53FOC.uSay5J2sf9zXsabi"
     },
@@ -803,8 +803,8 @@
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>bludgeoning damage</em></strong> plus <strong>7 (2d6) <em>acid damage</em></strong>.</p><p>If the target is wearing nonmagical metal armor, its armor is partly corroded and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10.</p></section><p>The Gray Ooze attacks with its Pseudopod. If the target is wearing nonmagical metal armor, its armor is partly corroded and takes a permanent and cumulative -1 penalty to the AC it offers.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>bludgeoning damage</em></strong> plus <strong>7 (2d6) <em>acid damage</em></strong>.</p><p>If the target is wearing nonmagical metal armor, its armor is partly corroded and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10.</p>",
+          "chat": "<p>The Gray Ooze attacks with its Pseudopod. If the target is wearing nonmagical metal armor, its armor is partly corroded and takes a permanent and cumulative -1 penalty to the AC it offers.</p>"
         },
         "source": {
           "custom": "",
@@ -1009,10 +1009,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676586,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fqbFYtbtkrL53FOC.KO4qRywgiEQ3F004"
     }

--- a/packs/_source/monsters/ooze/ochre-jelly.json
+++ b/packs/_source/monsters/ooze/ochre-jelly.json
@@ -627,8 +627,8 @@
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d6 + 2) <em>bludgeoning damage</em></strong> plus <strong>3 (1d6) <em>acid damage</em></strong>.</p><p></p></section><p>The Ochre Jelly attacks with its Pseudopod.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (2d6 + 2) <em>bludgeoning damage</em></strong> plus <strong>3 (1d6) <em>acid damage</em></strong>.</p>",
+          "chat": "<p>The Ochre Jelly attacks with its Pseudopod.</p>"
         },
         "source": {
           "custom": "",
@@ -833,10 +833,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676619,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!xBhG7Dos3tkg9jWz.SYdqeemFOudCYb9E"
     },
@@ -965,8 +965,8 @@
       "img": "icons/creatures/slimes/slime-movement-pseudopod-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>When a jelly that is Medium or larger is subjected to lightning or <em>slashing damage</em>, it splits into two new jellies if it has at least 10 Hit Points. Each new jelly has Hit Points equal to half the original jelly's, rounded down. New jellies are one size smaller than the original jelly.</p></section><p>The jelly splits into two new jellies. New jellies are one size smaller than the original jelly.</p>",
-          "chat": ""
+          "value": "<p>When a jelly that is Medium or larger is subjected to lightning or <em>slashing damage</em>, it splits into two new jellies if it has at least 10 Hit Points. Each new jelly has Hit Points equal to half the original jelly's, rounded down. New jellies are one size smaller than the original jelly.</p>",
+          "chat": "<p>The jelly splits into two new jellies. New jellies are one size smaller than the original jelly.</p>"
         },
         "source": {
           "custom": "",
@@ -1076,10 +1076,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676619,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!xBhG7Dos3tkg9jWz.2ifhxY5f2Xs4GMxR"
     }

--- a/packs/_source/monsters/plant/awakened-shrub.json
+++ b/packs/_source/monsters/plant/awakened-shrub.json
@@ -619,8 +619,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: 1 (1d4 - 1) <em>slashing damage</em>.</p></section>\n<p>The Awakened Shrub attacks with its Rake.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: 1 (1d4 - 1) <em>slashing damage</em>.</p>",
+          "chat": "<p>The Awakened Shrub attacks with its Rake.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676490,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gaSTr7DFZJLmgI2J.Vdk7dsybx2iYlKVx"
     },

--- a/packs/_source/monsters/plant/awakened-tree.json
+++ b/packs/_source/monsters/plant/awakened-tree.json
@@ -679,8 +679,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>14 (3d6 + 4) <em>bludgeoning damage</em></strong>.</p></section>\n<p>The Awakened Tree attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>14 (3d6 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Awakened Tree attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -869,10 +869,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676459,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UR2gWLFHmFwG7ReH.WEesSpitzLnaCknL"
     }

--- a/packs/_source/monsters/plant/shambling-mound.json
+++ b/packs/_source/monsters/plant/shambling-mound.json
@@ -808,8 +808,8 @@
       "img": "icons/magic/nature/trap-spikes-thorns-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The shambling mound engulfs a Medium or smaller creature grappled by it. The engulfed target is blinded, restrained, and unable to breathe, and it must succeed on a  <strong>DC 14 Constitution</strong> saving throw at the start of each of the mound's turns or take <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p><p>If the mound moves, the engulfed target moves with it. The mound can have only one creature engulfed at a time.</p></section><p>The shambling mound engulfs a Medium or smaller creature grappled by it. The engulfed target is blinded, restrained, and unable to breathe, and it must make a <strong>Constitution</strong> saving throw at the start of each of the mound's turns. If the mound moves, the engulfed target moves with it.</p>",
-          "chat": ""
+          "value": "<p>The shambling mound engulfs a Medium or smaller creature grappled by it. The engulfed target is blinded, restrained, and unable to breathe, and it must succeed on a  <strong>DC 14 Constitution</strong> saving throw at the start of each of the mound's turns or take <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p><p>If the mound moves, the engulfed target moves with it. The mound can have only one creature engulfed at a time.</p>",
+          "chat": "<p>The shambling mound engulfs a Medium or smaller creature grappled by it. The engulfed target is blinded, restrained, and unable to breathe, and it must make a <strong>Constitution</strong> saving throw at the start of each of the mound's turns. If the mound moves, the engulfed target moves with it.</p>"
         },
         "source": {
           "custom": "",
@@ -941,10 +941,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676589,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gGeLeV411iQ5Yijs.N42BQALoCmeYphD1"
     },
@@ -955,8 +955,8 @@
       "img": "icons/magic/fire/flame-burning-fist-strike.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Shambling Mound attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Shambling Mound attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -1143,10 +1143,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676589,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!gGeLeV411iQ5Yijs.lOIA9YKQU8xSx7Lj"
     }

--- a/packs/_source/monsters/plant/shrieker.json
+++ b/packs/_source/monsters/plant/shrieker.json
@@ -619,8 +619,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-human.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>When bright light or a creature is within 30 feet of the shrieker, it emits a shriek audible within 300 feet of it. The shrieker continues to shriek until the disturbance moves out of range and for 1d4 of the shrieker's turns afterward</p><p></p></section><p>When bright light or a creature is within 30 feet of the shrieker, it emits a shriek audible within 300 feet of it. </p>",
-          "chat": ""
+          "value": "<p>When bright light or a creature is within 30 feet of the shrieker, it emits a shriek audible within 300 feet of it. The shrieker continues to shriek until the disturbance moves out of range and for 1d4 of the shrieker's turns afterward</p>",
+          "chat": "<p>When bright light or a creature is within 30 feet of the shrieker, it emits a shriek audible within 300 feet of it. </p>"
         },
         "source": {
           "custom": "",
@@ -730,10 +730,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676384,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!TaK6nQMGqZ0y8gt7.Cvw6LMtbxmSBvVoZ"
     },

--- a/packs/_source/monsters/plant/treant.json
+++ b/packs/_source/monsters/plant/treant.json
@@ -625,8 +625,8 @@
       "img": "icons/magic/nature/tree-spirit-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The treant magically animates one or two trees it can see <strong>within 60 feet</strong> of it. These trees have the same statistics as a treant, except they have Intelligence and Charisma scores of 1, they can't speak, and they have only the Slam action option. </p><p>An animated tree acts as an ally of the treant. The tree remains animate for 1 day or until it dies; until the treant dies or is more than 120 feet from the tree; or until the treant takes a bonus action to turn it back into an inanimate tree. The tree then takes root if possible.</p></section><p>The treant magically animates one or two trees it can see <strong>within 60 feet</strong> of it.</p>",
-          "chat": ""
+          "value": "<p>The treant magically animates one or two trees it can see <strong>within 60 feet</strong> of it. These trees have the same statistics as a treant, except they have Intelligence and Charisma scores of 1, they can't speak, and they have only the Slam action option. </p><p>An animated tree acts as an ally of the treant. The tree remains animate for 1 day or until it dies; until the treant dies or is more than 120 feet from the tree; or until the treant takes a bonus action to turn it back into an inanimate tree. The tree then takes root if possible.</p>",
+          "chat": "<p>The treant magically animates one or two trees it can see <strong>within 60 feet</strong> of it.</p>"
         },
         "source": {
           "custom": "",
@@ -737,10 +737,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676791,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NB6wUgVqeOQtsQKu.8uUyRr6Ho7Yvx8pP"
     },
@@ -935,8 +935,8 @@
       "img": "icons/magic/earth/projectile-boulder-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Ranged Weapon Attack: +10 to hit, range 60/180 ft., one target. Hit: <strong>28 (4d10 + 6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Treant attacks with its Rock.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +10 to hit, range 60/180 ft., one target. Hit: <strong>28 (4d10 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Treant attacks with its Rock.</p>"
         },
         "source": {
           "custom": "",
@@ -1123,10 +1123,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676791,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NB6wUgVqeOQtsQKu.eTROJriR9B5abIZy"
     },
@@ -1196,8 +1196,8 @@
       "img": "icons/magic/nature/tree-animated-strike.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>16 (3d6 + 6) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Treant attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>16 (3d6 + 6) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Treant attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -1383,10 +1383,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676791,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NB6wUgVqeOQtsQKu.lisZZTaupqInGEi1"
     }

--- a/packs/_source/monsters/plant/violet-fungus.json
+++ b/packs/_source/monsters/plant/violet-fungus.json
@@ -619,8 +619,8 @@
       "img": "icons/creatures/claws/claw-curved-poison-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>4 (1d8) <em>necrotic damage</em></strong>.</p><p></p></section><p>The Violet Fungus attacks with its Rotting Touch.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>10 ft.,</strong> one creature. Hit: <strong>4 (1d8) <em>necrotic damage</em></strong>.</p>",
+          "chat": "<p>The Violet Fungus attacks with its Rotting Touch.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676408,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7EmUVycEASn7SFL0.OEx9iy4HDipiYsPt"
     },

--- a/packs/_source/monsters/undead/avatar-of-death.json
+++ b/packs/_source/monsters/undead/avatar-of-death.json
@@ -71,7 +71,7 @@
         "max": 1,
         "temp": 0,
         "tempmax": 0,
-        "formula": "Half of Summoner Max."
+        "formula": ""
       },
       "init": {
         "ability": "",
@@ -621,8 +621,8 @@
       "img": "icons/magic/air/air-wave-gust-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The avatar can move through other creatures and objects as if they were difficult terrain.</p>\n<p>It takes <strong>5 (1d10) <em>force damage</em></strong> if it ends its turn inside an object.</p>\n</section>\n<p>The avatar can move through other creatures and objects as if they were difficult terrain.</p>",
-          "chat": ""
+          "value": "<p>The avatar can move through other creatures and objects as if they were difficult terrain.</p><p>It takes <strong>5 (1d10) <em>force damage</em></strong> if it ends its turn inside an object.</p>",
+          "chat": "<p>The avatar can move through other creatures and objects as if they were difficult terrain.</p>"
         },
         "source": {
           "custom": "",
@@ -751,10 +751,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676519,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!XiSWKZzAUxdmFOLL.tXHiE3pxHbBF8bS6"
     },
@@ -824,8 +824,8 @@
       "img": "icons/skills/melee/strike-scythe-fire-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The avatar sweeps its spectral scythe through a creature within 5 feet of it, dealing <strong>7 (1d8 + 3) <em>slashing damage</em></strong> plus <strong>4 (1d8) <em>necrotic damage</em></strong>.</p>\n</section>\n<p>The avatar sweeps its spectral scythe through a creature within 5 feet of it.</p>",
-          "chat": ""
+          "value": "<p>The avatar sweeps its spectral scythe through a creature within 5 feet of it, dealing <strong>7 (1d8 + 3) <em>slashing damage</em></strong> plus <strong>4 (1d8) <em>necrotic damage</em></strong>.</p>",
+          "chat": "<p>The avatar sweeps its spectral scythe through a creature within 5 feet of it.</p>"
         },
         "source": {
           "custom": "",
@@ -972,10 +972,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676519,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!XiSWKZzAUxdmFOLL.d7ERliHkrcvQAF1X"
     }

--- a/packs/_source/monsters/undead/ghast.json
+++ b/packs/_source/monsters/undead/ghast.json
@@ -625,8 +625,8 @@
       "img": "icons/commodities/tech/smoke-bomb-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Any creature that starts its turn within <strong>5 ft.</strong> of the ghast must succeed on a <strong>DC 10 Constitution saving throw</strong> or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the ghast's Stench for 24 hours.</p></section><p>Any creature that starts its turn within <strong>5 ft.</strong> of the ghast must succeed on a Constitution saving throw.</p>",
-          "chat": ""
+          "value": "<p>Any creature that starts its turn within <strong>5 ft.</strong> of the ghast must succeed on a <strong>DC 10 Constitution saving throw</strong> or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the ghast's Stench for 24 hours.</p>",
+          "chat": "<p>Any creature that starts its turn within <strong>5 ft.</strong> of the ghast must succeed on a Constitution saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -741,10 +741,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676781,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!IyIybE5t2adMEVUM.gBiHo206x7uGoySO"
     },
@@ -814,8 +814,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>12 (2d8 + 3) <em>piercing damage</em></strong>.</p><p></p></section><p>The Ghast attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>12 (2d8 + 3) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Ghast attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1006,10 +1006,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676781,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!IyIybE5t2adMEVUM.nSgLkorv2oln5BIt"
     },
@@ -1020,8 +1020,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>. </p><p>If the target is a creature other than an undead, it must succeed on a  <strong>DC 10 Constitution</strong> saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p></section><p>The Ghast attacks with its Claws. If the target is a creature other than an undead, it must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing damage</em></strong>. </p><p>If the target is a creature other than an undead, it must succeed on a  <strong>DC 10 Constitution</strong> saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The Ghast attacks with its Claws. If the target is a creature other than an undead, it must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1208,10 +1208,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676781,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!IyIybE5t2adMEVUM.ricjyd1SKzeQ5gQE"
     }

--- a/packs/_source/monsters/undead/ghost.json
+++ b/packs/_source/monsters/undead/ghost.json
@@ -694,8 +694,8 @@
       "img": "icons/magic/air/air-wave-gust-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The ghost can move through other creatures and objects as if they were difficult terrain. </p><p>It takes <strong>5 (1d10) <em>force damage</em></strong> if it ends its turn inside an object.</p></section><p>The ghost can move through other creatures and objects as if they were difficult terrain.</p>",
-          "chat": ""
+          "value": "<p>The ghost can move through other creatures and objects as if they were difficult terrain. </p><p>It takes <strong>5 (1d10) <em>force damage</em></strong> if it ends its turn inside an object.</p>",
+          "chat": "<p>The ghost can move through other creatures and objects as if they were difficult terrain.</p>"
         },
         "source": {
           "custom": "",
@@ -739,10 +739,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676881,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qoFEjfrANBdrCP6m.SiBsPubItj26pcHa"
     },
@@ -753,8 +753,8 @@
       "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>17 (4d6 + 3) <em>necrotic damage</em></strong>.</p><p></p></section><p>The Ghost attacks with its Withering Touch.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>17 (4d6 + 3) <em>necrotic damage</em></strong>.</p>",
+          "chat": "<p>The Ghost attacks with its Withering Touch.</p>"
         },
         "source": {
           "custom": "",
@@ -941,10 +941,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676881,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qoFEjfrANBdrCP6m.wdOqdYfLb2Nu1Uud"
     },
@@ -1080,8 +1080,8 @@
       "img": "icons/magic/death/projectile-skull-fire-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>Each non-undead creature within 60 ft. of the ghost that can see it must succeed on a  <strong>DC 13 Wisdom</strong> saving throw or be frightened for 1 minute. If the save fails by 5 or more, the target also ages 1d4 x 10 years. </p><p>A frightened target can repeat the saving throw at the end of each of its turns, ending the frightened condition on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this ghost's Horrifying Visage for the next 24 hours. The aging effect can be reversed with a greater restoration spell, but only within 24 hours of it occurring.</p></section><p>Each non-undead creature within 60 ft. of the ghost that can see it must succeed make a <strong>Wisdom</strong> saving throw. A target can repeat the saving throw at the end of each of its turns, ending the condition on itself on a success.</p>",
-          "chat": ""
+          "value": "<p>Each non-undead creature within 60 ft. of the ghost that can see it must succeed on a  <strong>DC 13 Wisdom</strong> saving throw or be frightened for 1 minute. If the save fails by 5 or more, the target also ages 1d4 x 10 years. </p><p>A frightened target can repeat the saving throw at the end of each of its turns, ending the frightened condition on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this ghost's Horrifying Visage for the next 24 hours. The aging effect can be reversed with a greater restoration spell, but only within 24 hours of it occurring.</p>",
+          "chat": "<p>Each non-undead creature within 60 ft. of the ghost that can see it must succeed make a <strong>Wisdom</strong> saving throw. A target can repeat the saving throw at the end of each of its turns, ending the condition on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1196,10 +1196,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676881,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qoFEjfrANBdrCP6m.lOzkFHeXCdO2FB9X"
     },
@@ -1210,8 +1210,8 @@
       "img": "icons/magic/control/fear-fright-monster-grin-purple-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>One humanoid that the ghost can see within 5 ft. of it must succeed on a  <strong>DC 13 Charisma</strong> saving throw or be possessed by the ghost; the ghost then disappears, and the target is incapacitated and loses control of its body. The ghost now controls the body but doesn't deprive the target of awareness. </p><p>The ghost can't be targeted by any attack, spell, or other effect, except ones that turn undead, and it retains its alignment, Intelligence, Wisdom, Charisma, and immunity to being charmed and frightened. It otherwise uses the possessed target's statistics, but doesn't gain access to the target's knowledge, class features, or proficiencies.The possession lasts until the body drops to 0 hit points, the ghost ends it as a bonus action, or the ghost is turned or forced out by an effect like the dispel evil and good spell. When the possession ends, the ghost reappears in an unoccupied space within 5 ft. of the body. The target is immune to this ghost's Possession for 24 hours after succeeding on the saving throw or after the possession ends.</p></section><p>One humanoid that the ghost can see within 5 ft. of it must make a <strong>Charisma</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>One humanoid that the ghost can see within 5 ft. of it must succeed on a  <strong>DC 13 Charisma</strong> saving throw or be possessed by the ghost; the ghost then disappears, and the target is incapacitated and loses control of its body. The ghost now controls the body but doesn't deprive the target of awareness. </p><p>The ghost can't be targeted by any attack, spell, or other effect, except ones that turn undead, and it retains its alignment, Intelligence, Wisdom, Charisma, and immunity to being charmed and frightened. It otherwise uses the possessed target's statistics, but doesn't gain access to the target's knowledge, class features, or proficiencies.The possession lasts until the body drops to 0 hit points, the ghost ends it as a bonus action, or the ghost is turned or forced out by an effect like the dispel evil and good spell. When the possession ends, the ghost reappears in an unoccupied space within 5 ft. of the body. The target is immune to this ghost's Possession for 24 hours after succeeding on the saving throw or after the possession ends.</p>",
+          "chat": "<p>One humanoid that the ghost can see within 5 ft. of it must make a <strong>Charisma</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1343,10 +1343,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676881,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!qoFEjfrANBdrCP6m.UF0mfYsgI4ay6mzv"
     }

--- a/packs/_source/monsters/undead/ghoul.json
+++ b/packs/_source/monsters/undead/ghoul.json
@@ -623,8 +623,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>9 (2d6 + 2) <em>piercing damage</em></strong>.</p><p></p></section><p>The Ghoul attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>9 (2d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Ghoul attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -815,10 +815,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676672,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!OBujQLLPSmlJiZnL.E5cmqIqRIwyTkhgp"
     },
@@ -829,8 +829,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>slashing damage</em></strong>. </p><p>If the target is a creature other than an elf or undead, it must succeed on a  <strong>DC 10 Constitution</strong> saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p></section><p>The Ghoul attacks with its Claws. If the target is a creature other than an elf or undead, it must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>slashing damage</em></strong>. </p><p>If the target is a creature other than an elf or undead, it must succeed on a  <strong>DC 10 Constitution</strong> saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The Ghoul attacks with its Claws. If the target is a creature other than an elf or undead, it must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1017,10 +1017,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676672,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!OBujQLLPSmlJiZnL.ArxzPC3rsBztgUvI"
     }

--- a/packs/_source/monsters/undead/lich.json
+++ b/packs/_source/monsters/undead/lich.json
@@ -914,8 +914,8 @@
       "img": "icons/magic/perception/silhouette-stealth-shadow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The lich fixes its gaze on one creature it can see within 10 feet of it. The target must succeed on a  <strong>DC 18 Wisdom</strong> saving throw against this magic or become grappled for 1 minute. The grappled target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to the lich's gaze for the next 24 hours.</p>\n</section>\n<p>The lich fixes its gaze on one creature it can see within 10 feet of it. The target must make a <strong>Wisdom</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The lich fixes its gaze on one creature it can see within 10 feet of it. The target must succeed on a  <strong>DC 18 Wisdom</strong> saving throw against this magic or become grappled for 1 minute. The grappled target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to the lich's gaze for the next 24 hours.</p>",
+          "chat": "<p>The lich fixes its gaze on one creature it can see within 10 feet of it. The target must make a <strong>Wisdom</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1041,10 +1041,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676949,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bfh29vIEoGzI240e.Uox2GEp5GMXOOXOc"
     },
@@ -1055,8 +1055,8 @@
       "img": "icons/magic/death/projectile-skull-fire-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Each non-undead creature within 20 feet of the lich must make a  <strong>DC 18 Constitution</strong> saving throw against this magic, taking <strong>21 (6d6) <em>necrotic damage</em></strong> on a failed save, or half as much damage on a successful one.</p>\n</section>\n<p>Each non-undead creature within 20 feet of the lich must make a <strong>Constitution</strong> saving throw against this magic.</p>",
-          "chat": ""
+          "value": "<p>Each non-undead creature within 20 feet of the lich must make a  <strong>DC 18 Constitution</strong> saving throw against this magic, taking <strong>21 (6d6) <em>necrotic damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "chat": "<p>Each non-undead creature within 20 feet of the lich must make a <strong>Constitution</strong> saving throw against this magic.</p>"
         },
         "source": {
           "custom": "",
@@ -1199,10 +1199,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676949,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bfh29vIEoGzI240e.sXU9KTYnmgi08EQw"
     },
@@ -1348,8 +1348,8 @@
       "img": "icons/magic/control/debuff-energy-hold-levitate-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If it has a phylactery, a destroyed lich gains a new body in 1d10 days, regaining all its<strong> hit points</strong> and becoming active again. The new body appears <strong>within 5 feet</strong> of the phylactery.</p></section><p>A destroyed lich gains a new body in 1d10 days, regaining all its<strong> hit points</strong> and becoming active again.</p>",
-          "chat": ""
+          "value": "<p>If it has a phylactery, a destroyed lich gains a new body in 1d10 days, regaining all its<strong> hit points</strong> and becoming active again. The new body appears <strong>within 5 feet</strong> of the phylactery.</p>",
+          "chat": "<p>A destroyed lich gains a new body in 1d10 days, regaining all its<strong> hit points</strong> and becoming active again.</p>"
         },
         "source": {
           "custom": "",
@@ -1459,10 +1459,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676949,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bfh29vIEoGzI240e.stk9i3rPK7z99CDf"
     },
@@ -1473,8 +1473,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The lich is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 20, +12 to hit with spell attacks). The lich has the following wizard spells prepared:</p>\n<p>Cantrips (at will): mage hand, prestidigitation, ray of frost</p>\n<p>1st level (4 slots): detect magic, magic missile, shield, thunderwave</p>\n<p>2nd level (3 slots): detect thoughts, invisibility, acid arrow, mirror image</p>\n<p>3rd level (3 slots): animate dead, counterspell, dispel magic, fireball</p>\n<p>4th level (3 slots): blight, dimension door</p>\n<p>5th level (3 slots): cloudkill, scrying</p>\n<p>6th level (1 slot): disintegrate, globe of invulnerability</p>\n<p>7th level (1 slot): finger of death, plane shift</p>\n<p>8th level (1 slot): dominate monster, power word stun</p>\n<p>9th level (1 slot): power word kill</p>\n</section>\n<p>The lich is an spellcaster. Its spellcasting ability is Intelligence.</p>",
-          "chat": ""
+          "value": "<p>The lich is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 20, +12 to hit with spell attacks). The lich has the following wizard spells prepared:</p><p>Cantrips (at will): mage hand, prestidigitation, ray of frost</p><p>1st level (4 slots): detect magic, magic missile, shield, thunderwave</p><p>2nd level (3 slots): detect thoughts, invisibility, acid arrow, mirror image</p><p>3rd level (3 slots): animate dead, counterspell, dispel magic, fireball</p><p>4th level (3 slots): blight, dimension door</p><p>5th level (3 slots): cloudkill, scrying</p><p>6th level (1 slot): disintegrate, globe of invulnerability</p><p>7th level (1 slot): finger of death, plane shift</p><p>8th level (1 slot): dominate monster, power word stun</p><p>9th level (1 slot): power word kill</p>",
+          "chat": "<p>The lich is an spellcaster. Its spellcasting ability is Intelligence.</p>"
         },
         "source": {
           "custom": "",
@@ -1518,10 +1518,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676949,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bfh29vIEoGzI240e.UMoMhboTLq75ZJW8"
     },
@@ -1532,8 +1532,8 @@
       "img": "icons/magic/water/water-hand.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Spell Attack:</em><strong>+12 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>10 (3d6) <em>cold damage</em></strong>. </p><p>The target must succeed on a  <strong>DC 18 Constitution</strong> saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p></section><p>The Lich attacks with its Paralyzing Touch. The target must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Spell Attack:</em><strong>+12 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>10 (3d6) <em>cold damage</em></strong>. </p><p>The target must succeed on a  <strong>DC 18 Constitution</strong> saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>",
+          "chat": "<p>The Lich attacks with its Paralyzing Touch. The target must make a <strong>Constitution</strong> saving throw. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>"
         },
         "source": {
           "custom": "",
@@ -1813,10 +1813,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676949,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bfh29vIEoGzI240e.KDSrdpdFPDKnh80y"
     },
@@ -1886,8 +1886,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The lich can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The lich regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The lich can take 3 legendary actions.</p>",
-          "chat": ""
+          "value": "<p>The lich can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The lich regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The lich can take 3 legendary actions.</p>"
         },
         "source": {
           "custom": "",
@@ -1931,10 +1931,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676949,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bfh29vIEoGzI240e.GvT7gczoJ6QCocrA"
     },
@@ -2004,8 +2004,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2049,10 +2049,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676949,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!bfh29vIEoGzI240e.XbzBKNTXHSUjzWtt"
     },

--- a/packs/_source/monsters/undead/minotaur-skeleton.json
+++ b/packs/_source/monsters/undead/minotaur-skeleton.json
@@ -624,8 +624,8 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If the skeleton moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra <strong>9 (2d8) <em>piercing damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 14 Strength</strong> saving throw or be pushed up to 10 feet away and knocked prone.</p></section><p>If the skeleton moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes extra <em>piercing damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be pushed up to 10 feet away and knocked prone.</p>",
-          "chat": ""
+          "value": "<p>If the skeleton moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra <strong>9 (2d8) <em>piercing damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 14 Strength</strong> saving throw or be pushed up to 10 feet away and knocked prone.</p>",
+          "chat": "<p>If the skeleton moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes extra <em>piercing damage</em>. If the target is a creature, it must make a <strong>Strength</strong> saving throw or be pushed up to 10 feet away and knocked prone.</p>"
         },
         "source": {
           "custom": "",
@@ -844,10 +844,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676835,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!xple5bvGj42uGgdd.p7R5kkqAVQFKClRm"
     },
@@ -858,8 +858,8 @@
       "img": "icons/weapons/axes/axe-double.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>17 (2d12 + 4) <em>slashing damage</em></strong>.</p><p></p></section><p>The Minotaur Skeleton attacks with its Greataxe.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>17 (2d12 + 4) <em>slashing damage</em></strong>.</p>",
+          "chat": "<p>The Minotaur Skeleton attacks with its Greataxe.</p>"
         },
         "source": {
           "custom": "",
@@ -1052,10 +1052,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676835,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!xple5bvGj42uGgdd.vJAkNKhTmRrz6Zoq"
     },
@@ -1066,8 +1066,8 @@
       "img": "icons/skills/wounds/bone-broken-tooth-fang-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>piercing damage</em></strong>.</p><p></p></section><p>The Minotaur Skeleton attacks with its Gore.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Minotaur Skeleton attacks with its Gore.</p>"
         },
         "source": {
           "custom": "",
@@ -1254,10 +1254,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676835,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!xple5bvGj42uGgdd.3Fsct4zbAf7l47Lp"
     }

--- a/packs/_source/monsters/undead/mummy-lord.json
+++ b/packs/_source/monsters/undead/mummy-lord.json
@@ -631,8 +631,8 @@
       "img": "icons/magic/fire/barrier-wall-explosion-orange.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Blinding dust and sand swirls magically around the mummy lord. Each creature within 5 feet of the mummy lord must succeed on a  <strong>DC 16 Constitution</strong> saving throw or be blinded until the end of the creature's next turn.</p>\n</section>\n<p>Blinding dust and sand swirls magically around the mummy lord. Each creature within 5 feet of the mummy lord must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>Blinding dust and sand swirls magically around the mummy lord. Each creature within 5 feet of the mummy lord must succeed on a  <strong>DC 16 Constitution</strong> saving throw or be blinded until the end of the creature's next turn.</p>",
+          "chat": "<p>Blinding dust and sand swirls magically around the mummy lord. Each creature within 5 feet of the mummy lord must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -757,10 +757,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676962,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UFW8M3JHzHkxUEGM.Os0eEymWpLTVR2Xv"
     },
@@ -771,8 +771,8 @@
       "img": "icons/magic/air/wind-vortex-swirl-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The mummy lord utters a blasphemous word. Each non-undead creature within 10 feet of the mummy lord that can hear the magical utterance must succeed on a  <strong>DC 16 Constitution</strong> saving throw or be stunned until the end of the mummy lord's next turn.</p>\n</section>\n<p>The mummy lord utters a blasphemous word. Each non-undead creature within 10 feet of the mummy lord that can hear the magical utterance must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>The mummy lord utters a blasphemous word. Each non-undead creature within 10 feet of the mummy lord that can hear the magical utterance must succeed on a  <strong>DC 16 Constitution</strong> saving throw or be stunned until the end of the mummy lord's next turn.</p>",
+          "chat": "<p>The mummy lord utters a blasphemous word. Each non-undead creature within 10 feet of the mummy lord that can hear the magical utterance must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -897,10 +897,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676962,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UFW8M3JHzHkxUEGM.3PBv68cIzTlrzcYe"
     },
@@ -1105,8 +1105,8 @@
       "img": "icons/magic/control/debuff-energy-hold-levitate-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>A destroyed mummy lord gains a new body in 24 hours if its heart is intact, regaining all its<strong> hit points</strong> and becoming active again. The new body appears <strong>within 5 feet</strong> of the mummy lord's heart.</p></section><p>A destroyed mummy lord gains a new body in 24 hours.</p>",
-          "chat": ""
+          "value": "<p>A destroyed mummy lord gains a new body in 24 hours if its heart is intact, regaining all its<strong> hit points</strong> and becoming active again. The new body appears <strong>within 5 feet</strong> of the mummy lord's heart.</p>",
+          "chat": "<p>A destroyed mummy lord gains a new body in 24 hours.</p>"
         },
         "source": {
           "custom": "",
@@ -1150,10 +1150,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676962,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UFW8M3JHzHkxUEGM.AEc5FXdpe3M7KHQI"
     },
@@ -1164,8 +1164,8 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The mummy lord is a 10th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The mummy lord has the following cleric spells prepared:</p>\n<p>Cantrips (at will): sacred flame, thaumaturgy</p>\n<p>1st level (4 slots): command, guiding bolt, shield of faith</p>\n<p>2nd level (3 slots): hold person, silence, spiritual weapon</p>\n<p>3rd level (3 slots): animate dead, dispel magic</p>\n<p>4th level (3 slots): divination, guardian of faith</p>\n<p>5th level (2 slots): contagion, insect plague</p>\n<p>6th level (1 slot): harm</p>\n</section>\n<p>The mummy lord is a spellcaster. Its spellcasting ability is Wisdom.</p>",
-          "chat": ""
+          "value": "<p>The mummy lord is a 10th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The mummy lord has the following cleric spells prepared:</p><p>Cantrips (at will): sacred flame, thaumaturgy</p><p>1st level (4 slots): command, guiding bolt, shield of faith</p><p>2nd level (3 slots): hold person, silence, spiritual weapon</p><p>3rd level (3 slots): animate dead, dispel magic</p><p>4th level (3 slots): divination, guardian of faith</p><p>5th level (2 slots): contagion, insect plague</p><p>6th level (1 slot): harm</p>",
+          "chat": "<p>The mummy lord is a spellcaster. Its spellcasting ability is Wisdom.</p>"
         },
         "source": {
           "custom": "",
@@ -1209,10 +1209,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676962,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UFW8M3JHzHkxUEGM.FeMPdVmbrjP2L3CO"
     },
@@ -1348,8 +1348,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (3d6 + 4) <em>bludgeoning damage</em></strong> plus <strong>21 (6d6) <em>necrotic damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 16 Constitution</strong> saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the remove curse spell or other magic.</p></section><p>The Mummy Lord attacks with its Rotting Fist. If the target is a creature, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>14 (3d6 + 4) <em>bludgeoning damage</em></strong> plus <strong>21 (6d6) <em>necrotic damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 16 Constitution</strong> saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the remove curse spell or other magic.</p>",
+          "chat": "<p>The Mummy Lord attacks with its Rotting Fist. If the target is a creature, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1643,10 +1643,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676962,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UFW8M3JHzHkxUEGM.M6t9H8pMhzQxM9qv"
     },
@@ -1657,8 +1657,8 @@
       "img": "icons/magic/perception/hand-eye-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The mummy lord targets one creature it can see within 60 feet of it. If the target can see the mummy lord, it must succeed on a  <strong>DC 16 Wisdom</strong> saving throw against this magic or become frightened until the end of the mummy's next turn. </p><p>If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies and mummy lords for the next 24 hours.</p></section><p>The mummy lord targets one creature it can see within 60 ft. of it. If the target can see the mummy, it must make a <strong>Wisdom</strong> saving throw against this magic.</p>",
-          "chat": ""
+          "value": "<p>The mummy lord targets one creature it can see within 60 feet of it. If the target can see the mummy lord, it must succeed on a  <strong>DC 16 Wisdom</strong> saving throw against this magic or become frightened until the end of the mummy's next turn. </p><p>If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies and mummy lords for the next 24 hours.</p>",
+          "chat": "<p>The mummy lord targets one creature it can see within 60 ft. of it. If the target can see the mummy, it must make a <strong>Wisdom</strong> saving throw against this magic.</p>"
         },
         "source": {
           "custom": "",
@@ -1774,10 +1774,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676962,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UFW8M3JHzHkxUEGM.yHydHrxw4vlDlyjf"
     },
@@ -1788,8 +1788,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The mummy lord can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The mummy lord regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The mummy lord can take 3 legendary actions.</p>",
-          "chat": ""
+          "value": "<p>The mummy lord can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The mummy lord regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The mummy lord can take 3 legendary actions.</p>"
         },
         "source": {
           "custom": "",
@@ -1833,10 +1833,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676962,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UFW8M3JHzHkxUEGM.und47mebgauAcPu4"
     },
@@ -1847,8 +1847,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -1892,10 +1892,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676962,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!UFW8M3JHzHkxUEGM.NMN6cq7RkU8ccxKF"
     },

--- a/packs/_source/monsters/undead/mummy.json
+++ b/packs/_source/monsters/undead/mummy.json
@@ -753,8 +753,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong> plus <strong>10 (3d6) <em>necrotic damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 12 Constitution</strong> saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the remove curse spell or other magic.</p></section><p>The Mummy attacks with its Rotting Fist. If the target is a creature, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong> plus <strong>10 (3d6) <em>necrotic damage</em></strong>. </p><p>If the target is a creature, it must succeed on a  <strong>DC 12 Constitution</strong> saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the remove curse spell or other magic.</p>",
+          "chat": "<p>The Mummy attacks with its Rotting Fist. If the target is a creature, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1048,10 +1048,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676609,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!t8WYD7ak07X7xpx8.ik1IkSZi4fpiGbB3"
     },
@@ -1062,8 +1062,8 @@
       "img": "icons/magic/perception/hand-eye-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The mummy targets one creature it can see within 60 ft. of it. If the target can see the mummy, it must succeed on a  <strong>DC 11 Wisdom</strong> saving throw against this magic or become frightened until the end of the mummy's next turn. </p><p>If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies (but not mummy lords) for the next 24 hours.</p></section><p>The mummy targets one creature it can see within 60 ft. of it. If the target can see the mummy, it must make a <strong>Wisdom</strong> saving throw against this magic.</p>",
-          "chat": ""
+          "value": "<p>The mummy targets one creature it can see within 60 ft. of it. If the target can see the mummy, it must succeed on a  <strong>DC 11 Wisdom</strong> saving throw against this magic or become frightened until the end of the mummy's next turn. </p><p>If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies (but not mummy lords) for the next 24 hours.</p>",
+          "chat": "<p>The mummy targets one creature it can see within 60 ft. of it. If the target can see the mummy, it must make a <strong>Wisdom</strong> saving throw against this magic.</p>"
         },
         "source": {
           "custom": "",
@@ -1179,10 +1179,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676609,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!t8WYD7ak07X7xpx8.8Jju4CVZaIDab6Ju"
     }

--- a/packs/_source/monsters/undead/ogre-zombie.json
+++ b/packs/_source/monsters/undead/ogre-zombie.json
@@ -619,8 +619,8 @@
       "img": "icons/weapons/maces/mace-round-spiked-black.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Ogre Zombie attacks with its Morningstar.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Ogre Zombie attacks with its Morningstar.</p>"
         },
         "source": {
           "custom": "",
@@ -811,10 +811,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676571,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!RenLfmDT2XlbCF4x.Gj35Y1i6Ph90Wn3R"
     },
@@ -825,8 +825,8 @@
       "img": "icons/magic/acid/pouring-gas-smoke-liquid.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If damage reduces the zombie to <strong>0 hit points</strong>, it must make a <strong>Constitution</strong> saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to <strong>1 hit point</strong> instead.</p></section><p>If damage reduces the zombie to <strong>0 hit points</strong>, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>If damage reduces the zombie to <strong>0 hit points</strong>, it must make a <strong>Constitution</strong> saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to <strong>1 hit point</strong> instead.</p>",
+          "chat": "<p>If damage reduces the zombie to <strong>0 hit points</strong>, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -870,10 +870,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676571,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!RenLfmDT2XlbCF4x.NPmV7puA7Yg3esqg"
     }

--- a/packs/_source/monsters/undead/shadow.json
+++ b/packs/_source/monsters/undead/shadow.json
@@ -699,8 +699,8 @@
       "img": "icons/creatures/mammals/humanoid-cat-skulking-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>While in dim light or darkness, the shadow can take the Hide action as a bonus action.</p>\n</section>\n<p>The shadow can take the Hide action as a bonus action.</p>",
-          "chat": ""
+          "value": "<p>While in dim light or darkness, the shadow can take the Hide action as a bonus action.</p>",
+          "chat": "<p>The shadow can take the Hide action as a bonus action.</p>"
         },
         "source": {
           "custom": "",
@@ -810,10 +810,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676570,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!QGcQYZbVl4bWzi4E.Xa0lRW8VhYHTAQT0"
     },
@@ -883,8 +883,8 @@
       "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>9 (2d6 + 2) <em>necrotic damage</em></strong>.</p><p>The target's Strength score is reduced by 1d4. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest.If a non-evil humanoid dies from this attack, a new shadow rises from the corpse 1d4 hours later.</p></section><p>The Shadow attacks with its Strength Drain.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>9 (2d6 + 2) <em>necrotic damage</em></strong>.</p><p>The target's Strength score is reduced by 1d4. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest.If a non-evil humanoid dies from this attack, a new shadow rises from the corpse 1d4 hours later.</p>",
+          "chat": "<p>The Shadow attacks with its Strength Drain.</p>"
         },
         "source": {
           "custom": "",
@@ -1071,10 +1071,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676570,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!QGcQYZbVl4bWzi4E.2OUOBIN4TJDoL0sJ"
     }

--- a/packs/_source/monsters/undead/skeleton.json
+++ b/packs/_source/monsters/undead/skeleton.json
@@ -622,8 +622,8 @@
       "img": "icons/weapons/bows/shortbow-recurve.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Skeleton attacks with its Shortbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Skeleton attacks with its Shortbow.</p>"
         },
         "source": {
           "custom": "",
@@ -817,10 +817,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676698,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nU8GN8La8DCt8SDb.hrTC2vP0xMgI8q8y"
     },
@@ -831,8 +831,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p></section>\n<p>The Skeleton attacks with its Shortsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Skeleton attacks with its Shortsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1026,10 +1026,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676698,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!nU8GN8La8DCt8SDb.qXbbvudRpBoul3bH"
     }

--- a/packs/_source/monsters/undead/specter.json
+++ b/packs/_source/monsters/undead/specter.json
@@ -639,8 +639,8 @@
       "img": "icons/skills/movement/feet-winged-boots-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The specter can move through other creatures and objects as if they were difficult terrain.</p><p>It takes <strong>5 (1d10) <em>force damage</em></strong> if it ends its turn inside an object.</p></section><p>The specter can move through other creatures and objects as if they were difficult terrain.</p>",
-          "chat": ""
+          "value": "<p>The specter can move through other creatures and objects as if they were difficult terrain.</p><p>It takes <strong>5 (1d10) <em>force damage</em></strong> if it ends its turn inside an object.</p>",
+          "chat": "<p>The specter can move through other creatures and objects as if they were difficult terrain.</p>"
         },
         "source": {
           "custom": "",
@@ -769,10 +769,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676568,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PuPo4H4Dcxigf0fY.FpoS5qzlgE3YPZGN"
     },
@@ -783,8 +783,8 @@
       "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Spell Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>10 (3d6) <em>necrotic damage</em></strong>. </p><p>The target must succeed on a  <strong>DC 10 Constitution</strong> saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the creature finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p></section><p>The Specter attacks with its Life Drain.The target must make a <strong>Constitution</strong> saving throw. </p>",
-          "chat": ""
+          "value": "<p><em>Melee Spell Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>10 (3d6) <em>necrotic damage</em></strong>. </p><p>The target must succeed on a  <strong>DC 10 Constitution</strong> saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the creature finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p>",
+          "chat": "<p>The Specter attacks with its Life Drain.The target must make a <strong>Constitution</strong> saving throw. </p>"
         },
         "source": {
           "custom": "",
@@ -1058,10 +1058,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676568,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PuPo4H4Dcxigf0fY.pxm7rAqI5ackW8Oy"
     },

--- a/packs/_source/monsters/undead/vampire-spawn.json
+++ b/packs/_source/monsters/undead/vampire-spawn.json
@@ -622,8 +622,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>necrotic damage</em></strong>.</p><p>The target's hit point maximum is reduced by an amount equal to the <em>necrotic damage</em> taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p></section><p>The Vampire Spawn attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong> plus <strong>7 (2d6) <em>necrotic damage</em></strong>.</p><p>The target's hit point maximum is reduced by an amount equal to the <em>necrotic damage</em> taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p>",
+          "chat": "<p>The Vampire Spawn attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -832,10 +832,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676837,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zpaZb7I8alY32vWV.HebvJc2NqYvdR79s"
     },
@@ -846,8 +846,8 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>8 (2d4 + 3) <em>slashing damage</em></strong>. </p><p></p></section><p>The Vampire Spawn attacks with its Claws. Instead of dealing damage, the vampire can grapple the target.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>8 (2d4 + 3) <em>slashing damage</em></strong>. </p>",
+          "chat": "<p>The Vampire Spawn attacks with its Claws. Instead of dealing damage, the vampire can grapple the target.</p>"
         },
         "source": {
           "custom": "",
@@ -1034,10 +1034,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676837,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zpaZb7I8alY32vWV.DY9MW3aTF5T5zhpo"
     },
@@ -1173,8 +1173,8 @@
       "img": "icons/skills/wounds/anatomy-organ-heart-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The vampire regains <strong>10 hit points</strong> at the start of its turn if it has at least <strong>1 hit point</strong> and isn't in sunlight or running water. If the vampire takes <em>radiant damage</em> or damage from holy water, this trait doesn't function at the start of the vampire's next turn.</p></section><p>The vampire regains <strong>10 hit points</strong> at the start of its turn.</p>",
-          "chat": ""
+          "value": "<p>The vampire regains <strong>10 hit points</strong> at the start of its turn if it has at least <strong>1 hit point</strong> and isn't in sunlight or running water. If the vampire takes <em>radiant damage</em> or damage from holy water, this trait doesn't function at the start of the vampire's next turn.</p>",
+          "chat": "<p>The vampire regains <strong>10 hit points</strong> at the start of its turn.</p>"
         },
         "source": {
           "custom": "",
@@ -1295,10 +1295,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676837,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zpaZb7I8alY32vWV.wzRyhY2I1U0ytB7D"
     },

--- a/packs/_source/monsters/undead/vampire.json
+++ b/packs/_source/monsters/undead/vampire.json
@@ -622,8 +622,8 @@
       "img": "icons/magic/control/silhouette-hold-change-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If the vampire isn't in sun light or running water, it can use its action to <strong>polymorph</strong> into a Tiny bat or a Medium cloud of mist, or back into its true form.</p>\n<p>While in bat form, the vampire can't speak, its walking speed is <strong>5 feet,</strong> and it has a flying speed of <strong>30 feet.</strong> Its statistics, other than its size and speed, are unchanged. Anything it is wearing transforms with it, but nothing it is carrying does. It reverts to its true form if it dies<strong>. </strong>While in mist form, the vampire can't take any actions, speak, or manipulate objects. It is weightless, has a flying speed of <strong>20 feet,</strong> can hover, and can enter a hostile creature's space and stop there. In addition, if air can pass through a space, the mist can do so without squeezing, and it can't pass through water. It has<strong> advantage </strong>on Strength, Dexterity, and Constitution saving throws, and it is immune to all <strong>nonmagical damage</strong>, except the damage it takes from sunlight.</p>\n</section>\n<p>The vampire can use its action to <strong>polymorph</strong> or return to its true form.</p>",
-          "chat": ""
+          "value": "<p>If the vampire isn't in sun light or running water, it can use its action to <strong>polymorph</strong> into a Tiny bat or a Medium cloud of mist, or back into its true form.</p><p>While in bat form, the vampire can't speak, its walking speed is <strong>5 feet,</strong> and it has a flying speed of <strong>30 feet.</strong> Its statistics, other than its size and speed, are unchanged. Anything it is wearing transforms with it, but nothing it is carrying does. It reverts to its true form if it dies<strong>. </strong>While in mist form, the vampire can't take any actions, speak, or manipulate objects. It is weightless, has a flying speed of <strong>20 feet,</strong> can hover, and can enter a hostile creature's space and stop there. In addition, if air can pass through a space, the mist can do so without squeezing, and it can't pass through water. It has<strong> advantage </strong>on Strength, Dexterity, and Constitution saving throws, and it is immune to all <strong>nonmagical damage</strong>, except the damage it takes from sunlight.</p>",
+          "chat": "<p>The vampire can use its action to <strong>polymorph</strong> or return to its true form.</p>"
         },
         "source": {
           "custom": "",
@@ -667,10 +667,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676990,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!DDO9lDCDtNHkfShP.BqG5guVa93LaOAn1"
     },
@@ -816,8 +816,8 @@
       "img": "icons/magic/air/fog-gas-smoke-swirling-gray.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>When it drops to <strong>0 hit points</strong> outside its resting place, the vampire transforms into a cloud of mist (as in the Shapechanger trait) instead of falling unconscious, provided that it isn't in sunlight or running water. If it can't transform, it is destroyed.</p><p>While it has <strong>0 hit points</strong> in mist form, it can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to its vampire form. It is then paralyzed until it regains at least <strong>1 hit point</strong>. After spending 1 hour in its resting place with <strong>0 hit points</strong>, it regains <strong>1 hit point</strong>.</p></section><p>A slain vampire transforms into a cloud of mist (as in the Shapechanger trait) instead of falling unconscious.</p>",
-          "chat": ""
+          "value": "<p>When it drops to <strong>0 hit points</strong> outside its resting place, the vampire transforms into a cloud of mist (as in the Shapechanger trait) instead of falling unconscious, provided that it isn't in sunlight or running water. If it can't transform, it is destroyed.</p><p>While it has <strong>0 hit points</strong> in mist form, it can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to its vampire form. It is then paralyzed until it regains at least <strong>1 hit point</strong>. After spending 1 hour in its resting place with <strong>0 hit points</strong>, it regains <strong>1 hit point</strong>.</p>",
+          "chat": "<p>A slain vampire transforms into a cloud of mist (as in the Shapechanger trait) instead of falling unconscious.</p>"
         },
         "source": {
           "custom": "",
@@ -861,10 +861,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676990,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!DDO9lDCDtNHkfShP.pVlKFunmE2qxO0pe"
     },
@@ -875,8 +875,8 @@
       "img": "icons/skills/wounds/anatomy-organ-heart-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The vampire regains <strong>20 hit points</strong> at the start of its turn if it has at least <strong>1 hit point</strong> and isn't in sunlight or running water. If the vampire takes <em>radiant damage</em> or damage from holy water, this trait doesn't function at the start of the vampire's next turn.</p></section><p>The vampire regains <strong>20 hit points</strong> at the start of its turn.</p>",
-          "chat": ""
+          "value": "<p>The vampire regains <strong>20 hit points</strong> at the start of its turn if it has at least <strong>1 hit point</strong> and isn't in sunlight or running water. If the vampire takes <em>radiant damage</em> or damage from holy water, this trait doesn't function at the start of the vampire's next turn.</p>",
+          "chat": "<p>The vampire regains <strong>20 hit points</strong> at the start of its turn.</p>"
         },
         "source": {
           "custom": "",
@@ -997,10 +997,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676990,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!DDO9lDCDtNHkfShP.BDnluJG7T7FfBjsQ"
     },
@@ -1250,8 +1250,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>8 (1d8 + 4) <em>bludgeoning damage</em></strong>. </p><p>Instead of dealing damage, the vampire can grapple the target (escape DC 18).</p></section><p>The Vampire attacks with its Unarmed Strike.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>8 (1d8 + 4) <em>bludgeoning damage</em></strong>. </p><p>Instead of dealing damage, the vampire can grapple the target (escape DC 18).</p>",
+          "chat": "<p>The Vampire attacks with its Unarmed Strike.</p>"
         },
         "source": {
           "custom": "",
@@ -1438,10 +1438,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676990,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!DDO9lDCDtNHkfShP.jYBYvv9EF1UnOvqZ"
     },
@@ -1452,8 +1452,8 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: <strong>7 (1d6 + 4) <em>piercing damage</em></strong> plus <strong>10 (3d6) <em>necrotic damage</em></strong>. </p><p>The target's hit point maximum is reduced by an amount equal to the <em>necrotic damage</em> taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid slain in this way and then buried in the ground rises the following night as a vampire spawn under the vampire's control.</p></section><p>The Vampire attacks with its Bite.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5 ft.,</strong> one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: <strong>7 (1d6 + 4) <em>piercing damage</em></strong> plus <strong>10 (3d6) <em>necrotic damage</em></strong>. </p><p>The target's hit point maximum is reduced by an amount equal to the <em>necrotic damage</em> taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid slain in this way and then buried in the ground rises the following night as a vampire spawn under the vampire's control.</p>",
+          "chat": "<p>The Vampire attacks with its Bite.</p>"
         },
         "source": {
           "custom": "",
@@ -1658,10 +1658,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676990,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!DDO9lDCDtNHkfShP.uqHuj7Pjf2sjny21"
     },
@@ -1672,8 +1672,8 @@
       "img": "icons/creatures/eyes/human-single-blue.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The vampire targets one humanoid it can see within 30 ft. of it. If the target can see the vampire, the target must succeed on a  <strong>DC 17 Wisdom</strong> saving throw against this magic or be charmed by the vampire. The charmed target regards the vampire as a trusted friend to be heeded and protected. Although the target isn't under the vampire's control, it takes the vampire's requests or actions in the most favorable way it can, and it is a willing target for the vampire's bite attack.</p><p>Each time the vampire or the vampire's companions do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the vampire is destroyed, is on a different plane of existence than the target, or takes a bonus action to end the effect.</p></section><p>The vampire targets one humanoid it can see within 30 ft. of it. If the target can see the vampire, the target must make a <strong>Wisdom</strong> saving throw against this magic.</p>",
-          "chat": ""
+          "value": "<p>The vampire targets one humanoid it can see within 30 ft. of it. If the target can see the vampire, the target must succeed on a  <strong>DC 17 Wisdom</strong> saving throw against this magic or be charmed by the vampire. The charmed target regards the vampire as a trusted friend to be heeded and protected. Although the target isn't under the vampire's control, it takes the vampire's requests or actions in the most favorable way it can, and it is a willing target for the vampire's bite attack.</p><p>Each time the vampire or the vampire's companions do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the vampire is destroyed, is on a different plane of existence than the target, or takes a bonus action to end the effect.</p>",
+          "chat": "<p>The vampire targets one humanoid it can see within 30 ft. of it. If the target can see the vampire, the target must make a <strong>Wisdom</strong> saving throw against this magic.</p>"
         },
         "source": {
           "custom": "",
@@ -1789,10 +1789,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676990,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!DDO9lDCDtNHkfShP.RHezeN7HzNf2oKYP"
     },
@@ -1803,8 +1803,8 @@
       "img": "icons/magic/death/skull-trio-badge-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The vampire magically calls 2d4 swarms of bats or rats, provided that the sun isn't up. While outdoors, the vampire can call 3d6 wolves instead. </p><p>The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action.</p></section><p>The vampire magically calls swarms of bats or rats. While outdoors, the vampire can call wolves instead. </p>",
-          "chat": ""
+          "value": "<p>The vampire magically calls 2d4 swarms of bats or rats, provided that the sun isn't up. While outdoors, the vampire can call 3d6 wolves instead. </p><p>The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action.</p>",
+          "chat": "<p>The vampire magically calls swarms of bats or rats. While outdoors, the vampire can call wolves instead. </p>"
         },
         "source": {
           "custom": "",
@@ -1929,10 +1929,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676990,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!DDO9lDCDtNHkfShP.c9z4o0fkxq37v8KY"
     },
@@ -1943,8 +1943,8 @@
       "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>The vampire can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The vampire regains spent legendary actions at the start of its turn.</p>\n</section>\n<p>The vampire can take 3 legendary actions.</p>",
-          "chat": ""
+          "value": "<p>The vampire can take 3 legendary actions. Only one legendary action option can be used at a time and only at the end of another creature's turn. The vampire regains spent legendary actions at the start of its turn.</p>",
+          "chat": "<p>The vampire can take 3 legendary actions.</p>"
         },
         "source": {
           "custom": "",
@@ -1988,10 +1988,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676990,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!DDO9lDCDtNHkfShP.rQOFEdWpVwJWS2U4"
     },
@@ -2002,8 +2002,8 @@
       "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>\n</section>\n<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>",
-          "chat": ""
+          "value": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. On initiative count 20 (losing all initiative ties), it can use one of its lair action options. It can't do so while incapacitated or otherwise unable to take actions. If surprised, it can't use one until after its first turn in the combat.</p>",
+          "chat": "<p>If a legendary creature has lair actions, it can use them to harness the ambient magic in its lair. </p>"
         },
         "source": {
           "custom": "",
@@ -2047,10 +2047,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676990,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!DDO9lDCDtNHkfShP.hNBduaMwPI3vordA"
     },

--- a/packs/_source/monsters/undead/warhorse-skeleton.json
+++ b/packs/_source/monsters/undead/warhorse-skeleton.json
@@ -622,8 +622,8 @@
       "img": "icons/commodities/bones/hooves-cloven-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Warhorse Skeleton attacks with its Hooves.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Warhorse Skeleton attacks with its Hooves.</p>"
         },
         "source": {
           "custom": "",
@@ -813,10 +813,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676409,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!7KJ5vjnp0FJrdu6T.sIgV1p8nM1z4VZgY"
     }

--- a/packs/_source/monsters/undead/wight.json
+++ b/packs/_source/monsters/undead/wight.json
@@ -903,8 +903,8 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>\n</section>\n<p>The Wight attacks with its Longbow.</p>",
-          "chat": ""
+          "value": "<p>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>",
+          "chat": "<p>The Wight attacks with its Longbow.</p>"
         },
         "source": {
           "custom": "",
@@ -1099,10 +1099,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676856,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rbyp54px2D0ql4QK.PUYwkzEiKopyM6YL"
     },
@@ -1113,8 +1113,8 @@
       "img": "icons/weapons/swords/greatsword-crossguard-steel.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>slashing damage</em></strong>, or <strong>7 (1d10 + 2) <em>slashing damage</em></strong> if used with two hands.</p>\n</section>\n<p>The Wight attacks with its Longsword.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>slashing damage</em></strong>, or <strong>7 (1d10 + 2) <em>slashing damage</em></strong> if used with two hands.</p>",
+          "chat": "<p>The Wight attacks with its Longsword.</p>"
         },
         "source": {
           "custom": "",
@@ -1307,10 +1307,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676856,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rbyp54px2D0ql4QK.WZ3XGh48UoyAvBhS"
     },
@@ -1321,8 +1321,8 @@
       "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\">\n<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>necrotic damage</em></strong>.</p>\n<p>The target must succeed on a  <strong>DC 13 Constitution</strong> saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p>\n<p>A humanoid slain by this attack rises 24 hours later as a zombie under the wight's control, unless the humanoid is restored to life or its body is destroyed. The wight can have no more than twelve zombies under its control at one time.</p>\n</section>\n<p>The Wight attacks with its Life Drain. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>necrotic damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 13 Constitution</strong> saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p><p>A humanoid slain by this attack rises 24 hours later as a zombie under the wight's control, unless the humanoid is restored to life or its body is destroyed. The wight can have no more than twelve zombies under its control at one time.</p>",
+          "chat": "<p>The Wight attacks with its Life Drain. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1582,10 +1582,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676856,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!rbyp54px2D0ql4QK.NX8cqG6aZMns8wvY"
     }

--- a/packs/_source/monsters/undead/will-o-wisp.json
+++ b/packs/_source/monsters/undead/will-o-wisp.json
@@ -637,8 +637,8 @@
       "img": "icons/magic/life/heart-glowing-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>As a bonus action, the will-o'-wisp can target one creature it can see within <strong>5 ft.</strong> of it that has <strong>0 hit points</strong> and is still alive. </p><p>The target must succeed on a <strong>DC 10 Constitution saving throw</strong> against this magic or die. If the target dies, the will-o'-wisp regains 10 (3d6)<strong> hit points</strong>.</p></section><p>The will-o'-wisp can target one creature it can see within <strong>5 ft.</strong> The target must succeed on a Constitution saving throw.</p>",
-          "chat": ""
+          "value": "<p>As a bonus action, the will-o'-wisp can target one creature it can see within <strong>5 ft.</strong> of it that has <strong>0 hit points</strong> and is still alive. </p><p>The target must succeed on a <strong>DC 10 Constitution saving throw</strong> against this magic or die. If the target dies, the will-o'-wisp regains 10 (3d6)<strong> hit points</strong>.</p>",
+          "chat": "<p>The will-o'-wisp can target one creature it can see within <strong>5 ft.</strong> The target must succeed on a Constitution saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -769,10 +769,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676865,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8KSVpQZyzius93ko.RAnyTfj3CGaiGK3W"
     },
@@ -842,8 +842,8 @@
       "img": "icons/skills/movement/feet-winged-boots-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The will-o'-wisp can move through other creatures and objects as if they were difficult terrain.</p><p>It takes <strong>5 (1d10) <em>force damage</em></strong> if it ends its turn inside an object.</p></section><p>The will-o'-wisp can move through other creatures and objects as if they were difficult terrain.</p>",
-          "chat": ""
+          "value": "<p>The will-o'-wisp can move through other creatures and objects as if they were difficult terrain.</p><p>It takes <strong>5 (1d10) <em>force damage</em></strong> if it ends its turn inside an object.</p>",
+          "chat": "<p>The will-o'-wisp can move through other creatures and objects as if they were difficult terrain.</p>"
         },
         "source": {
           "custom": "",
@@ -972,10 +972,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676865,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8KSVpQZyzius93ko.MGdIOXhRAQQRrAcO"
     },
@@ -1045,8 +1045,8 @@
       "img": "icons/magic/lightning/bolt-forked-teal.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Spell Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>9 (2d8) <em>lightning damage</em></strong>.</p><p></p></section><p>The Will-o'-Wisp attacks with its Shock.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Spell Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>9 (2d8) <em>lightning damage</em></strong>.</p>",
+          "chat": "<p>The Will-o'-Wisp attacks with its Shock.</p>"
         },
         "source": {
           "custom": "",
@@ -1233,10 +1233,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676865,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8KSVpQZyzius93ko.np6oHDOwHQFsSn5B"
     },
@@ -1247,8 +1247,8 @@
       "img": "icons/magic/unholy/orb-glowing-yellow-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The will-o'-wisp and its light magically become invisible until it attacks or uses its Consume Life, or until its concentration ends (as if concentrating on a spell).</p><p></p></section><p>The will-o'-wisp and its light magically become invisible.</p>",
-          "chat": ""
+          "value": "<p>The will-o'-wisp and its light magically become invisible until it attacks or uses its Consume Life, or until its concentration ends (as if concentrating on a spell).</p>",
+          "chat": "<p>The will-o'-wisp and its light magically become invisible.</p>"
         },
         "source": {
           "custom": "",
@@ -1358,10 +1358,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676865,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!8KSVpQZyzius93ko.vJR81iEOZYNMuAdz"
     }

--- a/packs/_source/monsters/undead/wraith.json
+++ b/packs/_source/monsters/undead/wraith.json
@@ -639,8 +639,8 @@
       "img": "icons/creatures/abilities/dragon-breath-purple.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The wraith targets a humanoid within 10 feet of it that has been dead for no longer than 1 minute and died violently. </p><p>The target's spirit rises as a specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith's control. The wraith can have no more than seven specters under its control at one time.</p></section><p>The target's spirit rises as a specter in the space of its corpse or in the nearest unoccupied space. </p>",
-          "chat": ""
+          "value": "<p>The wraith targets a humanoid within 10 feet of it that has been dead for no longer than 1 minute and died violently. </p><p>The target's spirit rises as a specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith's control. The wraith can have no more than seven specters under its control at one time.</p>",
+          "chat": "<p>The target's spirit rises as a specter in the space of its corpse or in the nearest unoccupied space. </p>"
         },
         "source": {
           "custom": "",
@@ -750,10 +750,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676716,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ET4PEVEiNJLU4f7c.RADMbiPme1Hrfu8E"
     },
@@ -764,8 +764,8 @@
       "img": "icons/skills/movement/feet-winged-boots-brown.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>The wraith can move through other creatures and objects as if they were difficult terrain. </p><p>It takes <strong>5 (1d10) <em>force damage</em></strong> if it ends its turn inside an object.</p></section><p>The wraith can move through other creatures and objects as if they were difficult terrain.</p>",
-          "chat": ""
+          "value": "<p>The wraith can move through other creatures and objects as if they were difficult terrain. </p><p>It takes <strong>5 (1d10) <em>force damage</em></strong> if it ends its turn inside an object.</p>",
+          "chat": "<p>The wraith can move through other creatures and objects as if they were difficult terrain.</p>"
         },
         "source": {
           "custom": "",
@@ -894,10 +894,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676716,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ET4PEVEiNJLU4f7c.idILnIUj76QH9v8w"
     },
@@ -908,8 +908,8 @@
       "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>21 (4d8 + 3) <em>necrotic damage</em></strong>. </p><p>The target must succeed on a  <strong>DC 14 Constitution</strong> saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p></section><p>The Wraith attacks with its Life Drain. The target must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>21 (4d8 + 3) <em>necrotic damage</em></strong>. </p><p>The target must succeed on a  <strong>DC 14 Constitution</strong> saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p>",
+          "chat": "<p>The Wraith attacks with its Life Drain. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1185,10 +1185,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676716,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ET4PEVEiNJLU4f7c.xZPFtf2vCYraWXVe"
     },

--- a/packs/_source/monsters/undead/zombie.json
+++ b/packs/_source/monsters/undead/zombie.json
@@ -619,8 +619,8 @@
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>bludgeoning damage</em></strong>.</p><p></p></section><p>The Zombie attacks with its Slam.</p>",
-          "chat": ""
+          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>bludgeoning damage</em></strong>.</p>",
+          "chat": "<p>The Zombie attacks with its Slam.</p>"
         },
         "source": {
           "custom": "",
@@ -807,10 +807,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676561,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NAISFPoNNgUCsEyW.Ed7XgnZu9qRs3qdn"
     },
@@ -821,8 +821,8 @@
       "img": "icons/magic/acid/pouring-gas-smoke-liquid.webp",
       "system": {
         "description": {
-          "value": "<section class=\"secret\"><p>If damage reduces the zombie to <strong>0 hit points</strong>, it must make a <strong>Constitution</strong> saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to <strong>1 hit point</strong> instead.</p></section><p>If damage reduces the zombie to <strong>0 hit points</strong>, it must make a <strong>Constitution</strong> saving throw.</p>",
-          "chat": ""
+          "value": "<p>If damage reduces the zombie to <strong>0 hit points</strong>, it must make a <strong>Constitution</strong> saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to <strong>1 hit point</strong> instead.</p>",
+          "chat": "<p>If damage reduces the zombie to <strong>0 hit points</strong>, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -866,10 +866,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.2.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736804676561,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!NAISFPoNNgUCsEyW.RDeCoZRniQBNq0rX"
     }


### PR DESCRIPTION
Adjust all NPCs in the SRD to have item descriptions split between normal and chat descriptions, rather than hiding details with secret blocks.

Closes #3240