### PR TITLE
[#5125] Add habitat filter for Compendium Browser

### DIFF
--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -198,6 +198,26 @@ export default class NPCData extends CreatureTemplate {
           keyPath: "system.details.type.value"
         }
       }],
+      ["habitat", {
+        label: "DND5E.Habitat.Configuration.Label",
+        type: "set",
+        config: {
+          choices: CONFIG.DND5E.habitats
+        },
+        createFilter: (filters, value, def) => {
+          const { include, exclude } = Object.entries(value).reduce((d, [key, value]) => {
+            if ( value === 1 ) d.include.push(key);
+            else if ( value === -1 ) d.exclude.push(key);
+            return d;
+          }, { include: [], exclude: [] });
+          if ( include.length ) filters.push({
+            k: "system.details.habitat.value", o: "has", v: { k: "type", o: "in", v: include }
+          });
+          if ( exclude.length ) filters.push({
+            o: "NOT", v: { k: "system.details.habitat.value", o: "has", v: { k: "type", o: "in", v: exclude } }
+          });
+        }
+      }],
       ["cr", {
         label: "DND5E.ChallengeRating",
         type: "range",

--- a/module/filter.mjs
+++ b/module/filter.mjs
@@ -9,13 +9,14 @@
 
 /**
  * Check some data against a filter to determine if it matches.
- * @param {object} data                 Data to check.
- * @param {FilterDescription[]} filter  Filter to compare against.
+ * @param {object} data                                   Data to check.
+ * @param {FilterDescription|FilterDescription[]} filter  Filter to compare against.
  * @returns {boolean}
  * @throws
  */
 export function performCheck(data, filter=[]) {
-  return AND(data, filter);
+  if ( foundry.utils.getType(filter) === "Array" ) return AND(data, filter);
+  return _check(data, filter.k, filter.v, filter.o);
 }
 
 /* -------------------------------------------- */
@@ -245,7 +246,14 @@ export function endswith(data, value) {
  * @returns {boolean}
  */
 export function has(data, value) {
-  return in_(value, data);
+  // If the value is another filter description, apply that check against each member of the collection
+  if ( foundry.utils.getType(value) === "Object" ) {
+    switch ( foundry.utils.getType(data) ) {
+      case "Array":
+      case "Set": return !!data.find(d => performCheck(d, value));
+      default: return false;
+    }
+  } else return in_(value, data);
 }
 
 /* -------------------------------------------- */


### PR DESCRIPTION
Adds the ability to filter NPCs based on their habitat. Because of how habitat data is stored, this required adding support in the filtering system for applying sub-filters when searching a collection using the `has` comparison function.

Closes #5125