### PR TITLE
[#4921] Tweak monsters in Miscellaneous Creatures section of SRD

### DIFF
--- a/packs/_source/monsters/beast/ape.yml
+++ b/packs/_source/monsters/beast/ape.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 19
       max: 19
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d8 + 6
     init:
       ability: ''
@@ -574,8 +574,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741116506863
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!K5cKmPoFkpuOotis.hbxC3Wg3H8cSIvM0'
   - _id: jxC1VNaCf2VXlD6C
     name: Fist
@@ -583,10 +583,7 @@ items:
     img: icons/magic/fire/flame-burning-fist-strike.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Ape attacks with its Fist.</p>
       source:
         custom: ''
@@ -608,7 +605,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -726,9 +723,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: fist
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
@@ -737,9 +735,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676663
+      modifiedTime: 1741116921784
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!K5cKmPoFkpuOotis.jxC1VNaCf2VXlD6C'
   - _id: NsTx3MUaYkEI2t8M
@@ -748,9 +746,7 @@ items:
     img: icons/magic/earth/projectile-stone-ball-brown.webp
     system:
       description:
-        value: >-
-          <p>Ranged Weapon Attack: +5 to hit, range 25/50 ft., one target. Hit:
-          <strong>6 (1d6 + 3) <em>bludgeoning damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Ape attacks with its Rock.</p>
       source:
         custom: ''
@@ -893,7 +889,7 @@ items:
       identifier: rock
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
@@ -902,9 +898,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676663
+      modifiedTime: 1741116505945
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!K5cKmPoFkpuOotis.NsTx3MUaYkEI2t8M'
 effects: []
@@ -917,8 +913,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171221697
-  modifiedTime: 1726171443008
+  modifiedTime: 1741116511713
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!K5cKmPoFkpuOotis'

--- a/packs/_source/monsters/beast/axe-beak.yml
+++ b/packs/_source/monsters/beast/axe-beak.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 19
       max: 19
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d10 + 3
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Axe Beak attacks with its Beak.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -626,6 +623,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: beak
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -637,9 +635,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676455
+      modifiedTime: 1741116927233
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!SXXvwaLBNuzBymp3.FsSMPLEC46UKCf7T'
 effects: []
@@ -652,8 +650,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171232558
-  modifiedTime: 1726171444937
+  modifiedTime: 1741116605497
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!SXXvwaLBNuzBymp3'

--- a/packs/_source/monsters/beast/baboon.yml
+++ b/packs/_source/monsters/beast/baboon.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 3
       max: 3
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d6
     init:
       ability: ''
@@ -533,10 +533,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: 1 (1d4 - 1) <em>piercing
-          damage</em>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Baboon attacks with its Bite.</p>
       source:
         custom: ''
@@ -558,7 +555,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -676,6 +673,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -689,9 +687,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676438
+      modifiedTime: 1741116932388
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!JW8bXggOMBx1S6tF.EXVZptAEHLscbODF'
 effects: []
@@ -704,8 +702,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171221037
-  modifiedTime: 1726171442888
+  modifiedTime: 1741116629846
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!JW8bXggOMBx1S6tF'

--- a/packs/_source/monsters/beast/badger.yml
+++ b/packs/_source/monsters/beast/badger.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 3
       max: 3
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 + 1
     init:
       ability: ''
@@ -635,10 +635,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>piercing
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Badger attacks with its Bite.</p>
       source:
         custom: ''
@@ -660,7 +657,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -778,6 +775,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -791,9 +789,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676500
+      modifiedTime: 1741116938833
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!oQvORD924obyPdCc.siQuRYBFdjgVrKlA'
 effects: []
@@ -806,8 +804,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171257523
-  modifiedTime: 1726171449925
+  modifiedTime: 1741116741738
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!oQvORD924obyPdCc'

--- a/packs/_source/monsters/beast/bat.yml
+++ b/packs/_source/monsters/beast/bat.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -577,10 +577,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit:<strong> 1 <em>piercing
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Bat attacks with its Bite.</p>
       source:
         custom: ''
@@ -602,7 +599,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -672,7 +669,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -702,11 +699,11 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: ''
+            ability: none
             bonus: ''
             critical:
               threshold: null
-            flat: false
+            flat: true
             type:
               value: melee
               classification: weapon
@@ -716,10 +713,14 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -728,14 +729,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676510
+      modifiedTime: 1741117940876
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!qav2dvMIUiMQCCsy.N05hdQhXPTOHipkJ'
 effects: []
@@ -748,8 +753,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171260397
-  modifiedTime: 1726171450565
+  modifiedTime: 1741116824801
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!qav2dvMIUiMQCCsy'

--- a/packs/_source/monsters/beast/black-bear.yml
+++ b/packs/_source/monsters/beast/black-bear.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 19
       max: 19
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d8 + 6
     init:
       ability: ''
@@ -623,8 +623,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741116900995
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!D5WjGwKskeUT8HXa.ZBWu2XGwEnsaVNsH'
   - _id: 8VdhUFhUE9m12piC
     name: Bite
@@ -632,10 +632,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Black Bear attacks with its Bite.</p>
       source:
         custom: ''
@@ -657,7 +654,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -727,7 +724,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -757,7 +754,7 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
@@ -771,26 +768,34 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676657
+      modifiedTime: 1741116900067
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!D5WjGwKskeUT8HXa.8VdhUFhUE9m12piC'
   - _id: gaxofmkFqQG1zqK9
@@ -799,10 +804,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Black Bear attacks with its Claws.</p>
       source:
         custom: ''
@@ -824,7 +826,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -942,9 +944,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
@@ -953,9 +956,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676657
+      modifiedTime: 1741116910167
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!D5WjGwKskeUT8HXa.gaxofmkFqQG1zqK9'
 effects: []
@@ -968,8 +971,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171213778
-  modifiedTime: 1726171441455
+  modifiedTime: 1741116914702
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!D5WjGwKskeUT8HXa'

--- a/packs/_source/monsters/beast/blood-hawk.yml
+++ b/packs/_source/monsters/beast/blood-hawk.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 7
       max: 7
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d6
     init:
       ability: ''
@@ -685,10 +685,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Blood Hawk attacks with its Beak.</p>
       source:
         custom: ''
@@ -710,7 +707,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -829,6 +826,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: beak
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -840,9 +838,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676419
+      modifiedTime: 1741116964889
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!AJiJW7K957aJJCN6.Jt0l1S2jZWGIiXjE'
 effects: []
@@ -855,8 +853,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171209626
-  modifiedTime: 1726171440797
+  modifiedTime: 1741116953981
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!AJiJW7K957aJJCN6'

--- a/packs/_source/monsters/beast/boar.yml
+++ b/packs/_source/monsters/beast/boar.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 11
       max: 11
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d8 + 2
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Boar attacks with its Tusk.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -626,6 +623,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: tusk
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -637,9 +635,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676738
+      modifiedTime: 1741117003939
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!lZR4lhNmYSf89s4Q.ypnf9maxKh66ucMe'
   - _id: TSmET06nE61H6HC2
@@ -651,9 +649,9 @@ items:
         value: >-
           <p>If the boar moves at least 20 ft. straight toward a target and then
           hits it with a tusk attack on the same turn, the target takes an extra
-          <strong>3 (1d6) <em>slashing damage</em></strong>.</p><p>If the target
-          is a creature, it must succeed on a  <strong>DC 11 Strength</strong>
-          saving throw or be knocked prone.</p>
+          [[/damage average]] damage.</p><p>If the target is a creature, it must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>If the boar moves at least 20 ft. straight toward a target and then
           hits it with a tusk attack on the same turn, the target takes extra
@@ -695,7 +693,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -726,22 +724,21 @@ items:
             recovery: []
           damage:
             critical:
-              allow: false
+              allow: true
               bonus: ''
             parts:
-              - number: 1
-                denomination: 6
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: '6'
                 bonus: ''
                 types:
                   - slashing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -792,19 +789,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 1
-                denomination: 6
-                bonus: ''
-                types:
-                  - slashing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -823,14 +808,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676738
+      modifiedTime: 1741118127951
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!lZR4lhNmYSf89s4Q.TSmET06nE61H6HC2'
   - _id: U66PTM15QvmkenvW
@@ -957,8 +946,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171253780
-  modifiedTime: 1726171449080
+  modifiedTime: 1741117009204
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!lZR4lhNmYSf89s4Q'

--- a/packs/_source/monsters/beast/brown-bear.yml
+++ b/packs/_source/monsters/beast/brown-bear.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 34
       max: 34
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 4d10 + 12
     init:
       ability: ''
@@ -483,7 +483,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: "<p><em>Melee Weapon Attack: </em><strong>+6 to hit,</strong>\_<strong>5 ft.,</strong> one target. Hit: <strong>9 (1d8 + 4) <em>piercing damage</em></strong>.</p>"
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Brown Bear attacks with its Bite.</p>
       source:
         custom: ''
@@ -505,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -623,9 +623,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
@@ -636,9 +637,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676701
+      modifiedTime: 1741117039307
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!omcDpBoB69esCXeM.tOPVA2liaPY9pwgO'
   - _id: MozRn0kqcm5IG3WI
@@ -647,10 +648,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack: </em><strong>+6 to hit</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Brown Bear attacks with its Claws.</p>
       source:
         custom: ''
@@ -672,7 +670,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -790,9 +788,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
@@ -801,9 +800,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676701
+      modifiedTime: 1741117049292
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!omcDpBoB69esCXeM.MozRn0kqcm5IG3WI'
   - _id: D3rgzM9PCR2iXku5
@@ -952,8 +951,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741117023858
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!omcDpBoB69esCXeM.AVusgSNjauFD9XnU'
 effects: []
 folder: g8DmtGW2tiBpzCMk
@@ -965,8 +964,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171257893
-  modifiedTime: 1726171450018
+  modifiedTime: 1741117051210
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!omcDpBoB69esCXeM'

--- a/packs/_source/monsters/beast/camel.yml
+++ b/packs/_source/monsters/beast/camel.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 15
       max: 15
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d10 + 4
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>2 (1d4) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Camel attacks with its Bite.</p>
       source:
         custom: ''
@@ -578,7 +575,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -608,8 +605,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: ''
-            bonus: ''
+            ability: none
+            bonus: '3'
             critical:
               threshold: null
             flat: false
@@ -622,10 +619,14 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -634,14 +635,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676431
+      modifiedTime: 1741117095299
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!FQMFuzzSh73d0Nrd.XY89jRSGIvqLmLmw'
 effects: []
@@ -654,8 +659,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171216420
-  modifiedTime: 1726171441992
+  modifiedTime: 1741117101470
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!FQMFuzzSh73d0Nrd'

--- a/packs/_source/monsters/beast/cat.yml
+++ b/packs/_source/monsters/beast/cat.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 2
       max: 2
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>slashing
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Cat attacks with its Claws.</p>
       source:
         custom: ''
@@ -578,7 +575,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -608,11 +605,11 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: ''
+            ability: none
             bonus: ''
             critical:
               threshold: null
-            flat: false
+            flat: true
             type:
               value: melee
               classification: weapon
@@ -622,6 +619,9 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -631,15 +631,19 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676491
+      modifiedTime: 1741117128189
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hIf83RD3ZVW4Egfi.QEiTKu95xZ1ovW5K'
   - _id: rZhUwhHEUo6VBxPt
@@ -804,8 +808,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171249141
-  modifiedTime: 1726171448133
+  modifiedTime: 1741117135353
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!hIf83RD3ZVW4Egfi'

--- a/packs/_source/monsters/beast/constrictor-snake.yml
+++ b/packs/_source/monsters/beast/constrictor-snake.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 13
       max: 13
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d10 + 2
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Constrictor Snake attacks with its Bite.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -626,6 +623,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -639,9 +637,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676684
+      modifiedTime: 1741117147873
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!UTuKdTah1DKfPwWe.hZOM2L6WMmk8QOfO'
   - _id: haXdYCAfGXo0iVqC
@@ -651,11 +649,10 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>6 (1d8 + 2) <em>bludgeoning
-          damage</em></strong>. The target is grappled (escape DC 14). Until
-          this grapple ends, the creature is restrained, and the snake can't
-          constrict another target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
+          &amp;Reference[grappled] (escape DC 14). Until this grapple ends, the
+          creature is restrained, and the snake can't constrict another
+          target.</p>
         chat: >-
           <p>The Constrictor Snake attacks with its Constrict. The target is
           grappled. Until this grapple ends, the creature is restrained, and the
@@ -680,7 +677,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -798,6 +795,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: constrict
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -809,9 +807,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676684
+      modifiedTime: 1741124468636
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!UTuKdTah1DKfPwWe.haXdYCAfGXo0iVqC'
 effects: []
@@ -824,8 +822,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171234874
-  modifiedTime: 1726171445378
+  modifiedTime: 1741117185131
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!UTuKdTah1DKfPwWe'

--- a/packs/_source/monsters/beast/crab.yml
+++ b/packs/_source/monsters/beast/crab.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 2
       max: 2
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>bludgeoning
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Crab attacks with its Claw.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -578,7 +575,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -608,11 +605,11 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: none
             bonus: ''
             critical:
               threshold: null
-            flat: false
+            flat: true
             type:
               value: melee
               classification: weapon
@@ -622,24 +619,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676411
+      modifiedTime: 1741117285974
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!8RgUhb31VvjUNZU1.gvfgesIscW0VALbY'
   - _id: ciz8wAZjqxPnu5Pe
@@ -699,8 +704,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171207812
-  modifiedTime: 1726171440422
+  modifiedTime: 1741117214821
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!8RgUhb31VvjUNZU1'

--- a/packs/_source/monsters/beast/crocodile.yml
+++ b/packs/_source/monsters/beast/crocodile.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 19
       max: 19
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d10 + 3
     init:
       ability: ''
@@ -484,11 +484,10 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>7 (1d10 + 2) <em>piercing
-          damage</em></strong>.</p><p>The target is grappled (escape DC 12).
-          Until this grapple ends, the target is restrained, and the crocodile
-          can't bite another target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
+          &amp;Reference[grappled] (escape DC 12). Until this grapple ends, the
+          target is &amp;Reference[restrained], and the crocodile can't bite
+          another target.</p>
         chat: >-
           <p>The Crocodile attacks with its Bite. If successful, the target is
           grappled. Until this grapple ends, the target is restrained, and the
@@ -513,7 +512,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -631,6 +630,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -644,9 +644,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676414
+      modifiedTime: 1741124488915
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!8aCTKP5qaBPFOqxM.L0k8pFgKxxEEMEOY'
   - _id: vuDMChx74s6CMCab
@@ -708,8 +708,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171208318
-  modifiedTime: 1726171440529
+  modifiedTime: 1741117256913
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!8aCTKP5qaBPFOqxM'

--- a/packs/_source/monsters/beast/deer.yml
+++ b/packs/_source/monsters/beast/deer.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 4
       max: 4
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d8
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>2 (1d4) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Deer attacks with its Bite.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -626,6 +623,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -639,9 +637,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676400
+      modifiedTime: 1741117272047
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!4EODJbmPlpnNGVR7.EyXnPvAdgwKZz6LT'
 effects: []
@@ -654,8 +652,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171201639
-  modifiedTime: 1726171439386
+  modifiedTime: 1741117299688
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!4EODJbmPlpnNGVR7'

--- a/packs/_source/monsters/beast/dire-wolf.yml
+++ b/packs/_source/monsters/beast/dire-wolf.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 37
       max: 37
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d10 + 10
     init:
       ability: ''
@@ -581,11 +581,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing
-          damage</em></strong>.</p><p>If the target is a creature, it must
-          succeed on a  <strong>DC 13 Strength</strong> saving throw or be
-          knocked prone.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a creature, it must succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>The Dire Wolf attacks with its Bite. If the target is a creature,
           it must make a <strong>Strength</strong> saving throw or be knocked
@@ -610,7 +608,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -774,19 +772,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 2
-                denomination: 6
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -797,6 +783,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -805,14 +792,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676428
+      modifiedTime: 1741124505165
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!EYiQZ3rFL25fEJY5.tx9xPDEQ8osJq6ZQ'
 effects: []
@@ -825,8 +816,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171215639
-  modifiedTime: 1726171441806
+  modifiedTime: 1741117411427
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!EYiQZ3rFL25fEJY5'

--- a/packs/_source/monsters/beast/draft-horse.yml
+++ b/packs/_source/monsters/beast/draft-horse.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 19
       max: 19
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d10 + 3
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/commodities/bones/hooves-cloven-brown.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>9 (2d4 + 4) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Draft Horse attacks with its Hooves.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -626,6 +623,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: hooves
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -639,9 +637,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676421
+      modifiedTime: 1741117423029
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!Bupo3E9X5Ptx6XeT.dJyouOu3yDwHTXEX'
 effects: []
@@ -654,8 +652,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171212211
-  modifiedTime: 1726171441188
+  modifiedTime: 1741117425068
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!Bupo3E9X5Ptx6XeT'

--- a/packs/_source/monsters/beast/eagle.yml
+++ b/packs/_source/monsters/beast/eagle.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 3
       max: 3
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d6
     init:
       ability: ''
@@ -530,10 +530,7 @@ items:
     img: icons/creatures/claws/claw-scaled-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Eagle attacks with its Talons.</p>
       source:
         custom: ''
@@ -555,7 +552,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -673,6 +670,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: talons
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -684,9 +682,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676426
+      modifiedTime: 1741117433523
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!EI8w6XjzCZICkox9.FeybcW5pMzYjWRqq'
 effects: []
@@ -699,8 +697,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171214628
-  modifiedTime: 1726171441605
+  modifiedTime: 1741117436253
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!EI8w6XjzCZICkox9'

--- a/packs/_source/monsters/beast/elephant.yml
+++ b/packs/_source/monsters/beast/elephant.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 76
       max: 76
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 8d12 + 24
     init:
       ability: ''
@@ -484,11 +484,11 @@ items:
     system:
       description:
         value: >-
-          <p>If the elephant moves at least <strong>20 ft.</strong> straight
-          toward a creature and then hits it with a gore attack on the same
-          turn, that target must succeed on a <strong>DC 12 Strength saving
-          throw</strong> or be knocked prone. If the target is prone, the
-          elephant can make one stomp attack against it as a bonus action.</p>
+          <p>If the elephant moves at least 20 ft. straight toward a creature
+          and then hits it with a gore attack on the same turn, that target must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone]. If the target is prone, the elephant can make
+          one stomp attack against it as a bonus action.</p>
         chat: >-
           <p>If the elephant moves at least <strong>20 ft.</strong> straight
           toward a creature and then hits it with a gore attack on the same
