### PR TITLE
[#5117] Display rest/turn rolls inline on chat cards with deltas

### DIFF
--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -796,9 +796,11 @@ enchantment-application {
     a.rollable:hover .subtitle { text-shadow: none; }
   }
   .deltas ul {
-    li {
+    .delta {
       display: flex;
       justify-content: space-between;
+      .label { flex-grow: 1; }
+      .roll { font-size: var(--font-size-12); }
     }
   }
 }

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -135,7 +135,8 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
       type: game.i18n.format("DND5E.CONSUMPTION.Type.ActivityUses.Warning", {
         activity: this.activity.name, item: this.item.name
       }),
-      rolls: updates.rolls
+      rolls: updates.rolls,
+      delta: { item: this.item.id, keyPath: `system.activities.${this.activity.id}.uses.spent` }
     });
     if ( result ) foundry.utils.mergeObject(updates.activity, { "uses.spent": result.spent });
   }
@@ -150,8 +151,8 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * @throws ConsumptionError
    */
   static async consumeAttribute(config, updates) {
-    const cost = (await this.resolveCost({ config, rolls: updates.rolls })).total;
     const keyPath = `system.${this.target}`;
+    const cost = (await this.resolveCost({ config, delta: { keyPath }, rolls: updates.rolls })).total;
 
     if ( !foundry.utils.hasProperty(this.actor, keyPath) ) throw new ConsumptionError(
       game.i18n.format("DND5E.CONSUMPTION.Warning.MissingAttribute", {
@@ -239,7 +240,8 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
     const result = await this._usesConsumption(config, {
       uses: item.system.uses,
       type: game.i18n.format("DND5E.CONSUMPTION.Type.ItemUses.Warning", { name: this.item.name }),
-      rolls: updates.rolls
+      rolls: updates.rolls,
+      delta: { item: item.id, keyPath: "system.uses.spent" }
     });
     if ( !result ) return;
 
@@ -277,7 +279,8 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
       activity: this.activity.name, item: this.item.name
     }));
 
-    const cost = (await this.resolveCost({ config, rolls: updates.rolls })).total;
+    const delta = { item: item.id, keyPath: "system.quantity" };
+    const cost = (await this.resolveCost({ config, delta, rolls: updates.rolls })).total;
 
     let warningMessage;
     if ( cost > 0 && !item.system.quantity ) warningMessage = "DND5E.CONSUMPTION.Warning.None";
@@ -308,10 +311,11 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * @throws ConsumptionError
    */
   static async consumeSpellSlots(config, updates) {
-    const cost = (await this.resolveCost({ config, rolls: updates.rolls })).total;
     const levelNumber = Math.clamp(
       this.resolveLevel({ config, rolls: updates.rolls }), 1, Object.keys(CONFIG.DND5E.spellLevels).length - 1
     );
+    const keyPath = `system.spells.spell${levelNumber}.value`;
+    const cost = (await this.resolveCost({ config, delta: { keyPath }, rolls: updates.rolls })).total;
 
     // Check to see if enough slots are available at the specified level
     const levelData = this.actor.system.spells?.[`spell${levelNumber}`];
@@ -328,7 +332,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
       }));
     }
 
-    updates.actor[`system.spells.spell${levelNumber}.value`] = Math.max(0, newValue);
+    updates.actor[keyPath] = Math.max(0, newValue);
   }
 
   /* -------------------------------------------- */
@@ -340,11 +344,12 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * @param {UsesData} options.uses            Uses data to consume.
    * @param {string} options.type              Type label to be used in warning messages.
    * @param {BasicRoll[]} options.rolls        Rolls performed as part of the usages.
+   * @param {object} [options.delta]           Delta information stored in roll options.
    * @returns {{ spent: number, quantity: number }|null}
    * @internal
    */
