### PR TITLE
[#5102] Add variant rules settings application

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4726,7 +4726,7 @@
       "Variant": "Variant (encumbered & heavily encumbered)"
     },
     "HonorScore": {
-      "Hint": "Enable the use of the optional Honor ability score. Requires the world to be reloaded.",
+      "Hint": "Enable the use of the optional Honor ability score.",
       "Name": "Honor Ability Score"
     },
     "LevelingMode": {
@@ -4739,7 +4739,7 @@
     "ProficiencyModifier": {
       "Bonus": "PHB: Bonus (+2, +3, +4, +5, +6)",
       "Dice": "DMG: Dice (1d4, 1d6, 1d8, 1d10, 1d12)",
-      "Hint": "Configure proficiency modifier to use a fixed bonus or a dice roll. Reloading the world is required for this change to take effect.",
+      "Hint": "Configure proficiency modifier to use a fixed bonus or a dice roll.",
       "Name": "Proficiency Variant"
     },
     "Rest": {
@@ -4750,7 +4750,7 @@
       "Normal": "Player's Handbook (LR: 8 hours, SR: 1 hour)"
     },
     "SanityScore": {
-      "Hint": "Enable the use of the optional Sanity ability score. Requires the world to be reloaded.",
+      "Hint": "Enable the use of the optional Sanity ability score.",
       "Name": "Sanity Ability Score"
     }
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -4611,47 +4611,12 @@
 "SETTINGS.5eAutoCollapseCardN": "Collapse Item Cards in Chat",
 "SETTINGS.5eAutoSpellTemplateL": "When a spell is cast, defaults to begin the process to create the corresponding Measured Template if any (requires TRUSTED or higher player role)",
 "SETTINGS.5eAutoSpellTemplateN": "Always place Spell Template",
-"SETTINGS.5eCurWtL": "Carried currency affects character encumbrance following the rules on PHB pg. 143.",
-"SETTINGS.5eCurWtN": "Apply Currency Weight",
-"SETTINGS.5eDiagEuclidean": "Euclidean (7.07 ft. Diagonal)",
-"SETTINGS.5eDiagL": "Configure which diagonal movement rule should be used for games within this system.",
-"SETTINGS.5eDiagN": "Diagonal Movement Rule",
-"SETTINGS.5eDiagPHB": "PHB: Equidistant (5/5/5)",
-"SETTINGS.5eDiagDMG": "DMG: Alternating (5/10/5)",
-"SETTINGS.5eEncumbrance": {
-  "Hint": "Enable automatic tracking of encumbrance and the application of status effects for characters carrying too much.",
-  "Name": "Encumbrance Tracking",
-  "None": "None",
-  "Normal": "Normal (max carrying capacity)",
-  "Variant": "Variant (encumbered & heavily encumbered)"
-},
-"SETTINGS.5eFeatsL": "Allow players to choose a feat rather than taking an ability score improvement during class advancement when using the Legacy rules.",
-"SETTINGS.5eFeatsN": "Allow Feats",
-"SETTINGS.5eHonorL": "Enable the use of the optional Honor ability score. Requires the world to be reloaded.",
-"SETTINGS.5eHonorN": "Honor Ability Score",
 "SETTINGS.5eNoAdvancementsN": "Disable level-up automation",
 "SETTINGS.5eNoAdvancementsL": "Do not prompt for level-up or character creation choices.",
 "SETTINGS.5eNoConcentrationN": "Disable concentration tracking",
 "SETTINGS.5eNoConcentrationL": "Disable the system's automated tracking of concentration.",
-"SETTINGS.5eProfBonus": "PHB: Bonus (+2, +3, +4, +5, +6)",
-"SETTINGS.5eProfDice": "DMG: Dice (1d4, 1d6, 1d8, 1d10, 1d12)",
-"SETTINGS.5eProfL": "Configure proficiency modifier to use a fixed bonus or a dice roll. Reloading the world is required for this change to take effect.",
-"SETTINGS.5eProfN": "Proficiency Variant",
-"SETTINGS.5eReset": "Reset",
-"SETTINGS.5eRestL": "Configure which rest variant should be used for games within this system.",
-"SETTINGS.5eRestN": "Rest Variant",
-"SETTINGS.5eRestPHB": "Player's Handbook (LR: 8 hours, SR: 1 hour)",
-"SETTINGS.5eRestGritty": "Gritty Realism (LR: 7 days, SR: 8 hours)",
-"SETTINGS.5eRestEpic": "Epic Heroism (LR: 1 hour, SR: 1 min)",
 "SETTINGS.5eGridAlignedSquareTemplatesL": "When square templates are created as the result of casting a spell or using an item, they will be locked to the grid alignment and unable to be rotated.",
 "SETTINGS.5eGridAlignedSquareTemplatesN": "Grid-Aligned Square Templates",
-"SETTINGS.5eSanityL": "Enable the use of the optional Sanity ability score. Requires the world to be reloaded.",
-"SETTINGS.5eSanityN": "Sanity Ability Score",
-"SETTINGS.5eUndoChanges": "Undo Changes",
-"SETTINGS.5eTokenRings": {
-  "Name": "Disable Dynamic Token Rings",
-  "Hint": "Disabling the token ring animations can improve performance."
-},
 "SETTINGS.DND5E": {
   "ALLOWSUMMONING": {
     "Name": "Allow Summoning",
@@ -4702,13 +4667,7 @@
     "Name": "Default Skills",
     "Hint": "The default skills that appear on NPC sheets regardless of level of proficiency."
   },
-  "LEVELING": {
-    "Name": "Leveling Mode",
-    "Hint": "Determine how the players gain new levels.",
-    "NoXP": "Level Advancement without XP",
-    "XP": "Experience Points",
-    "XPBoons": "Experience Points with Epic Boons"
-  },
+  "General": "General",
   "LOYALTY": {
     "Hint": "Enable optional Loyalty tracking.",
     "Name": "Loyalty Score"
@@ -4746,6 +4705,54 @@
     "Hint": "Change handling of various rules between the 2024 and 2014 rule sets.",
     "Legacy": "Legacy Rules (2014)",
     "Modern": "Modern Rules (2024)"
+  },
+  "VARIANT": {
+    "Hint": "Enable and configure rules variations offered by the system.",
+    "Label": "Configure Variant Rules",
+    "Name": "Variant Rules",
+    "AllowFeats": {
+      "Hint": "Allow players to choose a feat rather than taking an ability score improvement during class advancement when using the Legacy rules.",
+      "Name": "Allow Feats"
+    },
+    "CurrencyWeight": {
+      "Hint": "Carried currency affects character encumbrance.",
+      "Name": "Track Currency Weight"
+    },
+    "Encumbrance": {
+      "Hint": "Enable automatic tracking of encumbrance and the application of status effects for characters carrying too much.",
+      "Name": "Encumbrance Tracking",
+      "None": "None",
+      "Normal": "Normal (max carrying capacity)",
+      "Variant": "Variant (encumbered & heavily encumbered)"
+    },
+    "HonorScore": {
+      "Hint": "Enable the use of the optional Honor ability score. Requires the world to be reloaded.",
+      "Name": "Honor Ability Score"
+    },
+    "LevelingMode": {
+      "Hint": "Determine how the players gain new levels.",
+      "Name": "Leveling Mode",
+      "NoXP": "Level Advancement without XP",
+      "XP": "Experience Points",
+      "XPBoons": "Experience Points with Epic Boons"
+    },
+    "ProficiencyModifier": {
+      "Bonus": "PHB: Bonus (+2, +3, +4, +5, +6)",
+      "Dice": "DMG: Dice (1d4, 1d6, 1d8, 1d10, 1d12)",
+      "Hint": "Configure proficiency modifier to use a fixed bonus or a dice roll. Reloading the world is required for this change to take effect.",
+      "Name": "Proficiency Variant"
+    },
+    "Rest": {
+      "Epic": "Epic Heroism (LR: 1 hour, SR: 1 min)",
+      "Gritty": "Gritty Realism (LR: 7 days, SR: 8 hours)",
+      "Hint": "Configure which rest variant should be used for games within this system.",
+      "Name": "Rest Variant",
+      "Normal": "Player's Handbook (LR: 8 hours, SR: 1 hour)"
+    },
+    "SanityScore": {
+      "Hint": "Enable the use of the optional Sanity ability score. Requires the world to be reloaded.",
+      "Name": "Sanity Ability Score"
+    }
   },
   "VISIBILITY": {
     "Hint": "Various configuration options that affect player visibility of certain information that the DM may wish to keep secret.",

--- a/module/applications/settings/variant-rules-settings.mjs
+++ b/module/applications/settings/variant-rules-settings.mjs
@@ -1,0 +1,66 @@
+import BaseSettingsConfig from "./base-settings.mjs";
+
+/**
+ * An application for configuring variant rules settings.
+ */
+export default class VariantRulesSettingsConfig extends BaseSettingsConfig {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    window: {
+      title: "SETTINGS.DND5E.VARIANT.Label"
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    general: {
+      template: "systems/dnd5e/templates/settings/base-config.hbs"
+    },
+    encumbrance: {
+      template: "systems/dnd5e/templates/settings/base-config.hbs"
+    },
+    abilities: {
+      template: "systems/dnd5e/templates/settings/base-config.hbs"
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preparePartContext(partId, context, options) {
+    context = await super._preparePartContext(partId, context, options);
+    switch ( partId ) {
+      case "general":
+        context.fields = [
+          game.settings.get("dnd5e", "rulesVersion") === "legacy" ? this.createSettingField("allowFeats") : null,
+          this.createSettingField("restVariant"),
+          this.createSettingField("proficiencyModifier"),
+          this.createSettingField("levelingMode")
+        ].filter(_ => _);
+        context.legend = game.i18n.localize("SETTINGS.DND5E.General");
+        break;
+      case "encumbrance":
+        context.fields = [
+          this.createSettingField("encumbrance"),
+          this.createSettingField("currencyWeight")
+        ];
+        context.legend = game.i18n.localize("DND5E.Encumbrance");
+        break;
+      case "abilities":
+        context.fields = [
+          this.createSettingField("honorScore"),
+          this.createSettingField("sanityScore")
+        ];
+        context.legend = game.i18n.localize("DND5E.Abilities");
+        break;
+    }
+    return context;
+  }
+}

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -2,6 +2,7 @@ import BastionSettingsConfig, { BastionSetting } from "./applications/settings/b
 import CombatSettingsConfig from "./applications/settings/combat-settings.mjs";
 import CompendiumBrowserSettingsConfig from "./applications/settings/compendium-browser-settings.mjs";
 import ModuleArtSettingsConfig from "./applications/settings/module-art-settings.mjs";
+import VariantRulesSettingsConfig from "./applications/settings/variant-rules-settings.mjs";
 import VisibilitySettingsConfig from "./applications/settings/visibility-settings.mjs";
 
 /**
@@ -49,21 +50,6 @@ export function registerSystemSettings() {
     default: ""
   });
 
-  // Encumbrance tracking
-  game.settings.register("dnd5e", "encumbrance", {
-    name: "SETTINGS.5eEncumbrance.Name",
-    hint: "SETTINGS.5eEncumbrance.Hint",
-    scope: "world",
-    config: true,
-    default: "none",
-    type: String,
-    choices: {
-      none: "SETTINGS.5eEncumbrance.None",
-      normal: "SETTINGS.5eEncumbrance.Normal",
-      variant: "SETTINGS.5eEncumbrance.Variant"
-    }
-  });
-
   // Rules version
   game.settings.register("dnd5e", "rulesVersion", {
     name: "SETTINGS.DND5E.RULESVERSION.Name",
@@ -79,39 +65,6 @@ export function registerSystemSettings() {
     requiresReload: true
   });
 
-  // Rest Recovery Rules
-  game.settings.register("dnd5e", "restVariant", {
-    name: "SETTINGS.5eRestN",
-    hint: "SETTINGS.5eRestL",
-    scope: "world",
-    config: true,
-    default: "normal",
-    type: String,
-    choices: {
-      normal: "SETTINGS.5eRestPHB",
-      gritty: "SETTINGS.5eRestGritty",
-      epic: "SETTINGS.5eRestEpic"
-    }
-  });
-
-  // Diagonal Movement Rule
-  if ( game.release.generation < 12 ) {
-    game.settings.register("dnd5e", "diagonalMovement", {
-      name: "SETTINGS.5eDiagN",
-      hint: "SETTINGS.5eDiagL",
-      scope: "world",
-      config: true,
-      default: "555",
-      type: String,
-      choices: {
-        555: "SETTINGS.5eDiagPHB",
-        5105: "SETTINGS.5eDiagDMG",
-        EUCL: "SETTINGS.5eDiagEuclidean"
-      },
-      onChange: rule => canvas.grid.diagonalRule = rule
-    });
-  }
-
   // Allow rotating square templates
   game.settings.register("dnd5e", "gridAlignedSquareTemplates", {
     name: "SETTINGS.5eGridAlignedSquareTemplatesN",
@@ -122,52 +75,6 @@ export function registerSystemSettings() {
     type: Boolean
   });
 
-  // Proficiency modifier type
-  game.settings.register("dnd5e", "proficiencyModifier", {
-    name: "SETTINGS.5eProfN",
-    hint: "SETTINGS.5eProfL",
-    scope: "world",
-    config: true,
-    default: "bonus",
-    type: String,
-    choices: {
-      bonus: "SETTINGS.5eProfBonus",
-      dice: "SETTINGS.5eProfDice"
-    }
-  });
-
-  // Allow feats during Ability Score Improvements
-  game.settings.register("dnd5e", "allowFeats", {
-    name: "SETTINGS.5eFeatsN",
-    hint: "SETTINGS.5eFeatsL",
-    scope: "world",
-    config: true,
-    default: true,
-    type: Boolean
-  });
-
-  // Use Honor ability score
-  game.settings.register("dnd5e", "honorScore", {
-    name: "SETTINGS.5eHonorN",
-    hint: "SETTINGS.5eHonorL",
-    scope: "world",
-    config: true,
-    default: false,
-    type: Boolean,
-    requiresReload: true
-  });
-
-  // Use Sanity ability score
-  game.settings.register("dnd5e", "sanityScore", {
-    name: "SETTINGS.5eSanityN",
-    hint: "SETTINGS.5eSanityL",
-    scope: "world",
-    config: true,
-    default: false,
-    type: Boolean,
-    requiresReload: true
-  });
-
   // Loyalty
   game.settings.register("dnd5e", "loyaltyScore", {
     name: "SETTINGS.DND5E.LOYALTY.Name",
@@ -176,30 +83,6 @@ export function registerSystemSettings() {
     config: true,
     default: false,
     type: Boolean
-  });
-
-  // Record Currency Weight
-  game.settings.register("dnd5e", "currencyWeight", {
-    name: "SETTINGS.5eCurWtN",
-    hint: "SETTINGS.5eCurWtL",
-    scope: "world",
-    config: true,
-    default: true,
-    type: Boolean
-  });
-
-  // Leveling Mode
-  game.settings.register("dnd5e", "levelingMode", {
-    name: "SETTINGS.DND5E.LEVELING.Name",
-    hint: "SETTINGS.DND5E.LEVELING.Hint",
-    scope: "world",
-    config: true,
-    default: "xpBoons",
-    choices: {
-      noxp: "SETTINGS.DND5E.LEVELING.NoXP",
-      xp: "SETTINGS.DND5E.LEVELING.XP",
-      xpBoons: "SETTINGS.DND5E.LEVELING.XPBoons"
-    }
   });
 
   // Disable Advancements
@@ -464,6 +347,109 @@ export function registerSystemSettings() {
       npcs: "SETTINGS.DND5E.COMBAT.InitiativeScore.NPCs",
       all: "SETTINGS.DND5E.COMBAT.InitiativeScore.All"
     }
+  });
+
+  // Variant Rules
+  game.settings.registerMenu("dnd5e", "variantRulesConfiguration", {
+    name: "SETTINGS.DND5E.VARIANT.Name",
+    label: "SETTINGS.DND5E.VARIANT.Label",
+    hint: "SETTINGS.DND5E.VARIANT.Hint",
+    icon: "fas fa-list-check",
+    type: VariantRulesSettingsConfig,
+    restricted: true
+  });
+
+  game.settings.register("dnd5e", "allowFeats", {
+    name: "SETTINGS.DND5E.VARIANT.AllowFeats.Name",
+    hint: "SETTINGS.DND5E.VARIANT.AllowFeats.Hint",
+    scope: "world",
+    config: false,
+    default: true,
+    type: Boolean
+  });
+
+  game.settings.register("dnd5e", "currencyWeight", {
+    name: "SETTINGS.DND5E.VARIANT.CurrencyWeight.Name",
+    hint: "SETTINGS.DND5E.VARIANT.CurrencyWeight.Hint",
+    scope: "world",
+    config: false,
+    default: true,
+    type: Boolean
+  });
+
+  game.settings.register("dnd5e", "encumbrance", {
+    name: "SETTINGS.DND5E.VARIANT.Encumbrance.Name",
+    hint: "SETTINGS.DND5E.VARIANT.Encumbrance.Hint",
+    scope: "world",
+    config: false,
+    default: "none",
+    type: String,
+    choices: {
+      none: "SETTINGS.DND5E.VARIANT.Encumbrance.None",
+      normal: "SETTINGS.DND5E.VARIANT.Encumbrance.Normal",
+      variant: "SETTINGS.DND5E.VARIANT.Encumbrance.Variant"
+    }
+  });
+
+  game.settings.register("dnd5e", "honorScore", {
+    name: "SETTINGS.DND5E.VARIANT.HonorScore.Name",
+    hint: "SETTINGS.DND5E.VARIANT.HonorScore.Hint",
+    scope: "world",
+    config: false,
+    default: false,
+    type: Boolean,
+    requiresReload: true
+  });
+
+  game.settings.register("dnd5e", "levelingMode", {
+    name: "SETTINGS.DND5E.VARIANT.LevelingMode.Name",
+    hint: "SETTINGS.DND5E.VARIANT.LevelingMode.Hint",
+    scope: "world",
+    config: false,
+    default: "xpBoons",
+    type: String,
+    choices: {
+      noxp: "SETTINGS.DND5E.VARIANT.LevelingMode.NoXP",
+      xp: "SETTINGS.DND5E.VARIANT.LevelingMode.XP",
+      xpBoons: "SETTINGS.DND5E.VARIANT.LevelingMode.XPBoons"
+    }
+  });
+
+  game.settings.register("dnd5e", "proficiencyModifier", {
+    name: "SETTINGS.DND5E.VARIANT.ProficiencyModifier.Name",
+    hint: "SETTINGS.DND5E.VARIANT.ProficiencyModifier.Hint",
+    scope: "world",
+    config: false,
+    default: "bonus",
+    type: String,
+    choices: {
+      bonus: "SETTINGS.DND5E.VARIANT.ProficiencyModifier.Bonus",
+      dice: "SETTINGS.DND5E.VARIANT.ProficiencyModifier.Dice"
+    }
+  });
+
+  game.settings.register("dnd5e", "restVariant", {
+    name: "SETTINGS.DND5E.VARIANT.Rest.Name",
+    hint: "SETTINGS.DND5E.VARIANT.Rest.Hint",
+    scope: "world",
+    config: false,
+    default: "normal",
+    type: String,
+    choices: {
+      normal: "SETTINGS.DND5E.VARIANT.Rest.Normal",
+      gritty: "SETTINGS.DND5E.VARIANT.Rest.Gritty",
+      epic: "SETTINGS.DND5E.VARIANT.Rest.Epic"
+    }
+  });
+
+  game.settings.register("dnd5e", "sanityScore", {
+    name: "SETTINGS.DND5E.VARIANT.SanityScore.Name",
+    hint: "SETTINGS.DND5E.VARIANT.SanityScore.Hint",
+    scope: "world",
+    config: false,
+    default: false,
+    type: Boolean,
+    requiresReload: true
   });
 
   // Visibility Settings


### PR DESCRIPTION
Adds a settings application for variant rules that contains the rest variant, proficiency variant, leveling mode, encumbrance settings, and additional ability scores.

<img width="515" alt="Variant Rules (modern)" src="https://github.com/user-attachments/assets/ad5d89ad-afba-4e2b-829a-a6016e65f9ce" />

Also includes the "Allow Feats" setting, but this only appears when the legacy rules version is selected.

<img width="513" alt="Variant Rules (legacy)" src="https://github.com/user-attachments/assets/574ddc43-2027-4b93-a921-17651e45f749" />

Also removes the unused diagonal movement setting and some unused setting localization strings.

Closes #5102