@@ -510,60 +510,6 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: ''
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '20'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -633,14 +579,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.yD51x4dihnbHwfsj
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.yD51x4dihnbHwfsj
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676820
+      modifiedTime: 1741124531918
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!jLPhaBnMtAbB5dp1.TtrZUBPjTrxKxoFn'
   - _id: r6mBkCtL5j6Y6sBr
@@ -649,10 +599,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>19 (3d8 + 6) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Elephant attacks with its Gore.</p>
       source:
         custom: ''
@@ -674,7 +621,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -792,6 +739,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: gore
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -803,9 +751,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676820
+      modifiedTime: 1741117449785
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!jLPhaBnMtAbB5dp1.r6mBkCtL5j6Y6sBr'
   - _id: ZHBbc5K4n6sU17rC
@@ -815,9 +763,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5
-          ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>22
-          (3d10 + 6) <em>bludgeoning damage</em></strong>.</p>
+          <p><em>Melee Weapon Attack:</em> [[/attack]], reach 5 ft., one prone
+          creature. <em>Hit:</em><strong> </strong>[[/damage average]]
+          damage.</p>
         chat: <p>The Elephant attacks with its Stomp.</p>
       source:
         custom: ''
@@ -839,7 +787,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -957,6 +905,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: stomp
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -968,9 +917,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676820
+      modifiedTime: 1741117593594
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!jLPhaBnMtAbB5dp1.ZHBbc5K4n6sU17rC'
 effects: []
@@ -983,8 +932,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171251661
-  modifiedTime: 1726171448680
+  modifiedTime: 1741117534138
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!jLPhaBnMtAbB5dp1'

--- a/packs/_source/monsters/beast/elk.yml
+++ b/packs/_source/monsters/beast/elk.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 13
       max: 13
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d10 + 2
     init:
       ability: ''
@@ -486,9 +486,9 @@ items:
         value: >-
           <p>If the elk moves at least 20 ft. straight toward a target and then
           hits it with a ram attack on the same turn, the target takes an extra
-          7 (2d6) damage.</p><p>If the target is a creature, it must succeed on
-          a  <strong>DC 13 Strength</strong> saving throw or be knocked
-          prone.</p>
+          [[/damage average]] damage.</p><p>If the target is a creature, it must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>If the elk moves at least 20 ft. straight toward a target and then
           hits it with a ram attack on the same turn, the target takes an extra
@@ -530,7 +530,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -561,21 +561,21 @@ items:
             recovery: []
           damage:
             critical:
-              allow: false
+              allow: true
               bonus: ''
             parts:
-              - number: 2
-                denomination: 6
-                bonus: ''
-                types: []
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 2
+                denomination: '6'
+                bonus: ''
+                types:
+                  - bludgeoning
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -656,14 +656,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676761
+      modifiedTime: 1741124571382
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!55PkbskG5iBZGrgR.slVyUWagsSZ5CXSh'
   - _id: 05Vs3AiPgtQkX84S
@@ -672,10 +676,7 @@ items:
     img: icons/creatures/mammals/ox-bull-horned-glowing-orange.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Elk attacks with its Ram.</p>
       source:
         custom: ''
@@ -697,7 +698,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -815,6 +816,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: ram
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -826,9 +828,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676761
+      modifiedTime: 1741117552303
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!55PkbskG5iBZGrgR.05Vs3AiPgtQkX84S'
   - _id: FneLrX10GhkE2o4E
@@ -838,9 +840,8 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>8 (2d4
-          + 3) <em>bludgeoning damage</em></strong>.</p>
+          <p><em>Melee Weapon Attack:</em> [[/attack]], reach5 ft., one prone
+          creature. <em>Hit:</em> [[/damage average]] damage.</p>
         chat: <p>The Elk attacks with its Hooves.</p>
       source:
         custom: ''
@@ -862,7 +863,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -980,6 +981,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: hooves
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -993,9 +995,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676761
+      modifiedTime: 1741117605580
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!55PkbskG5iBZGrgR.FneLrX10GhkE2o4E'
 effects: []
@@ -1008,8 +1010,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171202501
-  modifiedTime: 1726171439573
+  modifiedTime: 1741117607514
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!55PkbskG5iBZGrgR'

--- a/packs/_source/monsters/beast/flying-snake.yml
+++ b/packs/_source/monsters/beast/flying-snake.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 5
       max: 5
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d4
     init:
       ability: ''
@@ -532,10 +532,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>piercing damage</em>
-          </strong>plus <strong>7 (3d4) <em>poison damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Flying Snake attacks with its Bite.</p>
       source:
         custom: ''
@@ -557,7 +554,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -598,7 +595,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
+      properties:
+        - fin
       proficient: 1
       unidentified:
         description: ''
@@ -627,7 +625,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -670,23 +668,23 @@ items:
               bonus: ''
             includeBase: true
             parts:
-              - number: 3
-                denomination: 4
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
+                denomination: '4'
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -695,14 +693,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676453
+      modifiedTime: 1741117888824
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!SMfgOsfPgf6rb01k.ITtDDLuoOyJbDQpA'
 effects: []
@@ -715,8 +717,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171231941
-  modifiedTime: 1726171444817
+  modifiedTime: 1741117886831
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!SMfgOsfPgf6rb01k'

--- a/packs/_source/monsters/beast/frog.yml
+++ b/packs/_source/monsters/beast/frog.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -584,8 +584,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171215794
-  modifiedTime: 1726171441842
+  modifiedTime: 1741117970171
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!EZgiprHXA2D7Uyb3'

--- a/packs/_source/monsters/beast/giant-ape.yml
+++ b/packs/_source/monsters/beast/giant-ape.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 157
       max: 157
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 15d12 + 60
     init:
       ability: ''
@@ -574,8 +574,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741117974703
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!8MuL8xisavJW9bnw.NOajNyilBv8JIEVp'
   - _id: N86NeUNsfvruyJGq
     name: Fist
@@ -583,10 +583,7 @@ items:
     img: icons/magic/fire/flame-burning-fist-strike.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>,
-          <strong>10 ft.,</strong> one target. Hit: <strong>22 (3d10 + 6)
-          <em>bludgeoning damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Ape attacks with its Fist.</p>
       source:
         custom: ''
@@ -608,7 +605,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 10
+        value: null
         long: null
         units: ft
         reach: null
@@ -727,9 +724,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: fist
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
@@ -738,9 +736,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676644
+      modifiedTime: 1741117987508
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!8MuL8xisavJW9bnw.N86NeUNsfvruyJGq'
   - _id: CVDcFc8ZcjYVl1EV
@@ -749,9 +747,7 @@ items:
     img: icons/magic/earth/projectile-stone-ball-brown.webp
     system:
       description:
-        value: >-
-          <p>Ranged Weapon Attack: +9 to hit, range 50/100 ft., one target. Hit:
-          <strong>30 (7d6 + 6) <em>bludgeoning damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Ape attacks with its Rock.</p>
       source:
         custom: ''
@@ -814,8 +810,7 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - amm
+      properties: []
       proficient: 1
       unidentified:
         description: ''
@@ -889,12 +884,14 @@ items:
             parts: []
           sort: 0
       attuned: false
-      ammunition: {}
+      ammunition:
+        type: ''
       magicalBonus: null
       identifier: rock
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
@@ -903,9 +900,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676644
+      modifiedTime: 1741118010754
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!8MuL8xisavJW9bnw.CVDcFc8ZcjYVl1EV'
 effects: []
@@ -918,8 +915,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171207649
-  modifiedTime: 1726171440386
+  modifiedTime: 1741118015188
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!8MuL8xisavJW9bnw'

--- a/packs/_source/monsters/beast/giant-badger.yml
+++ b/packs/_source/monsters/beast/giant-badger.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 13
       max: 13
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d8 + 4
     init:
       ability: ''
@@ -623,8 +623,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741118018102
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!cJGY1ZywUOo6heNR.1lGtRKKScQMq9K3R'
   - _id: NTUVjYVsAjweAj1R
     name: Bite
@@ -632,10 +632,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Badger attacks with its Bite.</p>
       source:
         custom: ''
@@ -657,7 +654,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -775,9 +772,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
@@ -788,9 +786,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676690
+      modifiedTime: 1741118026489
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!cJGY1ZywUOo6heNR.NTUVjYVsAjweAj1R'
   - _id: BToZtvd0HCyQvoXC
@@ -799,10 +797,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (2d4 + 1) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Badger attacks with its Claws.</p>
       source:
         custom: ''
@@ -824,7 +819,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -942,9 +937,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
@@ -953,9 +949,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676690
+      modifiedTime: 1741118035349
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!cJGY1ZywUOo6heNR.BToZtvd0HCyQvoXC'
 effects: []
@@ -968,8 +964,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171243284
-  modifiedTime: 1726171446853
+  modifiedTime: 1741118036580
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!cJGY1ZywUOo6heNR'

--- a/packs/_source/monsters/beast/giant-bat.yml
+++ b/packs/_source/monsters/beast/giant-bat.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 22
       max: 22
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 4d10
     init:
       ability: ''
@@ -577,10 +577,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Bat attacks with its Bite.</p>
       source:
         custom: ''
@@ -602,7 +599,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -720,6 +717,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -733,9 +731,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676456
+      modifiedTime: 1741118044954
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!SoK7l5zJQKxTVgLL.r77BXFVYT1LuJCZs'
 effects: []
@@ -748,8 +746,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171232702
-  modifiedTime: 1726171444975
+  modifiedTime: 1741118048982
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!SoK7l5zJQKxTVgLL'

--- a/packs/_source/monsters/beast/giant-boar.yml
+++ b/packs/_source/monsters/beast/giant-boar.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 42
       max: 42
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d10 + 15
     init:
       ability: ''
@@ -486,9 +486,9 @@ items:
         value: >-
           <p>If the boar moves at least 20 ft. straight toward a target and then
           hits it with a tusk attack on the same turn, the target takes an extra
-          <strong>7 (2d6) <em>slashing damage</em></strong>.</p><p>If the target
-          is a creature, it must succeed on a  <strong>DC 13 Strength</strong>
-          saving throw or be knocked prone.</p>
+          [[/damage average]] damage.</p><p>If the target is a creature, it must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>If the boar moves at least 20 ft. straight toward a target and then
           hits it with a tusk attack on the same turn, the target takes extra
@@ -530,7 +530,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -561,22 +561,21 @@ items:
             recovery: []
           damage:
             critical:
-              allow: false
+              allow: true
               bonus: ''
             parts:
-              - number: 2
-                denomination: 6
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
+                denomination: '6'
                 bonus: ''
                 types:
                   - slashing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -627,19 +626,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 2
-                denomination: 6
-                bonus: ''
-                types:
-                  - slashing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -658,14 +645,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676726
+      modifiedTime: 1741118136943
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!SsuCaF2fIEoDdFA3.1ArcmRCn5G0t6sOo'
   - _id: byaGAd7ILpgsQ7Un
@@ -788,10 +779,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Boar attacks with its Tusk.</p>
       source:
         custom: ''
@@ -813,7 +801,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -931,6 +919,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: tusk
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -942,9 +931,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676726
+      modifiedTime: 1741118152595
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!SsuCaF2fIEoDdFA3.zHwaxxXcDz8AE8Bj'
 effects: []
@@ -957,8 +946,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171232996
-  modifiedTime: 1726171445057
+  modifiedTime: 1741118154292
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!SsuCaF2fIEoDdFA3'

--- a/packs/_source/monsters/beast/giant-centipede.yml
+++ b/packs/_source/monsters/beast/giant-centipede.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 4
       max: 4
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d6 + 1
     init:
       ability: ''
@@ -484,14 +484,12 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>4 (1d4 + 2) <em>piercing
-          damage</em></strong>.</p><p>The target must succeed on a  <strong>DC
-          11 Constitution</strong> saving throw or take <strong>10 (3d6)
-          <em>poison damage</em></strong>. If the <em>poison damage</em> reduces
-          the target to 0 hit points, the target is stable but poisoned for 1
-          hour, even after regaining hit points, and is paralyzed while poisoned
-          in this way.</p>
+          <p>[[/attack extended]]. [[/damage extended]] and the target must
+          succeed on a [[/save]] saving throw or take [[/damage average
+          activity=dnd5eactivity100]] damage. If the poison damage reduces the
+          target to 0 hit points, the target is stable but
+          &amp;Reference[poisoned] for 1 hour, even after regaining hit points,
+          and is &amp;Reference[paralyzed] while poisoned in this way.</p>
         chat: >-
           <p>The Giant Centipede attacks with its Bite. The target must succeed
           on a  <strong>DC 11 Constitution</strong> saving throw or take
@@ -519,7 +517,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -653,7 +651,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -683,30 +681,30 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts:
-              - number: 1
-                denomination: 4
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 3
+                denomination: '6'
+                bonus: ''
+                types:
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '11'
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -715,14 +713,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676436
+      modifiedTime: 1741118253828
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!Hn8FFLEzscgT7azz.8EvqvqLumOBhrjeD'
 effects: []
@@ -735,8 +737,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171219285
-  modifiedTime: 1726171442515
+  modifiedTime: 1741118256759
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!Hn8FFLEzscgT7azz'

--- a/packs/_source/monsters/beast/giant-constrictor-snake.yml
+++ b/packs/_source/monsters/beast/giant-constrictor-snake.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 60
       max: 60
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 8d12 + 8
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>,
-          <strong>10 ft.,</strong> one creature. Hit: <strong>11 (2d6 + 4)
-          <em>piercing damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Constrictor Snake attacks with its Bite.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 10
+        value: null
         long: null
         units: ft
         reach: null
@@ -627,6 +624,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -640,9 +638,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676669
+      modifiedTime: 1741118268365
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!NpvwE1feOHyEqAbP.qB9j7Epq7UVkGWzY'
   - _id: 3FIKn37A037kPgzc
@@ -652,11 +650,10 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>13 (2d8 + 4) <em>bludgeoning
-          damage</em></strong>.</p><p>The target is grappled (escape DC 16).
-          Until this grapple ends, the creature is restrained, and the snake
-          can't constrict another target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
+          &amp;Reference[grappled] (escape DC 16). Until this grapple ends, the
+          creature is restrained, and the snake can't constrict another
+          target.</p>
         chat: >-
           <p>The Giant Constrictor Snake attacks with its Constrict. The target
           is grappled. Until this grapple ends, the creature is restrained, and
@@ -681,7 +678,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -799,6 +796,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: constrict
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -810,9 +808,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676669
+      modifiedTime: 1741118420538
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!NpvwE1feOHyEqAbP.3FIKn37A037kPgzc'
 effects: []
@@ -825,8 +823,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171227428
-  modifiedTime: 1726171444016
+  modifiedTime: 1741118344139
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!NpvwE1feOHyEqAbP'

--- a/packs/_source/monsters/beast/giant-crab.yml
+++ b/packs/_source/monsters/beast/giant-crab.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 13
       max: 13
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d8
     init:
       ability: ''
@@ -531,10 +531,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>bludgeoning
-          damage</em></strong>.</p><p>The target is grappled (escape DC 11). The
-          crab has two claws, each of which can grapple only one target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
+          &amp;Reference[grappled] (escape DC 11). The crab has two claws, each
+          of which can grapple only one target.</p>
         chat: <p>The Giant Crab attacks with its Claw. The target is grappled.</p>
       source:
         custom: ''
@@ -674,6 +673,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -685,9 +685,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676420
+      modifiedTime: 1741118408615
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!AOJvmk1IchxNxQzP.7qDtYuaBNQ3zOnBC'
 effects: []
@@ -700,8 +700,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171209774
-  modifiedTime: 1726171440833
+  modifiedTime: 1741118365628
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!AOJvmk1IchxNxQzP'

--- a/packs/_source/monsters/beast/giant-crocodile.yml
+++ b/packs/_source/monsters/beast/giant-crocodile.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 85
       max: 85
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 9d12 + 27
     init:
       ability: ''
@@ -625,8 +625,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741118368431
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!3YwmvDupMwycWNCO.YSeYSzU3P0FooGIw'
   - _id: u7eurp95tuW3tYGl
     name: Bite
@@ -635,11 +635,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>21 (3d10 + 5) <em>piercing
-          damage</em></strong>.</p><p>The target is grappled (escape DC 16).
-          Until this grapple ends, the target is restrained, and the crocodile
-          can't bite another target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
+          &amp;Reference[grappled] (escape DC 16). Until this grapple ends, the
+          target is restrained, and the crocodile can't bite another target.</p>
         chat: >-
           <p>The Giant Crocodile attacks with its Bite. If successful, the
           target is grappled. Until this grapple ends, the target is restrained,
@@ -664,7 +662,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -782,9 +780,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
@@ -795,9 +794,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676637
+      modifiedTime: 1741118396110
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!3YwmvDupMwycWNCO.u7eurp95tuW3tYGl'
   - _id: VkCVMF2SvsuYWWYg
