### PR TITLE
[#3798, #4842] Add legendary action description to stat blocks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2720,7 +2720,7 @@
 "DND5E.Languages": "Languages",
 
 "DND5E.LegendaryAction": {
-  "Description": "Legendary Action Uses: {uses}. Immediately after another creature’s turn, the {name} can expend a use to take one of the following actions. The {name} regains all expended uses at the start of each of its turns.",
+  "Description": "Legendary Action Uses: {uses}.",
   "DescriptionLegacy": "The {name} can take {usesNamed}, choosing from the options below. Only one legendary action option can be used at a time and only at the end of another creature’s turn. The {name} regains spent legendary actions at the start of its turn.",
   "Label": "Legendary Action",
   "LairUses": "{normal} ({lair} in Lair)",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2720,7 +2720,10 @@
 "DND5E.Languages": "Languages",
 
 "DND5E.LegendaryAction": {
+  "Description": "Legendary Action Uses: {uses}. Immediately after another creature’s turn, the {name} can expend a use to take one of the following actions. The {name} regains all expended uses at the start of each of its turns.",
+  "DescriptionLegacy": "The {name} can take {usesNamed}, choosing from the options below. Only one legendary action option can be used at a time and only at the end of another creature’s turn. The {name} regains spent legendary actions at the start of its turn.",
   "Label": "Legendary Action",
+  "LairUses": "{normal} ({lair} in Lair)",
   "Max": "Maximum Legendary Actions",
   "Ordinal": {
     "one": "{n}st Legendary Action",

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -283,6 +283,8 @@
     .statblock-actions {
       color: var(--statblock-text-primary);
 
+      > p { font-style: italic; }
+
       .statblock-action {
         > p:first-child > .name {
           font-style: italic;

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -419,7 +419,7 @@ export default class NPCData extends CreatureTemplate {
     };
     AttributesFields.prepareHitPoints.call(this, this.attributes.hp, hpOptions);
 
-    this.resources.legact.label = ({ name }) => this.getLegendaryActionsDescription(name);
+    this.resources.legact.label = this.getLegendaryActionsDescription();
   }
 
   /* -------------------------------------------- */

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -922,7 +922,6 @@ function enrichLookup(config, fallback, options) {
   const data = activity ? activity.getRollData().activity : options.rollData
     ?? options.relativeTo?.getRollData?.() ?? {};
   let value = foundry.utils.getProperty(data, keyPath.substring(1)) ?? fallback;
-  if ( foundry.utils.getType(value) === "function" ) value = value(config);
   if ( value && style ) {
     if ( style === "capitalize" ) value = value.capitalize();
     else if ( style === "lowercase" ) value = value.toLowerCase();

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -922,6 +922,7 @@ function enrichLookup(config, fallback, options) {
   const data = activity ? activity.getRollData().activity : options.rollData
     ?? options.relativeTo?.getRollData?.() ?? {};
   let value = foundry.utils.getProperty(data, keyPath.substring(1)) ?? fallback;
+  if ( foundry.utils.getType(value) === "function" ) value = value(config);
   if ( value && style ) {
     if ( style === "capitalize" ) value = value.capitalize();
     else if ( style === "lowercase" ) value = value.toLowerCase();

--- a/templates/actors/embeds/npc-embed.hbs
+++ b/templates/actors/embeds/npc-embed.hbs
@@ -95,6 +95,7 @@
         {{#each actionSections}}
         <div class="statblock-actions {{ @key }}">
             <h5 class="statblock-actions-title">{{ label }}</h5>
+            {{{ description }}}
             {{#each actions}}
             <div class="statblock-action">
                 {{{ openingTag }}}


### PR DESCRIPTION
Adds the legendary action description to embedded NPC stat blocks. This will automatically use the description of an item with the `legendary-actions` identifier if present, otherwise it use an auto-generated description based on the rules version.

The auto-generated description is also available from the roll data in `resources.legact.label`. A modification has been made to the lookup enricher so that if it finds a function at its target location, it will call that function with the enricher config as its paremter. This allows for substituting the actor's name: `[[lookup @resources.legact.label name=dragon]]`.