### PR TITLE
Incorporate "movement actions" for V13

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -76,6 +76,10 @@ Hooks.once("init", function() {
   CONFIG.JournalEntryPage.documentClass = documents.JournalEntryPage5e;
   CONFIG.Token.documentClass = documents.TokenDocument5e;
   CONFIG.Token.objectClass = canvas.Token5e;
+  if ( game.release.generation > 12 ) {
+    CONFIG.Token.movement.actions =
+      Object.fromEntries(Object.entries(CONFIG.DND5E.movementTypes).map(([k, v]) => ([k, {label: v}])));
+  }
   CONFIG.User.documentClass = documents.User5e;
   CONFIG.time.roundTime = 6;
   Roll.TOOLTIP_TEMPLATE = "systems/dnd5e/templates/chat/roll-breakdown.hbs";

--- a/lang/en.json
+++ b/lang/en.json
@@ -874,6 +874,11 @@
     "Gold": "{value} ({claimed})",
     "NoOrders": "No orders issued to special facilities this turn.",
     "Order": "{link} completed the <strong>{order}</strong> order."
+  },
+  "Trade": {
+    "Cancel": "Cancel Pending Trade",
+    "Invalid": "Removing a pending trade will invalidate your trade order.",
+    "Pending": "Pending trade"
   }
 },
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -3152,6 +3152,7 @@
 "DND5E.MovementAir": "Air",
 "DND5E.MovementSpeeds": "Movement Speeds",
 "DND5E.MovementUnits": "Units",
+"DND5E.MovementCurrent": "Current Movement",
 
 "DND5E.SAVE": {
   "Title": {

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -648,17 +648,22 @@
       overflow: visible;
       cursor: pointer;
 
-      &.empty {
+      &.empty, &.pending {
         display: inline-grid;
         place-content: center;
 
         &::before {
           font-family: var(--font-awesome);
           font-weight: bold;
-          opacity: .15;
         }
       }
 
+      &.pending::before {
+        content: "\f51e";
+        color: var(--dnd5e-color-gold);
+      }
+
+      &.empty::before { opacity: .15; }
       &.hireling.empty::before { content: "\f007"; }
       &.defender.empty::before { content: "\f132"; }
       &.creature.empty::before { content: "\f7ab"; }
@@ -828,16 +833,21 @@
 
   &#bastion-turn {
     pointer-events: all;
-    margin: 0 5px 10px 15px;
+    margin: 0 0 -8px;
     color: var(--color-text-light-highlight);
-    width: var(--players-width);
+    width: var(--players-width, 200px);
     background: rgb(0 0 0 / 80%);
     border: 1px solid var(--color-border-dark);
+    cursor: var(--cursor-pointer), pointer;
+    height: 40px;
 
     &:hover {
       border-color: var(--color-border-highlight-alt);
       box-shadow: 0 0 10px var(--color-shadow-highlight);
     }
+
+    /* TODO: Remove when v12 is dropped */
+    &.v12 { margin: 0 5px 10px 15px; }
   }
 
   /* ---------------------------------- */

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -99,6 +99,7 @@
 /* Modifier Keys */
 :is(.chat-popout, #chat-log, .chat-log)[data-modifier-shift] {
   .message .message-header .message-delete { display: unset; }
+  .message .message-header .chat-control { display: none; }
 }
 
 /* ---------------------------------- */

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -132,11 +132,18 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     }
 
     // Speed
-    context.speed = Object.entries(CONFIG.DND5E.movementTypes).reduce((obj, [k, label]) => {
-      const value = attributes.movement[k];
-      if ( value > obj.value ) Object.assign(obj, { value, label });
-      return obj;
-    }, { value: 0, label: CONFIG.DND5E.movementTypes.walk });
+    if ( attributes.movement.current?.length ) {
+      context.speed = {
+        value: attributes.movement[attributes.movement.current],
+        label: CONFIG.DND5E.movementTypes[attributes.movement.current]
+      };
+    } else {
+      context.speed = Object.entries(CONFIG.DND5E.movementTypes).reduce((obj, [k, label]) => {
+        const value = attributes.movement[k];
+        if ( value > obj.value ) Object.assign(obj, { value, label });
+        return obj;
+      }, { value: 0, label: CONFIG.DND5E.movementTypes.walk });
+    }
 
     // Death Saves
     context.death.open = this._deathTrayOpen;

--- a/module/applications/actor/character-sheet-2.mjs
+++ b/module/applications/actor/character-sheet-2.mjs
@@ -514,6 +514,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     const { index } = event.target.closest("[data-index]")?.dataset ?? {};
     const facility = this.actor.items.get(facilityId);
     if ( !facility || !prop || (index === undefined) ) return;
+    if ( event.target.closest(".occupant-slot.pending") ) return this._onRemovePendingTrade(facility);
     let { value } = foundry.utils.getProperty(facility, prop);
     value = value.filter((_, i) => i !== Number(index));
     return facility.update({ [`${prop}.value`]: value });
@@ -538,6 +539,35 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
     }
     const result = await CompendiumBrowser.selectOne({ filters });
     if ( result ) this._onDropItemCreate(game.items.fromCompendium(await fromUuid(result), { keepId: true }));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle removing a pending trade from a facility.