@@ -807,12 +806,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>,
-          <strong>10 ft.,</strong> one target <strong>not grappled by the
-          crocodile</strong>. Hit: <strong>14 (2d8 + 5) <em>bludgeoning
-          damage</em></strong>.</p><p>If the target is a creature, it must
-          succeed on a  <strong>DC 16 Strength</strong> saving throw or be
-          knocked prone.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a creature, it must succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>The Giant Crocodile attacks with its Tail. If the target is a
           creature, it must make a <strong>Strength</strong> saving throw.</p>
@@ -836,7 +832,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 10
+        value: null
         long: null
         units: ft
         reach: null
@@ -1001,19 +997,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 2
-                denomination: 8
-                bonus: '@mod'
-                types:
-                  - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -1024,20 +1008,25 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: tail
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676637
+      modifiedTime: 1741118452325
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!3YwmvDupMwycWNCO.VkCVMF2SvsuYWWYg'
 effects: []
@@ -1050,8 +1039,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171200554
-  modifiedTime: 1726171439196
+  modifiedTime: 1741118469898
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!3YwmvDupMwycWNCO'

--- a/packs/_source/monsters/beast/giant-eagle.yml
+++ b/packs/_source/monsters/beast/giant-eagle.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 26
       max: 26
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 4d10 + 4
     init:
       ability: ''
@@ -623,8 +623,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741118472618
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!9bHoR8k5D2DKHaF3.QaRbm71tWEQzR4GK'
   - _id: vyI1tbobhrYMxj76
     name: Beak
@@ -632,10 +632,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Eagle attacks with its Beak.</p>
       source:
         custom: ''
@@ -657,7 +654,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -776,9 +773,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: beak
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
@@ -787,9 +785,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676645
+      modifiedTime: 1741118495139
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!9bHoR8k5D2DKHaF3.vyI1tbobhrYMxj76'
   - _id: sh91NilUd5bUZyiG
@@ -798,10 +796,7 @@ items:
     img: icons/creatures/claws/claw-scaled-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Eagle attacks with its Talons.</p>
       source:
         custom: ''
@@ -823,7 +818,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -942,9 +937,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: talons
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
@@ -953,9 +949,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676645
+      modifiedTime: 1741118487761
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!9bHoR8k5D2DKHaF3.sh91NilUd5bUZyiG'
 effects: []
@@ -968,8 +964,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171209066
-  modifiedTime: 1726171440681
+  modifiedTime: 1741118496451
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!9bHoR8k5D2DKHaF3'

--- a/packs/_source/monsters/beast/giant-elk.yml
+++ b/packs/_source/monsters/beast/giant-elk.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 42
       max: 42
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d12 + 10
     init:
       ability: ''
@@ -486,9 +486,8 @@ items:
         value: >-
           <p>If the elk moves at least 20 ft. straight toward a target and then
           hits it with a ram attack on the same turn, the target takes an extra
-          7 (2d6) damage.</p><p>If the target is a creature, it must succeed on
-          a  <strong>DC 14 Strength</strong> saving throw or be knocked
-          prone.</p>
+          [[/damage average]] damage.</p><p>If the target is a creature, it must
+          succeed on a [[/save]] saving throw or be knocked prone.</p>
         chat: >-
           <p>If the elk moves at least 20 ft. straight toward a target and then
           hits it with a ram attack on the same turn, the target takes an extra
@@ -530,7 +529,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -561,21 +560,20 @@ items:
             recovery: []
           damage:
             critical:
-              allow: false
+              allow: true
               bonus: ''
             parts:
-              - number: 2
-                denomination: 6
-                bonus: ''
-                types: []
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 2
+                denomination: '6'
+                bonus: ''
+                types: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -626,18 +624,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 2
-                denomination: 6
-                bonus: ''
-                types: []
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -656,14 +643,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676813
+      modifiedTime: 1741118522196
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hQt3qIahnB1Odb40.xSzDPptifNbKyf5N'
   - _id: jDA6wujGF6L3tPBM
@@ -673,9 +664,8 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one <strong>prone</strong> creature. Hit: <strong>22
-          (4d8 + 4) <em>bludgeoning damage</em></strong>.</p>
+          <p><em>Melee Weapon Attack:</em> [[/attack]], 5 ft., one prone
+          creature. <em>Hit:</em> [[/damage average]]<em> </em>damage.</p>
         chat: <p>The Giant Elk attacks with its Hooves.</p>
       source:
         custom: ''
@@ -697,7 +687,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -815,9 +805,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: hooves
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 200000
     ownership:
       default: 0
     flags:
@@ -828,9 +819,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676813
+      modifiedTime: 1741118571016
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hQt3qIahnB1Odb40.jDA6wujGF6L3tPBM'
   - _id: epOt7fzXcBz9Hf0i
@@ -839,10 +830,7 @@ items:
     img: icons/creatures/mammals/ox-bull-horned-glowing-orange.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>,
-          <strong>10 ft.,</strong> one target. Hit: <strong>11 (2d6 + 4)
-          <em>bludgeoning damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Elk attacks with its Ram.</p>
       source:
         custom: ''
@@ -864,7 +852,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 10
+        value: null
         long: null
         units: ft
         reach: null
@@ -983,9 +971,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: ram
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
@@ -994,9 +983,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676813
+      modifiedTime: 1741118565558
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hQt3qIahnB1Odb40.epOt7fzXcBz9Hf0i'
 effects: []
@@ -1009,8 +998,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171249318
-  modifiedTime: 1726171448175
+  modifiedTime: 1741118580607
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!hQt3qIahnB1Odb40'

--- a/packs/_source/monsters/beast/giant-fire-beetle.yml
+++ b/packs/_source/monsters/beast/giant-fire-beetle.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 4
       max: 4
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d6 + 1
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: 2 (1d6 - 1) <em>slashing
-          damage</em>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Fire Beetle attacks with its Bite.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -626,6 +623,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -639,9 +637,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676471
+      modifiedTime: 1741118590092
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!Z0GiAv3bJxTjUfjM.ytajTMHqbOxc0BvA'
   - _id: t1I5Ss8xvBplViSy
@@ -651,8 +649,8 @@ items:
     system:
       description:
         value: >-
-          <p>The beetle sheds bright light in a <strong>10-foot radius</strong>
-          and dim light for an additional <strong>10 feet</strong>.</p>
+          <p>The beetle sheds bright light in a 10-foot radius and dim light for
+          an additional 10 feet.</p>
         chat: ''
       source:
         custom: ''
@@ -688,10 +686,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741118598461
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!Z0GiAv3bJxTjUfjM.t1I5Ss8xvBplViSy'
 effects: []
 folder: g8DmtGW2tiBpzCMk
@@ -703,8 +701,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171238619
-  modifiedTime: 1726171446099
+  modifiedTime: 1741118601480
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!Z0GiAv3bJxTjUfjM'

--- a/packs/_source/monsters/beast/giant-fly.yml
+++ b/packs/_source/monsters/beast/giant-fly.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 19
       max: 19
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d10 + 3
     init:
       ability: ''
@@ -484,8 +484,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171261034
-  modifiedTime: 1726171450740
+  modifiedTime: 1741121004853
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!rLl22hYeAH3ljhdI'

--- a/packs/_source/monsters/beast/giant-frog.yml
+++ b/packs/_source/monsters/beast/giant-frog.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 18
       max: 18
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 4d8
     init:
       ability: ''
@@ -581,11 +581,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing
-          damage</em></strong>.</p><p>The target is grappled (escape DC 11).
-          Until this grapple ends, the target is restrained, and the frog can't
-          bite another target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
+          &amp;Reference[grappled] (escape DC 11). Until this grapple ends, the
+          target is restrained, and the frog can't bite another target.</p>
         chat: >-
           <p>The Giant Frog attacks with its Bite. If successful, the target is
           grappled. Until this grapple ends, the target is restrained, and the
@@ -610,7 +608,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -728,6 +726,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -741,9 +740,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676595
+      modifiedTime: 1741121035332
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!kSAi2KRonL4G4JpO.2y826IUSIAgmYf2c'
   - _id: 37M4eUyS3kovXqdr
@@ -755,13 +754,13 @@ items:
         value: >-
           <p>The frog makes one bite attack against a Small or smaller target it
           is grappling. If the attack hits, the target is swallowed, and the
-          grapple ends.</p><p>The swallowed target is blinded and restrained, it
-          has total cover against attacks and other effects outside the frog,
-          and it takes <strong>5 (2d4) <em>acid damage</em></strong> at the
-          start of each of the frog's turns. The frog can have only one target
-          swallowed at a time. If the frog dies, a swallowed creature is no
-          longer restrained by it and can escape from the corpse using 5 ft. of
-          movement, exiting prone.</p>
+          grapple ends.</p><p>The swallowed target is &amp;Reference[blinded]
+          and &amp;Reference[restrained], it has total cover against attacks and
+          other effects outside the frog, and it takes [[/damage average]]
+          damage at the start of each of the frog's turns. The frog can have
+          only one target swallowed at a time.</p><p>If the frog dies, a
+          swallowed creature is no longer restrained by it and can escape from
+          the corpse using 5 ft. of movement, exiting prone.</p>
         chat: <p>The Giant Frog attacks with its Swallow.</p>
       source:
         custom: ''
@@ -775,7 +774,7 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -862,9 +861,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676595
+      modifiedTime: 1741121102713
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!kSAi2KRonL4G4JpO.37M4eUyS3kovXqdr'
 effects: []
@@ -877,8 +876,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171252242
-  modifiedTime: 1726171448809
+  modifiedTime: 1741121107858
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!kSAi2KRonL4G4JpO'

--- a/packs/_source/monsters/beast/giant-goat.yml
+++ b/packs/_source/monsters/beast/giant-goat.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 19
       max: 19
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d10 + 3
     init:
       ability: ''
@@ -486,9 +486,9 @@ items:
         value: >-
           <p>If the goat moves at least 20 ft. straight toward a target and then
           hits it with a ram attack on the same turn, the target takes an extra
-          <strong>5 (2d4) <em>bludgeoning damage</em></strong>.</p><p>If the
-          target is a creature, it must succeed on a  <strong>DC 13
-          Strength</strong> saving throw or be knocked prone.</p>
+          [[/damage average]] damage.</p><p>If the target is a creature, it must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>If the goat moves at least 20 ft. straight toward a target and then
           hits it with a ram attack on the same turn, the target takes a extra
@@ -530,7 +530,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -561,22 +561,21 @@ items:
             recovery: []
           damage:
             critical:
-              allow: false
+              allow: true
               bonus: ''
             parts:
-              - number: 2
-                denomination: 4
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
+                denomination: '4'
                 bonus: ''
                 types:
                   - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -627,19 +626,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 2
-                denomination: 4
-                bonus: ''
-                types:
-                  - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -658,14 +645,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676608
+      modifiedTime: 1741121143075
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!rjqk7ToMD8sGr3n4.dBII3VhTvg43aTUI'
   - _id: kqrWunjvDSHdnPmW
@@ -723,10 +714,7 @@ items:
     img: icons/creatures/mammals/ox-bull-horned-glowing-orange.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>8 (2d4 + 3) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Goat attacks with its Ram.</p>
       source:
         custom: ''
@@ -748,7 +736,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -866,6 +854,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: ram
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -877,9 +866,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676608
+      modifiedTime: 1741121159304
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!rjqk7ToMD8sGr3n4.t8cKnWGtgVCfhW5v'
 effects: []
@@ -892,8 +881,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171261770
-  modifiedTime: 1726171450918
+  modifiedTime: 1741121161340
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!rjqk7ToMD8sGr3n4'

--- a/packs/_source/monsters/beast/giant-hyena.yml
+++ b/packs/_source/monsters/beast/giant-hyena.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 45
       max: 45
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 6d10 + 12
     init:
       ability: ''
@@ -500,10 +500,11 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
@@ -575,10 +576,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741121174035
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!aAqfEHPiVbhMwZ6j.QY2OI39oNi9VUuAY'
   - _id: X9XQ405Nx5lHP20E
     name: Bite
@@ -586,10 +587,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Hyena attacks with its Bite.</p>
       source:
         custom: ''
@@ -611,7 +609,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -729,6 +727,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -742,9 +741,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676474
+      modifiedTime: 1741121184241
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!aAqfEHPiVbhMwZ6j.X9XQ405Nx5lHP20E'
 effects: []
@@ -757,8 +756,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171240373
-  modifiedTime: 1726171446379
+  modifiedTime: 1741121185657
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!aAqfEHPiVbhMwZ6j'

--- a/packs/_source/monsters/beast/giant-lizard.yml
+++ b/packs/_source/monsters/beast/giant-lizard.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 19
       max: 19
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d10 + 3
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Lizard attacks with its Bite.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -626,6 +623,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -639,9 +637,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676502
+      modifiedTime: 1741121195032
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!pLzSh4dA517Tn73E.fLwfCY0GE5S7mMYv'
 effects: []
@@ -654,8 +652,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171258697
-  modifiedTime: 1726171450199
+  modifiedTime: 1741121198708
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!pLzSh4dA517Tn73E'

--- a/packs/_source/monsters/beast/giant-octopus.yml
+++ b/packs/_source/monsters/beast/giant-octopus.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 52
       max: 52
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 8d10 + 8
     init:
       ability: ''
@@ -742,12 +742,10 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>,
-          <strong>15 ft.,</strong> one target. Hit: <strong>10 (2d6 + 3)
-          <em>bludgeoning damage</em></strong>.</p><p>If the target is a
-          creature, it is grappled (escape DC 16). Until this grapple ends, the
-          target is restrained, and the octopus can't use its tentacles on
-          another target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a creature, it is &amp;Reference[grappled] (escape DC 16). Until this
+          grapple ends, the target is &amp;Reference[restrained], and the
+          octopus can't use its tentacles on another target.</p>
         chat: >-
           <p>The Giant Octopus attacks with its Tentacles. If the target is a
           creature, it is grappled. Until this grapple ends, the target is
@@ -773,10 +771,10 @@ items:
       identified: true
       cover: null
       range:
-        value: 15
+        value: null
         long: null
         units: ft
-        reach: null
+        reach: 15
       uses:
         max: ''
         recovery: []
@@ -892,6 +890,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: tentacles
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -905,9 +904,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676607
+      modifiedTime: 1741121241899
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!p9Xnr820UAZBOIVN.yOZK7sWcCRFmuAxz'
 effects: []
@@ -920,8 +919,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171258232
-  modifiedTime: 1726171450104
+  modifiedTime: 1741121257640
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!p9Xnr820UAZBOIVN'

--- a/packs/_source/monsters/beast/giant-owl.yml
+++ b/packs/_source/monsters/beast/giant-owl.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 19
       max: 19
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d10 + 3
     init:
       ability: ''
@@ -579,10 +579,7 @@ items:
     img: icons/creatures/claws/claw-scaled-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>8 (2d6 + 1) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Owl attacks with its Talons.</p>
       source:
         custom: ''
@@ -604,7 +601,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -722,6 +719,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: talons
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -733,9 +731,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676462
+      modifiedTime: 1741121277920
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!VVXly3ue0i3YgGrB.6jw1NtpZQXIesO4Y'
 effects: []
@@ -748,8 +746,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171236134
-  modifiedTime: 1726171445608
+  modifiedTime: 1741121280035
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!VVXly3ue0i3YgGrB'

--- a/packs/_source/monsters/beast/giant-poisonous-snake.yml
+++ b/packs/_source/monsters/beast/giant-poisonous-snake.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 11
       max: 11
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d8 + 2
     init:
       ability: ''
@@ -484,12 +484,10 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>,
-          <strong>10 ft.,</strong> one target. Hit: <strong>6 (1d4 + 4)
-          <em>piercing damage</em></strong>.</p><p>The target must make a 
-          <strong>DC 11 Constitution</strong> saving throw, taking <strong>10
-          (3d6) <em>poison damage</em></strong> on a failed save, or half as
-          much damage on a successful one.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          make a [[/save]] saving throw, taking [[/damage average
+          activity=dnd5eactivity100]] damage on a failed save, or half as much
+          damage on a successful one.</p>
         chat: >-
           <p>The Giant Poisonous Snake attacks with its Bite. The target must
           make a <strong>Constitution</strong> saving throw.</p>
@@ -513,7 +511,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 10
+        value: null
         long: null
         units: ft
         reach: null
@@ -648,7 +646,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -680,28 +678,28 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 1
-                denomination: 4
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 3
+                denomination: '6'
+                bonus: ''
+                types:
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '11'
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -710,14 +708,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676473
+      modifiedTime: 1741121328396
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!ZW39DE2zI3TXVYC9.GlOJaYXJFUP0Hd80'
 effects: []
@@ -730,8 +732,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171239448
-  modifiedTime: 1726171446244
+  modifiedTime: 1741121336076
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!ZW39DE2zI3TXVYC9'

--- a/packs/_source/monsters/beast/giant-rat-diseased.yml
+++ b/packs/_source/monsters/beast/giant-rat-diseased.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 7
       max: 7
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d6
     init:
       ability: ''
@@ -484,14 +484,12 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>3 (1d4 + 2) <em>piercing
-          damage</em></strong>.</p><p>If the target is a creature, it must
-          succeed on a  <strong>DC 10 Constitution</strong> saving throw or
-          contract a disease. Until the disease is cured, the target can't
-          regain hit points except by magical means, and the target's hit point
-          maximum decreases by 3 (1d6) every 24 hours. If the target's hit point
-          maximum drops to 0 as a result of this disease, the target dies.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a creature, it must succeed on a [[/save]] saving throw or contract a
+          disease. Until the disease is cured, the target can't regain hit
+          points except by magical means, and the target's hit point maximum
+          decreases by 3 (1d6) every 24 hours. If the target's hit point maximum
+          drops to 0 as a result of this disease, the target dies.</p>
         chat: >-
           <p>The Giant Rat (Diseased) attacks with its Bite. If the target is a
           creature, it must make a <strong>Constitution</strong> saving
