### PR TITLE
[#1721, #2737] Add sorting control to item grant/choice advancement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -536,6 +536,9 @@
           "label": "Type"
         }
       },
+      "sorting": {
+        "label": "Sorting Mode"
+      },
       "type": {
         "Any": "Anything",
         "hint": "Restrict what Item types can be chosen.",
@@ -568,6 +571,9 @@
       "optional": {
         "label": "Optional",
         "hint": "If the whole advancement is marked optional, players may opt out of any of the following items, otherwise all non-optional items are granted."
+      },
+      "sorting": {
+        "label": "Sorting Mode"
       }
     },
     "Hint": "Grant the character items (such as equipment, features, or spells) when they reach a certain level.",

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -171,6 +171,7 @@
         line-height: 1;
       }
 
+      button, button:hover:not(:disabled) { color: currentcolor; }
       .radio-button {
         background: var(--dnd5e-background-alt-1);
         &[aria-pressed="true"]::before { background: var(--dnd5e-color-gold); }
@@ -228,6 +229,18 @@
         .sign { color: var(--color-text-tertiary); }
       }
     }
+  }
+
+  .drag-bar {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inset-block: 0;
+    inset-inline-end: 0;
+    inline-size: 16px;
+    cursor: var(--cursor-grab);
+    color: var(--dnd5e-color-faint);
   }
 
   .unlist {
@@ -658,6 +671,7 @@
         > li {
           margin: 0 -.75em;
           padding: 6px .75em;
+          position: relative;
 
           &:nth-child(odd) { background: var(--dnd5e-color-table-row-odd); }
           &:nth-child(even) { background: var(--dnd5e-color-table-row-even); }
@@ -672,6 +686,7 @@
         text-align: right;
         flex-wrap: nowrap;
         gap: 4px;
+        &:has(> .drag-bar) { margin-inline-end: 8px; }
       }
 
       .name-header { padding-inline-start: 16px; }

--- a/less/v2/items.less
+++ b/less/v2/items.less
@@ -578,17 +578,6 @@
       justify-content: space-between;
       margin-block-end: 4px;
     }
