### PR TITLE
[#5132] Display compendium browser link in item choice advancement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -336,6 +336,10 @@
     }
   },
   "ItemChoice": {
+    "Action": {
+      "SelectGeneric": "Select Item",
+      "SelectSpecific": "Select {type}"
+    },
     "Choose": "choose {count}",
     "Chosen": "Chosen: {current} of {max}",
     "Details": "Choice Details",
@@ -388,6 +392,7 @@
     "Warning": {
       "FeatureLevel": "Must be at least level {level} to take this feature.",
       "InvalidType": "Only {type} items can be selected for this choice.",
+      "MaxSelected": "No additional items can be selected, uncheck items before selecting more.",
       "NoOriginal": "Previously selected choice no longer available for replacement.",
       "PreviouslyChosen": "This item has already been chosen at a previous level.",
       "SpellLevelAvailable": "Only {level} or lower spells can be chosen for this advancement.",

--- a/less/v1/advancement.less
+++ b/less/v1/advancement.less
@@ -349,8 +349,10 @@
     }
     label.flexrow {
       justify-content: space-between;
-      input[type=checkbox] { flex: none; }
+      dnd5e-checkbox { margin-inline: 6px; }
     }
+    .item-name + .item-name { margin-block-start: 4px; }
+    .pill-lg { margin-block-start: 12px; }
   }
 
   form[data-type="ScaleValue"] {

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -1,4 +1,5 @@
 import Actor5e from "../../documents/actor/actor.mjs";
+import CompendiumBrowser from "../compendium-browser.mjs";
 import ItemGrantFlow from "./item-grant-flow.mjs";
 
 /**
@@ -127,6 +128,19 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     context.abilities.disabled = previouslySelected.size;
     this.ability ??= context.abilities.selected;
 
+    if ( this.advancement.configuration.type ) {
+      let type = game.i18n.localize(CONFIG.Item.typeLabels[this.advancement.configuration.type]);
+      if ( (this.advancement.configuration.type === "feat") && this.advancement.configuration.restriction.type ) {
+        const typeConfig = CONFIG.DND5E.featureTypes[this.advancement.configuration.restriction.type];
+        const subtype = typeConfig.subtypes?.[this.advancement.configuration.restriction.subtype];
+        if ( subtype ) type = subtype;
+        else type = typeConfig.label;
+      }
+      context.selectLabel = game.i18n.format("DND5E.ADVANCEMENT.ItemChoice.Action.SelectSpecific", { type });
+    } else {
+      context.selectLabel = game.i18n.localize("DND5E.ADVANCEMENT.ItemChoice.Action.SelectGeneric");
+    }
+
     return context;
   }
 
@@ -135,7 +149,65 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
   /** @inheritDoc */
   activateListeners(html) {
     super.activateListeners(html);
-    html.find(".item-delete").click(this._onItemDelete.bind(this));
+    html.find('[data-action="browse"]').click(this._onBrowseCompendium.bind(this));
+    html.find('[data-action="delete"]').click(this._onItemDelete.bind(this));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle opening the compendium browser and displaying the result.
+   * @param {Event} event  The originating click event.
+   * @protected
+   */
+  async _onBrowseCompendium(event) {
+    event.preventDefault();
+
+    // Determine how many items can be selected
+    const max = this.advancement.configuration.choices[this.level]?.count ?? 0;
+    const current = this.selected.size;
+    if ( current >= max ) {
+      ui.notifications.warn("DND5E.ADVANCEMENT.ItemChoice.Warning.MaxSelected", { localize: true });
+      return;
+    }
+
+    const config = this.advancement.configuration;
+    const filters = { locked: { additional: { }, documentClass: "Item" } };
+
+    // Apply restrictions based on type
+    if ( config.type ) {
+      filters.locked.types = new Set([config.type]);
+      if ( (config.type === "feat") && config.restriction.type ) {
+        const typeConfig = CONFIG.DND5E.featureTypes[config.restriction.type];
+        const subtype = typeConfig.subtypes?.[config.restriction.subtype];
+        filters.locked.additional.category = { [config.restriction.type]: 1 };
+        if ( subtype ) filters.locked.additional.subtype = { [config.restriction.subtype]: 1 };
+      }
+    }
+
+    // Apply restrictions based on level
+    if ( config.type === "feat" ) {
+      filters.locked.arbitrary = [{ k: "system.prerequisites.level", o: "lte", v: this.level }];
+    } else if ( (config.type === "spell") && (config.restriction.level !== "") ) {
+      filters.locked.additional.level = {
+        min: config.restriction.level === "available" ? undefined : Number(config.restriction.level),
+        max: config.restriction.level === "available" ? this._maxSpellSlotLevel() : Number(config.restriction.level)
+      };
+    }
+
+    const result = await CompendiumBrowser.select({ filters, selection: { min: 1, max: max - current } });
+    if ( !result?.size ) return;
+
+    const items = await Promise.all(Array.from(result).map(uuid => fromUuid(uuid)));
+    for ( const item of items ) {
+      this.selected.add(item.uuid);
+      if ( !this.pool.find(i => i.uuid === item.uuid) ) {
+        this.dropped.push(item);
+        item.dropped = true;
+      }
+    }
+
+    this.render();
   }
 
   /* -------------------------------------------- */
@@ -160,7 +232,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
    */
   async _onItemDelete(event) {
     event.preventDefault();
-    const uuidToDelete = event.currentTarget.closest(".item-name")?.querySelector("dnd5e-checkbox")?.name;
+    const uuidToDelete = event.currentTarget.closest("[data-uuid]")?.dataset.uuid;
     if ( !uuidToDelete ) return;
     this.dropped.findSplice(i => i.uuid === uuidToDelete);
     this.selected.delete(uuidToDelete);

--- a/templates/advancement/item-choice-flow.hbs
+++ b/templates/advancement/item-choice-flow.hbs
@@ -45,14 +45,14 @@
         </h4>
 
         {{#each items}}
-        <div class="item-name flexrow">
+        <div class="item-name flexrow" data-uuid="{{ uuid }}">
             <div class="item-image" style="background-image: url({{ img }});"></div>
             <label class="flexrow">
                 <h4>
-                    <a data-uuid="{{this.uuid}}">{{ name }}</a>
+                    <a data-uuid="{{ uuid }}">{{ name }}</a>
                 </h4>
                 {{#if dropped}}
-                <button type="button" class="unbutton control-button item-control item-delete"
+                <button type="button" class="unbutton control-button item-control item-delete" data-action="delete"
                         data-tooltip="DND5E.ItemDelete" aria-label="{{ localize 'DND5E.ItemDelete' }}">
                     <i class="fa-solid fa-trash" inert></i>
                 </button>
@@ -65,7 +65,9 @@
         {{/each}}
 
         {{#if advancement.configuration.allowDrops}}
-        <p class="hint centered">{{ localize "DND5E.AdvancementFlowDropAreaHint" }}</p>
+        <div class="pill-lg roboto-upper empty" data-action="browse">
+            {{ localize selectLabel }}
+        </div>
         {{/if}}
     </div>
 </form>


### PR DESCRIPTION
When "Allow Drops" is set for an choose items advancement then a compendium browser link will be displayed. Clicking on it will open the browser with filters applied based on the restrictions set on the advancement.

Closes #5132