### PR TITLE
Adjust sourced items on actors to use remapped UUIDs

### DIFF
--- a/module/applications/journal/spells-page-sheet.mjs
+++ b/module/applications/journal/spells-page-sheet.mjs
@@ -1,4 +1,5 @@
 import SpellListJournalPageData from "../../data/journal/spells.mjs";
+import parseUuid from "../../parse-uuid.mjs";
 import { linkForUuid, sortObjectEntries } from "../../utils.mjs";
 import Items5e from "../../data/collection/items-collection.mjs";
 import SpellsUnlinkedConfig from "./spells-unlinked-config.mjs";
@@ -123,28 +124,15 @@ export default class JournalSpellListPageSheet extends JournalPageSheet {
       }
     }
 
-    // TODO: Remove when https://github.com/foundryvtt/foundryvtt/issues/11991 is resolved
-    const parseUuid = uuid => {
-      const parsed = foundry.utils.parseUuid(uuid);
-      const remappedUuid = uuid.startsWith("Compendium") ? [
-        "Compendium",
-        parsed.collection.metadata.id,
-        parsed.primaryType ?? parsed.documentType,
-        parsed.primaryId ?? parsed.documentId,
-        ...parsed.embedded
-      ].join(".") : uuid;
-      return { ...parsed, remappedUuid };
-    };
-
     let collections = new Collection();
     const remappedUuids = new Set();
-    for ( const uuid of uuids ) {
-      const { collection, remappedUuid } = parseUuid(uuid);
-      remappedUuids.add(remappedUuid);
+    for ( const baseUuid of uuids ) {
+      const { collection, uuid } = parseUuid(baseUuid);
+      remappedUuids.add(uuid);
       if ( collection && !collections.has(collection) ) {
         if ( collection instanceof Items5e ) collections.set(collection, collection);
         else collections.set(collection, collection.getIndex({ fields }));
-      } else if ( !collection ) uuids.delete(uuid);
+      } else if ( !collection ) uuids.delete(baseUuid);
     }
 
     const spells = (await Promise.all(collections.values())).flatMap(c => c.filter(s => remappedUuids.has(s.uuid)));

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -5,6 +5,7 @@ import PropertyAttribution from "../../applications/property-attribution.mjs";
 import { ActorDeltasField } from "../../data/chat-message/fields/deltas-field.mjs";
 import { _applyDeprecatedD20Configs, _createDeprecatedD20Config } from "../../dice/d20-roll.mjs";
 import { createRollLabel } from "../../enrichers.mjs";
+import parseUuid from "../../parse-uuid.mjs";
 import { convertTime, defaultUnits, formatNumber, formatTime, simplifyBonus, staticID } from "../../utils.mjs";
 import ActiveEffect5e from "../active-effect.mjs";
 import Item5e from "../item.mjs";
