### PR TITLE
Allow Custom Die for d20-based Rolls

### DIFF
--- a/module/dice/d20-die.mjs
+++ b/module/dice/d20-die.mjs
@@ -1,3 +1,5 @@
+import { getDieParts } from "../utils.mjs";
+
 const { Die } = foundry.dice.terms;
 
 /**
@@ -67,13 +69,15 @@ export default class D20Die extends Die {
    * @param {number} advantageMode  Advantage mode to apply.
    */
   applyAdvantage(advantageMode) {
+    const customDieParts = getDieParts(this.options.customDie);
+    const dieNumber = customDieParts?.number ?? 1;
     this.options.advantageMode = advantageMode;
     this.modifiers.findSplice(m => ["kh", "kl"].includes(m));
-    if ( advantageMode === CONFIG.Dice.D20Roll.ADV_MODE.NORMAL ) this.number = 1;
+    if ( advantageMode === CONFIG.Dice.D20Roll.ADV_MODE.NORMAL ) this.number = dieNumber;
     else {
       const isAdvantage = advantageMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
-      this.number = (isAdvantage && this.options.elvenAccuracy) ? 3 : 2;
-      this.modifiers.push(isAdvantage ? "kh" : "kl");
+      this.number = (isAdvantage && this.options.elvenAccuracy) ? (dieNumber * 3) : dieNumber * 2;
+      this.modifiers.push(isAdvantage ? `kh${dieNumber}` : `kl${dieNumber}`);
     }
   }
 

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -240,7 +240,7 @@ export default class D20Roll extends BasicRoll {
   configureModifiers() {
     if ( !this.validD20Roll ) return;
 
-    if (this.options.customDie) this.d20.options.customDie = this.options.customDie;
+    if ( this.options.customDie ) this.d20.options.customDie = this.options.customDie;
 
     if ( this.options.advantageMode === undefined ) {
       const { advantage, disadvantage } = this.options;

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -77,7 +77,8 @@ export default class D20Roll extends BasicRoll {
 
   /** @inheritDoc */
   static fromConfig(config, process) {
-    const formula = [new CONFIG.Dice.D20Die().formula].concat(config.parts ?? []).join(" + ");
+    const die = config.options?.customDie || new CONFIG.Dice.D20Die().formula;
+    const formula = [die].concat(config.parts ?? []).join(" + ");
     config.options.criticalSuccess ??= CONFIG.Dice.D20Die.CRITICAL_SUCCESS_TOTAL;
     config.options.criticalFailure ??= CONFIG.Dice.D20Die.CRITICAL_FAILURE_TOTAL;
     config.options.elvenAccuracy ??= process.elvenAccuracy;
@@ -201,7 +202,7 @@ export default class D20Roll extends BasicRoll {
    * @type {boolean}
    */
   get validD20Roll() {
-    return (this.d20 instanceof CONFIG.Dice.D20Die) && this.d20.isValid;
+    return !!this.options.customDie || ( (this.d20 instanceof CONFIG.Dice.D20Die) && this.d20.isValid );
   }
 
   /* -------------------------------------------- */
@@ -238,6 +239,8 @@ export default class D20Roll extends BasicRoll {
    */
   configureModifiers() {
     if ( !this.validD20Roll ) return;
+
+    if (this.options.customDie) this.d20.options.customDie = this.options.customDie;
 
     if ( this.options.advantageMode === undefined ) {
       const { advantage, disadvantage } = this.options;

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -235,6 +235,21 @@ export function getPluralRules({ type="cardinal" }={}) {
 }
 
 /* -------------------------------------------- */
+/*  Destructuring                               */
+/* -------------------------------------------- */
+
+/**
+ * Get parts of a die.
+ * @param {string} die The die to parse
+ * @returns {object|null} The die parts
+ */
+export function getDieParts(die) {
+  const match = die?.match(/\b(\d+)[dD](\d+)\b/);
+  return match ? { number: parseInt(match[1], 10), faces: parseInt(match[2], 10) } : null;
+}
+
+
+/* -------------------------------------------- */
 /*  Formulas                                    */
 /* -------------------------------------------- */
 


### PR DESCRIPTION
Adds handling for a custom die via an `options.customDie` property to allow modules/scripts to easily swap out the d20 with a different die face or number of dice.

```js
Hooks.on("dnd5e.preRollV2", (config, dialog, message) => {
  config.rolls[0].options.customDie = "2d10";
  config.rolls[0].options.criticalSuccess = 20;
  config.rolls[0].options.criticalFailure = 2;
});
```