### PR TITLE
Recognize when last attack is critical and set damage & default button accordingly

### DIFF
--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -334,7 +334,11 @@ export default class AttackActivity extends ActivityMixin(AttackActivityData) {
         : actor.items.get(lastAttack.getFlag("dnd5e", "roll.ammunition"));
     }
 
-    this.rollDamage({ event, ammunition, attackMode });
+    const isCritical = lastAttack?.rolls[0]?.isCritical;
+    const dialogConfig = {};
+    if ( isCritical ) dialogConfig.options = { defaultButton: "critical" };
+
+    this.rollDamage({ event, ammunition, attackMode, isCritical }, dialogConfig);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Partially addresses #4968 
When rolling damage from an attack activity's chat card, check `lastAttack` for whether it was a crit. If so, pass `isCritical` in the `config` argument and `options: { defaultButton: "critical" }` in the `dialog` argument. This way, shift-clicking damage after a crit will roll critical damage, and going through the dialog will show the crit dice & highlight the crit button (similar to the default behavior of advantage/disadvantage for the rolls that currently have that functionality).