### PR TITLE
Allow embedded roll table result column to be renamed

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -64,6 +64,7 @@ Hooks.once("init", function() {
   CONFIG.Item.collection = dataModels.collection.Items5e;
   CONFIG.Item.compendiumIndexFields.push("system.container");
   CONFIG.Item.documentClass = documents.Item5e;
+  CONFIG.RollTable.documentClass = documents.RollTable5e;
   CONFIG.Token.documentClass = documents.TokenDocument5e;
   CONFIG.Token.objectClass = canvas.Token5e;
   CONFIG.User.documentClass = documents.User5e;

--- a/module/documents/_module.mjs
+++ b/module/documents/_module.mjs
@@ -7,6 +7,7 @@ export {default as ChatMessage5e} from "./chat-message.mjs";
 export {default as Combat5e} from "./combat.mjs";
 export {default as Combatant5e} from "./combatant.mjs";
 export {default as Item5e} from "./item.mjs";
+export {default as RollTable5e} from "./roll-table.mjs";
 export {default as TokenDocument5e} from "./token.mjs";
 export {default as User5e} from "./user.mjs";
 

--- a/module/documents/roll-table.mjs
+++ b/module/documents/roll-table.mjs
@@ -1,0 +1,12 @@
+/**
+ * System version of roll tables with some customized embed behavior.
+ */
+export default class RollTable5e extends RollTable {
+  async _buildEmbedHTML(config, options={}) {
+    const embed = await super._buildEmbedHTML(config, options);
+    if ( config.resultsHeader && (embed instanceof HTMLElement) ) {
+      embed.querySelector("thead th:last-of-type").innerText = config.resultsHeader;
+    }
+    return embed;
+  }
+}


### PR DESCRIPTION
Adds the `resultsHeader` config option that is supported by roll tables and replaces the default "Results" header with a custom value:

```
@Embed[Compendium.dnd5e.tables.RollTable.4ryVFV5LPHPzRKxl resultsHeader="Bean Effects" rollable]
```

<img width="629" alt="Screenshot 2025-01-15 at 13 02 16" src="https://github.com/user-attachments/assets/f48c4c2e-9d1c-41cd-87c5-c5c4035fea9d" />
