### PR TITLE
Add link to embedded actor if `cite` is set, use label as name

### DIFF
--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -202,6 +202,11 @@
     h4.statblock-title {
       color: color-mix(in oklab, var(--statblock-text-header) 75%, transparent);
       font-size: var(--font-size-18);
+      .content-link {
+        padding: 0;
+        text-decoration: none;
+        > i { display: none; }
+      }
     }
     h5.statblock-actions-title {
       margin-block-start: 8px;

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -574,6 +574,11 @@ export default class NPCData extends CreatureTemplate {
     if ( !config.statblock ) return super.toEmbed(config, options);
 
     const context = await this._prepareEmbedContext();
+    context.name = config.label || this.parent.name;
+    if ( config.cite && !config.inline ) {
+      config.cite = false;
+      context.anchor = this.parent.toAnchor({ name: context.name }).outerHTML;
+    }
     const template = document.createElement("template");
     template.innerHTML = await renderTemplate("systems/dnd5e/templates/actors/embeds/npc-embed.hbs", context);
 

--- a/templates/actors/embeds/npc-embed.hbs
+++ b/templates/actors/embeds/npc-embed.hbs
@@ -1,5 +1,5 @@
 <div class="statblock npc">
-    <h4 class="statblock-title">{{ document.name }}</h4>
+    <h4 class="statblock-title">{{#if anchor}}{{{ anchor }}}{{else}}{{ name }}{{/if}}</h4>
     <span class="statblock-tags">{{ summary.tag }}</span>
     <div class="statblock-content">
         <div class="statblock-header">


### PR DESCRIPTION
- Links the actor name on embedded NPC stat blocks if the embed has `cite` set to `true`
- If a label is provided for the embed, the label will be displayed as the name instead of the document name