### PR TITLE
[#4708] Redesign `AdvancementMigrationDialog` for V2 app & styles

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -441,6 +441,14 @@
       "ModifyChoices": "Modify Choices"
     }
   },
+  "Migration": {
+    "Action": {
+      "Confirm": "Apply Migrations"
+    },
+    "Hint": "Select which of the following advancements will be added to {name}.",
+    "Selection": "Advancement Selection",
+    "Title": "Migrate Advancement"
+  },
   "ScaleValue": {
     "Action": {
       "CopyFormula": "Copy Formula"
@@ -644,9 +652,6 @@
 "DND5E.AdvancementLevelNoneHeader": "No Level",
 "DND5E.AdvancementLevelDownConfirmationMessage": "Leveling this class down will also undo all advancement choices made for it. These changes will be removed from your character as long as the checkbox below is checked.",
 "DND5E.AdvancementLevelDownConfirmationTitle": "Confirm Leveling Down",
-"DND5E.AdvancementMigrationConfirm": "Apply Migrations",
-"DND5E.AdvancementMigrationHint": "Select which of the following advancements will be added to {name}.",
-"DND5E.AdvancementMigrationTitle": "Migrate Advancement",
 "DND5E.AdvancementModifyChoices": "Modify Choices",
 "DND5E.AdvancementSaveButton": "Save Advancement",
 "DND5E.AdvancementSelectionCreateButton": "Create Advancement",

--- a/less/v1/advancement.less
+++ b/less/v1/advancement.less
@@ -246,12 +246,6 @@
   }
 }
 
-.dnd5e.advancement-migration {
-  .items-list {
-    margin-block-end: 1em;
-  }
-}
-
 /* ----------------------------------------- */
 /*  Advancement Flow                         */
 /* ----------------------------------------- */

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -361,4 +361,7 @@
     grid-template-columns: [name] 1fr [controls] 30px;
     .item, .item-name { gap: 8px; }
   }
+  .form-group.hint {
+    padding: 0 8px 8px;
+  }
 }

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -2,7 +2,7 @@
 /*  Advancement Config Sheet                 */
 /* ----------------------------------------- */
 
