### PR TITLE
[#5171, #5173, #5174] Add advantage to abilities, skills & tools

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -65,6 +65,8 @@
 
 "DND5E.ABILITY": {
   "Configure": {
+    "CheckLabel": "{ability} Check",
+    "SaveLabel": "{ability} Save",
     "Title": "Configure {ability}"
   },
   "SECTIONS": {

--- a/module/applications/actor/config/ability-config.mjs
+++ b/module/applications/actor/config/ability-config.mjs
@@ -38,6 +38,8 @@ export default class AbilityConfig extends BaseProficiencyConfig {
       { value: 0, label: CONFIG.DND5E.proficiencyLevels[0] },
       { value: 1, label: CONFIG.DND5E.proficiencyLevels[1] }
     ];
+    context.checkLabel = game.i18n.format("DND5E.ABILITY.Configure.CheckLabel", { ability: context.label });
+    context.saveLabel = game.i18n.format("DND5E.ABILITY.Configure.SaveLabel", { ability: context.label });
     return context;
   }
 }

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -1,4 +1,5 @@
 import { simplifyBonus } from "../../../utils.mjs";
+import AdvantageModeField from "../../fields/advantage-mode-field.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 import MappingField from "../../fields/mapping-field.mjs";
 import RollConfigField from "../../shared/roll-config-field.mjs";

--- a/module/data/fields/advantage-mode-field.mjs
+++ b/module/data/fields/advantage-mode-field.mjs
@@ -40,7 +40,7 @@ export default class AdvantageModeField extends foundry.data.fields.NumberField 
   _applyChangeAdd(value, delta, model, change) {
     // Add a source of advantage or disadvantage.
     if ( (delta !== -1) && (delta !== 1) ) return value;
-    const counts = this.constructor.getCounts(model, change);
+    const counts = this.constructor.getCounts(model, change.key);
     if ( delta === 1 ) counts.advantages.count++;
     else counts.disadvantages.count++;
     return this.constructor.resolveMode(model, change, counts);
@@ -52,7 +52,7 @@ export default class AdvantageModeField extends foundry.data.fields.NumberField 
   _applyChangeDowngrade(value, delta, model, change) {
     // Downgrade the roll so that it can no longer benefit from advantage.
     if ( (delta !== -1) && (delta !== 0) ) return value;
-    const counts = this.constructor.getCounts(model, change);
+    const counts = this.constructor.getCounts(model, change.key);
     counts.advantages.suppressed = true;
     if ( delta === -1 ) counts.disadvantages.count++;
     return this.constructor.resolveMode(model, change, counts);
@@ -71,7 +71,7 @@ export default class AdvantageModeField extends foundry.data.fields.NumberField 
   _applyChangeOverride(value, delta, model, change) {
     // Force a given roll mode.
     if ( (delta === -1) || (delta === 0) || (delta === 1) ) {
-      this.constructor.getCounts(model, change).override = delta;
+      this.constructor.getCounts(model, change.key).override = delta;
       return delta;
     }
     return value;
@@ -94,13 +94,44 @@ export default class AdvantageModeField extends foundry.data.fields.NumberField 
   /* -------------------------------------------- */
 
   /**
+   * Retrieve the counts from several advantage mode fields and determine the final advantage mode.
+   * @param {DataModel} model    The model containing the fields.
+   * @param {string[]} keyPaths  Paths to the individual fields to combine within the model.
+   * @returns {{ advantage: boolean, disadvantage: boolean, mode: number }}
+   */
+  static combineFields(model, keyPaths) {
+    const counts = {
+      override: null,
+      advantages: { count: 0, suppressed: false },
+      disadvantages: { count: 0, suppressed: false }
+    };
+    for ( const kp of keyPaths ) {
+      const c = this.getCounts(model, kp);
+      const src = foundry.utils.getProperty(model._source, kp) ?? 0;
+      if ( c.override ) counts.override = c.override;
+      if ( c.advantages.suppressed ) counts.advantages.suppressed = true;
+      if ( c.disadvantages.suppressed ) counts.disadvantages.suppressed = true;
+      counts.advantages.count += c.advantages.count + Number(src === 1);
+      counts.disadvantages.count += c.disadvantages.count + Number(src === -1);
+    }
+    return {
+      advantage: (counts.advantages.count > 0) && !counts.advantages.suppressed,
+      disadvantage: (counts.disadvantages.count > 0) && !counts.disadvantages.suppressed,
+      mode: this.resolveMode(model, null, counts)
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Retrieve the advantage/disadvantage counts from the model.
-   * @param {DataModel} model          The model the change is applied to.
-   * @param {EffectChangeData} change  The change to apply.
+   * @param {DataModel} model                  The model the change is applied to.
+   * @param {string|EffectChangeData} keyPath  Path to the field or effect change being applied.
    * @returns {AdvantageModeData}
    */
-  static getCounts(model, change) {
-    const parentKey = change.key.substring(0, change.key.lastIndexOf("."));
+  static getCounts(model, keyPath) {
+    keyPath = foundry.utils.getType(keyPath) === "Object" ? keyPath.key : keyPath;
+    const parentKey = keyPath.substring(0, keyPath.lastIndexOf("."));
     const roll = foundry.utils.getProperty(model, parentKey) ?? {};
     return roll.modeCounts ??= {
       override: null,
@@ -113,16 +144,17 @@ export default class AdvantageModeField extends foundry.data.fields.NumberField 
 
   /**
    * Resolve multiple sources of advantage and disadvantage into a single roll mode per the game rules.
-   * @param {DataModel} model             The model the change is applied to.
-   * @param {EffectChangeData} change     The change to applied.
-   * @param {AdvantageModeData} [counts]  The current advantage/disadvantage counts.
-   * @returns {number}                    An integer in the interval [-1, 1], indicating advantage (1),
-   *                                      disadvantage (-1), or neither (0).
+   * @param {DataModel} model                  The model the change is applied to.
+   * @param {string|EffectChangeData} keyPath  Path to the field or effect change being applied.
+   * @param {AdvantageModeData} [counts]       The current advantage/disadvantage counts.
+   * @returns {number}                         An integer in the interval [-1, 1], indicating advantage (1),
+   *                                           disadvantage (-1), or neither (0).
    */
-  static resolveMode(model, change, counts) {
-    const { override, advantages, disadvantages } = counts ?? this.getCounts(model, change);
+  static resolveMode(model, keyPath, counts) {
+    keyPath = foundry.utils.getType(keyPath) === "Object" ? keyPath.key : keyPath;
+    const { override, advantages, disadvantages } = counts ?? this.getCounts(model, keyPath);
     if ( override !== null ) return override;
-    const src = foundry.utils.getProperty(model._source, change.key) ?? 0;
+    const src = foundry.utils.getProperty(model._source, keyPath) ?? 0;
     const advantageCount = advantages.suppressed ? 0 : advantages.count + Number(src === 1);
     const disadvantageCount = disadvantages.suppressed ? 0 : disadvantages.count + Number(src === -1);
     return Math.sign(advantageCount) - Math.sign(disadvantageCount);

--- a/module/dice/d20-die.mjs
+++ b/module/dice/d20-die.mjs
@@ -104,7 +104,8 @@ export default class D20Die extends Die {
    * @param {number} [values.maximum]
    */
   applyRange(values) {
-    for ( const [key, value] of Object.entries(values) ) {
+    for ( let [key, value] of Object.entries(values) ) {
+      if ( !Number.isFinite(value) ) value = undefined;
       this.options[key] = value;
       const mod = key.substring(0, 3);
       this.modifiers.findSplice(m => m.startsWith(mod));

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -4,6 +4,7 @@ import SkillToolRollConfigurationDialog from "../../applications/dice/skill-tool
 import PropertyAttribution from "../../applications/property-attribution.mjs";
 import ActivationsField from "../../data/chat-message/fields/activations-field.mjs";
 import { ActorDeltasField } from "../../data/chat-message/fields/deltas-field.mjs";
+import AdvantageModeField from "../../data/fields/advantage-mode-field.mjs";
 import { _applyDeprecatedD20Configs, _createDeprecatedD20Config } from "../../dice/d20-roll.mjs";
 import { createRollLabel } from "../../enrichers.mjs";
 import parseUuid from "../../parse-uuid.mjs";
@@ -1172,20 +1173,25 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     const relevant = type === "skill" ? this.system.skills?.[config.skill] : this.system.tools?.[config.tool];
+    const abilityId = relevant?.ability ?? (type === "skill" ? skillConfig.ability : toolConfig.ability);
+    const ability = this.system.abilities?.[abilityId];
     const buildConfig = this._buildSkillToolConfig.bind(this, type);
 
+    const { advantage, disadvantage } = AdvantageModeField.combineFields(this.system, [
+      `abilities.${abilityId}.check.roll.mode`,
+      `${type}s.${type === "skill" ? config.skill : config.tool}.roll.mode`
+    ]);
+
     const rollConfig = foundry.utils.mergeObject({
-      ability: relevant?.ability ?? (type === "skill" ? skillConfig.ability : toolConfig.ability),
-      advantage: relevant?.roll.mode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE,
-      disadvantage: relevant?.roll.mode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE,
+      ability: abilityId, advantage, disadvantage,
       halflingLucky: this.getFlag("dnd5e", "halflingLucky"),
       reliableTalent: (relevant?.value >= 1) && this.getFlag("dnd5e", "reliableTalent")
     }, config);
     rollConfig.hookNames = [...(config.hookNames ?? []), type, "abilityCheck", "d20Test"];
     rollConfig.rolls = [BasicRoll.mergeConfigs({
       options: {
-        maximum: relevant?.roll.max,
-        minimum: relevant?.roll.min
+        maximum: Math.min(relevant?.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity),
+        minimum: Math.max(relevant?.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
       }
     }, config.rolls?.shift())].concat(config.rolls ?? []);
     rollConfig.subject = this;
@@ -1198,7 +1204,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       }
     }, dialog);
 
-    const abilityLabel = CONFIG.DND5E.abilities[relevant?.ability ?? skillConfig?.ability ?? ""]?.label;
+    const abilityLabel = CONFIG.DND5E.abilities[abilityId]?.label ?? "";
 
     const messageConfig = foundry.utils.mergeObject({
       create: true,
@@ -1443,7 +1449,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       [`${type}Bonus`]: this.system.bonuses?.abilities?.[type],
       cover: (config.ability === "dex") && (type === "save") ? this.system.attributes?.ac?.cover : null
     }, rollData);
-    const options = {};
+    const options = {
+      advantage: ability?.[type]?.roll.mode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE,
+      disadvantage: ability?.[type]?.roll.mode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE,
+      maximum: ability?.[type]?.roll.max,
+      minimum: ability?.[type]?.roll.min
+    };
 
     const rollConfig = foundry.utils.mergeObject({
       halflingLucky: this.getFlag("dnd5e", "halflingLucky")
@@ -1716,20 +1727,29 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       _applyDeprecatedD20Configs(config, dialog, message, oldConfig);
     }
 
+    const abilityId = (conc.ability in CONFIG.DND5E.abilities) ? conc.ability
+      : CONFIG.DND5E.defaultAbilities.concentration;
+    const ability = this.system.abilities?.[abilityId];
+
+    const { advantage, disadvantage } = AdvantageModeField.combineFields(this.system, [
+      `abilities.${abilityId}.save.roll.mode`,
+      "attributes.concentration.roll.mode"
+    ]);
+
     let data = {};
     const parts = [];
     const options = {
-      advantage: conc.roll.mode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE,
-      disadvantage: conc.roll.mode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE,
-      maximum: conc.roll.max,
-      minimum: conc.roll.min
+      advantage,
+      disadvantage,
+      maximum: Math.min(conc.roll.max ?? Infinity, ability?.save.roll.max ?? Infinity),
+      minimum: Math.max(conc.roll.min ?? -Infinity, ability?.save.roll.min ?? -Infinity)
     };
 
     // Concentration bonus
     if ( conc.bonuses.save ) parts.push(conc.bonuses.save);
 
     const rollConfig = foundry.utils.mergeObject({
-      ability: (conc.ability in CONFIG.DND5E.abilities) ? conc.ability : CONFIG.DND5E.defaultAbilities.concentration,
+      ability: abilityId,
       isConcentration: true,
       target: 10
     }, config);

--- a/templates/actors/config/ability-config.hbs
+++ b/templates/actors/config/ability-config.hbs
@@ -27,6 +27,42 @@
                      localize=true rootId=partId }}
     </fieldset>
 
+    {{!-- Check Rolls --}}
+    <fieldset class="card">
+        <legend>{{ localize "DND5E.ROLL.Section" label=checkLabel }}</legend>
+        {{ formField fields.check.fields.roll.fields.mode name=(concat prefix "check.roll.mode")
+                     value=data.check.roll.mode options=advantageModeOptions localize=true rootId=partId }}
+        <div class="form-group split-group">
+            <label>{{ localize "DND5E.ROLL.Range.Label" }}</label>
+            <div class="form-fields">
+                {{ formField fields.check.fields.roll.fields.min name=(concat prefix "check.roll.min")
+                             value=data.check.roll.min placeholder="1" type="number" localize=true
+                             label=(localize "DND5E.Minimum") hint=false classes="label-top" rootId=partId }}
+                {{ formField fields.check.fields.roll.fields.max name=(concat prefix "check.roll.max")
+                             value=data.check.roll.max placeholder="20" type="number" localize=true
+                             label=(localize "DND5E.Maximum") hint=false classes="label-top" rootId=partId }}
+            </div>
+        </div>
+    </fieldset>
+
+    {{!-- Save Rolls --}}
+    <fieldset class="card">
+        <legend>{{ localize "DND5E.ROLL.Section" label=saveLabel }}</legend>
+        {{ formField fields.save.fields.roll.fields.mode name=(concat prefix "save.roll.mode")
+                     value=data.save.roll.mode options=advantageModeOptions localize=true rootId=partId }}
+        <div class="form-group split-group">
+            <label>{{ localize "DND5E.ROLL.Range.Label" }}</label>
+            <div class="form-fields">
+                {{ formField fields.save.fields.roll.fields.min name=(concat prefix "save.roll.min")
+                             value=data.save.roll.min placeholder="1" type="number" localize=true
+                             label=(localize "DND5E.Minimum") hint=false classes="label-top" rootId=partId }}
+                {{ formField fields.save.fields.roll.fields.max name=(concat prefix "save.roll.max")
+                             value=data.save.roll.max placeholder="20" type="number" localize=true
+                             label=(localize "DND5E.Maximum") hint=false classes="label-top" rootId=partId }}
+            </div>
+        </div>
+    </fieldset>
+
     {{!-- Global Bonuses --}}
     {{#if global}}
     <fieldset class="card">

--- a/templates/actors/config/skill-tool-config.hbs
+++ b/templates/actors/config/skill-tool-config.hbs
@@ -25,6 +25,8 @@
     {{!-- Rolls --}}
     <fieldset class="card">
         <legend>{{ localize "DND5E.ROLL.Section" label=label }}</legend>
+        {{ formField fields.roll.fields.mode name=(concat prefix "roll.mode") value=data.roll.mode
+                     options=advantageModeOptions localize=true rootId=partId }}
         <div class="form-group split-group">
             <label>{{ localize "DND5E.ROLL.Range.Label" }}</label>
             <div class="form-fields">


### PR DESCRIPTION
Adds the ability to configure roll mode, minimum, and maximum to ability checks & saves, and roll mode for skills & tools.

Adds a new method `AdvantageModeField#combineFields` that takes the key paths for two or more fields on a model and combines their advantage counts to find a final advantage mode.

This new method is then used when rolling skill checks, tool checks, or concentration saves to find the final advantage mode.

Closes #5171
Closes #5173