### PR TITLE
[#5093] Adjust scaling label for cantrips

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1599,8 +1599,10 @@
   },
   "Scaling": {
     "Half": "Every Other Level",
+    "HalfCantrip": "Half Cantrip Scaling",
     "None": "No Scaling",
-    "Whole": "Every Level"
+    "Whole": "Every Level",
+    "WholeCantrip": "Cantrip Scaling"
   }
 },
 

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -302,9 +302,10 @@ export default class ActivitySheet extends PseudoDocumentSheet {
       ...CONFIG.DND5E.dieSteps.map(value => ({ value, label: `d${value}` }))
     ];
     if ( context.activity.damage?.parts ) {
+      const scaleKey = (this.item.type === "spell" && this.item.system.level === 0) ? "labelCantrip" : "label";
       const scalingOptions = [
         { value: "", label: game.i18n.localize("DND5E.DAMAGE.Scaling.None") },
-        ...Object.entries(CONFIG.DND5E.damageScalingModes).map(([value, config]) => ({ value, label: config.label }))
+        ...Object.entries(CONFIG.DND5E.damageScalingModes).map(([value, { [scaleKey]: label }]) => ({ value, label }))
       ];
       const typeOptions = Object.entries(CONFIG.DND5E.damageTypes).map(([value, { label }]) => ({ value, label }));
       const makePart = (data, index) => this._prepareDamagePartContext(context, {

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -302,7 +302,7 @@ export default class ActivitySheet extends PseudoDocumentSheet {
       ...CONFIG.DND5E.dieSteps.map(value => ({ value, label: `d${value}` }))
     ];
     if ( context.activity.damage?.parts ) {
-      const scaleKey = (this.item.type === "spell" && this.item.system.level === 0) ? "labelCantrip" : "label";
+      const scaleKey = (this.item.type === "spell") && (this.item.system.level === 0) ? "labelCantrip" : "label";
       const scalingOptions = [
         { value: "", label: game.i18n.localize("DND5E.DAMAGE.Scaling.None") },
         ...Object.entries(CONFIG.DND5E.damageScalingModes).map(([value, { [scaleKey]: label }]) => ({ value, label }))

--- a/module/applications/activity/heal-sheet.mjs
+++ b/module/applications/activity/heal-sheet.mjs
@@ -35,9 +35,10 @@ export default class HealSheet extends ActivitySheet {
     context.typeOptions = Object.entries(CONFIG.DND5E.healingTypes).map(([value, config]) => ({
       value, label: config.label, selected: context.activity.healing.types.has(value)
     }));
+    const scaleKey = (this.item.type === "spell" && this.item.system.level === 0) ? "labelCantrip" : "label";
     context.scalingOptions = [
       { value: "", label: game.i18n.localize("DND5E.DAMAGE.Scaling.None") },
-      ...Object.entries(CONFIG.DND5E.damageScalingModes).map(([value, { label }]) => ({ value, label }))
+      ...Object.entries(CONFIG.DND5E.damageScalingModes).map(([value, { [scaleKey]: label }]) => ({ value, label }))
     ];
     return context;
   }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2313,7 +2313,7 @@ DND5E.dieSteps = [4, 6, 8, 10, 12, 20, 100];
 
 /**
  * Methods by which damage scales relative to the overall scaling increase.
- * @enum {{ label: string }}
+ * @enum {{ label: string, labelCantrip: string }}
  */
 DND5E.damageScalingModes = {
   whole: {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2317,13 +2317,15 @@ DND5E.dieSteps = [4, 6, 8, 10, 12, 20, 100];
  */
 DND5E.damageScalingModes = {
   whole: {
-    label: "DND5E.DAMAGE.Scaling.Whole"
+    label: "DND5E.DAMAGE.Scaling.Whole",
+    labelCantrip: "DND5E.DAMAGE.Scaling.WholeCantrip"
   },
   half: {
-    label: "DND5E.DAMAGE.Scaling.Half"
+    label: "DND5E.DAMAGE.Scaling.Half",
+    labelCantrip: "DND5E.DAMAGE.Scaling.HalfCantrip"
   }
 };
-preLocalize("damageScalingModes", { key: "label" });
+preLocalize("damageScalingModes", { keys: ["label", "labelCantrip"] });
 
 /* -------------------------------------------- */
 


### PR DESCRIPTION
Closes #5093 
Adds `HalfCantrip` and `WholeCantrip` localizations, `labelCantrip` properties to `CONFIG.DND5E.damageScalingModes`'s fields, and uses the them instead of `label` when the item in question is a "spell" type item with `level` of 0.
On a cantrip:
![Screenshot 2025-02-02 122208](https://github.com/user-attachments/assets/03a16751-3b13-424b-aa50-deacb2bf71c7)
On a non-cantrip:
![Screenshot 2025-02-02 122225](https://github.com/user-attachments/assets/82318723-e648-4e83-a9ef-82873ace3f68)
