### PR TITLE
[#4628] Preserve initial roll configuration for rebuilding.

### DIFF
--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -128,7 +128,7 @@ export default class BasicRoll extends Roll {
    * @param {BasicRollProcessConfiguration} [config={}]   Configuration for the rolls.
    * @param {BasicRollDialogConfiguration} [dialog={}]    Configuration for roll prompt.
    * @param {BasicRollMessageConfiguration} [message={}]  Configuration for message creation.
-   * @returns {BasicRoll[]}
+   * @returns {Promise<BasicRoll[]>}
    */
   static async buildConfigure(config={}, dialog={}, message={}) {
     config.hookNames = [...(config.hookNames ?? []), ""];
@@ -151,8 +151,12 @@ export default class BasicRoll extends Roll {
     this.applyKeybindings(config, dialog, message);
 
     let rolls;
-    if ( dialog.configure === false ) rolls = config.rolls?.map(c => this.fromConfig(c, config)) ?? [];
-    else {
+    if ( dialog.configure === false ) {
+      rolls = config.rolls?.map((r, index) => {
+        dialog.options?.buildConfig(config, r, null, index);
+        return this.fromConfig(r, config);
+      }) ?? [];
+    } else {
       const DialogClass = dialog.applicationClass ?? this.DefaultConfigurationDialog;
       rolls = await DialogClass.configure(config, dialog, message);
     }

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -153,7 +153,7 @@ export default class BasicRoll extends Roll {
     let rolls;
     if ( dialog.configure === false ) {
       rolls = config.rolls?.map((r, index) => {
-        dialog.options?.buildConfig(config, r, null, index);
+        dialog.options?.buildConfig?.(config, r, null, index);
         return this.fromConfig(r, config);
       }) ?? [];
     } else {
@@ -409,5 +409,34 @@ export default class BasicRoll extends Roll {
     }
 
     this.resetFormula();
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Merge two roll configurations.
+   * @param {Partial<BasicRollConfiguration>} original  The initial configuration that will be merged into.
+   * @param {Partial<BasicRollConfiguration>} other     The configuration to merge.
+   * @returns {Partial<BasicRollConfiguration>}         The original instance.
+   */
+  static mergeConfigs(original, other={}) {
+    if ( other.data ) {
+      original.data ??= {};
+      Object.assign(original.data, other.data);
+    }
+
+    if ( other.parts?.length ) {
+      original.parts ??= [];
+      original.parts.unshift(...other.parts);
+    }
+
+    if ( other.options ) {
+      original.options ??= {};
+      foundry.utils.mergeObject(original.options, other.options);
+    }
+
+    return original;
   }
 }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1187,7 +1187,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       }
     }].concat(config.rolls ?? []);
     rollConfig.subject = this;
-    rollConfig.rolls.forEach((r, index) => buildConfig(rollConfig, r, null, index));
 
     const dialogConfig = foundry.utils.mergeObject({
       applicationClass: SkillToolRollConfigurationDialog,
@@ -1232,7 +1231,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( !rolls.length ) return null;
 
     /**
-     * A hook event that fires after an skill or tool check has been rolled.
+     * A hook event that fires after a skill or tool check has been rolled.
      * @function dnd5e.rollSkillV2
      * @function dnd5e.rollToolCheckV2
      * @memberof hookEvents
@@ -1295,8 +1294,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     // Add exhaustion reduction
     this.addRollExhaustion(parts, data);
 
-    config.parts = parts;
-    config.data = data;
+    config.parts = [...(config.parts ?? []), ...parts];
+    config.data = { ...data, ...(config.data ?? {}) };
     config.data.abilityId = abilityId;
     config.options = options;
   }


### PR DESCRIPTION
- Closes #4628 

Just a draft to run this potential solution by you. I think the root issue was we were running this line too early in `#rollSkillTool`.

```js
rollConfig.rolls.forEach((r, index) => buildConfig(rollConfig, r, null, index));
```

This is mutating our initial roll configs before they are stored by the roll dialog. That means that when we try to rebuild the rolls, we have to ignore the roll configs entirely, because they are contaminated with 'derived' data from the pre-dialog call to `buildConfig`.

It seems we are only performing this early `buildConfig` call in case the roll dialog is not instantiated at all, and never gets a chance to call `buildConfig` itself. So I think that by moving this logic into `BasicRoll.buildConfigure` and calling it only when `dialog.configure === false`, then we avoid having to contaminate the original roll configs.

Since we can trust the roll configs now, we can appropriately merge them rather than ignoring them in `_buildSkillToolConfig`.

I tested with a similar snippet to the one posted in the issue when rolling a skill check, and it seemed to correctly add the part.

```js
dialog.config.rolls[0].parts = ['1d4'];
dialog.rebuild();
```

Let me know if I'm missing something and we can't actually go with this solution. If not, I'll make the appropriate changes to the various other roll methods, and also see what I can do about the `initialRoll` logic also.