### PR TITLE
[#5049] Add view option to item context menus.

### DIFF
--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -190,15 +190,15 @@ export default class InventoryElement extends HTMLElement {
     // Standard Options
     const options = [
       {
+        name: "DND5E.ItemView",
+        icon: '<i class="fas fa-eye"></i>',
+        callback: li => this._onAction(li[0], "view")
+      },
+      {
         name: "DND5E.ContextMenuActionEdit",
         icon: "<i class='fas fa-edit fa-fw'></i>",
         condition: () => item.isOwner && !item.compendium?.locked,
         callback: li => this._onAction(li[0], "edit")
-      },
-      {
-        name: "DND5E.ItemView",
-        icon: '<i class="fas fa-eye"></i>',
-        callback: li => this._onAction(li[0], "view")
       },
       {
         name: "DND5E.ContextMenuActionDuplicate",

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -198,7 +198,6 @@ export default class InventoryElement extends HTMLElement {
       {
         name: "DND5E.ItemView",
         icon: '<i class="fas fa-eye"></i>',
-        condition: () => !item.isOwner || item.compendium?.locked,
         callback: li => this._onAction(li[0], "view")
       },
       {

--- a/module/applications/item/item-compendium.mjs
+++ b/module/applications/item/item-compendium.mjs
@@ -61,7 +61,9 @@ class ItemCompendium5eV13 extends foundry.applications.sidebar.apps.Compendium {
   async _onClickEntry(event) {
     const { entryId } = event.target.closest("[data-entry-id]")?.dataset ?? {};
     const item = await this.collection.getDocument?.(entryId);
-    item?.sheet.render(true, { mode: this.collection.locked ? ItemSheet5e2.MODES.PLAY : ItemSheet5e2.MODES.EDIT });
+    if ( !item ) return;
+    const mode = item.sheet?._mode ?? (this.collection.locked ? ItemSheet5e2.MODES.PLAY : ItemSheet5e2.MODES.EDIT);
+    item.sheet.render(true, { mode });
   }
 }
 
@@ -119,6 +121,8 @@ class ItemCompendium5eV12 extends Compendium {
   async _onClickEntryName(event) {
     const { entryId } = event.target.closest("[data-entry-id]")?.dataset ?? {};
     const item = await this.collection.getDocument?.(entryId);
-    item?.sheet.render(true, { mode: this.collection.locked ? ItemSheet5e2.MODES.PLAY : ItemSheet5e2.MODES.EDIT });
+    if ( !item ) return;
+    const mode = item.sheet?._mode ?? (this.collection.locked ? ItemSheet5e2.MODES.PLAY : ItemSheet5e2.MODES.EDIT);
+    item.sheet.render(true, { mode });
   }
 }

--- a/module/applications/item/item-directory.mjs
+++ b/module/applications/item/item-directory.mjs
@@ -32,6 +32,8 @@ export default class ItemDirectory5e extends ItemDirectory {
   async _onClickEntryName(event) {
     const { entryId } = event.target.closest("[data-entry-id]")?.dataset ?? {};
     const item = this.collection.get(entryId);
-    item?.sheet.render(true, { mode: ItemSheet5e2.MODES.EDIT });
+    if ( !item ) return;
+    const mode = item.sheet?._mode ?? (this.collection.locked ? ItemSheet5e2.MODES.PLAY : ItemSheet5e2.MODES.EDIT);
+    item.sheet.render(true, { mode });
   }
 }

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -53,12 +53,11 @@ export default function DocumentSheetV2Mixin(Base) {
 
     /** @inheritDoc */
     async _render(force, { mode, ...options }={}) {
-      if ( !this._mode ) {
-        this._mode = mode ?? this.constructor.MODES.PLAY;
-        if ( this.rendered ) {
-          const toggle = this.element[0].querySelector(".window-header .mode-slider");
-          toggle.checked = this._mode === this.constructor.MODES.EDIT;
-        }
+      if ( (mode === undefined) && (options.renderContext === "createItem") ) mode = this.constructor.MODES.EDIT;
+      this._mode = mode ?? this._mode ?? this.constructor.MODES.PLAY;
+      if ( this.rendered ) {
+        const toggle = this.element[0].querySelector(".window-header .mode-slider");
+        toggle.checked = this._mode === this.constructor.MODES.EDIT;
       }
       return super._render(force, options);
     }


### PR DESCRIPTION
- Closes #5049
- 'View' option for item context menus is now always visible, instead of only visible when the user lacks ownership, allowing users to opt-into exactly which mode they intend when opening the item sheet.
- Creating a new item now renders the sheet in Edit mode.
- Opening items from the sidebar or compendium packs will default to Edit mode, but will remember the chosen mode for the session.