-.dnd5e2.advancement.sheet {
+.dnd5e2.advancement.sheet, .dnd5e2.advancement-migration {
   &.grid-columns {
     --grid-column-left-size: 1fr;
     --grid-column-center-size: 1fr;
@@ -347,5 +347,18 @@
     display: grid;
     > .form-group { grid-column: 1 / -1; }
     .traits li.category { gap: 0; }
+  }
+}
+
+/* ----------------------------------------- */
+/*  Advancement Migration                    */
+/* ----------------------------------------- */
+
+.dnd5e2.advancement-migration {
+  --icon-size: 32px;
+  --gold-icon-size: 32px;
+  .items {
+    grid-template-columns: [name] 1fr [controls] 30px;
+    .item, .item-name { gap: 8px; }
   }
 }

--- a/module/applications/advancement/advancement-migration-dialog.mjs
+++ b/module/applications/advancement/advancement-migration-dialog.mjs
@@ -1,54 +1,88 @@
+import Dialog5e from "../api/dialog.mjs";
+
 /**
  * Dialog to select which new advancements should be added to an item.
  */
-export default class AdvancementMigrationDialog extends Dialog {
+export default class AdvancementMigrationDialog extends Dialog5e {
 
   /** @inheritDoc */
-  static get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["dnd5e", "advancement-migration", "dialog"],
-      jQuery: false,
+  static DEFAULT_OPTIONS = {
+    classes: ["advancement-migration"],
+    actions: {
+      complete: AdvancementMigrationDialog.#onComplete
+    },
+    advancements: [],
+    position: {
       width: 500
-    });
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Result of the migration dialog.
+   * @type {Advancement[]}
+   */
+  result = null;
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle clicking the migrate button.
+   * @this {AdvancementMigrationDialog}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static async #onComplete(event, target) {
+    const formData = new FormDataExtended(this.element.querySelector("form"));
+    this.result = this.options.advancements.filter(a => formData.object[a.id]);
+    this.close();
   }
 
+  /* -------------------------------------------- */
+  /*  Factory Methods                             */
   /* -------------------------------------------- */
 
   /**
    * A helper constructor function which displays the migration dialog.
    * @param {Item5e} item                    Item to which the advancements are being added.
    * @param {Advancement[]} advancements     New advancements that should be displayed in the prompt.
-   * @returns {Promise<Advancement[]|null>}  Resolves with the advancements that should be added, if any.
+   * @returns {Promise<Advancement[]>}       Resolves with the advancements that should be added, if any.
+   * @throws
    */
-  static createDialog(item, advancements) {
+  static async createDialog(item, advancements) {
     const advancementContext = advancements.map(a => ({
-      id: a.id, icon: a.icon, title: a.title,
+      id: a.id, icon: a.icon, svg: a.icon?.endsWith(".svg"), title: a.title,
       summary: a.levels.length === 1 ? a.summaryForLevel(a.levels[0]) : ""
     }));
-    return new Promise(async (resolve, reject) => {
-      const dialog = new this({
-        title: `${game.i18n.localize("DND5E.AdvancementMigrationTitle")}: ${item.name}`,
-        content: await renderTemplate(
-          "systems/dnd5e/templates/advancement/advancement-migration-dialog.hbs",
-          { item, advancements: advancementContext }
-        ),
-        buttons: {
-          continue: {
-            icon: '<i class="fas fa-check"></i>',
-            label: game.i18n.localize("DND5E.AdvancementMigrationConfirm"),
-            callback: html => resolve(advancements.filter(a => html.querySelector(`[name="${a.id}"]`)?.checked))
-          },
-          cancel: {
-            icon: '<i class="fas fa-times"></i>',
-            label: game.i18n.localize("Cancel"),
-            callback: html => reject(null)
-          }
-        },
-        default: "continue",
-        close: () => reject(null)
-      });
-      dialog.render(true);
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const dialog = new this({
+      advancements,
+      buttons: [
+        {
+          action: "complete",
+          default: true,
+          icon: "fa-solid fa-check",
+          label: game.i18n.localize("DND5E.ADVANCEMENT.Migration.Action.Confirm")
+        }
+      ],
+      content: await renderTemplate(
+        "systems/dnd5e/templates/advancement/advancement-migration-dialog.hbs",
+        { item, advancements: advancementContext }
+      ),
+      rejectClose: false,
+      window: {
+        title: game.i18n.localize("DND5E.ADVANCEMENT.Migration.Title"),
+        subtitle: item.name
+      }
     });
+    dialog.addEventListener("close", () => dialog.result ? resolve(dialog.result) : reject(null), { once: true });
+    dialog.render({ force: true });
+    return promise;
   }
 
 }

--- a/module/applications/advancement/advancement-migration-dialog.mjs
+++ b/module/applications/advancement/advancement-migration-dialog.mjs
@@ -23,7 +23,7 @@ export default class AdvancementMigrationDialog extends Dialog5e {
 
   /**
    * Result of the migration dialog.
-   * @type {Advancement[]}
+   * @type {Advancement[]|null}
    */
   result = null;
 
@@ -55,6 +55,7 @@ export default class AdvancementMigrationDialog extends Dialog5e {
    * @throws
    */
   static async createDialog(item, advancements) {
+    console.log("AdvancementMigrationDialog#createDialog", advancements);
     const advancementContext = advancements.map(a => ({
       id: a.id, icon: a.icon, svg: a.icon?.endsWith(".svg"), title: a.title,
       summary: a.levels.length === 1 ? a.summaryForLevel(a.levels[0]) : ""

--- a/module/applications/api/dialog.mjs
+++ b/module/applications/api/dialog.mjs
@@ -19,7 +19,7 @@ export default class Dialog5e extends Application5e {
   /** @override */
   static PARTS = {
     content: {
-      template: ""
+      template: "systems/dnd5e/templates/shared/dialog-content.hbs"
     },
     footer: {
       template: "templates/generic/form-footer.hbs"
@@ -60,6 +60,7 @@ export default class Dialog5e extends Application5e {
    * @protected
    */
   async _prepareContentContext(context, options) {
+    context.content = this.options.content ?? "";
     return context;
   }
 

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -646,6 +646,7 @@ export default class ItemSheet5e extends ItemSheet {
      */
     const allowed = Hooks.call("dnd5e.dropItemSheetData", item, this, data);
     if ( allowed === false ) return;
+    event.stopPropagation();
 
     switch ( data.type ) {
       case "ActiveEffect":

--- a/templates/advancement/advancement-migration-dialog.hbs
+++ b/templates/advancement/advancement-migration-dialog.hbs
@@ -1,6 +1,6 @@
 <fieldset class="card items">
     <legend>{{ localize "DND5E.ADVANCEMENT.Migration.Selection" }}</legend>
-    <div class="form-group">
+    <div class="form-group hint">
         <p class="hint">{{ localize "DND5E.ADVANCEMENT.Migration.Hint" name=item.name }}</p>
     </div>
     <div class="header">

--- a/templates/advancement/advancement-migration-dialog.hbs
+++ b/templates/advancement/advancement-migration-dialog.hbs
@@ -1,25 +1,32 @@
-<div class="advancement">
-    <p>{{localize "DND5E.AdvancementMigrationHint" name=item.name}}</p>
-    <ol class="items-list">
-        <li class="items-header flexrow">
-            <h3 class="item-name flexrow">{{localize "DND5E.AdvancementTitle"}}</h3>
-            <div class="item-controls flexrow">{{localize "DND5E.Add"}}</div>
-        </li>
+<fieldset class="card items">
+    <legend>{{ localize "DND5E.ADVANCEMENT.Migration.Selection" }}</legend>
+    <div class="form-group">
+        <p class="hint">{{ localize "DND5E.ADVANCEMENT.Migration.Hint" name=item.name }}</p>
+    </div>
+    <div class="header">
+        <div class="item-name">{{ localize "DND5E.AdvancementTitle" }}</div>
+        <div class="item-controls">{{ localize "DND5E.Add" }}</div>
+    </div>
+    <ol class="items-list unlist">
         {{#each advancements}}
         <li class="advancement-item item flexrow">
             <div class="item-name flexrow">
-                <div class="item-image" style="background-image: url('{{this.icon}}')"></div>
-                <h4>{{this.title}}</h4>
+                {{#if svg}}
+                <dnd5e-icon src="{{ icon }}"></dnd5e-icon>
+                {{else}}
+                <img class="gold-icon" src="{{ icon }}" alt="{{ title }}">
+                {{/if}}
+                <span class="name">{{ title }}</span>
             </div>
             <div class="item-controls flexrow">
-                <input type="checkbox" name="{{this.id}}" checked>
+                <dnd5e-checkbox name="{{ id }}" checked></dnd5e-checkbox>
             </div>
-            {{#if this.summary}}
+            {{#if summary}}
             <div class="item-summary">
-                {{{this.summary}}}
+                {{{ summary }}}
             </div>
             {{/if}}
         </li>
         {{/each}}
     </ol>
-</div>
+</fieldset>

--- a/templates/shared/dialog-content.hbs
+++ b/templates/shared/dialog-content.hbs
@@ -1,0 +1,3 @@
+<section>
+    {{{ content }}}
+</section>


### PR DESCRIPTION
Convert `AdvancementMigrationDialog` to use `Dialog5e` and the V2 styles.

<img width="521" alt="Advancement Migration V2" src="https://github.com/user-attachments/assets/a01f6045-ee3b-4c66-a123-25a7299031d6" />