### PR TITLE
[#4799] Add setting for automatically recharging NPC abilities

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4688,6 +4688,13 @@
   },
   "NPCS": {
     "Name": "NPCs",
+    "AutoRecharge": {
+      "Name": "Recharge Abilities",
+      "Hint": "Roll to recharge NPC abilities automatically at the start of the NPC's turn.",
+      "No": "Do not recharge",
+      "Silent": "Recharge without creating chat card",
+      "Yes": "Recharge and display chat card"
+    },
     "AutoRollNPCHP": {
       "Name": "Hit Points",
       "Hint": "Configure whether to roll for NPC max HP whenever a new token is created.",

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -412,7 +412,7 @@ export default class InventoryElement extends HTMLElement {
 
     switch ( action ) {
       case "activity-recharge":
-        return activity?.uses?.rollRecharge({ event });
+        return activity?.uses?.rollRecharge({ apply: true, event });
       case "activity-use":
         return activity?.use({ event });
       case "attune":
@@ -441,7 +441,7 @@ export default class InventoryElement extends HTMLElement {
       case "prepare":
         return item.update({"system.preparation.prepared": !item.system.preparation?.prepared});
       case "recharge":
-        return item.system.uses?.rollRecharge({ event });
+        return item.system.uses?.rollRecharge({ apply: true, event });
       case "toggleCharge":
         return item.update({ "system.uses.spent": 1 - item.system.uses.spent });
       case "unfavorite":

--- a/module/applications/settings/combat-settings.mjs
+++ b/module/applications/settings/combat-settings.mjs
@@ -53,6 +53,7 @@ export default class CombatSettingsConfig extends BaseSettingsConfig {
         break;
       case "npcs":
         context.fields = [
+          this.createSettingField("autoRecharge"),
           this.createSettingField("autoRollNPCHP")
         ];
         context.legend = game.i18n.localize("SETTINGS.DND5E.NPCS.Name");

--- a/module/data/chat-message/fields/deltas-field.mjs
+++ b/module/data/chat-message/fields/deltas-field.mjs
@@ -15,6 +15,7 @@ const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.field
  * @property {string} delta             The formatted numeric change.
  * @property {Actor5e|Item5e} document  The document to which the delta applies.
  * @property {string} label             The formatted label for the attribute.
+ * @property {Roll[]} [rolls]           Any rolls associated with the delta.
  */
 
 /**
@@ -52,14 +53,17 @@ export class ActorDeltasField extends SchemaField {
   /**
    * Prepare deltas for display in a chat message.
    * @this {ActorDeltasData}
-   * @param {Actor5e} actor  Actor to which this delta applies.
+   * @param {Actor5e} actor   Actor to which this delta applies.
+   * @param {Roll[]} [rolls]  Rolls that may be associated with a delta.
    * @returns {DeltaDisplayContext[]}
    */
-  static processDeltas(actor) {
+  static processDeltas(actor, rolls=[]) {
     return [
-      ...this.actor.map(d => IndividualDeltaField.processDelta.call(d, actor)),
+      ...this.actor.map(d => IndividualDeltaField.processDelta.call(d, actor, rolls
+        .filter(r => !r.options.delta?.item && (r.options.delta?.keyPath === d.keyPath)))),
       ...Object.entries(this.item).flatMap(([id, deltas]) =>
-        deltas.map(d => IndividualDeltaField.processDelta.call(d, actor.items.get(id)))
+        deltas.map(d => IndividualDeltaField.processDelta.call(d, actor.items.get(id), rolls
+          .filter(r => (r.options.delta?.item === id) && (r.options.delta?.keyPath === d.keyPath))))
       )
     ];
   }
@@ -110,17 +114,17 @@ export class IndividualDeltaField extends SchemaField {
    * Prepare a delta for display in a chat message.
    * @this {IndividualDeltaData}
    * @param {Actor5e|Item5e} doc  Actor or item to which this delta applies.
+   * @param {Roll[]} [rolls]      Rolls that may be associated with a delta.
    * @returns {DeltaDisplayContext}
    */
-  static processDelta(doc) {
+  static processDelta(doc, rolls=[]) {
     const type = doc instanceof Actor ? "actor" : "item";
     const value = this.keyPath.endsWith(".spent") ? -this.delta : this.delta;
     return {
-      type,
+      type, rolls,
       delta: formatNumber(value, { signDisplay: "always" }),
       document: doc,
       label: getHumanReadableAttributeLabel(this.keyPath, { [type]: doc }) ?? this.keyPath
-      // TODO: If any rolls were performed for recovery, associate with delta
     };
   }
 }

--- a/module/data/chat-message/rest-message-data.mjs
+++ b/module/data/chat-message/rest-message-data.mjs
@@ -63,7 +63,7 @@ export default class RestMessageData extends ChatMessageDataModel {
 
     if ( context.actor?.isOwner ) {
       context.activities = ActivationsField.processActivations.call(this.activations, this.actor);
-      context.deltas = ActorDeltasField.processDeltas.call(this.deltas, this.actor);
+      context.deltas = ActorDeltasField.processDeltas.call(this.deltas, this.actor, this.parent.rolls);
     }
 
     return context;

--- a/module/data/chat-message/turn-message-data.mjs
+++ b/module/data/chat-message/turn-message-data.mjs
@@ -90,7 +90,7 @@ export default class TurnMessageData extends ChatMessageDataModel {
 
     if ( context.actor?.isOwner ) {
       context.activities = ActivationsField.processActivations.call(this.activations, this.actor);
-      context.deltas = ActorDeltasField.processDeltas.call(this.deltas, this.actor);
+      context.deltas = ActorDeltasField.processDeltas.call(this.deltas, this.actor, this.parent.rolls);
     }
 
     return context;

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -327,7 +327,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
     const shouldRecharge = periods.includes("turnStart") && (this.parent.actor.type === "npc")
       && (autoRecharge !== "no");
     const recharge = async doc => {
-      const config = { returnUpdates: true };
+      const config = { apply: false };
       const message = { create: autoRecharge !== "silent" };
       const result = await UsesField.rollRecharge.call(doc, config, {}, message);
       if ( result ) {

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -323,12 +323,26 @@ export default class ActivitiesTemplate extends SystemDataModel {
   async recoverUses(periods, rollData) {
     const updates = {};
     const rolls = [];
+    const autoRecharge = game.settings.get("dnd5e", "autoRecharge");
+    const shouldRecharge = periods.includes("turnStart") && (this.parent.actor.type === "npc")
+      && (autoRecharge !== "no");
+    const recharge = async doc => {
+      const config = { returnUpdates: true };
+      const message = { create: autoRecharge !== "silent" };
+      const result = await UsesField.rollRecharge.call(doc, config, {}, message);
+      if ( result ) {
+        if ( doc instanceof Item ) foundry.utils.mergeObject(updates, result.updates);
+        else foundry.utils.mergeObject(updates, { [`system.activities.${doc.id}`]: result.updates });
+        rolls.push(...result.rolls);
+      }
+    };
 
     const result = await UsesField.recoverUses.call(this, periods, rollData);
     if ( result ) {
       foundry.utils.mergeObject(updates, { "system.uses": result.updates });
       rolls.push(...result.rolls);
     }
+    if ( shouldRecharge ) await recharge(this.parent);
 
     for ( const activity of this.activities ) {
       const result = await UsesField.recoverUses.call(activity, periods, rollData);
@@ -336,6 +350,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
         foundry.utils.mergeObject(updates, { [`system.activities.${activity.id}.uses`]: result.updates });
         rolls.push(...result.rolls);
       }
+      if ( shouldRecharge ) await recharge(activity);
     }
 
     return { updates, rolls };

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -4,6 +4,12 @@ import FormulaField from "../fields/formula-field.mjs";
 const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
+ * @import {
+ *   BasicRollProcessConfiguration, BasicRollDialogConfiguration, BasicRollMessageConfiguration
+ * } from "../../dice/basic-roll.mjs";
+ */
+
+/**
  * @typedef {object} UsesData
  * @property {number} spent                 Number of uses that have been spent.
  * @property {string} max                   Formula for the maximum number of uses.
@@ -191,12 +197,19 @@ export default class UsesField extends SchemaField {
   /* -------------------------------------------- */
 
   /**
+   * @typedef {BasicRollProcessConfiguration} RechargeRollProcessConfiguration
+   * @property {boolean} [returnUpdates]  Return item updates rather then performing them. If set to `true`, then the
+   *                                      `dnd5e.postRollRecharge` hook won't be called.
+   */
+
+  /**
    * Rolls a recharge test for an Item or Activity that uses the d6 recharge mechanic.
    * @this {Item5e|Activity}
-   * @param {BasicRollProcessConfiguration} config   Configuration information for the roll.
-   * @param {BasicRollDialogConfiguration} dialog    Configuration for the roll dialog.
-   * @param {BasicRollMessageConfiguration} message  Configuration for the roll message.
-   * @returns {Promise<BasicRoll[]|void>}            The created Roll instances, or `null` if no die was rolled.
+   * @param {RechargeRollProcessConfiguration} config  Configuration information for the roll.
+   * @param {BasicRollDialogConfiguration} dialog      Configuration for the roll dialog.
+   * @param {BasicRollMessageConfiguration} message    Configuration for the roll message.
+   * @returns {Promise<BasicRoll[]|{ rolls: BasicRoll[], updates: object }|void>}  The created Roll instances, update
+   *                                                                               data, or nothing if not rolled.
    */
   static async rollRecharge(config={}, dialog={}, message={}) {
     const uses = this.system ? this.system.uses : this.uses;
@@ -208,6 +221,8 @@ export default class UsesField extends SchemaField {
         parts: ["1d6"],
         data: this.getRollData(),
         options: {
+          delta: this instanceof Item ? { item: this.id, keyPath: "system.uses.spent" }
+            : { item: this.item.id, keyPath: `system.activities.${this.id}.uses.spent` },
           target: parseInt(recharge.formula)
         }
       }]
@@ -217,13 +232,13 @@ export default class UsesField extends SchemaField {
 
     const dialogConfig = foundry.utils.mergeObject({ configure: false }, dialog);
 
-    const messageConfig = foundry.utils.mergeObject(({
+    const messageConfig = foundry.utils.mergeObject({
       create: true,
       data: {
         speaker: ChatMessage.getSpeaker({ actor: this.actor, token: this.actor.token })
       },
       rollMode: game.settings.get("core", "rollMode")
-    }));
+    }, message);
 
     if ( "dnd5e.preRollRecharge" in Hooks.events ) {
       foundry.utils.logCompatibilityWarning(
@@ -277,6 +292,7 @@ export default class UsesField extends SchemaField {
       if ( Hooks.call("dnd5e.rollRecharge", this, rolls[0]) === false ) return rolls;
     }
 
+    if ( rollConfig.returnUpdates ) return { rolls, updates };
     if ( !foundry.utils.isEmpty(updates) ) await this.update(updates);
 
     /**

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -21,12 +21,14 @@ export default class Combatant5e extends Combatant {
    * @param {object} [data={}]
    * @param {ActorDeltasData} [data.deltas]
    * @param {string[]} [data.periods]
+   * @param {BasicRoll[]} [data.rolls]
    * @returns {ChatMessage5e|void}
    */
-  async createTurnMessage({ deltas, periods }={}) {
+  async createTurnMessage({ deltas, periods, rolls }={}) {
     const messageConfig = {
       create: false,
       data: {
+        rolls,
         speaker: ChatMessage.getSpeaker({ actor: this.actor, token: this.token }),
         system: {
           deltas, periods,
@@ -127,7 +129,7 @@ export default class Combatant5e extends Combatant {
     if ( !foundry.utils.isEmpty(results.actor) ) await this.actor.update(results.actor);
     if ( results.item.length ) await this.actor.updateEmbeddedDocuments("Item", results.item);
 
-    const message = await this.createTurnMessage({ deltas, periods });
+    const message = await this.createTurnMessage({ deltas, periods, rolls: results.rolls });
 
     /**
      * A hook event that fires after combat-related recovery changes have been applied.

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -299,7 +299,7 @@ export function registerSystemSettings() {
     hint: "SETTINGS.DND5E.NPCS.AutoRecharge.Hint",
     scope: "world",
     config: false,
-    default: "yes",
+    default: "no",
     type: String,
     choices: {
       no: "SETTINGS.DND5E.NPCS.AutoRecharge.No",

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -294,6 +294,20 @@ export function registerSystemSettings() {
     restricted: true
   });
 
+  game.settings.register("dnd5e", "autoRecharge", {
+    name: "SETTINGS.DND5E.NPCS.AutoRecharge.Name",
+    hint: "SETTINGS.DND5E.NPCS.AutoRecharge.Hint",
+    scope: "world",
+    config: false,
+    default: "yes",
+    type: String,
+    choices: {
+      no: "SETTINGS.DND5E.NPCS.AutoRecharge.No",
+      silent: "SETTINGS.DND5E.NPCS.AutoRecharge.Silent",
+      yes: "SETTINGS.DND5E.NPCS.AutoRecharge.Yes"
+    }
+  });
+
   game.settings.register("dnd5e", "autoRollNPCHP", {
     name: "SETTINGS.DND5E.NPCS.AutoRollNPCHP.Name",
     hint: "SETTINGS.DND5E.NPCS.AutoRollNPCHP.Hint",


### PR DESCRIPTION
Adds a setting that allows for automatically recharging NPC abilities at the start of their turn, either displaying the roll chat message or hiding it.

This includes some changes to the `rollRecharge` method so that it can return the updates to perform rather than performing them itself to allow the system to perform all combatant updates at the same time.

Also adds some data to the recharge roll options to allow the roll to be associated back with the delta data. This should support displaying a roll tooltip on the turn chat message next to the delta entry. This data will also need to be added to rolls performed during the normal recovery process.

Closes #4799