### PR TITLE
Fix damage shortcut key bug introduced by #5015

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4609,7 +4609,7 @@
 "KEYBINDINGS.DND5E.DragMove": "Force Move when Dragging Document",
 "KEYBINDINGS.DND5E.SkipDialogNormal": "Skip Dialog",
 "KEYBINDINGS.DND5E.SkipDialogAdvantage": "Skip Dialog (roll with Advantage/Critical)",
-"KEYBINDINGS.DND5E.SkipDialogDisadvantage": "Skip Dialog (roll with Disadvantage)",
+"KEYBINDINGS.DND5E.SkipDialogDisadvantage": "Skip Dialog (roll with Disadvantage/Non-Critical)",
 
 "MACRO.5eMissingTargetWarn": "Your controlled actor '{actor}' does not have an {type} with name '{name}'.",
 "MACRO.5eMultipleTargetsWarn": "Your controlled actor '{actor}' has more than one {type} with name '{name}'. The first match will be chosen.",

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -97,8 +97,8 @@ export default class DamageRoll extends BasicRoll {
   /** @override */
   static applyKeybindings(config, dialog, message) {
     const keys = {
-      normal: areKeysPressed(config.event, "skipDialogNormal")
-        || areKeysPressed(config.event, "skipDialogDisadvantage"),
+      default: areKeysPressed(config.event, "skipDialogNormal"),
+      normal: areKeysPressed(config.event, "skipDialogDisadvantage"),
       critical: areKeysPressed(config.event, "skipDialogAdvantage")
     };
 
@@ -108,7 +108,7 @@ export default class DamageRoll extends BasicRoll {
     // Determine critical mode
     for ( const roll of config.rolls ) {
       roll.options ??= {};
-      roll.options.isCritical ??= config.isCritical ?? keys.critical;
+      roll.options.isCritical ??= (config.isCritical || keys.critical) && !keys.normal;
     }
   }
 


### PR DESCRIPTION
In #5015 I set `config.isCritical` to `false` or `true`, will only ever be `undefined` if there was no "last attack." Since `applyKeybindings` relied on `config.isCritical` being `undefined` in order to care about holding the critical key down, that functionality broke.

New functionality while clicking damage:
- Holding shift (by default) skips the dialog, doing whatever the default would be
- Holding ctrl (by default) skips the dialog, rolling _normal_ damage regardless of last attack
- Holding alt (by default) skips the dialog, rolling _critical_ damage regardless of last attack