@@ -516,7 +514,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -681,19 +679,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 1
-                denomination: 4
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: con
             dc:
@@ -704,6 +690,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -712,14 +699,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676517
+      modifiedTime: 1741121382111
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!z0zvgcIugizwcuxJ.52m3BQ2wpXvT0jOM'
   - _id: uQpDpdmzlAyQKbRu
@@ -829,8 +820,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171266989
-  modifiedTime: 1726171452111
+  modifiedTime: 1741121387159
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!z0zvgcIugizwcuxJ'

--- a/packs/_source/monsters/beast/giant-rat.yml
+++ b/packs/_source/monsters/beast/giant-rat.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 7
       max: 7
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d6
     init:
       ability: ''
@@ -580,10 +580,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Rat attacks with its Bite.</p>
       source:
         custom: ''
@@ -605,7 +602,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -724,6 +721,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -737,9 +735,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676505
+      modifiedTime: 1741121346775
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!q1YJIeIt6rK8fCKn.D98YkFEPQRdesZUW'
 effects: []
@@ -752,8 +750,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171259173
-  modifiedTime: 1726171450320
+  modifiedTime: 1741121348693
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!q1YJIeIt6rK8fCKn'

--- a/packs/_source/monsters/beast/giant-scorpion.yml
+++ b/packs/_source/monsters/beast/giant-scorpion.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 52
       max: 52
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 7d10 + 14
     init:
       ability: ''
@@ -576,8 +576,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741121391002
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!GxgIVRX5GbVTifiF.wpqra38jsZPRAuov'
   - _id: OJ2b64O3e1nni21W
     name: Claw
@@ -586,10 +586,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>bludgeoning
-          damage</em></strong>.</p><p>The target is grappled (escape DC 12). The
-          scorpion has two claws, each of which can grapple only one target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
+          &amp;Reference[grappled] (escape DC 12). The scorpion has two claws,
+          each of which can grapple only one target.</p>
         chat: >-
           <p>The Giant Scorpion attacks with its Claw. The target is
           grappled.</p>
@@ -613,7 +612,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -731,9 +730,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
@@ -742,9 +742,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676659
+      modifiedTime: 1741121402908
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!GxgIVRX5GbVTifiF.OJ2b64O3e1nni21W'
   - _id: q6uVUHWyzht5OpwV
@@ -754,12 +754,10 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>7 (1d10 + 2) <em>piercing
-          damage</em></strong>.</p><p>The target must make a  <strong>DC 12
-          Constitution</strong> saving throw, taking <strong>22 (4d10)
-          <em>poison damage</em></strong> on a failed save, or half as much
-          damage on a successful one.</p>
+          <p>&amp;Reference[grappled]</p><p>The target must make a [[/save]]
+          saving throw, taking [[/damage average activity=dnd5eactivity100]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p>
         chat: >-
           <p>The Giant Scorpion attacks with its Sting. The target must make a
           <strong>Constitution</strong> saving throw.</p>
@@ -783,7 +781,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -916,7 +914,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -948,96 +946,46 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 1
-                denomination: 10
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 4
+                denomination: '10'
+                bonus: ''
+                types:
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '12'
           sort: 0
-        dnd5eactivity300:
-          _id: dnd5eactivity300
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '5'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: 4d10
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: sting
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676659
+      modifiedTime: 1741121453770
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!GxgIVRX5GbVTifiF.q6uVUHWyzht5OpwV'
 effects: []
@@ -1050,8 +998,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171218252
-  modifiedTime: 1726171442322
+  modifiedTime: 1741121465576
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!GxgIVRX5GbVTifiF'

--- a/packs/_source/monsters/beast/giant-sea-horse.yml
+++ b/packs/_source/monsters/beast/giant-sea-horse.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 16
       max: 16
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d10
     init:
       ability: ''
@@ -486,9 +486,8 @@ items:
         value: >-
           <p>If the sea horse moves at least 20 ft. straight toward a target and
           then hits it with a ram attack on the same turn, the target takes an
-          extra <strong>7 (2d6) <em>bludgeoning damage</em></strong>.</p><p>If
-          the target is a creature, it must succeed on a  <strong>DC 11
-          Strength</strong> saving throw or be knocked prone.</p>
+          extra [[/damage average]] damage.</p><p>If the target is a creature,
+          it must succeed on a [[/save]] saving throw or be knocked prone.</p>
         chat: >-
           <p>If the sea horse moves at least 20 ft. straight toward a target and
           then hits it with a ram attack on the same turn, the target takes
@@ -512,72 +511,6 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: damage
-          activation:
-            type: ''
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '20'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            critical:
-              allow: false
-              bonus: ''
-            parts:
-              - number: 2
-                denomination: 6
-                bonus: ''
-                types:
-                  - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -597,7 +530,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -628,25 +561,71 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 2
-                denomination: 6
-                bonus: ''
-                types:
-                  - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
               calculation: ''
               formula: '11'
-          sort: 0
+          sort: 200000
+          name: ''
+          img: ''
+          appliedEffects: []
+        djeuuB0KX1WtfTRV:
+          type: damage
+          _id: djeuuB0KX1WtfTRV
+          sort: 100000
+          activation:
+            type: ''
+            value: null
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          range:
+            override: false
+            units: self
+            special: ''
+          target:
+            template:
+              contiguous: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          damage:
+            critical:
+              allow: true
+              bonus: ''
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
+                denomination: '6'
+                bonus: ''
+                types:
+                  - bludgeoning
+          name: ''
+          img: ''
+          appliedEffects: []
       enchant: {}
       prerequisites:
         level: null
@@ -659,14 +638,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676581
+      modifiedTime: 1741121563161
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!c9XDGsTJRy9HUaxQ.MB7KUNGnxz6mw1J5'
   - _id: yCZ6sgHxxIr0zIxO
@@ -722,10 +705,7 @@ items:
     img: icons/creatures/mammals/ox-bull-horned-glowing-orange.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Sea Horse attacks with its Ram.</p>
       source:
         custom: ''
@@ -747,7 +727,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -865,6 +845,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: ram
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -876,9 +857,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676581
+      modifiedTime: 1741121595669
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!c9XDGsTJRy9HUaxQ.tTZCmbeeSHXXFZGJ'
 effects: []
@@ -891,8 +872,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171242626
-  modifiedTime: 1726171446710
+  modifiedTime: 1741121578595
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!c9XDGsTJRy9HUaxQ'

--- a/packs/_source/monsters/beast/giant-shark.yml
+++ b/packs/_source/monsters/beast/giant-shark.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 126
       max: 126
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 11d12 + 55
     init:
       ability: ''
@@ -580,10 +580,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>22 (3d10 + 6) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Shark attacks with its Bite.</p>
       source:
         custom: ''
@@ -605,7 +602,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -723,6 +720,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -736,9 +734,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676445
+      modifiedTime: 1741121588795
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!MWlwLlKXh8jUUxOL.fGIh2Vq3XhIzacIg'
 effects: []
@@ -751,8 +749,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171225932
-  modifiedTime: 1726171443740
+  modifiedTime: 1741121598504
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!MWlwLlKXh8jUUxOL'

--- a/packs/_source/monsters/beast/giant-spider.yml
+++ b/packs/_source/monsters/beast/giant-spider.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 26
       max: 26
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 4d10 + 4
     init:
       ability: ''
@@ -629,13 +629,11 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>7 (1d8 + 3) <em>piercing
-          damage</em></strong>.</p><p>The target must make a  <strong>DC 11
-          Constitution</strong> saving throw, taking <strong>9 (2d8) <em>poison
-          damage</em></strong> on a failed save, or half as much damage on a
-          successful one. If the <em>poison damage</em> reduces the target to 0
-          hit points, the target is stable but poisoned for 1 hour, even after
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          make a [[/save]] saving throw, taking [[/damage average
+          activity=dnd5eactivity100]] damage on a failed save, or half as much
+          damage on a successful one. If the poison damage reduces the target to
+          0 hit points, the target is stable but poisoned for 1 hour, even after
           regaining hit points, and is paralyzed while poisoned in this way.</p>
         chat: >-
           <p>The Giant Spider attacks with its Bite. The target must make a
@@ -660,7 +658,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -794,7 +792,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -826,28 +824,28 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 1
-                denomination: 8
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 2
+                denomination: '8'
+                bonus: ''
+                types:
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '11'
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -856,14 +854,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676616
+      modifiedTime: 1741121646752
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!v99wOosUJjUgcUNF.SuRAERXystPvC7Ci'
   - _id: g7e60AxXarlQ9xQC
@@ -873,12 +875,12 @@ items:
     system:
       description:
         value: >-
-          <p>Ranged Weapon Attack: +5 to hit, range 30/60 ft., one creature.
-          Hit: The target is restrained by webbing.</p><p>As an action, the
-          restrained target can make a DC 12 Strength check, bursting the
-          webbing on a success. The webbing can also be attacked and destroyed
-          (AC 10; hp 5; vulnerability to <em>fire damage</em>; immunity to
-          bludgeoning, poison, and <em>psychic damage</em>).</p>
+          <p>[[/attack extended]]. <em>Hit:</em> The target is
+          &amp;Reference[restrained] by webbing.</p><p>As an action, the
+          restrained target can make a [[/check]] check, bursting the webbing on
+          a success. The webbing can also be attacked and destroyed (AC 10; hp
+          5; vulnerability to fire damage; immunity to bludgeoning, poison, and
+          psychic damage).</p>
         chat: >-
           <p>The target is restrained by webbing. As an action, the restrained
           target can make a Strength check, bursting the webbing on a
@@ -972,69 +974,54 @@ items:
             includeBase: true
             parts: []
           sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
-          type: save
+        2VqlhWfTutD2tVYA:
+          type: check
+          _id: 2VqlhWfTutD2tVYA
+          sort: 0
           activation:
             type: action
-            value: 1
-            condition: ''
+            value: null
             override: false
+            condition: ''
           consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
           range:
-            value: '30'
-            units: ft
-            special: ''
             override: false
+            units: self
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
-              special: ''
-            prompt: true
+              type: ''
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: str
+            max: ''
+          check:
+            associated: []
             dc:
               calculation: ''
               formula: '12'
-          sort: 0
+            ability: str
+          name: ''
+          img: ''
+          appliedEffects: []
       enchant: {}
       prerequisites:
         level: null
@@ -1047,14 +1034,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.i8WDjw4J1gJWQmqG
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.i8WDjw4J1gJWQmqG
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676616
+      modifiedTime: 1741121710947
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!v99wOosUJjUgcUNF.g7e60AxXarlQ9xQC'
 effects: []
@@ -1067,8 +1058,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171264897
-  modifiedTime: 1726171451611
+  modifiedTime: 1741121766147
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!v99wOosUJjUgcUNF'

--- a/packs/_source/monsters/beast/giant-toad.yml
+++ b/packs/_source/monsters/beast/giant-toad.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 39
       max: 39
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 6d10 + 6
     init:
       ability: ''
@@ -581,12 +581,10 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>7 (1d10 + 2) <em>piercing
-          damage</em></strong> plus <strong>5 (1d10) <em>poison
-          damage</em></strong>.</p><p>The target is grappled (escape DC 13).
-          Until this grapple ends, the target is restrained, and the toad can't
-          bite another target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
+          &amp;Reference[grappled] (escape DC 13). Until this grapple ends, the
+          target is &amp;Reference[restrained], and the toad can't bite another
+          target.</p>
         chat: >-
           <p>The Giant Toad attacks with its Bite. The target is grappled. Until
           this grapple ends, the target is restrained, and the toad can't bite
@@ -611,7 +609,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -741,6 +739,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -754,9 +753,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676549
+      modifiedTime: 1741121794121
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!Ixo5shumxy4I9qyD.lYSWskOMRCVLyWLZ'
   - _id: 6aBDwlIsxceFMXxL
@@ -770,11 +769,11 @@ items:
           it is grappling. If the attack hits, the target is swallowed, and the
           grapple ends.</p><p>The swallowed target is blinded and restrained, it
           has total cover against attacks and other effects outside the toad,
-          and it takes <strong>10 (3d6) <em>acid damage</em></strong> at the
-          start of each of the toad's turns. The toad can have only one target
-          swallowed at a time. If the toad dies, a swallowed creature is no
-          longer restrained by it and can escape from the corpse using 5 ft. of
-          movement, exiting prone.</p>
+          and it takes [[/damage average]] damage at the start of each of the
+          toad's turns. The toad can have only one target swallowed at a time.
+          If the toad dies, a swallowed creature is no longer restrained by it
+          and can escape from the corpse using 5 ft. of movement, exiting
+          prone.</p>
         chat: <p>The Giant Toad attacks with its Swallow.</p>
       source:
         custom: ''
@@ -875,9 +874,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676549
+      modifiedTime: 1741121814614
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!Ixo5shumxy4I9qyD.6aBDwlIsxceFMXxL'
 effects: []
@@ -890,8 +889,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171219941
-  modifiedTime: 1726171442669
+  modifiedTime: 1741121823304
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!Ixo5shumxy4I9qyD'

--- a/packs/_source/monsters/beast/giant-vulture.yml
+++ b/packs/_source/monsters/beast/giant-vulture.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 22
       max: 22
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d10 + 6
     init:
       ability: ''
@@ -674,8 +674,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741121826545
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!4ZlUHt4xmB7GdPfk.5kigRXx2FSlzVUWm'
   - _id: t6TG4rgkOXBefYZQ
     name: Beak
@@ -683,10 +683,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Vulture attacks with its Beak.</p>
       source:
         custom: ''
@@ -708,7 +705,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -827,9 +824,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: beak
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
@@ -838,9 +836,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676641
+      modifiedTime: 1741121839561
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!4ZlUHt4xmB7GdPfk.t6TG4rgkOXBefYZQ'
   - _id: AXKWmB2ZU1hebo5S
@@ -849,10 +847,7 @@ items:
     img: icons/creatures/claws/claw-scaled-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>9 (2d6 + 2) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Vulture attacks with its Talons.</p>
       source:
         custom: ''
@@ -874,7 +869,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -993,9 +988,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: talons
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
@@ -1004,9 +1000,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676641
+      modifiedTime: 1741121847737
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!4ZlUHt4xmB7GdPfk.AXKWmB2ZU1hebo5S'
 effects: []
@@ -1019,8 +1015,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171201989
-  modifiedTime: 1726171439458
+  modifiedTime: 1741121849455
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!4ZlUHt4xmB7GdPfk'

--- a/packs/_source/monsters/beast/giant-wasp.yml
+++ b/packs/_source/monsters/beast/giant-wasp.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 13
       max: 13
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d8
     init:
       ability: ''
@@ -484,13 +484,11 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>5 (1d6 + 2) <em>piercing
-          damage</em></strong>.</p><p>The target must make a  <strong>DC 11
-          Constitution</strong> saving throw, taking <strong>10 (3d6) <em>poison
-          damage</em></strong> on a failed save, or half as much damage on a
-          successful one. If the <em>poison damage</em> reduces the target to 0
-          hit points, the target is stable but poisoned for 1 hour, even after
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          make a [[/save]] saving throw, taking [[/damage average
+          activity=dnd5eactivity100]] damage on a failed save, or half as much
+          damage on a successful one. If the poison damage reduces the target to
+          0 hit points, the target is stable but poisoned for 1 hour, even after
           regaining hit points, and is paralyzed while poisoned in this way.</p>
         chat: >-
           <p>The Giant Wasp attacks with its Sting. The target must make a
@@ -515,7 +513,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -649,7 +647,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -681,42 +679,46 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 1
-                denomination: 6
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 3
+                denomination: '6'
+                bonus: ''
+                types:
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '11'
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: sting
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676403
+      modifiedTime: 1741121882633
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!4tl0s2SnaLjkoDiI.L1TmhBXd2UrVxExn'
 effects: []
@@ -729,8 +731,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171202163
-  modifiedTime: 1726171439498
+  modifiedTime: 1741121890621
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!4tl0s2SnaLjkoDiI'

--- a/packs/_source/monsters/beast/giant-weasel.yml
+++ b/packs/_source/monsters/beast/giant-weasel.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 9
       max: 9
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d8
     init:
       ability: ''
@@ -530,10 +530,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>5 (1d4 + 3) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Giant Weasel attacks with its Bite.</p>
       source:
         custom: ''
@@ -555,7 +552,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -674,6 +671,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -687,9 +685,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676412
+      modifiedTime: 1741121898673
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!8VXxqeBvN54rPh81.BrbVh5Sx3clXLHIi'
 effects: []
@@ -702,8 +700,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171208173
-  modifiedTime: 1726171440495
+  modifiedTime: 1741121900306
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!8VXxqeBvN54rPh81'

--- a/packs/_source/monsters/beast/giant-wolf-spider.yml
+++ b/packs/_source/monsters/beast/giant-wolf-spider.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 11
       max: 11
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d8 + 2
     init:
       ability: ''
@@ -533,13 +533,11 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>4 (1d6 + 1) <em>piercing
-          damage</em></strong>.</p><p>The target must make a  <strong>DC 11
-          Constitution</strong> saving throw, taking <strong>7 (2d6) <em>poison
-          damage</em></strong> on a failed save, or half as much damage on a
-          successful one. If the <em>poison damage</em> reduces the target to 0
-          hit points, the target is stable but poisoned for 1 hour, even after
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          make a [[/save]] saving throw, taking [[/damage average
+          activity=dnd5eactivity100]] damage on a failed save, or half as much
+          damage on a successful one. If the poison damage reduces the target to
+          0 hit points, the target is stable but poisoned for 1 hour, even after
           regaining hit points, and is paralyzed while poisoned in this way.</p>
         chat: >-
           <p>The Giant Wolf Spider attacks with its Bite. The target must make a
@@ -564,7 +562,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -697,7 +695,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -729,28 +727,28 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 1
-                denomination: 6
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 2
+                denomination: '6'
+                bonus: ''
+                types:
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '11'
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -759,14 +757,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676483
+      modifiedTime: 1741121931174
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!f9JbhBfWucrY2eDA.Et0GP61ZnJkxxqvN'
   - _id: OwNnGHVHu2XX0oPc
@@ -875,8 +877,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171246091
-  modifiedTime: 1726171447485
+  modifiedTime: 1741121936831
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!f9JbhBfWucrY2eDA'

--- a/packs/_source/monsters/beast/goat.yml
+++ b/packs/_source/monsters/beast/goat.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 4
       max: 4
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d8
     init:
       ability: ''
@@ -486,9 +486,9 @@ items:
         value: >-
           <p>If the goat moves at least 20 ft. straight toward a target and then
           hits it with a ram attack on the same turn, the target takes an extra
-          <strong>2 (1d4) <em>bludgeoning damage</em></strong>.</p><p>If the
-          target is a creature, it must succeed on a  <strong>DC 10
-          Strength</strong> saving throw or be knocked prone.</p>
+          [[/damage average]] damage.</p><p>If the target is a creature, it must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>If the goat moves at least 20 ft. straight toward a target and then
           hits it with a ram attack on the same turn, the target takes a extra
@@ -530,7 +530,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -561,22 +561,21 @@ items:
             recovery: []
           damage:
             critical:
-              allow: false
+              allow: true
               bonus: ''
             parts:
-              - number: 1
-                denomination: 4
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: '4'
                 bonus: ''
                 types:
                   - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -647,14 +646,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676621
+      modifiedTime: 1741121988728
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!y8sRU8Ks2lcrGsaf.fmILoB0arLdodNGB'
   - _id: gyY5rw0x4itzMKoj
@@ -712,10 +715,7 @@ items:
     img: icons/creatures/mammals/ox-bull-horned-glowing-orange.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>3 (1d4 + 1) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Goat attacks with its Ram.</p>
       source:
         custom: ''
@@ -737,7 +737,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -855,6 +855,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: ram
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -866,9 +867,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676621
+      modifiedTime: 1741122003155
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!y8sRU8Ks2lcrGsaf.I3ioyE4CVHPLGGy7'
 effects: []
@@ -881,8 +882,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171266312
-  modifiedTime: 1726171451930
+  modifiedTime: 1741122005582
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!y8sRU8Ks2lcrGsaf'

--- a/packs/_source/monsters/beast/hawk.yml
+++ b/packs/_source/monsters/beast/hawk.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -530,10 +530,7 @@ items:
     img: icons/creatures/claws/claw-talons-glowing-orange.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>slashing
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Hawk attacks with its Talons.</p>
       source:
         custom: ''
@@ -596,7 +593,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
+      properties:
+        - fin
       proficient: 1
       unidentified:
         description: ''
@@ -673,6 +671,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: talons
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -684,9 +683,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676486
+      modifiedTime: 1741122026485
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!fnkPNfIpS62LqOu4.0Di3cqTRD7ot8ZCa'
 effects: []
@@ -699,8 +698,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171246620
-  modifiedTime: 1726171447614
+  modifiedTime: 1741122040112
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!fnkPNfIpS62LqOu4'

--- a/packs/_source/monsters/beast/hunter-shark.yml
+++ b/packs/_source/monsters/beast/hunter-shark.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 45
       max: 45
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 6d10 + 12
     init:
       ability: ''
@@ -580,10 +580,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>13 (2d8 + 4) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Hunter Shark attacks with its Bite.</p>
       source:
         custom: ''
@@ -605,7 +602,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -723,6 +720,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -736,9 +734,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676515
+      modifiedTime: 1741122052326
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!siBUEAj4UVdaiH6p.KcQolnG6732GPN3o'
 effects: []
@@ -751,8 +749,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171262917
-  modifiedTime: 1726171451193
+  modifiedTime: 1741122054564
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!siBUEAj4UVdaiH6p'

--- a/packs/_source/monsters/beast/hyena.yml
+++ b/packs/_source/monsters/beast/hyena.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 5
       max: 5
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d8 + 1
     init:
       ability: ''
@@ -533,10 +533,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>3 (1d6) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Hyena attacks with its Bite.</p>
       source:
         custom: ''
@@ -558,7 +555,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -676,6 +673,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -689,9 +687,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676475
+      modifiedTime: 1741122064346
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!cDr1JtzEV26bP5Ym.gqMeY9GtWfBNt1bf'
 effects: []
@@ -704,8 +702,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171242793
-  modifiedTime: 1726171446753
+  modifiedTime: 1741122068291
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!cDr1JtzEV26bP5Ym'

--- a/packs/_source/monsters/beast/jackal.yml
+++ b/packs/_source/monsters/beast/jackal.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 3
       max: 3
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d6
     init:
       ability: ''
@@ -580,10 +580,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: 1 (1d4 - 1) <em>piercing
-          damage</em>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Jackal attacks with its Bite.</p>
       source:
         custom: ''
@@ -605,7 +602,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -723,6 +720,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -736,9 +734,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676446
+      modifiedTime: 1741122077294
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!MZYCPIVoBs918qGZ.ggHLjL39tb62Bwxy'
 effects: []
@@ -751,8 +749,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171226101
-  modifiedTime: 1726171443778
+  modifiedTime: 1741122079927
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!MZYCPIVoBs918qGZ'

--- a/packs/_source/monsters/beast/killer-whale.yml
+++ b/packs/_source/monsters/beast/killer-whale.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 90
       max: 90
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 12d12 + 12
     init:
       ability: ''
@@ -624,10 +624,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>21 (5d6 + 4) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Killer Whale attacks with its Bite.</p>
       source:
         custom: ''
@@ -649,7 +646,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -767,6 +764,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -780,9 +778,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676478
+      modifiedTime: 1741122089913
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!ciLSItjCpwT7nMmk.2JDxekOVx1NSUwuP'
 effects: []
@@ -795,8 +793,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171243449
-  modifiedTime: 1726171446894
+  modifiedTime: 1741122103560
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!ciLSItjCpwT7nMmk'

--- a/packs/_source/monsters/beast/lion.yml
+++ b/packs/_source/monsters/beast/lion.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 26
       max: 26
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 4d10 + 4
     init:
       ability: ''
@@ -510,7 +510,7 @@ items:
       identifier: keen-smell
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
@@ -521,8 +521,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741122224466
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hjhERRzafCiFFVLA.ZFsvhBgKXqgf17TZ'
   - _id: Kztga4jBHZCUjO3A
     name: Pack Tactics
@@ -558,7 +558,7 @@ items:
       identifier: pack-tactics
     effects: []
     folder: null
-    sort: 0
+    sort: 200000
     ownership:
       default: 0
     flags:
@@ -571,8 +571,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741122224466
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hjhERRzafCiFFVLA.Kztga4jBHZCUjO3A'
   - _id: pQdtHaxlArSTjbqb
     name: Pounce
@@ -581,10 +581,10 @@ items:
     system:
       description:
         value: >-
-          <p>If the lion moves at least <strong>20 ft.</strong> straight toward
-          a creature and then hits it with a claw attack on the same turn, that
-          target must succeed on a <strong>DC 13 Strength saving throw</strong>
-          or be knocked prone.</p><p>If the target is prone, the lion can make
+          <p>If the lion moves at least 20 ft. straight toward a creature and
+          then hits it with a claw attack on the same turn, that target must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p><p>If the target is prone, the lion can make
           one bite attack against it as a bonus action.</p>
         chat: >-
           <p>If the lion moves at least <strong>20 ft.</strong> straight toward
@@ -724,7 +724,7 @@ items:
       identifier: pounce
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags:
@@ -735,9 +735,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676816
+      modifiedTime: 1741122291080
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hjhERRzafCiFFVLA.pQdtHaxlArSTjbqb'
   - _id: 3dmAdKAVc8JqLgIj
@@ -773,7 +773,7 @@ items:
       identifier: running-leap
     effects: []
     folder: null
-    sort: 0
+    sort: 400000
     ownership:
       default: 0
     flags:
@@ -786,8 +786,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741122224466
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hjhERRzafCiFFVLA.3dmAdKAVc8JqLgIj'
   - _id: gKj1TlVfDhLp5WIk
     name: Bite
@@ -795,10 +795,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Lion attacks with its Bite.</p>
       source:
         custom: ''
@@ -820,7 +817,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -938,6 +935,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -951,9 +949,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676816
+      modifiedTime: 1741122245145
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hjhERRzafCiFFVLA.gKj1TlVfDhLp5WIk'
   - _id: CHIayoaCAZj0GBkM
@@ -962,10 +960,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Lion attacks with its Claw.</p>
       source:
         custom: ''
@@ -987,7 +982,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -1106,6 +1101,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -1117,9 +1113,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676816
+      modifiedTime: 1741122241114
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hjhERRzafCiFFVLA.CHIayoaCAZj0GBkM'
 effects: []
@@ -1132,8 +1128,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171249889
-  modifiedTime: 1726171448316
+  modifiedTime: 1741122246651
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!hjhERRzafCiFFVLA'

--- a/packs/_source/monsters/beast/lizard.yml
+++ b/packs/_source/monsters/beast/lizard.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 2
       max: 2
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>piercing
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Lizard attacks with its Bite.</p>
       source:
         custom: ''
@@ -578,7 +575,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -608,11 +605,11 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: ''
+            ability: none
             bonus: ''
             critical:
               threshold: null
-            flat: false
+            flat: true
             type:
               value: melee
               classification: weapon
@@ -622,10 +619,14 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -634,14 +635,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676437
+      modifiedTime: 1741122267463
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!I2x01hzOjVN4NUjf.AlO7NtMS64z0faPM'
 effects: []
@@ -654,8 +659,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171219434
-  modifiedTime: 1726171442553
+  modifiedTime: 1741122271812
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!I2x01hzOjVN4NUjf'

--- a/packs/_source/monsters/beast/mammoth.yml
+++ b/packs/_source/monsters/beast/mammoth.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 126
       max: 126
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 11d12 + 55
     init:
       ability: ''
@@ -484,11 +484,11 @@ items:
     system:
       description:
         value: >-
-          <p>If the mammoth moves at least <strong>20 ft.</strong> straight
-          toward a creature and then hits it with a gore attack on the same
-          turn, that target must succeed on a <strong>DC 18 Strength saving
-          throw</strong> or be knocked prone. If the target is prone, the
-          mammoth can make one stomp attack against it as a bonus action.</p>
+          <p>If the mammoth moves at least 20 ft. straight toward a creature and
+          then hits it with a gore attack on the same turn, that target must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p><p>If the target is prone, the mammoth can
+          make one stomp attack against it as a bonus action.</p>
         chat: >-
           <p>If the mammoth moves at least <strong>20 ft.</strong> straight
           toward a creature and then hits it with a gore attack on the same
@@ -638,9 +638,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676786
+      modifiedTime: 1741122303693
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!MiYRAIHwm9It1in8.4LYRJH02EsSnZUNc'
   - _id: S7i3GTdoo6tyc2wL
@@ -649,10 +649,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>,
-          <strong>10 ft.,</strong> one target. Hit: <strong>25 (4d8 + 7)
-          <em>piercing damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Mammoth attacks with its Gore.</p>
       source:
         custom: ''
@@ -793,6 +790,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: gore
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -804,9 +802,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676786
+      modifiedTime: 1741122313887
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!MiYRAIHwm9It1in8.S7i3GTdoo6tyc2wL'
   - _id: Hx541foatcQiMSZj
@@ -816,9 +814,8 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>,
-          <strong>5 ft.,</strong> one <strong>prone</strong> creature. Hit:
-          <strong>29 (4d10 + 7) <em>bludgeoning damage</em></strong>.</p>
+          <p><em>Melee Weapon Attack: </em>[[/attack]], 5 ft., one prone
+          creature. <em>Hit:</em> [[/damage average]]<em> </em>damage.</p>
         chat: <p>The Mammoth attacks with its Stomp.</p>
       source:
         custom: ''
@@ -958,6 +955,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: stomp
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -969,9 +967,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676786
+      modifiedTime: 1741122342968
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!MiYRAIHwm9It1in8.Hx541foatcQiMSZj'
 effects: []
@@ -984,8 +982,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171226268
-  modifiedTime: 1726171443818
+  modifiedTime: 1741122351458
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!MiYRAIHwm9It1in8'

--- a/packs/_source/monsters/beast/mastiff.yml
+++ b/packs/_source/monsters/beast/mastiff.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 5
       max: 5
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d8 + 1
     init:
       ability: ''
@@ -531,11 +531,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d6 + 1) <em>piercing
-          damage</em></strong>.</p><p>If the target is a creature, it must
-          succeed on a  <strong>DC 11 Strength</strong> saving throw or be
-          knocked prone.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a creature, it must succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>The Mastiff attacks with its Bite. If the target is a creature, it
           must succeed on a Strength saving throw or be knocked prone.</p>
