### PR TITLE
[#5156] Add dialog for splitting items in inventory into two stacks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4240,6 +4240,11 @@
 "DND5E.SpellUsage": "Spell Usage",
 "DND5E.Spellbook": "Spellbook",
 "DND5E.Spent": "Spent",
+"DND5E.SplitStack": {
+  "Action": "Split",
+  "Title": "Split Stack"
+},
+
 "DND5E.StartingEquipment": {
   "Title": "Starting Equipment",
   "Action": {

--- a/less/elements.less
+++ b/less/elements.less
@@ -29,6 +29,23 @@ copyable-text {
 }
 
 /* ---------------------------------- */
+/*  Double Range Picker               */
+/* ---------------------------------- */
+
+double-range-picker {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  > input[type="range"] { flex: 1; }
+  > input[type="number"] {
+    flex: 0 0 40px;
+    text-align: center;
+    padding: 0;
+    font-size: 0.8em;
+  }
+}
+
+/* ---------------------------------- */
 /*  Filter State                      */
 /* ---------------------------------- */
 

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -540,7 +540,7 @@
     }
   }
 
-  range-picker {
+  range-picker, double-range-picker {
     input[type="range"] {
       --range-thumb-background-color: var(--dnd5e-color-card);
       --range-thumb-border-color: var(--dnd5e-color-gold);

--- a/module/applications/components/_module.mjs
+++ b/module/applications/components/_module.mjs
@@ -3,6 +3,7 @@ import AdoptedStyleSheetMixin from "./adopted-stylesheet-mixin.mjs";
 import CheckboxElement from "./checkbox.mjs";
 import CopyableTextElement from "./copyable-text.mjs";
 import DamageApplicationElement from "./damage-application.mjs";
+import DoubleRangePickerElement from "./double-range-picker.mjs";
 import EffectApplicationElement from "./effect-application.mjs";
 import EffectsElement from "./effects.mjs";
 import EnchantmentApplicationElement from "./enchantment-application.mjs";
@@ -18,6 +19,7 @@ window.customElements.define(CopyableTextElement.tagName, CopyableTextElement);
 window.customElements.define(DamageApplicationElement.tagName, DamageApplicationElement);
 window.customElements.define(ActivitiesElement.tagName, ActivitiesElement);
 window.customElements.define(CheckboxElement.tagName, CheckboxElement);
+window.customElements.define(DoubleRangePickerElement.tagName, DoubleRangePickerElement);
 window.customElements.define(EffectsElement.tagName, EffectsElement);
 window.customElements.define(IconElement.tagName, IconElement);
 window.customElements.define(InventoryElement.tagName, InventoryElement);
@@ -31,6 +33,7 @@ window.customElements.define(SlideToggleElement.tagName, SlideToggleElement);
 
 export {
   ActivitiesElement, AdoptedStyleSheetMixin, CopyableTextElement, CheckboxElement, DamageApplicationElement,
-  EffectApplicationElement, EffectsElement, EnchantmentApplicationElement, FiligreeBoxElement, FilterStateElement,
-  IconElement, InventoryElement, ItemListControlsElement, ProficiencyCycleElement, SlideToggleElement
+  DoubleRangePickerElement, EffectApplicationElement, EffectsElement, EnchantmentApplicationElement,
+  FiligreeBoxElement, FilterStateElement, IconElement, InventoryElement, ItemListControlsElement,
+  ProficiencyCycleElement, SlideToggleElement
 };

--- a/module/applications/components/double-range-picker.mjs
+++ b/module/applications/components/double-range-picker.mjs
@@ -1,0 +1,102 @@
+/**
+ * Version of the default range picker that has number inputs on both sides.
+ */
+export default class DoubleRangePickerElement extends foundry.applications.elements.HTMLRangePickerElement {
+  constructor() {
+    super();
+    this.#min = Number(this.getAttribute("min")) ?? 0;
+    this.#max = Number(this.getAttribute("max")) ?? 1;
+  }
+
+  /** @override */
+  static tagName = "double-range-picker";
+
+  /**
+   * The range input.
+   * @type {HTMLInputElement}
+   */
+  #rangeInput;
+
+  /**
+   * The left number input.
+   * @type {HTMLInputElement}
+   */
+  #leftInput;
+
+  /**
+   * The right number input.
+   * @type {HTMLInputElement}
+   */
+  #rightInput;
+
+  /**
+   * The minimum allowed value for the range.
+   * @type {number}
+   */
+  #min;
+
+  /**
+   * The maximum allowed value for the range.
+   * @type {number}
+   */
+  #max;
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _buildElements() {
+    const [range, right] = super._buildElements();
+    this.#rangeInput = range;
+    this.#rightInput = right;
+    this.#leftInput = this.#rightInput.cloneNode();
+    return [this.#leftInput, this.#rangeInput, this.#rightInput];
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _refresh() {
+    super._refresh();
+    if ( !this.#rangeInput ) return;
+    this.#leftInput.valueAsNumber = this.#max - this.#rightInput.valueAsNumber + this.#min;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _activateListeners() {
+    super._activateListeners();
+    this.#rangeInput.addEventListener("input", this.#onDragSlider.bind(this));
+    this.#leftInput.addEventListener("change", this.#onChangeInput.bind(this));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Update display of the number input as the range slider is actively changed.
+   * @param {InputEvent} event     The originating input event
+   */
+  #onDragSlider(event) {
+    event.preventDefault();
+    this.#leftInput.valueAsNumber = this.#max - this.#rangeInput.valueAsNumber + this.#min;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle changes to the left input.
+   * @param {InputEvent} event     The originating input change event
+   */
+  #onChangeInput(event) {
+    event.stopPropagation();
+    this.value = this.#max - event.currentTarget.valueAsNumber + this.#min;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _toggleDisabled(disabled) {
+    super._toggleDisabled(disabled);
+    this.#leftInput.toggleAttribute("disabled", disabled);
+  }
+}

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -2,6 +2,7 @@ import ContextMenu5e from "../context-menu.mjs";
 import UtilityActivity from "../../documents/activity/utility.mjs";
 import CurrencyManager from "../currency-manager.mjs";
 import ItemSheet5e from "../item/item-sheet.mjs";
+import SplitStackDialog from "../item/split-stack-dialog.mjs";
 import { parseInputDelta } from "../../utils.mjs";
 import Item5e from "../../documents/item.mjs";
 
@@ -371,6 +372,12 @@ export default class InventoryElement extends (foundry.applications.elements.Ado
         const scroll = await Item.implementation.createScrollFromSpell(item);
         if ( scroll ) void Item.implementation.create(scroll, { parent: this.actor });
       }
+    }, {
+      label: "DND5E.SplitStack.Title",
+      icon: '<i class="fa-solid fa-arrows-split-up-and-left"></i>',
+      visible: () => item.isOwner && !compendiumLocked && ((item.system.quantity ?? 0) > 1),
+      onClick: () => new SplitStackDialog({ document: item }).render({ force: true }),
+      group: "action"
     }, {
       label: "DND5E.ConcentrationBreak",
       icon: '<dnd5e-icon src="systems/dnd5e/icons/svg/break-concentration.svg"></dnd5e-icon>',

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -376,7 +376,10 @@ export default class InventoryElement extends (foundry.applications.elements.Ado
       label: "DND5E.SplitStack.Title",
       icon: '<i class="fa-solid fa-arrows-split-up-and-left"></i>',
       visible: () => item.isOwner && !compendiumLocked && ((item.system.quantity ?? 0) > 1),
-      onClick: () => new SplitStackDialog({ document: item }).render({ force: true }),
+      onClick: () => {
+        if ( item.system.quantity === 2 ) item.system.split();
+        else new SplitStackDialog({ document: item }).render({ force: true })
+      },
       group: "action"
     }, {
       label: "DND5E.ConcentrationBreak",

--- a/module/applications/item/split-stack-dialog.mjs
+++ b/module/applications/item/split-stack-dialog.mjs
@@ -1,0 +1,69 @@
+import Dialog5e from "../api/dialog.mjs";
+
+/**
+ * Small dialog for splitting a stack of items into two.
+ */
+export default class SplitStackDialog extends Dialog5e {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    buttons: [{
+      id: "split",
+      label: "DND5E.SplitStack.Action",
+      icon: "fa-solid fa-arrows-split-up-and-left"
+    }],
+    classes: ["split-stack"],
+    document: null,
+    form: {
+      handler: SplitStackDialog.#handleFormSubmission
+    },
+    position: {
+      width: 400
+    },
+    window: {
+      title: "DND5E.SplitStack.Title"
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static PARTS = {
+    ...super.PARTS,
+    content: {
+      template: "systems/dnd5e/templates/apps/split-stack-dialog.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContentContext(context, options) {
+    const total = this.options.document.system.quantity ?? 1;
+    context.max = Math.max(1, total - 1);
+    context.left = Math.ceil(total / 2);
+    context.right = total - context.left;
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle submission of the dialog.
+   * @this {SplitStackDialog}
+   * @param {Event|SubmitEvent} event    The form submission event.
+   * @param {HTMLFormElement} form       The submitted form.
+   * @param {FormDataExtended} formData  Data from the dialog.
+   */
+  static async #handleFormSubmission(event, form, formData) {
+    const right = formData.object.right ?? 0;
+    const left = (this.options.document.system.quantity ?? 1) - right;
+    if ( left === this.options.document.system.quantity ) return;
+    await this.options.document.update({ "system.quantity": left }, { render: false });
+    await this.options.document.clone({ "system.quantity": right }, { addSource: true, save: true });
+    this.close();
+  }
+}

--- a/module/applications/item/split-stack-dialog.mjs
+++ b/module/applications/item/split-stack-dialog.mjs
@@ -59,11 +59,17 @@ export default class SplitStackDialog extends Dialog5e {
    * @param {FormDataExtended} formData  Data from the dialog.
    */
   static async #handleFormSubmission(event, form, formData) {
+    const doc = this.options.document;
     const right = formData.object.right ?? 0;
-    const left = (this.options.document.system.quantity ?? 1) - right;
-    if ( left === this.options.document.system.quantity ) return;
-    await this.options.document.update({ "system.quantity": left }, { render: false });
-    await this.options.document.clone({ "system.quantity": right }, { addSource: true, save: true });
+    const left = (doc.system.quantity ?? 1) - right;
+    if ( left === doc.system.quantity ) return;
+    const clone = doc.clone({ "system.quantity": right }, { addSource: true });
+    await foundry.documents.modifyBatch([
+      {
+        action: "update", documentName: "Item", updates: [{ _id: doc.id, "system.quantity": left }], parent: doc.parent
+      },
+      { action: "create", documentName: "Item", data: [clone.toObject()], parent: doc.parent }
+    ]);
     this.close();
   }
 }

--- a/module/applications/item/split-stack-dialog.mjs
+++ b/module/applications/item/split-stack-dialog.mjs
@@ -59,17 +59,7 @@ export default class SplitStackDialog extends Dialog5e {
    * @param {FormDataExtended} formData  Data from the dialog.
    */
   static async #handleFormSubmission(event, form, formData) {
-    const doc = this.options.document;
-    const right = formData.object.right ?? 0;
-    const left = (doc.system.quantity ?? 1) - right;
-    if ( left === doc.system.quantity ) return;
-    const clone = doc.clone({ "system.quantity": right }, { addSource: true });
-    await foundry.documents.modifyBatch([
-      {
-        action: "update", documentName: "Item", updates: [{ _id: doc.id, "system.quantity": left }], parent: doc.parent
-      },
-      { action: "create", documentName: "Item", data: [clone.toObject()], parent: doc.parent }
-    ]);
+    await this.options.document.system.split(formData.object.right ?? 0);
     this.close();
   }
 }

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -384,6 +384,25 @@ export default class PhysicalItemTemplate extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
+   * Split a stack of this item into two.
+   * @param {number} [splitQuantity=1]  Number of items to split off into a new stack.
+   * @returns {Promise}
+   */
+  split(splitQuantity=1) {
+    const remainingQuantity = this.quantity - splitQuantity;
+    if ( (splitQuantity <= 0) || (remainingQuantity <= 0) ) return;
+
+    const clone = this.parent.clone({ "system.quantity": splitQuantity }, { addSource: true });
+    const details = { documentName: "Item", parent: this.parent.actor, pack: this.parent.pack };
+    return foundry.documents.modifyBatch([
+      { action: "update", updates: [{ _id: this.parent.id, "system.quantity": remainingQuantity }], ...details },
+      { action: "create", data: [clone.toObject()], ...details }
+    ]);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Calculate the total weight and return it in specific units.
    * @param {string} units  Units in which the weight should be returned.
    * @returns {number|Promise<number>}

--- a/templates/apps/split-stack-dialog.hbs
+++ b/templates/apps/split-stack-dialog.hbs
@@ -1,0 +1,3 @@
+<section class="flexrow">
+    <double-range-picker name="right" value="{{ right }}" min="1" max="{{ max }}" step="1"></double-range-picker>
+</section>


### PR DESCRIPTION
Adds a "Split Stack" context menu option for an item that has a quantity of at least 2. Contains a modified version of core's `<range-picker>` element that has a number input on the left side. ~~This modified element won't be required if
https://github.com/foundryvtt/foundryvtt/issues/12147 is resolved.~~

Closes #5156