### PR TITLE
[#5259] Add temp HP formula to transformation, replacing `addTemp`

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -119,11 +119,11 @@ Hooks.once("init", function() {
     delete DND5E.spellcastingTypes.leveled.progression.half.roundUp;
 
     // Adjust Wild Shape and Polymorph presets.
-    DND5E.transformation.presets.wildshape.settings.keep.delete("hp");
-    DND5E.transformation.presets.wildshape.settings.keep.delete("type");
-    delete DND5E.transformation.presets.polymorph.settings.addTemp;
-    DND5E.transformation.presets.polymorph.settings.keep.delete("hp");
-    DND5E.transformation.presets.polymorph.settings.keep.delete("type");
+    for ( const preset of ["polymorph", "wildshape"] ) {
+      DND5E.transformation.presets[preset].settings.keep.delete("hp");
+      DND5E.transformation.presets[preset].settings.keep.delete("type");
+      delete DND5E.transformation.presets[preset].settings.tempFormula;
+    }
 
     // Adjust language categories.
     delete DND5E.languages.standard.children.sign;
@@ -476,6 +476,7 @@ Hooks.once("i18nInit", () => {
   utils.performPreLocalization(CONFIG.DND5E);
   Object.values(CONFIG.DND5E.activityTypes).forEach(c => c.documentClass.localize());
   Object.values(CONFIG.DND5E.advancementTypes).forEach(c => c.documentClass.localize());
+  Localization.localizeDataModel(dataModels.settings.TransformationSetting);
 });
 
 /* -------------------------------------------- */
@@ -600,15 +601,6 @@ Hooks.on("preCreateScene", (doc, createData, options, userId) => {
       }
     });
   }
-});
-
-// TODO: Generalize this logic and make it available in the re-designed transform application.
-Hooks.on("dnd5e.transformActor", (subject, target, d, options) => {
-  const isLegacy = game.settings.get("dnd5e", "rulesVersion") === "legacy";
-  if ( (options.preset !== "wildshape") || !subject.classes?.druid || isLegacy ) return;
-  let temp = subject.classes.druid.system.levels;
-  if ( subject.classes.druid.subclass?.identifier === "moon" ) temp *= 3;
-  d.system.attributes.hp.temp = temp;
 });
 
 /* -------------------------------------------- */

--- a/lang/en.json
+++ b/lang/en.json
@@ -4026,8 +4026,30 @@
       },
       "Spell": {
         "Label": "Spell Effects"
+      }
+    },
+    "FIELDS": {
+      "effects": {
+        "label": "Active Effects"
       },
-      "Title": "Active Effects"
+      "keep": {
+        "hint": "These details will be retained from the source actor.",
+        "label": "Keep"
+      },
+      "merge": {
+        "hint": "Merge these proficiencies, keeping whichever has the higher modifier.",
+        "label": "Merge"
+      },
+      "other": {
+        "label": "Other Options"
+      },
+      "tempFormula": {
+        "hint": "Formula for temp HP that will be added upon transformation.",
+        "label": "Temp Formula"
+      },
+      "transformTokens": {
+        "label": "Transform Tokens"
+      }
     },
     "Keep": {
       "Biography": {
@@ -4045,7 +4067,6 @@
       "Health": {
         "Label": "Hit Points & Hit Dice"
       },
-      "Hint": "These details will be retained from the source actor.",
       "Mental": {
         "Hint": "Keep intelligence, wisdom, and charisma scores.",
         "Label": "Mental Abilities"
@@ -4070,27 +4091,17 @@
       "Spells": {
         "Label": "Spells"
       },
-      "Title": "Keep",
       "Vision": {
         "Label": "Vision"
       }
     },
     "Merge": {
-      "Hint": "Merge these proficiencies, keeping whichever has the higher modifier.",
       "Saves": {
         "Label": "Save Proficiencies"
       },
       "Skills": {
         "Label": "Skill Proficiencies"
-      },
-      "Title": "Merge"
-    },
-    "Other": {
-      "AddTemp": {
-        "Hint": "Add the target's current HP as temporary HP",
-        "Label": "Add Temp HP"
-      },
-      "Title": "Other Options"
+      }
     }
   },
   "TemporaryClass": "Temporary Class",

