### PR TITLE
[#5037] Add units display to ranged communication pill

### DIFF
--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -273,7 +273,7 @@ export default function ActorSheetV2Mixin(Base) {
         const data = this.actor.system.traits?.languages?.communication?.[key];
         if ( !data?.value ) continue;
         traits.languages ??= [];
-        traits.languages.push({ label, value: data.value });
+        traits.languages.push({ label, value: formatLength(data.value, data.units) });
       }
 
       // Display weapon masteries


### PR DESCRIPTION
Closes #5037 
Changes pill under Languages to display units alongside any ranged communication (currently only telepathy):
![image](https://github.com/user-attachments/assets/0a92ad27-145d-4f16-92fa-e670a2f99d97)

Senses also accept multiple units, but as they're more likely to almost always be whatever the "default" unit of measure is (feet, typically) it doesn't make much sense to give them this same functionality. Maybe specifically for non-feet, non-meter units. But that'd be a different PR.