### PR TITLE
[#3751] Add ability to automatically manually sort compendiums

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -23,7 +23,7 @@ import * as enrichers from "./module/enrichers.mjs";
 import * as Filter from "./module/filter.mjs";
 import * as migrations from "./module/migration.mjs";
 import ModuleArt from "./module/module-art.mjs";
-import registerModuleData from "./module/module-registration.mjs";
+import {registerModuleData, setupModulePacks} from "./module/module-registration.mjs";
 import parseUuid from "./module/parse-uuid.mjs";
 import {default as registry} from "./module/registry.mjs";
 import Tooltips5e from "./module/tooltips.mjs";
@@ -55,7 +55,7 @@ DragDrop = DragDrop5e;
 
 Hooks.once("init", function() {
   globalThis.dnd5e = game.dnd5e = Object.assign(game.system, globalThis.dnd5e);
-  console.log(`D&D 5e | Initializing the D&D Fifth Game System - Version ${dnd5e.version}\n${DND5E.ASCII}`);
+  utils.log(`Initializing the D&D Fifth Game System - Version ${dnd5e.version}\n${DND5E.ASCII}`);
 
   if ( game.release.generation < 13 ) patchFromUuid();
 
@@ -400,14 +400,8 @@ Hooks.once("setup", function() {
   // Register settings after modules have had a chance to initialize
   registerDeferredSettings();
 
-  // Apply table of contents compendium style if specified in flags
-  game.packs
-    .filter(p => p.metadata.flags?.display === "table-of-contents")
-    .forEach(p => p.applicationClass = applications.journal.TableOfContentsCompendium);
-
-  // Apply custom item compendium
-  game.packs.filter(p => p.metadata.type === "Item")
-    .forEach(p => p.applicationClass = applications.item.ItemCompendium5e);
+  // Set up compendiums with custom applications & sorting
+  setupModulePacks();
 
   // Create CSS for currencies
   const style = document.createElement("style");

--- a/module/applications/advancement/advancement-manager.mjs
+++ b/module/applications/advancement/advancement-manager.mjs
@@ -1,4 +1,5 @@
 import Advancement from "../../documents/advancement/advancement.mjs";
+import { log } from "../../utils.mjs";
 import Application5e from "../api/application.mjs";
 
 /**
@@ -861,7 +862,7 @@ export default class AdvancementManager extends Application5e {
      * @param {string[]} toDelete                      IDs of items that will be deleted on the actor.
      */
     if ( Hooks.call("dnd5e.preAdvancementManagerComplete", this, updates, toCreate, toUpdate, toDelete) === false ) {
-      console.log("AdvancementManager completion was prevented by the 'preAdvancementManagerComplete' hook.");
+      log("AdvancementManager completion was prevented by the 'preAdvancementManagerComplete' hook.");
       return this.close({ skipConfirmation: true });
     }
 

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -1,3 +1,5 @@
+import { log } from "./utils.mjs";
+
 /**
  * Perform a system migration for the entire World, applying migrations for Actors, Items, and Compendium packs.
  * @param {object} [options={}]
@@ -22,7 +24,7 @@ export async function migrateWorld({ bypassVersionCheck=false }={}) {
       const version = actor._stats.systemVersion;
       let updateData = migrateActorData(actor, source, migrationData, flags, { actorUuid: actor.uuid });
       if ( !foundry.utils.isEmpty(updateData) ) {
-        console.log(`Migrating Actor document ${actor.name}`);
+        log(`Migrating Actor document ${actor.name}`);
         if ( flags.persistSourceMigration ) {
           updateData = foundry.utils.mergeObject(source, updateData, {inplace: false});
         }
@@ -51,7 +53,7 @@ export async function migrateWorld({ bypassVersionCheck=false }={}) {
       const source = valid ? item.toObject() : game.data.items.find(i => i._id === item.id);
       let updateData = migrateItemData(item, source, migrationData, flags);
       if ( !foundry.utils.isEmpty(updateData) ) {
-        console.log(`Migrating Item document ${item.name}`);
+        log(`Migrating Item document ${item.name}`);
         if ( flags.persistSourceMigration ) {
           if ( "effects" in updateData ) updateData.effects = source.effects.map(effect => foundry.utils.mergeObject(
             effect, updateData.effects.find(e => e._id === effect._id) ?? {}, { inplace: false, performDeletions: true }
@@ -73,7 +75,7 @@ export async function migrateWorld({ bypassVersionCheck=false }={}) {
     try {
       const updateData = migrateMacroData(m.toObject(), migrationData);
       if ( !foundry.utils.isEmpty(updateData) ) {
-        console.log(`Migrating Macro document ${m.name}`);
+        log(`Migrating Macro document ${m.name}`);
         await m.update(updateData, {enforceTypes: false, render: false});
       }
     } catch(err) {
@@ -87,7 +89,7 @@ export async function migrateWorld({ bypassVersionCheck=false }={}) {
     try {
       const updateData = migrateRollTableData(table.toObject(), migrationData);
       if ( !foundry.utils.isEmpty(updateData) ) {
-        console.log(`Migrating RollTable document ${table.name}`);
+        log(`Migrating RollTable document ${table.name}`);
         await table.update(updateData, { enforceTypes: false, render: false });
       }
     } catch(err) {
@@ -101,7 +103,7 @@ export async function migrateWorld({ bypassVersionCheck=false }={}) {
     try {
       const updateData = migrateSceneData(s, migrationData);
       if ( !foundry.utils.isEmpty(updateData) ) {
-        console.log(`Migrating Scene document ${s.name}`);
+        log(`Migrating Scene document ${s.name}`);
         await s.update(updateData, {enforceTypes: false, render: false});
       }
     } catch(err) {
@@ -117,7 +119,7 @@ export async function migrateWorld({ bypassVersionCheck=false }={}) {
         const source = token.actor.toObject();
         let updateData = migrateActorData(token.actor, source, migrationData, flags, { actorUuid: token.actor.uuid });
         if ( !foundry.utils.isEmpty(updateData) ) {
-          console.log(`Migrating ActorDelta document ${token.actor.name} [${token.delta.id}] in Scene ${s.name}`);
+          log(`Migrating ActorDelta document ${token.actor.name} [${token.delta.id}] in Scene ${s.name}`);
           if ( flags.persistSourceMigration ) {
             updateData = foundry.utils.mergeObject(source, updateData, { inplace: false });
           } else {
@@ -226,7 +228,7 @@ export async function migrateCompendium(pack, { bypassVersionCheck=false, strict
         if ( foundry.utils.isEmpty(updateData) ) continue;
         if ( flags.persistSourceMigration ) updateData = foundry.utils.mergeObject(source, updateData);
         await doc.update(updateData, { diff: !flags.persistSourceMigration });
-        console.log(`Migrated ${documentName} document ${doc.name} in Compendium ${pack.collection}`);
+        log(`Migrated ${documentName} document ${doc.name} in Compendium ${pack.collection}`);
       }
 
       // Handle migration failures
@@ -237,7 +239,7 @@ export async function migrateCompendium(pack, { bypassVersionCheck=false, strict
       }
     }
 
-    console.log(`Migrated all ${documentName} documents from Compendium ${pack.collection}`);
+    log(`Migrated all ${documentName} documents from Compendium ${pack.collection}`);
   } finally {
     // Apply the original locked status for the pack
     await pack.configure({locked: wasLocked});
@@ -356,7 +358,7 @@ export async function migrateArmorClass(pack) {
 
   for ( const actor of actors ) {
     try {
-      console.log(`Migrating ${actor.name}...`);
+      log(`Migrating ${actor.name}...`);
       const src = actor.toObject();
       const update = {_id: actor.id};
 
@@ -381,7 +383,7 @@ export async function migrateArmorClass(pack) {
   await Actor.implementation.updateDocuments(updates, {pack: pack.collection});
   await pack.getDocuments(); // Force a re-prepare of all actors.
   await pack.configure({locked: wasLocked});
-  console.log(`Migrated the AC of all Actors from Compendium ${pack.collection}`);
+  log(`Migrated the AC of all Actors from Compendium ${pack.collection}`);
 }
 
 /* -------------------------------------------- */
@@ -920,7 +922,7 @@ export async function purgeFlags(pack) {
       });
     }
     await doc.update(update, {recursive: false});
-    console.log(`Purged flags from ${doc.name}`);
+    log(`Purged flags from ${doc.name}`);
   }
   await pack.configure({locked: true});
 }

--- a/module/module-registration.mjs
+++ b/module/module-registration.mjs
@@ -65,9 +65,10 @@ export function setupModulePacks() {
       const complete = setupMethods.map(m => m(pack)).filter(r => r);
       if ( complete.length ) log(`Finished setting up ${pack.metadata.label}: ${complete.join(", ")}`);
     } catch(err) {
-      log(`Error setting up ${pack.metadata.label}\n`, { extras: [err.message], level: "error" });
+      log(`Error setting up ${pack.title}\n`, { extras: [err.message], level: "error" });
     }
   }