--- a/module/applications/actor/transform-dialog.mjs
+++ b/module/applications/actor/transform-dialog.mjs
@@ -153,9 +153,9 @@ export default class TransformDialog extends Dialog5e {
   async _prepareSettingsContext(context, options) {
     context.categories = ["keep", "merge", "effects", "other"].map(cat => ({
       category: cat,
-      title: `DND5E.TRANSFORM.Setting.${cat.capitalize()}.Title`,
-      hint: game.i18n.has(`DND5E.TRANSFORM.Setting.${cat.capitalize()}.Hint`)
-        ? `DND5E.TRANSFORM.Setting.${cat.capitalize()}.Hint` : "",
+      title: `DND5E.TRANSFORM.Setting.FIELDS.${cat}.label`,
+      hint: game.i18n.has(`DND5E.TRANSFORM.Setting.FIELDS.${cat}.hint`)
+        ? `DND5E.TRANSFORM.Setting.FIELDS.${cat}.hint` : "",
       settings: Object.entries(CONFIG.DND5E.transformation[cat]).map(([name, config]) => ({
         field: new BooleanField({ label: config.label, hint: config.hint }),
         input: context.inputs.createCheckboxInput,
@@ -163,6 +163,20 @@ export default class TransformDialog extends Dialog5e {
         value: this.#settings[cat]?.has(name)
       }))
     }));
+    const fields = TransformationSetting.schema.fields;
+    context.categories[3].settings.push(
+      {
+        field: fields.tempFormula,
+        name: "tempFormula",
+        value: this.#settings.tempFormula
+      },
+      {
+        field: fields.transformTokens,
+        input: context.inputs.createCheckboxInput,
+        name: "transformTokens",
+        value: this.#settings.transformTokens
+      }
+    );
     return context;
   }
 
@@ -218,11 +232,12 @@ export default class TransformDialog extends Dialog5e {
    */
   static async #setPreset(event, target) {
     const preset = CONFIG.DND5E.transformation.presets[target.dataset.preset];
-    if ( preset ) {
-      this.#settings = new TransformationSetting({ ...preset.settings, preset: target.dataset.preset });
-    } else {
-      this.#settings = new TransformationSetting();
-    }
+    if ( preset ) this.#settings = new TransformationSetting({
+      ...preset.settings,
+      preset: target.dataset.preset,
+      transformTokens: this.element.querySelector('[name="transformTokens"]').checked
+    });
+    else this.#settings = new TransformationSetting();
     this.render({ parts: ["presets", "settings"] });
   }
 

