### PR TITLE
[#4774] Add properties to classes with Sidekick property

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1130,6 +1130,9 @@
         "label": "Primary Ability",
         "hint": "Abilities used most by this class. Used to determine multi-classing restrictions."
       }
+    },
+    "properties": {
+      "label": "Class Properties"
     }
   }
 },
@@ -2695,6 +2698,7 @@
     "Reload": "Reload",
     "Returning": "Returning",
     "Ritual": "Ritual",
+    "Sidekick": "Sidekick",
     "Silvered": "Silvered",
     "Somatic": "Somatic",
     "Special": "Special",

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -534,6 +534,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     if ( classIdentifier ) filters.locked.additional = { class: { [classIdentifier]: 1 } };
     if ( type === "class" ) {
       const existingIdentifiers = new Set(Object.keys(this.actor.classes));
+      filters.initial = { additional: { properties: { sidekick: -1 } } };
       filters.locked.arbitrary = [{ o: "NOT", v: { k: "system.identifier", o: "in", v: existingIdentifiers } }];
     }
     const result = await CompendiumBrowser.selectOne({ filters });

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -64,10 +64,12 @@ export default class CompendiumBrowser extends Application5e {
       this._applyModeFilters(this.options.mode);
     }
 
-    const isAdvanced = this._mode === this.constructor.MODES.ADVANCED;
-    const tab = this.constructor.TABS.find(t => t.tab === this.options.tab);
-    if ( !tab || (!!tab.advanced !== isAdvanced) ) this.options.tab = isAdvanced ? "actors" : "classes";
-    this._applyTabFilters(this.options.tab);
+    if ( foundry.utils.isEmpty(this.options.filters.locked) ) {
+      const isAdvanced = this._mode === this.constructor.MODES.ADVANCED;
+      const tab = this.constructor.TABS.find(t => t.tab === this.options.tab);
+      if ( !tab || (!!tab.advanced !== isAdvanced) ) this.options.tab = isAdvanced ? "actors" : "classes";
+      this._applyTabFilters(this.options.tab);
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2017,6 +2017,9 @@ DND5E.itemProperties = {
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.FjWqT5iyJ89kohdA",
     isTag: true
   },
+  sidekick: {
+    label: "DND5E.Item.Property.Sidekick"
+  },
   sil: {
     label: "DND5E.Item.Property.Silvered",
     isPhysical: true
@@ -2062,6 +2065,9 @@ preLocalize("itemProperties", { keys: ["label", "abbreviation"], sort: true });
  * @enum {object}
  */
 DND5E.validProperties = {
+  class: new Set([
+    "sidekick"
+  ]),
   consumable: new Set([
     "mgc"
   ]),

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -13,16 +13,17 @@ const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringFiel
  * @mixes ItemDescriptionTemplate
  * @mixes StartingEquipmentTemplate
  *
+ * @property {object[]} advancement             Advancement objects for this class.
+ * @property {object} hd                        Object describing hit dice properties.
+ * @property {string} hd.additional             Additional hit dice beyond the level of the class.
+ * @property {string} hd.denomination           Denomination of hit dice available as defined in `DND5E.hitDieTypes`.
+ * @property {number} hd.spent                  Number of hit dice consumed.
  * @property {number} levels                    Current number of levels in this class.
  * @property {object} primaryAbility
  * @property {Set<string>} primaryAbility.value List of primary abilities used by this class.
  * @property {boolean} primaryAbility.all       If multiple abilities are selected, does multiclassing require all of
  *                                              them to be 13 or just one.
- * @property {object} hd                        Object describing hit dice properties.
- * @property {string} hd.additional             Additional hit dice beyond the level of the class.
- * @property {string} hd.denomination           Denomination of hit dice available as defined in `DND5E.hitDieTypes`.
- * @property {number} hd.spent                  Number of hit dice consumed.
- * @property {object[]} advancement             Advancement objects for this class.
+ * @property {Set<string>} properties           General properties of a class item.
  * @property {SpellcastingField} spellcasting   Details on class's spellcasting ability.
  */
 export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTemplate, StartingEquipmentTemplate) {
@@ -39,11 +40,7 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      levels: new NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 1 }),
-      primaryAbility: new SchemaField({
-        value: new SetField(new StringField()),
-        all: new BooleanField({ initial: true })
-      }),
+      advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" }),
       hd: new SchemaField({
         additional: new FormulaField({ deterministic: true, required: true }),
         denomination: new StringField({
@@ -52,7 +49,12 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
         }),
         spent: new NumberField({ required: true, nullable: false, integer: true, initial: 0, min: 0 })
       }),
-      advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" }),
+      levels: new NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 1 }),
+      primaryAbility: new SchemaField({
+        value: new SetField(new StringField()),
+        all: new BooleanField({ initial: true })
+      }),
+      properties: new SetField(new StringField()),
       spellcasting: new SpellcastingField()
     });
   }
@@ -71,7 +73,8 @@ export default class ClassData extends ItemDataModel.mixin(ItemDescriptionTempla
           if ( value === -1 ) filters.push(filter);
           else filters.push({ o: "NOT", v: filter });
         }
-      }]
+      }],
+      ["properties", this.compendiumBrowserPropertiesFilter("class")]
     ]);
   }
 

--- a/templates/items/details/details-class.hbs
+++ b/templates/items/details/details-class.hbs
@@ -31,6 +31,10 @@
     {{#if source.hd.additional}}
     {{ formGroup fields.hd.fields.additional value=source.hd.additional localize=true }}
     {{/if}}
+
+    {{!-- Class Properties --}}
+    {{ formField fields.properties options=properties.options input=inputs.createMultiCheckboxInput stacked=true
+                 classes="checkbox-grid checkbox-grid-3" }}
 </fieldset>
 
 <fieldset>


### PR DESCRIPTION
Adds properties to classes and give them support for the "Sidekick" property. Also sets the initial filter when browsing classes on a PC to exclude sidekicks (but not locked, in case a DM wants to use the character sheet for their sidekicks).