@@ -559,7 +557,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -723,19 +721,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 1
-                denomination: 6
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -746,6 +732,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -754,14 +741,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676468
+      modifiedTime: 1741122373366
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!YTpL2c3NO4sOn2UA.QLJgy1aF5ijBEp4K'
 effects: []
@@ -774,8 +765,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171238245
-  modifiedTime: 1726171446028
+  modifiedTime: 1741122380029
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!YTpL2c3NO4sOn2UA'

--- a/packs/_source/monsters/beast/mule.yml
+++ b/packs/_source/monsters/beast/mule.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 11
       max: 11
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d8 + 2
     init:
       ability: ''
@@ -581,10 +581,7 @@ items:
     img: icons/commodities/bones/hooves-cloven-brown.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Mule attacks with its Hooves.</p>
       source:
         custom: ''
@@ -606,7 +603,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -724,6 +721,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: hooves
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -737,9 +735,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676463
+      modifiedTime: 1741122424518
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!Vk7uHVkJ5b26gaTh.Ou2VI9ORGu2JnZqj'
 effects: []
@@ -752,8 +750,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171236292
-  modifiedTime: 1726171445642
+  modifiedTime: 1741122399097
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!Vk7uHVkJ5b26gaTh'

--- a/packs/_source/monsters/beast/octopus.yml
+++ b/packs/_source/monsters/beast/octopus.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 3
       max: 3
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d6
     init:
       ability: ''
@@ -484,11 +484,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>bludgeoning
-          damage</em>.</strong></p><p>The target is grappled (escape DC 10).
-          Until this grapple ends, the octopus can't use its tentacles on
-          another target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
+          &amp;Reference[grappled] (escape DC 10). Until this grapple ends, the
+          octopus can't use its tentacles on another target.</p>
         chat: >-
           <p>The Octopus attacks with its Tentacles. The target is grappled .
           Until this grapple ends, the octopus can't use its tentacles on
@@ -513,7 +511,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -631,6 +629,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: tentacles
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -644,9 +643,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676522
+      modifiedTime: 1741122417975
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!3UUNbGiG2Yf1ZPxM.SLnyx0Ta2ksVM9QL'
   - _id: TKztZERtXehbxu2q
@@ -918,8 +917,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171200368
-  modifiedTime: 1726171439159
+  modifiedTime: 1741122420299
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!3UUNbGiG2Yf1ZPxM'

--- a/packs/_source/monsters/beast/owl.yml
+++ b/packs/_source/monsters/beast/owl.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -579,10 +579,7 @@ items:
     img: icons/creatures/claws/claw-scaled-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>slashing
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Owl attacks with its Talons.</p>
       source:
         custom: ''
@@ -604,7 +601,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -722,6 +719,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: talons
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -733,9 +731,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676480
+      modifiedTime: 1741122444317
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!d0prpsGSAorDadec.c3NnWQRHnaBpqtbe'
 effects: []
@@ -748,8 +746,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171243940
-  modifiedTime: 1726171446987
+  modifiedTime: 1741122446228
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!d0prpsGSAorDadec'

--- a/packs/_source/monsters/beast/panther.yml
+++ b/packs/_source/monsters/beast/panther.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 13
       max: 13
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d8
     init:
       ability: ''
@@ -531,11 +531,11 @@ items:
     system:
       description:
         value: >-
-          <p>If the panther moves at least <strong>20 ft.</strong> straight
-          toward a creature and then hits it with a claw attack on the same
-          turn, that target must succeed on a <strong>DC 12 Strength saving
-          throw</strong> or be knocked prone. </p><p>If the target is prone, the
-          panther can make one bite attack against it as a bonus action.</p>
+          <p>If the panther moves at least 20 ft. straight toward a creature and
+          then hits it with a claw attack on the same turn, that target must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p><p>If the target is prone, the panther can
+          make one bite attack against it as a bonus action.</p>
         chat: >-
           <p>If the panther moves at least <strong>20 ft.</strong> straight
           toward a creature and then hits it with a claw attack on the same
@@ -686,9 +686,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676768
+      modifiedTime: 1741122459760
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!AijNdqMurWxDxUSl.6UmjtTyihpEERg1I'
   - _id: c7iYo6g3A6DP8V4w
@@ -697,10 +697,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Panther attacks with its Bite.</p>
       source:
         custom: ''
@@ -722,7 +719,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -840,6 +837,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -853,9 +851,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676768
+      modifiedTime: 1741122480428
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!AijNdqMurWxDxUSl.c7iYo6g3A6DP8V4w'
   - _id: t4bERcqBVDvjJ2gx
@@ -864,10 +862,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>4 (1d4 + 2) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Panther attacks with its Claw.</p>
       source:
         custom: ''
