### PR TITLE
Implement UI for pending livestock trades.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -874,6 +874,11 @@
     "Gold": "{value} ({claimed})",
     "NoOrders": "No orders issued to special facilities this turn.",
     "Order": "{link} completed the <strong>{order}</strong> order."
+  },
+  "Trade": {
+    "Cancel": "Cancel Pending Trade",
+    "Invalid": "Removing a pending trade will invalidate your trade order.",
+    "Pending": "Pending trade"
   }
 },
 

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -648,17 +648,22 @@
       overflow: visible;
       cursor: pointer;
 
-      &.empty {
+      &.empty, &.pending {
         display: inline-grid;
         place-content: center;
 
         &::before {
           font-family: var(--font-awesome);
           font-weight: bold;
-          opacity: .15;
         }
       }
 
+      &.pending::before {
+        content: "\f51e";
+        color: var(--dnd5e-color-gold);
+      }
+
+      &.empty::before { opacity: .15; }
       &.hireling.empty::before { content: "\f007"; }
       &.defender.empty::before { content: "\f132"; }
       &.creature.empty::before { content: "\f7ab"; }
@@ -828,16 +833,21 @@
 
   &#bastion-turn {
     pointer-events: all;
-    margin: 0 5px 10px 15px;
+    margin: 0 0 -8px;
     color: var(--color-text-light-highlight);
-    width: var(--players-width);
+    width: var(--players-width, 200px);
     background: rgb(0 0 0 / 80%);
     border: 1px solid var(--color-border-dark);
+    cursor: var(--cursor-pointer), pointer;
+    height: 40px;
 
     &:hover {
       border-color: var(--color-border-highlight-alt);
       box-shadow: 0 0 10px var(--color-shadow-highlight);
     }
+
+    /* TODO: Remove when v12 is dropped */
+    .v12 { margin: 0 5px 10px 15px; }
   }
 
   /* ---------------------------------- */

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -514,6 +514,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     const { index } = event.target.closest("[data-index]")?.dataset ?? {};
     const facility = this.actor.items.get(facilityId);
     if ( !facility || !prop || (index === undefined) ) return;
+    if ( event.target.closest(".occupant-slot.pending") ) return this._onRemovePendingTrade(facility);
     let { value } = foundry.utils.getProperty(facility, prop);
     value = value.filter((_, i) => i !== Number(index));
     return facility.update({ [`${prop}.value`]: value });
@@ -538,6 +539,35 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     }
     const result = await CompendiumBrowser.selectOne({ filters });
     if ( result ) this._onDropItemCreate(game.items.fromCompendium(await fromUuid(result), { keepId: true }));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle removing a pending trade from a facility.
+   * @param {Item5e} facility  The target facility.
+   * @returns {Promise<void|Item5e>}
+   * @protected
+   */
+  async _onRemovePendingTrade(facility) {
+    const result = await foundry.applications.api.DialogV2.confirm({
+      content: `
+        <p><strong>${game.i18n.localize("AreYouSure")}</strong> ${game.i18n.localize("DND5E.Bastion.Trade.Invalid")}</p>
+      `,
+      window: {
+        icon: "fa-solid fa-coins",
+        title: "DND5E.Bastion.Trade.Cancel"
+      },
+      position: { width: 400 }
+    }, { rejectClose: false });
+    if ( result ) return facility.update({
+      system: {
+        progress: { max: null, order: "", value: null },
+        trade: {
+          pending: { creatures: [], operation: null }
+        }
+      }
+    });
   }
 
   /* -------------------------------------------- */