-    .drag-bar {
-      position: absolute;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      inset-block: 0;
-      inset-inline-end: 0;
-      inline-size: 16px;
-      cursor: var(--cursor-grab);
-      color: var(--dnd5e-color-faint);
-    }
     [data-action="delete-entry"] {
       --size: 26px;
       flex: 0 0 var(--size);

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -135,4 +135,13 @@ export default class ItemChoiceConfig extends ItemSharedConfig {
 
     return configuration;
   }
+
+  /* -------------------------------------------- */
+  /*  Drag & Drop                                 */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _validateDroppedItem(event, item) {
+    this.advancement._validateItemType(item, { type: false });
+  }
 }

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -53,7 +53,7 @@ export default class ItemChoiceConfig extends ItemSharedConfig {
       index: fromUuidSync(data.uuid)
     })).sort((lhs, rhs) => context.manualSort
       ? lhs.data.sort - rhs.data.sort
-      : lhs.index.name.localeCompare(rhs.index.name));
+      : lhs.index?.name.localeCompare(rhs.index?.name));
 
     context.abilityOptions = Object.entries(CONFIG.DND5E.abilities).map(([value, { label }]) => ({ value, label }));
     context.choices = context.levels.reduce((obj, { value, label }) => {

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -1,12 +1,12 @@
-import AdvancementConfig from "./advancement-config-v2.mjs";
+import ItemSharedConfig from "./item-shared-config.mjs";
 
 /**
  * Configuration application for item choices.
  */
-export default class ItemChoiceConfig extends AdvancementConfig {
+export default class ItemChoiceConfig extends ItemSharedConfig {
   /** @override */
   static DEFAULT_OPTIONS = {
-    classes: ["item-choice", "three-column"],
+    classes: ["item-choice"],
     dropKeyPath: "pool",
     position: {
       width: 800
@@ -51,7 +51,9 @@ export default class ItemChoiceConfig extends AdvancementConfig {
       data,
       fields: this.advancement.configuration.schema.fields.pool.element.fields,
       index: fromUuidSync(data.uuid)
-    }));
+    })).sort((lhs, rhs) => context.manualSort
+      ? lhs.data.sort - rhs.data.sort
+      : lhs.index.name.localeCompare(rhs.index.name));
 
     context.abilityOptions = Object.entries(CONFIG.DND5E.abilities).map(([value, { label }]) => ({ value, label }));
     context.choices = context.levels.reduce((obj, { value, label }) => {
@@ -132,14 +134,5 @@ export default class ItemChoiceConfig extends AdvancementConfig {
     configuration.pool = pool;
 
     return configuration;
-  }
-
-  /* -------------------------------------------- */
-  /*  Drag & Drop                                 */
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  _validateDroppedItem(event, item) {
-    this.advancement._validateItemType(item, { type: false });
   }
 }

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -86,7 +86,11 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     const config = this.advancement.configuration;
     const counts = this.counts;
     const value = this.advancement.value;
-    this.pool ??= (await Promise.all(config.pool.map(i => fromUuid(i.uuid)))).filter(_ => _);
+    this.pool ??= (await Promise.all(config.pool
+      .sort((lhs, rhs) => this.advancement.configuration.sorting === "m" ? lhs.sort - rhs.sort : 0)
+      .map(i => fromUuid(i.uuid))
+    )).filter(_ => _)
+      .sort((lhs, rhs) => this.advancement.configuration.sorting === "a" ? lhs.name.localeCompare(rhs.name) : 0);
     this.retained ??= Object.entries(value.added).reduce((obj, [level, added]) => {
       obj[level] = Object.fromEntries(Object.entries(added).map(([id]) => [id, actor.items.get(id)]));
       return obj;

--- a/module/applications/advancement/item-grant-config.mjs
+++ b/module/applications/advancement/item-grant-config.mjs
@@ -1,9 +1,9 @@
-import AdvancementConfig from "./advancement-config-v2.mjs";
+import ItemSharedConfig from "./item-shared-config.mjs";
 
 /**
  * Configuration application for item grants.
  */
-export default class ItemGrantConfig extends AdvancementConfig {
+export default class ItemGrantConfig extends ItemSharedConfig {
   /** @override */
   static DEFAULT_OPTIONS = {
     classes: ["item-grant"],
@@ -38,7 +38,9 @@ export default class ItemGrantConfig extends AdvancementConfig {
       data,
       fields: this.advancement.configuration.schema.fields.items.element.fields,
       index: fromUuidSync(data.uuid)
-    }));
+    })).sort((lhs, rhs) => context.manualSort
+      ? lhs.data.sort - rhs.data.sort
+      : lhs.index.name.localeCompare(rhs.index.name));
 
     context.abilityOptions = Object.entries(CONFIG.DND5E.abilities).map(([value, { label }]) => ({ value, label }));
     context.showContainerWarning = context.items.some(i => i.index?.type === "container");
@@ -66,14 +68,5 @@ export default class ItemGrantConfig extends AdvancementConfig {
   async prepareConfigurationUpdate(configuration) {
     if ( configuration.spell ) configuration.spell.ability ??= [];
     return configuration;
-  }
-
-  /* -------------------------------------------- */
-  /*  Drag & Drop                                 */
-  /* -------------------------------------------- */
-
-  /** @override */
-  _validateDroppedItem(event, item) {
-    this.advancement._validateItemType(item);
   }
 }

--- a/module/applications/advancement/item-grant-config.mjs
+++ b/module/applications/advancement/item-grant-config.mjs
@@ -40,7 +40,7 @@ export default class ItemGrantConfig extends ItemSharedConfig {
       index: fromUuidSync(data.uuid)
     })).sort((lhs, rhs) => context.manualSort
       ? lhs.data.sort - rhs.data.sort
-      : lhs.index.name.localeCompare(rhs.index.name));
+      : lhs.index?.name.localeCompare(rhs.index?.name));
 
     context.abilityOptions = Object.entries(CONFIG.DND5E.abilities).map(([value, { label }]) => ({ value, label }));
     context.showContainerWarning = context.items.some(i => i.index?.type === "container");

