### PR TITLE
[#4830] Only defer to item abilities if attack activity matches attack type

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -98,11 +98,15 @@ export default class AttackActivityData extends BaseActivityData {
    * @type {Set<string>}
    */
   get availableAbilities() {
-    // Defer to item if available
-    if ( this.item.system.availableAbilities ) return this.item.system.availableAbilities;
+    const attackClassification = this.attack.type.classification;
+
+    // Defer to item if available and matching attack classification
+    if ( this.item.system.availableAbilities && this.item.type === attackClassification ) {
+      return this.item.system.availableAbilities;
+    }
 
     // Spell attack not associated with a single class, use highest spellcasting ability on actor
-    if ( this.attack.type.classification === "spell" ) return new Set(
+    if ( attackClassification === "spell" ) return new Set(
       this.actor?.system.attributes?.spellcasting
         ? [this.actor.system.attributes.spellcasting]
         : Object.values(this.actor?.spellcastingClasses ?? {}).map(c => c.spellcasting.ability)

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -98,15 +98,13 @@ export default class AttackActivityData extends BaseActivityData {
    * @type {Set<string>}
    */
   get availableAbilities() {
-    const attackClassification = this.attack.type.classification;
-
     // Defer to item if available and matching attack classification
-    if ( this.item.system.availableAbilities && this.item.type === attackClassification ) {
+    if ( this.item.system.availableAbilities && (this.item.type === this.attack.type.classification) ) {
       return this.item.system.availableAbilities;
     }
 
     // Spell attack not associated with a single class, use highest spellcasting ability on actor
-    if ( attackClassification === "spell" ) return new Set(
+    if ( this.attack.type.classification === "spell" ) return new Set(
       this.actor?.system.attributes?.spellcasting
         ? [this.actor.system.attributes.spellcasting]
         : Object.values(this.actor?.spellcastingClasses ?? {}).map(c => c.spellcasting.ability)


### PR DESCRIPTION
Would close #4830 
When the activity's `attack.ability` was left to default, it would pull from its item's `availableActivities`, meaning that a spell attack on a weapon would use str or dex, and a weapon attack on a spell would use whatever was set on the spell as the spellcasting ability. By only using the parent item's `availableActivities` if the attack type matches (i.e. weapon attack on a weapon, spell attack on a spell), this problem is avoided without any side effects (to my knowledge).