### PR TITLE
[#4665] Add compendium browser to select feat in ASI advancement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -257,8 +257,9 @@
 
 "DND5E.ADVANCEMENT": {
   "AbilityScoreImprovement": {
-    "Title": "Ability Score Improvement",
-    "Hint": "Allow the player to increase one or more ability scores or take an optional feat.",
+    "Action": {
+      "Select": "Select Feat"
+    },
     "CapDisplay": {
       "one": "Max {points} point per score",
       "other": "Max {points} points per score"
@@ -290,6 +291,7 @@
         "increase": "Increase Points"
       }
     },
+    "Hint": "Allow the player to increase one or more ability scores or take an optional feat.",
     "Journal": {
       "DescriptionLegacy": "<p>When you reach {firstLevelOrdinal} level, and again at {otherLevelsOrdinal} level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can’t increase an ability score above {maxAbilityScore} using this feature.</p><p>Using the optional feats rule, you can forgo taking this feature to take a feat of your choice instead.</p>",
       "DescriptionModern": "<p>You gain the Ability Score Improvement feat or another feat of your choice for which you qualify. You gain this feature again at {class} levels {otherLevels}.</p>",
@@ -300,6 +302,7 @@
       "one": "{points} Point Remaining",
       "other": "{points} Points Remaining"
     },
+    "Title": "Ability Score Improvement",
     "Warning": {
       "Level": "Must be at least level {level} to take this feat.",
       "Type": "Only features with the \"feat\" type can be selected."
@@ -544,8 +547,11 @@
     "FreeCasting": "Free Casting"
   },
   "Subclass": {
-    "Title": "Subclass",
+    "Action": {
+      "Select": "Select Subclass"
+    },
     "Hint": "Specify what level this class receives its subclass.",
+    "Title": "Subclass",
     "Warning": {
       "InvalidType": "Only subclasses may be selected."
     }

--- a/less/v1/advancement.less
+++ b/less/v1/advancement.less
@@ -200,18 +200,7 @@
         opacity: 60%;
       }
     }
-    .drop-area {
-      padding-block: 0.5em;
-      align-items: center;
-      .name { font-size: var(--font-size-16); }
-      .item-control { flex: 0; }
-    }
-    .drop-area.empty {
-      padding-block: 1em;
-      border: 1px dashed var(--color-border-light-2);
-      border-radius: 5px;
-      justify-content: center;
-    }
+    .feat-section { gap: 8px; }
   }
 
   /* ----------------------------------------- */

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -273,6 +273,22 @@
         border: none;
       }
     }
+
+    .pill-lg {
+      max-width: unset;
+      &.empty:not(.disabled) {
+        cursor: pointer;
+        transition: opacity 250ms ease;
+        &:hover { opacity: .5; }
+      }
+      &.locked { opacity: .7; }
+      .name-stacked { flex: 1; }
+      .control-button { padding-inline: 4px; }
+      img[data-action] {
+        cursor: pointer;
+        &:hover { box-shadow: 0 0 12px var(--dnd5e-color-gold); }
+      }
+    }
   }
 }
 

