### PR TITLE
[#5137] Add spell list restriction to Choose Items advancement

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -493,6 +493,7 @@ Hooks.once("ready", function() {
 
   // Register items by type
   dnd5e.registry.classes.initialize();
+  dnd5e.registry.subclasses.initialize();
 
   // Chat message listeners
   documents.ChatMessage5e.activateListeners();

--- a/lang/en.json
+++ b/lang/en.json
@@ -409,6 +409,10 @@
           "hint": "Only allow choices from spells of this level.",
           "label": "Spell Level"
         },
+        "list": {
+          "hint": "Only allow spells from this list.",
+          "label": "Spell List"
+        },
         "subtype": {
           "label": "Subtype"
         },
@@ -434,7 +438,8 @@
       "NoOriginal": "Previously selected choice no longer available for replacement.",
       "PreviouslyChosen": "This item has already been chosen at a previous level.",
       "SpellLevelAvailable": "Only {level} or lower spells can be chosen for this advancement.",
-      "SpellLevelSpecific": "Only {level} spells can be chosen for this advancement."
+      "SpellLevelSpecific": "Only {level} spells can be chosen for this advancement.",
+      "SpellList": "Only spells available on the {list} spell list can be chosen for this advancement."
     }
   },
   "ItemGrant": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -410,8 +410,8 @@
           "label": "Spell Level"
         },
         "list": {
-          "hint": "Only allow spells from this list.",
-          "label": "Spell List"
+          "hint": "Only allow spells from these lists.",
+          "label": "Spell Lists"
         },
         "subtype": {
           "label": "Subtype"

--- a/lang/en.json
+++ b/lang/en.json
@@ -439,7 +439,7 @@
       "PreviouslyChosen": "This item has already been chosen at a previous level.",
       "SpellLevelAvailable": "Only {level} or lower spells can be chosen for this advancement.",
       "SpellLevelSpecific": "Only {level} spells can be chosen for this advancement.",
-      "SpellList": "Only spells available on the {list} spell list can be chosen for this advancement."
+      "SpellList": "Only spells available on the {lists} spell list can be chosen for this advancement."
     }
   },
   "ItemGrant": {

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -67,6 +67,10 @@ export default class ItemChoiceConfig extends AdvancementConfig {
       { rule: true },
       ...Object.entries(CONFIG.DND5E.spellLevels).map(([value, label]) => ({ value, label }))
     ];
+    context.listRestrictionOptions = [
+      { value: "", label: "" },
+      ...dnd5e.registry.spellLists.options
+    ];
     context.showContainerWarning = context.items.some(i => i.index?.type === "container");
     context.showSpellConfig = this.advancement.configuration.type === "spell";
     context.showRequireSpellSlot = !this.advancement.configuration.spell?.preparation

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -67,10 +67,7 @@ export default class ItemChoiceConfig extends AdvancementConfig {
       { rule: true },
       ...Object.entries(CONFIG.DND5E.spellLevels).map(([value, label]) => ({ value, label }))
     ];
-    context.listRestrictionOptions = [
-      { value: "", label: "" },
-      ...dnd5e.registry.spellLists.options
-    ];
+    context.listRestrictionOptions = dnd5e.registry.spellLists.options;
     context.showContainerWarning = context.items.some(i => i.index?.type === "container");
     context.showSpellConfig = this.advancement.configuration.type === "spell";
     context.showRequireSpellSlot = !this.advancement.configuration.spell?.preparation

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -121,7 +121,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
         i.checked = this.selected.has(i.uuid);
         i.disabled = !i.checked && context.choices.full;
         const validLevel = (i.system.prerequisites?.level ?? -Infinity) <= this.level;
-        const validSpell = validateSpellLevel && (i.system.level <= maxSlot);
+        const validSpell = !validateSpellLevel || (i.system.level <= maxSlot);
         const available = !previouslySelected.has(i.uuid) || i.system.prerequisites?.repeatable;
         if ( available && validLevel && validSpell ) items.push(i);
       }
@@ -256,7 +256,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     let spells;
 
     // For advancements on classes or subclasses, use the largest slot available for that class
