### PR TITLE
[#5114, #5284] Fix journal editor headers, system styling

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -578,6 +578,10 @@ Hooks.on("renderCompendiumDirectory", (app, html) => {
 });
 
 Hooks.on("renderJournalPageSheet", applications.journal.JournalSheet5e.onRenderJournalPageSheet);
+Hooks.on(
+  "renderJournalEntryPageProseMirrorSheet",
+  applications.journal.JournalSheet5e.onRenderJournalEntryPageProseMirrorSheet
+);
 
 Hooks.on("renderActiveEffectConfig", documents.ActiveEffect5e.onRenderActiveEffectConfig);
 

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -485,3 +485,25 @@
     .editor-container { overflow-y: auto; }
   }
 }
+
+.dnd5e2-journal.app .editable {
+  .journal-header {
+    flex: 0;
+    flex-wrap: nowrap;
+    .title {
+      height: 50px;
+      background: rgb(0 0 0 / .1);
+      border-radius: 4px;
+      font-size: var(--font-size-32);
+      line-height: 50px;
+    }
+    .page-level {
+      flex: 0 0 110px;
+      align-items: flex-end;
+    }
+    .heading-level {
+      width: 100%;
+      align-items: center;
+    }
+  }
+}

--- a/module/applications/journal/journal-sheet.mjs
+++ b/module/applications/journal/journal-sheet.mjs
@@ -59,4 +59,19 @@ export default class JournalSheet5e extends JournalSheet {
       element?.classList.add("dnd5e2-journal");
     }
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add class to journal ProseMirror editor.
+   * @param {JournalEntryPageProseMirrorSheet} page  The journal page application.
+   * @param {HTMLElement} element                    The rendered Application HTML.
+   * @param {object} context                         Rendering context provided.
+   * @param {object} options                         Rendering options provided.
+   */
+  static onRenderJournalEntryPageProseMirrorSheet(page, element, context, options) {
+    if ( page.document.parent.sheet instanceof JournalSheet5e ) {
+      element.classList.add("dnd5e2-journal");
+    }
+  }
 }


### PR DESCRIPTION
Adds a new hook to ensure the proper class is added to the journal editor in V13 so the system styles can apply to it.

Partially re-implements V12 styling for the journal editor header to keep it displaying properly in V13.

Closes #5114
Closes #5284