@@ -3515,7 +3516,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
  */
 class SourcedItemsMap extends Map {
   /** @inheritDoc */
-  get(key, { legacy=true }={}) {
+  get(key, { remap=true, legacy=true }={}) {
+    if ( remap ) ({ key: uuid } = parseUuid(key));
     if ( legacy ) {
       foundry.utils.logCompatibilityWarning(
         "The `sourcedItems` data on actor has changed from storing individual items to storing Sets of items. Pass `legacy: false` to retrieve the new Set data.",
@@ -3530,8 +3532,24 @@ class SourcedItemsMap extends Map {
 
   /** @inheritDoc */
   set(key, value) {
-    if ( !this.has(key) ) super.set(key, new Set());
-    this.get(key, { legacy: false }).add(value);
+    const { uuid } = parseUuid(key);
+    if ( !this.has(uuid) ) super.set(uuid, new Set());
+    this.get(uuid, { remap: false, legacy: false }).add(value);
     return this;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Adjust keys once compendium UUID redirects have been initialized.
+   */
+  _redirectKeys() {
+    for ( const [key, value] of this.entries() ) {
+      const { uuid } = parseUuid(key);
+      if ( key !== uuid ) {
+        this.set(uuid, value);
+        this.delete(key);
+      }
+    }
   }
 }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3517,7 +3517,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 class SourcedItemsMap extends Map {
   /** @inheritDoc */
   get(key, { remap=true, legacy=true }={}) {
-    if ( remap ) ({ key: uuid } = parseUuid(key));
+    if ( remap ) ({ uuid: key } = parseUuid(key));
     if ( legacy ) {
       foundry.utils.logCompatibilityWarning(
         "The `sourcedItems` data on actor has changed from storing individual items to storing Sets of items. Pass `legacy: false` to retrieve the new Set data.",

--- a/module/parse-uuid.mjs
+++ b/module/parse-uuid.mjs
@@ -1,0 +1,76 @@
+/**
+ * FIXME: Remove when v12 support dropped or https://github.com/foundryvtt/foundryvtt/issues/11991 backported.
+ * Should NOT be exported for general use.
+ * @ignore
+ */
+export default function parseUuid(uuid, {relative}={}) {
+  if ( game.release.generation >= 12 ) return foundry.utils.parseUuid(uuid, { relative });
+  if ( !uuid ) throw new Error("A UUID string is required.");
+  if ( uuid.startsWith(".") && relative ) return _resolveRelativeUuid(uuid, relative);
+  const parsed = foundry.utils.parseUuid(uuid, {relative});
+  const remappedUuid = uuid.startsWith("Compendium") ? [
+    "Compendium",
+    parsed.collection.metadata.id,
+    parsed.primaryType ?? parsed.documentType,
+    parsed.primaryId ?? parsed.documentId,
+    ...parsed.embedded
+  ].join(".") : uuid;
+  return { ...parsed, uuid: remappedUuid };
+}
+
+/** @ignore */
+function _resolveRelativeUuid(uuid, relative) {
+  if ( !(relative instanceof foundry.abstract.Document) ) {
+    throw new Error("A relative Document instance must be provided to _resolveRelativeUuid");
+  }
+  uuid = uuid.substring(1);
+  const parts = uuid.split(".");
+  if ( !parts.length ) throw new Error("Invalid relative UUID");
+  let id;
+  let type;
+  let root;
+  let primaryType;
+  let primaryId;
+  let collection;
+
+  // Identify the root document and its collection
+  const getRoot = doc => {
+    if ( doc.parent ) parts.unshift(doc.documentName, doc.id);
+    return doc.parent ? getRoot(doc.parent) : doc;
+  };
+
+  // Even-numbered parts include an explicit child document type
+  if ( (parts.length % 2) === 0 ) {
+    root = getRoot(relative);
+    id = parts.at(-1);
+    type = parts.at(-2);
+    primaryType = root.documentName;
+    primaryId = root.id;
+    uuid = [primaryType, primaryId, ...parts].join(".");
+  }
+
+  // Relative Embedded Document
+  else if ( relative.parent ) {
+    id = parts.at(-1);
+    type = relative.documentName;
+    parts.unshift(type);
+    root = getRoot(relative.parent);
+    primaryType = root.documentName;
+    primaryId = root.id;
+    uuid = [primaryType, primaryId, ...parts].join(".");
+  }
+
+  // Relative Document
+  else {
+    root = relative;
+    id = parts.pop();
+    type = relative.documentName;
+    uuid = [type, id].join(".");
+  }
+
+  // Recreate fully-qualified UUID and return the resolved result
+  collection = root.pack ? root.compendium : root.collection;
+  if ( root.pack ) uuid = `Compendium.${root.pack}.${uuid}`;
+  return {uuid, type, id, collection, primaryType, primaryId, embedded: parts,
+    documentType: primaryType ?? type, documentId: primaryId ?? id};
+}


### PR DESCRIPTION
Moves the `parseUuid` changes from `JournalSpellListPageSheet` into a shared implementation and applied it to `SourcedItemsMap` during get and set operations so it always handles remapped UUIDs. Because the initial setup of sourced items occurs before the UUID redirects are loaded, the system will re-adjust the map during the `ready` hook.