### PR TITLE
[#5014] Modify usage chat cards to include activity name & icon

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1069,6 +1069,9 @@
   },
   "TURN": {
     "NoCombatant": "Combatant no longer exists!"
+  },
+  "USAGE": {
+    "Title": "{item}: {activity}"
   }
 },
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -887,6 +887,8 @@ export default function ActivityMixin(Base) {
         const { spellLevels, spellSchools } = CONFIG.DND5E;
         data.subtitle = [spellLevels[spellLevel], spellSchools[this.item.system.school]?.label].filterJoin(" &bull; ");
       }
+      const img = (this.img === this.metadata.img) ? this.item.img : this.img;
+      const title = game.i18n.format("DND5E.CHATMESSAGE.USAGE.Title", { item: this.item.name, activity: this.name});
 
       return {
         activity: this,
@@ -897,7 +899,9 @@ export default function ActivityMixin(Base) {
         description: data.description,
         properties: properties.length ? properties : null,
         subtitle: this.description.chatFlavor || data.subtitle,
-        supplements
+        supplements,
+        img,
+        title
       };
     }
 

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -347,12 +347,16 @@ export default class ChatMessage5e extends ChatMessage {
           </header>
         </section>
       `;
+      const imgSrc = (activity?.img === activity?.metadata.img) ? item.img : activity.img;
+      const titleText = activity
+        ? game.i18n.format("DND5E.CHATMESSAGE.USAGE.Title", { item: item.name, activity: activity.name})
+        : item.name;
       const icon = document.createElement("img");
-      Object.assign(icon, { className: "gold-icon", src: item.img, alt: item.name });
+      Object.assign(icon, { className: "gold-icon", src: imgSrc, alt: titleText });
       flavor.querySelector("header").insertAdjacentElement("afterbegin", icon);
       const title = document.createElement("span");
       title.classList.add("title");
-      title.append(item.name);
+      title.append(titleText);
       flavor.querySelector(".name-stacked").insertAdjacentElement("afterbegin", title);
       html.querySelector(".message-header .flavor-text").remove();
       html.querySelector(".message-content").insertAdjacentElement("afterbegin", flavor);

--- a/templates/chat/activity-card.hbs
+++ b/templates/chat/activity-card.hbs
@@ -1,9 +1,9 @@
 <div class="dnd5e2 chat-card activation-card">
     <section class="card-header description collapsible" {{#if description.concealed}}data-concealed{{/if}}>
         <header class="summary">
-            <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
+            <img class="gold-icon" src="{{ img }}" alt="{{ title }}">
             <div class="name-stacked border">
-                <span class="title">{{ item.name }}</span>
+                <span class="title">{{ title }}</span>
                 {{#if subtitle}}
                 <span class="subtitle">{{{ subtitle }}}</span>
                 {{/if}}


### PR DESCRIPTION
Closes #5014 
When an activity is used (or a chat action from an activity is used):
1. Add activity name to the chat card title
2. Replace the icon, if set on the activity

Example below with a longsword. The Attack activity has no icon set, but the Save activity does.
![Screenshot 2025-02-17 111259](https://github.com/user-attachments/assets/7f2742d5-405d-418d-97d9-4bbc6b673e5a)