@@ -781,7 +811,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
       const context = {
         id, labels, name, building, disabled, free, progress,
         craft: craft.item ? await fromUuid(craft.item) : null,
-        creatures: await this._prepareFacilityOccupants(trade.creatures),
+        creatures: await this._prepareFacilityLivestock(trade),
         defenders: await this._prepareFacilityOccupants(defenders),
         executing: CONFIG.DND5E.facilities.orders[progress.order]?.icon,
         hirelings: await this._prepareFacilityOccupants(hirelings),
@@ -822,6 +852,25 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
   /* -------------------------------------------- */
 
   /**
+   * Prepare facility livestock for display.
+   * @param {object} trade  Facility trade information.
+   * @returns {Promise<object[]>}
+   * @protected
+   */
+  async _prepareFacilityLivestock(trade) {
+    const creatures = await this._prepareFacilityOccupants(trade.creatures);
+    const pending = trade.pending.creatures;
+    return [
+      ...(await Promise.all((pending ?? []).map(async (uuid, index) => {
+        return { index, actor: await fromUuid(uuid), pending: true };
+      }))),
+      ...creatures
+    ];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Prepare facility occupants for display.
    * @param {FacilityOccupants} occupants  The occupants.
    * @returns {Promise<object[]>}
@@ -829,9 +878,9 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
    */
   _prepareFacilityOccupants(occupants) {
     const { max, value } = occupants;
-    return Promise.all(Array.fromRange(max).map(async i => {
-      const uuid = value[i];
-      if ( uuid ) return { actor: await fromUuid(uuid) };
+    return Promise.all(Array.fromRange(max).map(async index => {
+      const uuid = value[index];
+      if ( uuid ) return { index, actor: await fromUuid(uuid) };
       return { empty: true };
     }));
   }

--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -208,6 +208,9 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
 
     if ( this.disabled ) this.progress.order = "repair";
 
+    // Trade
+    if ( Number.isFinite(this.trade.creatures.max) ) this.trade.creatures.max -= this.trade.pending.creatures.length;
+
     // Labels
     const labels = this.parent.labels ??= {};
     if ( this.order ) labels.order = game.i18n.localize(`DND5E.FACILITY.Orders.${this.order}.present`);

--- a/module/documents/activity/order.mjs
+++ b/module/documents/activity/order.mjs
@@ -164,10 +164,13 @@ export default class OrderActivity extends ActivityMixin(OrderActivityData) {
       }
       updates["system.trade.pending.value"] = trade.sell ? (trade.creatures.price ?? 0) : costs.gold;
       updates["system.trade.pending.creatures"] = creatures;
-      // TODO: We need a way to visualize 'pending' animal purchases/sales. For now update immediately.
-      updates["system.trade.creatures.value"] = trade.sell
-        ? system.trade.creatures.value.filter((_, i) => !trade.creatures.sell[i])
-        : system.trade.creatures.value.concat(creatures);
+
+      // Sold livestock are removed immediately. Bought livestock remain pending until the order is complete.
+      if ( trade.sell ) {
+        updates["system.trade.creatures.value"] = system.trade.creatures.value.filter((_, i) => {
+          return !trade.creatures.sell[i];
+        });
+      }
     }
   }
 

--- a/module/documents/actor/bastion.mjs
+++ b/module/documents/actor/bastion.mjs
@@ -284,11 +284,16 @@ export default class Bastion {
       if ( (trade.pending.value === null) && trade.pending.stocked ) updates["system.trade.stock.stocked"] = true;
 
       // Bought goods
-      else if ( trade.pending.value !== null && !trade.pending.creatures.length ) {
-        updates["system.trade.stock.value"] = Math.min(trade.stock.value + trade.pending.value, trade.stock.max);
+      else if ( trade.pending.value !== null ) {
+        if ( trade.pending.creatures.length ) {
+          const creatures = trade.creatures.value.concat(trade.pending.creatures);
+          const diff = trade.creatures.max - creatures.length;
+          if ( diff < 0 ) creatures.splice(diff);
+          updates["system.trade.creatures.value"] = creatures;
+        }
+        else updates["system.trade.stock.value"] = Math.min(trade.stock.value + trade.pending.value, trade.stock.max);
       }
     } else if ( trade.pending.value !== null ) {
-      // See OrderActivity#_finalizeTrade for creatures TODO
       // Sold goods
       let sold = trade.pending.value;
       if ( !trade.pending.creatures.length ) {
@@ -546,8 +551,9 @@ export default class Bastion {
     }
 
     if ( !turnButton ) {
-      document.getElementById("controls")?.insertAdjacentHTML("afterend", `
-        <button type="button" id="bastion-turn" data-action="bastionTurn" class="dnd5e2">
+      const v12 = game.release.generation < 13 ? "v12" : "";
+      document.querySelector("#controls, #scene-controls")?.insertAdjacentHTML("afterend", `
+        <button type="button" id="bastion-turn" data-action="bastionTurn" class="dnd5e2 ${v12}">
           <i class="fas fa-chess-rook"></i>
           <span>${game.i18n.localize("DND5E.Bastion.Action.BastionTurn")}</span>
         </button>

--- a/templates/actors/tabs/character-bastion.hbs
+++ b/templates/actors/tabs/character-bastion.hbs
@@ -129,21 +129,21 @@
     {{#if hirelings.length}}
     <div class="slots facility-occupants hirelings" data-prop="system.hirelings">
         {{#each hirelings}}
-            {{> ".occupant" type="hireling" index=@key }}
+            {{> ".occupant" type="hireling" }}
         {{/each}}
     </div>
     {{/if}}
     {{#if defenders.length}}
     <div class="slots facility-occupants defenders" data-prop="system.defenders">
         {{#each defenders}}
-            {{> ".occupant" type="defender" index=@key }}
+            {{> ".occupant" type="defender" }}
         {{/each}}
     </div>
     {{/if}}
     {{#if creatures.length}}
     <div class="slots facility-occupants creatures" data-prop="system.trade.creatures">
         {{#each creatures}}
-            {{> ".occupant" type="creature" index=@key }}
+            {{> ".occupant" type="creature" }}
         {{/each}}
     </div>
     {{/if}}
@@ -152,13 +152,18 @@
 
 {{#*inline ".occupant"}}
 <div {{#if actor}}data-actor-uuid="{{ actor.uuid }}" data-action="viewOccupant"{{/if}}
-      class="slot occupant-slot {{ type }} {{#if empty}}empty{{/if}}" data-index="{{ index }}">
+      class="slot occupant-slot {{ type }} {{#if empty}}empty{{/if}} {{#if pending}}pending{{/if}}"
+      data-index="{{ index }}" {{#if pending}}data-tooltip="{{ localize "DND5E.Bastion.Trade.Pending" }}"{{/if}}>
     {{#if actor}}
+    {{#unless pending}}
     <img src="{{ actor.img }}" alt="{{ actor.name }}">
+    {{/unless}}
+    {{/if}}
     {{#if @root.editable}}
+    {{#if (or actor pending)}}
     <a class="deletion-control" data-action="deleteOccupant"
        aria-label="{{ localize "DND5E.FACILITY.Action.DeleteOccupant" }}">
-        <i class="fas fa-circle-xmark"></i>
+        <i class="fas fa-circle-xmark" inert></i>
     </a>
     {{/if}}
     {{/if}}


### PR DESCRIPTION
Clears out some remaining TODOs from the Bastion system. Pending livestock trades will now show with a special icon, and deleting them will invalidate the trade order entirely. Sold livestock are removed immediately and marked as pending, while bought livestock are marked as pending until the bastion order is complete, at which point they appear in the Stable.

![image](https://github.com/user-attachments/assets/39d72216-62fb-4c9b-a31f-44c3f8f8b321)