### PR TITLE
[#5033] Add dark mode styling for embedded stat blocks

### DIFF
--- a/less/v2/dark/journal.less
+++ b/less/v2/dark/journal.less
@@ -37,9 +37,11 @@
     --statblock-ability-header-2nd: rgb(62, 68, 48);
     --statblock-ability-stat-1st: rgb(89, 63, 63);
     --statblock-ability-stat-2nd: rgb(89, 67, 87);
-    --statblock-border: var(--dnd5e-color-gold);
+    --statblock-border: var(--dnd5e-color-blue-gray-1);
     --statblock-text-header: var(--color-text-dark-primary);
     --statblock-text-primary: var(--color-text-dark-primary);
-    --statblock-text-secondary: color-mix(in oklab, var(--color-text-dark-primary), transparent 25%)
+    --statblock-text-secondary: color-mix(in oklab, var(--color-text-dark-primary), transparent 25%);
+
+    h4.statblock-title, h5.statblock-actions-title { border-color: var(--dnd5e-color-blue-gray-3); }
   }
 }

--- a/less/v2/dark/journal.less
+++ b/less/v2/dark/journal.less
@@ -29,4 +29,17 @@
 
     &::before, &::after { filter: grayscale(1); }
   }
+
+  .statblock.npc {
+    --statblock-background: rgb(0 0 0 / .35);
+    --statblock-ability-border: black;
+    --statblock-ability-header-1st: rgb(83, 73, 50);
+    --statblock-ability-header-2nd: rgb(62, 68, 48);
+    --statblock-ability-stat-1st: rgb(89, 63, 63);
+    --statblock-ability-stat-2nd: rgb(89, 67, 87);
+    --statblock-border: var(--dnd5e-color-gold);
+    --statblock-text-header: var(--color-text-dark-primary);
+    --statblock-text-primary: var(--color-text-dark-primary);
+    --statblock-text-secondary: color-mix(in oklab, var(--color-text-dark-primary), transparent 25%)
+  }
 }

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -177,6 +177,7 @@
   /* NPC Stat Blocks */
   .statblock.npc {
     --statblock-background: rgb(235 228 214 / .35);
+    --statblock-ability-border: white;
     --statblock-ability-header-1st: rgb(234 229 217);
     --statblock-ability-header-2nd: rgb(215 217 208);
     --statblock-ability-stat-1st: rgb(218 211 203);
@@ -269,7 +270,7 @@
         }
         tbody {
           tr {
-            border-block: 1px solid white;
+            border-block: 1px solid var(--statblock-ability-border);
             &:nth-of-type(odd) {
               th, .score { background: var(--statblock-ability-header-1st); }
               td { background: var(--statblock-ability-stat-1st); }


### PR DESCRIPTION
Adjusts the colors the embedded stat blocks for dark mode.

<img width="522" alt="Stat Block Dark Mode" src="https://github.com/user-attachments/assets/7b05390c-e211-4883-981b-3a13a4c8da88" />

Closes #5033