### PR TITLE
[#3798] Display in-lair XP on embedded NPC stat blocks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1745,18 +1745,24 @@
 "DND5E.Equipped": "Equipped",
 "DND5E.Exhaustion": "Exhaustion",
 "DND5E.ExhaustionLevel": "Exhaustion Level {n}",
-"DND5E.ExperiencePoints": "Experience Points",
-"DND5E.ExperiencePointsAbbr": "XP",
-"DND5E.ExperiencePointsBoons": {
-  "one": "{number} Boon",
-  "other": "{number} Boons"
+
+"DND5E.ExperiencePoints": {
+  "Abbreviation": "XP",
+  "Boons": {
+    "one": "{number} Boon",
+    "other": "{number} Boons"
+  },
+  "Current": "Current XP",
+  "Format": "{value} XP",
+  "Label": "Experience Points",
+  "Progress": "Progress to next Level",
+  "StatBlock": {
+    "Standard": "XP {value}",
+    "Lair": "XP {value}, or {lair} in lair"
+  },
+  "Value": "XP Value"
 },
-"DND5E.ExperiencePointsCurrent": "Current XP",
-"DND5E.ExperiencePointsFormat": "{value} XP",
-"DND5E.ExperiencePointsLabel": "Progress to next level",
-"DND5E.ExperiencePointsMax": "XP for Next Level",
-"DND5E.ExperiencePointsMin": "Minimum XP for This Level",
-"DND5E.ExperiencePointsValue": "XP Value",
+
 "DND5E.Expertise": "Expertise",
 
 "DND5E.FACILITY": {

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -236,7 +236,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     if ( context.system.details.xp.boonsEarned !== undefined ) {
       const pluralRules = new Intl.PluralRules(game.i18n.lang);
       context.epicBoonsEarned = game.i18n.format(
-        `DND5E.ExperiencePointsBoons.${pluralRules.select(context.system.details.xp.boonsEarned ?? 0)}`,
+        `DND5E.ExperiencePoints.Boons.${pluralRules.select(context.system.details.xp.boonsEarned ?? 0)}`,
         { number: formatNumber(context.system.details.xp.boonsEarned ?? 0, { signDisplay: "always" }) }
       );
     }

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -63,7 +63,7 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
     const [elements] = this.element.find(".header-elements");
     if ( !elements || this.actor.limited ) return;
     const xp = this.actor.system.details.xp.value;
-    elements.querySelector(".cr-xp").innerHTML = xp === null ? "" : game.i18n.format("DND5E.ExperiencePointsFormat", {
+    elements.querySelector(".cr-xp").innerHTML = xp === null ? "" : game.i18n.format("DND5E.ExperiencePoints.Format", {
       value: new Intl.NumberFormat(game.i18n.lang).format(xp)
     });
   }

--- a/module/applications/award.mjs
+++ b/module/applications/award.mjs
@@ -253,7 +253,7 @@ export default class Award extends DialogMixin(FormApplication) {
       }
       if ( result.xp ) entries.push(`
         <span class="award-entry">
-          ${formatNumber(result.xp)} ${game.i18n.localize("DND5E.ExperiencePointsAbbr")}
+          ${formatNumber(result.xp)} ${game.i18n.localize("DND5E.ExperiencePoints.Abbreviation")}
         </span>
       `);
       if ( !entries.length ) continue;

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -140,9 +140,9 @@ export default class CharacterData extends CreatureTemplate {
         originalClass: new StringField({ required: true, label: "DND5E.ClassOriginal" }),
         xp: new SchemaField({
           value: new NumberField({
-            required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.ExperiencePointsCurrent"
+            required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.ExperiencePoints.Current"
           })
-        }, { label: "DND5E.ExperiencePoints" }),
+        }, { label: "DND5E.ExperiencePoints.Label" }),
         appearance: new StringField({ required: true, label: "DND5E.Appearance" }),
         trait: new StringField({ required: true, label: "DND5E.PersonalityTraits" }),
         gender: new StringField({ label: "DND5E.Gender" }),

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -70,8 +70,8 @@ export default class GroupActor extends ActorDataModel.mixin(CurrencyTemplate) {
       }, { label: "DND5E.Attributes" }),
       details: new SchemaField({
         xp: new SchemaField({
-          value: new NumberField({ integer: true, min: 0, label: "DND5E.ExperiencePointsCurrent" })
-        }, { label: "DND5E.ExperiencePoints" })
+          value: new NumberField({ integer: true, min: 0, label: "DND5E.ExperiencePoints.Current" })
+        }, { label: "DND5E.ExperiencePoints.Label" })
       }, { label: "DND5E.Details" })
     });
   }

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -554,9 +554,12 @@ export default class NPCData extends CreatureTemplate {
       document: this.parent,
       summary: {
         // Challenge Rating (e.g. `23 (XP 50,000; PB +7`))
-        // TODO: Handle increased XP in lair for 2024 creatures
-        cr: `${formatCR(this.details.cr, { narrow: false })} (${game.i18n.localize("DND5E.ExperiencePointsAbbr")} ${
-          formatNumber(this.details.xp.value)}; ${game.i18n.localize("DND5E.ProficiencyBonusAbbr")} ${
+        cr: `${formatCR(this.details.cr, { narrow: false })} (${
+          game.i18n.format(`DND5E.ExperiencePoints.StatBlock.${
+            (this.resources.lair.value) && (this.details.cr !== null) ? "Lair" : "Standard"}`, {
+            value: formatNumber(this.parent.getCRExp(this.details.cr)),
+            lair: formatNumber(this.parent.getCRExp(this.details.cr + 1))
+          })}; ${game.i18n.localize("DND5E.ProficiencyBonusAbbr")} ${
           formatNumber(this.attributes.prof, { signDisplay: "always" })})`,
 
         // Gear

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -261,7 +261,7 @@ async function enrichAward(config, label, options) {
   }
   if ( parsed.xp ) entries.push(`
     <span class="award-entry">
-      ${formatNumber(parsed.xp)} ${game.i18n.localize("DND5E.ExperiencePointsAbbr")}
+      ${formatNumber(parsed.xp)} ${game.i18n.localize("DND5E.ExperiencePoints.Abbreviation")}
     </span>
   `);
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1050,7 +1050,7 @@ export function getHumanReadableAttributeLabel(attr, { actor }={}) {
   }
 
   if ( (attr === "details.xp.value") && (actor?.type === "npc") ) {
-    return game.i18n.localize("DND5E.ExperiencePointsValue");
+    return game.i18n.localize("DND5E.ExperiencePoints.Value");
   }
 
   if ( attr.startsWith(".") && actor ) {

--- a/templates/actors/character-sheet-2.hbs
+++ b/templates/actors/character-sheet-2.hbs
@@ -102,7 +102,7 @@
                     <span class="max">{{ dnd5e-numberFormat max }}</span>
                     {{/unless}}
                 </div>
-                <div class="xp-bar" role="meter" aria-label="{{ localize "DND5E.ExperiencePointsLabel" }}"
+                <div class="xp-bar" role="meter" aria-label="{{ localize "DND5E.ExperiencePoints.Progress" }}"
                      aria-valuemin="{{ min }}" aria-valuenow="{{ value }}" aria-valuemax="{{ max }}"
                      aria-valuetext="{{ pct }}%" style="--bar-percentage: {{ pct }}%;"></div>
                 {{/with}}

--- a/templates/actors/group-sheet.hbs
+++ b/templates/actors/group-sheet.hbs
@@ -41,7 +41,7 @@
                 </li>
                 {{#if xp}}
                 <li class="attribute xp">
-                    <h4 class="attribute-name box-title">{{localize "DND5E.ExperiencePoints"}}</h4>
+                    <h4 class="attribute-name box-title">{{localize "DND5E.ExperiencePoints.Label"}}</h4>
                     <div class="attribute-value">
                         {{ numberInput xp.value name="system.details.xp.value" min=0 step=1
                            placeholder=(dnd5e-numberFormat xp.derived) }}

--- a/templates/actors/tabs/group-members.hbs
+++ b/templates/actors/tabs/group-members.hbs
@@ -82,7 +82,7 @@
             {{#if section.displayChallengeColumn}}
             <div class="challenge">
                 <abbr>{{localize "DND5E.AbbreviationCR"}}</abbr> {{member.cr}}{{#if member.xp}} —
-                {{member.xp}} <abbr>{{localize "DND5E.ExperiencePointsAbbr"}}</abbr>{{/if}}
+                {{member.xp}} <abbr>{{localize "DND5E.ExperiencePoints.Abbreviation"}}</abbr>{{/if}}
             </div>
             {{/if}}
             <div class="controls">

--- a/templates/apps/award.hbs
+++ b/templates/apps/award.hbs
@@ -7,7 +7,7 @@
     </div>
     {{#unless hideXP}}
     <label class="xp currency-style">
-        <span class="roboto-upper">{{localize "DND5E.ExperiencePoints"}}</span>
+        <span class="roboto-upper">{{localize "DND5E.ExperiencePoints.Label"}}</span>
         {{numberInput xp name="xp" class="uninput" min=0 step=1}}
     </label>
     {{/unless}}


### PR DESCRIPTION
Formats the NPC XP to display an alternate value if the creature has a lair.

Closes #3798