-    if ( spellcasting ) {
+    if ( spellcasting?.type ) {
       const progression = { slot: 0, pact: 0 };
       const maxSpellLevel = CONFIG.DND5E.SPELL_SLOT_TABLE[CONFIG.DND5E.SPELL_SLOT_TABLE.length - 1].length;
       spells = Object.fromEntries(Array.fromRange(maxSpellLevel, 1).map(l => [`spell${l}`, {}]));

--- a/module/data/advancement/item-choice.mjs
+++ b/module/data/advancement/item-choice.mjs
@@ -27,9 +27,10 @@ const {
  * @property {Record<number, ItemChoiceLevelConfig>} choices  Choices & config for specific levels.
  * @property {ItemChoicePoolEntry[]} pool                     Items that can be chosen.
  * @property {object} restriction
- * @property {string} restriction.type                        Specific item type allowed.
- * @property {string} restriction.subtype                     Item sub-type allowed.
  * @property {"available"|number} restriction.level           Level of spell allowed.
+ * @property {string} restriction.list                        Spell list from which a spell must be selected.
+ * @property {string} restriction.subtype                     Item sub-type allowed.
+ * @property {string} restriction.type                        Specific item type allowed.
  * @property {SpellConfigurationData} spell                   Mutations applied to spell items.
  * @property {string} type                                    Type of item allowed, if it should be restricted.
  */
@@ -55,6 +56,7 @@ export class ItemChoiceConfigurationData extends foundry.abstract.DataModel {
       pool: new ArrayField(new SchemaField({ uuid: new StringField() })),
       restriction: new SchemaField({
         level: new StringField(),
+        list: new StringField(),
         subtype: new StringField(),
         type: new StringField()
       }),

--- a/module/data/advancement/item-choice.mjs
+++ b/module/data/advancement/item-choice.mjs
@@ -2,7 +2,7 @@ import MappingField from "../fields/mapping-field.mjs";
 import SpellConfigurationData from "./spell-config.mjs";
 
 const {
-  ArrayField, BooleanField, EmbeddedDataField, ForeignDocumentField, NumberField, SchemaField, StringField
+  ArrayField, BooleanField, EmbeddedDataField, ForeignDocumentField, NumberField, SchemaField, SetField, StringField
 } = foundry.data.fields;
 
 /**
@@ -28,7 +28,7 @@ const {
  * @property {ItemChoicePoolEntry[]} pool                     Items that can be chosen.
  * @property {object} restriction
  * @property {"available"|number} restriction.level           Level of spell allowed.
- * @property {string} restriction.list                        Spell list from which a spell must be selected.
+ * @property {Set<string>} restriction.list                   Spell lists from which a spell must be selected.
  * @property {string} restriction.subtype                     Item sub-type allowed.
  * @property {string} restriction.type                        Specific item type allowed.
  * @property {SpellConfigurationData} spell                   Mutations applied to spell items.
@@ -56,7 +56,7 @@ export class ItemChoiceConfigurationData extends foundry.abstract.DataModel {
       pool: new ArrayField(new SchemaField({ uuid: new StringField() })),
       restriction: new SchemaField({
         level: new StringField(),
-        list: new StringField(),
+        list: new SetField(new StringField()),
         subtype: new StringField(),
         type: new StringField()
       }),

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -118,7 +118,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
         },
         config: {
           choices: dnd5e.registry.spellLists.options.reduce((obj, entry) => {
-            obj[`${entry.type}.${entry.value}`] = entry.label;
+            obj[entry.value] = entry.label;
             return obj;
           }, {})
         }

--- a/module/documents/advancement/item-choice.mjs
+++ b/module/documents/advancement/item-choice.mjs
@@ -164,13 +164,15 @@ export default class ItemChoiceAdvancement extends ItemGrantAdvancement {
     type ??= this.configuration.type;
     restriction ??= this.configuration.restriction;
 
+    const handleError = (localizationKey, data) => {
+      if ( strict ) throw new Error(game.i18n.format(localizationKey, data));
+      return false;
+    };
+
     // Type restriction is set and the item type does not match the selected type
     if ( type && (type !== item.type) ) {
       type = game.i18n.localize(CONFIG.Item.typeLabels[restriction]);
-      if ( strict ) {
-        throw new Error(game.i18n.format("DND5E.ADVANCEMENT.ItemChoice.Warning.InvalidType", { type: typeLabel }));
-      }
-      return false;
+      return handleError("DND5E.ADVANCEMENT.ItemChoice.Warning.InvalidType", { type: typeLabel });
     }
 
     // If additional type restrictions applied, make sure they are valid
@@ -180,33 +182,24 @@ export default class ItemChoiceAdvancement extends ItemGrantAdvancement {
       let errorLabel;
       if ( restriction.type !== item.system.type.value ) errorLabel = typeConfig.label;
       else if ( subtype && (restriction.subtype !== item.system.type.subtype) ) errorLabel = subtype;
-      if ( errorLabel ) {
-        if ( strict ) {
-          throw new Error(game.i18n.format("DND5E.ADVANCEMENT.ItemChoice.Warning.InvalidType", { type: errorLabel }));
-        }
-        return false;
-      }
+      if ( errorLabel ) return handleError("DND5E.ADVANCEMENT.ItemChoice.Warning.InvalidType", { type: errorLabel });
     }
 
     // If spell level is restricted, ensure the spell is of the appropriate level
     const l = parseInt(restriction.level);
     if ( (type === "spell") && !Number.isNaN(l) && (item.system.level !== l) ) {
       const level = CONFIG.DND5E.spellLevels[l];
-      if ( strict ) {
-        throw new Error(game.i18n.format("DND5E.ADVANCEMENT.ItemChoice.Warning.SpellLevelSpecific", { level }));
-      }
-      return false;
+      return handleError("DND5E.ADVANCEMENT.ItemChoice.Warning.SpellLevelSpecific", { level });
     }
 
     // If spell list is specified, ensure the spell is on that list
-    if ( (type === "spell") && restriction.list ) {
-      const list = dnd5e.registry.spellLists.forType(...restriction.list.split("."));
-      if ( !list?.has(item) ) {
-        if ( strict ) {
-          throw new Error(game.i18n.format("DND5E.ADVANCEMENT.ItemChoice.Warning.SpellList", { list: list.name }));
-        }
-        return false;
-      }
+    if ( (type === "spell") && restriction.list.size ) {
+      const lists = Array.from(restriction.list)
+        .map(l => dnd5e.registry.spellLists.forType(...l.split(".")))
+        .filter(_ => _);
+      if ( !lists.some(l => l.has(item)) ) return handleError("DND5E.ADVANCEMENT.ItemChoice.Warning.SpellList", {
+        lists: game.i18n.getListFormatter({ type: "disjunction" }).format(lists.map(l => l.name))
+      });
     }
 
     return true;

--- a/module/documents/advancement/item-choice.mjs
+++ b/module/documents/advancement/item-choice.mjs
@@ -198,6 +198,17 @@ export default class ItemChoiceAdvancement extends ItemGrantAdvancement {
       return false;
     }
 
+    // If spell list is specified, ensure the spell is on that list
+    if ( (type === "spell") && restriction.list ) {
+      const list = dnd5e.registry.spellLists.forType(...restriction.list.split("."));
+      if ( !list?.has(item) ) {
+        if ( strict ) {
+          throw new Error(game.i18n.format("DND5E.ADVANCEMENT.ItemChoice.Warning.SpellList", { list: list.name }));
+        }
+        return false;
+      }
+    }
+
     return true;
   }
 }

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -285,7 +285,7 @@ class SpellListRegistry {
       const lists = this.#byType.get(type);
       if ( !lists ) return [];
       return Array.from(lists.entries())
-        .map(([value, list]) => ({ value, label: list.name, group, type }))
+        .map(([value, list]) => ({ value: `${type}.${value}`, label: list.name, group, type }))
         .sort((lhs, rhs) => lhs.label.localeCompare(rhs.label, game.i18n.lang));
     }).flat();
   }
@@ -376,7 +376,8 @@ export class SpellList {
    * @enum {string}
    */
   static #REGISTRIES = {
-    class: "classes"
+    class: "classes",
+    subclass: "subclasses"
   };
 
   /* -------------------------------------------- */
@@ -474,6 +475,18 @@ export class SpellList {
     }
 
     return added;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Determine whether the provided spell is included in the list.
+   * @param {Item5e|string} spell  Spell item or a compendium UUID.
+   * @returns {boolean}
+   */
+  has(spell) {
+    if ( spell instanceof Item ) spell = spell._stats?.compendiumSource ?? spell.uuid;
+    return this.#spells.has(spell);
   }
 
   /* -------------------------------------------- */
@@ -597,5 +610,6 @@ export default {
   messages: MessageRegistry,
   ready: RegistryStatus.ready,
   spellLists: SpellListRegistry,
+  subclasses: new ItemRegistry("subclass"),
   summons: SummonRegistry
 };

--- a/templates/advancement/item-choice-config-details.hbs
+++ b/templates/advancement/item-choice-config-details.hbs
@@ -17,6 +17,8 @@
     {{#if @root.showSpellConfig}}
     {{ formGroup fields.level name="configuration.restriction.level" value=data.level
                  options=@root.levelRestrictionOptions rootId=@root.partId }}
+    {{ formGroup fields.list name="configuration.restriction.list" value=data.list options=@root.listRestrictionOptions
+                 rootId=@root.partId }}
     {{/if}}
     {{/with}}
     {{/with}}


### PR DESCRIPTION
Adds a new restriction when the spell type is selected in the item choice advancement that only allows spells from a specific spell list.

Also adds a subclass registry to match the class one to improve the naming of subclass spell lists.

Closes #5137