### PR TITLE
Add DamageTraitField and SimpleTraitField exports to module

### DIFF
--- a/module/data/actor/_module.mjs
+++ b/module/data/actor/_module.mjs
@@ -10,6 +10,8 @@ export {
   VehicleData
 };
 export {default as GroupSystemFlags} from "./group-system-flags.mjs";
+export {default as DamageTraitField} from "./fields/damage-trait-field.mjs";
+export {default as SimpleTraitField} from "./fields/simple-trait-field.mjs";
 export {default as AttributesFields} from "./templates/attributes.mjs";
 export {default as CommonTemplate} from "./templates/common.mjs";
 export {default as CreatureTemplate} from "./templates/creature.mjs";


### PR DESCRIPTION
With makeSimpleTrait and makeDamageTrait being deprecated I couldn't find the SimpleTraitField and DamageTraitField classes available anywhere so I added them to the export for actor data.