@@ -889,7 +884,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -1007,6 +1002,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -1018,9 +1014,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676768
+      modifiedTime: 1741122472472
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!AijNdqMurWxDxUSl.t4bERcqBVDvjJ2gx'
 effects: []
@@ -1033,8 +1029,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171209943
-  modifiedTime: 1726171440868
+  modifiedTime: 1741122484373
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!AijNdqMurWxDxUSl'

--- a/packs/_source/monsters/beast/plesiosaurus.yml
+++ b/packs/_source/monsters/beast/plesiosaurus.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 68
       max: 68
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 8d10 + 24
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>,
-          <strong>10 ft.,</strong> one target. Hit: <strong>14 (3d6 + 4)
-          <em>piercing damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Plesiosaurus attacks with its Bite.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 10
+        value: null
         long: null
         units: ft
         reach: null
@@ -627,6 +624,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -640,9 +638,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676402
+      modifiedTime: 1741123023212
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!4OeZZguYgJcsZoM9.RbcK5H5JO9EnIiCA'
   - _id: PtGDikGuH6rHkITy
@@ -702,8 +700,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171201790
-  modifiedTime: 1726171439422
+  modifiedTime: 1741123026052
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!4OeZZguYgJcsZoM9'

--- a/packs/_source/monsters/beast/poisonous-snake.yml
+++ b/packs/_source/monsters/beast/poisonous-snake.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 2
       max: 2
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4
     init:
       ability: ''
@@ -484,12 +484,10 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>piercing
-          damage</em>.</strong></p><p>The target must make a  <strong>DC 10
-          Constitution</strong> saving throw, taking <strong>5 (2d4) <em>poison
-          damage</em></strong> on a failed save, or half as much damage on a
-          successful one.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          make a [[/save]] saving throw, taking [[/damage average
+          activity=dnd5eactivity100]] damage on a failed save, or half as much
+          damage on a successful one.</p>
         chat: >-
           <p>The Poisonous Snake attacks with its Bite. The target must make a
           <strong>Constitution</strong> saving throw.</p>
@@ -646,7 +644,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -678,28 +676,28 @@ items:
           damage:
             onSave: half
             parts:
-              - number: null
-                denomination: null
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
+                denomination: '4'
                 bonus: ''
                 types:
-                  - piercing
-                custom:
-                  enabled: true
-                  formula: '1'
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '10'
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -708,14 +706,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676423
+      modifiedTime: 1741122627468
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!D5rwVIxmfFrdyyxT.obYv0JJqJiMTsoIF'
 effects: []
@@ -728,8 +730,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171213950
-  modifiedTime: 1726171441491
+  modifiedTime: 1741122636020
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!D5rwVIxmfFrdyyxT'

--- a/packs/_source/monsters/beast/polar-bear.yml
+++ b/packs/_source/monsters/beast/polar-bear.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 42
       max: 42
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d10 + 15
     init:
       ability: ''
@@ -623,8 +623,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741122652177
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hb6pjvdCNYmLLp8V.hJyurwicMrRIt2TC'
   - _id: c8cisRQ7Ki3qiXgL
     name: Bite
@@ -632,10 +632,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>9 (1d8 + 5) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Polar Bear attacks with its Bite.</p>
       source:
         custom: ''
@@ -657,7 +654,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -775,9 +772,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
@@ -788,9 +786,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676696
+      modifiedTime: 1741122659644
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hb6pjvdCNYmLLp8V.c8cisRQ7Ki3qiXgL'
   - _id: jFBgpP0EO1Y2HRL0
@@ -799,10 +797,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Polar Bear attacks with its Claws.</p>
       source:
         custom: ''
@@ -824,7 +819,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -942,9 +937,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
@@ -953,9 +949,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676696
+      modifiedTime: 1741122666920
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!hb6pjvdCNYmLLp8V.jFBgpP0EO1Y2HRL0'
 effects: []
@@ -968,8 +964,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171249697
-  modifiedTime: 1726171448273
+  modifiedTime: 1741122668745
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!hb6pjvdCNYmLLp8V'

--- a/packs/_source/monsters/beast/pony.yml
+++ b/packs/_source/monsters/beast/pony.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 11
       max: 11
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d8 + 2
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/commodities/bones/hooves-cloven-brown.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Pony attacks with its Hooves.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -626,6 +623,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: hooves
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -639,9 +637,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676449
+      modifiedTime: 1741122676235
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!PHO4J98zK2p4KNyc.bDVZoB8Y0b3nkveO'
 effects: []
@@ -654,8 +652,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171229095
-  modifiedTime: 1726171444308
+  modifiedTime: 1741122678451
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!PHO4J98zK2p4KNyc'

--- a/packs/_source/monsters/beast/quipper.yml
+++ b/packs/_source/monsters/beast/quipper.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -580,10 +580,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>piercing
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Quipper attacks with its Bite.</p>
       source:
         custom: ''
@@ -605,7 +602,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -723,6 +720,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -736,9 +734,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676499
+      modifiedTime: 1741122685928
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!nkyCGJ9wXeAZkyyz.0SJofXpPrHJsVXOy'
 effects: []
@@ -751,8 +749,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171257014
-  modifiedTime: 1726171449786
+  modifiedTime: 1741122689051
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!nkyCGJ9wXeAZkyyz'

--- a/packs/_source/monsters/beast/rat.yml
+++ b/packs/_source/monsters/beast/rat.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -530,10 +530,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+0 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>piercing
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Rat attacks with its Bite.</p>
       source:
         custom: ''
@@ -625,7 +622,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -655,11 +652,11 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: ''
+            ability: none
             bonus: ''
             critical:
               threshold: null
-            flat: false
+            flat: true
             type:
               value: melee
               classification: weapon
@@ -669,10 +666,14 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -681,14 +682,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676503
+      modifiedTime: 1741122699538
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!pozQUPTnLZW8epox.QpysqgoHq9LXsShc'
 effects: []
@@ -701,8 +706,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171259028
-  modifiedTime: 1726171450278
+  modifiedTime: 1741122704283
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!pozQUPTnLZW8epox'

--- a/packs/_source/monsters/beast/raven.yml
+++ b/packs/_source/monsters/beast/raven.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -534,10 +534,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit:<strong> 1 <em>piercing
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Raven attacks with its Beak.</p>
       source:
         custom: ''
@@ -559,7 +556,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -600,7 +597,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
+      properties:
+        - fin
       proficient: 1
       unidentified:
         description: ''
@@ -677,6 +675,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: beak
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -688,9 +687,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676444
+      modifiedTime: 1741122721938
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!LPdX5YLlwci0NDZx.p8JmuP7pndzbZVzj'
 effects: []
@@ -703,8 +702,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171224025
-  modifiedTime: 1726171443447
+  modifiedTime: 1741122724866
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!LPdX5YLlwci0NDZx'

--- a/packs/_source/monsters/beast/reef-shark.yml
+++ b/packs/_source/monsters/beast/reef-shark.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 22
       max: 22
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 4d8 + 4
     init:
       ability: ''
@@ -580,10 +580,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d8 + 2) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Reef Shark attacks with its Bite.</p>
       source:
         custom: ''
@@ -605,7 +602,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -723,6 +720,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -736,9 +734,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676430
+      modifiedTime: 1741122732235
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!F0yILX4xKKt4dxKY.9xaHEynEl0adgcJ4'
 effects: []
@@ -751,8 +749,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171216270
-  modifiedTime: 1726171441956
+  modifiedTime: 1741122733839
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!F0yILX4xKKt4dxKY'

--- a/packs/_source/monsters/beast/rhinoceros.yml
+++ b/packs/_source/monsters/beast/rhinoceros.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 45
       max: 45
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 6d10 + 12
     init:
       ability: ''
@@ -486,10 +486,9 @@ items:
         value: >-
           <p>If the rhinoceros moves at least 20 ft. straight toward a target
           and then hits it with a gore attack on the same turn, the target takes
-          an extra <strong>9 (2d8) <em>bludgeoning
-          damage</em></strong>.</p><p>If the target is a creature, it must
-          succeed on a  <strong>DC 15 Strength</strong> saving throw or be
-          knocked prone.</p>
+          an extra [[/damage average]] damage.</p><p>If the target is a
+          creature, it must succeed on a [[/save]] saving throw or be knocked
+          prone.</p>
         chat: >-
           <p>If the rhinoceros moves at least 20 ft. straight toward a target
           and then hits it with a gore attack on the same turn, the target takes
@@ -532,7 +531,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -563,22 +562,21 @@ items:
             recovery: []
           damage:
             critical:
-              allow: false
+              allow: true
               bonus: ''
             parts:
-              - number: 2
-                denomination: 8
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
+                denomination: '8'
                 bonus: ''
                 types:
                   - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -629,19 +627,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 2
-                denomination: 8
-                bonus: ''
-                types:
-                  - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -660,14 +646,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WqRzbokPG0am6AHb
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676573
+      modifiedTime: 1741122761194
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!SBCe2BSa6opTS5M4.e1ZjZT7dyExUSEOu'
   - _id: uFv78t6CwySS1gio
@@ -676,10 +666,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>14 (2d8 + 5) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Rhinoceros attacks with its Gore.</p>
       source:
         custom: ''
@@ -701,7 +688,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -819,6 +806,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: gore
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -830,9 +818,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676573
+      modifiedTime: 1741122781475
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!SBCe2BSa6opTS5M4.uFv78t6CwySS1gio'
 effects: []
@@ -845,8 +833,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171231795
-  modifiedTime: 1726171444778
+  modifiedTime: 1741122784621
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!SBCe2BSa6opTS5M4'

--- a/packs/_source/monsters/beast/riding-horse.yml
+++ b/packs/_source/monsters/beast/riding-horse.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 13
       max: 13
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d10 + 2
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/commodities/bones/hooves-cloven-brown.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>8 (2d4 + 3) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Riding Horse attacks with its Hooves.</p>
       source:
         custom: ''
@@ -508,7 +505,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -626,6 +623,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: hooves
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -639,9 +637,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676512
+      modifiedTime: 1741122792075
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!rz8UTUnFT87BsAFR.CwpmLFcikAet169F'
 effects: []
@@ -654,8 +652,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171261917
-  modifiedTime: 1726171450964
+  modifiedTime: 1741122793490
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!rz8UTUnFT87BsAFR'

--- a/packs/_source/monsters/beast/saber-toothed-tiger.yml
+++ b/packs/_source/monsters/beast/saber-toothed-tiger.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 52
       max: 52
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 7d10 + 14
     init:
       ability: ''
@@ -531,10 +531,10 @@ items:
     system:
       description:
         value: >-
-          <p>If the tiger moves at least <strong>20 ft.</strong> straight toward
-          a creature and then hits it with a claw attack on the same turn, that
-          target must succeed on a <strong>DC 14 Strength saving throw</strong>
-          or be knocked prone.</p><p>If the target is prone, the lion can make
+          <p>If the tiger moves at least 20 ft. straight toward a creature and
+          then hits it with a claw attack on the same turn, that target must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p><p>If the target is prone, the lion can make
           one bite attack against it as a bonus action.</p>
         chat: >-
           <p>If the tiger moves at least <strong>20 ft.</strong> straight toward
@@ -685,9 +685,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676832
+      modifiedTime: 1741122804994
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!tYYoifu9teGLetVI.6f3yWYLcONtKe72e'
   - _id: npiswgaiGzupcEmw
@@ -696,10 +696,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>10 (1d10 + 5) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Saber-Toothed Tiger attacks with its Bite.</p>
       source:
         custom: ''
@@ -721,7 +718,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -839,6 +836,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -852,9 +850,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676832
+      modifiedTime: 1741122814476
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!tYYoifu9teGLetVI.npiswgaiGzupcEmw'
   - _id: I9zJprscDFYpwwJR
@@ -863,10 +861,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>12 (2d6 + 5) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Saber-Toothed Tiger attacks with its Claw.</p>
       source:
         custom: ''
@@ -888,7 +883,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -1007,6 +1002,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -1018,9 +1014,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676832
+      modifiedTime: 1741122838509
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!tYYoifu9teGLetVI.I9zJprscDFYpwwJR'
 effects: []
@@ -1033,8 +1029,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171263421
-  modifiedTime: 1726171451318
+  modifiedTime: 1741122842960
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!tYYoifu9teGLetVI'

--- a/packs/_source/monsters/beast/scorpion.yml
+++ b/packs/_source/monsters/beast/scorpion.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -484,12 +484,10 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit:<strong> 1 <em>piercing
-          damage</em>.</strong></p><p>The target must make a  <strong>DC 9
-          Constitution</strong> saving throw, taking <strong>4 (1d8) <em>poison
-          damage</em></strong> on a failed save, or half as much damage on a
-          successful one.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          make a [[/save]] saving throw, taking [[/damage average
+          activity=dnd5eactivity100]] damage on a failed save, or half as much
+          damage on a successful one.</p>
         chat: >-
           <p>The Scorpion attacks with its Sting. The target must make a
           <strong>Constitution</strong> saving throw.</p>
@@ -513,7 +511,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -583,7 +581,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -613,7 +611,7 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: ''
+            ability: none
             bonus: ''
             critical:
               threshold: null
@@ -627,6 +625,9 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -646,7 +647,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -678,96 +679,46 @@ items:
           damage:
             onSave: half
             parts:
-              - number: null
-                denomination: null
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: '8'
                 bonus: ''
                 types:
-                  - piercing
-                custom:
-                  enabled: true
-                  formula: '1'
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '9'
           sort: 0
-        dnd5eactivity300:
-          _id: dnd5eactivity300
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '5'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: 1d8
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: sting
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676467
+      modifiedTime: 1741122891662
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!Y0vxQVF7w2P38FK2.ltue5DUb1SZfphHE'
 effects: []
@@ -780,8 +731,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171237862
-  modifiedTime: 1726171445955
+  modifiedTime: 1741122900971
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!Y0vxQVF7w2P38FK2'

--- a/packs/_source/monsters/beast/sea-horse.yml
+++ b/packs/_source/monsters/beast/sea-horse.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -534,8 +534,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171216563
-  modifiedTime: 1726171442028
+  modifiedTime: 1741122904604
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!FWSDiq9SZsdiBAa8'

--- a/packs/_source/monsters/beast/spider.yml
+++ b/packs/_source/monsters/beast/spider.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -533,11 +533,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit:<strong> 1 <em>piercing
-          damage</em>.</strong></p><p>The target must succeed on a  <strong>DC 9
-          Constitution</strong> saving throw or take <strong>2 (1d4) <em>poison
-          damage</em></strong>.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          succeed on a [[/save]] saving throw or take [[/damage average
+          activity=dnd5eactivity100]] damage.</p>
         chat: >-
           <p>The Spider attacks with its Bite. The target must make a
           <strong>Constitution</strong> saving throw.</p>
@@ -602,7 +600,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
+      properties:
+        - fin
       proficient: 1
       unidentified:
         description: ''
@@ -672,19 +671,7 @@ items:
             critical:
               bonus: ''
             includeBase: true
-            parts:
-              - number: 1
-                denomination: 4
-                bonus: ''
-                types:
-                  - poison
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           sort: 0
         dnd5eactivity100:
           _id: dnd5eactivity100
@@ -705,7 +692,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -736,28 +723,28 @@ items:
           damage:
             onSave: half
             parts:
-              - number: null
-                denomination: null
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: '4'
                 bonus: ''
                 types:
-                  - piercing
-                custom:
-                  enabled: true
-                  formula: '1'
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '9'
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -766,14 +753,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676396
+      modifiedTime: 1741122951513
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!28gU50HtG8Kp7uIz.ysV0KgiPcJOYCdMh'
   - _id: JxuVwnSxsKwGVL0x
@@ -882,8 +873,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171199655
-  modifiedTime: 1726171439046
+  modifiedTime: 1741122955830
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!28gU50HtG8Kp7uIz'

--- a/packs/_source/monsters/beast/stirge.yml
+++ b/packs/_source/monsters/beast/stirge.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 2
       max: 2
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4
     init:
       ability: ''
@@ -484,14 +484,12 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>5 (1d4 + 3) <em>piercing
-          damage</em></strong>.</p><p>The stirge attaches to the target. While
-          attached, the stirge doesn't attack. Instead, at the start of each of
-          the stirge's turns, the target loses 5 (1d4 + 3) hit points due to
-          blood loss.The stirge can detach itself by spending 5 feet of its
-          movement. It does so after it drains 10 hit points of blood from the
-          target or the target dies.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The stirge
+          attaches to the target. While attached, the stirge doesn't attack.
+          Instead, at the start of each of the stirge's turns, the target loses
+          5 (1d4 + 3) hit points due to blood loss.The stirge can detach itself
+          by spending 5 feet of its movement. It does so after it drains 10 hit
+          points of blood from the target or the target dies.</p>
         chat: >-
           <p>The Stirge attacks with its Blood Drain. A creature, including the
           target, can use its action to detach the stirge.</p>
@@ -585,7 +583,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -603,8 +601,8 @@ items:
               height: ''
               units: ''
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -628,24 +626,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: blood-drain
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676488
+      modifiedTime: 1741122985601
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!gKRtiMNAjZiCVfwz.MEFgfFD6YUD9cE08'
 effects: []
@@ -658,8 +664,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171247697
-  modifiedTime: 1726171447865
+  modifiedTime: 1741123007495
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!gKRtiMNAjZiCVfwz'

--- a/packs/_source/monsters/beast/swarm-of-bats.yml
+++ b/packs/_source/monsters/beast/swarm-of-bats.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 22
       max: 22
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d8
     init:
       ability: ''
