### PR TITLE
[#3776, #4422, #5109] Improve handling of initiative advantage

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -132,8 +132,9 @@ Hooks.once("init", function() {
     DND5E.languages.druidic = DND5E.languages.exotic.children.druidic;
     delete DND5E.languages.exotic.children.druidic;
 
-    // Stunned stops movement in legacy.
+    // Stunned stops movement in legacy & surprised doesn't provide initiative disadvantage
     DND5E.conditionEffects.noMovement.add("stunned");
+    DND5E.conditionEffects.initiativeDisadvantage.delete("surprised");
   }
 
   // Register Roll Extensions

--- a/module/applications/actor/config/initiative-config.mjs
+++ b/module/applications/actor/config/initiative-config.mjs
@@ -71,12 +71,12 @@ export default class InitiativeConfig extends BaseConfigSheet {
         field: new BooleanField({ label: game.i18n.localize("DND5E.FlagsAlert") }),
         name: "flags.dnd5e.initiativeAlert",
         value: source.flags.dnd5e?.initiativeAlert
-      },
-      advantage: {
-        field: new BooleanField({ label: game.i18n.localize("DND5E.FlagsInitiativeAdv") }),
-        name: "flags.dnd5e.initiativeAdv",
-        value: source.flags.dnd5e?.initiativeAdv
       }
+    };
+    if ( source.flags.dnd5e?.initiativeAdv ) context.flags.advantage = {
+      field: new BooleanField({ label: game.i18n.localize("DND5E.FlagsInitiativeAdv") }),
+      name: "flags.dnd5e.initiativeAdv",
+      value: source.flags.dnd5e?.initiativeAdv
     };
 
     return context;

--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -236,8 +236,10 @@ export default function ActorSheetV2Mixin(Base) {
         else if ( config.type === Number ) flag.field = new foundry.data.fields.NumberField(fieldOptions);
         else flag.fields = new foundry.data.fields.StringField(fieldOptions);
 
-        sections[config.section] ??= [];
-        sections[config.section].push(flag);
+        if ( !config.deprecated || flag.value ) {
+          sections[config.section] ??= [];
+          sections[config.section].push(flag);
+        }
       }
 
       // Global Bonuses
@@ -249,7 +251,7 @@ export default function ActorSheetV2Mixin(Base) {
       addBonus(this.document.system.schema.fields.bonuses);
       if ( globals.length ) sections[game.i18n.localize("DND5E.BONUSES.FIELDS.bonuses.label")] = globals;
 
-      flags.sections = Object.entries(sections).map(([label, fields]) => ({ label, fields }))
+      flags.sections = Object.entries(sections).map(([label, fields]) => ({ label, fields }));
       return flags;
     }
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3734,7 +3734,8 @@ DND5E.conditionEffects = {
   halfMovement: new Set(["exhaustion-2"]),
   crawl: new Set(["prone", "exceedingCarryingCapacity"]),
   petrification: new Set(["petrified"]),
-  halfHealth: new Set(["exhaustion-4"])
+  halfHealth: new Set(["exhaustion-4"]),
+  initiativeDisadvantage: new Set(["surprised"])
 };
 
 /* -------------------------------------------- */
@@ -4207,6 +4208,7 @@ preLocalize("traitModes", { keys: ["label", "hint"] });
  * @property {string} placeholder
  * @property {string[]} [abilities]
  * @property {Object<string, string>} [choices]
+ * @property {boolean} [deprecated]               Hide the flag unless it already has a value.
  * @property {string[]} [skills]
  */
 
@@ -4244,7 +4246,8 @@ DND5E.characterFlags = {
     name: "DND5E.FlagsInitiativeAdv",
     hint: "DND5E.FlagsInitiativeAdvHint",
     section: "DND5E.Feats",
-    type: Boolean
+    type: Boolean,
+    deprecated: true
   },
   initiativeAlert: {
     name: "DND5E.FlagsAlert",

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -1,6 +1,7 @@
 import ActiveEffect5e from "../../../documents/active-effect.mjs";
 import Proficiency from "../../../documents/actor/proficiency.mjs";
 import { convertLength, convertWeight, replaceFormulaData, simplifyBonus } from "../../../utils.mjs";
+import AdvantageModeField from "../../fields/advantage-mode-field.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 import MovementField from "../../shared/movement-field.mjs";
 import RollConfigField from "../../shared/roll-config-field.mjs";
@@ -380,13 +381,21 @@ export default class AttributesFields {
     const alert = flags.initiativeAlert && !isLegacy;
     init.prof = new Proficiency(prof, alert ? 1 : (joat || ra) ? 0.5 : 0, !ra);
 
+    // Adjust rolling mode
+    if ( (flags.remarkableAthlete && !isLegacy) || flags.initiativeAdv ) {
+      AdvantageModeField.setMode(this, "attributes.init.roll.mode", 1);
+    }
+    if ( this.parent.hasConditionEffect("initiativeDisadvantage") ) {
+      AdvantageModeField.setMode(this, "attributes.init.roll.mode", -1);
+    }
+
     // Total initiative includes all numeric terms
     const initBonus = simplifyBonus(init.bonus, rollData);
     const abilityBonus = simplifyBonus(ability.bonuses?.check, rollData);
     init.total = init.mod + initBonus + abilityBonus + globalCheckBonus
       + (flags.initiativeAlert && isLegacy ? 5 : 0)
       + (Number.isNumeric(init.prof.term) ? init.prof.flat : 0);
-    init.score = 10 + init.total;
+    init.score = 10 + init.total + (init.roll.mode * 5);
   }
 
   /* -------------------------------------------- */

--- a/module/data/fields/advantage-mode-field.mjs
+++ b/module/data/fields/advantage-mode-field.mjs
@@ -127,4 +127,25 @@ export default class AdvantageModeField extends foundry.data.fields.NumberField 
     const disadvantageCount = disadvantages.suppressed ? 0 : disadvantages.count + Number(src === -1);
     return Math.sign(advantageCount) - Math.sign(disadvantageCount);
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Helper for setting the advantage mode programmatically.
+   * @param {DataModel} model                   The model the change is applied to.
+   * @param {string} keyPath                    Path to the advantage mode field on the model.
+   * @param {number} value                      An integer in the interval [-1, 1], indicating advantage (1),
+   *                                            disadvantage (-1), or neither (0).
+   * @param {object} [options={}]
+   * @param {boolean} [options.override=false]  Override the mode rather than following the normal advantage rules.
+   * @returns {number}                          Final advantage value.
+   */
+  static setMode(model, keyPath, value, { override=false }={}) {
+    const field = keyPath.startsWith("system.") ? model.system.schema.getField(keyPath.slice(7))
+      : model.schema.getField(keyPath);
+    const change = { key: keyPath, value, mode: CONST.ACTIVE_EFFECT_MODES[override ? "OVERRIDE" : "ADD"] };
+    const final = field.applyChange(foundry.utils.getProperty(model, keyPath), model, change);
+    foundry.utils.setProperty(model, keyPath, final);
+    return final;
+  }
 }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1861,8 +1861,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       alert: flags.initiativeAlert && (game.settings.get("dnd5e", "rulesVersion") === "legacy") ? 5 : null
     }, rollData);
 
