### PR TITLE
Fix incorrect key use for StringField character flags

### DIFF
--- a/module/applications/actor/sheet-v2-mixin.mjs
+++ b/module/applications/actor/sheet-v2-mixin.mjs
@@ -234,7 +234,7 @@ export default function ActorSheetV2Mixin(Base) {
           flag.input = createCheckboxInput;
         }
         else if ( config.type === Number ) flag.field = new foundry.data.fields.NumberField(fieldOptions);
-        else flag.fields = new foundry.data.fields.StringField(fieldOptions);
+        else flag.field = new foundry.data.fields.StringField(fieldOptions);
 
         sections[config.section] ??= [];
         sections[config.section].push(flag);


### PR DESCRIPTION
`flag.field` is the expected value, leaving it unset (by accidentally setting `flag.fields`) and adding a `StringField` type character flag would prevent the sheet from opening in v12 and throw errors in v13.