+  if ( sortingChanged ) game.settings.set("core", "collectionSortingModes", collectionSortingModes);
   console.groupEnd();
 }
 
@@ -89,10 +90,8 @@ function setupPackDisplay(pack) {
 
 /* -------------------------------------------- */
 
-let sortingChanges;
-const debouncedUpdateSorting = foundry.utils.debounce(() =>
-  game.settings.set("core", "collectionSortingModes", sortingChanges)
-, 250);
+let collectionSortingModes;
+let sortingChanged = false;
 
 /**
  * Set default sorting order based on `flags.dnd5e.sorting`.
@@ -100,9 +99,9 @@ const debouncedUpdateSorting = foundry.utils.debounce(() =>
  * @returns {string|void}    Description of the step.
  */
 function setupPackSorting(pack) {
-  sortingChanges ??= game.settings.get("core", "collectionSortingModes") ?? {};
-  if ( !pack.metadata.flags.dnd5e?.sorting || sortingChanges[pack.metadata.id] ) return;
-  sortingChanges[pack.metadata.id] = pack.metadata.flags.dnd5e.sorting;
-  debouncedUpdateSorting();
+  collectionSortingModes ??= game.settings.get("core", "collectionSortingModes") ?? {};
+  if ( !pack.metadata.flags.dnd5e?.sorting || collectionSortingModes[pack.metadata.id] ) return;
+  collectionSortingModes[pack.metadata.id] = pack.metadata.flags.dnd5e.sorting;
+  sortingChanged = true;
   return "default sorting";
 }

--- a/module/module-registration.mjs
+++ b/module/module-registration.mjs
@@ -1,22 +1,28 @@
+import ItemCompendium5e from "./applications/item/item-compendium.mjs";
+import TableOfContentsCompendium from "./applications/journal/table-of-contents.mjs";
+import { log } from "./utils.mjs";
+
+/* -------------------------------------------- */
+/*  Module Data                                 */
+/* -------------------------------------------- */
+
 /**
  * Scan module manifests for any data that should be integrated into the system configuration.
  */
-export default function registerModuleData() {
-  console.groupCollapsed("D&D 5e | Registering Module Data");
+export function registerModuleData() {
+  log("Registering Module Data", { level: "groupCollapsed" });
   for ( const manifest of [game.system, ...game.modules.filter(m => m.active), game.world] ) {
     try {
-      const complete = methods.map(m => m(manifest)).filter(r => r);
-      if ( complete.length ) {
-        console.log(`D&D 5e | Registered ${manifest.title} data: ${complete.join(", ")}`);
-      }
+      const complete = registerMethods.map(m => m(manifest)).filter(r => r);
+      if ( complete.length ) log(`Registered ${manifest.title} data: ${complete.join(", ")}`);
     } catch(err) {
-      console.error(`D&D 5e | Error registering ${manifest.title}\n`, err.message);
+      log(`Error registering ${manifest.title}\n`, { extras: [err.message], level: "error" });
     }
   }
   console.groupEnd();
 }
 
-const methods = [registerSourceBooks, registerSpellLists];
+const registerMethods = [registerSourceBooks, registerSpellLists];
 
 /* -------------------------------------------- */
 
@@ -42,4 +48,61 @@ function registerSpellLists(manifest) {
   if ( foundry.utils.getType(manifest.flags.dnd5e?.spellLists) !== "Array" ) return;
   manifest.flags.dnd5e.spellLists.forEach(uuid => dnd5e.registry.spellLists.register(uuid));
   return "spell lists";
+}
+
+/* -------------------------------------------- */
+/*  Compendium Packs                            */
+/* -------------------------------------------- */
+
+/**
+ * Apply any changes to compendium packs during the setup hook.
+ */
+export function setupModulePacks() {
+  log("Setting Up Compendium Packs", { level: "groupCollapsed" });
+  for ( const pack of game.packs ) {
+    if ( pack.metadata.type === "Item" ) pack.applicationClass = ItemCompendium5e;
+    try {
+      const complete = setupMethods.map(m => m(pack)).filter(r => r);
+      if ( complete.length ) log(`Finished setting up ${pack.metadata.label}: ${complete.join(", ")}`);
+    } catch(err) {
+      log(`Error setting up ${pack.metadata.label}\n`, { extras: [err.message], level: "error" });
+    }
+  }
+  console.groupEnd();
+}
+
+const setupMethods = [setupPackDisplay, setupPackSorting];
+
+/* -------------------------------------------- */
+
+/**
+ * Set application based on `flags.dnd5e.display`.
+ * @param {Compendium} pack  Pack to set up.
+ * @returns {string|void}    Description of the step.
+ */
+function setupPackDisplay(pack) {
+  const display = pack.metadata.flags.display ?? pack.metadata.flags.dnd5e?.display;
+  if ( display !== "table-of-contents" ) return;
+  pack.applicationClass = TableOfContentsCompendium;
+  return "table of contents";
+}
+
+/* -------------------------------------------- */
+
+let sortingChanges;
+const debouncedUpdateSorting = foundry.utils.debounce(() =>
+  game.settings.set("core", "collectionSortingModes", sortingChanges)
+, 250);
+
+/**
+ * Set default sorting order based on `flags.dnd5e.sorting`.
+ * @param {Compendium} pack  Pack to set up.
+ * @returns {string|void}    Description of the step.
+ */
+function setupPackSorting(pack) {
+  sortingChanges ??= game.settings.get("core", "collectionSortingModes") ?? {};
+  if ( !pack.metadata.flags.dnd5e?.sorting || sortingChanges[pack.metadata.id] ) return;
+  sortingChanges[pack.metadata.id] = pack.metadata.flags.dnd5e.sorting;
+  debouncedUpdateSorting();
+  return "default sorting";
 }

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -414,6 +414,24 @@ export function areKeysPressed(event, action) {
 }
 
 /* -------------------------------------------- */
+/*  Logging                                     */
+/* -------------------------------------------- */
+
+/**
+ * Log a console message with the "D&D 5e" prefix and styling.
+ * @param {string} message                    Message to display.
+ * @param {object} [options={}]
+ * @param {string} [options.color="#6e0000"]  Color to use for the log.
+ * @param {any[]} [options.extras=[]]         Extra options passed to the logging method.
+ * @param {string} [options.level="log"]      Console logging method to call.
+ */
+export function log(message, { color="#6e0000", extras=[], level="log" }={}) {
+  console[level](
+    `%cD&D 5e | %c${message}`, `color: ${color}; font-variant: small-caps`, "color: revert", ...extras
+  );
+}
+
+/* -------------------------------------------- */
 /*  Object Helpers                              */
 /* -------------------------------------------- */
 

--- a/system.json
+++ b/system.json
@@ -171,6 +171,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sorting": "m",
           "types": ["spell"]
         }
       }


### PR DESCRIPTION
Adds a new compendium flag `dnd5e.sorting` that sets the default sorting for a compendium if the user hasn't already adjusted the sorting. This allows for setting a compendium to be manually sorted.

To implement this a new `setupModulePacks` method has been added to the module registration system that is called during setup and sets compendium applications and the sorting mode.

Also adds a new `log` utility method that adds the "D&D 5e | " prefix automatically with a nice red color to make system-specific logs distinct from Foundry core logs.

Closes #3751