### PR TITLE
Store scale value data in a sparse format

### DIFF
--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -277,11 +277,15 @@
       .number-header, .level-number { grid-column: number; }
       .faces-header, .level-faces { grid-column: faces; }
     }
-    select option[value=""] { color: var(--color-text-tertiary); }
-    .new-scale-value select { font-weight: bold; }
-    li.level:not(.new-scale-value) select {
-      color: var(--color-text-tertiary);
-      option:not([value=""]) { color: var(--color-text-primary); }
+    input, select {
+      font-weight: bold;
+      color: var(--color-text-dark-primary);
+    }
+    div.placeholder {
+      input, select {
+        color: var(--color-text-tertiary);
+        font-weight: normal;
+      }
     }
   }
 }

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -279,7 +279,7 @@
     }
     input, select {
       font-weight: bold;
-      color: var(--color-text-dark-primary);
+      color: var(--color-text-primary);
     }
     div.placeholder {
       input, select {

--- a/module/applications/advancement/scale-value-config.mjs
+++ b/module/applications/advancement/scale-value-config.mjs
@@ -102,6 +102,10 @@ export default class ScaleValueConfig extends AdvancementConfig {
    * @param {*} lastValue  The previous value.
    */
   _mergeScaleValues(value, lastValue) {
+    foundry.utils.logCompatibilityWarning(
+      "`ScaleValueConfig#_mergeScaleValues` has been deprecated without replacement.",
+      { since: "DnD5e 6.0", until: "DnD5e 6.2" }
+    );
     for ( const k of Object.keys(lastValue ?? {}) ) {
       if ( value[k] == null ) value[k] = lastValue[k];
     }

--- a/module/applications/advancement/scale-value-config.mjs
+++ b/module/applications/advancement/scale-value-config.mjs
@@ -33,6 +33,19 @@ export default class ScaleValueConfig extends AdvancementConfig {
   };
 
   /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Range of levels that can be used based on what item type this advancement is within.
+   * @type {number[]}
+   */
+  get levelRange() {
+    let levels = Array.fromRange(CONFIG.DND5E.maxLevel + 1);
+    return ["class", "subclass"].includes(this.advancement.item.type) ? levels.slice(1) : levels;
+  }
+
+  /* -------------------------------------------- */
   /*  Rendering                                   */
   /* -------------------------------------------- */
 
@@ -69,21 +82,14 @@ export default class ScaleValueConfig extends AdvancementConfig {
    * @protected
    */
   _prepareLevelData() {
-    let lastValue = null;
-    let levels = Array.fromRange(CONFIG.DND5E.maxLevel + 1);
-    if ( ["class", "subclass"].includes(this.advancement.item.type) ) levels = levels.slice(1);
-    return levels.reduce((obj, level) => {
-      const value = this.advancement.configuration.scale[level]?.clone();
+    const TypeClass = TYPES[this.advancement.configuration.type];
+    return this.levelRange.reduce((obj, level) => {
+      const value = new TypeClass(this.advancement.configuration.scale[level] ?? {});
+      const lastValue = this.advancement.valueForLevel(level - 1);
       obj[level] = {
-        fields: TYPES[this.advancement.configuration.type].getFields(level, value, lastValue),
-        value: null
+        fields: TypeClass.getFields(level, value, lastValue),
+        value: this.advancement.configuration.scale[level] ?? {}
       };
-      if ( value ) {
-        this._mergeScaleValues(value, lastValue);
-        obj[level].className = "new-scale-value";
-        obj[level].value = value;
-        lastValue = value;
-      }
       return obj;
     }, {});
   }
@@ -128,16 +134,34 @@ export default class ScaleValueConfig extends AdvancementConfig {
 
   /** @inheritDoc */
   prepareConfigurationUpdate(configuration) {
-    // Ensure multiple values in a row are not the same
-    let lastValue = null;
-    for ( const [lvl, value] of Object.entries(configuration.scale) ) {
-      if ( this.advancement.testEquality(lastValue, value) ) configuration.scale[lvl] = null;
-      else if ( this.constructor._hasValue(value) ) {
-        this._mergeScaleValues(value, lastValue);
-        lastValue = value;
+    const TypeClass = TYPES[configuration.type ?? this.advancement.configuration.type];
+    const validKeys = Object.keys(TypeClass.schema.fields);
+
+    let lastValue = {};
+    const scale = {};
+    for ( const level of this.levelRange ) {
+      const value = configuration.scale[level] ?? {};
+      scale[level] = {};
+
+      // Fetch data for valid keys, skipping if value is empty or the same as a previous level
+      for ( const key of validKeys ) {
+        if ( (value[key] === null) || (value[key] === "") || (value[key] === lastValue[key]) ) scale[level][key] = _del;
+        else lastValue[key] = scale[level][key] = value[key];
+        // TODO: Ensure value is valid
+      }
+
+      // Strip out any invalid keys
+      for ( const key of Object.keys(this.advancement.configuration.scale[level] ?? {}) ) {
+        if ( !validKeys.includes(key) ) scale[level][key] = _del;
+      }
+
+      // If all updates were removals, just remove the level as a whole
+      if ( Object.values(scale[level]).every(v => v instanceof foundry.data.operators.ForcedDeletion) ) {
+        scale[level] = _del;
       }
     }
-    configuration.scale = this.constructor._cleanedObject(configuration.scale);
+
+    configuration.scale = scale;
     return configuration;
   }
 
@@ -145,44 +169,22 @@ export default class ScaleValueConfig extends AdvancementConfig {
 
   /** @inheritDoc */
   async _processSubmitData(event, submitData) {
-    const typeChange = foundry.utils.hasProperty(submitData, "configuration.type");
-    if ( typeChange && (submitData.configuration.type !== this.advancement.configuration.type) ) {
-      // Clear existing scale value data to prevent error during type update
-      await this.advancement.update(Array.fromRange(CONFIG.DND5E.maxLevel, 1).reduce((obj, lvl) => {
-        obj[`configuration.scale.${lvl}`] = _del;
-        return obj;
-      }, {}));
-      submitData.configuration.scale ??= {};
-      const OriginalType = TYPES[this.advancement.configuration.type];
-      const NewType = TYPES[submitData.configuration.type];
-      for ( const [lvl, data] of Object.entries(submitData.configuration.scale) ) {
-        const original = new OriginalType(data, { parent: this.advancement, strict: false });
-        submitData.configuration.scale[lvl] = NewType.convertFrom(original)?.toObject();
+    const type = submitData.configuration.type;
+    if ( type && (submitData.configuration.type !== this.advancement.configuration.type) ) {
+      // Perform the update with the old type
+      delete submitData.configuration.type;
+      await super._processSubmitData(event, submitData);
+
+      // Transform values into new type
+      const NewType = TYPES[type];
+      for ( const level of this.levelRange ) {
+        const value = this.advancement.valueForLevel(level);
+        if ( value ) submitData.configuration.scale[level] = _replace(NewType.convertFrom(value)?.toObject());
+        else submitData.configuration.scale[level] = _del;
       }
+
+      submitData.configuration.type = type;
     }
     return super._processSubmitData(event, submitData);
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  static _cleanedObject(object) {
-    return Object.entries(object).reduce((obj, [key, value]) => {
-      if ( this._hasValue(value) ) obj[key] = value;
-      else obj[key] = _del;
-      return obj;
-    }, {});
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Is a scale value entry non-empty?
-   * @param {object} value  Scale value entry.
-   * @returns {boolean}
-   * @protected
-   */
-  static _hasValue(value) {
-    return Object.keys(value ?? {}).some(k => (value[k] != null) && (value[k] !== ""));
   }
 }

--- a/module/data/advancement/_types.mjs
+++ b/module/data/advancement/_types.mjs
@@ -124,7 +124,7 @@
  * @property {string} type                   Type of data represented by this scale value.
  * @property {object} [distance]
  * @property {string} [distance.units]       If distance type is selected, the units each value uses.
- * @property {Object<string, object>} scale  Sparse scale values for each level.
+ * @property {Record<string, object>} scale  Sparse scale values for each level.
  */
 
 /**

--- a/module/data/advancement/_types.mjs
+++ b/module/data/advancement/_types.mjs
@@ -120,11 +120,11 @@
 
 /**
  * @typedef ScaleValueAdvancementConfigurationData
- * @property {string} identifier        Identifier used to select this scale value in roll formulas.
- * @property {string} type              Type of data represented by this scale value.
+ * @property {string} identifier             Identifier used to select this scale value in roll formulas.
+ * @property {string} type                   Type of data represented by this scale value.
  * @property {object} [distance]
- * @property {string} [distance.units]  If distance type is selected, the units each value uses.
- * @property {Object<string, *>} scale  Scale values for each level. Value format is determined by type.
+ * @property {string} [distance.units]       If distance type is selected, the units each value uses.
+ * @property {Object<string, object>} scale  Sparse scale values for each level.
  */
 
 /**

--- a/module/data/advancement/scale-value-data.mjs
+++ b/module/data/advancement/scale-value-data.mjs
@@ -1,9 +1,9 @@
-import { formatLength } from "../../utils.mjs";
+import { filteredKeys, formatLength } from "../../utils.mjs";
 import IdentifierField from "../fields/identifier-field.mjs";
 import MappingField from "../fields/mapping-field.mjs";
 import { createCheckboxInput } from "../../applications/fields.mjs";
 
-const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { BooleanField, NumberField, ObjectField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import {
@@ -34,7 +34,7 @@ export class ScaleValueConfigurationData extends foundry.abstract.DataModel {
       identifier: new IdentifierField({ required: true }),
       type: new StringField({ required: true, initial: "string", choices: TYPES }),
       distance: new SchemaField({ units: new StringField({ required: true }) }),
-      scale: new MappingField(new ScaleValueEntryField(), { required: true })
+      scale: new MappingField(new ObjectField(), { required: true })
     };
   }
 
@@ -45,11 +45,11 @@ export class ScaleValueConfigurationData extends foundry.abstract.DataModel {
   /** @inheritDoc */
   static migrateData(source) {
     super.migrateData(source);
-    if ( !source ) return source;
+    if ( !source?.type ) return source;
 
     if ( source.type === "numeric" ) source.type = "number";
     for ( const [k, v] of Object.entries(source.scale ?? {}) ) {
-      if ( foundry.utils.isDeletionKey(k) ) continue;
+      if ( v instanceof foundry.data.operators.ForcedDeletion ) continue;
       TYPES[source.type].migrateData(v);
     }
 
@@ -97,6 +97,11 @@ export class ScaleValueEntryField extends foundry.data.fields.ObjectField {
  * @mixes ScaleValueStringTypeData
  */
 export class ScaleValueType extends foundry.abstract.DataModel {
+  constructor(data = {}, options = {}) {
+    const explicitKeys = new Set(filteredKeys(data));
+    super(data, options);
+    this.#explicitKeys = explicitKeys;
+  }
 
   /* -------------------------------------------- */
   /*  Model Configuration                         */
@@ -146,6 +151,14 @@ export class ScaleValueType extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Keys provided directly to the model rather than filled in automatically from default values.
+   * @type {Set<string>}
+   */
+  #explicitKeys;
+
+  /* -------------------------------------------- */
+
+  /**
    * This scale value prepared to be used in roll formulas.
    * @type {string|null}
    */
@@ -176,23 +189,34 @@ export class ScaleValueType extends foundry.abstract.DataModel {
   /**
    * Retrieve field data with associated values.
    * @param {number} level                Level for which this data is being prepared.
-   * @param {ScaleValueType} [value]      Value for the field at this level.
    * @param {ScaleValueType} [lastValue]  Previous value used to generate placeholders.
    * @returns {Record<string, object>}
    */
-  static getFields(level, value, lastValue) {
+  getFields(level, lastValue) {
     const fields = {};
     for ( const [name, field] of Object.entries(this.schema.fields) ) {
       if ( field.options.hidden ) continue;
       fields[name] = {
         field,
         input: field instanceof BooleanField ? createCheckboxInput : null,
+        isPlaceholder: !this.#explicitKeys.has(name),
         name: `configuration.scale.${level}.${name}`,
-        placeholder: this.getPlaceholder(name, lastValue),
-        value: value?.[name]
+        placeholder: this.constructor.getPlaceholder(name, lastValue),
+        value: this.#explicitKeys.has(name) ? this[name] : null
       };
     }
     return fields;
+  }
+
+  /**
+   * Retrieve field data with associated values.
+   * @param {number} level                Level for which this data is being prepared.
+   * @param {ScaleValueType} value        Value for this level.
+   * @param {ScaleValueType} [lastValue]  Previous value used to generate placeholders.
+   * @returns {Record<string, object>}
+   */
+  static getFields(level, value, lastValue) {
+    return value.getFields(level, lastValue);
   }
 
   /* -------------------------------------------- */
@@ -247,6 +271,13 @@ export class ScaleValueTypeNumber extends ScaleValueType {
     if ( (original.formula === null) || (original.formula === "") || Number.isNaN(value) ) return null;
     return new this({value}, options);
   }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get formula() { return String(this.value); }
 }
 
 
@@ -402,8 +433,10 @@ export class ScaleValueTypeDice extends ScaleValueType {
 
   /** @inheritDoc */
   static migrateData(source) {
+    if ( !source ) return super.migrateData(source);
     if ( source.n ) source.number = source.n;
     if ( source.die ) source.faces = source.die;
+    return super.migrateData(source);
   }
 
   /* -------------------------------------------- */

--- a/module/data/advancement/scale-value-data.mjs
+++ b/module/data/advancement/scale-value-data.mjs
@@ -62,31 +62,12 @@ export class ScaleValueConfigurationData extends foundry.abstract.DataModel {
  * Data field that automatically selects the appropriate ScaleValueType based on the selected type.
  */
 export class ScaleValueEntryField extends foundry.data.fields.ObjectField {
-  /** @override */
-  _cleanType(value, options, _state) {
-    if ( !(typeof value === "object") ) value = {};
-
-    // Use a defined DataModel
-    const cls = TYPES[options.source?.type];
-    if ( cls ) return cls.cleanData(value, options, _state);
-
-    return value;
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  initialize(value, model, options={}) {
-    const cls = TYPES[model.type];
-    if ( !value || !cls ) return value;
-    return new cls(value, {parent: model, ...options});
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  toObject(value) {
-    return value.toObject(false);
+  constructor(...args) {
+    foundry.utils.logCompatibilityWarning(
+      "`ScaleValueEntryField` has been deprecated and replaced with a regular `ObjectField`.",
+      { since: "DnD5e 6.0", until: "DnD5e 6.2" }
+    );
+    super(...args);
   }
 }
 
@@ -97,8 +78,8 @@ export class ScaleValueEntryField extends foundry.data.fields.ObjectField {
  * @mixes ScaleValueStringTypeData
  */
 export class ScaleValueType extends foundry.abstract.DataModel {
-  constructor(data = {}, options = {}) {
-    const explicitKeys = new Set(filteredKeys(data));
+  constructor(data={}, options={}) {
+    const explicitKeys = new Set(filteredKeys(data, v => (v !== null) && (v !== "")));
     super(data, options);
     this.#explicitKeys = explicitKeys;
   }
@@ -269,7 +250,7 @@ export class ScaleValueTypeNumber extends ScaleValueType {
   static convertFrom(original, options) {
     const value = Number(original.formula);
     if ( (original.formula === null) || (original.formula === "") || Number.isNaN(value) ) return null;
-    return new this({value}, options);
+    return new this({ value }, options);
   }
 
   /* -------------------------------------------- */
@@ -381,7 +362,7 @@ export class ScaleValueTypeDice extends ScaleValueType {
   static convertFrom(original, options) {
     const [number, faces] = (original.formula ?? "").split("d");
     if ( !faces || !Number.isNumeric(number) || !Number.isNumeric(faces) ) return null;
-    return new this({number: Number(number) || null, faces: Number(faces)}, options);
+    return new this({ number: Number(number) || null, faces: Number(faces) }, options);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/advancement/scale-value.mjs
+++ b/module/documents/advancement/scale-value.mjs
@@ -79,15 +79,19 @@ export default class ScaleValueAdvancement extends Advancement {
 
   /**
    * Scale value for the given level.
-   * @param {number} level      Level for which to get the scale value.
-   * @returns {ScaleValueType}  Scale value at the given level or null if none exists.
+   * @param {number} level           Level for which to get the scale value.
+   * @returns {ScaleValueType|null}  Scale value at the given level or null if none exists.
    */
   valueForLevel(level) {
-    const key = Object.keys(this.configuration.scale).reverse().find(l => Number(l) <= level);
-    const data = this.configuration.scale[key];
     const TypeClass = this.constructor.TYPES[this.configuration.type];
-    if ( !data || !TypeClass ) return null;
-    return new TypeClass(data, { parent: this });
+    if ( !TypeClass ) return null;
+    const validKeys = Object.keys(TypeClass.schema.fields);
+    const data = {};
+    for ( const [key, value] of Object.entries(this.configuration.scale).reverse() ) {
+      if ( Number(key) > level ) continue;
+      validKeys.forEach(k => (data[k] ??= value[k]));
+    }
+    return foundry.utils.isEmpty(data) ? null : new TypeClass(data, { parent: this });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/advancement/scale-value.mjs
+++ b/module/documents/advancement/scale-value.mjs
@@ -103,6 +103,10 @@ export default class ScaleValueAdvancement extends Advancement {
    * @returns {boolean}
    */
   testEquality(a, b) {
+    foundry.utils.logCompatibilityWarning(
+      "`ScaleValueAdvancement#testEquality` has been deprecated without replacement.",
+      { since: "DnD5e 6.0", until: "DnD5e 6.2" }
+    );
     const keys = Object.keys(a ?? {});
     if ( keys.length !== Object.keys(b ?? {}).length ) return false;
     for ( const k of keys ) {

--- a/templates/advancement/scale-value-config-levels.hbs
+++ b/templates/advancement/scale-value-config-levels.hbs
@@ -14,10 +14,10 @@
     </div>
     <ol class="levels-list unlist">
         {{#each levels}}
-        <li class="level {{ className }}">
+        <li class="level">
             <div class="level-level">{{ @key }}</div>
             {{#each fields}}
-            <div class="level-{{ @key }}">
+            <div class="level-{{ @key }} {{~#if isPlaceholder}} placeholder{{/if}}">
                 {{ formInput field name=name value=value input=input options=options placeholder=placeholder }}
             </div>
             {{/each}}


### PR DESCRIPTION
Changes how scale value data is stored from storing all keys for each level to just storing the keys that were changed at a given level.

```javascript
// Original
{
  1: { number: 1, faces: 6 },
  5: { number: 1, faces: 8 },
  11: { number: 1, faces: 10 }
}

// New
{
  1: { number: 1, faces: 6 },
  5: { faces: 8 },
  11: { faces: 10 }
}
```

<img width="219" alt="Scale Value Sparse" src="https://github.com/user-attachments/assets/fab6adad-45d2-40c9-a13d-a8bfaa1caf0f" />

This has the advantage of making it easier to change part of a value. For example, if you had a scale value like Sneak Attack that changes every other level and you wanted to modify it from one die to two then it currently would require changing that one in 10 places. With this change the number of dice would only need to be updated at level 1.