### PR TITLE
Allow special ToC sections to be seen in chapters that hide pages

### DIFF
--- a/module/applications/journal/table-of-contents.mjs
+++ b/module/applications/journal/table-of-contents.mjs
@@ -143,7 +143,9 @@ class TableOfContentsCompendiumV13 extends (foundry.applications.sidebar?.apps?.
     }
 
     for ( const chapter of context.chapters ) {
-      chapter.pages.sort((lhs, rhs) => lhs.sort - rhs.sort);
+      chapter.pages = chapter.pages
+        .filter(p => !p.flags.tocHidden && (chapter.showPages || p.entry))
+        .sort((lhs, rhs) => lhs.sort - rhs.sort);
       for ( const page of chapter.pages ) {
         if ( page.pages ) page.pages.sort((lhs, rhs) => lhs.sort - rhs.sort);
       }
@@ -279,7 +281,9 @@ class TableOfContentsCompendiumV12 extends (foundry.applications?.sidebar?.apps?
     }
 
     for ( const chapter of context.chapters ) {
-      chapter.pages.sort((lhs, rhs) => lhs.sort - rhs.sort);
+      chapter.pages = chapter.pages
+        .filter(p => !p.flags.tocHidden && (chapter.showPages || p.entry))
+        .sort((lhs, rhs) => lhs.sort - rhs.sort);
       for ( const page of chapter.pages ) {
         if ( page.pages ) page.pages.sort((lhs, rhs) => lhs.sort - rhs.sort);
       }

--- a/templates/journal/table-of-contents.hbs
+++ b/templates/journal/table-of-contents.hbs
@@ -30,7 +30,7 @@
             {{#each chapters}}
             <div class="chapter" data-document-id="{{ id }}" data-entry-id="{{ id }}">
                 <h3><a class="journal-entry-link" data-action="activateEntry">{{ name }}</a></h3>
-                {{#if (and showPages pages.length)}}{{> "pages" }}{{/if}}
+                {{#if pages.length}}{{> "pages" }}{{/if}}
             </div>
             {{/each}}
         </section>


### PR DESCRIPTION
Currently "special" table of contents that append to an existing chapter won't appear if `showPages` is `false` for that chapter. This change moves some of the page display logic into the app and allows for displaying those special pages while hiding all other pages in the chapter.