### PR TITLE
[#5074] Convert `PropertyAttribution` to `ApplicationV2`

### DIFF
--- a/module/applications/api/application-v2-mixin.mjs
+++ b/module/applications/api/application-v2-mixin.mjs
@@ -116,7 +116,7 @@ export default function ApplicationV2Mixin(Base) {
       // Subtitles
       const subtitle = document.createElement("h2");
       subtitle.classList.add("window-subtitle");
-      frame.querySelector(".window-title").insertAdjacentElement("afterend", subtitle);
+      frame?.querySelector(".window-title")?.insertAdjacentElement("afterend", subtitle);
 
       // Icon
       if ( (options.window?.icon ?? "").includes(".") ) {

--- a/module/applications/property-attribution.mjs
+++ b/module/applications/property-attribution.mjs
@@ -32,8 +32,9 @@ export default class PropertyAttribution extends Application5e {
   /** @override */
   static DEFAULT_OPTIONS = {
     classes: ["property-attribution"],
-    position: {
-      width: 320
+    window: {
+      frame: false,
+      positioned: false
     }
   };
 
@@ -55,14 +56,14 @@ export default class PropertyAttribution extends Application5e {
    * @returns {Promise<string>}
    */
   async renderTooltip() {
-    const options = {};
-    this._configureRenderOptions(options);
-    const context = await this._prepareContext(options);
-    const rendered = await this._renderHTML(context, options);
-    const div = document.createElement("div");
-    div.append(...Object.values(rendered));
-    return div.innerHTML;
+    await this.render({ force: true });
+    return this.element.innerHTML;
   }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _insertElement(element) {}
 
   /* -------------------------------------------- */
 

--- a/module/applications/property-attribution.mjs
+++ b/module/applications/property-attribution.mjs
@@ -1,3 +1,5 @@
+import Application5e from "./api/application.mjs";
+
 /**
  * Description for a single part of a property attribution.
  * @typedef {object} AttributionDescription
@@ -17,7 +19,7 @@
  * @param {string} property                        Dot separated path to the property.
  * @param {object} [options={}]                    Application rendering options.
  */
-export default class PropertyAttribution extends Application {
+export default class PropertyAttribution extends Application5e {
   constructor(object, attributions, property, options={}) {
     super(options);
     this.object = object;
@@ -27,17 +29,25 @@ export default class PropertyAttribution extends Application {
 
   /* -------------------------------------------- */
 
-  /** @inheritDoc */
-  static get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      id: "property-attribution",
-      classes: ["dnd5e", "property-attribution"],
-      template: "systems/dnd5e/templates/apps/property-attribution.hbs",
-      width: 320,
-      height: "auto"
-    });
-  }
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["property-attribution"],
+    position: {
+      width: 320
+    }
+  };
 
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    attribution: {
+      template: "systems/dnd5e/templates/apps/property-attribution.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
   /* -------------------------------------------- */
 
   /**
@@ -45,14 +55,19 @@ export default class PropertyAttribution extends Application {
    * @returns {Promise<string>}
    */
   async renderTooltip() {
-    const data = this.getData(this.options);
-    return (await this._renderInner(data))[0].outerHTML;
+    const options = {};
+    this._configureRenderOptions(options);
+    const context = await this._prepareContext(options);
+    const rendered = await this._renderHTML(context, options);
+    const div = document.createElement("div");
+    div.append(...Object.values(rendered));
+    return div.innerHTML;
   }
 
   /* -------------------------------------------- */
 
-  /** @inheritDoc */
-  getData(options={}) {
+  /** @override */
+  async _prepareContext(options) {
     const property = foundry.utils.getProperty(this.object.system, this.property);
     let total;
     if ( Number.isNumeric(property)) total = property;
@@ -72,6 +87,8 @@ export default class PropertyAttribution extends Application {
     };
   }
 
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
   /* -------------------------------------------- */
 
   /**


### PR DESCRIPTION
No change in design due to property attribution being styled like core's tooltips, but now uses `ApplicationV2` rather than the old API.