### PR TITLE
[#4802] Add "display chat card" button to inventory item context menu

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1660,6 +1660,7 @@
 "DND5E.Disadvantage": "Disadvantage",
 "DND5E.Discord": "Discord",
 "DND5E.Disclaimer": "Disclaimer",
+"DND5E.DisplayCard": "Display in Chat",
 "DND5E.DistAny": "Any",
 "DND5E.DistFt": "Feet",
 "DND5E.DistFtAbbr": "ft",

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -216,7 +216,7 @@ export default class InventoryElement extends HTMLElement {
       {
         name: "DND5E.DisplayCard",
         icon: '<i class="fas fa-message"></i>',
-        callback: () => item.displayCard({ flags: { "dnd5e.displayOnly": true } })
+        callback: () => item.displayCard()
       },
       {
         name: "DND5E.Scroll.CreateScroll",

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -214,6 +214,11 @@ export default class InventoryElement extends HTMLElement {
         callback: li => this._onAction(li[0], "delete")
       },
       {
+        name: "DND5E.DisplayCard",
+        icon: '<i class="fas fa-message"></i>',
+        callback: () => item.displayCard({ flags: { "dnd5e.displayOnly": true } })
+      },
+      {
         name: "DND5E.Scroll.CreateScroll",
         icon: '<i class="fa-solid fa-scroll"></i>',
         callback: async li => {

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -652,17 +652,11 @@ export default class ChatMessage5e extends ChatMessage {
    * @protected
    */
   _enrichUsageEffects(html) {
-    if ( this.getFlag("dnd5e", "displayOnly") ) return;
+    if ( this.getFlag("dnd5e", "messageType") !== "usage" ) return;
     const item = this.getAssociatedItem();
-    let effects;
-    if ( this.getFlag("dnd5e", "messageType") === "usage" ) {
-      effects = this.getFlag("dnd5e", "use.effects")?.map(id => item?.effects.get(id));
-    } else {
-      if ( this.getFlag("dnd5e", "roll.type") ) return;
-      effects = item?.effects.filter(e => (e.type !== "enchantment")
-        && !item.getFlag("dnd5e", "riders.effect")?.includes(e.id));
-    }
-    effects = effects?.filter(e => e && (game.user.isGM || (e.transfer && (this.author.id === game.user.id))));
+    const effects = this.getFlag("dnd5e", "use.effects")
+      ?.map(id => item?.effects.get(id))
+      .filter(e => e && (game.user.isGM || (e.transfer && (this.author.id === game.user.id))));
     if ( !effects?.length ) return;
 
     const effectApplication = document.createElement("effect-application");

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -652,6 +652,7 @@ export default class ChatMessage5e extends ChatMessage {
    * @protected
    */
   _enrichUsageEffects(html) {
+    if ( this.getFlag("dnd5e", "displayOnly") ) return;
     const item = this.getAssociatedItem();
     let effects;
     if ( this.getFlag("dnd5e", "messageType") === "usage" ) {


### PR DESCRIPTION
Closes #4802 
Adds an option to the context menu for inventory items to display in chat. In order not to show the effect application tray for a display-only use of `displayCard`, used a new `dnd5e.displayOnly` flag on the message which, if `true`, blocks the enriching of usage effects.
![image](https://github.com/user-attachments/assets/c3948cfd-d446-4972-aa16-bf4011530569)
Not sure whether any conditions (like owning the item, for instance) should be necessary, or whether it's in the appropriate section of the context menu.