### PR TITLE
[#5102] Add combat settings application with initiative & criticals

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4554,10 +4554,6 @@
 "SETTINGS.5eAutoCollapseCardN": "Collapse Item Cards in Chat",
 "SETTINGS.5eAutoSpellTemplateL": "When a spell is cast, defaults to begin the process to create the corresponding Measured Template if any (requires TRUSTED or higher player role)",
 "SETTINGS.5eAutoSpellTemplateN": "Always place Spell Template",
-"SETTINGS.5eCriticalMaxDiceN": "Critical Damage Maximize Dice",
-"SETTINGS.5eCriticalMaxDiceL": "Make critical hits more deadly by maximizing the values of base damage dice.",
-"SETTINGS.5eCriticalModifiersN": "Critical Damage Multiply Modifiers",
-"SETTINGS.5eCriticalModifiersL": "Make critical hits more deadly by multiplying non-dice modifiers in addition to rolled dice.",
 "SETTINGS.5eCurWtL": "Carried currency affects character encumbrance following the rules on PHB pg. 143.",
 "SETTINGS.5eCurWtN": "Apply Currency Weight",
 "SETTINGS.5eDiagEuclidean": "Euclidean (7.07 ft. Diagonal)",
@@ -4576,8 +4572,6 @@
 "SETTINGS.5eFeatsN": "Allow Feats",
 "SETTINGS.5eHonorL": "Enable the use of the optional Honor ability score. Requires the world to be reloaded.",
 "SETTINGS.5eHonorN": "Honor Ability Score",
-"SETTINGS.5eInitTBL": "Append the raw Dexterity ability score to break ties in Initiative.",
-"SETTINGS.5eInitTBN": "Initiative Dexterity Tiebreaker",
 "SETTINGS.5eNoAdvancementsN": "Disable level-up automation",
 "SETTINGS.5eNoAdvancementsL": "Do not prompt for level-up or character creation choices.",
 "SETTINGS.5eNoConcentrationN": "Disable concentration tracking",
@@ -4620,16 +4614,36 @@
     "Older": "Collapse Older Trays",
     "Never": "Expand All"
   },