@@ -495,10 +495,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>0
-          ft.,</strong> one creature in the swarm's space. Hit: <strong>5 (2d4)
-          <em>piercing damage</em></strong>, or <strong>2 (1d4) <em>piercing
-          damage</em></strong> if the swarm has half of its hit points or
+          <p>Melee Weapon Attack: [[/attack]], 0 ft., one creature in the
+          swarm's space. Hit: [[/damage average]] damage, or [[/damage 1d4
+          piercing average]] damage if the swarm has half of its hit points or
           fewer.</p>
         chat: <p>The Swarm of Bats attacks with a flurry of Bites.</p>
       source:
@@ -524,7 +523,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 0
       uses:
         max: ''
         recovery: []
@@ -591,7 +590,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -620,8 +619,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
-            bonus: ''
+            ability: none
+            bonus: '@abilities.dex.mod'
             critical:
               threshold: null
             flat: false
@@ -634,24 +633,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bites
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676451
+      modifiedTime: 1741123130838
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!PcZ0QjIG6bHpffp9.0NpX1YUDTXjgIm23'
   - _id: cBVltbg8hNBBuTZ7
@@ -689,7 +696,7 @@ items:
       identifier: swarm
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
@@ -702,8 +709,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741123040007
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!PcZ0QjIG6bHpffp9.cBVltbg8hNBBuTZ7'
   - _id: AKRFqSGc4D9j3Mhl
     name: Keen Hearing
@@ -783,7 +790,7 @@ items:
       identifier: echolocation
     effects: []
     folder: null
-    sort: 0
+    sort: -100000
     ownership:
       default: 0
     flags:
@@ -796,8 +803,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741123042944
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!PcZ0QjIG6bHpffp9.tRdXVBesxDaXdhqP'
 effects: []
 folder: g8DmtGW2tiBpzCMk
@@ -809,8 +816,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171229635
-  modifiedTime: 1726171444389
+  modifiedTime: 1741123137805
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!PcZ0QjIG6bHpffp9'

--- a/packs/_source/monsters/beast/swarm-of-beetles.yml
+++ b/packs/_source/monsters/beast/swarm-of-beetles.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 22
       max: 22
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d8
     init:
       ability: ''
@@ -546,11 +546,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0
-          ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4)
-          <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing
-          damage</em></strong> if the swarm has half of its hit points or
-          fewer.</p>
+          <p>Melee Weapon Attack: [[/attack]], 0 ft., one target in the swarm's
+          space. Hit: [[/damage average]] damage, or [[/damage 2d4 piercing
+          average]] damage if the swarm has half of its hit points or fewer.</p>
         chat: <p>The Swarm of Beetles attacks with a flurry of Bites.</p>
       source:
         custom: ''
@@ -575,7 +573,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 0
       uses:
         max: ''
         recovery: []
@@ -643,7 +641,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -672,8 +670,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
-            bonus: ''
+            ability: none
+            bonus: '@abilities.dex.mod'
             critical:
               threshold: null
             flat: false
@@ -686,24 +684,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bites
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676481
+      modifiedTime: 1741123185757
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!dZZFmG8LiBlgWi76.neEOya9BCR7VSH09'
 effects: []
@@ -716,8 +722,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171244325
-  modifiedTime: 1726171447074
+  modifiedTime: 1741123198565
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!dZZFmG8LiBlgWi76'

--- a/packs/_source/monsters/beast/swarm-of-centipedes.yml
+++ b/packs/_source/monsters/beast/swarm-of-centipedes.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 22
       max: 22
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d8
     init:
       ability: ''
@@ -546,13 +546,13 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0
-          ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4)
-          <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing
-          damage</em></strong> if the swarm has half of its hit points or
+          <p>Melee Weapon Attack: [[/attack]], 0 ft., one target in the swarm's
+          space. Hit: [[/damage average]] damage, or [[/damage 2d4 piercing
+          average]] damage if the swarm has half of its hit points or
           fewer.</p><p>A creature reduced to 0 hit points by a swarm of
-          centipedes is stable but poisoned for 1 hour, even after regaining hit
-          points, and paralyzed while poisoned in this way.</p>
+          centipedes is stable but &amp;Reference[poisoned] for 1 hour, even
+          after regaining hit points, and paralyzed while poisoned in this
+          way.</p>
         chat: <p>The Swarm of Centipedes attacks with a flurry of Bites.</p>
       source:
         custom: ''
@@ -577,7 +577,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 0
       uses:
         max: ''
         recovery: []
@@ -645,7 +645,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -674,8 +674,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
-            bonus: ''
+            ability: none
+            bonus: '@abilities.dex.mod'
             critical:
               threshold: null
             flat: false
@@ -688,24 +688,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bites
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676440
+      modifiedTime: 1741123486200
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!KC4tYOolARhajP18.E6zkvUOJARx1t0nc'
 effects: []
@@ -718,8 +726,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171221852
-  modifiedTime: 1726171443047
+  modifiedTime: 1741123379510
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!KC4tYOolARhajP18'

--- a/packs/_source/monsters/beast/swarm-of-insects.yml
+++ b/packs/_source/monsters/beast/swarm-of-insects.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 22
       max: 22
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d8
     init:
       ability: ''
@@ -546,11 +546,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0
-          ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4)
-          <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing
-          damage</em></strong> if the swarm has half of its hit points or
-          fewer.</p>
+          <p>Melee Weapon Attack: [[/attack]], 0 ft., one target in the swarm's
+          space. Hit: [[/damage average]] damage, or [[/damage 2d4 piercing
+          average]] damage if the swarm has half of its hit points or fewer.</p>
         chat: <p>The Swarm of Insects attacks with a flurry of Bites.</p>
       source:
         custom: ''
@@ -575,7 +573,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 0
       uses:
         max: ''
         recovery: []
@@ -643,7 +641,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -672,8 +670,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
-            bonus: ''
+            ability: none
+            bonus: '@abilities.dex.mod'
             critical:
               threshold: null
             flat: false
@@ -686,24 +684,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bites
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676452
+      modifiedTime: 1741123491647
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!S0zDrv6lbnwWaz9E.1yXz3JunJtlQs6vV'
 effects: []
@@ -716,8 +722,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171231646
-  modifiedTime: 1726171444738
+  modifiedTime: 1741123419273
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!S0zDrv6lbnwWaz9E'

--- a/packs/_source/monsters/beast/swarm-of-poisonous-snakes.yml
+++ b/packs/_source/monsters/beast/swarm-of-poisonous-snakes.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 36
       max: 36
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 8d8
     init:
       ability: ''
@@ -546,14 +546,12 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>0
-          ft.,</strong> one creature in the swarm's space. Hit: <strong>7 (2d6)
-          <em>piercing damage</em></strong>, or <strong>3 (1d6) <em>piercing
-          damage</em></strong> if the swarm has half of its hit points or
-          fewer.</p><p>The target must make a  <strong>DC 10
-          Constitution</strong> saving throw, taking <strong>14 (4d6) <em>poison
-          damage</em></strong> on a failed save, or half as much damage on a
-          successful one.</p>
+          <p>Melee Weapon Attack: [[/attack]], 0 ft., one creature in the
+          swarm's space. Hit: [[/damage average]] damage, or [[/damage 1d6
+          piercing average]] damage if the swarm has half of its hit points or
+          fewer.</p><p>The target must make a [[/save]] saving throw, taking
+          [[/damage average activity=dnd5eactivity100]] damage on a failed save,
+          or half as much damage on a successful one.</p>
         chat: >-
           <p>The Swarm of Poisonous Snakes attacks with a flurry of Bites. The
           target must make a <strong>Constitution</strong> saving throw.</p>
@@ -580,7 +578,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 0
       uses:
         max: ''
         recovery: []
@@ -648,7 +646,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -677,8 +675,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
-            bonus: ''
+            ability: none
+            bonus: '@abilities.dex.mod'
             critical:
               threshold: null
             flat: false
@@ -691,6 +689,9 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -710,7 +711,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -741,95 +742,46 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 2
-                denomination: 6
-                bonus: ''
-                types:
-                  - piercing
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 4
+                denomination: '6'
+                bonus: ''
+                types:
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '10'
           sort: 0
-        dnd5eactivity300:
-          _id: dnd5eactivity300
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: 4d6
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bites
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676466
+      modifiedTime: 1741123471464
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!XfQMBoTh892XSnCX.OyLoUiIl3p2j4p59'
 effects: []
@@ -842,8 +794,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171237545
-  modifiedTime: 1726171445882
+  modifiedTime: 1741123477918
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!XfQMBoTh892XSnCX'

--- a/packs/_source/monsters/beast/swarm-of-quippers.yml
+++ b/packs/_source/monsters/beast/swarm-of-quippers.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 28
       max: 28
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 8d8 - 8
     init:
       ability: ''
@@ -643,10 +643,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>0
-          ft.,</strong> one creature in the swarm's space. Hit: <strong>14 (4d6)
-          <em>piercing damage</em></strong>, or <strong>7 (2d6) <em>piercing
-          damage</em></strong> if the swarm has half of its hit points or
+          <p>Melee Weapon Attack: [[/attack]], 0 ft., one creature in the
+          swarm's space. Hit: [[/damage average]] damage, or [[/damage 2d6
+          piercing average]] damage if the swarm has half of its hit points or
           fewer.</p>
         chat: <p>The Swarm of Quippers attacks with a flurry of Bites.</p>
       source:
@@ -672,7 +671,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 0
       uses:
         max: ''
         recovery: []
@@ -740,7 +739,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -769,8 +768,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
-            bonus: ''
+            ability: none
+            bonus: '@abilities.dex.mod'
             critical:
               threshold: null
             flat: false
@@ -783,24 +782,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bites
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676443
+      modifiedTime: 1741123546450
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!KXG5XLIwKhn1V0Y5.hZiOYQNCqAFq0sD6'
 effects: []
@@ -813,8 +820,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171223227
-  modifiedTime: 1726171443332
+  modifiedTime: 1741123498123
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!KXG5XLIwKhn1V0Y5'

--- a/packs/_source/monsters/beast/swarm-of-rats.yml
+++ b/packs/_source/monsters/beast/swarm-of-rats.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 24
       max: 24
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 7d8 - 7
     init:
       ability: ''
@@ -593,11 +593,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>0
-          ft.,</strong> one target in the swarm's space. Hit: <strong>7 (2d6)
-          <em>piercing damage</em></strong>, or <strong>3 (1d6) <em>piercing
-          damage</em></strong> if the swarm has half of its hit points or
-          fewer.</p>
+          <p>Melee Weapon Attack: [[/attack]], 0 ft., one target in the swarm's
+          space. Hit: [[/damage average]] damage, or [[/damage 1d6 piercing
+          average]] damage if the swarm has half of its hit points or fewer.</p>
         chat: <p>The Swarm of Rats attacks with a flurry of Bites.</p>
       source:
         custom: ''
@@ -622,7 +620,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 0
       uses:
         max: ''
         recovery: []
@@ -690,7 +688,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -719,8 +717,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
-            bonus: ''
+            ability: none
+            bonus: '@abilities.dex.mod'
             critical:
               threshold: null
             flat: false
@@ -733,24 +731,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bites
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676415
+      modifiedTime: 1741123586612
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!8ihbbjkaOFTPbI73.ESv9NuVeZhnEW1ua'
 effects: []
@@ -763,8 +769,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171208469
-  modifiedTime: 1726171440565
+  modifiedTime: 1741123588306
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!8ihbbjkaOFTPbI73'

--- a/packs/_source/monsters/beast/swarm-of-ravens.yml
+++ b/packs/_source/monsters/beast/swarm-of-ravens.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 24
       max: 24
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 7d8 - 7
     init:
       ability: ''
@@ -546,11 +546,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target in the swarm's space. Hit: <strong>7 (2d6)
-          <em>piercing damage</em></strong>, or <strong>3 (1d6) <em>piercing
-          damage</em></strong> if the swarm has half of its hit points or
-          fewer.</p>
+          <p>Melee Weapon Attack: [[/attack]], 5 ft., one target in the swarm's
+          space. Hit: [[/damage average]] damage, or [[/damage 1d6 piercing
+          average]] damage if the swarm has half of its hit points or fewer.</p>
         chat: <p>The Swarm of Ravens attacks with its Beaks.</p>
       source:
         custom: ''
@@ -572,10 +570,10 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
-        reach: null
+        reach: 0
       uses:
         max: ''
         recovery: []
@@ -643,7 +641,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -673,8 +671,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
-            bonus: ''
+            ability: none
+            bonus: '@abilities.dex.mod'
             critical:
               threshold: null
             flat: false
@@ -687,24 +685,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: beaks
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676487
+      modifiedTime: 1741123634879
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!g40zN6xMye6bSS94.rQWSxwspySRtFst2'
 effects: []
@@ -717,8 +723,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171247183
-  modifiedTime: 1726171447743
+  modifiedTime: 1741123641951
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!g40zN6xMye6bSS94'

--- a/packs/_source/monsters/beast/swarm-of-spiders.yml
+++ b/packs/_source/monsters/beast/swarm-of-spiders.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 22
       max: 22
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d8
     init:
       ability: ''
@@ -546,11 +546,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0
-          ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4)
-          <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing
-          damage</em></strong> if the swarm has half of its hit points or
-          fewer.</p>
+          <p>Melee Weapon Attack: [[/attack]], 0 ft., one target in the swarm's
+          space. Hit: [[/damage average]] damage, or [[/damage 2d4 piercing
+          average]] damage if the swarm has half of its hit points or fewer.</p>
         chat: <p>The Swarm of Spiders attacks with a flurry of Bites.</p>
       source:
         custom: ''
@@ -575,7 +573,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 0
       uses:
         max: ''
         recovery: []
@@ -643,7 +641,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -672,8 +670,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
-            bonus: ''
+            ability: none
+            bonus: '@abilities.dex.mod'
             critical:
               threshold: null
             flat: false
@@ -686,24 +684,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bites
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676405
+      modifiedTime: 1741123675763
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!4udpeEneFSZK9NTB.qoIR278ckqhlVaNr'
   - _id: KYBcEhA6mh3gqPG8
@@ -861,8 +867,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171202327
-  modifiedTime: 1726171439535
+  modifiedTime: 1741123679009
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!4udpeEneFSZK9NTB'

--- a/packs/_source/monsters/beast/swarm-of-wasps.yml
+++ b/packs/_source/monsters/beast/swarm-of-wasps.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 22
       max: 22
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d8
     init:
       ability: ''
@@ -546,11 +546,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>0
-          ft.,</strong> one target in the swarm's space. Hit: <strong>10 (4d4)
-          <em>piercing damage</em></strong>, or <strong>5 (2d4) <em>piercing
-          damage</em></strong> if the swarm has half of its hit points or
-          fewer.</p>
+          <p>Melee Weapon Attack: [[/attack]], 0 ft., one target in the swarm's
+          space. Hit: [[/damage average]] damage, or [[/damage 2d4 piercing
+          average]] damage if the swarm has half of its hit points or fewer.</p>
         chat: <p>The Swarm of Wasps attacks with a flurry of Bites.</p>
       source:
         custom: ''
@@ -575,7 +573,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 0
       uses:
         max: ''
         recovery: []
@@ -643,7 +641,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -672,8 +670,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
-            bonus: ''
+            ability: none
+            bonus: '@abilities.dex.mod'
             critical:
               threshold: null
             flat: false
@@ -686,24 +684,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bites
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676469
+      modifiedTime: 1741123709164
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!YUaprnengdFDNG8P.bmjRGkZH4lnTX72M'
 effects: []
@@ -716,8 +722,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171238465
-  modifiedTime: 1726171446064
+  modifiedTime: 1741123718268
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!YUaprnengdFDNG8P'

--- a/packs/_source/monsters/beast/tiger.yml
+++ b/packs/_source/monsters/beast/tiger.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 37
       max: 37
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d10 + 10
     init:
       ability: ''
@@ -531,10 +531,10 @@ items:
     system:
       description:
         value: >-
-          <p>If the tiger moves at least <strong>20 ft.</strong> straight toward
-          a creature and then hits it with a claw attack on the same turn, that
-          target must succeed on a <strong>DC 13 Strength saving throw</strong>
-          or be knocked prone.</p><p>If the target is prone, the panther can
+          <p>If the tiger moves at least 20 ft. straight toward a creature and
+          then hits it with a claw attack on the same turn, that target must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p><p>If the target is prone, the panther can
           make one bite attack against it as a bonus action.</p>
         chat: >-
           <p>If the tiger moves at least <strong>20 ft.</strong> straight toward
@@ -685,9 +685,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676775
+      modifiedTime: 1741123736236
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!FayqbnjBMszO6Pat.wklAUVakX97y0z2S'
   - _id: YypXtXEL61FqWYOP
@@ -696,10 +696,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Tiger attacks with its Bite.</p>
       source:
         custom: ''
@@ -721,7 +718,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -839,6 +836,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -852,9 +850,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676775
+      modifiedTime: 1741123751274
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!FayqbnjBMszO6Pat.YypXtXEL61FqWYOP'
   - _id: 7GCnVtakQo6iZyn7
@@ -863,10 +861,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Tiger attacks with its Claw.</p>
       source:
         custom: ''
@@ -888,7 +883,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -1007,6 +1002,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -1018,9 +1014,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676775
+      modifiedTime: 1741123760572
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!FayqbnjBMszO6Pat.7GCnVtakQo6iZyn7'
 effects: []
@@ -1033,8 +1029,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171216735
-  modifiedTime: 1726171442068
+  modifiedTime: 1741123763812
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!FayqbnjBMszO6Pat'

--- a/packs/_source/monsters/beast/triceratops.yml
+++ b/packs/_source/monsters/beast/triceratops.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 95
       max: 95
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 10d12 + 30
     init:
       ability: ''
@@ -483,10 +483,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>24 (4d8 + 6) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Triceratops attacks with its Gore.</p>
       source:
         custom: ''
