### PR TITLE
[#5003] Add ability attack, spell attack, & spell ability labels

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -263,7 +263,7 @@ function _configureTrackableAttributes() {
       ...common.value,
       ...Object.keys(DND5E.skills).map(skill => `skills.${skill}.passive`),
       ...Object.keys(DND5E.senses).map(sense => `attributes.senses.${sense}`),
-      "attributes.spelldc"
+      "attributes.spell.attack", "attributes.spell.dc"
     ]
   };
 
@@ -274,7 +274,7 @@ function _configureTrackableAttributes() {
     },
     npc: {
       bar: [...creature.bar, "resources.legact", "resources.legres"],
-      value: [...creature.value, "details.cr", "details.spellLevel", "details.xp.value"]
+      value: [...creature.value, "attributes.spell.level", "details.cr", "details.xp.value"]
     },
     vehicle: {
       bar: [...common.bar, "attributes.hp"],

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -1116,7 +1116,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
       if ( modes[preparationMode]?.cantrips ) {
         prep.mode = "prepared";
       } else if ( !preparationMode ) {
-        const isCaster = this.document.system.details.spellLevel || progs.size;
+        const isCaster = this.document.system.attributes.spell?.level || progs.size;
         prep.mode = isCaster ? "prepared" : "innate";
       } else {
         prep.mode = preparationMode;
@@ -1127,7 +1127,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
     // Case 2: Drop a leveled spell in a section without a mode.
     else if ( (level === "0") || !preparationMode ) {
       if ( this.document.type === "npc" ) {
-        prep.mode = this.document.system.details.spellLevel ? "prepared" : "innate";
+        prep.mode = this.document.system.attributes.spell.level ? "prepared" : "innate";
       } else {
         const m = progs.has("leveled") ? "prepared" : (progs.first() ?? "innate");
         prep.mode = progs.has(prep.mode) ? prep.mode : m;

--- a/module/applications/actor/npc-sheet-2.mjs
+++ b/module/applications/actor/npc-sheet-2.mjs
@@ -304,7 +304,7 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
    * @protected
    */
   _prepareSpellcasting(context) {
-    const { abilities, attributes, bonuses, details } = this.actor.system;
+    const { abilities, attributes, bonuses } = this.actor.system;
     context.spellcasting = [];
     const msak = simplifyBonus(bonuses.msak.attack, context.rollData);
     const rsak = simplifyBonus(bonuses.rsak.attack, context.rollData);
@@ -318,7 +318,7 @@ export default class ActorSheet5eNPC2 extends ActorSheetV2Mixin(ActorSheet5eNPC)
       label: game.i18n.format("DND5E.SpellcastingClass", {
         class: spellcaster?.name ?? game.i18n.format("DND5E.NPC.Label")
       }),
-      level: spellcaster?.system.levels ?? details.spellLevel,
+      level: spellcaster?.system.levels ?? attributes.spell.level,
       ability: {
         ability, mod,
         label: CONFIG.DND5E.abilities[ability]?.abbreviation

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3524,8 +3524,8 @@ preLocalize("cover");
  */
 DND5E.trackableAttributes = [
   "attributes.ac.value", "attributes.init.bonus", "attributes.movement", "attributes.senses",
-  "attributes.spell.attack", "attributes.spell.dc", "attributes.spellLevel", "details.cr",
-  "details.spellLevel", "details.xp.value", "skills.*.passive", "abilities.*.value"
+  "attributes.spell.attack", "attributes.spell.dc", "attributes.spell.level", "details.cr",
+  "details.xp.value", "skills.*.passive", "abilities.*.value"
 ];
 
 /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3523,9 +3523,9 @@ preLocalize("cover");
  * @deprecated since v10
  */
 DND5E.trackableAttributes = [
-  "attributes.ac.value", "attributes.init.bonus", "attributes.movement", "attributes.senses", "attributes.spelldc",
-  "attributes.spellLevel", "details.cr", "details.spellLevel", "details.xp.value", "skills.*.passive",
-  "abilities.*.value"
+  "attributes.ac.value", "attributes.init.bonus", "attributes.movement", "attributes.senses",
+  "attributes.spell.attack", "attributes.spell.dc", "attributes.spellLevel", "details.cr",
+  "details.spellLevel", "details.xp.value", "skills.*.passive", "abilities.*.value"
 ];
 
 /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -36,6 +36,8 @@ const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringFiel
  * @property {string} attributes.death.bonuses.save   Numeric or dice bonus to death saving throws.
  * @property {number} attributes.death.success        Number of successful death saves.
  * @property {number} attributes.death.failure        Number of failed death saves.
+ * @property {object} attributes.spell
+ * @property {number} attributes.spell.level     Spellcasting level of this NPC.
  * @property {object} details
  * @property {TypeData} details.type             Creature type of this NPC.
  * @property {string} details.type.value         NPC's type as defined in the system configuration.
@@ -48,7 +50,6 @@ const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringFiel
  * @property {object} details.treasure
  * @property {Set<string>} details.treasure.value  Random treasure generation categories for this NPC.
  * @property {number} details.cr                 NPC's challenge rating.
- * @property {number} details.spellLevel         Spellcasting level of this NPC.
  * @property {object} resources
  * @property {object} resources.legact           NPC's legendary actions.
  * @property {number} resources.legact.value     Currently available legendary actions.
@@ -118,7 +119,12 @@ export default class NPCData extends CreatureTemplate {
           bonuses: new SchemaField({
             save: new FormulaField({ required: true, label: "DND5E.DeathSaveBonus" })
           })
-        }, {label: "DND5E.DeathSave"})
+        }, {label: "DND5E.DeathSave"}),
+        spell: new SchemaField({
+          level: new NumberField({
+            required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.SpellcasterLevel"
+          })
+        })
       }, {label: "DND5E.Attributes"}),
       details: new SchemaField({
         ...DetailsFields.common,
@@ -133,9 +139,6 @@ export default class NPCData extends CreatureTemplate {
         }),
         cr: new NumberField({
           required: true, nullable: true, min: 0, initial: 1, label: "DND5E.ChallengeRating"
-        }),
-        spellLevel: new NumberField({
-          required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.SpellcasterLevel"
         }),
         treasure: new SchemaField({
           value: new SetField(new StringField())
@@ -232,6 +235,7 @@ export default class NPCData extends CreatureTemplate {
     super._migrateData(source);
     NPCData.#migrateEnvironment(source);
     NPCData.#migrateSource(source);
+    NPCData.#migrateSpellLevel(source);
     NPCData.#migrateTypeData(source);
     AttributesFields._migrateInitiative(source.attributes);
   }
@@ -262,6 +266,18 @@ export default class NPCData extends CreatureTemplate {
     if ( custom ) {
       source.source ??= {};
       source.source.custom = custom;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Move spell level from `details.spellLevel` to `attributes.spell.level`.
+   * @param {object} source  The candidate source data from which the model will be constructed.
+   */
+  static #migrateSpellLevel(source) {
+    if ( source.details?.spellLevel !== undefined ) {
+      foundry.utils.setProperty(source, "attributes.spell.level", source.details.spellLevel);
     }
   }
 
@@ -360,8 +376,25 @@ export default class NPCData extends CreatureTemplate {
     else this.attributes.prof = Proficiency.calculateMod(Math.max(this.details.cr, this.details.level, 1));
 
     // Spellcaster Level
-    if ( this.attributes.spellcasting && !Number.isNumeric(this.details.spellLevel) ) {
-      this.details.spellLevel = Math.max(this.details.cr, 1);
+    const attributes = this.attributes;
+    Object.defineProperty(this.details, "spellLevel", {
+      get() {
+        foundry.utils.logCompatibilityWarning(
+          "The `details.spellLevel` property on NPCs have moved to `attributes.spell.level`.",
+          { since: "DnD5e 4.3", until: "DnD5e 5.0" }
+        );
+        return attributes.spell.level;
+      },
+      set(value) {
+        foundry.utils.logCompatibilityWarning(
+          "The `details.spellLevel` property on NPCs have moved to `attributes.spell.level`.",
+          { since: "DnD5e 4.3", until: "DnD5e 5.0" }
+        );
+        attributes.spell.level = value;
+      }
+    });
+    if ( this.attributes.spellcasting && !Number.isNumeric(this.attributes.spell.level) ) {
+      this.attributes.spell.level = Math.max(this.details.cr, 1);
     }
 
     AttributesFields.prepareBaseArmorClass.call(this);
@@ -450,7 +483,7 @@ export default class NPCData extends CreatureTemplate {
    */
   cantripLevel(spell) {
     if ( spell.system.preparation.mode === "innate" ) return this.details.cr;
-    return this.details.level ? this.details.level : this.details.spellLevel;
+    return this.details.level ? this.details.level : this.attributes.spell.level;
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -461,17 +461,16 @@ export default class AttributesFields {
    */
   static prepareSpellcastingAbility() {
     const ability = this.abilities?.[this.attributes.spellcasting];
-    this.attributes.spell = {
-      abilityLabel: CONFIG.DND5E.abilities[this.attributes.spellcasting]?.label ?? "",
-      attack: ability ? ability.attack : this.attributes.prof,
-      dc: ability ? ability.dc : 8 + this.attributes.prof,
-      mod: ability ? ability.mod : 0
-    };
+    this.attributes.spell ??= {};
+    this.attributes.spell.abilityLabel = CONFIG.DND5E.abilities[this.attributes.spellcasting]?.label ?? "";
+    this.attributes.spell.attack = ability ? ability.attack : this.attributes.prof;
+    this.attributes.spell.dc = ability ? ability.dc : 8 + this.attributes.prof;
+    this.attributes.spell.mod = ability ? ability.mod : 0;
     Object.defineProperty(this.attributes, "spelldc", {
       get() {
         foundry.utils.logCompatibilityWarning(
           "The `attributes.spelldc` property on actors has been moved to `attributes.spell.dc`.",
-          { since: "DnD5e 4.2", until: "DnD5e 5.0" }
+          { since: "DnD5e 4.3", until: "DnD5e 5.0" }
         );
         return this.spell.dc;
       }
@@ -480,7 +479,7 @@ export default class AttributesFields {
       get() {
         foundry.utils.logCompatibilityWarning(
           "The `attributes.spellmod` property on actors has been moved to `attributes.spell.mod`.",
-          { since: "DnD5e 4.2", until: "DnD5e 5.0" }
+          { since: "DnD5e 4.3", until: "DnD5e 5.0" }
         );
         return this.spell.mod;
       }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -460,8 +460,30 @@ export default class AttributesFields {
    * @this {CharacterData|NPCData}
    */
   static prepareSpellcastingAbility() {
-    const spellcastingAbility = this.abilities[this.attributes.spellcasting];
-    this.attributes.spelldc = spellcastingAbility ? spellcastingAbility.dc : 8 + this.attributes.prof;
-    this.attributes.spellmod = spellcastingAbility ? spellcastingAbility.mod : 0;
+    const ability = this.abilities?.[this.attributes.spellcasting];
+    this.attributes.spell = {
+      abilityLabel: CONFIG.DND5E.abilities[this.attributes.spellcasting]?.label ?? "",
+      attack: ability ? ability.attack : this.attributes.prof,
+      dc: ability ? ability.dc : 8 + this.attributes.prof,
+      mod: ability ? ability.mod : 0
+    };
+    Object.defineProperty(this.attributes, "spelldc", {
+      get() {
+        foundry.utils.logCompatibilityWarning(
+          "The `attributes.spelldc` property on actors has been moved to `attributes.spell.dc`.",
+          { since: "DnD5e 4.2", until: "DnD5e 5.0" }
+        );
+        return this.spell.dc;
+      }
+    });
+    Object.defineProperty(this.attributes, "spellmod", {
+      get() {
+        foundry.utils.logCompatibilityWarning(
+          "The `attributes.spellmod` property on actors has been moved to `attributes.spell.mod`.",
+          { since: "DnD5e 4.2", until: "DnD5e 5.0" }
+        );
+        return this.spell.mod;
+      }
+    });
   }
 }

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -154,6 +154,7 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
 
       abl.save.value = abl.mod + abl.saveBonus;
       if ( Number.isNumeric(abl.saveProf.term) ) abl.save.value += abl.saveProf.flat;
+      abl.attack = abl.mod + prof;
       abl.dc = 8 + abl.mod + prof + dcBonus;
 
       if ( !Number.isFinite(abl.max) ) abl.max = CONFIG.DND5E.maxAbilityScore;

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -500,7 +500,7 @@ export default class SummonActivity extends ActivityMixin(SummonActivityData) {
 
       // Match saves
       if ( this.match.saves && item.hasSave ) {
-        let dc = rollData.abilities?.[this.ability]?.dc ?? rollData.attributes.spelldc;
+        let dc = rollData.abilities?.[this.ability]?.dc ?? rollData.attributes.spell.dc;
         if ( this.item.type === "spell" ) {
           const ability = this.item.system.availableAbilities?.first();
           if ( ability ) dc = rollData.abilities[ability]?.dc ?? dc;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -385,8 +385,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     );
 
     if ( this.type === "npc" ) {
-      if ( progression.slot || progression.pact ) this.system.details.spellLevel = progression.slot || progression.pact;
-      else progression.slot = this.system.details.spellLevel ?? 0;
+      if ( progression.slot || progression.pact ) {
+        this.system.attributes.spell.level = progression.slot || progression.pact;
+      } else progression.slot = this.system.attributes.spell.level ?? 0;
     }
 
     for ( const type of Object.keys(CONFIG.DND5E.spellcastingTypes) ) {
@@ -538,7 +539,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     // Slot override
     if ( (keyLevel === 0) && (actor.type === "npc") && (override !== null) ) {
-      keyLevel = actor.system.details.spellLevel;
+      keyLevel = actor.system.attributes.spell.level;
     }
 
     const [, keyConfig] = Object.entries(table).reverse().find(([l]) => Number(l) <= keyLevel) ?? [];

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1551,8 +1551,8 @@ export default class Item5e extends SystemDocumentMixin(Item) {
         values.bonus = spellcastingClass.spellcasting.attack;
         values.dc = spellcastingClass.spellcasting.save;
       } else {
-        values.bonus = spell.actor.system.attributes?.spellmod;
-        values.dc = spell.actor.system.attributes?.spelldc;
+        values.bonus = spell.actor.system.attributes?.spell?.mod;
+        values.dc = spell.actor.system.attributes?.spell?.dc;
       }
     }
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1157,7 +1157,7 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   // Derived fields.
   else if ( attr === "attributes.init.total" ) label = "DND5E.InitiativeBonus";
   else if ( (attr === "attributes.ac.value") || (attr === "attributes.ac.flat") ) label = "DND5E.ArmorClass";
-  else if ( attr === "attributes.spelldc" ) label = "DND5E.SpellDC";
+  else if ( attr === "attributes.spell.dc" ) label = "DND5E.SpellDC";
 
   // Abilities.
   else if ( attr.startsWith("abilities.") ) {

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -107,7 +107,7 @@
                         <span>{{system.attributes.ac.value}}</span>
                     </div>
                     <footer class="attribute-footer">
-                        <span class="spell-dc">{{localize "DND5E.SpellDC"}} {{system.attributes.spelldc}}</span>
+                        <span class="spell-dc">{{localize "DND5E.SpellDC"}} {{system.attributes.spell.dc}}</span>
                     </footer>
                 </li>
 

--- a/templates/actors/parts/actor-spellbook.hbs
+++ b/templates/actors/parts/actor-spellbook.hbs
@@ -5,7 +5,7 @@
         <label>{{localize "DND5E.Spellcasting"}}</label>
         {{else}}
         <label>{{localize "DND5E.Level"}}</label>
-        {{numberInput system.details.spellLevel name="system.details.spellLevel" class="spellcasting-level"
+        {{numberInput system.attributes.spell.level name="system.attributes.spell.level" class="spellcasting-level"
                       placeholder="0" min=0 step=1 disabled=classSpellcasting}}
         {{/unless}}
         <select name="system.attributes.spellcasting" data-type="String">

--- a/templates/actors/parts/actor-spellbook.hbs
+++ b/templates/actors/parts/actor-spellbook.hbs
@@ -12,7 +12,7 @@
             {{ selectOptions config.abilities selected=system.attributes.spellcasting labelAttr="label"
                              blank=(localize "DND5E.None") }}
         </select>
-        <span>{{localize "DND5E.AbbreviationDC"}} {{system.attributes.spelldc}}</span>
+        <span>{{localize "DND5E.AbbreviationDC"}} {{system.attributes.spell.dc}}</span>
     </div>
 
     <ul class="filter-list flexrow" data-filter="spellbook">

--- a/templates/actors/tabs/creature-spells.hbs
+++ b/templates/actors/tabs/creature-spells.hbs
@@ -48,7 +48,7 @@
             <div class="level">
                 <span class="label">{{ localize "DND5E.Level" }}</span>
                 {{#if (and @root.editable noSpellcaster)}}
-                {{ numberInput @root.system.details.spellLevel name="system.details.spellLevel" min=0 step=1
+                {{ numberInput @root.system.attributes.spell.level name="system.attributes.spell.level" min=0 step=1
                                placeholder="—" }}
                 {{else}}
                 <span class="value">{{ level }}</span>


### PR DESCRIPTION
Adds `attack` to each ability which is the default attack to hit using that ability (e.g. prof + mod).

Also adds the spell attack and ability label to actor attributes inside a new `attributes.spells` object. This moves the old `spelldc` and `spellmod` into that object with deprecation warnings.

Closes #5003