### PR TITLE
Add "Followup Activity" to activities to allow one activity to "flow" into another

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -193,7 +193,8 @@
 "DND5E.ACTIVITY": {
   "Action": {
     "Create": "Create Activity",
-    "Delete": "Delete Activity"
+    "Delete": "Delete Activity",
+    "Followup": "Follow-up: {activityName}"
   },
   "Title": {
     "one": "Activity",
@@ -209,6 +210,10 @@
     },
     "effects": {
       "label": "Applied Effects"
+    },
+    "followupActivity": {
+      "label": "Followup Activity",
+      "hint": "Which activity, if any, should be usable from this activity's chat card."
     },
     "img": {
       "label": "Icon"

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -349,6 +349,17 @@ export default class ActivitySheet extends PseudoDocumentSheet {
       name: game.i18n.localize(this.activity.metadata.title),
       img: this.activity.metadata.img
     };
+    const filterCycles = (activity, visitedIds) => {
+      if ( visitedIds.includes(activity.id) ) return false;
+      visitedIds.push(activity.id);
+      const nextActivity = this.item.system.activities.get(activity.followupActivityId || activity.activity?.id);
+      if ( !nextActivity ) return true;
+      return filterCycles(nextActivity, visitedIds);
+    };
+    context.followupActivityOptions = Array.from(this.item.system.activities.values())
+      .filter(a => filterCycles(a, [this.activity.id]))
+      .map(a => ({ label: a.name, value: a.id }));
+    context.followupActivityOptions.unshift({ label: "DND5E.None", value: "" });
     return context;
   }
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -41,6 +41,7 @@ const {
  * @property {boolean} duration.concentration    Does this effect require concentration?
  * @property {boolean} duration.override         Override duration values inferred from item.
  * @property {EffectApplicationData[]} effects   Linked effects that can be applied.
+ * @property {string} followupActivityId                 ID of the follow-up activity, if any
  * @property {object} range
  * @property {boolean} range.override            Override range values inferred from item.
  * @property {TargetData} target
@@ -98,7 +99,8 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
         override: new BooleanField(),
         prompt: new BooleanField({ initial: true })
       }),
-      uses: new UsesField()
+      uses: new UsesField(),
+      followupActivityId: new StringField({ required: true, initial: () => "" })
     };
   }
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1363,6 +1363,12 @@ export default function ActivityMixin(Base) {
 
     /* -------------------------------------------- */
 
+    /**
+     * Handle using the follow-up activity from a chat card.
+     * @param {PointerEvent} event     Triggering click event.
+     * @param {HTMLElement} target     The capturing HTML elmeent which defined a [data-action].
+     * @param {ChatMessage5e} message  Message associated with the activation.
+     */
     async #useFollowup(event, target, message) {
       const followupActivity = this.item.system.activities.get(this.followupActivityId);
       if ( !followupActivity ) return;

--- a/templates/activity/parts/activity-identity.hbs
+++ b/templates/activity/parts/activity-identity.hbs
@@ -3,4 +3,8 @@
     {{ formField fields.name value=source.name placeholder=placeholder.name }}
     {{ formField fields.img value=source.img placeholder=placeholder.img }}
     {{ formField fields.description.fields.chatFlavor value=source.description.chatFlavor }}
+    {{#unless (or (eq source.type "forward") (eq source.type "cast"))}}
+        {{ formField fields.followupActivityId value=source.followupActivityId options=followupActivityOptions 
+                     label="DND5E.ACTIVITY.FIELDS.followupActivity.label" hint="DND5E.ACTIVITY.FIELDS.followupActivity.hint" localize=true }}
+    {{/unless}}
 </fieldset>


### PR DESCRIPTION
Somewhat fulfills the ask of #4513 - perhaps obsoletes it.
Implements the "Follow-up Activities" section of #1964 

Done so far:
- Adds a "Followup Activity" dropdown to every activity sheet (except for Forward and Cast, which don't have their "own" chat cards to display). 
- The added dropdown displays a list of the other activities on the item (filtered so as not to allow any cycles, taking forwarded activities into account). 
- When an activity with a followup is used, an additional button appears in the chat card which, when clicked, will use the followup activity.
- Scaling & spell slot info, if they exists in the original message's flags, are passed into the new use, so that the "cast at level" box will be pre-filled with the level used to cast the original Activity, if it was a spell.

Parts I'm not sure about:
- Currently, I've put it in the `parts/activity-identity.hbs` template, and check if the activity type is `forward` or `cast` and, if so, don't show it. I don't know whether it belongs there, but I do think it should exist in the "default" activity template, perhaps gated by a `canHaveFollowup` static property on activity types, so that future activity types (or those added by modules) can make use of followup Activities without having to modify their templates at all.
- There's a case to be made for activities which are selected as followup activities to not be options when using an item directly. I suspect there's also a case to be made that they _should_ be accessible without having to first use whatever activity has them as a followup, so I'm not sure the best way to handle that, if at all. The middle ground would be a "Don't prompt this activity" checkbox, but that's almost entirely unrelated to the scope of this PR, and would fit in better with a PR dedicated to conditional activity visibility.

Followup activity selection:
![image](https://github.com/user-attachments/assets/7212643a-018a-4d05-969e-e24b4f3dffdd)

Auto-filled scaling:
![image](https://github.com/user-attachments/assets/e1b4bc22-fcef-4e1b-8f36-892949bbe8ae)

Chat after proceeding through the above dialog:
![image](https://github.com/user-attachments/assets/609fc34b-0a1b-4974-a2ae-a0fcafc4695a)