+   * @param {Item5e} facility  The target facility.
+   * @returns {Promise<void|Item5e>}
+   * @protected
+   */
+  async _onRemovePendingTrade(facility) {
+    const result = await foundry.applications.api.DialogV2.confirm({
+      content: `
+        <p><strong>${game.i18n.localize("AreYouSure")}</strong> ${game.i18n.localize("DND5E.Bastion.Trade.Invalid")}</p>
+      `,
+      window: {
+        icon: "fa-solid fa-coins",
+        title: "DND5E.Bastion.Trade.Cancel"
+      },
+      position: { width: 400 }
+    }, { rejectClose: false });
+    if ( result ) return facility.update({
+      system: {
+        progress: { max: null, order: "", value: null },
+        trade: {
+          pending: { creatures: [], operation: null }
+        }
+      }
+    });
   }
 
   /* -------------------------------------------- */
@@ -781,7 +811,7 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
       const context = {
         id, labels, name, building, disabled, free, progress,
         craft: craft.item ? await fromUuid(craft.item) : null,
-        creatures: await this._prepareFacilityOccupants(trade.creatures),
+        creatures: await this._prepareFacilityLivestock(trade),
         defenders: await this._prepareFacilityOccupants(defenders),
         executing: CONFIG.DND5E.facilities.orders[progress.order]?.icon,
         hirelings: await this._prepareFacilityOccupants(hirelings),
@@ -822,6 +852,25 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
   /* -------------------------------------------- */
 
   /**
+   * Prepare facility livestock for display.
+   * @param {object} trade  Facility trade information.
+   * @returns {Promise<object[]>}
+   * @protected
+   */
+  async _prepareFacilityLivestock(trade) {
+    const creatures = await this._prepareFacilityOccupants(trade.creatures);
+    const pending = trade.pending.creatures;
+    return [
+      ...(await Promise.all((pending ?? []).map(async (uuid, index) => {
+        return { index, actor: await fromUuid(uuid), pending: true };
+      }))),
+      ...creatures
+    ];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Prepare facility occupants for display.
    * @param {FacilityOccupants} occupants  The occupants.
    * @returns {Promise<object[]>}
@@ -829,9 +878,9 @@ export default class ActorSheet5eCharacter2 extends ActorSheetV2Mixin(ActorSheet
    */
   _prepareFacilityOccupants(occupants) {
     const { max, value } = occupants;
-    return Promise.all(Array.fromRange(max).map(async i => {
-      const uuid = value[i];
-      if ( uuid ) return { actor: await fromUuid(uuid) };
+    return Promise.all(Array.fromRange(max).map(async index => {
+      const uuid = value[index];
+      if ( uuid ) return { index, actor: await fromUuid(uuid) };
       return { empty: true };
     }));
   }

--- a/module/applications/shared/movement-senses-config.mjs
+++ b/module/applications/shared/movement-senses-config.mjs
@@ -93,6 +93,16 @@ export default class MovementSensesConfig extends BaseConfigSheet {
       );
     }
 
+    context.currentOptions = Object.entries(CONFIG.DND5E.movementTypes).map(([value, label]) => ({value, label}));
+    const highestMovement = Object.keys(CONFIG.DND5E.movementTypes).reduce((obj, key) => {
+      const value = context.data[key];
+      if ( value > obj.value ) Object.assign(obj, { value, key });
+      return obj;
+    }, { value: 0, key: "walk" });
+    context.currentOptions.unshift(
+      { value: "", label: game.i18n.format("DND5E.DefaultSpecific", { default: highestMovement.key })}
+    );
+
     return context;
   }
 

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -122,6 +122,29 @@ export default class Token5e extends (foundry.canvas?.placeables?.Token ?? Token
   /* -------------------------------------------- */
 
   /** @override */
+  _getDragWaypointProperties() {
+    return {
+      action: this.document.getMovementAction()
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _getKeyboardMovementAction() {
+    return this.document.getMovementAction();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _getHUDMovementAction() {
+    return this.document.getMovementAction();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   getRingColors() {
     return this.document.getRingColors();
   }

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -54,38 +54,49 @@ export default class Token5e extends (foundry.canvas?.placeables?.Token ?? Token
     const c = CONFIG.DND5E.tokenHPColors;
 
     // Determine the container size (logic borrowed from core)
-    const w = this.w;
-    let h = Math.max((canvas.dimensions.size / 12), 8);
-    if ( this.document.height >= 2 ) h *= 1.6;
-    const bs = Math.clamp(h / 8, 1, 2);
-    const bs1 = bs+1;
+    let s = 1;
+    const bw = this.w;
+    let bh;
+    let bs;
+    let bs1;
+    if ( game.release.generation > 12 ) {
+      s = canvas.dimensions.uiScale;
+      bh = 8 * (this.document.height >= 2 ? 1.5 : 1) * s;
+      bs = s;
+      bs1 = bs + s;
+    } else {
+      bh = Math.max(canvas.dimensions.size / 12, 8);
+      if ( this.document.height >= 2 ) bh *= 1.6;
+      bs = Math.clamp(bh / 8, 1, 2);
+      bs1 = bs + 1;
+    }
 
     // Overall bar container
     bar.clear();
-    bar.beginFill(blk, 0.5).lineStyle(bs, blk, 1.0).drawRoundedRect(0, 0, w, h, 3);
+    bar.beginFill(blk, 0.5).lineStyle(bs, blk, 1.0).drawRoundedRect(0, 0, bw, bh, 3 * s);
 
     // Temporary maximum HP
     if (tempmax > 0) {
       const pct = max / effectiveMax;
-      bar.beginFill(c.tempmax, 1.0).lineStyle(1, blk, 1.0).drawRoundedRect(pct*w, 0, (1-pct)*w, h, 2);
+      bar.beginFill(c.tempmax, 1.0).lineStyle(1, blk, 1.0).drawRoundedRect(pct * bw, 0, (1 - pct) * bw, bh, 2 * s);
     }
 
     // Maximum HP penalty
     else if (tempmax < 0) {
       const pct = (max + tempmax) / max;
-      bar.beginFill(c.negmax, 1.0).lineStyle(1, blk, 1.0).drawRoundedRect(pct*w, 0, (1-pct)*w, h, 2);
+      bar.beginFill(c.negmax, 1.0).lineStyle(1, blk, 1.0).drawRoundedRect(pct * bw, 0, (1 - pct) * bw, bh, 2 * s);
     }
 
     // Health bar
-    bar.beginFill(hpColor, 1.0).lineStyle(bs, blk, 1.0).drawRoundedRect(0, 0, colorPct*w, h, 2);
+    bar.beginFill(hpColor, 1.0).lineStyle(bs, blk, 1.0).drawRoundedRect(0, 0, colorPct * bw, bh, 2 * s);
 
     // Temporary hit points
     if ( temp > 0 ) {
-      bar.beginFill(c.temp, 1.0).lineStyle(0).drawRoundedRect(bs1, bs1, (tempPct*w)-(2*bs1), h-(2*bs1), 1);
+      bar.beginFill(c.temp, 1.0).lineStyle(0).drawRoundedRect(bs1, bs1, (tempPct * bw) - (2 * bs1), bh - (2 * bs1), s);
     }
 
     // Set position
-    let posY = (number === 0) ? (this.h - h) : 0;
+    let posY = (number === 0) ? (this.h - bh) : 0;
     bar.position.set(0, posY);
   }
 

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -3,15 +3,19 @@ import { ItemDataModel } from "../abstract.mjs";
 import BaseActivityData from "../activity/base-activity.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import UsesField from "../shared/uses-field.mjs";
+import ItemTypeField from "./fields/item-type-field.mjs";
 import ActivitiesTemplate from "./templates/activities.mjs";
 import EquippableItemTemplate from "./templates/equippable-item.mjs";
 import IdentifiableTemplate from "./templates/identifiable.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ItemTypeTemplate from "./templates/item-type.mjs";
 import PhysicalItemTemplate from "./templates/physical-item.mjs";
-import ItemTypeField from "./fields/item-type-field.mjs";
 
 const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+
+/**
+ * @import { ItemTypeData } from "./fields/item-type-field.mjs";
+ */
 
 /**
  * Data definition for Consumable items.
@@ -23,10 +27,11 @@ const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundr
  * @mixes EquippableItemTemplate
  *
  * @property {object} damage
- * @property {DamageData} damage.base    Damage caused by this ammunition.
- * @property {string} damage.replace     Should ammunition damage replace the base weapon's damage?
- * @property {number} magicalBonus       Magical bonus added to attack & damage rolls by ammunition.
- * @property {Set<string>} properties    Ammunition properties.
+ * @property {DamageData} damage.base               Damage caused by this ammunition.
+ * @property {string} damage.replace                Should ammunition damage replace the base weapon's damage?
+ * @property {number} magicalBonus                  Magical bonus added to attack & damage rolls by ammunition.
+ * @property {Set<string>} properties               Ammunition properties.
+ * @property {Omit<ItemTypeData, "baseItem">} type  Ammunition type and subtype.
  * @property {object} uses
  * @property {boolean} uses.autoDestroy  Should this item be destroyed when it runs out of uses.
  */
@@ -47,13 +52,13 @@ export default class ConsumableData extends ItemDataModel.mixin(
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({ baseItem: false }, { label: "DND5E.ItemConsumableType" }),
       damage: new SchemaField({
         base: new DamageField(),
         replace: new BooleanField()
       }),
       magicalBonus: new NumberField({ min: 0, integer: true }),
       properties: new SetField(new StringField()),
+      type: new ItemTypeField({ baseItem: false }, { label: "DND5E.ItemConsumableType" }),
       uses: new UsesField({
         autoDestroy: new BooleanField({ required: true })
       })

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -11,6 +11,10 @@ import ItemTypeField from "./fields/item-type-field.mjs";
 const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
+ * @import { ItemTypeData } from "./fields/item-type-field.mjs";
+ */
+
+/**
  * Data definition for Equipment items.
  * @mixes ActivitiesTemplate
  * @mixes ItemDescriptionTemplate
@@ -20,12 +24,14 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
  * @mixes EquippableItemTemplate
  * @mixes MountableTemplate
  *
- * @property {object} armor               Armor details and equipment type information.
- * @property {number} armor.value         Base armor class or shield bonus.
- * @property {number} armor.dex           Maximum dex bonus added to armor class.
- * @property {number} armor.magicalBonus  Bonus added to AC from the armor's magical nature.
- * @property {number} strength            Minimum strength required to use a piece of armor.
- * @property {number} proficient          Does the owner have proficiency in this piece of equipment?
+ * @property {object} armor                        Armor details and equipment type information.
+ * @property {number} armor.value                  Base armor class or shield bonus.
+ * @property {number} armor.dex                    Maximum dex bonus added to armor class.
+ * @property {number} armor.magicalBonus           Bonus added to AC from the armor's magical nature.
+ * @property {number} proficient                   Does the owner have proficiency in this piece of equipment?
+ * @property {Set<string>} properties              Equipment properties.
+ * @property {number} strength                     Minimum strength required to use a piece of armor.
+ * @property {Omit<ItemTypeData, "subtype">} type  Equipment type & base item.
  */
 export default class EquipmentData extends ItemDataModel.mixin(
   ActivitiesTemplate, ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate,
@@ -44,17 +50,17 @@ export default class EquipmentData extends ItemDataModel.mixin(
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({ subtype: false }, { label: "DND5E.ItemEquipmentType" }),
       armor: new SchemaField({
         value: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.ArmorClass" }),
         magicalBonus: new NumberField({ min: 0, integer: true, label: "DND5E.MagicalBonus" }),
         dex: new NumberField({ required: true, integer: true, label: "DND5E.ItemEquipmentDexMod" })
       }),
-      properties: new SetField(new StringField(), { label: "DND5E.ItemEquipmentProperties" }),
-      strength: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.ItemRequiredStr" }),
       proficient: new NumberField({
         required: true, min: 0, max: 1, integer: true, initial: null, label: "DND5E.ProficiencyLevel"
-      })
+      }),
+      properties: new SetField(new StringField(), { label: "DND5E.ItemEquipmentProperties" }),
+      strength: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.ItemRequiredStr" }),
+      type: new ItemTypeField({ subtype: false }, { label: "DND5E.ItemEquipmentType" })
     });
   }
 

--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -8,6 +8,10 @@ import OrderActivity from "../../documents/activity/order.mjs";
 const { ArrayField, BooleanField, DocumentUUIDField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
+ * @import { ItemTypeData } from "./fields/item-type-field.mjs";
+ */
+
+/**
  * @typedef FacilityOccupants
  * @property {string[]} value  A list of Actor UUIDs assigned to the facility.
  * @property {number} max      The facility's maximum occupant capacity.
@@ -19,37 +23,38 @@ const { ArrayField, BooleanField, DocumentUUIDField, NumberField, SchemaField, S
  * @mixes ItemDescriptionTemplate
  *
  * @property {object} building
- * @property {boolean} building.built             Whether the facility has been fully built. Only applicable to basic
- *                                                facilities.
- * @property {string} building.size               The target size for the facility to be built at.
+ * @property {boolean} building.built                Whether the facility has been fully built. Only applicable to basic
+ *                                                   facilities.
+ * @property {string} building.size                  The target size for the facility to be built at.
  * @property {object} craft
- * @property {string} craft.item                  The Item the facility is currently crafting.
- * @property {number} craft.quantity              The number of Items being crafted.
- * @property {FacilityOccupants} defenders        The facility's configured defenders.
- * @property {boolean} disabled                   Whether the facility is currently disabled.
- * @property {boolean} enlargeable                Whether the facility is capable of being enlarged.
- * @property {boolean} free                       Whether the facility counts towards the character's maximum special
- *                                                facility cap.
- * @property {FacilityOccupants} hirelings        The facility's configured hirelings.
- * @property {number} level                       The minimum level required to build this facility.
- * @property {string} order                       The order type associated with this facility.
+ * @property {string} craft.item                     The Item the facility is currently crafting.
+ * @property {number} craft.quantity                 The number of Items being crafted.
+ * @property {FacilityOccupants} defenders           The facility's configured defenders.
+ * @property {boolean} disabled                      Whether the facility is currently disabled.
+ * @property {boolean} enlargeable                   Whether the facility is capable of being enlarged.
+ * @property {boolean} free                          Whether the facility counts towards the character's maximum special
+ *                                                   facility cap.
+ * @property {FacilityOccupants} hirelings           The facility's configured hirelings.
+ * @property {number} level                          The minimum level required to build this facility.
+ * @property {string} order                          The order type associated with this facility.
  * @property {object} progress
- * @property {number} progress.value              The number of days' progress made towards completing the order.
- * @property {number} progress.max                The number of days required to complete the order.
- * @property {string} progress.order              The order that is currently being executed.
- * @property {string} size                        The size category of the facility.
+ * @property {number} progress.value                 The number of days' progress made towards completing the order.
+ * @property {number} progress.max                   The number of days required to complete the order.
+ * @property {string} progress.order                 The order that is currently being executed.
+ * @property {string} size                           The size category of the facility.
  * @property {object} trade
- * @property {FacilityOccupants} trade.creatures  The trade facility's stocked creatures.
+ * @property {FacilityOccupants} trade.creatures     The trade facility's stocked creatures.
  * @property {object} trade.pending
- * @property {string[]} trade.pending.creatures   Creatures being bought or sold.
+ * @property {string[]} trade.pending.creatures      Creatures being bought or sold.
  * @property {"buy"|"sell"} trade.pending.operation  The type of trade operation that was executed this turn.
- * @property {boolean} trade.pending.stocked      Whether the inventory will be fully stocked when the order completes.
- * @property {number} trade.pending.value         The base value transacted during the trade operation this turn.
- * @property {number} trade.profit                The trade facility's profit factor as a percentage.
+ * @property {boolean} trade.pending.stocked         The inventory will be fully stocked when the order completes.
+ * @property {number} trade.pending.value            The base value transacted during the trade operation this turn.
+ * @property {number} trade.profit                   The trade facility's profit factor as a percentage.
  * @property {object} trade.stock
- * @property {boolean} trade.stock.stocked        Whether the facility is fully stocked.
- * @property {number} trade.stock.value           The value of the currently stocked goods.
- * @property {number} trade.stock.max             The maximum value of goods this facility can stock.
+ * @property {boolean} trade.stock.stocked           Whether the facility is fully stocked.
+ * @property {number} trade.stock.value              The value of the currently stocked goods.
+ * @property {number} trade.stock.max                The maximum value of goods this facility can stock.
+ * @property {Omit<ItemTypeData, "baseItem">} type   Facility type & subtype.
  */
 export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate, ItemDescriptionTemplate) {
   /* -------------------------------------------- */

--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -213,6 +213,11 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
 
     if ( this.disabled ) this.progress.order = "repair";
 
+    // Trade
+    if ( Number.isFinite(this.trade.creatures.max) ) {
+      this.trade.creatures.max = this._source.trade.creatures.max - this.trade.pending.creatures.length;
+    }
+
     // Labels
     const labels = this.parent.labels ??= {};
     if ( this.order ) labels.order = game.i18n.localize(`DND5E.FACILITY.Orders.${this.order}.present`);

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -9,6 +9,10 @@ import ItemTypeField from "./fields/item-type-field.mjs";
 const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
+ * @import { ItemTypeData } from "./fields/item-type-field.mjs";
+ */
+
+/**
  * Data definition for Feature items.
  * @mixes ActivitiesTemplate
  * @mixes ItemDescriptionTemplate
@@ -25,6 +29,7 @@ const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringFiel
  * @property {boolean} prerequisites.repeatable     Can this item be selected more than once?
  * @property {Set<string>} properties               General properties of a feature item.
  * @property {string} requirements                  Actor details required to use this feature.
+ * @property {Omit<ItemTypeData, "baseItem">} type  Feature type and subtype.
  */
 export default class FeatData extends ItemDataModel.mixin(
   ActivitiesTemplate, ItemDescriptionTemplate, ItemTypeTemplate

--- a/module/data/item/fields/item-type-field.mjs
+++ b/module/data/item/fields/item-type-field.mjs
@@ -1,3 +1,12 @@
+const { SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * @typedef ItemTypeData
+ * @param {string} value     Primary type for this item.
+ * @param {string} subtype   Secondary type within the primary type.
+ * @param {string} baseItem  Base item identifier.
+ */
+
 /**
  * A field for storing Item type data.
  *
@@ -7,16 +16,16 @@
  * @param {string|boolean} [options.baseItem]     An initial value for the Item's baseItem, or false to exclude it.
  * @param {DataFieldOptions} [schemaOptions={}]   Options forwarded to the SchemaField.
  */
-export default class ItemTypeField extends foundry.data.fields.SchemaField {
+export default class ItemTypeField extends SchemaField {
   constructor(options={}, schemaOptions={}) {
     const fields = {
-      value: new foundry.data.fields.StringField({
+      value: new StringField({
         required: true, blank: true, initial: options.value ?? "", label: "DND5E.Type"
       }),
-      subtype: new foundry.data.fields.StringField({
+      subtype: new StringField({
         required: true, blank: true, initial: options.subtype ?? "", label: "DND5E.Subtype"
       }),
-      baseItem: new foundry.data.fields.StringField({
+      baseItem: new StringField({
         required: true, blank: true, initial: options.baseItem ?? "", label: "DND5E.BaseItem"
       })
     };

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -8,11 +8,18 @@ import ItemTypeField from "./fields/item-type-field.mjs";
 const { SetField, StringField } = foundry.data.fields;
 
 /**
+ * @import { ItemTypeData } from "./fields/item-type-field.mjs";
+ */
+
+/**
  * Data definition for Loot items.
  * @mixes ItemDescriptionTemplate
  * @mixes ItemTypeTemplate
  * @mixes IdentifiableTemplate
  * @mixes PhysicalItemTemplate
+ *
+ * @property {Set<string>} properties               General properties of a loot item.
+ * @property {Omit<ItemTypeData, "baseItem">} type  Loot type and subtype.
  */
 export default class LootData extends ItemDataModel.mixin(
   ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate, PhysicalItemTemplate

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -11,6 +11,10 @@ import PhysicalItemTemplate from "./templates/physical-item.mjs";
 const { NumberField, SetField, StringField } = foundry.data.fields;
 
 /**
+ * @import { ItemTypeData } from "./fields/item-type-field.mjs";
+ */
+
+/**
  * Data definition for Tool items.
  * @mixes ActivitiesTemplate
  * @mixes ItemDescriptionTemplate
@@ -19,10 +23,12 @@ const { NumberField, SetField, StringField } = foundry.data.fields;
  * @mixes PhysicalItemTemplate
  * @mixes EquippableItemTemplate
  *
- * @property {string} ability     Default ability when this tool is being used.
- * @property {string} chatFlavor  Additional text added to chat when this tool is used.
- * @property {number} proficient  Level of proficiency in this tool as defined in `DND5E.proficiencyLevels`.
- * @property {string} bonus       Bonus formula added to tool rolls.
+ * @property {string} ability                      Default ability when this tool is being used.
+ * @property {string} bonus                        Bonus formula added to tool rolls.
+ * @property {string} chatFlavor                   Additional text added to chat when this tool is used.
+ * @property {number} proficient                   Level of proficiency as defined in `DND5E.proficiencyLevels`.
+ * @property {Set<string>} properties              Tool properties.
+ * @property {Omit<ItemTypeData, "subtype">} type  Tool type and base item.
  */
 export default class ToolData extends ItemDataModel.mixin(
   ActivitiesTemplate, ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate,

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -14,6 +14,10 @@ import MountableTemplate from "./templates/mountable.mjs";
 const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
+ * @import { ItemTypeData } from "./fields/item-type-field.mjs";
+ */
+
+/**
  * Data definition for Weapon items.
  * @mixes ActivitiesTemplate
  * @mixes ItemDescriptionTemplate
@@ -24,21 +28,22 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
  * @mixes MountableTemplate
  *
  * @property {object} ammunition
- * @property {string} ammunition.type       Type of ammunition fired by this weapon.
+ * @property {string} ammunition.type              Type of ammunition fired by this weapon.
  * @property {object} armor
- * @property {number} armor.value           Siege or vehicle weapon's armor class.
+ * @property {number} armor.value                  Siege or vehicle weapon's armor class.
  * @property {object} damage
- * @property {DamageData} damage.base       Weapon's base damage.
- * @property {DamageData} damage.versatile  Weapon's versatile damage.
- * @property {number} magicalBonus          Magical bonus added to attack & damage rolls.
- * @property {string} mastery               Mastery Property usable with this weapon.
- * @property {Set<string>} properties       Weapon's properties.
- * @property {number} proficient            Does the weapon's owner have proficiency?
+ * @property {DamageData} damage.base              Weapon's base damage.
+ * @property {DamageData} damage.versatile         Weapon's versatile damage.
+ * @property {number} magicalBonus                 Magical bonus added to attack & damage rolls.
+ * @property {string} mastery                      Mastery Property usable with this weapon.
+ * @property {Set<string>} properties              Weapon's properties.
+ * @property {number} proficient                   Does the weapon's owner have proficiency?
  * @property {object} range
- * @property {number} range.value           Short range of the weapon.
- * @property {number} range.long            Long range of the weapon.
- * @property {number|null} range.reach      Reach of the weapon.
- * @property {string} range.units           Units used to measure the weapon's range and reach.
+ * @property {number} range.value                  Short range of the weapon.
+ * @property {number} range.long                   Long range of the weapon.
+ * @property {number|null} range.reach             Reach of the weapon.
+ * @property {string} range.units                  Units used to measure the weapon's range and reach.
+ * @property {Omit<ItemTypeData, "subtype">} type  Weapon type and base item.
  */
 export default class WeaponData extends ItemDataModel.mixin(
   ActivitiesTemplate, ItemDescriptionTemplate, IdentifiableTemplate, ItemTypeTemplate,
@@ -57,7 +62,6 @@ export default class WeaponData extends ItemDataModel.mixin(
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      type: new ItemTypeField({value: "simpleM", subtype: false}, {label: "DND5E.ItemWeaponType"}),
       ammunition: new SchemaField({
         type: new StringField()
       }),
@@ -79,7 +83,8 @@ export default class WeaponData extends ItemDataModel.mixin(
         long: new NumberField({ min: 0 }),
         reach: new NumberField({ min: 0 }),
         units: new StringField()
-      })
+      }),
+      type: new ItemTypeField({value: "simpleM", subtype: false}, {label: "DND5E.ItemWeaponType"})
     });
   }
 

--- a/module/data/shared/movement-field.mjs
+++ b/module/data/shared/movement-field.mjs
@@ -2,13 +2,14 @@ const { BooleanField, NumberField, StringField } = foundry.data.fields;
 
 /**
  * @typedef {object} MovementData
- * @property {number} burrow  Actor burrowing speed.
- * @property {number} climb   Actor climbing speed.
- * @property {number} fly     Actor flying speed.
- * @property {number} swim    Actor swimming speed.
- * @property {number} walk    Actor walking speed.
- * @property {string} units   Movement used to measure the various speeds.
- * @property {boolean} hover  This flying creature able to hover in place.
+ * @property {number} burrow   Actor burrowing speed.
+ * @property {number} climb    Actor climbing speed.
+ * @property {number} fly      Actor flying speed.
+ * @property {number} swim     Actor swimming speed.
+ * @property {number} walk     Actor walking speed.
+ * @property {string} current  Current speed to be used/shown.
+ * @property {string} units    Movement used to measure the various speeds.
+ * @property {boolean} hover   This flying creature able to hover in place.
  */
 
 /**
@@ -23,6 +24,9 @@ export default class MovementField extends foundry.data.fields.SchemaField {
       fly: new NumberField({ ...numberConfig, label: "DND5E.MovementFly" }),
       swim: new NumberField({ ...numberConfig, label: "DND5E.MovementSwim" }),
       walk: new NumberField({ ...numberConfig, label: "DND5E.MovementWalk" }),
+      current: new StringField({
+        required: true, nullable: false, blank: true, initial: "", label: "DND5E.MovementCurrent"
+      }),
       units: new StringField({
         required: true, nullable: true, blank: false, initial: initialUnits, label: "DND5E.MovementUnits"
       }),

--- a/module/documents/actor/bastion.mjs
+++ b/module/documents/actor/bastion.mjs
@@ -284,11 +284,13 @@ export default class Bastion {
       if ( (trade.pending.value === null) && trade.pending.stocked ) updates["system.trade.stock.stocked"] = true;
 
       // Bought goods
-      else if ( trade.pending.value !== null && !trade.pending.creatures.length ) {
-        updates["system.trade.stock.value"] = Math.min(trade.stock.value + trade.pending.value, trade.stock.max);
+      else if ( trade.pending.value !== null ) {
+        if ( trade.pending.creatures.length ) {
+          updates["system.trade.creatures.value"] = trade.creatures.value.concat(trade.pending.creatures);
+        }
+        else updates["system.trade.stock.value"] = Math.min(trade.stock.value + trade.pending.value, trade.stock.max);
       }
     } else if ( trade.pending.value !== null ) {
-      // See OrderActivity#_finalizeTrade for creatures TODO
       // Sold goods
       let sold = trade.pending.value;
       if ( !trade.pending.creatures.length ) {
@@ -546,8 +548,9 @@ export default class Bastion {
     }
 
     if ( !turnButton ) {
-      document.getElementById("controls")?.insertAdjacentHTML("afterend", `
-        <button type="button" id="bastion-turn" data-action="bastionTurn" class="dnd5e2">
+      const v12 = game.release.generation < 13 ? "v12" : "faded-ui";
+      document.querySelector("#controls, #scene-controls")?.insertAdjacentHTML("afterend", `
+        <button type="button" id="bastion-turn" data-action="bastionTurn" class="dnd5e2 ${v12}">
           <i class="fas fa-chess-rook"></i>
           <span>${game.i18n.localize("DND5E.Bastion.Action.BastionTurn")}</span>
         </button>

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -309,6 +309,7 @@ export default class ChatMessage5e extends ChatMessage {
     const metadata = html.querySelector(".message-metadata");
     const deleteButton = metadata.querySelector(".message-delete");
     if ( !game.user.isGM ) deleteButton?.remove();
+    else deleteButton.querySelector("i").classList.add("fa-fw");
     const anchor = document.createElement("a");
     anchor.setAttribute("aria-label", game.i18n.localize("DND5E.AdditionalControls"));
     anchor.classList.add("chat-control");

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -59,6 +59,16 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
   /* -------------------------------------------- */
 
   /**
+   * Get the current Movement Action
+   * @returns {string}
+   */
+  getMovementAction() {
+    return this.actor?.system.attributes.movement.current ?? "walk";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Get an Array of attribute choices which are suitable for being consumed by an item usage.
    * @param {object} data  The actor data.
    * @returns {string[]}

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -63,7 +63,15 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
    * @returns {string}
    */
   getMovementAction() {
-    return this.actor?.system.attributes.movement.current ?? "walk";
+    const movement = this.actor?.system.attributes.movement;
+    if ( !movement ) return "walk";
+    if ( movement.current?.length ) return movement.current;
+    const highestMovement = Object.keys(CONFIG.DND5E.movementTypes).reduce((obj, key) => {
+      const value = movement[key];
+      if ( value > obj.value ) Object.assign(obj, { value, key });
+      return obj;
+    }, { value: 0, key: "walk" });
+    return highestMovement.key;
   }
 
   /* -------------------------------------------- */

--- a/system.json
+++ b/system.json
@@ -2,14 +2,14 @@
   "id": "dnd5e",
   "title": "Dungeons & Dragons Fifth Edition",
   "description": "A system for playing the fifth edition of the world's most popular role-playing game in the Foundry Virtual Tabletop environment.",
-  "version": "4.3.6",
+  "version": "4.4.0",
   "compatibility": {
     "minimum": "12.331",
     "verified": "13.336"
   },
   "url": "https://github.com/foundryvtt/dnd5e/",
   "manifest": "https://raw.githubusercontent.com/foundryvtt/dnd5e/master/system.json",
-  "download": "https://github.com/foundryvtt/dnd5e/releases/download/release-4.3.6/dnd5e-release-4.3.6.zip",
+  "download": "https://github.com/foundryvtt/dnd5e/releases/download/release-4.4.0/dnd5e-release-4.4.0.zip",
   "authors": [
     {
       "name": "Atropos",

--- a/templates/actors/tabs/character-bastion.hbs
+++ b/templates/actors/tabs/character-bastion.hbs
@@ -129,21 +129,21 @@
     {{#if hirelings.length}}
     <div class="slots facility-occupants hirelings" data-prop="system.hirelings">
         {{#each hirelings}}
-            {{> ".occupant" type="hireling" index=@key }}
+            {{> ".occupant" type="hireling" }}
         {{/each}}
     </div>
     {{/if}}
     {{#if defenders.length}}
     <div class="slots facility-occupants defenders" data-prop="system.defenders">
         {{#each defenders}}
-            {{> ".occupant" type="defender" index=@key }}
+            {{> ".occupant" type="defender" }}
         {{/each}}
     </div>
     {{/if}}
     {{#if creatures.length}}
     <div class="slots facility-occupants creatures" data-prop="system.trade.creatures">
         {{#each creatures}}
-            {{> ".occupant" type="creature" index=@key }}
+            {{> ".occupant" type="creature" }}
         {{/each}}
     </div>
     {{/if}}
@@ -152,13 +152,18 @@
 
 {{#*inline ".occupant"}}
 <div {{#if actor}}data-actor-uuid="{{ actor.uuid }}" data-action="viewOccupant"{{/if}}
-      class="slot occupant-slot {{ type }} {{#if empty}}empty{{/if}}" data-index="{{ index }}">
+      class="slot occupant-slot {{ type }} {{#if empty}}empty{{/if}} {{#if pending}}pending{{/if}}"
+      data-index="{{ index }}" {{#if pending}}data-tooltip="{{ localize "DND5E.Bastion.Trade.Pending" }}"{{/if}}>
     {{#if actor}}
+    {{#unless pending}}
     <img src="{{ actor.img }}" alt="{{ actor.name }}">
+    {{/unless}}
+    {{/if}}
     {{#if @root.editable}}
+    {{#if (or actor pending)}}
     <a class="deletion-control" data-action="deleteOccupant"
        aria-label="{{ localize "DND5E.FACILITY.Action.DeleteOccupant" }}">
-        <i class="fas fa-circle-xmark"></i>
+        <i class="fas fa-circle-xmark" inert></i>
     </a>
     {{/if}}
     {{/if}}

--- a/templates/shared/config/movement-senses-config.hbs
+++ b/templates/shared/config/movement-senses-config.hbs
@@ -2,6 +2,7 @@
     <fieldset class="card">
         {{#each types}}{{ formField field value=value placeholder=placeholder localize=true }}{{/each}}
         {{#if (or fields.units extras.length)}}<hr>{{/if}}
+        {{#if fields.current}}{{ formField fields.current value=data.current options=currentOptions localize=true }}{{/if}}
         {{#if fields.units}}{{ formField fields.units value=data.units options=unitsOptions localize=true }}{{/if}}
         {{#each extras}}{{ formField field value=value input=input localize=true }}{{/each}}
     </fieldset>


### PR DESCRIPTION
While this is technically functional & mergeable in its current state, more work needs to be done on it.
As a byproduct of the changes necessary, this closes #4379.
Current changes:
- Add all `CONFIG.DND5E.movementTypes` to `CONFIG.Token.movement.actions` (in V13) to allow configuration of cost multipliers for each in the new region behavior type.
- Add `current` to `MovementField`, representing the "current" movement type/action, and render as a dropdown in the movement config
- The above field is respected on the Actor sheet, if set, showing the selected movement type & speed rather than just the highest (currently, "default" behavior is the same as it was before)
- Add the relevant overrides to `Token5e` so that any movement is considered to be of the "current" type (though it currently defaults to "walk" rather than whatever the highest speed is)

Potential further changes:
- Change `CONFIG.DND5E.movementTypes` to a nested object with `label` and `icon`, to match the `CONFIG.Token.movement.actions` format
- Align default behaviors so that what's shown on the sheet always represents the "current" movement type (not sure what the best strategy is - I think maybe just always defaulting to "walk", if indeed the displayed movement speed should be coupled to the "current" movement action for v13's sake)
- Add a better way of switching "current" movement action ad-hoc, probably via the Token HUD somehow
- Consider modifying drag ruler behavior to show maximum movable distance with "current" movement action during combat, perhaps both with text and via some sort of (maybe-optional) color highlighting to represent "can do this", "could do this if dashing", and "can't do this" (this is maybe better left as a 5.0 issue)

Potential snags:
- #4976 changes `MovementField`, so would have to account for that once merged
- The "Default (whatever)" option in the movement config is based on the speeds pre-condition-changes & pre-active-effects. So, for instance, a walk speed of 30 and swim speed of 40 would result in "Default (swim)", but if the actor was then made Prone, swim speed becomes 0, and therefore walk speed would be shown on the sheet. Similarly, an AE that gives a fly speed of 80 wouldn't be registered in the movement config, and therefore the "Default (swim)" would still show up, but in actuality Fly would be displayed on the sheet. Not sure the ideal hangling for this, as I mentioned in the second "Potential further changes" bullet