--- a/module/applications/advancement/subclass-flow.mjs
+++ b/module/applications/advancement/subclass-flow.mjs
@@ -46,9 +46,9 @@ export default class SubclassFlow extends AdvancementFlow {
   activateListeners(jQuery) {
     super.activateListeners(jQuery);
     const [html] = jQuery;
-    html.querySelector("a[data-uuid]")?.addEventListener("click", this._onClickFeature.bind(this));
     html.querySelector('[data-action="browse"]')?.addEventListener("click", this._onBrowseCompendium.bind(this));
-    html.querySelector('[data-action="deleteItem"]')?.addEventListener("click", this._onItemDelete.bind(this));
+    html.querySelector('[data-action="delete"]')?.addEventListener("click", this._onItemDelete.bind(this));
+    html.querySelector("[data-action='viewItem']")?.addEventListener("click", this._onClickFeature.bind(this));
   }
 
   /* -------------------------------------------- */
@@ -80,7 +80,7 @@ export default class SubclassFlow extends AdvancementFlow {
    */
   async _onClickFeature(event) {
     event.preventDefault();
-    const uuid = event.currentTarget.dataset.uuid;
+    const uuid = event.target.closest("[data-uuid]")?.dataset.uuid;
     const item = await fromUuid(uuid);
     item?.sheet.render(true);
   }

--- a/templates/advancement/ability-score-improvement-flow.hbs
+++ b/templates/advancement/ability-score-improvement-flow.hbs
@@ -1,5 +1,5 @@
 <form id="{{ appId }}" data-level="{{ level }}" data-id="{{ advancement.id }}" data-type="{{ type }}">
-    <h3>{{{ this.title }}}</h3>
+    <h3>{{{ title }}}</h3>
     {{#if advancement.hint}}<p>{{ advancement.hint }}</p>{{/if}}
 
     {{#if showImprovement}}
@@ -21,30 +21,38 @@
     {{/if}}
 
     {{#if advancement.allowFeat}}
-    {{#if showImprovement}}<h3>{{ localize "DND5E.Feature.Feat.Label" }}</h3>{{/if}}
+    <div class="feat-section flexcol">
+        {{#if showImprovement}}<h3>{{ localize "DND5E.Feature.Feat.Label" }}</h3>{{/if}}
 
-    {{#if showASIFeat}}
-    <div class="item-name flexrow drop-area dnd5e2">
-        <div class="item-image"
-             style="background-image: url('icons/skills/melee/weapons-crossed-swords-white-blue.webp');"></div>
-        <span class="name">{{ localize "DND5E.ADVANCEMENT.AbilityScoreImprovement.Feat.ASIName" }}</span>
-        <dnd5e-checkbox class="item-control" name="asi-selected" {{ checked feat.isASI }}></dnd5e-checkbox>
-    </div>
-    {{/if}}
-
-    {{#unless feat.isASI}}
-    <div class="item-name flexrow drop-area {{#unless feat}}empty{{/unless}}">
-        {{#if feat}}
-        <div class="item-image" style="background-image: url('{{ feat.img }}');"></div>
-        <a class="name" data-uuid="{{ feat.uuid }}">{{ feat.name }}</a>
-        <button type="button" class="unbutton control-button item-control" data-action="delete"
-                data-tooltip="DND5E.ItemDelete" aria-label="{{ localize 'DND5E.ItemDelete' }}">
-            <i class="fas fa-trash" inert></i>
-        </button>
-        {{else}}
-        {{ localize "DND5E.ADVANCEMENT.AbilityScoreImprovement.Feat.Hint" }}
+        {{#if showASIFeat}}
+        <div class="pill-lg {{#if lockImprovement}}locked{{/if}}">
+            <img class="gold-icon" src="icons/skills/melee/weapons-crossed-swords-white-blue.webp"
+                 alt="{{ localize 'DND5E.ADVANCEMENT.AbilityScoreImprovement.Feat.ASIName' }}">
+            <div class="name-stacked">
+                <div class="title">{{ localize "DND5E.ADVANCEMENT.AbilityScoreImprovement.Feat.ASIName" }}</div>
+            </div>
+            <dnd5e-checkbox class="item-control" name="asi-selected" {{ checked feat.isASI }}
+                            {{ disabled lockImprovement }}></dnd5e-checkbox>
+        </div>
         {{/if}}
+
+        {{#unless feat.isASI}}
+        <div class="pill-lg {{#unless feat}}roboto-upper empty{{/unless}}"
+             {{~#if feat}} data-uuid="{{ feat.uuid }}"{{else}} data-action="browse"{{/if}}>
+            {{#if feat}}
+            <img class="gold-icon" data-action="viewItem" src="{{ feat.img }}" alt="{{ feat.name }}">
+            <div class="name-stacked">
+                <div class="title">{{ feat.name }}</div>
+            </div>
+            <button type="button" class="unbutton control-button item-control" data-action="delete"
+                    data-tooltip="DND5E.ItemDelete" aria-label="{{ localize 'DND5E.ItemDelete' }}">
+                <i class="fas fa-trash" inert></i>
+            </button>
+            {{else}}
+            {{ localize "DND5E.ADVANCEMENT.AbilityScoreImprovement.Action.Select" }}
+            {{/if}}
+        </div>
+        {{/unless}}
     </div>
-    {{/unless}}
     {{/if}}
 </form>

--- a/templates/advancement/subclass-flow.hbs
+++ b/templates/advancement/subclass-flow.hbs
@@ -2,23 +2,19 @@
     <h3>{{{ title }}}</h3>
     {{#if advancement.hint}}<p>{{ advancement.hint }}</p>{{/if}}
 
-    <div class="drop-target">
+    <div class="pill-lg {{#unless subclass}}roboto-upper empty{{/unless}}"
+         {{~#if subclass}} data-uuid="{{ subclass.uuid }}"{{else}} data-action="browse"{{/if}}>
         {{#if subclass}}
-        <div class="item-name flexrow">
-            <div class="item-image" style="background-image: url({{ subclass.img }});"></div>
-            <label class="flexrow">
-                <h4><a data-uuid="{{ subclass.uuid }}">{{ subclass.name }}</a></h4>
-                <a class="item-control item-delete" title="{{ localize 'DND5E.ItemDelete' }}" data-action="deleteItem">
-                  <i class="fas fa-trash" inert></i>
-                </a>
-                <input type="hidden" name="uuid" value="{{ subclass.uuid }}">
-            </label>
+        <img class="gold-icon" data-action="viewItem" src="{{ subclass.img }}" alt="{{ subclass.name }}">
+        <div class="name-stacked">
+            <div class="title">{{ subclass.name }}</div>
         </div>
-        {{else}}
-        <button type="button" data-action="browse">
-            <i class="fa-solid fa-book-open-reader" inert></i>
-            {{ localize "DND5E.CompendiumBrowser.Action.Open" }}
+        <button type="button" class="unbutton control-button item-control" data-action="delete"
+                data-tooltip="DND5E.ItemDelete" aria-label="{{ localize 'DND5E.ItemDelete' }}">
+            <i class="fas fa-trash" inert></i>
         </button>
+        {{else}}
+        {{ localize "DND5E.ADVANCEMENT.Subclass.Action.Select" }}
         {{/if}}
     </div>
 </form>


### PR DESCRIPTION
Adds a button to open the compendium browser to select a feat within the ASI advancement flow. This button takes the design of the species/background/class pills on the character sheet.

<img width="478" alt="ASI Flow Pills Empty" src="https://github.com/user-attachments/assets/830c1ada-89ec-486e-8b14-f93549d17537" />
<img width="479" alt="ASI Flow Pills Selected" src="https://github.com/user-attachments/assets/13de90b0-0854-4b67-aa91-caead531cbe4" />

Also modifies the button on the subclass flow to match this new style.

<img width="476" alt="Subclass PIll Empty" src="https://github.com/user-attachments/assets/dec433a6-8181-4065-93f5-087f0fc1871b" />
<img width="479" alt="Subclass Pill Selected" src="https://github.com/user-attachments/assets/5b2f4959-5425-400a-a223-c45de7d9a2a5" />

Closes #4665