--- a/module/applications/advancement/item-grant-flow.mjs
+++ b/module/applications/advancement/item-grant-flow.mjs
@@ -25,13 +25,18 @@ export default class ItemGrantFlow extends AdvancementFlow {
     const checked = new Set(Object.values(added ?? {}));
     return {
       optional: this.advancement.configuration.optional,
-      items: config.items.map(i => {
-        const item = foundry.utils.deepClone(fromUuidSync(i.uuid));
-        if ( !item ) return null;
-        item.checked = added ? checked.has(item.uuid) : (config.optional && !i.optional);
-        item.optional = config.optional || i.optional;
-        return item;
-      }, []).filter(i => i),
+      items: config.items
+        .map(i => {
+          const item = foundry.utils.deepClone(fromUuidSync(i.uuid));
+          if ( !item ) return null;
+          item.checked = added ? checked.has(item.uuid) : (config.optional && !i.optional);
+          item.optional = config.optional || i.optional;
+          item.sort = i.sort;
+          return item;
+        }, [])
+        .filter(_ => _)
+        .sort((lhs, rhs) => this.advancement.configuration.sorting === "m"
+          ? lhs.sort - rhs.sort : lhs.name.localeCompare(rhs.name)),
       abilities: this.getSelectAbilities()
     };
   }

