### PR TITLE
[#5275, #5319] Fix flat damage label, display scaled cantrips

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -209,7 +209,7 @@ export default class AttackActivityData extends BaseActivityData {
 
     rollData ??= this.getRollData({ deterministic: true });
     super.prepareFinalData(rollData);
-    this.prepareDamageLabel(this.damage.parts, rollData);
+    this.prepareDamageLabel(rollData);
 
     const { data, parts } = this.getAttackData();
     const roll = new Roll(parts.join("+"), data);

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -613,20 +613,15 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Prepare the label for a compiled and simplified damage formula.
-   * @param {DamageData[]} parts  Damage parts to create labels for.
-   * @param {object} rollData     Deterministic roll data from the item.
+   * @param {object} rollData  Deterministic roll data from the item.
    */
-  prepareDamageLabel(parts, rollData) {
-    this.labels.damage = parts.map((part, index) => {
+  prepareDamageLabel(rollData) {
+    const config = this.getDamageConfig();
+    this.labels.damage = (config.rolls ?? []).map((part, index) => {
       let formula;
       try {
-        formula = part.formula;
-        if ( part.base ) {
-          if ( this.item.system.magicAvailable ) formula += ` + ${this.item.system.magicalBonus ?? 0}`;
-          if ( (this.item.type === "weapon") && !/@mod\b/.test(formula) ) formula += " + @mod";
-        }
-        if ( !index && this.item.system.damageBonus ) formula += ` + ${this.item.system.damageBonus}`;
-        const roll = new CONFIG.Dice.BasicRoll(formula, rollData);
+        formula = part.parts.join(" + ");
+        const roll = new CONFIG.Dice.DamageRoll(formula, rollData);
         roll.simplify();
         formula = simplifyRollFormula(roll.formula, { preserveFlavor: true });
       } catch(err) {
@@ -636,15 +631,18 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       }
 
       let label = formula;
-      if ( part.types.size ) {
+      const types = part.options?.types ?? part.options?.type ? [part.options.type] : [];
+      if ( types.length ) {
         label = `${formula} ${game.i18n.getListFormatter({ type: "conjunction" }).format(
-          Array.from(part.types)
-            .map(p => CONFIG.DND5E.damageTypes[p]?.label ?? CONFIG.DND5E.healingTypes[p]?.label)
-            .filter(t => t)
+          types.map(p => CONFIG.DND5E.damageTypes[p]?.label ?? CONFIG.DND5E.healingTypes[p]?.label).filter(_ => _)
         )}`;
       }
 
-      return { formula, damageType: part.types.size === 1 ? part.types.first() : null, label, base: part.base };
+      return {
+        formula, label,
+        base: part.base,
+        damageType: part.options?.types.length === 1 ? part.options.types[0] : null
+      };
     });
   }
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -614,8 +614,17 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /**
    * Prepare the label for a compiled and simplified damage formula.
    * @param {object} rollData  Deterministic roll data from the item.
+   * @param {object} _rollData
    */
-  prepareDamageLabel(rollData) {
+  prepareDamageLabel(rollData, _rollData=rollData) {
+    if ( foundry.utils.getType(rollData) === "Array" ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `BaseActivityData#prepareDamageLabel` no longer takes damage parts as an input.",
+        { since: "DnD5e 4.4", until: "DnD5e 5.1" }
+      );
+      rollData = _rollData;
+    }
+
     const config = this.getDamageConfig();
     this.labels.damage = (config.rolls ?? []).map((part, index) => {
       let formula;
@@ -631,7 +640,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       }
 
       let label = formula;
-      const types = part.options?.types ?? part.options?.type ? [part.options.type] : [];
+      const types = part.options?.types ?? (part.options?.type ? [part.options.type] : []);
       if ( types.length ) {
         label = `${formula} ${game.i18n.getListFormatter({ type: "conjunction" }).format(
           types.map(p => CONFIG.DND5E.damageTypes[p]?.label ?? CONFIG.DND5E.healingTypes[p]?.label).filter(_ => _)

--- a/module/data/activity/damage-data.mjs
+++ b/module/data/activity/damage-data.mjs
@@ -54,7 +54,7 @@ export default class DamageActivityData extends BaseActivityData {
   prepareFinalData(rollData) {
     rollData ??= this.getRollData({ deterministic: true });
     super.prepareFinalData(rollData);
-    this.prepareDamageLabel(this.damage.parts, rollData);
+    this.prepareDamageLabel(rollData);
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/heal-data.mjs
+++ b/module/data/activity/heal-data.mjs
@@ -34,7 +34,7 @@ export default class HealActivityData extends BaseActivityData {
   prepareFinalData(rollData) {
     rollData ??= this.getRollData({ deterministic: true });
     super.prepareFinalData(rollData);
-    this.prepareDamageLabel([this.healing], rollData);
+    this.prepareDamageLabel(rollData);
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -110,7 +110,7 @@ export default class SaveActivityData extends BaseActivityData {
   prepareFinalData(rollData) {
     rollData ??= this.getRollData({ deterministic: true });
     super.prepareFinalData(rollData);
-    this.prepareDamageLabel(this.damage.parts, rollData);
+    this.prepareDamageLabel(rollData);
 
     const bonus = this.save.dc.bonus ? simplifyBonus(this.save.dc.bonus, rollData) : 0;
 


### PR DESCRIPTION
Switches to using `getDamageConfig` rather than using the raw damage parts when generating the damage labels. This allows the de-duplication in handling for `@mod` and other bonuses.

This also means the scaled cantrip damage is displayed, rather than just showing the base damage.

Closes #5275
Closes #5319