### PR TITLE
Allow for arbitrary bonus to save DC on activities.

### DIFF
--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -101,6 +101,7 @@ export default class SaveActivityData extends BaseActivityData {
     super.prepareData();
     if ( !this.damage.onSave ) this.damage.onSave = this.isSpell && (this.item.system.level === 0) ? "none" : "half";
     if ( this.save.dc.calculation === "initial" ) this.save.dc.calculation = this.isSpell ? "spellcasting" : "";
+    this.save.dc.bonus = "";
   }
 
   /* -------------------------------------------- */
@@ -111,11 +112,14 @@ export default class SaveActivityData extends BaseActivityData {
     super.prepareFinalData(rollData);
     this.prepareDamageLabel(this.damage.parts, rollData);
 
+    const bonus = this.save.dc.bonus ? simplifyBonus(this.save.dc.bonus, rollData) : 0;
+
     let ability;
     if ( this.save.dc.calculation ) ability = this.ability;
     else this.save.dc.value = simplifyBonus(this.save.dc.formula, rollData);
     this.save.dc.value ??= this.actor?.system.abilities?.[ability]?.dc
       ?? 8 + (this.actor?.system.attributes?.prof ?? 0);
+    this.save.dc.value += bonus;
 
     if ( this.save.dc.value ) this.labels.save = game.i18n.format("DND5E.SaveDC", {
       dc: this.save.dc.value,

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -34,7 +34,8 @@ export default class ActiveEffect5e extends ActiveEffect {
     "system.attributes.encumbrance.multipliers.encumbered",
     "system.attributes.encumbrance.multipliers.heavilyEncumbered",
     "system.attributes.encumbrance.multipliers.maximum",
-    "system.attributes.encumbrance.multipliers.overall"
+    "system.attributes.encumbrance.multipliers.overall",
+    "save.dc.bonus"
   ]);
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Currently, if wanting to increase the DC of a save activity via enchantments, the activity cannot derive its DC from `save.dc.calculation`, only custom formulas work.

This adds a `save.dc.bonus` property during data prep that can be targeted by enchantments and accepts roll data. It works with both custom formula and ability-derived DCs.