--- a/module/applications/advancement/item-shared-config.mjs
+++ b/module/applications/advancement/item-shared-config.mjs
@@ -1,0 +1,96 @@
+import AdvancementConfig from "./advancement-config-v2.mjs";
+
+/**
+ * Shared base configuration application for Item Grant & Item Choice advancement.
+ */
+export default class ItemSharedConfig extends AdvancementConfig {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    actions: {
+      sort: ItemSharedConfig.#toggleSorting
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.manualSort = this.advancement.configuration.sorting === "m";
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle toggling the sorting on the item list.
+   * @this {ItemSharedConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static async #toggleSorting(event, target) {
+    const sorting = this.advancement.configuration.sorting === "m" ? "a" : "m";
+    this.submit({ updateData: { configuration: { sorting } }});
+  }
+
+  /* -------------------------------------------- */
+  /*  Drag & Drop                                 */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _onDragStart(event) {
+    const row = event.target.closest("[data-item-uuid]");
+    const uuid = row?.dataset.itemUuid;
+    if ( !uuid ) return;
+    const box = row.getBoundingClientRect();
+    event.dataTransfer.setData("text/plain", JSON.stringify({ type: "row", uuid }));
+    event.dataTransfer.setDragImage(row, box.width - 6, box.height / 2);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onDrop(event) {
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+    const items = foundry.utils.getProperty(this.advancement.configuration, this.options.dropKeyPath);
+    if ( data?.type !== "row" ) return super._onDrop(event);
+
+    const dropArea = event.target.closest("[data-item-uuid]");
+    const dragEntry = items.find(i => i.uuid === data.uuid);
+    if ( !dragEntry ) return;
+
+    let target = items.find(i => i.uuid === dropArea?.dataset.itemUuid);
+    let sortBefore;
+
+    // If dropped outside any entry, sort to top or bottom of list
+    if ( !target ) {
+      const box = this.element.querySelector('[data-application-part="items"]').getBoundingClientRect();
+      sortBefore = (event.clientY - box.y) < (box.height * .5);
+      const sortedEntries = items.sort((lhs, rhs) => lhs.sort - rhs.sort);
+      target = sortBefore ? sortedEntries[0] : sortedEntries.at(-1);
+    }
+
+    if ( !target || (target === dragEntry) ) return;
+
+    const siblings = items.filter(i => i.uuid !== dragEntry.uuid);
+    const sortUpdates = foundry.utils.performIntegerSort(dragEntry, { target, siblings, sortBefore });
+    const updatedItems = [];
+    for ( const item of items ) {
+      const update = sortUpdates.find(u => u.target.uuid === item.uuid);
+      if ( update ) item.sort = update.update.sort;
+      updatedItems.push(item);
+    }
+    await this.advancement.update({ [`configuration.${this.options.dropKeyPath}`]: updatedItems });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _validateDroppedItem(event, item) {
+    this.advancement._validateItemType(item);
+  }
+}

--- a/module/data/advancement/_types.mjs
+++ b/module/data/advancement/_types.mjs
@@ -42,6 +42,7 @@
  * @property {Set<string>} restriction.list                   Spell lists from which a spell must be selected.
  * @property {string} restriction.subtype                     Item sub-type allowed.
  * @property {string} restriction.type                        Specific item type allowed.
+ * @property {string} sorting                                 Sorting mode for the item list.
  * @property {AdvancementSpellConfigurationData} spell        Mutations applied to spell items.
  * @property {string} type                                    Type of item allowed, if it should be restricted.
  */
@@ -54,6 +55,7 @@
 
 /**
  * @typedef ItemChoicePoolEntry
+ * @property {number} sort  Manual sorting value for the entry.
  * @property {string} uuid  UUID of the item to present as a choice.
  */
 
@@ -77,13 +79,15 @@
  * @typedef ItemGrantAdvancementConfigurationData
  * @property {ItemGrantItemConfiguration[]} items       Data for the items to be granted.
  * @property {boolean} optional                         Should user be able to de-select any individual option?
+ * @property {string} sorting                           Sorting mode for the item list.
  * @property {AdvancementSpellConfigurationData} spell  Data used to modify any granted spells.
  */
 
 /**
  * @typedef ItemGrantItemConfiguration
- * @property {string} uuid       UUID of the item to grant.
  * @property {boolean} optional  Is this item optional? Has no effect if whole advancement is optional.
+ * @property {number} sort       Manual sorting value for the entry.
+ * @property {string} uuid       UUID of the item to grant.
  */
 
 /* -------------------------------------------- */

--- a/module/data/advancement/_types.mjs
+++ b/module/data/advancement/_types.mjs
@@ -42,7 +42,7 @@
  * @property {Set<string>} restriction.list                   Spell lists from which a spell must be selected.
  * @property {string} restriction.subtype                     Item sub-type allowed.
  * @property {string} restriction.type                        Specific item type allowed.
- * @property {string} sorting                                 Sorting mode for the item list.
+ * @property {"a"|"m"} sorting                                Sorting mode for the item list.
  * @property {AdvancementSpellConfigurationData} spell        Mutations applied to spell items.
  * @property {string} type                                    Type of item allowed, if it should be restricted.
  */
@@ -79,7 +79,7 @@
  * @typedef ItemGrantAdvancementConfigurationData
  * @property {ItemGrantItemConfiguration[]} items       Data for the items to be granted.
  * @property {boolean} optional                         Should user be able to de-select any individual option?
- * @property {string} sorting                           Sorting mode for the item list.
+ * @property {"a"|"m"} sorting                          Sorting mode for the item list.
  * @property {AdvancementSpellConfigurationData} spell  Data used to modify any granted spells.
  */
 

--- a/module/data/advancement/item-choice-data.mjs
+++ b/module/data/advancement/item-choice-data.mjs
@@ -2,7 +2,8 @@ import MappingField from "../fields/mapping-field.mjs";
 import SpellConfigurationData from "./spell-config.mjs";
 
 const {
-  ArrayField, BooleanField, EmbeddedDataField, ForeignDocumentField, NumberField, SchemaField, SetField, StringField
+  ArrayField, BooleanField, EmbeddedDataField, ForeignDocumentField,
+  IntegerSortField, NumberField, SchemaField, SetField, StringField
 } = foundry.data.fields;
 
 /**
@@ -33,13 +34,17 @@ export class ItemChoiceConfigurationData extends foundry.abstract.DataModel {
         count: new NumberField({integer: true, min: 0}),
         replacement: new BooleanField()
       })),
-      pool: new ArrayField(new SchemaField({ uuid: new StringField() })),
+      pool: new ArrayField(new SchemaField({
+        sort: new IntegerSortField(),
+        uuid: new StringField()
+      })),
       restriction: new SchemaField({
         level: new StringField(),
         list: new SetField(new StringField()),
         subtype: new StringField(),
         type: new StringField()
       }),
+      sorting: new StringField({ initial: "a", choices: Folder.SORTING_MODES }),
       spell: new EmbeddedDataField(SpellConfigurationData, { nullable: true, initial: null }),
       type: new StringField({ blank: false, nullable: true, initial: null })
     };

--- a/module/data/advancement/item-grant-data.mjs
+++ b/module/data/advancement/item-grant-data.mjs
@@ -1,6 +1,6 @@
 import SpellConfigurationData from "./spell-config.mjs";
 
-const { ArrayField, BooleanField, EmbeddedDataField, SchemaField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, EmbeddedDataField, IntegerSortField, SchemaField, StringField } = foundry.data.fields;
 
 /**
  * @import { ItemGrantAdvancementConfigurationData } from "./_types.mjs";
@@ -26,10 +26,12 @@ export default class ItemGrantConfigurationData extends foundry.abstract.DataMod
   static defineSchema() {
     return {
       items: new ArrayField(new SchemaField({
-        uuid: new StringField(),
-        optional: new BooleanField()
+        optional: new BooleanField(),
+        sort: new IntegerSortField(),
+        uuid: new StringField()
       }), { required: true }),
       optional: new BooleanField({ required: true }),
+      sorting: new StringField({ initial: "m", choices: Folder.SORTING_MODES }),
       spell: new EmbeddedDataField(SpellConfigurationData, { required: true, nullable: true, initial: null })
     };
   }

--- a/module/documents/advancement/item-choice.mjs
+++ b/module/documents/advancement/item-choice.mjs
@@ -281,7 +281,7 @@ export default class ItemChoiceAdvancement extends ItemGrantAdvancement {
 
     // Type restriction is set and the item type does not match the selected type
     if ( type && (type !== item.type) ) {
-      type = _loc(CONFIG.Item.typeLabels[restriction.type]);
+      type = _loc(CONFIG.Item.typeLabels[type]);
       return handleError("DND5E.ADVANCEMENT.ItemChoice.Warning.InvalidType", { type });
     }
 

--- a/module/documents/advancement/item-grant.mjs
+++ b/module/documents/advancement/item-grant.mjs
@@ -55,8 +55,12 @@ export default class ItemGrantAdvancement extends Advancement {
   /** @inheritDoc */
   summaryForLevel(level, { configMode=false }={}) {
     // Link to compendium items
-    if ( !this.value.added || configMode ) return this.configuration.items.filter(i => fromUuidSync(i.uuid))
-      .reduce((html, i) => html + dnd5e.utils.linkForUuid(i.uuid), "");
+    if ( !this.value.added || configMode ) return this.configuration.items
+      .map(i => [i, fromUuidSync(i.uuid)])
+      .sort((lhs, rhs) => this.configuration.sorting === "m"
+        ? lhs[0].sort - rhs[0].sort
+        : lhs[1].name.localeCompare(rhs[1].name))
+      .reduce((html, [i]) => html + dnd5e.utils.linkForUuid(i.uuid), "");
 
     // Link to items on the actor
     else {

--- a/module/documents/advancement/item-grant.mjs
+++ b/module/documents/advancement/item-grant.mjs
@@ -57,6 +57,7 @@ export default class ItemGrantAdvancement extends Advancement {
     // Link to compendium items
     if ( !this.value.added || configMode ) return this.configuration.items
       .map(i => [i, fromUuidSync(i.uuid)])
+      .filter(([, _]) => _)
       .sort((lhs, rhs) => this.configuration.sorting === "m"
         ? lhs[0].sort - rhs[0].sort
         : lhs[1].name.localeCompare(rhs[1].name))

--- a/templates/advancement/item-choice-config-items.hbs
+++ b/templates/advancement/item-choice-config-items.hbs
@@ -2,19 +2,35 @@
     <legend>{{ localize "DND5E.ADVANCEMENT.ItemChoice.FIELDS.pool.label" }}</legend>
     <div class="header">
         <div class="item-name name-header">{{ localize "DOCUMENT.Item" }}</div>
+        <div class="item-controls">
+            {{#if @root.editable}}
+            {{#with (ifThen @root.manualSort "SIDEBAR.SortModeManual" "SIDEBAR.SortModeAlpha") as |label|}}
+            <button type="button" class="unbutton control-button sorting-mode" data-action="sort"
+                    data-tooltip aria-label="{{ localize label }}">
+                <i class="fa-solid fa-arrow-down-{{ ifThen @root.manualSort 'short-wide' 'a-z'}}" inert></i>
+            </button>
+            {{/with}}
+            {{/if}}
+        </div>
     </div>
     <ol class="items-list unlist">
         {{#each items}}
         <li class="item flexrow" data-item-uuid="{{ data.uuid }}">
             <div class="item-name">
                 {{{ dnd5e-linkForUuid data.uuid renderBroken=true }}}
+                <input type="hidden" name="configuration.pool.{{ @index }}.sort" value="{{ data.sort }}">
                 <input type="hidden" name="configuration.pool.{{ @index }}.uuid" value="{{ data.uuid }}">
             </div>
             <div class="item-controls flexrow">
-                <a class="item-control item-action" data-action="deleteItem" data-tooltip
-                   aria-label="{{ localize 'DND5E.ItemDelete' }}">
+                {{#if @root.editable}}
+                <button type="button" class="unbutton control-button" data-action="deleteItem"
+                        data-tooltip aria-label="{{ localize 'DND5E.ItemDelete' }}">
                     <i class="fas fa-trash" inert></i>
-                </a>
+                </button>
+                {{#if @root.manualSort}}
+                <div class="drag-bar draggable"><i class="fa-solid fa-grip-lines-vertical" inert></i></div>
+                {{/if}}
+                {{/if}}
             </div>
         </li>
         {{/each}}

--- a/templates/advancement/item-grant-config-items.hbs
+++ b/templates/advancement/item-grant-config-items.hbs
@@ -3,6 +3,16 @@
     <div class="header">
         <div class="item-optional">{{ localize "DND5E.ADVANCEMENT.ItemGrant.FIELDS.optional.label" }}</div>
         <div class="item-name name-header">{{ localize "DOCUMENT.Item" }}</div>
+        <div class="item-controls">
+            {{#if @root.editable}}
+            {{#with (ifThen @root.manualSort "SIDEBAR.SortModeManual" "SIDEBAR.SortModeAlpha") as |label|}}
+            <button type="button" class="unbutton control-button sorting-mode" data-action="sort"
+                    data-tooltip aria-label="{{ localize label }}">
+                <i class="fa-solid fa-arrow-down-{{ ifThen @root.manualSort 'short-wide' 'a-z'}}" inert></i>
+            </button>
+            {{/with}}
+            {{/if}}
+        </div>
     </div>
     <ol class="items-list unlist">
         {{#each items}}
@@ -13,14 +23,18 @@
             </div>
             <div class="item-name">
                 {{{ dnd5e-linkForUuid data.uuid renderBroken=true }}}
+                <input type="hidden" name="configuration.items.{{ @index }}.sort" value="{{ data.sort }}">
                 <input type="hidden" name="configuration.items.{{ @index }}.uuid" value="{{ data.uuid }}">
             </div>
             <div class="item-controls flexrow">
                 {{#if @root.editable}}
-                <a class="item-control item-action" data-action="deleteItem" data-tooltip
-                   aria-label="{{ localize 'DND5E.ItemDelete' }}">
+                <button type="button" class="unbutton control-button" data-action="deleteItem"
+                        data-tooltip aria-label="{{ localize 'DND5E.ItemDelete' }}">
                     <i class="fas fa-trash" inert></i>
-                </a>
+                </button>
+                {{#if @root.manualSort}}
+                <div class="drag-bar draggable"><i class="fa-solid fa-grip-lines-vertical" inert></i></div>
+                {{/if}}
                 {{/if}}
             </div>
         </li>


### PR DESCRIPTION
Adds manual & alphabetical sorting modes to Item Grant & Choice advancement types togglable using a control in the item list header. When in manual mode, a drag handle appears to allow for dragging entries.

<img width="690" alt="Item Pool Sorting" src="https://github.com/user-attachments/assets/fe08cea9-6fbb-4ee3-8c57-2f903b667983" />

### Todo
 - [ ] Set initial sort value for newly dropped entries

Closes #1721
Closes #2737