### PR TITLE
[#5196] Adds handling to `replaceFormulaData` to parse shims

### DIFF
--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -166,7 +166,12 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
       abl.save.toString = function() {
         foundry.utils.logCompatibilityWarning("The 'abilities.<ability>.save' property is now stored in "
           + "'abilities.<ability>.save.value'.", { since: "4.3", until: "4.5" });
-        return abl.save.value;
+        return String(abl.save.value);
+      };
+      abl.save.toJSON = function() {
+        foundry.utils.logCompatibilityWarning("The 'abilities.<ability>.save' property is now stored in "
+          + "'abilities.<ability>.save.value'.", { since: "4.3", until: "4.5" });
+        return `!${abl.save.value}!`;
       };
     }
   }

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -328,6 +328,18 @@ export default class BasicRoll extends Roll {
   }
 
   /* -------------------------------------------- */
+  /*  Roll Formula Parsing                        */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static replaceFormulaData(formula, data, options) {
+    // This looks for the pattern `$!!$` and replaces it with just the value between the marks (the bang has
+    // been added to ensure this is a deliberate shim from the system, not a unintentional usage that should
+    // show an error).
+    return super.replaceFormulaData(formula, data, options).replaceAll(/\$"?!(.+?)!"?\$/g, "$1");
+  }
+
+  /* -------------------------------------------- */
   /*  Maximize/Minimize Methods                   */
   /* -------------------------------------------- */
 


### PR DESCRIPTION
To get around core limitation that prevents a `toString` shim on plain objects when used in roll formulas, this allows `toJSON` to be used as the shim. Since that results in the final value being surrounded by `$`, this looks for the pattern `$!!$` and replaces it with just the value between the marks (the bang has been added to ensure this is a deliberate shim from the system, not a unintentional usage that should show an error).

Closes #5196