### PR TITLE
Make new rider status dropdown's insertion more resilient to potential AE Config modifications

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -646,8 +646,8 @@ export default class ActiveEffect5e extends ActiveEffect {
       name: "flags.dnd5e.riders.statuses",
       value: app.document.getFlag("dnd5e", "riders.statuses") ?? [],
       options: CONFIG.statusEffects.map(se => ({ value: se.id, label: se.name }))
-    }).outerHTML;
-    html.querySelector("[data-tab=details] > .form-group:last-of-type").insertAdjacentHTML("afterend", element);
+    });
+    html.querySelector("[data-tab=details] > .form-group:has([name=statuses])")?.after(element);
 
     if ( game.release.generation < 13 ) {
       html.querySelector(".form-fields:has([name=statuses])").insertAdjacentHTML("afterend", `

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -647,7 +647,7 @@ export default class ActiveEffect5e extends ActiveEffect {
       value: app.document.getFlag("dnd5e", "riders.statuses") ?? [],
       options: CONFIG.statusEffects.map(se => ({ value: se.id, label: se.name }))
     }).outerHTML;
-    html.querySelector("[data-tab=details] > .form-group:last-child").insertAdjacentHTML("afterend", element);
+    html.querySelector("[data-tab=details] > .form-group:last-of-type").insertAdjacentHTML("afterend", element);
 
     if ( game.release.generation < 13 ) {
       html.querySelector(".form-fields:has([name=statuses])").insertAdjacentHTML("afterend", `


### PR DESCRIPTION
Using `:last-of-type` instead of `:last-child` means that if the details tab changes at some point (or a module extends/changes it) such that the final child on the tab no longer has the `form-group` class, the `querySelector` won't fail, but will simply append after what actually _is_ the final `form-group`-class-having element. 

Once in V13 only (if the system hasn't made a custom AE config application yet), could potentially be changed to
```js
html.querySelector("[data-tab=details] > .form-group.statuses").insertAdjacentHTML("afterend", element);
```