### PR TITLE
[#5340] Add `PrimarySheetMixin`, move section expansion

### DIFF
--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -21,8 +21,7 @@ export default class ActivitySheet extends PseudoDocumentSheet {
       deleteDamagePart: ActivitySheet.#deleteDamagePart,
       deleteEffect: ActivitySheet.#deleteEffect,
       deleteRecovery: ActivitySheet.#deleteRecovery,
-      dissociateEffect: ActivitySheet.#dissociateEffect,
-      toggleCollapsed: ActivitySheet.#toggleCollapsed
+      dissociateEffect: ActivitySheet.#dissociateEffect
     },
     position: {
       width: 500,
@@ -85,18 +84,6 @@ export default class ActivitySheet extends PseudoDocumentSheet {
    */
   get activity() {
     return this.document;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Expanded states for additional settings sections.
-   * @type {Map<string, boolean>}
-   */
-  #expandedSections = new Map();
-
-  get expandedSections() {
-    return this.#expandedSections;
   }
 
   /* -------------------------------------------- */
@@ -602,23 +589,6 @@ export default class ActivitySheet extends PseudoDocumentSheet {
     if ( !this.activity.effects || !effectId ) return;
     const effects = this.activity.toObject().effects.filter(e => e._id !== effectId);
     this.activity.update({ effects });
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Handle toggling the collapsed state of an additional settings section.
-   * @this {ActivitySheet}
-   * @param {Event} event         Triggering click event.
-   * @param {HTMLElement} target  Button that was clicked.
-   */
-  static #toggleCollapsed(event, target) {
-    if ( event.target.closest(".collapsible-content") ) return;
-    target.classList.toggle("collapsed");
-    this.#expandedSections.set(
-      target.closest("[data-expand-id]")?.dataset.expandId,
-      !target.classList.contains("collapsed")
-    );
   }
 
   /* -------------------------------------------- */

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -394,19 +394,6 @@ export default class ActivitySheet extends PseudoDocumentSheet {
   }
 
   /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  _replaceHTML(result, content, options) {
-    for ( const part of Object.values(result) ) {
-      for ( const element of part.querySelectorAll("[data-expand-id]") ) {
-        element.querySelector(".collapsible")?.classList
-          .toggle("collapsed", !this.#expandedSections.get(element.dataset.expandId));
-      }
-    }
-    super._replaceHTML(result, content, options);
-  }
-
-  /* -------------------------------------------- */
   /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -34,6 +34,7 @@ import WeaponsConfig from "./config/weapons-config.mjs";
 
 /**
  * @import { DropEffectValue } from "../../drag-drop.mjs"
+ * @import { FilterState5e } from "../components/item-list-controls.mjs";
  */
 
 /**
@@ -41,12 +42,6 @@ import WeaponsConfig from "./config/weapons-config.mjs";
  * @abstract
  */
 export default class ActorSheet5e extends ActorSheetMixin(foundry.appv1?.sheets?.ActorSheet ?? ActorSheet) {
-
-  /**
-   * @typedef {object} FilterState5e
-   * @property {string} name             Filtering by name.
-   * @property {Set<string>} properties  Filtering by some property.
-   */
 
   /**
    * Track the set of item filters which are applied

--- a/module/applications/api/_module.mjs
+++ b/module/applications/api/_module.mjs
@@ -2,4 +2,5 @@ export { default as Application5e } from "./application.mjs";
 export { default as ApplicationV2Mixin } from "./application-v2-mixin.mjs";
 export { default as Dialog5e } from "./dialog.mjs";
 export { default as DocumentSheet5e } from "./document-sheet.mjs";
+export { default as PrimarySheetMixin } from "./primary-sheet-mixin.mjs";
 export { default as PseudoDocumentSheet } from "./pseudo-document-sheet.mjs";

--- a/module/applications/api/application-v2-mixin.mjs
+++ b/module/applications/api/application-v2-mixin.mjs
@@ -18,6 +18,9 @@ export default function ApplicationV2Mixin(Base) {
   class BaseApplication5e extends HandlebarsApplicationMixin(Base) {
     /** @override */
     static DEFAULT_OPTIONS = {
+      actions: {
+        toggleCollapsed: BaseApplication5e.#toggleCollapsed
+      },
       classes: ["dnd5e2"],
       window: {
         subtitle: ""
@@ -215,21 +218,13 @@ export default function ApplicationV2Mixin(Base) {
     /*  Event Listeners and Handlers                */
     /* -------------------------------------------- */
 
-    /** @inheritDoc */
-    _onClickAction(event, target) {
-      if ( target.dataset.action === "toggleCollapsed" ) this.#toggleCollapsed(event, target);
-      else super._onClickAction(event, target);
-    }
-
-    /* -------------------------------------------- */
-
     /**
      * Handle toggling the collapsed state of collapsible sections.
      * @this {BaseApplication5e}
      * @param {Event} event         Triggering click event.
      * @param {HTMLElement} target  Button that was clicked.
      */
-    #toggleCollapsed(event, target) {
+    static #toggleCollapsed(event, target) {
       if ( event.target.closest(".collapsible-content") ) return;
       target.classList.toggle("collapsed");
       this.#expandedSections.set(

--- a/module/applications/api/primary-sheet-mixin.mjs
+++ b/module/applications/api/primary-sheet-mixin.mjs
@@ -1,0 +1,440 @@
+import DragDropApplicationMixin from "../mixins/drag-drop-mixin.mjs";
+
+/**
+ * @import { FilterState5e } from "../components/item-list-controls.mjs";
+ */
+
+/**
+ * Adds V2 sheet functionality shared between primary document sheets (Actors & Items).
+ * @param {typeof DocumentSheet5e} Base  The base class being mixed.
+ * @returns {typeof PrimarySheet5e}
+ */
+export default function PrimarySheetMixin(Base) {
+  return class PrimarySheet5e extends DragDropApplicationMixin(Base) {
+    /**
+     * @typedef {object} SheetTabDescriptor5e
+     * @property {string} tab                       The tab key.
+     * @property {string} label                     The tab label's localization key.
+     * @property {string} [icon]                    A font-awesome icon.
+     * @property {string} [svg]                     An SVG icon.
+     * @property {SheetTabCondition5e} [condition]  A predicate to check before rendering the tab.
+     */
+
+    /**
+     * @callback SheetTabCondition5e
+     * @param {Document} doc  The Document instance.
+     * @returns {boolean}     Whether to render the tab.
+     */
+
+    /**
+     * Sheet tabs.
+     * @type {SheetTabDescriptor5e[]}
+     */
+    static TABS = [];
+
+    /**
+     * Available sheet modes.
+     * @enum {number}
+     */
+    static MODES = {
+      PLAY: 1,
+      EDIT: 2
+    };
+
+    /* -------------------------------------------- */
+
+    /**
+     * Dynamically configured part descriptors, backported from V13.
+     * @type {Readonly<Record<string, HandlebarsTemplatePart>>}
+     */
+    #partDescriptors;
+
+    /* -------------------------------------------- */
+    /*  Properties                                  */
+    /* -------------------------------------------- */
+
+    /**
+     * Filters for applied inventory sections.
+     * @type {Record<string, FilterState5e>}
+     */
+    _filters = {};
+
+    /* -------------------------------------------- */
+
+    /**
+     * The mode the sheet is currently in.
+     * @type {PrimarySheet5e.MODES|null}
+     * @protected
+     */
+    _mode = null;
+
+    /* -------------------------------------------- */
+    /*  Rendering                                   */
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    _configureRenderOptions(options) {
+      super._configureRenderOptions(options);
+
+      // Set initial mode
+      let { mode, renderContext } = options;
+      if ( (mode === undefined) && (renderContext === "createItem") ) mode = this.constructor.MODES.EDIT;
+      this._mode = mode ?? this._mode ?? this.constructor.MODES.PLAY;
+
+      // Handle only rendering some parts in V12
+      if ( game.release.generation < 13 ) {
+        this.#partDescriptors ??= Object.freeze(this._configureRenderParts(options));
+        options.parts = options.parts.filter(p => p in this.#partDescriptors) ?? Object.keys(partDescriptors);
+      }
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    _configureRenderParts(options) {
+      const parts = game.release.generation < 13 ? foundry.utils.deepClone(this.constructor.PARTS)
+        : super._configureRenderParts(options);
+      for ( const key of Object.keys(parts) ) {
+        const tab = this.constructor.TABS.find(t => t.tab === key);
+        if ( tab?.condition && !tab.condition(this.document) ) delete parts[key];
+      }
+      return parts;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    async _renderFrame(options) {
+      const html = await super._renderFrame(options);
+      const header = html.querySelector(".window-header");
+
+      if ( !game.user.isGM && this.document.limited ) {
+        html.classList.add("limited");
+        return html;
+      }
+
+      // Add edit <-> play slide toggle.
+      if ( this.isEditable ) {
+        const toggle = document.createElement("slide-toggle");
+        toggle.checked = this._mode === this.constructor.MODES.EDIT;
+        toggle.classList.add("mode-slider");
+        toggle.dataset.tooltip = "DND5E.SheetModeEdit";
+        toggle.setAttribute("aria-label", game.i18n.localize("DND5E.SheetModeEdit"));
+        toggle.addEventListener("change", this._onChangeSheetMode.bind(this));
+        toggle.addEventListener("dblclick", event => event.stopPropagation());
+        header.prepend(toggle);
+      }
+
+      return html;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Render source information in the Document's title bar.
+     * @param {HTMLElement} html  The outer frame HTML.
+     * @protected
+     */
+    _renderSourceFrame(html) {
+      const elements = document.createElement("div");
+      elements.classList.add("header-elements");
+      elements.innerHTML = `
+        <div class="source-book">
+          <button type="button" class="unbutton control-button" data-action="showConfiguration" data-config="source"
+                  data-tooltip="DND5E.SOURCE.Action.Configure"
+                  aria-label="${game.i18n.localize("DND5E.SOURCE.Action.Configure")}">
+            <i class="fas fa-cog" inert></i>
+          </button>
+          <span></span>
+        </div>
+      `;
+      html.querySelector(".window-subtitle")?.after(elements);
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Update the source information when re-rendering the sheet.
+     * @protected
+     */
+    _renderSource() {
+      const elements = this.element.querySelector(".header-elements .source-book");
+      const source = this.document?.system.source;
+      if ( !elements || !source ) return;
+      const editable = this.isEditable && (this._mode === this.constructor.MODES.EDIT);
+      elements.querySelector("button")?.toggleAttribute("hidden", !editable);
+      elements.querySelector("span").innerText = editable
+        ? (source.label || game.i18n.localize("DND5E.SOURCE.FIELDS.source.label"))
+        : source.label;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    async _prepareContext(options) {
+      const context = await super._prepareContext(options);
+      context.editable = this.isEditable && (this._mode === this.constructor.MODES.EDIT);
+      context.tabs = this._getTabs();
+      return context;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    async _preparePartContext(partId, options) {
+      const context = await super._preparePartContext(partId, options);
+      context.tab = context.tabs[partId];
+      return context;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Prepare the tab information for the sheet.
+     * @returns {Record<string, Partial<ApplicationTab>>}
+     * @protected
+     */
+    _getTabs() {
+      return this.constructor.TABS.reduce((tabs, { tab, condition, ...config }) => {
+        if ( !condition || condition(this.document) ) tabs[tab] = {
+          ...config,
+          id: tab,
+          group: "sheet",
+          active: this.tabGroups.sheet === tab,
+          cssClass: this.tabGroups.sheet === tab ? "active" : ""
+        };
+        return tabs;
+      }, {});
+    }
+
+    /* -------------------------------------------- */
+    /*  Life-Cycle Handlers                         */
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    async _onFirstRender(context, options) {
+      await super._onFirstRender(context, options);
+      this.element.classList.add(`tab-${this.tabGroups.sheet}`);
+
+      // Create child button
+      const button = document.createElement("button");
+      button.ariaLabel = game.i18n.localize("CONTROLS.CommonCreate");
+      button.classList.add("create-child", "gold-button", "interface-only");
+      button.dataset.action = "addDocument";
+      button.innerHTML = '<i class="fas fa-plus" inert></i>';
+      this.element.querySelector(".window-content").append(button);
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    async _onRender(context, options) {
+      await super._onRender(context, options);
+
+      // Set toggle state and add status class to frame
+      const toggle = this.element.querySelector(".window-header .mode-slider");
+      if ( toggle ) toggle.checked = this._mode === this.constructor.MODES.EDIT;
+      this.element.classList.toggle("editable", this.isEditable && (this._mode === this.constructor.MODES.EDIT));
+      this.element.classList.toggle("interactable", this.isEditable && (this._mode === this.constructor.MODES.PLAY));
+      this.element.classList.toggle("locked", !this.isEditable);
+
+      // Add event listeners
+      this.element.querySelectorAll("[data-toggle-description]")
+        .forEach(e => e.addEventListener("click", this._onToggleDescription.bind(this)));
+      this.element.querySelectorAll(".item-tooltip").forEach(this._applyItemTooltips.bind(this));
+
+      // Disable fields in play mode
+      if ( this._mode === this.constructor.MODES.PLAY ) this._disableFields();
+    }
+
+    /* -------------------------------------------- */
+    /*  Event Listeners & Handlers                  */
+    /* -------------------------------------------- */
+
+    /**
+     * Handle creating a new embedded child.
+     * @param {Event} event         Triggering click event.
+     * @param {HTMLElement} target  Button that was clicked.
+     * @returns {any}
+     * @protected
+     * @abstract
+     */
+    _addDocument(event, target) {}
+
+    /* -------------------------------------------- */
+
+    /**
+     * Initialize item tooltips on an element.
+     * @param {HTMLElement} element  The tooltipped element.
+     * @protected
+     */
+    _applyItemTooltips(element) {
+      if ( "tooltip" in element.dataset ) return;
+      const target = element.closest("[data-item-id], [data-effect-id], [data-uuid]");
+      let uuid = target.dataset.uuid;
+      if ( !uuid && target.dataset.itemId ) {
+        const item = this.actor?.items.get(target.dataset.itemId);
+        uuid = item?.uuid;
+      } else if ( !uuid && target.dataset.effectId ) {
+        const { effectId, parentId } = target.dataset;
+        const collection = parentId ? this.actor?.items.get(parentId).effects : this.actor?.effects;
+        uuid = collection?.get(effectId)?.uuid;
+      }
+      if ( !uuid ) return;
+      element.dataset.tooltip = `
+        <section class="loading" data-uuid="${uuid}"><i class="fas fa-spinner fa-spin-pulse"></i></section>
+      `;
+      element.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip";
+      element.dataset.tooltipDirection ??= "LEFT";
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    changeTab(tab, group, options) {
+      super.changeTab(tab, group, options);
+      if ( group !== "sheet" ) return;
+      this.element.className = this.element.className.replace(/tab-\w+/g, "");
+      this.element.classList.add(`tab-${tab}`);
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Handle the user toggling the sheet mode.
+     * @param {Event} event  The triggering event.
+     * @protected
+     */
+    async _onChangeSheetMode(event) {
+      const { MODES } = this.constructor;
+      const toggle = event.currentTarget;
+      const label = game.i18n.localize(`DND5E.SheetMode${toggle.checked ? "Play" : "Edit"}`);
+      toggle.dataset.tooltip = label;
+      toggle.setAttribute("aria-label", label);
+      this._mode = toggle.checked ? MODES.EDIT : MODES.PLAY;
+      await this.submit();
+      this.render();
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    _onClickAction(event, target) {
+      if ( target.dataset.action === "addDocument" ) this._addDocument(event, target);
+      else if ( target.dataset.action === "editImage" ) this._editImage(event, target);
+      else super._onClickAction(event, target);
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Handle toggling an Item's description within an inventory list.
+     * @param {PointerEvent} event  The triggering event.
+     * @protected
+     */
+    async _onToggleDescription(event) {
+      const target = event.currentTarget;
+      const icon = target.querySelector(":scope > i");
+      const row = target.closest("[data-uuid]");
+      const summary = row.querySelector(":scope > .item-description > .wrapper");
+      const { uuid } = row.dataset;
+      const item = await fromUuid(uuid);
+      if ( !item ) return;
+
+      const expanded = this._expanded.has(item.id);
+      if ( expanded ) {
+        summary.parentElement.addEventListener("transitionend", () => {
+          if ( row.classList.contains("collapsed") ) summary.querySelector(".item-summary")?.remove();
+        }, { once: true });
+        this._expanded.delete(item.id);
+      } else {
+        const context = await item.getChatData({ secrets: item.isOwner });
+        const content = await renderTemplate("systems/dnd5e/templates/items/parts/item-summary.hbs", context);
+        summary.querySelectorAll(".item-summary").forEach(el => el.remove());
+        summary.insertAdjacentHTML("beforeend", content);
+        await new Promise(resolve => requestAnimationFrame(resolve));
+        this._expanded.add(item.id);
+      }
+
+      row.classList.toggle("collapsed", expanded);
+      icon.classList.toggle("fa-compress", !expanded);
+      icon.classList.toggle("fa-expand", expanded);
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Handle editing an image.
+     * @param {Event} event         Triggering click event.
+     * @param {HTMLElement} target  Button that was clicked.
+     */
+    async _editImage(event, target) {
+      if ( target.nodeName !== "IMG" ) {
+        throw new Error("The editImage action is available only for IMG elements.");
+      }
+      const attr = target.dataset.edit;
+      const current = foundry.utils.getProperty(this.document._source, attr);
+      const defaultArtwork = this.document.constructor.getDefaultArtwork?.(this.document._source) ?? {};
+      const defaultImage = foundry.utils.getProperty(defaultArtwork, attr);
+      const fp = new FilePicker({
+        current,
+        type: "image",
+        redirectToRoot: defaultImage ? [defaultImage] : [],
+        callback: path => {
+          target.src = path;
+          if ( this.options.form.submitOnChange ) {
+            const submit = new Event("submit", {cancelable: true});
+            this.element.dispatchEvent(submit);
+          }
+        },
+        position: {
+          top: this.position.top + 40,
+          left: this.position.left + 10
+        }
+      });
+      await fp.browse();
+    }
+
+    /* -------------------------------------------- */
+    /*  Drag & Drop                                 */
+    /* -------------------------------------------- */
+
+    /** @override */
+    _allowedDropBehaviors(event, data) {
+      if ( !data.uuid ) return new Set(["copy", "link"]);
+      const allowed = new Set(["copy", "move", "link"]);
+      const s = foundry.utils.parseUuid(data.uuid);
+      const t = foundry.utils.parseUuid(this.document.uuid);
+      const sCompendium = s.collection instanceof CompendiumCollection;
+      const tCompendium = t.collection instanceof CompendiumCollection;
+
+      // If either source or target are within a compendium, but not inside the same compendium, move not allowed
+      if ( (sCompendium || tCompendium) && (s.collection !== t.collection) ) allowed.delete("move");
+
+      return allowed;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    _defaultDropBehavior(event, data) {
+      if ( !data.uuid ) return "copy";
+      const d = foundry.utils.parseUuid(data.uuid);
+      const t = foundry.utils.parseUuid(this.document.uuid);
+      const base = d.embedded?.length ? "document" : "primary";
+      return (d.collection === t.collection) && (d[`${base}Id`] === t[`${base}Id`])
+        && (d[`${base}Type`] === t[`${base}Type`]) ? "move" : "copy";
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    async _onDragStart(event) {
+      await super._onDragStart(event);
+      if ( !this.document.isOwner
+        || this.document[game.release.generation < 13 ? "compendium" : "collection"]?.locked ) {
+        event.dataTransfer.effectAllowed = "copyLink";
+      }
+    }
+  };
+}

--- a/module/applications/api/primary-sheet-mixin.mjs
+++ b/module/applications/api/primary-sheet-mixin.mjs
@@ -349,8 +349,7 @@ export default function PrimarySheetMixin(Base) {
     /** @inheritDoc */
     async _onDragStart(event) {
       await super._onDragStart(event);
-      if ( !this.document.isOwner
-        || this.document[game.release.generation < 13 ? "compendium" : "collection"]?.locked ) {
+      if ( !this.document.isOwner || this.document.collection?.locked ) {
         event.dataTransfer.effectAllowed = "copyLink";
       }
     }

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -21,14 +21,7 @@ export default class EffectsElement extends HTMLElement {
     }
 
     for ( const control of this.querySelectorAll("[data-context-menu]") ) {
-      control.addEventListener("click", event => {
-        event.preventDefault();
-        event.stopPropagation();
-        const { clientX, clientY } = event;
-        event.currentTarget.closest("[data-effect-id]").dispatchEvent(new PointerEvent("contextmenu", {
-          view: window, bubbles: true, cancelable: true, clientX, clientY
-        }));
-      });
+      control.addEventListener("click", ContextMenu5e.triggerEvent);
     }
 
     const MenuCls = this.hasAttribute("v2") ? ContextMenu5e : ContextMenu;

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -40,14 +40,7 @@ export default class InventoryElement extends HTMLElement {
     }
 
     for ( const control of this.querySelectorAll("[data-context-menu]") ) {
-      control.addEventListener("click", event => {
-        event.preventDefault();
-        event.stopPropagation();
-        const { clientX, clientY } = event;
-        event.currentTarget.closest("[data-item-id]").dispatchEvent(new PointerEvent("contextmenu", {
-          view: window, bubbles: true, cancelable: true, clientX, clientY
-        }));
-      });
+      control.addEventListener("click", ContextMenu5e.triggerEvent);
     }
 
     this.querySelectorAll("input").forEach(e => e.addEventListener("focus", () => e.select()));

--- a/module/applications/components/item-list-controls.mjs
+++ b/module/applications/components/item-list-controls.mjs
@@ -29,6 +29,12 @@ export default class ItemListControlsElement extends HTMLElement {
   /* -------------------------------------------- */
 
   /**
+   * @typedef {object} FilterState5e
+   * @property {string} name             Filtering by name.
+   * @property {Set<string>} properties  Filtering by some property.
+   */
+
+  /**
    * @typedef {object} SortModeConfiguration5e
    * @property {string} icon
    * @property {string} label

--- a/module/applications/context-menu.mjs
+++ b/module/applications/context-menu.mjs
@@ -33,4 +33,21 @@ export default class ContextMenu5e extends (foundry.applications?.ui?.ContextMen
     const theme = target.closest("[data-theme]")?.dataset.theme ?? "";
     setTheme(html, theme);
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Trigger a context menu event in response to a normal click on a additional options button.
+   * @param {PointerEvent} event
+   */
+  static triggerEvent(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const { clientX, clientY } = event;
+    const selector = "[data-id],[data-effect-id],[data-item-id],[data-message-id]";
+    const target = event.target.closest(selector) ?? event.currentTarget.closest(selector);
+    target?.dispatchEvent(new PointerEvent("contextmenu", {
+      view: window, bubbles: true, cancelable: true, clientX, clientY
+    }));
+  }
 }

--- a/module/applications/item/item-sheet-2.mjs
+++ b/module/applications/item/item-sheet-2.mjs
@@ -228,14 +228,7 @@ export default class ItemSheet5e2 extends ItemSheetV2Mixin(ItemSheet5e) {
     super.activateListeners(html);
 
     for ( const control of html[0].querySelectorAll(".tab.advancement [data-context-menu]") ) {
-      control.addEventListener("click", event => {
-        event.preventDefault();
-        event.stopPropagation();
-        const { clientX, clientY } = event;
-        event.currentTarget.closest("[data-id]").dispatchEvent(new PointerEvent("contextmenu", {
-          view: window, bubbles: true, cancelable: true, clientX, clientY
-        }));
-      });
+      control.addEventListener("click", ContextMenu5e.triggerEvent);
     }
 
     html.find(".activities .activity .name").on("click", this._onEditActivity.bind(this));

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -49,9 +49,6 @@ export default function DocumentSheetV2Mixin(Base) {
     /** @inheritDoc */
     static _customElements = super._customElements.concat(["dnd5e-checkbox", "proficiency-cycle", "slide-toggle"]);
 
-    /** @inheritDoc */
-    static _customElements = super._customElements.concat(["dnd5e-checkbox"]);
-
     /* -------------------------------------------- */
     /*  Rendering                                   */
     /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,6 +1,7 @@
 import ActivityChoiceDialog from "../applications/activity/activity-choice-dialog.mjs";
 import AdvancementManager from "../applications/advancement/advancement-manager.mjs";
 import AdvancementConfirmationDialog from "../applications/advancement/advancement-confirmation-dialog.mjs";
+import ContextMenu5e from "../applications/context-menu.mjs";
 import CreateScrollDialog from "../applications/item/create-scroll-dialog.mjs";
 import ClassData from "../data/item/class.mjs";
 import ContainerData from "../data/item/container.mjs";
@@ -1112,15 +1113,8 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   static chatListeners(html) {
     html = html instanceof HTMLElement ? html : html[0];
     html.addEventListener("click", event => {
-      if ( event.target.closest("[data-context-menu]") ) {
-        event.preventDefault();
-        event.stopPropagation();
-        event.target.closest("[data-message-id]").dispatchEvent(new PointerEvent("contextmenu", {
-          view: window, bubbles: true, cancelable: true
-        }));
-      } else if ( event.target.closest(".collapsible") ) {
-        this._onChatCardToggleContent(event);
-      }
+      if ( event.target.closest("[data-context-menu]") ) ContextMenu5e.triggerEvent(event);
+      else if ( event.target.closest(".collapsible") ) this._onChatCardToggleContent(event);
     });
   }
 


### PR DESCRIPTION
Introduces `PrimarySheetMixin` which is a V2-compatible version of `DocumentSheetV2Mixin` that handles tabs, edit/play toggle, and some other behavior that will be shared between the `ApplicationV2` versions of the actor and item sheets.

Also moves the section expansion code from `ActivitySheet` into `ApplicationV2Mixin` so it can be used to handle the description sections on the item sheets.

Adds the `triggerEvent` static method to `ContextMenu5e` to consolidate some duplicate code for the "Additional Options" dots buttons.