### PR TITLE
[#5220] Fix displaying cached spells on actors in compendiums

### DIFF
--- a/module/data/activity/cast-data.mjs
+++ b/module/data/activity/cast-data.mjs
@@ -43,19 +43,13 @@ export default class CastActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  prepareData() {
-    const spell = fromUuidSync(this.spell.uuid);
-    if ( spell ) {
-      this.name = this.name || spell.name;
-      this.img = this.img || spell.img;
-    }
-    super.prepareData();
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
   prepareFinalData(rollData) {
+    const spell = fromUuidSync(this.spell.uuid) ?? this.cachedSpell;
+    if ( spell ) {
+      this.name = this._source.name || spell.name || this.name;
+      this.img = this._source.img || spell.img || this.name;
+    }
+
     super.prepareFinalData(rollData);
 
     for ( const field of ["activation", "duration", "range", "target"] ) {

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -356,7 +356,11 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   get linkedActivity() {
     const relative = this.parent.actor;
     if ( !relative ) return null;
-    return fromUuidSync(this.parent.getFlag("dnd5e", "cachedFor"), { relative, strict: false }) ?? null;
+    const data = foundry.utils.parseUuid(this.parent.getFlag("dnd5e", "cachedFor"), { relative });
+    const [, itemId, , activityId] = data?.embedded ?? [];
+    return relative.items.get(itemId)?.system.activities?.get(activityId) ?? null;
+    // TODO: Swap back to fromUuidSync once https://github.com/foundryvtt/foundryvtt/issues/11214 is resolved
+    // return fromUuidSync(this.parent.getFlag("dnd5e", "cachedFor"), { relative, strict: false }) ?? null;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Manually implement relative fetching of the activity using a relative UUID. Should be reverted once foundryvtt/foundryvtt#11214 is fixed.

Closes #5220