### PR TITLE
Adding tools to Active Effects Guide wiki page

### DIFF
--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -452,6 +452,108 @@ These are properties that cause the actor to take increased or decreased damage 
 
 ---
 
+## Tools
+
+```
+system.tools.[abbreviation].value
+                             bonuses.check
+```
+
+### Artisan Tools
+
+> <details>
+> <summary>Artisan Tools</summary>
+>
+> | Tool Type | Value         |
+> | ----------------------- | --------------- |
+> | Alchemist's Supplies    | `acalchemist`   |
+> | Brewer's Supplies       | `brewer`        |
+> | Calligrapher's Supplies | `calligrapher`  |
+> | Carpenter's Tools       | `carpenter`     |
+> | Cartographer's Tools    | `cartographer`  |
+> | Cobbler's Tools         | `cobbler`       |
+> | Cook's Utensils         | `cook`          |
+> | Glassblower's Tools     | `glassblower`   |
+> | Jeweler's Kit           | `jeweler`       |
+> | Leatherworker's Tools   | `leatherworker` |
+> | Mason's Tools           | `mason`         |
+> | Painter's Supplies      | `painter`       |
+> | Potter's Tools          | `potter`        |
+> | Smith's Tools           | `smith`         |
+> | Tinker's Tools          | `tinker`        |
+> | Weavers's Tools         | `weaver`        |
+> | Woodcarver's Tools      | `woodcarver`    |
+>
+> Source: `CONFIG.DND5E.tools`
+> </details>
+
+### Gaming Sets
+
+> <details>
+> <summary>Gaming Sets</summary>
+>
+> | Gaming Set | Value         |
+> | ----------------- | ------------- |
+> | Playing Cards Set | `card`        |
+> | Chess Set         | `chess`       |
+> | Dice Set          | `dice`        |
+>
+> Source: `CONFIG.DND5E.tools`
+> </details>
+
+### Musical Instruments
+
+> <details>
+> <summary>Musical Instruments</summary>
+>
+> | Musical Instrument | Value         |
+> | ----------- | ------------- |
+> | Bagpipes    | `bagpipes`    |
+> | Drum        | `drum`        |
+> | Dulcimer    | `dulcimer`    |
+> | Flute       | `flute`       |
+> | Horn        | `horn`        |
+> | Lute        | `lute`        |
+> | Lyre        | `lyre`        |
+> | Pan Flute   | `panflute `   |
+> | Shawm       | `shawm`       |
+> | Viol        | `viol `       |
+>
+> Source: `CONFIG.DND5E.tools`
+> </details>
+
+### Other Tools
+
+> <details>
+> <summary>Other Tools</summary>
+>
+> | Damage Type | Value         |
+> | ----------------- | ------------- |
+> | Disguise Kit      | `disg`        |
+> | Forgery Kit       | `forg`        |
+> | Herbalism Kit     | `herb`        |
+> | Navigator's Tools | `navg`        |
+> | Poisoner's Kit    | `pois`        |
+> | Thieves' Tools    | `thief`       |
+>
+> Source: `CONFIG.DND5E.tools`
+> </details>
+
+### Bonus to a Specific Tool Check
+
+| Attribute Key                                | Change Mode | Effect Value | Roll Data? |
+| -------------------------------------------- | ----------- | ------------ | ---------- |
+| `system.tools.[abbreviation].bonuses.check`  | Add         | `[formula]`  | Yes        |
+
+### Upgrade Proficiency Level to Expertise
+The number must be one of 0, 0.5, 1, and 2.
+
+| Attribute Key                        | Change Mode | Effect Value | Roll Data? |
+| ------------------------------------ | ----------- | ------------ | ---------- |
+| `system.tools.[abbreviation].value`  | Upgrade     | `[number]`   | No         |
+
+---
+
 ## Creature Type
 Temporarily override the displayed creature type of an actor. For example using 'humanoid' as the `value` and 'elf' as the `subtype` to display an actor's creature type as 'Humanoid (elf)'.
 

--- a/wiki/Active-Effect-Guide.md
+++ b/wiki/Active-Effect-Guide.md
@@ -464,7 +464,7 @@ system.tools.[abbreviation].value
 > <details>
 > <summary>Artisan Tools</summary>
 >
-> | Tool Type | Value         |
+> | Tool Type               | Value           |
 > | ----------------------- | --------------- |
 > | Alchemist's Supplies    | `acalchemist`   |
 > | Brewer's Supplies       | `brewer`        |
@@ -492,7 +492,7 @@ system.tools.[abbreviation].value
 > <details>
 > <summary>Gaming Sets</summary>
 >
-> | Gaming Set | Value         |
+> | Gaming Set        | Value         |
 > | ----------------- | ------------- |
 > | Playing Cards Set | `card`        |
 > | Chess Set         | `chess`       |
@@ -506,7 +506,7 @@ system.tools.[abbreviation].value
 > <details>
 > <summary>Musical Instruments</summary>
 >
-> | Musical Instrument | Value         |
+> | Instrument  | Value         |
 > | ----------- | ------------- |
 > | Bagpipes    | `bagpipes`    |
 > | Drum        | `drum`        |
@@ -527,7 +527,7 @@ system.tools.[abbreviation].value
 > <details>
 > <summary>Other Tools</summary>
 >
-> | Damage Type | Value         |
+> | Damage Type       | Value         |
 > | ----------------- | ------------- |
 > | Disguise Kit      | `disg`        |
 > | Forgery Kit       | `forg`        |


### PR DESCRIPTION
Adds a section in the Active Effects Guide for Artisans Tools, Gaming Sets, Musical Instruments and the "other tools" 

Closes #5066 