+  "COMBAT": {
+    "Hint": "Various configuration options that affect combat.",
+    "Label": "Configure Combat",
+    "Name": "Combat",
+    "DEXTIEBREAKER": {
+      "Name": "Dexterity Tiebreaker",
+      "Hint": "Append the raw Dexterity ability score to break ties in Initiative."
+    },
+    "INITIATIVESCORE": {
+      "Name": "Initiative Score",
+      "Hint": "Use a creature's initiative score (10 + bonus) rather than rolling for initiative.",
+      "All": "Use Score for Everyone",
+      "None": "Always Roll for Initiative",
+      "NPCs": "Use Score for GM NPCs"
+    }
+  },
+  "CRITICAL": {
+    "Name": "Critical Damage",
+    "MaxDice": {
+      "Name": "Maximize Dice",
+      "Hint": "Make critical hits more deadly by maximizing the values of base damage dice."
+    },
+    "MultiplyModifiers": {
+      "Name": "Multiply Modifiers",
+      "Hint": "Make critical hits more deadly by multiplying non-dice modifiers in addition to rolled dice."
+    }
+  },
   "DEFAULTSKILLS": {
     "Name": "Default Skills",
     "Hint": "The default skills that appear on NPC sheets regardless of level of proficiency."
-  },
-  "INITIATIVESCORE": {
-    "Name": "Initiative Score",
-    "Hint": "Use a creature's initiative score (10 + bonus) rather than rolling for initiative.",
-    "All": "Use Score for Everyone",
-    "None": "Always Roll for Initiative",
-    "NPCs": "Use Score for GM NPCs"
   },
   "LEVELING": {
     "Name": "Leveling Mode",

--- a/module/applications/settings/combat-settings.mjs
+++ b/module/applications/settings/combat-settings.mjs
@@ -1,0 +1,54 @@
+import BaseSettingsConfig from "./base-settings.mjs";
+
+/**
+ * An application for configuring combat settings.
+ */
+export default class CombatSettingsConfig extends BaseSettingsConfig {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    window: {
+      title: "SETTINGS.DND5E.COMBAT.Label"
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    initiative: {
+      template: "systems/dnd5e/templates/settings/base-config.hbs"
+    },
+    criticals: {
+      template: "systems/dnd5e/templates/settings/base-config.hbs"
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preparePartContext(partId, context, options) {
+    context = await super._preparePartContext(partId, context, options);
+    switch ( partId ) {
+      case "initiative":
+        context.fields = [
+          this.createSettingField("initiativeDexTiebreaker"),
+          this.createSettingField("initiativeScore")
+        ];
+        context.legend = game.i18n.localize("DND5E.Initiative");
+        break;
+      case "criticals":
+        context.fields = [
+          this.createSettingField("criticalDamageModifiers"),
+          this.createSettingField("criticalDamageMaxDice")
+        ];
+        context.legend = game.i18n.localize("SETTINGS.DND5E.CRITICAL.Name");
+        break;
+    }
+    return context;
+  }
+}

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -1,4 +1,5 @@
 import BastionSettingsConfig, { BastionSetting } from "./applications/settings/bastion-settings.mjs";
+import CombatSettingsConfig from "./applications/settings/combat-settings.mjs";
 import CompendiumBrowserSettingsConfig from "./applications/settings/compendium-browser-settings.mjs";
 import ModuleArtSettingsConfig from "./applications/settings/module-art-settings.mjs";
 import VisibilitySettingsConfig from "./applications/settings/visibility-settings.mjs";
@@ -46,48 +47,6 @@ export function registerSystemSettings() {
     config: false,
     type: String,
     default: ""
-  });
-
-  game.settings.register("dnd5e", "challengeVisibility", {
-    name: "SETTINGS.DND5E.VISIBILITY.CHALLENGE.Name",
-    hint: "SETTINGS.DND5E.VISIBILITY.CHALLENGE.Hint",
-    scope: "world",
-    config: false,
-    default: "player",
-    type: String,
-    choices: {
-      all: "SETTINGS.DND5E.VISIBILITY.CHALLENGE.All",
-      player: "SETTINGS.DND5E.VISIBILITY.CHALLENGE.Player",
-      none: "SETTINGS.DND5E.VISIBILITY.CHALLENGE.None"
-    }
-  });
-
-  game.settings.register("dnd5e", "attackRollVisibility", {
-    name: "SETTINGS.DND5E.VISIBILITY.ATTACK.Name",
-    hint: "SETTINGS.DND5E.VISIBILITY.ATTACK.Hint",
-    scope: "world",
-    config: false,
-    default: "none",
-    type: String,
-    choices: {
-      all: "SETTINGS.DND5E.VISIBILITY.ATTACK.All",
-      hideAC: "SETTINGS.DND5E.VISIBILITY.ATTACK.HideAC",
-      none: "SETTINGS.DND5E.VISIBILITY.ATTACK.None"
-    }
-  });
-
-  game.settings.register("dnd5e", "bloodied", {
-    name: "SETTINGS.DND5E.BLOODIED.Name",
-    hint: "SETTINGS.DND5E.BLOODIED.Hint",
-    scope: "world",
-    config: false,
-    default: "player",
-    type: String,
-    choices: {
-      all: "SETTINGS.DND5E.BLOODIED.All",
-      player: "SETTINGS.DND5E.BLOODIED.Player",
-      none: "SETTINGS.DND5E.BLOODIED.None"
-    }
   });
 
   // Encumbrance tracking
@@ -217,31 +176,6 @@ export function registerSystemSettings() {
     config: true,
     default: false,
     type: Boolean
-  });
-
-  // Apply Dexterity as Initiative Tiebreaker
-  game.settings.register("dnd5e", "initiativeDexTiebreaker", {
-    name: "SETTINGS.5eInitTBN",
-    hint: "SETTINGS.5eInitTBL",
-    scope: "world",
-    config: true,
-    default: false,
-    type: Boolean
-  });
-
-  // Use initiative scores for NPCs
-  game.settings.register("dnd5e", "initiativeScore", {
-    name: "SETTINGS.DND5E.INITIATIVESCORE.Name",
-    hint: "SETTINGS.DND5E.INITIATIVESCORE.Hint",
-    scope: "world",
-    config: true,
-    default: "none",
-    type: String,
-    choices: {
-      none: "SETTINGS.DND5E.INITIATIVESCORE.None",
-      npcs: "SETTINGS.DND5E.INITIATIVESCORE.NPCs",
-      all: "SETTINGS.DND5E.INITIATIVESCORE.All"
-    }
   });
 
   // Record Currency Weight
@@ -395,26 +329,6 @@ export function registerSystemSettings() {
     default: false
   });
 
