### PR TITLE
[#5164] Support other advancement types on features

### DIFF
--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -91,7 +91,7 @@ export default class ActorSheet5eCharacter extends ActorSheet5e {
 
       // Item grouping
       ctx.ungroup = "passive";
-      const [originId] = item.getFlag("dnd5e", "advancementOrigin")?.split(".") ?? [];
+      const [originId] = (item.flags.dnd5e?.ultimateOrigin ?? item.flags.dnd5e?.advancementOrigin)?.split(".") ?? [];
       const group = this.actor.items.get(originId);
       switch ( group?.type ) {
         case "race": ctx.group = "race"; break;

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4390,7 +4390,7 @@ DND5E.activityTypes = {
  * @property {boolean} [hidden]                  Should this advancement type be hidden in the selection dialog?
  */
 
-const _ALL_ITEM_TYPES = ["background", "class", "race", "subclass"];
+const _ALL_ITEM_TYPES = ["background", "class", "feat", "race", "subclass"];
 
 /**
  * Advancement types that can be added to items.

--- a/module/documents/advancement/advancement.mjs
+++ b/module/documents/advancement/advancement.mjs
@@ -307,11 +307,13 @@ export default class Advancement extends PseudoDocumentMixin(BaseAdvancement) {
     const source = await fromUuid(uuid);
     if ( !source ) return null;
     const { _stats } = game.items.fromCompendium(source);
+    const advancementOrigin = `${this.item.id}.${this.id}`;
     return source.clone({
       _stats,
       _id: id ?? foundry.utils.randomID(),
       "flags.dnd5e.sourceId": uuid,
-      "flags.dnd5e.advancementOrigin": `${this.item.id}.${this.id}`
+      "flags.dnd5e.advancementOrigin": advancementOrigin,
+      "flags.dnd5e.ultimateOrigin": this.item.getFlag("dnd5e", "ultimateOrigin") ?? advancementOrigin
     }, { keepId: true }).toObject();
   }
 

--- a/module/documents/advancement/subclass.mjs
+++ b/module/documents/advancement/subclass.mjs
@@ -56,12 +56,14 @@ export default class SubclassAdvancement extends Advancement {
   /*  Application Methods                         */
   /* -------------------------------------------- */
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   async apply(level, data, retainedData) {
     const useRetained = data.uuid === foundry.utils.getProperty(retainedData, "flags.dnd5e.sourceId");
     let itemData = useRetained ? retainedData : null;
     if ( !itemData ) {
       itemData = await this.createItemData(data.uuid);
+      delete itemData.flags?.dnd5e?.advancementOrigin;
+      delete itemData.flags?.dnd5e?.ultimateOrigin;
       foundry.utils.setProperty(itemData, "system.classIdentifier", this.item.identifier);
     }
     if ( itemData ) {


### PR DESCRIPTION
Adds enables `ItemChoice`, `ItemGrant`, `ScaleValue`, and `Trait` advancement types to be added to `feat` items.

To better support grouping on the actor sheet, this also adds a `ultimateOrigin` flag to items added via advancement that points to the origin item in the advancement chain. So if a class adds a feat which adds its own feature, then the `advancementOrigin` on the feature will point to the feat, while the `ultimateOrigin` will point to the class. A small exception to this logic has been added for subclasses added directly by classes so that subclass features point back to the subclass, not the class.

A point of future work is adding some control over the levels on feat advancement. Currently the levels for those advancement types refer to the character level, even if it is on a feature added by a class. Potentially an option could be added to advancements on feats that controls how their level information is determined.

Closes #5164