### PR TITLE
[#5180] Improve presentation of conditions applied by effects

### DIFF
--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -99,7 +99,13 @@
   .items-section {
 
     .items-header, .item {
+      outline: 2px dotted transparent;
+      outline-offset: 4px;
+      border-radius: 2px;
+      transition: outline-color 150ms ease;
+
       &[hidden] { display: none; }
+      &.highlighted { outline-color: red; }
       .condensed { font-family: var(--dnd5e-font-roboto-condensed); }
 
       .item-row {

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -255,6 +255,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
         name, reference,
         id: k,
         img: existing?.img ?? img,
+        active: this.actor.statuses.has(k) && !this.actor.system.traits?.ci?.value?.has(k),
         disabled: existing ? disabled : true
       });
       return arr;
@@ -1176,6 +1177,12 @@ export default class BaseActorSheet extends PrimarySheetMixin(
         event.preventDefault();
       }
     });
+
+    // Highlight conditions
+    for ( const element of this.element.querySelectorAll(".conditions-list .condition") ) {
+      element.addEventListener("pointerenter", this.#hoverCondition.bind(this));
+      element.addEventListener("pointerleave", this.#hoverCondition.bind(this));
+    }
   }
 
   /* -------------------------------------------- */
@@ -1264,6 +1271,20 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     // Toggle sidebar
     const sidebarCollapsed = game.user.getFlag("dnd5e", this._sidebarCollapsedKeyPath);
     if ( sidebarCollapsed !== undefined ) this._toggleSidebar(sidebarCollapsed);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Highlight effects imposing a condition if hovered on the actor sheet.
+   * @param {PointerEvent} event  The triggering event.
+   */
+  #hoverCondition(event) {
+    const condition = event.target.dataset.conditionId;
+    const effects = this.actor.effects.filter(e => e.statuses.has(condition)).map(e => `[data-effect-id="${e.id}"]`);
+    for ( const element of this.element.querySelectorAll(`:is(${effects.join(",")})`) ) {
+      element.classList.toggle("highlighted", event.type === "pointerenter");
+    }
   }
 
   /* -------------------------------------------- */

--- a/templates/shared/active-effects2.hbs
+++ b/templates/shared/active-effects2.hbs
@@ -120,7 +120,7 @@
 
             <ul class="conditions-list unlist">
                 {{#each conditions}}
-                <li class="condition {{#unless disabled}}active{{/unless}} {{#if reference}}content-link{{/if}}"
+                <li class="condition {{#if active}}active{{/if}} {{#if reference}}content-link{{/if}}"
                     data-action="toggleCondition" data-uuid="{{ reference }}" data-condition-id="{{ id }}"
                     data-tooltip="<section class=&quot;loading&quot;><i class=&quot;fas fa-spinner fa-spin-pulse&quot;></i></section>">
                     <div class="icon">


### PR DESCRIPTION
In order to improve communication over statuses imposed using the "Status Conditions" option on effects, this applies two UI improvements:

First, the condition will be highlighted as applied on the actor sheet (though the toggle won't be in the enabled position). This should show that that effect is taking place on the actor and will take condition immunities into account.

<img width="818" alt="Highlight Effects" src="https://github.com/user-attachments/assets/f6aaefd8-9c40-4754-896b-5d06537afb1c" />

Secondly, when hovering over one of the Conditions on the effects tab, it will highlight the active effects that have imposed that condition, making it easier to track down what is causing your character to be paralyzed.

Closes #5180