-    const remarkableAthlete = flags.remarkableAthlete && (game.settings.get("dnd5e", "rulesVersion") === "modern");
-    if ( flags.initiativeAdv || remarkableAthlete ) options.advantage ??= true;
+    if ( init.roll.mode === 1 ) options.advantage ??= true;
+    else if ( init.roll.mode === -1 ) options.disadvantage ??= true;
 
     // Add exhaustion reduction
     this.addRollExhaustion(parts, data);

--- a/templates/actors/config/initiative-config.hbs
+++ b/templates/actors/config/initiative-config.hbs
@@ -13,6 +13,8 @@
     {{!-- Rolls --}}
     <fieldset class="card">
         <legend>{{ localize "DND5E.ROLL.Section" label=(localize "DND5E.Initiative") }}</legend>
+        {{ formField fields.roll.fields.mode value=data.roll.mode options=advantageModeOptions localize=true
+                     rootId=partId }}
         <div class="form-group split-group">
             <label>{{ localize "DND5E.ROLL.Range.Label" }}</label>
             <div class="form-fields">


### PR DESCRIPTION
Adjust the initiative score by +5 or -5 relative to the provided advantage mode. To fully support this adds roll mode to the initiative config and deprecated the old initiative advantage flag. If an actor has the deprecated flag set it will appear in the config app, but as soon as it is unchecked the option will disappear. The same is true for the special traits tab.

Adds a new helper to `AdvantageModeField` to help setting the mode from code. If the actor has the initative advantage flag, remarkable athlete flag, or the surpised status  then the initiative roll mode will be adjusted accordingly.

The initiative rolling now reflects the roll mode rather than using the flags directly.

Closes #3776
Closes #4422
Closes #5109