### PR TITLE
Fix nested keys values retrieving

### DIFF
--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -227,7 +227,7 @@ export default function ActorSheetV2Mixin(Base) {
 
       // Character Flags
       for ( const [key, config] of Object.entries(CONFIG.DND5E.characterFlags) ) {
-        const flag = { ...config, name: `flags.dnd5e.${key}`, value: flags.data[key] };
+        const flag = { ...config, name: `flags.dnd5e.${key}`, value: foundry.utils.getProperty(flags.data, key) };
         const fieldOptions = { label: config.name, hint: config.hint };
         if ( config.type === Boolean ) {
           flag.field = new foundry.data.fields.BooleanField(fieldOptions);


### PR DESCRIPTION
Been using nested keys such as `dnd5e.crafting.rune` and `dnd5e.crafting.alchemy`. Current special traits tab never retrieved values properly.