### PR TITLE
Avoid crash when drag-dropping facility to low-level actor

### DIFF
--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -243,7 +243,8 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
     const actor = this.parent?.parent;
     if ( !actor ) return;
     const { basic } = CONFIG.DND5E.facilities.advancement;
-    const [, available = 0] = Object.entries(basic).reverse().find(([level]) => level <= actor.system.details.level) || [];
+    const [, available = 0] = Object.entries(basic).reverse()
+      .find(([level]) => level <= actor.system.details.level) ?? [];
     const existing = actor.itemTypes.facility.filter(f => f.system.type.value === "basic").length;
     const free = available - existing;
     if ( free > 0 ) this.updateSource({ "building.built": true });

--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -243,7 +243,7 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
     const actor = this.parent?.parent;
     if ( !actor ) return;
     const { basic } = CONFIG.DND5E.facilities.advancement;
-    const [, available] = Object.entries(basic).reverse().find(([level]) => level <= actor.system.details.level);
+    const [, available = 0] = Object.entries(basic).reverse().find(([level]) => level <= actor.system.details.level) || [];
     const existing = actor.itemTypes.facility.filter(f => f.system.type.value === "basic").length;
     const free = available - existing;
     if ( free > 0 ) this.updateSource({ "building.built": true });


### PR DESCRIPTION
This change removes a junk error from the log when attempting to drag-drop a facility to a low-level actor. Note that this makes no functional difference, as a level <5 actor will not trigger the "set built" conditional.