### PR TITLE
[#5040] Fix human readable attribute labels for activities

### DIFF
--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1101,7 +1101,7 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
 
   // Activity labels
   if ( item && attr.startsWith("activities.") ) {
-    let [, activityId, ...keyPath] = attr;
+    let [, activityId, ...keyPath] = attr.split(".");
     const activity = item.system.activities?.get(activityId);
     if ( !activity ) return attr;
     attr = keyPath.join(".");


### PR DESCRIPTION
Closes #5040 
Missing `.split(".")` meant that something like `activities.<id>.uses.spent` was being improperly parsed as `activityId = 'c'` etc, so the full path would be returned instead of the actual label. Can be seen if an activity has recovery during rests with the new rest card.