### PR TITLE
[#4992] Store roll type (attack, skill, ability, save, damage) in roll options

### DIFF
--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -157,6 +157,10 @@ export default class BasicRoll extends Roll {
       rolls = await DialogClass.configure(config, dialog, message);
     }
 
+    // Store the roll type in roll.options so it can be accessed from only the roll
+    const rollType = foundry.utils.getProperty(message, "data.flags.dnd5e.roll.type");
+    if ( rollType ) rolls.forEach(roll => roll.options.type ??= rollType);
+
     /**
      * A hook event that fires after roll configuration is complete, but before the roll is evaluated.
      * Multiple hooks may be called depending on the rolling method (e.g. `dnd5e.postSkillCheckRollConfiguration`,

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -159,7 +159,7 @@ export default class BasicRoll extends Roll {
 
     // Store the roll type in roll.options so it can be accessed from only the roll
     const rollType = foundry.utils.getProperty(message, "data.flags.dnd5e.roll.type");
-    if ( rollType ) rolls.forEach(roll => roll.options.type ??= rollType);
+    if ( rollType ) rolls.forEach(roll => roll.options.rollType ??= rollType);
 
     /**
      * A hook event that fires after roll configuration is complete, but before the roll is evaluated.


### PR DESCRIPTION
Closes #4992 
Allows the type of roll to be ascertained solely from the roll object.
Originally put it under `options.type` but, while that would work fine, that's also where damage rolls store the damage type, so while `??=` wouldn't clobber that (and whether it's a "Damage" roll could be checked by looking at whether it's a `DamageRoll`) it felt cleaner to give it a new property.