-  // Critical Damage Modifiers
-  game.settings.register("dnd5e", "criticalDamageModifiers", {
-    name: "SETTINGS.5eCriticalModifiersN",
-    hint: "SETTINGS.5eCriticalModifiersL",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: false
-  });
-
-  // Critical Damage Maximize
-  game.settings.register("dnd5e", "criticalDamageMaxDice", {
-    name: "SETTINGS.5eCriticalMaxDiceN",
-    hint: "SETTINGS.5eCriticalMaxDiceL",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: false
-  });
-
   // Strict validation
   game.settings.register("dnd5e", "strictValidation", {
     scope: "world",
@@ -487,6 +401,57 @@ export function registerSystemSettings() {
     onChange: () => game.dnd5e.bastion.initializeUI()
   });
 
+  // Combat Settings
+  game.settings.registerMenu("dnd5e", "combatConfiguration", {
+    name: "SETTINGS.DND5E.COMBAT.Name",
+    label: "SETTINGS.DND5E.COMBAT.Label",
+    hint: "SETTINGS.DND5E.COMBAT.Hint",
+    icon: "fas fa-explosion",
+    type: CombatSettingsConfig,
+    restricted: true
+  });
+
+  game.settings.register("dnd5e", "initiativeDexTiebreaker", {
+    name: "SETTINGS.DND5E.COMBAT.DEXTIEBREAKER.Name",
+    hint: "SETTINGS.DND5E.COMBAT.DEXTIEBREAKER.Hint",
+    scope: "world",
+    config: false,
+    default: false,
+    type: Boolean
+  });
+
+  game.settings.register("dnd5e", "initiativeScore", {
+    name: "SETTINGS.DND5E.COMBAT.INITIATIVESCORE.Name",
+    hint: "SETTINGS.DND5E.COMBAT.INITIATIVESCORE.Hint",
+    scope: "world",
+    config: false,
+    default: "none",
+    type: String,
+    choices: {
+      none: "SETTINGS.DND5E.COMBAT.INITIATIVESCORE.None",
+      npcs: "SETTINGS.DND5E.COMBAT.INITIATIVESCORE.NPCs",
+      all: "SETTINGS.DND5E.COMBAT.INITIATIVESCORE.All"
+    }
+  });
+
+  game.settings.register("dnd5e", "criticalDamageModifiers", {
+    name: "SETTINGS.DND5E.CRITICAL.MultiplyModifiers.Name",
+    hint: "SETTINGS.DND5E.CRITICAL.MultiplyModifiers.Hint",
+    scope: "world",
+    config: false,
+    type: Boolean,
+    default: false
+  });
+
+  game.settings.register("dnd5e", "criticalDamageMaxDice", {
+    name: "SETTINGS.DND5E.CRITICAL.MaxDice.Name",
+    hint: "SETTINGS.DND5E.CRITICAL.MaxDice.Hint",
+    scope: "world",
+    config: false,
+    type: Boolean,
+    default: false
+  });
+
   // Visibility Settings
   game.settings.registerMenu("dnd5e", "visibilityConfiguration", {
     name: "SETTINGS.DND5E.VISIBILITY.Name",
@@ -495,6 +460,48 @@ export function registerSystemSettings() {
     icon: "fas fa-eye",
     type: VisibilitySettingsConfig,
     restricted: true
+  });
+
+  game.settings.register("dnd5e", "attackRollVisibility", {
+    name: "SETTINGS.DND5E.VISIBILITY.ATTACK.Name",
+    hint: "SETTINGS.DND5E.VISIBILITY.ATTACK.Hint",
+    scope: "world",
+    config: false,
+    default: "none",
+    type: String,
+    choices: {
+      all: "SETTINGS.DND5E.VISIBILITY.ATTACK.All",
+      hideAC: "SETTINGS.DND5E.VISIBILITY.ATTACK.HideAC",
+      none: "SETTINGS.DND5E.VISIBILITY.ATTACK.None"
+    }
+  });
+
+  game.settings.register("dnd5e", "bloodied", {
+    name: "SETTINGS.DND5E.BLOODIED.Name",
+    hint: "SETTINGS.DND5E.BLOODIED.Hint",
+    scope: "world",
+    config: false,
+    default: "player",
+    type: String,
+    choices: {
+      all: "SETTINGS.DND5E.BLOODIED.All",
+      player: "SETTINGS.DND5E.BLOODIED.Player",
+      none: "SETTINGS.DND5E.BLOODIED.None"
+    }
+  });
+
+  game.settings.register("dnd5e", "challengeVisibility", {
+    name: "SETTINGS.DND5E.VISIBILITY.CHALLENGE.Name",
+    hint: "SETTINGS.DND5E.VISIBILITY.CHALLENGE.Hint",
+    scope: "world",
+    config: false,
+    default: "player",
+    type: String,
+    choices: {
+      all: "SETTINGS.DND5E.VISIBILITY.CHALLENGE.All",
+      player: "SETTINGS.DND5E.VISIBILITY.CHALLENGE.Player",
+      none: "SETTINGS.DND5E.VISIBILITY.CHALLENGE.None"
+    }
   });
 
   game.settings.register("dnd5e", "concealItemDescriptions", {

--- a/templates/settings/base-config.hbs
+++ b/templates/settings/base-config.hbs
@@ -1,4 +1,4 @@
 <fieldset>
-    <legend>{{ localize "SETUP.Configuration" }}</legend>
+    <legend>{{ ifThen legend legend (localize "SETUP.Configuration") }}</legend>
     {{> "dnd5e.fieldlist" fields}}
 </fieldset>


### PR DESCRIPTION
Adds a new "Configure Combat" application that contains combat related settings including dexterity tiebreaker, initiative score, critical multiply modifiers, and critical maximize dice.

<img width="519" alt="Combat Settings" src="https://github.com/user-attachments/assets/df90b47f-8627-424e-bee2-cc52d946e85b" />
