### PR TITLE
[#5133] Add HP bar to short rest dialog

### DIFF
--- a/less/v2/actors.less
+++ b/less/v2/actors.less
@@ -237,69 +237,28 @@
   /*  Meters                            */
   /* ---------------------------------- */
 
-  .bars .bar {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-
-    label {
-      flex: 0 0 25px;
-      text-transform: uppercase;
-      font-weight: bold;
-      color: var(--dnd5e-color-gold);
-      text-align: center;
-      font-size: var(--font-size-11);
-    }
-
-    .meter {
-      --border-width: 0;
-      flex: 1;
-      height: 8px;
-
-      &.hit-points::before { background: linear-gradient(to right, var(--dnd5e-color-hp-1) 0%, var(--dnd5e-color-hp-2) 100%); }
-      &.hit-dice::before { background: linear-gradient(to right, var(--dnd5e-color-hd-1) 0%, var(--dnd5e-color-hd-2) 100%); }
-      &.uses::before { background: linear-gradient(to right, #023491 0%, var(--dnd5e-color-blue) 100%,); }
-    }
-
-    .values {
-      flex: 0 0 48px;
-      font-weight: bold;
-      font-size: var(--font-size-11);
-      text-shadow: var(--group-vitals-shadow);
-    }
-  }
-
   .meter {
-    &.hit-points {
-      height: 32px;
-      font-size: var(--font-size-16);
+    &.meter-lg {
+      &.hit-points {
+        height: 32px;
+        font-size: var(--font-size-16);
 
-      .progress::before {
-        background: linear-gradient(to right, var(--dnd5e-color-hp-1) 0%, var(--dnd5e-color-hp-2) 100%);
-        border-inline-end: none;
+        .progress::before {
+          background: linear-gradient(to right, var(--dnd5e-color-hp-1) 0%, var(--dnd5e-color-hp-2) 100%);
+          border-inline-end: none;
+        }
+        .temp-positive .label :is(.max, .bonus) { color: color-mix(in oklab, currentcolor, blue 25%); }
+        .temp-negative .label :is(.max, .bonus) { color: color-mix(in oklab, currentcolor, red 25%); }
       }
-      .temp-positive .label :is(.max, .bonus) { color: color-mix(in oklab, currentcolor, blue 25%); }
-      .temp-negative .label :is(.max, .bonus) { color: color-mix(in oklab, currentcolor, red 25%); }
-    }
 
-    &.hit-dice {
-      height: 25px;
-      font-size: var(--font-size-14);
+      &.hit-dice {
+        height: 25px;
+        font-size: var(--font-size-14);
 
-      &.progress::before {
-        background: linear-gradient(to right, var(--dnd5e-color-hd-1) 0%, var(--dnd5e-color-hd-2) 100%);
-        border-inline-end: none;
-      }
-    }
-
-    &.hit-points, &.hit-dice, &.uses {
-      &.progress::before, .progress::before {
-        block-size: unset;
-        clip-path: unset;
-        box-shadow: inset 0 1px 0 1px var(--dnd5e-highlight-40);
-        inset: 1px auto 1px 1px;
-        inline-size: calc(var(--bar-percentage) - 2px);
-        border-radius: 2px;
+        &.progress::before {
+          background: linear-gradient(to right, var(--dnd5e-color-hd-1) 0%, var(--dnd5e-color-hd-2) 100%);
+          border-inline-end: none;
+        }
       }
     }
 

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -742,54 +742,6 @@
     + .meter-group { margin-block-start: .5rem; }
   }
 
-  .meter {
-    border: 1px solid var(--dnd5e-color-gold);
-    border-radius: 4px;
-    background: var(--meter-background);
-    font-family: var(--dnd5e-font-roboto);
-    font-weight: bold;
-    box-shadow: inset 0 0 16px rgb(0 0 0 / 25%);
-    position: relative;
-    display: flex;
-    align-items: center;
-    overflow: hidden;
-
-    &.progress, .progress {
-      --bar-percentage: 0%;
-      --border-width: 3px;
-      overflow: hidden;
-
-      &::before {
-        content: "";
-        position: absolute;
-        block-size: 100%;
-        inline-size: var(--bar-percentage);
-        box-shadow: 0 0 6px var(--dnd5e-shadow-45);
-        clip-path: polygon(0 0, calc(100% + 6px) 0, calc(100% + 6px) 100%, 0 100%);
-      }
-    }
-
-    .label {
-      inline-size: 100%;
-      display: flex;
-      align-items: center;
-      gap: .25rem;
-      position: relative;
-      padding-inline-start: 8px;
-      padding-inline-end: 12px;
-      color: var(--color-text-light-0);
-
-      &[hidden] { display: none; }
-      .value, .max { text-shadow: 0 0 4px var(--dnd5e-color-gold); }
-      .separator { color: var(--dnd5e-color-gold); }
-      .bonus {
-        margin-inline-start: auto;
-        font-size: var(--font-size-14);
-        opacity: .8;
-      }
-    }
-  }
-
   /* ---------------------------------- */
   /*  Slots                             */
   /* ---------------------------------- */
@@ -1892,43 +1844,21 @@ dialog.dnd5e2.application {
 /* ---------------------------------- */
 
 .rest.application {
-  @keyframes fade-in-out {
-    50% {opacity: 10%;}
-  }
   .window-content > section.flexcol { gap: 12px; }
   [data-action="rollHitDie"] { flex: 0; }
 
-  .meter.hit-points {
-    height: 32px;
-    font-size: var(--font-size-16);
+  .bar.hit-points {
+    margin: 4px 0 0 -4px;
 
-    > div {
-      height: 100%;
+    .meter:not(.full)::before { border-radius: 2px 0 0 2px; }
+
+    .progress-potential-min, .progress-potential-max {
+      position: absolute;
+      inset-block: 1px;
     }
 
-    .label {
-      z-index: 4;
-    }
-  
-    .progress-potential-max {
-      z-index: 1;
-      background: linear-gradient(to right, var(--dnd5e-color-hp-1) 0%, var(--dnd5e-color-hp-3) 100%);
-      position: absolute;
-      animation: fade-in-out 2s infinite;
-    }
-  
-    .progress-potential-min {
-      z-index: 2;
-      background-color: var(--dnd5e-color-hp-1);
-      position: absolute;
-      animation: fade-in-out 2s infinite;
-    }
-  
-    .progress {
-      z-index: 3;
-      background: linear-gradient(to right, var(--dnd5e-color-hp-1) 0%, var(--dnd5e-color-hp-2) 100%);
-      position: absolute;
-    }
+    .progress-potential-min { background: var(--dnd5e-color-hp-2); }
+    .progress-potential-max { background: var(--dnd5e-color-hp-1); }
   }
 }
 

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1892,6 +1892,9 @@ dialog.dnd5e2.application {
 /* ---------------------------------- */
 
 .rest.application {
+  @keyframes fade-in-out {
+    50% {opacity: 10%;}
+  }
   .window-content > section.flexcol { gap: 12px; }
   [data-action="rollHitDie"] { flex: 0; }
 
@@ -1909,14 +1912,16 @@ dialog.dnd5e2.application {
   
     .progress-potential-max {
       z-index: 1;
-      background: linear-gradient(to right, #d9313138 0%, #bb777738 100%);
+      background: linear-gradient(to right, var(--dnd5e-color-hp-1) 0%, var(--dnd5e-color-hp-3) 100%);
       position: absolute;
+      animation: fade-in-out 2s infinite;
     }
   
     .progress-potential-min {
       z-index: 2;
-      background-color: #d93131;
+      background-color: var(--dnd5e-color-hp-1);
       position: absolute;
+      animation: fade-in-out 2s infinite;
     }
   
     .progress {

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1894,6 +1894,39 @@ dialog.dnd5e2.application {
 .rest.application {
   .window-content > section.flexcol { gap: 12px; }
   [data-action="rollHitDie"] { flex: 0; }
+
+  .healthbar {
+    width: 100%;
+    height: 20px;
+    border-radius: 5px;
+    overflow: hidden;
+    
+    > div {
+      height: 100%;
+    }
+
+    .progress-potential {
+      z-index: 1;
+      background-color: #bb7777;
+    }
+
+    .progress {
+      z-index: 2;
+      background-color: #d93131;
+      position: relative;
+      top: -20px;
+    }
+
+    .overlay {
+      z-index: 3;
+      position: relative;
+      top: -40px;
+      text-align: center;
+      color: white;
+      box-shadow: 0 0 2px 2px inset rgb(0 0 0 / 25%);
+      line-height: 20px;
+    }
+  }
 }
 
 /* ---------------------------------- */

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1895,36 +1895,34 @@ dialog.dnd5e2.application {
   .window-content > section.flexcol { gap: 12px; }
   [data-action="rollHitDie"] { flex: 0; }
 
-  .healthbar {
-    width: 100%;
-    height: 20px;
-    border-radius: 5px;
-    overflow: hidden;
-    
+  .meter.hit-points {
+    height: 32px;
+    font-size: var(--font-size-16);
+
     > div {
       height: 100%;
     }
 
-    .progress-potential {
-      z-index: 1;
-      background-color: #bb7777;
+    .label {
+      z-index: 4;
     }
-
-    .progress {
+  
+    .progress-potential-max {
+      z-index: 1;
+      background: linear-gradient(to right, #d9313138 0%, #bb777738 100%);
+      position: absolute;
+    }
+  
+    .progress-potential-min {
       z-index: 2;
       background-color: #d93131;
-      position: relative;
-      top: -20px;
+      position: absolute;
     }
-
-    .overlay {
+  
+    .progress {
       z-index: 3;
-      position: relative;
-      top: -40px;
-      text-align: center;
-      color: white;
-      box-shadow: 0 0 2px 2px inset rgb(0 0 0 / 25%);
-      line-height: 20px;
+      background: linear-gradient(to right, var(--dnd5e-color-hp-1) 0%, var(--dnd5e-color-hp-2) 100%);
+      position: absolute;
     }
   }
 }

--- a/less/v2/blocks.less
+++ b/less/v2/blocks.less
@@ -301,4 +301,107 @@
       justify-self: end;
     }
   }
+
+  /* ---------------------------------- */
+  /*  Meters                            */
+  /* ---------------------------------- */
+
+  .bar {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+
+    label {
+      color: var(--dnd5e-color-gold);
+      flex: 0 0 25px;
+      font-size: var(--font-size-11);
+      font-weight: bold;
+      text-align: center;
+      text-transform: uppercase;
+    }
+
+    .values {
+      flex: 0 0 48px;
+      font-weight: bold;
+      font-size: var(--font-size-11);
+      text-shadow: var(--group-vitals-shadow);
+    }
+  }
+
+  .meter {
+    align-items: center;
+    background: var(--meter-background);
+    border: 1px solid var(--dnd5e-color-gold);
+    border-radius: 4px;
+    box-shadow: inset 0 0 16px rgb(0 0 0 / 25%);
+    display: flex;
+    font-family: var(--dnd5e-font-roboto);
+    font-weight: bold;
+    overflow: hidden;
+    position: relative;
+
+    &.progress, .progress {
+      --bar-percentage: 0%;
+      --border-width: 3px;
+      overflow: hidden;
+
+      &::before {
+        block-size: 100%;
+        box-shadow: 0 0 6px var(--dnd5e-shadow-45);
+        clip-path: polygon(0 0, calc(100% + 6px) 0, calc(100% + 6px) 100%, 0 100%);
+        content: "";
+        inline-size: var(--bar-percentage);
+        position: absolute;
+      }
+    }
+
+    &.progress::before {
+      --bar-color-2: color-mix(in oklab, var(--dnd5e-color-blue), var(--dnd5e-color-maroon) var(--bar-percentage));
+      --bar-color-1: color-mix(in oklab, var(--bar-color-2), black 33%);
+      --bar-color-3: color-mix(in oklab, var(--bar-color-2), black 20%);
+      background: linear-gradient(to right, var(--bar-color-1), var(--bar-color-2));
+      border-right: var(--border-width) solid var(--bar-color-3);
+    }
+
+    .label {
+      align-items: center;
+      color: var(--color-text-light-0);
+      display: flex;
+      inline-size: 100%;
+      gap: .25rem;
+      padding-inline-start: 8px;
+      padding-inline-end: 12px;
+      position: relative;
+
+      &[hidden] { display: none; }
+      .value, .max { text-shadow: 0 0 4px var(--dnd5e-color-gold); }
+      .separator { color: var(--dnd5e-color-gold); }
+      .bonus {
+        font-size: var(--font-size-14);
+        opacity: .8;
+        margin-inline-start: auto;
+      }
+    }
+
+    &.hit-points, &.hit-dice, &.uses {
+      &.progress::before, .progress::before {
+        block-size: unset;
+        border-radius: 2px;
+        box-shadow: inset 0 1px 0 1px var(--dnd5e-highlight-40);
+        clip-path: unset;
+        inline-size: calc(var(--bar-percentage) - 2px);
+        inset: 1px auto 1px 1px;
+      }
+    }
+
+    &.meter-sm {
+      --border-width: 0;
+      flex: 1;
+      height: 8px;
+
+      &.hit-points::before { background: linear-gradient(to right, var(--dnd5e-color-hp-1) 0%, var(--dnd5e-color-hp-2) 100%); }
+      &.hit-dice::before { background: linear-gradient(to right, var(--dnd5e-color-hd-1) 0%, var(--dnd5e-color-hd-2) 100%); }
+      &.uses::before { background: linear-gradient(to right, #023491 0%, var(--dnd5e-color-blue) 100%); }
+    }
+  }
 }

--- a/less/v2/sheets.less
+++ b/less/v2/sheets.less
@@ -116,15 +116,6 @@ body.detached .dnd5e2.sheet .tab { max-height: unset; }
   /*  Sheet Body                        */
   /* ---------------------------------- */
 
-  .meter.progress::before {
-    // Becomes more red the closer it is to 100% encumbrance.
-    --bar-color-2: color-mix(in oklab, var(--dnd5e-color-blue), var(--dnd5e-color-maroon) var(--bar-percentage));
-    --bar-color-1: color-mix(in oklab, var(--bar-color-2), black 33%);
-    --bar-color-3: color-mix(in oklab, var(--bar-color-2), black 20%);
-    background: linear-gradient(to right, var(--bar-color-1), var(--bar-color-2));
-    border-right: var(--border-width) solid var(--bar-color-3);
-  }
-
   /* Encumbrance */
   .encumbrance, .difficulty {
     display: flex;

--- a/module/applications/actor/rest/short-rest-dialog.mjs
+++ b/module/applications/actor/rest/short-rest-dialog.mjs
@@ -88,13 +88,15 @@ export default class ShortRestDialog extends BaseRestDialog {
     const numericalDenom = Number(context.hitDice.denomination?.slice(1));
     if ( numericalDenom ) {
       const { value: currHP, max: maxHP } = this.actor.system.attributes.hp;
-      context.healthBarText = `${game.i18n.localize("DND5E.HP")}: ${currHP} / ${maxHP}`;
       context.progressBar = 100 * currHP / maxHP;
-      let potentialRegain = numericalDenom;
+      let minRegain = Math.max(1 + this.actor.system.abilities.con.mod, 1);
+      let maxRegain = Math.max(numericalDenom + this.actor.system.abilities.con.mod, 1);
       if (context.config.autoHD) {
-        potentialRegain = context.hitDice.options.reduce((arr, hd) => arr + (Number(hd.value.slice(1)) * hd.number), 0);
+        minRegain = minRegain * context.hd.value;
+        maxRegain = context.hitDice.options.reduce((arr, hd) => arr + (Number(hd.value.slice(1)) * hd.number), 0);
       }
-      context.progressBarPotential = 100 * (currHP + potentialRegain) / maxHP;
+      context.potentialMin = 100 * (currHP + minRegain) / maxHP;
+      context.potentialMax = 100 * (currHP + maxRegain) / maxHP;
     }
 
     return context;

--- a/module/applications/actor/rest/short-rest-dialog.mjs
+++ b/module/applications/actor/rest/short-rest-dialog.mjs
@@ -85,22 +85,21 @@ export default class ShortRestDialog extends BaseRestDialog {
       });
     }
 
-    const numericalDenom = Number(context.hitDice.denomination?.slice(1));
-    if ( numericalDenom ) {
-      const { value: currHP, max: maxHP } = this.actor.system.attributes.hp;
-      context.progressBar = 100 * currHP / maxHP;
-      const conMod = this.actor.system.abilities.con.mod;
-      let minRegain = Math.max(1 + conMod, 1);
-      let maxRegain = Math.max(numericalDenom + conMod, 1);
-      if (context.config.autoHD) {
+    const denom = Number(context.hitDice.denomination?.slice(1));
+    if ( denom ) {
+      const { pct, effectiveMax: max } = this.actor.system.attributes.hp;
+      context.progress = { pct };
+      const con = this.actor.system.abilities.con.mod;
+      let minRegain = Math.max(1 + con, 1);
+      let maxRegain = Math.max(denom + con, 1);
+      if ( context.config.autoHD ) {
         minRegain = minRegain * context.hd.value;
         maxRegain = context.hitDice.options.reduce((acc, hd) => {
-          return acc + (Math.max(Number(hd.value.slice(1)) + conMod, 1) * hd.number);
+          return acc + (Math.max(Number(hd.value.slice(1)) + con, 1) * hd.number);
         }, 0);
       }
-      context.potentialMin = 100 * minRegain / maxHP;
-      context.potentialMax = 100 * maxRegain / maxHP;
-      context.maxLeft = context.potentialMin + context.progressBar;
+      context.progress.potential = { max: 100 * (maxRegain - minRegain) / max, min: 100 * minRegain / max };
+      context.progress.left = context.progress.potential.min + pct;
     }
 
     return context;

--- a/module/applications/actor/rest/short-rest-dialog.mjs
+++ b/module/applications/actor/rest/short-rest-dialog.mjs
@@ -89,14 +89,18 @@ export default class ShortRestDialog extends BaseRestDialog {
     if ( numericalDenom ) {
       const { value: currHP, max: maxHP } = this.actor.system.attributes.hp;
       context.progressBar = 100 * currHP / maxHP;
-      let minRegain = Math.max(1 + this.actor.system.abilities.con.mod, 1);
-      let maxRegain = Math.max(numericalDenom + this.actor.system.abilities.con.mod, 1);
+      const conMod = this.actor.system.abilities.con.mod;
+      let minRegain = Math.max(1 + conMod, 1);
+      let maxRegain = Math.max(numericalDenom + conMod, 1);
       if (context.config.autoHD) {
         minRegain = minRegain * context.hd.value;
-        maxRegain = context.hitDice.options.reduce((arr, hd) => arr + (Number(hd.value.slice(1)) * hd.number), 0);
+        maxRegain = context.hitDice.options.reduce((acc, hd) => {
+          return acc + (Math.max(Number(hd.value.slice(1)) + conMod, 1) * hd.number);
+        }, 0);
       }
-      context.potentialMin = 100 * (currHP + minRegain) / maxHP;
-      context.potentialMax = 100 * (currHP + maxRegain) / maxHP;
+      context.potentialMin = 100 * minRegain / maxHP;
+      context.potentialMax = 100 * maxRegain / maxHP;
+      context.maxLeft = context.potentialMin + context.progressBar;
     }
 
     return context;

--- a/module/applications/actor/rest/short-rest-dialog.mjs
+++ b/module/applications/actor/rest/short-rest-dialog.mjs
@@ -56,7 +56,8 @@ export default class ShortRestDialog extends BaseRestDialog {
         denomination: `d${hd.denomination}`,
         options: [{
           value: `d${hd.denomination}`,
-          label: `d${hd.denomination} (${_loc("DND5E.HITDICE.Available", { number: hd.value })})`
+          label: `d${hd.denomination} (${_loc("DND5E.HITDICE.Available", { number: hd.value })})`,
+          number: hd.value
         }]
       };
     }
@@ -68,7 +69,7 @@ export default class ShortRestDialog extends BaseRestDialog {
           value, label: `${value} (${_loc("DND5E.HITDICE.Available", { number })})`, number
         }))
       };
-      context.denomination = (this.actor.system.attributes.hd.bySize[this.#denom] > 0)
+      context.hitDice.denomination = (this.actor.system.attributes.hd.bySize[this.#denom] > 0)
         ? this.#denom : context.hitDice.options.find(o => o.number > 0)?.value;
     }
 
@@ -82,6 +83,18 @@ export default class ShortRestDialog extends BaseRestDialog {
         name: "autoHD",
         value: context.config.autoHD
       });
+    }
+
+    const numericalDenom = Number(context.hitDice.denomination?.slice(1));
+    if ( numericalDenom ) {
+      const { value: currHP, max: maxHP } = this.actor.system.attributes.hp;
+      context.healthBarText = `${game.i18n.localize("DND5E.HP")}: ${currHP} / ${maxHP}`;
+      context.progressBar = 100 * currHP / maxHP;
+      let potentialRegain = numericalDenom;
+      if (context.config.autoHD) {
+        potentialRegain = context.hitDice.options.reduce((arr, hd) => arr + (Number(hd.value.slice(1)) * hd.number), 0);
+      }
+      context.progressBarPotential = 100 * (currHP + potentialRegain) / maxHP;
     }
 
     return context;
@@ -101,6 +114,15 @@ export default class ShortRestDialog extends BaseRestDialog {
     this.#denom = this.form.denom.value;
     await this.actor.rollHitDie({ denomination: this.#denom });
     foundry.utils.mergeObject(this.config, new foundry.applications.ux.FormDataExtended(this.form).object);
+    this.render();
+  }
+
+  /* -------------------------------------------- */
+
+  _onChangeForm(formConfig, event) {
+    super._onChangeForm(formConfig, event);
+    this.#denom = this.form.denom.value;
+    foundry.utils.mergeObject(this.config, new FormDataExtended(this.form).object);
     this.render();
   }
 }

--- a/templates/actors/character-sidebar.hbs
+++ b/templates/actors/character-sidebar.hbs
@@ -137,7 +137,7 @@
                     {{/if}}
                 </div>
                 {{#with system.attributes.hp}}
-                <div class="meter sectioned hit-points">
+                <div class="meter sectioned hit-points meter-lg">
                     <div class="progress hit-points
                          {{~#if (gt tempmax 0)}} temp-positive
                          {{~else if (lt tempmax 0)}} temp-negative{{/if}}"
@@ -177,7 +177,7 @@
                     </button>
                     {{/if}}
                 </div>
-                <div class="meter hit-dice progress" role="meter" aria-valuemin="0"
+                <div class="meter hit-dice progress meter-lg" role="meter" aria-valuemin="0"
                      aria-valuenow="{{ value }}" aria-valuemax="{{ max }}"
                      style="--bar-percentage: {{ pct }}%">
                     <div class="label">

--- a/templates/actors/group/member.hbs
+++ b/templates/actors/group/member.hbs
@@ -21,7 +21,7 @@
             {{#if max}}
             <div class="hp-bar bar">
                 <label>{{ localize "DND5E.HP" }}</label>
-                <div class="meter hit-points progress" role="meter" aria-valuemin="0"
+                <div class="meter hit-points progress meter-sm" role="meter" aria-valuemin="0"
                      aria-valuenow="{{ value }}" aria-valuemax="{{ max }}"
                      style="--bar-percentage: {{ pct }}%"></div>
                 <div class="values">
@@ -37,7 +37,7 @@
             {{#with system.attributes.hd}}
             <div class="hd-bar bar">
                 <label>{{ localize "DND5E.HITDICE.Abbreviation" }}</label>
-                <div class="meter hit-dice progress" role="meter" aria-valuemin="0"
+                <div class="meter hit-dice progress meter-sm" role="meter" aria-valuemin="0"
                      aria-valuenow="{{ value }}" aria-valuemax="{{ max }}"
                      style="--bar-percentage: {{ pct }}%"></div>
                 <div class="values">

--- a/templates/actors/npc-header.hbs
+++ b/templates/actors/npc-header.hbs
@@ -132,7 +132,7 @@
 
                 {{!-- HP --}}
                 {{#with system.attributes.hp}}
-                <div class="meter hit-points sectioned">
+                <div class="meter hit-points sectioned meter-lg">
                     <div class="progress hit-points {{#if (gt tempmax 0)}}temp-positive{{else if (lt tempmax 0)~}}
                          temp-negative{{/if}}" role="meter" aria-valuemin="0" aria-valuenow="{{ value }}"
                          aria-valuemax="{{ max }}" style="--bar-percentage: {{ pct }}%">

--- a/templates/actors/rest/parts/hit-dice.hbs
+++ b/templates/actors/rest/parts/hit-dice.hbs
@@ -10,16 +10,22 @@
             <i class="fa-solid fa-dice-d20" inert></i>
         </button>
     </div>
-    <div class="meter hit-points">
-        <div class="label">
-            <span class="value">{{ hp.value }}</span>
-            <span class="separator">/</span>
-            <span class="max">{{ hp.effectiveMax }}</span>
+    {{#with progress}}
+    <div class="hit-points bar">
+        <label>{{ localize "DND5E.HP" }}</label>
+        <div class="meter hit-points progress meter-sm {{#if (gt pct 99)}}full{{/if}}" role="meter" aria-valuemin="0"
+             aria-valuenow="{{ ../hp.value }}" aria-valuemax="{{ ../hp.effectiveMax }}"
+             style="--bar-percentage: {{ pct }}%">
+            <div class="progress-potential-min" style="width: {{ potential.min }}%; left: {{ pct }}%"></div>
+            <div class="progress-potential-max" style="width: {{ potential.max }}%; left: {{ left }}%"></div>
         </div>
-        <div class="progress-potential-max" style="width:{{potentialMax}}%; left:{{maxLeft}}%"></div>
-        <div class="progress-potential-min" style="width:{{potentialMin}}%; left:{{progressBar}}%"></div>
-        <div class="progress" style="width:{{progressBar}}%"></div>
+        <div class="values">
+            <span class="value">{{ ../hp.value }}</span>
+            <span class="separator">&sol;</span>
+            <span class="max">{{ ../hp.effectiveMax }}</span>
+        </div>
     </div>
+    {{/with}}
     {{ formField autoRoll name="autoHD" value=config.autoHD input=inputs.createCheckboxInput rootId=partId }}
 </fieldset>
 {{else}}

--- a/templates/actors/rest/parts/hit-dice.hbs
+++ b/templates/actors/rest/parts/hit-dice.hbs
@@ -10,14 +10,14 @@
             <i class="fa-solid fa-dice-d20" inert></i>
         </button>
     </div>
-    <div class="meter hit-points healthbar">
+    <div class="meter hit-points">
         <div class="label">
             <span class="value">{{ hp.value }}</span>
             <span class="separator">/</span>
             <span class="max">{{ hp.effectiveMax }}</span>
         </div>
-        <div class="progress-potential-max" style="width:{{potentialMax}}%"></div>
-        <div class="progress-potential-min" style="width:{{potentialMin}}%"></div>
+        <div class="progress-potential-max" style="width:{{potentialMax}}%; left:{{maxLeft}}%"></div>
+        <div class="progress-potential-min" style="width:{{potentialMin}}%; left:{{progressBar}}%"></div>
         <div class="progress" style="width:{{progressBar}}%"></div>
     </div>
     {{ formField autoRoll name="autoHD" value=config.autoHD input=inputs.createCheckboxInput rootId=partId }}

--- a/templates/actors/rest/parts/hit-dice.hbs
+++ b/templates/actors/rest/parts/hit-dice.hbs
@@ -10,6 +10,11 @@
             <i class="fa-solid fa-dice-d20" inert></i>
         </button>
     </div>
+    <div class="healthbar">
+        <div class="progress-potential" style="width:{{progressBarPotential}}%"></div>
+        <div class="progress" style="width:{{progressBar}}%"></div>
+        <div class="overlay">{{healthBarText}}</div>
+    </div>
     {{ formField autoRoll name="autoHD" value=config.autoHD input=inputs.createCheckboxInput rootId=partId }}
 </fieldset>
 {{else}}

--- a/templates/actors/rest/parts/hit-dice.hbs
+++ b/templates/actors/rest/parts/hit-dice.hbs
@@ -10,10 +10,15 @@
             <i class="fa-solid fa-dice-d20" inert></i>
         </button>
     </div>
-    <div class="healthbar">
-        <div class="progress-potential" style="width:{{progressBarPotential}}%"></div>
+    <div class="meter hit-points healthbar">
+        <div class="label">
+            <span class="value">{{ hp.value }}</span>
+            <span class="separator">/</span>
+            <span class="max">{{ hp.effectiveMax }}</span>
+        </div>
+        <div class="progress-potential-max" style="width:{{potentialMax}}%"></div>
+        <div class="progress-potential-min" style="width:{{potentialMin}}%"></div>
         <div class="progress" style="width:{{progressBar}}%"></div>
-        <div class="overlay">{{healthBarText}}</div>
     </div>
     {{ formField autoRoll name="autoHD" value=config.autoHD input=inputs.createCheckboxInput rootId=partId }}
 </fieldset>

--- a/templates/actors/vehicle/stations.hbs
+++ b/templates/actors/vehicle/stations.hbs
@@ -85,7 +85,7 @@
 
                 <div class="hp-bar bar">
                     <label>{{ localize "DND5E.HP" }}</label>
-                    <div class="meter hit-points progress" role="meter" aria-valuemin="0" aria-valuenow="{{ value }}"
+                    <div class="meter hit-points progress meter-sm" role="meter" aria-valuemin="0" aria-valuenow="{{ value }}"
                          aria-valuemax="{{ max }}" style="--bar-percentage: {{ pct }}%"></div>
                     <div class="values">
                         <span class="display value">{{ value }}</span>
@@ -109,7 +109,7 @@
 
                 <div class="uses-bar bar">
                     <label>{{ localize "DND5E.Uses" }}</label>
-                    <div class="meter uses progress" role="meter" aria-valuemin="0" aria-valuenow="{{ value }}"
+                    <div class="meter uses progress meter-sm" role="meter" aria-valuemin="0" aria-valuenow="{{ value }}"
                          aria-valuemax="{{ max }}" style="--bar-percentage: {{ pct }}%"></div>
                     <div class="values">
                         <span class="display value">{{ value }}</span>


### PR DESCRIPTION
Closes #5133 
I anticipate some changes to style (colors, primarily - not sure what the ideal dark mode appearance should be wrt the box shadow) and potentially the "preview" part of the hp bar, depending on what the "right" way to show potential regained HP is.

Also happened across a minor bug (`context.denomination` was being set, when it should've been `context.hitDice.denomination`), though the behavior with that fixed and the `_onChangeForm` addition is that when you try to select a "0 remaining" hit die, it doesn't let you. Which doesn't necessarily feel like the _wrong_ behavior, but worth bringing up.