### PR TITLE
Suppress some V13 warnings and add alternate paths to others

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -58,6 +58,9 @@ Hooks.once("init", function() {
   utils.log(`Initializing the D&D Fifth Game System - Version ${dnd5e.version}\n${DND5E.ASCII}`);
 
   if ( game.release.generation < 13 ) patchFromUuid();
+  CONFIG.compatibility.excludePatterns.push(
+    /now namespaced under/, /V1 Application framework/, /Set#isSubset/, /ChatMessage#getHTML/, /renderChatMessage/
+  );
 
   // Record Configuration Values
   CONFIG.DND5E = DND5E;

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -666,7 +666,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
     }
 
     // Owner Only Listeners, for non-compendium actors.
-    if ( this.actor.isOwner && !this.actor.compendium ) {
+    if ( this.actor.isOwner && !this.actor[game.release.generation < 13 ? "compendium" : "inCompendium"] ) {
       // Ability Checks
       html.find(".ability-name").click(this._onRollAbilityTest.bind(this));
 

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -346,11 +346,12 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
 
     // Apply special context menus for items outside inventory elements
     const featuresElement = html[0].querySelector(`[data-tab="features"] ${this.options.elements.inventory}`);
-    if ( featuresElement ) {
-      new ContextMenu5e(html, ".pills-lg [data-item-id], .favorites [data-item-id], .facility[data-item-id]", [], {
-        onOpen: (...args) => featuresElement._onOpenContextMenu(...args)
-      });
-    }
+    if ( featuresElement ) new ContextMenu5e(
+      game.release.generation < 13 ? html : html[0],
+      ".pills-lg [data-item-id], .favorites [data-item-id], .facility[data-item-id]",
+      [],
+      { onOpen: (...args) => featuresElement._onOpenContextMenu(...args), jQuery: false }
+    );
 
     // Edit mode only.
     if ( this._mode === this.constructor.MODES.EDIT ) {

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -347,10 +347,8 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     // Apply special context menus for items outside inventory elements
     const featuresElement = html[0].querySelector(`[data-tab="features"] ${this.options.elements.inventory}`);
     if ( featuresElement ) new ContextMenu5e(
-      game.release.generation < 13 ? html : html[0],
-      ".pills-lg [data-item-id], .favorites [data-item-id], .facility[data-item-id]",
-      [],
-      { onOpen: (...args) => featuresElement._onOpenContextMenu(...args), jQuery: false }
+      html[0], ".pills-lg [data-item-id], .favorites [data-item-id], .facility[data-item-id]", [],
+      { onOpen: (...args) => featuresElement._onOpenContextMenu(...args), jQuery: true }
     );
 
     // Edit mode only.

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -31,12 +31,12 @@ export default class EffectsElement extends HTMLElement {
     }
 
     const MenuCls = this.hasAttribute("v2") ? ContextMenu5e : ContextMenu;
-    new MenuCls(this, "[data-effect-id]", [], {onOpen: element => {
+    new MenuCls(this, "[data-effect-id]", [], { onOpen: element => {
       const effect = this.getEffect(element.dataset);
       if ( !effect ) return;
       ui.context.menuItems = this._getContextOptions(effect);
       Hooks.call("dnd5e.getActiveEffectContextOptions", effect, ui.context.menuItems);
-    }});
+    }, jQuery: true });
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -187,7 +187,7 @@ export default class InventoryElement extends HTMLElement {
    * @protected
    */
   _getContextOptions(item, element) {
-    const compendiumLocked = this.item[game.release.generation < 13 ? "compendium" : "collection"]?.locked;
+    const compendiumLocked = item[game.release.generation < 13 ? "compendium" : "collection"]?.locked;
     // TODO: Move away from using jQuery in callbacks once V12 support is dropped
 
     // Standard Options

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -53,12 +53,12 @@ export default class InventoryElement extends HTMLElement {
 
     // Bind activity menu to child to work around lack of stopImmediatePropagation in ContextMenu#bind
     new ContextMenu5e(this.querySelector(".items-list"), ".activity-row[data-activity-id]", [], {
-      onOpen: this._onOpenContextMenu.bind(this)
+      onOpen: this._onOpenContextMenu.bind(this), jQuery: true
     });
 
     // Item context menus
     const MenuCls = this.hasAttribute("v2") ? ContextMenu5e : ContextMenu;
-    new MenuCls(this, "[data-item-id]", [], { onOpen: this._onOpenContextMenu.bind(this) });
+    new MenuCls(this, "[data-item-id]", [], { onOpen: this._onOpenContextMenu.bind(this), jQuery: true });
   }
 
   /* -------------------------------------------- */
@@ -187,6 +187,9 @@ export default class InventoryElement extends HTMLElement {
    * @protected
    */
   _getContextOptions(item, element) {
+    const compendiumLocked = this.item[game.release.generation < 13 ? "compendium" : "collection"]?.locked;
+    // TODO: Move away from using jQuery in callbacks once V12 support is dropped
+
     // Standard Options
     const options = [
       {
@@ -197,19 +200,19 @@ export default class InventoryElement extends HTMLElement {
       {
         name: "DND5E.ContextMenuActionEdit",
         icon: "<i class='fas fa-edit fa-fw'></i>",
-        condition: () => item.isOwner && !item.compendium?.locked,
+        condition: () => item.isOwner && !compendiumLocked,
         callback: li => this._onAction(li[0], "edit")
       },
       {
         name: "DND5E.ContextMenuActionDuplicate",
         icon: "<i class='fas fa-copy fa-fw'></i>",
-        condition: () => item.canDuplicate && item.isOwner && !item.compendium?.locked,
+        condition: () => item.canDuplicate && item.isOwner && !compendiumLocked,
         callback: li => this._onAction(li[0], "duplicate")
       },
       {
         name: "DND5E.ContextMenuActionDelete",
         icon: "<i class='fas fa-trash fa-fw'></i>",
-        condition: () => item.canDelete && item.isOwner && !item.compendium?.locked,
+        condition: () => item.canDelete && item.isOwner && !compendiumLocked,
         callback: li => this._onAction(li[0], "delete")
       },
       {
@@ -225,7 +228,7 @@ export default class InventoryElement extends HTMLElement {
           if ( scroll ) Item5e.create(scroll, { parent: this.actor });
         },
         condition: li => (item.type === "spell") && !item.getFlag("dnd5e", "cachedFor") && this.actor?.isOwner
-          && !this.actor?.compendium?.locked,
+          && !this.actor?.[game.release.generation < 13 ? "compendium" : "collection"]?.locked,
         group: "action"
       },
       {
@@ -244,7 +247,7 @@ export default class InventoryElement extends HTMLElement {
       options.push({
         name: item.system.attuned ? "DND5E.ContextMenuActionUnattune" : "DND5E.ContextMenuActionAttune",
         icon: "<i class='fas fa-sun fa-fw'></i>",
-        condition: () => item.isOwner && !item.compendium?.locked,
+        condition: () => item.isOwner && !compendiumLocked,
         callback: li => this._onAction(li[0], "attune"),
         group: "state"
       });
@@ -254,7 +257,7 @@ export default class InventoryElement extends HTMLElement {
     if ( "equipped" in item.system ) options.push({
       name: item.system.equipped ? "DND5E.ContextMenuActionUnequip" : "DND5E.ContextMenuActionEquip",
       icon: "<i class='fas fa-shield-alt fa-fw'></i>",
-      condition: () => item.isOwner && !item.compendium?.locked,
+      condition: () => item.isOwner && !compendiumLocked,
       callback: li => this._onAction(li[0], "equip"),
       group: "state"
     });
@@ -263,7 +266,7 @@ export default class InventoryElement extends HTMLElement {
     if ( item.hasRecharge ) options.push({
       name: item.isOnCooldown ? "DND5E.ContextMenuActionCharge" : "DND5E.ContextMenuActionExpendCharge",
       icon: '<i class="fa-solid fa-bolt"></i>',
-      condition: () => item.isOwner && !item.compendium?.locked,
+      condition: () => item.isOwner && !compendiumLocked,
       callback: li => this._onAction(li[0], "toggleCharge"),
       group: "state"
     });
@@ -273,7 +276,7 @@ export default class InventoryElement extends HTMLElement {
       && !item.getFlag("dnd5e", "cachedFor") ) options.push({
       name: item.system?.preparation?.prepared ? "DND5E.ContextMenuActionUnprepare" : "DND5E.ContextMenuActionPrepare",
       icon: "<i class='fas fa-sun fa-fw'></i>",
-      condition: () => item.isOwner && !item.compendium?.locked,
+      condition: () => item.isOwner && !compendiumLocked,
       callback: li => this._onAction(li[0], "prepare"),
       group: "state"
     });
@@ -282,7 +285,7 @@ export default class InventoryElement extends HTMLElement {
     if ( "identified" in item.system ) options.push({
       name: "DND5E.Identify",
       icon: '<i class="fas fa-magnifying-glass"></i>',
-      condition: () => item.isOwner && !item.compendium?.locked && !item.system.identified,
+      condition: () => item.isOwner && !compendiumLocked && !item.system.identified,
       callback: () => item.update({ "system.identified": true }),
       group: "state"
     });
@@ -294,7 +297,7 @@ export default class InventoryElement extends HTMLElement {
       options.push({
         name: isFavorited ? "DND5E.FavoriteRemove" : "DND5E.Favorite",
         icon: '<i class="fas fa-bookmark fa-fw"></i>',
-        condition: () => item.isOwner && !item.compendium?.locked,
+        condition: () => item.isOwner && !compendiumLocked,
         callback: li => this._onAction(li[0], isFavorited ? "unfavorite" : "favorite"),
         group: "state"
       });

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -254,7 +254,8 @@ export default class RollConfigurationDialog extends Dialog5e {
       field: new foundry.data.fields.StringField({ label: game.i18n.localize("DND5E.RollMode") }),
       name: "rollMode",
       value: this.message.rollMode ?? this.options.default?.rollMode ?? game.settings.get("core", "rollMode"),
-      options: Object.entries(CONFIG.Dice.rollModes).map(([value, l]) => ({ value, label: game.i18n.localize(`${l}`) }))
+      options: Object.entries(CONFIG.Dice.rollModes)
+        .map(([value, l]) => ({ value, label: game.i18n.localize(`${game.release.generation < 13 ? l : l.label}`) }))
     }];
     return context;
   }

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -233,11 +233,12 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
       html.find("button.control-button").on("click", this._onSheetAction.bind(this));
     }
 
+    if ( game.release.generation >= 13 ) [html] = html;
     new ContextMenu5e(html, ".advancement-item[data-id]", [], {
-      onOpen: target => dnd5e.documents.advancement.Advancement.onContextMenu(this.item, target)
+      onOpen: target => dnd5e.documents.advancement.Advancement.onContextMenu(this.item, target), jQuery: false
     });
     new ContextMenu5e(html, ".activity[data-activity-id]", [], {
-      onOpen: target => dnd5e.documents.activity.UtilityActivity.onContextMenu(this.item, target)
+      onOpen: target => dnd5e.documents.activity.UtilityActivity.onContextMenu(this.item, target), jQuery: false
     });
   }
 

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -233,11 +233,10 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
       html.find("button.control-button").on("click", this._onSheetAction.bind(this));
     }
 
-    if ( game.release.generation >= 13 ) [html] = html;
-    new ContextMenu5e(html, ".advancement-item[data-id]", [], {
+    new ContextMenu5e(html[0], ".advancement-item[data-id]", [], {
       onOpen: target => dnd5e.documents.advancement.Advancement.onContextMenu(this.item, target), jQuery: false
     });
-    new ContextMenu5e(html, ".activity[data-activity-id]", [], {
+    new ContextMenu5e(html[0], ".activity[data-activity-id]", [], {
       onOpen: target => dnd5e.documents.activity.UtilityActivity.onContextMenu(this.item, target), jQuery: false
     });
   }

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -326,7 +326,10 @@ export default function DocumentSheetV2Mixin(Base) {
     /** @inheritDoc */
     async _onDragStart(event) {
       await super._onDragStart(event);
-      if ( !this.document.isOwner || this.document.compendium?.locked ) event.dataTransfer.effectAllowed = "copyLink";
+      if ( !this.document.isOwner
+        || this.document[game.release.generation < 13 ? "compendium" : "collection"]?.locked ) {
+        event.dataTransfer.effectAllowed = "copyLink";
+      }
     }
   };
 }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1189,8 +1189,9 @@ export default function ActivityMixin(Base) {
      */
     getContextMenuOptions() {
       const entries = [];
+      const compendiumLocked = this.item[game.release.generation < 13 ? "compendium" : "collection"]?.locked;
 
-      if ( this.item.isOwner && !this.item.compendium?.locked ) {
+      if ( this.item.isOwner && !compendiumLocked ) {
         entries.push({
           name: "DND5E.ContextMenuActionEdit",
           icon: '<i class="fas fa-pen-to-square fa-fw"></i>',
@@ -1222,7 +1223,7 @@ export default function ActivityMixin(Base) {
         entries.push({
           name: isFavorited ? "DND5E.FavoriteRemove" : "DND5E.Favorite",
           icon: '<i class="fas fa-bookmark fa-fw"></i>',
-          condition: () => this.item.isOwner && !this.item.compendium?.locked,
+          condition: () => this.item.isOwner && !compendiumLocked,
           callback: () => {
             if ( isFavorited ) this.actor.system.removeFavorite(uuid);
             else this.actor.system.addFavorite({ type: "activity", id: uuid });

--- a/module/documents/advancement/advancement.mjs
+++ b/module/documents/advancement/advancement.mjs
@@ -324,7 +324,7 @@ export default class Advancement extends PseudoDocumentMixin(BaseAdvancement) {
    * @returns {ContextMenuEntry[]}
    */
   getContextMenuOptions() {
-    if ( this.item.isOwner && !this.item.compendium?.locked ) return [
+    if ( this.item.isOwner && !this.item[game.release.generation < 13 ? "compendium" : "collection"]?.locked ) return [
       {
         name: "DND5E.ADVANCEMENT.Action.Edit",
         icon: "<i class='fas fa-edit fa-fw'></i>",


### PR DESCRIPTION
- Suppress namespace warnings
- Suppress ApplicationV1 warnings
- Suppress `Set#isSubset` warning
- Suppress `ChatMessage#getHTML` warning
- Suppress `renderchatMessage` warning
- Adjust creation of `ContextMenu` objects to pass in `HTMLElement` in V13 and pass the `jQuery` option
- Modified access to `Document#compendium` when running in V13 to use either `Document#collection` or `Document#inCompendium`