### PR TITLE
[#3754] Add `system.damage.bonus` AE target & adjust summoning

### DIFF
--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -602,7 +602,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * @param {object} rollData     Deterministic roll data from the item.
    */
   prepareDamageLabel(parts, rollData) {
-    this.labels.damage = parts.map(part => {
+    this.labels.damage = parts.map((part, index) => {
       let formula;
       try {
         formula = part.formula;
@@ -610,6 +610,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
           if ( this.item.system.magicAvailable ) formula += ` + ${this.item.system.magicalBonus ?? 0}`;
           if ( (this.item.type === "weapon") && !/@mod\b/.test(formula) ) formula += " + @mod";
         }
+        if ( !index && this.item.system.damage?.bonus ) formula += ` + ${this.item.system.damage.bonus}`;
         const roll = new CONFIG.Dice.BasicRoll(formula, rollData);
         roll.simplify();
         formula = simplifyRollFormula(roll.formula, { preserveFlavor: true });
@@ -699,6 +700,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       const actionType = this.getActionType(rollConfig.attackMode);
       const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.bonuses.${actionType}.damage`);
       if ( bonus && !/^0+$/.test(bonus) ) parts.push(bonus);
+      if ( this.item.system.damage?.bonus ) parts.push(String(this.item.system.damage.bonus));
     }
 
     const lastType = this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`);

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -523,9 +523,9 @@ export default class SummonActivity extends ActivityMixin(SummonActivityData) {
       else if ( item.isHealing ) damageBonus = healingBonus;
       if ( damageBonus && item.system.activities.find(a => a.damage?.parts?.length || a.healing?.formula) ) {
         changes.push({
-          key: "system.damage.parts",
+          key: "system.damage.bonus",
           mode: CONST.ACTIVE_EFFECT_MODES.ADD,
-          value: JSON.stringify({ bonus: damageBonus })
+          value: damageBonus
         });
       }
 


### PR DESCRIPTION
Adds `system.damage.bonus` as an enchanntment target that adds to the first damage part for an item, allowing for the damage bonus on summons to be properlty typed.

Closes #3754