### PR TITLE
[#2187] Add usage scale value type

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -717,7 +717,7 @@
       },
       "Usage": {
         "FIELDS": {
-          "per": {
+          "period": {
             "label": "Period"
           },
           "value": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -714,6 +714,18 @@
         "Hint": "Use this if you are unsure of the type of the scale values, or if the type does not matter.",
         "Identifier": "This scale value for the current level will be available in a formula using:<br><copyable-text>@scale.{class}.{identifier}</copyable-text>",
         "Label": "Anything"
+      },
+      "Usage": {
+        "FIELDS": {
+          "per": {
+            "label": "Period"
+          },
+          "value": {
+            "label": "Uses"
+          }
+        },
+        "Hint": "Use this to represent item uses over a certain period.",
+        "Label": "Usage"
       }
     }
   },

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -277,6 +277,10 @@
       .number-header, .level-number { grid-column: number; }
       .faces-header, .level-faces { grid-column: faces; }
     }
+    &[data-type="usage"] {
+      grid-template-columns: [level] max-content [value] 1fr [period] 2fr;
+      .period-header, .level-period { grid-column: period; }
+    }
     input, select {
       font-weight: bold;
       color: var(--color-text-primary);

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -349,8 +349,8 @@
  * @typedef LimitedUsePeriodConfiguration
  * @property {string} label                Localized label.
  * @property {string}  abbreviation        Shorthand form of the label.
- * @property {"combat"|"special"} [group]  Grouping if outside the normal "time" group.
  * @property {boolean} [formula]           Whether this limited use period restores charges via formula.
+ * @property {"combat"|"special"} [type]   Grouping if outside the normal "time" group.
  */
 
 /* -------------------------------------------- */

--- a/module/data/advancement/_types.mjs
+++ b/module/data/advancement/_types.mjs
@@ -145,6 +145,12 @@
  */
 
 /**
+ * @typedef ScaleValueUsesTypeData
+ * @property {number} value           Number of uses.
+ * @property {string} per             Usage refresh period.
+ */
+
+/**
  * Information on how a scale value of this type is configured.
  *
  * @typedef ScaleValueTypeMetadata

--- a/module/data/advancement/_types.mjs
+++ b/module/data/advancement/_types.mjs
@@ -147,7 +147,7 @@
 /**
  * @typedef ScaleValueUsesTypeData
  * @property {number} value           Number of uses.
- * @property {string} per             Usage refresh period.
+ * @property {string} period          Usage refresh period.
  */
 
 /**

--- a/module/data/advancement/scale-value-data.mjs
+++ b/module/data/advancement/scale-value-data.mjs
@@ -495,7 +495,7 @@ export class ScaleValueTypeUsage extends ScaleValueTypeNumber {
   static defineSchema() {
     return {
       value: new NumberField({ nullable: true, integer: true, min: 0 }),
-      per: new StringField({ blank: false })
+      period: new StringField({ blank: false })
     };
   }
 
@@ -525,7 +525,7 @@ export class ScaleValueTypeUsage extends ScaleValueTypeNumber {
 
   /** @inheritdoc */
   get display() {
-    return `${this.value}/${CONFIG.DND5E.limitedUsePeriods[this.per]?.abbreviation ?? ""}`;
+    return `${this.value}/${CONFIG.DND5E.limitedUsePeriods[this.period]?.abbreviation ?? ""}`;
   }
 
   /* -------------------------------------------- */
@@ -535,8 +535,8 @@ export class ScaleValueTypeUsage extends ScaleValueTypeNumber {
   /** @inheritDoc */
   static getFields(level, value, lastValue) {
     const fields = super.getFields(level, value, lastValue);
-    fields.per.options = [
-      { value: "", label: fields.per.placeholder, rule: true },
+    fields.period.options = [
+      { value: "", label: fields.period.placeholder, rule: true },
       ...CONFIG.DND5E.limitedUsePeriods.recoveryOptions.filter(r => r.value !== "recharge")
     ];
     return fields;
@@ -546,7 +546,7 @@ export class ScaleValueTypeUsage extends ScaleValueTypeNumber {
 
   /** @inheritDoc */
   static getPlaceholder(name, lastValue) {
-    if ( (name === "per") && lastValue?.per ) return CONFIG.DND5E.limitedUsePeriods[lastValue.per]?.label;
+    if ( (name === "period") && lastValue?.period ) return CONFIG.DND5E.limitedUsePeriods[lastValue.period]?.label;
     return super.getPlaceholder(name, lastValue);
   }
 }

--- a/module/data/advancement/scale-value-data.mjs
+++ b/module/data/advancement/scale-value-data.mjs
@@ -8,7 +8,7 @@ const { BooleanField, NumberField, ObjectField, SchemaField, SetField, StringFie
 /**
  * @import {
  *   ScaleValueAdvancementConfigurationData, ScaleValueDiceTypeData, ScaleValueNumberTypeData,
- *   ScaleValueStringTypeData, ScaleValueTypeMetadata
+ *   ScaleValueStringTypeData, ScaleValueTypeMetadata, ScaleValueUsesTypeData
  * } from "./_types.mjs";
  */
 
@@ -476,6 +476,83 @@ export class ScaleValueTypeDistance extends ScaleValueTypeNumber {
 
 
 /**
+ * Scale value data that stores a feature's usage number.
+ * @extends {ScaleValueType<ScaleValueUsesTypeData>}
+ * @mixes ScaleValueUsesTypeData
+ */
+export class ScaleValueTypeUsage extends ScaleValueTypeNumber {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.ADVANCEMENT.ScaleValue.Type.Usage"];
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return {
+      value: new NumberField({ nullable: true, integer: true, min: 0 }),
+      per: new StringField({ blank: false })
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      label: "DND5E.ADVANCEMENT.ScaleValue.Type.Usage.Label",
+      hint: "DND5E.ADVANCEMENT.ScaleValue.Type.Usage.Hint"
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static convertFrom(original, options) {
+    let value = parseInt(original.formula);
+    if ( Number.isNaN(value) ) return null;
+    if ( value < 1 ) value = 1;
+    return new this({ value }, options);
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  get display() {
+    return `${this.value}/${CONFIG.DND5E.limitedUsePeriods[this.per]?.abbreviation ?? ""}`;
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static getFields(level, value, lastValue) {
+    const fields = super.getFields(level, value, lastValue);
+    fields.per.options = [
+      { value: "", label: fields.per.placeholder, rule: true },
+      ...CONFIG.DND5E.limitedUsePeriods.recoveryOptions.filter(r => r.value !== "recharge")
+    ];
+    return fields;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static getPlaceholder(name, lastValue) {
+    if ( (name === "per") && lastValue?.per ) return CONFIG.DND5E.limitedUsePeriods[lastValue.per]?.label;
+    return super.getPlaceholder(name, lastValue);
+  }
+}
+
+
+/**
  * The available types of scaling value.
  * @enum {ScaleValueType}
  */
@@ -484,5 +561,6 @@ export const TYPES = {
   number: ScaleValueTypeNumber,
   cr: ScaleValueTypeCR,
   dice: ScaleValueTypeDice,
-  distance: ScaleValueTypeDistance
+  distance: ScaleValueTypeDistance,
+  usage: ScaleValueTypeUsage
 };


### PR DESCRIPTION
Adds a usage scale value type that tracks number of uses and the recovery period. This can be used to set the uses of an item and will display better in the class journal page.

<img width="923" alt="Scale Value Usage" src="https://github.com/user-attachments/assets/60e2fa83-d1e7-43be-a304-6a185c2b94d0" />

Additional work needs to be done to allow for changing the recvoery period based on the scale value.