@@ -625,6 +622,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: gore
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -636,9 +634,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676803
+      modifiedTime: 1741123788739
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!e5IQxSJO7ySEDdSH.h5lGnMKW65NWIi2W'
   - _id: 6UWSefP0BqnmYwAz
@@ -648,9 +646,8 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+9 to hit,</strong>, <strong>5
-          ft.,</strong> one prone creature. Hit: <strong>22 (3d10 + 6)
-          <em>bludgeoning damage</em></strong>.</p>
+          <p><em>Melee Weapon Attack:</em> [[/attack]], reach 5 ft., one prone
+          creature. Hit: [[/damage average]] damage.</p>
         chat: <p>The Triceratops attacks with its Stomp.</p>
       source:
         custom: ''
@@ -789,6 +786,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: stomp
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -800,9 +798,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676803
+      modifiedTime: 1741123830633
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!e5IQxSJO7ySEDdSH.6UWSefP0BqnmYwAz'
   - _id: 4jztSrWQNxc4q55u
@@ -812,12 +810,11 @@ items:
     system:
       description:
         value: >-
-          <p>If the triceratops moves at least <strong>20 ft.</strong> straight
-          toward a creature and then hits it with a gore attack on the same
-          turn, that target must succeed on a <strong>DC 13 Strength saving
-          throw</strong> or be knocked prone. If the target is prone, the
-          triceratops can make one stomp attack against it as a bonus
-          action.</p>
+          <p>If the triceratops moves at least 20 ft. straight toward a creature
+          and then hits it with a gore attack on the same turn, that target must
+          succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone]. If the target is prone, the triceratops can
+          make one stomp attack against it as a bonus action.</p>
         chat: >-
           <p>If the triceratops moves at least <strong>20 ft.</strong> straight
           toward a creature and then hits it with a gore attack on the same
@@ -912,9 +909,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676803
+      modifiedTime: 1741123777625
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!e5IQxSJO7ySEDdSH.4jztSrWQNxc4q55u'
 effects: []
@@ -927,8 +924,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171244487
-  modifiedTime: 1726171447112
+  modifiedTime: 1741123835698
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!e5IQxSJO7ySEDdSH'

--- a/packs/_source/monsters/beast/tyrannosaurus-rex.yml
+++ b/packs/_source/monsters/beast/tyrannosaurus-rex.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 136
       max: 136
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 13d12 + 52
     init:
       ability: ''
@@ -484,12 +484,11 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>,
-          <strong>10 ft.,</strong> one target. Hit: <strong>33 (4d12 + 7)
-          <em>piercing damage</em></strong>. </p><p>If the target is a Medium or
-          smaller creature, it is grappled (escape DC 17). Until this grapple
-          ends, the target is restrained, and the tyrannosaurus can't bite
-          another target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a Medium or smaller creature, it is &amp;Reference[grappled] (escape
+          DC 17). Until this grapple ends, the target is
+          &amp;Reference[restrained], and the tyrannosaurus can't bite another
+          target.</p>
         chat: >-
           <p>The Tyrannosaurus Rex attacks with its Bite. If the target is a
           Medium or smaller creature, it is grappled. Until this grapple ends,
@@ -515,7 +514,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 10
+        value: null
         long: null
         units: ft
         reach: null
@@ -556,7 +555,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
+      properties:
+        - rch
       proficient: 1
       unidentified:
         description: ''
@@ -633,9 +633,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
@@ -646,9 +647,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676662
+      modifiedTime: 1741123874342
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!HlddcPm4cWptj3ka.O8pEyHMhxCwROJ6O'
   - _id: Fi45qe2ncVZHNq43
@@ -750,8 +751,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741123839715
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!HlddcPm4cWptj3ka.Fi45qe2ncVZHNq43'
   - _id: jw9SyNUWRzgHe37B
     name: Tail
@@ -759,10 +760,7 @@ items:
     img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+10 to hit,</strong>,
-          <strong>10 ft.,</strong> one target. Hit: <strong>20 (3d8 + 7)
-          <em>bludgeoning damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Tyrannosaurus Rex attacks with its Tail.</p>
       source:
         custom: ''
@@ -784,7 +782,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 10
+        value: null
         long: null
         units: ft
         reach: null
@@ -825,7 +823,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
+      properties:
+        - rch
       proficient: 1
       unidentified:
         description: ''
@@ -902,9 +901,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: tail
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
@@ -913,9 +913,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676662
+      modifiedTime: 1741123889768
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!HlddcPm4cWptj3ka.jw9SyNUWRzgHe37B'
 effects: []
@@ -928,8 +928,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171218926
-  modifiedTime: 1726171442440
+  modifiedTime: 1741123894634
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!HlddcPm4cWptj3ka'

--- a/packs/_source/monsters/beast/vulture.yml
+++ b/packs/_source/monsters/beast/vulture.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 5
       max: 5
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d8 + 1
     init:
       ability: ''
@@ -581,10 +581,7 @@ items:
     img: icons/skills/wounds/bone-broken-tooth-fang-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>2 (1d4) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Vulture attacks with its Beak.</p>
       source:
         custom: ''
@@ -606,7 +603,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -647,7 +644,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
+      properties:
+        - fin
       proficient: 1
       unidentified:
         description: ''
@@ -724,6 +722,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: beak
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -735,9 +734,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676484
+      modifiedTime: 1741123918751
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!fkJ8Z8zi2JtlcHh9.MnAKUayu6jCzzRsS'
 effects: []
@@ -750,8 +749,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171246455
-  modifiedTime: 1726171447571
+  modifiedTime: 1741123923909
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!fkJ8Z8zi2JtlcHh9'

--- a/packs/_source/monsters/beast/warhorse.yml
+++ b/packs/_source/monsters/beast/warhorse.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 19
       max: 19
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d10 + 3
     init:
       ability: ''
@@ -650,10 +650,7 @@ items:
     img: icons/commodities/bones/hooves-cloven-brown.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Warhorse attacks with its Hooves.</p>
       source:
         custom: ''
@@ -675,7 +672,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -793,6 +790,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: hooves
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -806,9 +804,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676574
+      modifiedTime: 1741123934411
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!T1xZTDCGuvMBSq8d.7MiLYgDyM2Rm3nEb'
 effects: []
@@ -821,8 +819,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171233148
-  modifiedTime: 1726171445097
+  modifiedTime: 1741123935710
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!T1xZTDCGuvMBSq8d'

--- a/packs/_source/monsters/beast/weasel.yml
+++ b/packs/_source/monsters/beast/weasel.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 1
       max: 1
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 1d4 - 1
     init:
       ability: ''
@@ -530,10 +530,7 @@ items:
     img: icons/creatures/abilities/mouth-teeth-long-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit:<strong> 1 <em>piercing
-          damage</em>.</strong></p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Weasel attacks with its Bite.</p>
       source:
         custom: ''
@@ -555,7 +552,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -673,6 +670,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -686,9 +684,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676465
+      modifiedTime: 1741123943806
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!WOdeacKCYVhgLDuN.qQmFFG5fOGkUEeu2'
 effects: []
@@ -701,8 +699,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171236820
-  modifiedTime: 1726171445755
+  modifiedTime: 1741123944819
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!WOdeacKCYVhgLDuN'

--- a/packs/_source/monsters/beast/wolf.yml
+++ b/packs/_source/monsters/beast/wolf.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 11
       max: 11
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d8 + 2
     init:
       ability: ''
@@ -581,11 +581,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>7 (2d4 + 2) <em>piercing
-          damage</em></strong>.</p><p>If the target is a creature, it must
-          succeed on a  <strong>DC 11 Strength</strong> saving throw or be
-          knocked prone.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a creature, it must succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>The Wolf attacks with its Bite. If the target is a creature, it
           must make a <strong>Strength</strong> saving throw or be knocked
@@ -610,7 +608,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -775,19 +773,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 2
-                denomination: 4
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -798,6 +784,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -806,14 +793,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676516
+      modifiedTime: 1741123975483
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!yawTeS8u2FCfzzZH.MuH5aMoKOyZanrFf'
 effects: []
@@ -826,8 +817,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171266835
-  modifiedTime: 1726171452063
+  modifiedTime: 1741123979627
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!yawTeS8u2FCfzzZH'

--- a/packs/_source/monsters/monstrosity/death-dog.yml
+++ b/packs/_source/monsters/monstrosity/death-dog.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 39
       max: 39
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 6d8 + 12
     init:
       ability: ''
@@ -484,15 +484,13 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing
-          damage</em></strong>.</p><p>If the target is a creature, it must
-          succeed on a  <strong>DC 12 Constitution</strong> saving throw against
-          disease or become poisoned until the disease is cured. Every 24 hours
-          that elapse, the creature must repeat the saving throw, reducing its
-          hit point maximum by 5 (1d10) on a failure. This reduction lasts until
-          the disease is cured. The creature dies if the disease reduces its hit
-          point maximum to 0.</p>
+          <p>[[/attack extended]]. [[/damage extended]]. If the target is a
+          creature, it must succeed on a [[/save]] saving throw against disease
+          or become &amp;Reference[poisoned] until the disease is cured. Every
+          24 hours that elapse, the creature must repeat the saving throw,
+          reducing its hit point maximum by 5 (1d10) on a failure. This
+          reduction lasts until the disease is cured. The creature dies if the
+          disease reduces its hit point maximum to 0.</p>
         chat: >-
           <p>The Death Dog attacks with its Bite. If the target is a creature,
           it must make a <strong>Constitution</strong> saving throw. Every 24
@@ -517,7 +515,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -681,19 +679,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 1
-                denomination: 6
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: con
             dc:
@@ -704,22 +690,27 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 200000
     ownership:
       default: 0
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676448
+      modifiedTime: 1741117372468
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!PH78NBdvoaszAb61.TKV9mS1lvqMAyCaB'
   - _id: xpakQFJhIVCQz3Si
@@ -856,7 +847,7 @@ items:
       identifier: multiattack
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
@@ -869,8 +860,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741117308382
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!PH78NBdvoaszAb61.EHX3CeEnlmzwnnK5'
 effects: []
 folder: MMKVDW6XI98WdIVu
@@ -882,8 +873,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171228934
-  modifiedTime: 1726171444273
+  modifiedTime: 1741117376314
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!PH78NBdvoaszAb61'

--- a/packs/_source/monsters/monstrosity/phase-spider.yml
+++ b/packs/_source/monsters/monstrosity/phase-spider.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 32
       max: 32
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d10 + 5
     init:
       ability: ''
@@ -502,7 +502,8 @@ items:
         value: ''
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
@@ -574,10 +575,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1741122573573
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!llSG0Hi4eGlRlQ4o.LKJEecvimhbb9hhg'
   - _id: X78NpT0YZG0rZcaP
     name: Spider Climb
@@ -682,14 +683,13 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>7 (1d10 + 2) <em>piercing
-          damage</em></strong>.</p><p>The target must make a  <strong>DC 11
-          Constitution</strong> saving throw, taking <strong>18 (4d8) <em>poison
-          damage</em></strong> on a failed save, or half as much damage on a
-          successful one. If the <em>poison damage</em> reduces the target to 0
-          hit points, the target is stable but poisoned for 1 hour, even after
-          regaining hit points, and is paralyzed while poisoned in this way.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          make a [[/save]] saving throw, taking [[/damage average
+          activity=dnd5eactivity100]] damage on a failed save, or half as much
+          damage on a successful one. If the poison damage reduces the target to
+          0 hit points, the target is stable but &amp;Reference[poisoned] for 1
+          hour, even after regaining hit points, and is
+          &amp;Reference[paralyzed] while poisoned in this way.</p>
         chat: >-
           <p>The Phase Spider attacks with its Bite. The target must make a
           <strong>Constitution</strong> saving throw.</p>
@@ -713,7 +713,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -846,7 +846,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -878,82 +878,28 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 1
-                denomination: 10
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 4
+                denomination: '8'
+                bonus: ''
+                types:
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '11'
           sort: 0
-        dnd5eactivity300:
-          _id: dnd5eactivity300
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '5'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: 4d8
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -962,14 +908,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676496
+      modifiedTime: 1741122560151
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!llSG0Hi4eGlRlQ4o.2HPk5TdUTeEhD2eG'
 effects: []
@@ -982,8 +932,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171253960
-  modifiedTime: 1726171449116
+  modifiedTime: 1741122580134
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!llSG0Hi4eGlRlQ4o'

--- a/packs/_source/monsters/monstrosity/winter-wolf.yml
+++ b/packs/_source/monsters/monstrosity/winter-wolf.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 75
       max: 75
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 10d10 + 20
     init:
       ability: ''
@@ -634,11 +634,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>11 (2d6 + 4) <em>piercing
-          damage</em></strong>. If the target is a creature, it must succeed on
-          a <strong>DC 14 Strength saving throw</strong> or be knocked
-          prone.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a creature, it must succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>The Winter Wolf attacks with its Bite. If the target is a creature,
           it must make a <strong>Strength</strong> saving throw or be knocked
@@ -663,7 +661,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -827,19 +825,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 2
-                denomination: 6
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -850,6 +836,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -858,14 +845,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676623
+      modifiedTime: 1741124014456
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!yGTh874etxUckmAf.5PmQuifZGbPWxAYz'
   - _id: Rj3oSInoQMIfHrPc
@@ -876,10 +867,9 @@ items:
       description:
         value: >-
           <p>The wolf exhales a blast of freezing wind in a 15-foot cone. Each
-          creature in that area must make a  <strong>DC 12 Dexterity</strong>
-          saving throw, taking <strong>18 (4d8) <em>cold damage</em></strong> on
-          a failed save, or half as much damage on a successful one. Recharge
-          5-6.</p>
+          creature in that area must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
         chat: >-
           <p>The wolf exhales a blast of freezing wind in a 15-foot cone. Each
           creature in that area must make a <strong>Dexterity</strong> saving
@@ -893,7 +883,10 @@ items:
         revision: 1
       uses:
         max: '1'
-        recovery: []
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
         spent: 0
       type:
         value: ''
@@ -901,95 +894,6 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: attack
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-              - type: activityUses
-                target: ''
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '15'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: '1'
-            recovery:
-              - period: recharge
-                type: recoverAll
-                formula: '5'
-          attack:
-            ability: ''
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: ranged
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts:
-              - number: 4
-                denomination: 8
-                bonus: ''
-                types:
-                  - cold
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -1085,14 +989,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.iHOaiOqwUWIfCljJ
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.iHOaiOqwUWIfCljJ
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676623
+      modifiedTime: 1741124061365
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!yGTh874etxUckmAf.Rj3oSInoQMIfHrPc'
 effects: []
@@ -1105,8 +1013,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171266486
-  modifiedTime: 1726171451968
+  modifiedTime: 1741124065912
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!yGTh874etxUckmAf'

--- a/packs/_source/monsters/monstrosity/worg.yml
+++ b/packs/_source/monsters/monstrosity/worg.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 26
       max: 26
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 4d10 + 4
     init:
       ability: ''
@@ -533,11 +533,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>10 (2d6 + 3) <em>piercing
-          damage</em></strong>.</p><p>If the target is a creature, it must
-          succeed on a  <strong>DC 13 Strength</strong> saving throw or be
-          knocked prone.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a creature, it must succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone].</p>
         chat: >-
           <p>The Worg attacks with its Bite. If the target is a creature, it
           must make a <strong>Strength</strong> saving throw or be knocked
@@ -562,7 +560,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -726,19 +724,7 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts:
-              - number: 2
-                denomination: 6
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            parts: []
           save:
             ability: str
             dc:
@@ -749,6 +735,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -757,14 +744,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676460
+      modifiedTime: 1741124088537
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!VBkp2rGQKvMcCOus.UnONIXYgZcE3Jya0'
 effects: []
@@ -777,8 +768,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171235437
-  modifiedTime: 1726171445488
+  modifiedTime: 1741124092684
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!VBkp2rGQKvMcCOus'

--- a/packs/_source/monsters/plant/awakened-shrub.yml
+++ b/packs/_source/monsters/plant/awakened-shrub.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 10
       max: 10
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d6
     init:
       ability: ''
@@ -485,10 +485,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+1 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: 1 (1d4 - 1) <em>slashing
-          damage</em>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Awakened Shrub attacks with its Rake.</p>
       source:
         custom: ''
@@ -639,9 +636,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676490
+      modifiedTime: 1741116544844
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!gaSTr7DFZJLmgI2J.Vdk7dsybx2iYlKVx'
   - _id: cfgn9yboSN7jIsDC
@@ -703,8 +700,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171247847
-  modifiedTime: 1726171447908
+  modifiedTime: 1741116553216
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!gaSTr7DFZJLmgI2J'

--- a/packs/_source/monsters/plant/awakened-tree.yml
+++ b/packs/_source/monsters/plant/awakened-tree.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 59
       max: 59
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 7d12 + 14
     init:
       ability: ''
@@ -535,10 +535,7 @@ items:
     img: icons/skills/melee/unarmed-punch-fist-yellow-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>,
-          <strong>10 ft.,</strong> one target. Hit: <strong>14 (3d6 + 4)
-          <em>bludgeoning damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Awakened Tree attacks with its Slam.</p>
       source:
         custom: ''
@@ -690,9 +687,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.4.0
       createdTime: null
-      modifiedTime: 1736804676459
+      modifiedTime: 1741116564017
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!UR2gWLFHmFwG7ReH.WEesSpitzLnaCknL'
 effects: []
@@ -705,8 +702,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1726171234693
-  modifiedTime: 1726171445344
+  modifiedTime: 1741116567041
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!UR2gWLFHmFwG7ReH'


### PR DESCRIPTION
Adjust all of the creatures found in Appendix MM-A of the SRD to use the new extended attack & damage enrichers, fixing duplicate damage for saves, and a variety of other small fixes.