### PR TITLE
Fix damage type in Sling Bullets of Slaying, fix activities in Manacles, many adjustments to Otyugh.

### DIFF
--- a/packs/_source/items/ammunition/sling-bullet-of-slaying.json
+++ b/packs/_source/items/ammunition/sling-bullet-of-slaying.json
@@ -37,7 +37,7 @@
     "damage": {
       "base": {
         "number": null,
-        "denomination": 0,
+        "denomination": null,
         "types": [],
         "custom": {
           "enabled": false
@@ -123,10 +123,10 @@
                 "formula": ""
               },
               "number": 6,
-              "denomination": "10",
+              "denomination": 10,
               "bonus": "",
               "types": [
-                "piercing"
+                "bludgeoning"
               ]
             }
           ]
@@ -158,14 +158,21 @@
   "ownership": {
     "default": 0
   },
-  "flags": {},
+  "flags": {
+    "dnd5e": {
+      "riders": {
+        "activity": [],
+        "effect": []
+      }
+    }
+  },
   "_stats": {
     "duplicateSource": null,
-    "coreVersion": "12.331",
+    "coreVersion": "13.335",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.0",
     "createdTime": 1725037171579,
-    "modifiedTime": 1725992507771,
+    "modifiedTime": 1739615746351,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!Mj8fTo5VZKJJ7uMv"

--- a/packs/_source/items/trinket/manacles.json
+++ b/packs/_source/items/trinket/manacles.json
@@ -5,7 +5,7 @@
   "img": "icons/sundries/survival/cuffs-shackles-steel.webp",
   "system": {
     "description": {
-      "value": "<p>These metal restraints can bind a Small or Medium creature. Escaping the manacles requires a successful DC 20 Dexterity check. Breaking them requires a successful DC 20 Strength check. Each set of manacles comes with one key. Without the key, a creature proficient with thieves' tools can pick the manacles' lock with a successful DC 15 Dexterity check. Manacles have 15 hit points.</p>",
+      "value": "<p>These metal restraints can bind a Small or Medium creature. Escaping the manacles requires a successful [[/check activity=dnd5eactivity000]] check. Breaking them requires a successful [[/check activity=mLC6xcSBAuwPuhVn]] check. Each set of manacles comes with one key. Without the key, a creature proficient with thieves' tools can pick the manacles' lock with a successful [[/check activity=JuQrIeoUh5Q5uAEq]]{DC 15 Dexterity} check. Manacles have 15 hit points.</p>",
       "chat": ""
     },
     "source": {
@@ -29,7 +29,7 @@
     "rarity": "",
     "identified": true,
     "uses": {
-      "max": "1",
+      "max": "",
       "recovery": [],
       "autoDestroy": false,
       "spent": 0
@@ -65,21 +65,11 @@
         "activation": {
           "type": "action",
           "value": 1,
-          "condition": "Creature must be Small or Medium.",
+          "condition": "",
           "override": false
         },
         "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
+          "targets": [],
           "scaling": {
             "allowed": false,
             "max": ""
@@ -98,7 +88,7 @@
         },
         "effects": [],
         "range": {
-          "units": "touch",
+          "units": "",
           "special": "",
           "override": false
         },
@@ -113,8 +103,8 @@
             "units": ""
           },
           "affects": {
-            "count": "1",
-            "type": "creature",
+            "count": "",
+            "type": "",
             "choice": false,
             "special": ""
           },
@@ -122,82 +112,6 @@
           "override": false
         },
         "check": {
-          "ability": "",
-          "dc": {}
-        },
-        "uses": {
-          "spent": 0,
-          "recovery": []
-        },
-        "sort": 0
-      },
-      "dnd5eactivity100": {
-        "_id": "dnd5eactivity100",
-        "type": "save",
-        "activation": {
-          "type": "action",
-          "value": 1,
-          "condition": "Creature must be Small or Medium.",
-          "override": false
-        },
-        "consumption": {
-          "targets": [
-            {
-              "type": "itemUses",
-              "target": "",
-              "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
-            }
-          ],
-          "scaling": {
-            "allowed": false,
-            "max": ""
-          },
-          "spellSlot": true
-        },
-        "description": {
-          "chatFlavor": ""
-        },
-        "duration": {
-          "concentration": false,
-          "value": "",
-          "units": "",
-          "special": "",
-          "override": false
-        },
-        "effects": [],
-        "range": {
-          "units": "touch",
-          "special": "",
-          "override": false
-        },
-        "target": {
-          "template": {
-            "count": "",
-            "contiguous": false,
-            "type": "",
-            "size": "",
-            "width": "",
-            "height": "",
-            "units": ""
-          },
-          "affects": {
-            "count": "1",
-            "type": "creature",
-            "choice": false,
-            "special": ""
-          },
-          "prompt": true,
-          "override": false
-        },
-        "damage": {
-          "onSave": "half",
-          "parts": []
-        },
-        "save": {
           "ability": "dex",
           "dc": {
             "calculation": "",
@@ -206,9 +120,145 @@
         },
         "uses": {
           "spent": 0,
-          "recovery": []
+          "recovery": [],
+          "max": ""
         },
-        "sort": 0
+        "sort": 0,
+        "name": "Dexterity Check",
+        "img": "",
+        "appliedEffects": []
+      },
+      "mLC6xcSBAuwPuhVn": {
+        "type": "check",
+        "activation": {
+          "type": "action",
+          "value": 1,
+          "condition": "",
+          "override": false
+        },
+        "consumption": {
+          "targets": [],
+          "scaling": {
+            "allowed": false,
+            "max": ""
+          },
+          "spellSlot": true
+        },
+        "description": {
+          "chatFlavor": ""
+        },
+        "duration": {
+          "concentration": false,
+          "value": "",
+          "units": "",
+          "special": "",
+          "override": false
+        },
+        "effects": [],
+        "range": {
+          "units": "",
+          "special": "",
+          "override": false
+        },
+        "target": {
+          "template": {
+            "count": "",
+            "contiguous": false,
+            "type": "",
+            "size": "",
+            "width": "",
+            "height": "",
+            "units": ""
+          },
+          "affects": {
+            "count": "",
+            "type": "",
+            "choice": false,
+            "special": ""
+          },
+          "prompt": true,
+          "override": false
+        },
+        "check": {
+          "ability": "str",
+          "dc": {
+            "calculation": "",
+            "formula": "20"
+          },
+          "associated": []
+        },
+        "uses": {
+          "spent": 0,
+          "recovery": [],
+          "max": ""
+        },
+        "sort": 0,
+        "name": "Strength Check",
+        "_id": "mLC6xcSBAuwPuhVn",
+        "img": "",
+        "appliedEffects": []
+      },
+      "JuQrIeoUh5Q5uAEq": {
+        "type": "check",
+        "name": "Pick Lock",
+        "_id": "JuQrIeoUh5Q5uAEq",
+        "sort": 0,
+        "activation": {
+          "type": "action",
+          "override": false,
+          "condition": ""
+        },
+        "consumption": {
+          "scaling": {
+            "allowed": false
+          },
+          "spellSlot": true,
+          "targets": []
+        },
+        "description": {
+          "chatFlavor": ""
+        },
+        "duration": {
+          "units": "inst",
+          "concentration": false,
+          "override": false
+        },
+        "effects": [],
+        "range": {
+          "override": false,
+          "units": "",
+          "special": ""
+        },
+        "target": {
+          "template": {
+            "contiguous": false,
+            "units": "ft",
+            "type": ""
+          },
+          "affects": {
+            "choice": false,
+            "type": ""
+          },
+          "override": false,
+          "prompt": true
+        },
+        "uses": {
+          "spent": 0,
+          "recovery": [],
+          "max": ""
+        },
+        "check": {
+          "associated": [
+            "thief"
+          ],
+          "dc": {
+            "calculation": "",
+            "formula": "15"
+          },
+          "ability": "dex"
+        },
+        "img": "",
+        "appliedEffects": []
       }
     },
     "attuned": false,
@@ -220,14 +270,21 @@
   "ownership": {
     "default": 0
   },
-  "flags": {},
+  "flags": {
+    "dnd5e": {
+      "riders": {
+        "activity": [],
+        "effect": []
+      }
+    }
+  },
   "_stats": {
     "duplicateSource": null,
-    "coreVersion": "12.331",
+    "coreVersion": "13.335",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.0",
     "createdTime": 1725037308976,
-    "modifiedTime": 1725992553939,
+    "modifiedTime": 1739616297010,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!tWJLHIL6ZIZUez9k"

--- a/packs/_source/monsters/aberration/otyugh.json
+++ b/packs/_source/monsters/aberration/otyugh.json
@@ -69,8 +69,8 @@
       "hp": {
         "value": 114,
         "max": 114,
-        "temp": 0,
-        "tempmax": 0,
+        "temp": null,
+        "tempmax": null,
         "formula": "12d10 + 48"
       },
       "init": {
@@ -102,7 +102,7 @@
         "units": "ft",
         "special": ""
       },
-      "spellcasting": "",
+      "spellcasting": "str",
       "exhaustion": 0,
       "concentration": {
         "ability": "",
@@ -173,7 +173,13 @@
       },
       "languages": {
         "value": [],
-        "custom": "Otyugh"
+        "custom": "Otyugh",
+        "communication": {
+          "telepathy": {
+            "value": 120,
+            "units": "ft"
+          }
+        }
       },
       "dm": {
         "amount": {},
@@ -590,7 +596,6 @@
     "detectionModes": [],
     "appendNumber": false,
     "prependAdjective": false,
-    "hexagonalShape": 1,
     "occludable": {
       "radius": 0
     },
@@ -605,6 +610,12 @@
         "scale": 1,
         "texture": null
       }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
     }
   },
   "items": [
@@ -615,7 +626,7 @@
       "img": "icons/magic/defensive/illusion-evasion-echo-purple.webp",
       "system": {
         "description": {
-          "value": "<p>The otyugh can magically transmit simple messages and images to any creature within <strong>120 ft.</strong> of it that can understand a language. This form of telepathy doesn't allow the receiving creature to telepathically respond.</p>",
+          "value": "<p>The [[lookup @name lowercase]] can magically transmit simple messages and images to any creature within 120 ft. of it that can understand a language. This form of telepathy doesn't allow the receiving creature to telepathically respond.</p>",
           "chat": ""
         },
         "source": {
@@ -658,12 +669,12 @@
       "_stats": {
         "compendiumSource": "Compendium.dnd5e.monsterfeatures.xna3UTd4EFLCZMt9",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.335",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1739617710208,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jcZblJ6lqtW0ePxe.z8zfieQSSbMtBNQz"
     },
@@ -674,7 +685,7 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>12 (2d8 + 3) <em>piercing damage</em></strong>.</p><p>If the target is a creature, it must succeed on a  <strong>DC 15 Constitution</strong> saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the target must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. The disease is cured on a success. The target dies if the disease reduces its hit point maximum to 0. This reduction to the target's hit point maximum lasts until the disease is cured.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is a creature, it must succeed on a [[/save]] saving throw against disease or become &amp;reference[poisoned] until the disease is cured. Every 24 hours that elapse, the target must repeat the saving throw, reducing its hit point maximum by [[/damage 1d10 average]] on a failure. The disease is cured on a success. The target dies if the disease reduces its hit point maximum to 0. This reduction to the target's hit point maximum lasts until the disease is cured.</p>",
           "chat": "<p>The Otyugh attacks with its Bite. If the target is a creature, it must make a <strong>Constitution</strong> saving throw. Every 24 hours that elapse, the target must repeat the saving throw.</p>"
         },
         "source": {
@@ -700,7 +711,7 @@
         "identified": true,
         "cover": null,
         "range": {
-          "value": 5,
+          "value": null,
           "long": null,
           "units": "ft",
           "reach": null
@@ -754,7 +765,7 @@
           "conditions": ""
         },
         "properties": [],
-        "proficient": 1,
+        "proficient": null,
         "unidentified": {
           "description": ""
         },
@@ -810,8 +821,8 @@
                 "units": ""
               },
               "affects": {
-                "count": "",
-                "type": "",
+                "count": "1",
+                "type": "creature",
                 "choice": false,
                 "special": ""
               },
@@ -824,14 +835,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "str",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -842,15 +853,18 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           },
           "dnd5eactivity100": {
             "_id": "dnd5eactivity100",
             "type": "save",
             "activation": {
-              "type": "action",
+              "type": "special",
               "value": 1,
-              "condition": "",
+              "condition": "Follow-up to the attack.",
               "override": false
             },
             "consumption": {
@@ -867,8 +881,8 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
-              "special": "",
+              "units": "spec",
+              "special": "Until cured.",
               "override": false
             },
             "effects": [],
@@ -904,60 +918,52 @@
             },
             "damage": {
               "onSave": "half",
-              "parts": [
-                {
-                  "number": 2,
-                  "denomination": 8,
-                  "bonus": "@mod",
-                  "types": [
-                    "piercing"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "parts": []
             },
             "save": {
               "ability": "con",
               "dc": {
-                "calculation": "",
+                "calculation": "str",
                 "formula": "15"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "bite"
+        "identifier": "bite",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 100000,
       "ownership": {
         "default": 0
       },
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
         "compendiumSource": "Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.335",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.0",
         "createdTime": null,
-        "modifiedTime": 1736804676821,
+        "modifiedTime": 1739617636945,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jcZblJ6lqtW0ePxe.CCawltKiVU4Mup9i"
@@ -969,8 +975,8 @@
       "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>bludgeoning damage</em></strong> plus <strong>4 (1d8) <em>piercing damage</em></strong>.</p><p>If the target is Medium or smaller, it is grappled (escape DC 13) and restrained until the grapple ends. The otyugh has two tentacles, each of which can grapple one target.</p>",
-          "chat": "<p>The Otyugh attacks with its Tentacle. If the target is Medium or smaller, it is grappled, and restrained until the grapple ends. The otyugh has two tentacles, each of which can grapple one target.</p>"
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is Medium or smaller, it is grappled (escape DC 13) and restrained until the grapple ends. The [[lookup @name lowercase]] has two tentacles, each of which can grapple one target.</p>",
+          "chat": "<p>The [[lookup @name lowercase]] attacks with its [[lookup @item.name lowercase]]. If the target is Medium or smaller, it is grappled, and restrained until the grapple ends. The [[lookup @name lowercase]] has two tentacles, each of which can grapple one target.</p>"
         },
         "source": {
           "custom": "",
@@ -995,10 +1001,10 @@
         "identified": true,
         "cover": null,
         "range": {
-          "value": 10,
+          "value": null,
           "long": null,
           "units": "ft",
-          "reach": null
+          "reach": 10
         },
         "uses": {
           "max": "",
@@ -1048,10 +1054,8 @@
           "dt": null,
           "conditions": ""
         },
-        "properties": [
-          "rch"
-        ],
-        "proficient": 1,
+        "properties": [],
+        "proficient": null,
         "unidentified": {
           "description": ""
         },
@@ -1089,7 +1093,11 @@
               "special": "",
               "override": false
             },
-            "effects": [],
+            "effects": [
+              {
+                "_id": "5KVU3uhvAdcAUSCX"
+              }
+            ],
             "range": {
               "value": "10",
               "units": "ft",
@@ -1107,8 +1115,8 @@
                 "units": ""
               },
               "affects": {
-                "count": "",
-                "type": "",
+                "count": "1",
+                "type": "creature",
                 "choice": false,
                 "special": ""
               },
@@ -1121,7 +1129,7 @@
               "recovery": []
             },
             "attack": {
-              "ability": "str",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
@@ -1139,47 +1147,99 @@
               "includeBase": true,
               "parts": [
                 {
+                  "custom": {
+                    "enabled": false,
+                    "formula": ""
+                  },
                   "number": 1,
                   "denomination": 8,
                   "bonus": "",
                   "types": [
                     "piercing"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  ]
                 }
               ]
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "tentacle"
+        "identifier": "tentacle",
+        "mastery": ""
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Tentacle",
+          "img": "icons/creatures/tentacles/tentacles-thing-green.webp",
+          "origin": "Compendium.dnd5e.monsters.Actor.jcZblJ6lqtW0ePxe.Item.BPYsBEkmZMcGYZDh",
+          "transfer": false,
+          "_id": "5KVU3uhvAdcAUSCX",
+          "type": "base",
+          "system": {},
+          "changes": [],
+          "disabled": false,
+          "duration": {
+            "startTime": null,
+            "combat": null,
+            "seconds": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "<p>You are &amp;reference[grappled apply=false] (escape DC 13). While grappled in this way, you are also &amp;reference[restrained apply=false].</p>",
+          "tint": "#ffffff",
+          "statuses": [
+            "grappled",
+            "restrained"
+          ],
+          "sort": 0,
+          "flags": {
+            "dnd5e": {
+              "riders": {
+                "statuses": []
+              }
+            }
+          },
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "coreVersion": "13.335",
+            "systemId": "dnd5e",
+            "systemVersion": "4.3.0",
+            "createdTime": 1739617218237,
+            "modifiedTime": 1739617314839,
+            "lastModifiedBy": "dnd5ebuilder0000"
+          },
+          "_key": "!actors.items.effects!jcZblJ6lqtW0ePxe.BPYsBEkmZMcGYZDh.5KVU3uhvAdcAUSCX"
+        }
+      ],
       "folder": null,
-      "sort": 0,
+      "sort": 300000,
       "ownership": {
         "default": 0
       },
-      "flags": {},
+      "flags": {
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.335",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.0",
         "createdTime": null,
-        "modifiedTime": 1736804676821,
+        "modifiedTime": 1739617689264,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jcZblJ6lqtW0ePxe.BPYsBEkmZMcGYZDh"
@@ -1191,8 +1251,8 @@
       "img": "icons/magic/death/undead-skeleton-deformed-red.webp",
       "system": {
         "description": {
-          "value": "<p>The otyugh slams creatures grappled by it into each other or a solid surface. Each creature must succeed on a  <strong>DC 14 Constitution</strong> saving throw or take <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong> and be stunned until the end of the otyugh's next turn. </p><p>On a successful save, the target takes half the <em>bludgeoning damage</em> and isn't stunned.</p>",
-          "chat": "<p>The otyugh slams creatures grappled by it into each other or a solid surface. Each creature must make a <strong>Constitution</strong> saving throw.</p>"
+          "value": "<p>The [[lookup @name lowercase]] slams creatures grappled by it into each other or a solid surface. Each creature must succeed on a [[/save]]<strong> </strong>saving throw or take [[/damage average]] and be &amp;reference[stunned] until the end of the [[lookup @name lowercase]]'s next turn.</p><p>On a successful save, the target takes half the bludgeoning damage and isn't stunned.</p>",
+          "chat": "<p>The [[lookup @name lowercase]] slams creatures grappled by it into each other or a solid surface. Each creature must make a Constitution saving throw.</p>"
         },
         "source": {
           "custom": "",
@@ -1208,108 +1268,12 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
         "properties": [],
         "activities": {
-          "dnd5eactivity000": {
-            "_id": "dnd5eactivity000",
-            "type": "attack",
-            "activation": {
-              "type": "action",
-              "value": 1,
-              "condition": "",
-              "override": false
-            },
-            "consumption": {
-              "targets": [],
-              "scaling": {
-                "allowed": false,
-                "max": ""
-              },
-              "spellSlot": true
-            },
-            "description": {
-              "chatFlavor": ""
-            },
-            "duration": {
-              "concentration": false,
-              "value": "",
-              "units": "",
-              "special": "",
-              "override": false
-            },
-            "effects": [],
-            "range": {
-              "units": "",
-              "special": "",
-              "override": false
-            },
-            "target": {
-              "template": {
-                "count": "",
-                "contiguous": false,
-                "type": "",
-                "size": "",
-                "width": "",
-                "height": "",
-                "units": ""
-              },
-              "affects": {
-                "count": "",
-                "type": "",
-                "choice": false,
-                "special": ""
-              },
-              "prompt": true,
-              "override": false
-            },
-            "uses": {
-              "spent": 0,
-              "max": "",
-              "recovery": []
-            },
-            "attack": {
-              "ability": "str",
-              "bonus": "",
-              "critical": {
-                "threshold": null
-              },
-              "flat": false,
-              "type": {
-                "value": "melee",
-                "classification": "weapon"
-              }
-            },
-            "damage": {
-              "critical": {
-                "bonus": ""
-              },
-              "includeBase": true,
-              "parts": [
-                {
-                  "number": 2,
-                  "denomination": 6,
-                  "bonus": "@mod",
-                  "types": [
-                    "bludgeoning"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
-            },
-            "sort": 0
-          },
           "dnd5eactivity100": {
             "_id": "dnd5eactivity100",
             "type": "save",
@@ -1371,32 +1335,30 @@
               "onSave": "half",
               "parts": [
                 {
+                  "custom": {
+                    "enabled": false,
+                    "formula": ""
+                  },
                   "number": 2,
                   "denomination": 6,
                   "bonus": "@mod",
                   "types": [
                     "bludgeoning"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  ]
                 }
               ]
             },
             "save": {
               "ability": "con",
               "dc": {
-                "calculation": "",
+                "calculation": "str",
                 "formula": "14"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1407,23 +1369,29 @@
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 400000,
       "ownership": {
         "default": 0
       },
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.monsterfeatures.QiM1nbPzbLzKnfmP"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
         "compendiumSource": "Compendium.dnd5e.monsterfeatures.QiM1nbPzbLzKnfmP",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.335",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.0",
         "createdTime": null,
-        "modifiedTime": 1736804676821,
+        "modifiedTime": 1739617636945,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jcZblJ6lqtW0ePxe.9d1ZhvT1vIJsNnN1"
@@ -1435,7 +1403,7 @@
       "img": "icons/skills/melee/blade-tips-triple-steel.webp",
       "system": {
         "description": {
-          "value": "<p>The otyugh makes three attacks: one with its bite and two with its tentacles.</p>",
+          "value": "<p>The [[lookup @name lowercase]] makes three attacks: one with its [[/item Bite]] and two with its [[/item Tentacle]]{Tentacles}.</p>",
           "chat": ""
         },
         "source": {
@@ -1452,7 +1420,7 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
@@ -1544,12 +1512,12 @@
       "_stats": {
         "compendiumSource": "Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.335",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1739617637703,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!jcZblJ6lqtW0ePxe.O9otNESvCCUdwYhc"
     }
@@ -1563,11 +1531,11 @@
   "flags": {},
   "_stats": {
     "duplicateSource": null,
-    "coreVersion": "12.331",
+    "coreVersion": "13.335",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.0",
     "createdTime": 1726171252040,
-    "modifiedTime": 1726171448766,
+    "modifiedTime": 1739617714371,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!jcZblJ6lqtW0ePxe"


### PR DESCRIPTION
Fixes wrong damage type in Sling Bullets of Slaying.

Fixes stuff with Manacles item - closes #4336.

Fixes all kinds of stuff with Otyugh - related to #4553.