### PR TITLE
[#5006] Fix issues around misconfigured save abilities

### DIFF
--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -905,7 +905,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
       if ( foundry.utils.getType(save?.ability) === "Set" ) save = {
         ...save, ability: save.ability.size > 2
           ? game.i18n.localize("DND5E.AbbreviationDC")
-          : Array.from(save.ability).map(k => CONFIG.DND5E.abilities[k].abbreviation).join(" / ")
+          : Array.from(save.ability).map(k => CONFIG.DND5E.abilities[k]?.abbreviation).filterJoin(" / ")
       };
 
       const css = [];

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -83,7 +83,7 @@ export default class SaveActivityData extends BaseActivityData {
         parts: source.system.damage?.parts?.map(part => this.transformDamagePartData(source, part)) ?? []
       },
       save: {
-        ability: [source.system.save?.ability ?? Object.keys(CONFIG.DND5E.abilities)[0]],
+        ability: [source.system.save?.ability || Object.keys(CONFIG.DND5E.abilities)[0]],
         dc: {
           calculation,
           formula: String(source.system.save?.dc ?? "")


### PR DESCRIPTION
Closes #5006 
`character-sheet-2.mjs` change fixes bug where sheet couldn't render if a favorited spell's Save activity had `Set([''])` as its `save.ability` property (which could be caused by migrating a poorly configured 3.x save item).
`save-data.mjs` change makes it so that the empty string is considered equally as invalid as a missing or `null` value (which should be the case - a 3.x item missing the save ability stores it as `''`).