### PR TITLE
Restore v12 functionality to "Separate Status Conditions"

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -647,6 +647,7 @@ export default class ActiveEffect5e extends ActiveEffect {
       value: app.document.getFlag("dnd5e", "riders.statuses") ?? [],
       options: CONFIG.statusEffects.map(se => ({ value: se.id, label: se.name }))
     }).outerHTML;
+    // Have to use outerHTML and insertAdjacentHTML for v12 compatibility
     html.querySelector("[data-tab=details] > .form-group:has([name=statuses])")?.insertAdjacentHTML("afterend", element);
 
     if ( game.release.generation < 13 ) {

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -646,8 +646,8 @@ export default class ActiveEffect5e extends ActiveEffect {
       name: "flags.dnd5e.riders.statuses",
       value: app.document.getFlag("dnd5e", "riders.statuses") ?? [],
       options: CONFIG.statusEffects.map(se => ({ value: se.id, label: se.name }))
-    });
-    html.querySelector("[data-tab=details] > .form-group:has([name=statuses])")?.after(element);
+    }).outerHTML;
+    html.querySelector("[data-tab=details] > .form-group:has([name=statuses])")?.insertAdjacentHTML("afterend", element);
 
     if ( game.release.generation < 13 ) {
       html.querySelector(".form-fields:has([name=statuses])").insertAdjacentHTML("afterend", `


### PR DESCRIPTION
Turns out Zhell used `outerHTML` and `insertAdjacentHTML` for a reason. 
https://github.com/foundryvtt/foundryvtt/issues/11567