-  async _usesConsumption(config, { uses, type, rolls }) {
-    const cost = (await this.resolveCost({ config, rolls })).total;
+  async _usesConsumption(config, { uses, type, rolls, delta }) {
+    const cost = (await this.resolveCost({ config, delta, rolls })).total;
 
     let warningMessage;
     if ( cost > 0 && !uses.value ) warningMessage = "DND5E.CONSUMPTION.Warning.None";
@@ -711,14 +716,15 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    * @param {string} formula                   Formula for the initial value.
    * @param {number} scaling                   Amount to scale the formula.
    * @param {object} [options={}]
+   * @param {object} [options.delta]           Delta information stored in roll options.
    * @param {boolean} [options.evaluate=true]  Should the slot roll be evaluated?
    * @param {BasicRoll[]} [options.rolls]      Rolls performed as part of the usages.
    * @returns {Promise<BasicRoll>|BasicRoll}
    * @internal
    */
-  _resolveScaledRoll(formula, scaling, { evaluate=true, rolls }={}) {
+  _resolveScaledRoll(formula, scaling, { delta, evaluate=true, rolls }={}) {
     const rollData = this.activity.getRollData();
-    const roll = new CONFIG.Dice.BasicRoll(formula, rollData);
+    const roll = new CONFIG.Dice.BasicRoll(formula, rollData, { delta });
 
     if ( scaling ) {
       // If a scaling formula is provided, multiply it and add to the end of the initial formula

--- a/module/data/chat-message/fields/deltas-field.mjs
+++ b/module/data/chat-message/fields/deltas-field.mjs
@@ -121,10 +121,11 @@ export class IndividualDeltaField extends SchemaField {
     const type = doc instanceof Actor ? "actor" : "item";
     const value = this.keyPath.endsWith(".spent") ? -this.delta : this.delta;
     return {
-      type, rolls,
+      type,
       delta: formatNumber(value, { signDisplay: "always" }),
       document: doc,
-      label: getHumanReadableAttributeLabel(this.keyPath, { [type]: doc }) ?? this.keyPath
+      label: getHumanReadableAttributeLabel(this.keyPath, { [type]: doc }) ?? this.keyPath,
+      rolls: rolls.map(roll => ({ roll, anchor: roll.toAnchor().outerHTML.replace(`${roll.total}</a>`, "</a>") }))
     };
   }
 }

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -157,7 +157,9 @@ export default class UsesField extends SchemaField {
       let roll;
       let total;
       try {
-        roll = new CONFIG.Dice.BasicRoll(profile.formula, rollData);
+        const delta = this.parent instanceof Item ? { item: this.parent.id, keyPath: "system.uses.spent" }
+          : { item: this.item.id, keyPath: `system.activities.${this.id}.uses.spent` };
+        roll = new CONFIG.Dice.BasicRoll(profile.formula, rollData, { delta });
         if ( ["day", "dawn", "dusk"].includes(profile.period)
           && (game.settings.get("dnd5e", "restVariant") === "gritty") ) {
           roll.alter(7, 0, { multiplyNumeric: true });

--- a/templates/chat/parts/card-deltas.hbs
+++ b/templates/chat/parts/card-deltas.hbs
@@ -2,8 +2,11 @@
     <strong class="roboto-condensed-upper">{{ localize "DND5E.CHATMESSAGE.Deltas.Recovery" }}</strong>
     <ul class="unlist">
         {{#each deltas}}
-        <li class="delta-{{ type }}">
+        <li class="delta delta-{{ type }}">
             <span class="label">{{ label }}</span>
+            {{#each rolls}}
+            <span class="roll">{{{ anchor }}}</span>
+            {{/each}}
             <span class="value">{{ delta }}</span>
         </li>
         {{/each}}


### PR DESCRIPTION
Displays the rolls associated with recovery during rest or combat turn with the deltas in their chat cards. Uses core's inline roll display so that mousing over the roll icon displays the formula and clicking it will display the roll breakdown.

<img width="309" alt="Chat Message Rolls" src="https://github.com/user-attachments/assets/1a9eb1a4-d282-406e-8a4d-1c81c0f3b971" />

Also adds the necessary data to the rolls performed during consumption to display them correctly, but changes will need to be made to the usage chat message to fully display those.