--- a/module/applications/actor/transform-dialog.mjs
+++ b/module/applications/actor/transform-dialog.mjs
@@ -35,9 +35,9 @@ export default class TransformDialog extends Dialog5e {
       width: 1000
     },
     transform: {
+      host: null,
       settings: null,
-      source: null,
-      target: null
+      source: null
     },
     window: {
       title: "DND5E.TRANSFORM.Dialog.Title",
@@ -116,7 +116,7 @@ export default class TransformDialog extends Dialog5e {
    */
   async _prepareDetailsContext(context, options) {
     context.sourceActor = this.options.transform.source;
-    context.targetActor = this.options.transform.target;
+    context.hostActor = this.options.transform.host;
     return context;
   }
 
@@ -269,15 +269,15 @@ export default class TransformDialog extends Dialog5e {
 
   /**
    * Display the transform dialog.
-   * @param {Actor5e} target                         Actor that will be transformed.
-   * @param {Actor5e} source                         Actor whose data will be applied to the target.
+   * @param {Actor5e} host                           Actor that will be transformed.
+   * @param {Actor5e} source                         Actor whose data will be applied to the host.
    * @param {object} [options={}]                    Additional options for the application.
    * @returns {Promise<TransformationSetting|null>}  Transformation settings to apply.
    */
-  static async promptSettings(target, source, options={}) {
+  static async promptSettings(host, source, options={}) {
     return new Promise(resolve => {
       options.transform ??= {};
-      options.transform.target = target;
+      options.transform.host = host;
       options.transform.source = source;
       const dialog = new this(options);
       dialog.addEventListener("close", event =>

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3501,12 +3501,7 @@ DND5E.transformation = {
       disables: ["keep.skills"]
     }
   },
-  other: {
-    addTemp: {
-      label: "DND5E.TRANSFORM.Setting.Other.AddTemp.Label",
-      hint: "DND5E.TRANSFORM.Setting.Other.AddTemp.Hint"
-    }
-  },
+  other: {},
   presets: {
     wildshape: {
       icon: '<i class="fas fa-paw" inert></i>',
@@ -3514,7 +3509,8 @@ DND5E.transformation = {
       settings: {
         effects: new Set(["otherOrigin", "origin", "feat", "spell", "class", "background"]),
         keep: new Set(["bio", "class", "feats", "hp", "mental", "type"]),
-        merge: new Set(["saves", "skills"])
+        merge: new Set(["saves", "skills"]),
+        tempFormula: "max(@classes.druid.levels, @subclasses.moon.levels * 3)"
       }
     },
     polymorph: {
@@ -3523,7 +3519,7 @@ DND5E.transformation = {
       settings: {
         effects: new Set(["otherOrigin", "origin", "spell"]),
         keep: new Set(["hp", "type"]),
-        other: new Set(["addTemp"])
+        tempFormula: "@source.attributes.hp.max"
       }
     },
     polymorphSelf: {

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -274,12 +274,40 @@ export default class CreatureTemplate extends CommonTemplate {
   /** @inheritDoc */
   getRollData({ deterministic=false }={}) {
     const data = super.getRollData({ deterministic });
-    data.classes = {};
-    for ( const [identifier, cls] of Object.entries(this.parent.classes) ) {
-      data.classes[identifier] = {...cls.system};
-      data.classes[identifier].hitDice = cls.system.hd.denomination; // Backwards compatibility
-      if ( cls.subclass ) data.classes[identifier].subclass = cls.subclass.system;
-    }
+
+    const ItemData = class {
+      constructor(data) {
+        this.#exists = !!data;
+        Object.assign(this, data);
+      }
+
+      #exists = false;
+
+      toString() { return this.#exists ? "1" : "0"; }
+    };
+
+    data.classes = new Proxy(this.parent, {
+      get(target, prop, receiver) {
+        const cls = target.classes[prop];
+        if ( !cls ) return new ItemData();
+        const data = { ...cls.system, hitDice: cls.system.hd.denomination };
+        if ( cls.subclass ) data.subclass = cls.subclass.system;
+        return new ItemData(data);
+      },
+      has(target, prop) {
+        return true;
+      }
+    });
+
+    data.subclasses = new Proxy(this.parent, {
+      get(target, prop, receiver) {
+        const subclass = target.subclasses[prop];
+        return subclass ? new ItemData({ levels: subclass.class?.system.levels }) : new ItemData();
+      },
+      has(target, prop) {
+        return true;
+      }
+    });
     return data;
   }
 }

--- a/module/data/settings/transformation-setting.mjs
+++ b/module/data/settings/transformation-setting.mjs
@@ -1,3 +1,5 @@
+import FormulaField from "../fields/formula-field.mjs";
+
 const { BooleanField, SetField, StringField } = foundry.data.fields;
 
 /**
@@ -7,6 +9,7 @@ const { BooleanField, SetField, StringField } = foundry.data.fields;
  * @property {Set<string>} merge
  * @property {Set<string>} other
  * @property {string} [preset]
+ * @property {string} [tempFormula]       Formula for temp HP that will be added during transformation.
  * @property {boolean} [transformTokens]
  */
 
@@ -14,6 +17,12 @@ const { BooleanField, SetField, StringField } = foundry.data.fields;
  * A data model that represents the previous transformation preset.
  */
 export default class TransformationSetting extends foundry.abstract.DataModel {
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.TRANSFORM.Setting"];
+
+  /* -------------------------------------------- */
+
   /** @override */
   static defineSchema() {
     return {
@@ -22,6 +31,7 @@ export default class TransformationSetting extends foundry.abstract.DataModel {
       merge: new SetField(new StringField(), { initial: () => TransformationSetting.#initial("merge") }),
       other: new SetField(new StringField(), { initial: () => TransformationSetting.#initial("other") }),
       preset: new StringField({ initial: null, nullable: true }),
+      tempFormula: new FormulaField({ determinstic: true }),
       transformTokens: new BooleanField({ initial: true })
     };
   }

--- a/templates/apps/transform-details.hbs
+++ b/templates/apps/transform-details.hbs
@@ -1,5 +1,5 @@
 <div>
-    {{> ".actor" actor=targetActor class="target" }}
+    {{> ".actor" actor=hostActor class="host" }}
     <dnd5e-icon src="systems/dnd5e/icons/svg/range-connector.svg"></dnd5e-icon>
     {{> ".actor" actor=sourceActor class="source" }}
 </div>


### PR DESCRIPTION
Adds a new formula field to define how much temp HP the transformed actor gets. The roll data in this field provides both the target actor's roll data as well as the source actor. This allows the polymorph preset formula to be `@source.attributes.hp.max`.

<img width="391" alt="Polymorph Temp Formula" src="https://github.com/user-attachments/assets/e0a7be50-f222-4d56-af19-91fbd2e13f0b" />

This PR also adds information on subclasses to the roll data, using a `Proxy` setup that allows for determining whether a specific subclass exists in roll data (so `@subclasses.moon` will resolve to `1` if the player has the Moon Druid subclass, or `0` if they do not). This allows setting the 2024 wild shape temp HP formula to be `max(@classes.druid.levels, @subclasses.moon.levels * 3)`.

Closes #5259