### PR TITLE
[#3754] Move `system.damage.bonus` AE key to `system.damageBonus`

### DIFF
--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -34,6 +34,9 @@ export default class EnchantmentData extends foundry.abstract.TypeDataModel {
           changes[`system.activities.${activity.id}.${key}`] = ActiveEffect.applyField(activity, { ...change, key });
         }
         return false;
+      case "system.damage.bonus":
+        change.key = "system.damageBonus";
+        break;
       case "system.damage.parts":
         try {
           let damage;

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -615,7 +615,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
           if ( this.item.system.magicAvailable ) formula += ` + ${this.item.system.magicalBonus ?? 0}`;
           if ( (this.item.type === "weapon") && !/@mod\b/.test(formula) ) formula += " + @mod";
         }
-        if ( !index && this.item.system.damage?.bonus ) formula += ` + ${this.item.system.damage.bonus}`;
+        if ( !index && this.item.system.damageBonus ) formula += ` + ${this.item.system.damageBonus}`;
         const roll = new CONFIG.Dice.BasicRoll(formula, rollData);
         roll.simplify();
         formula = simplifyRollFormula(roll.formula, { preserveFlavor: true });
@@ -705,7 +705,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       const actionType = this.getActionType(rollConfig.attackMode);
       const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.bonuses.${actionType}.damage`);
       if ( bonus && !/^0+$/.test(bonus) ) parts.push(bonus);
-      if ( this.item.system.damage?.bonus ) parts.push(String(this.item.system.damage.bonus));
+      if ( this.item.system.damageBonus ) parts.push(String(this.item.system.damageBonus));
     }
 
     const lastType = this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`);


### PR DESCRIPTION
Internally adjusts the damage bonus key from `system.damage.bonus` to `system.damageBonus` to avoid conflicts with shims. This is designed to be undone when the shims are removed so that the ideal key can be used in the future.