### PR TITLE
[#5129] Add rest request chat card that can be invoked from party

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -554,6 +554,7 @@ Hooks.on("renderChatLog", (app, html, data) => {
 Hooks.on("renderChatPopout", (app, html, data) => documents.Item5e.chatListeners(html));
 
 Hooks.on("chatMessage", (app, message, data) => applications.Award.chatMessage(message));
+Hooks.on("createChatMessage", dataModels.chatMessage.RestRequestMessageData.onCreateRestMessage);
 
 Hooks.on("renderActorDirectory", (app, html, data) => documents.Actor5e.onRenderActorDirectory(html));
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -21,6 +21,7 @@
 
 "TYPES.ChatMessage": {
   "rest": "Rest Message",
+  "restRequest": "Rest Request Message",
   "turn": "Combat Turn Message"
 },
 
@@ -1071,6 +1072,10 @@
   "Activities": "Activities",
   "Deltas": {
     "Recovery": "Recovery"
+  },
+  "RESTREQUEST": {
+    "Complete": "Rest Complete",
+    "PartyMembers": "Party Members"
   },
   "TURN": {
     "NoCombatant": "Combatant no longer exists!"
@@ -3091,6 +3096,13 @@
   "NewDay": {
     "Hint": "Recover limited use abilities which recharge at dusk, dawn, or on a new day.",
     "Label": "New Day"
+  },
+  "Request": {
+    "AutoRest": {
+      "Hint": "Automatically perform the rest for selected party actors, rather than sending a rest request to players.",
+      "Label": "Auto Rest"
+    },
+    "Label": "Rest Request"
   },
   "Short": {
     "Abbreviation": "SR",

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -787,15 +787,23 @@ enchantment-application {
     display: block;
     margin-block-start: 1em;
   }
-  .activities ul {
+  ul.action-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
     margin-block-start: 8px;
 
     li {
       --gold-icon-size: 32px;
       gap: 8px;
+      align-items: center;
     }
 
     a.rollable:hover .subtitle { text-shadow: none; }
+    .status {
+      flex: 0 0 30px;
+      text-align: center;
+    }
   }
   .deltas ul {
     .delta {

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -1,3 +1,4 @@
+import { filteredKeys } from "../../../utils.mjs";
 import Dialog5e from "../../api/dialog.mjs";
 
 const { BooleanField } = foundry.data.fields;
@@ -59,6 +60,16 @@ export default class BaseRestDialog extends Dialog5e {
   /* -------------------------------------------- */
 
   /**
+   * Is the resting actor a party?
+   * @type {boolean}
+   */
+  get isPartyGroup() {
+    return (this.actor.type === "group") && (this.actor.system.type.value === "party");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Should the user be prompted as to whether a new day has occurred?
    * @type {boolean}
    */
@@ -99,6 +110,7 @@ export default class BaseRestDialog extends Dialog5e {
       variant: game.settings.get("dnd5e", "restVariant")
     };
     if ( this.promptNewDay ) context.fields.push({
+      disabled: !!this.config.request,
       field: new BooleanField({
         label: game.i18n.localize("DND5E.REST.NewDay.Label"),
         hint: game.i18n.localize("DND5E.REST.NewDay.Hint")
@@ -107,6 +119,31 @@ export default class BaseRestDialog extends Dialog5e {
       name: "newDay",
       value: context.config.newDay
     });
+    if ( this.isPartyGroup ) {
+      const restSettings = this.actor.getFlag("dnd5e", "restSettings") ?? {};
+      context.request = [
+        {
+          field: new BooleanField({
+            label: game.i18n.localize("DND5E.REST.Request.AutoRest.Label"),
+            hint: game.i18n.localize("DND5E.REST.Request.AutoRest.Hint")
+          }),
+          name: "autoRest",
+          input: context.inputs.createCheckboxInput,
+          value: restSettings.autoRest
+        },
+        ...this.actor.system.members
+          .filter(m => ["character", "npc"].includes(m.actor?.type))
+          .map(m => ({
+            field: new BooleanField({
+              label: m.actor.name
+            }),
+            name: `targets.${m.actor.id}`,
+            input: context.inputs.createCheckboxInput,
+            value: restSettings.targets ? restSettings.targets?.has(m.actor.id) : true
+          }))
+      ];
+      await loadTemplates(["systems/dnd5e/templates/actors/rest/rest-request.hbs"]);
+    }
     return context;
   }
 
@@ -122,7 +159,12 @@ export default class BaseRestDialog extends Dialog5e {
    * @param {FormDataExtended} formData  Data from the dialog.
    */
   static async #handleFormSubmission(event, form, formData) {
-    foundry.utils.mergeObject(this.config, formData.object);
+    const data = foundry.utils.expandObject(formData.object);
+    if ( this.isPartyGroup ) {
+      data.targets = filteredKeys(data.targets ?? {});
+      this.actor.setFlag("dnd5e", "restSettings", data);
+    }
+    foundry.utils.mergeObject(this.config, data);
     this.#rested = true;
     await this.close();
   }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2915,6 +2915,8 @@ DND5E.hitDieTypes = ["d4", "d6", "d8", "d10", "d12"];
  * @typedef {object} RestConfiguration
  * @property {Record<string, number>} duration      Duration of different rest variants in minutes.
  * @property {string} label                         Localized label for the rest type.
+ * @property {string} icon                          Icon representing this rest type. Can be either a set of FontAwesome
+ *                                                  classes or an image path.
  * @property {string[]} [activationPeriods]         Activation types that should be displayed in the chat card.
  * @property {boolean} [recoverHitDice]             Should hit dice be recovered during this rest?
  * @property {boolean} [recoverHitPoints]           Should hit points be recovered during this rest?
@@ -2936,6 +2938,7 @@ DND5E.restTypes = {
       epic: 1
     },
     label: "DND5E.REST.Short.Label",
+    icon: "fa-solid fa-utensils",
     activationPeriods: ["shortRest"],
     recoverPeriods: ["sr"],
     recoverSpellSlotTypes: new Set(["pact"])
@@ -2947,6 +2950,7 @@ DND5E.restTypes = {
       epic: 60
     },
     label: "DND5E.REST.Long.Label",
+    icon: "fa-solid fa-campground",
     activationPeriods: ["longRest"],
     recoverHitDice: true,
     recoverHitPoints: true,

--- a/module/data/actor/group-system-flags.mjs
+++ b/module/data/actor/group-system-flags.mjs
@@ -1,17 +1,22 @@
-const { ForeignDocumentField, SetField } = foundry.data.fields;
+const { BooleanField, DocumentIdField, SchemaField, SetField } = foundry.data.fields;
 
 /**
  * A custom model to validate system flags on Group Actors.
  *
- * @property {Set<string>} awardDestinations  Saved targets from previous use of award button.
+ * @property {Set<string>} awardDestinations       Saved targets from previous use of award button.
+ * @property {object} [restSettings]
+ * @property {boolean} [restSettings.autoRest]     Saved Auto Rest setting from previous group rest.
+ * @property {Set<string>} [restSettings.targets]  Saved targets form previous group rest.
  */
 export default class GroupSystemFlags extends foundry.abstract.DataModel {
   /** @override */
   static defineSchema() {
     return {
-      awardDestinations: new SetField(
-        new ForeignDocumentField(foundry.documents.BaseActor, { idOnly: true }), { required: false }
-      )
+      awardDestinations: new SetField(new DocumentIdField(), { required: false }),
+      restSettings: new SchemaField({
+        autoRest: new BooleanField(),
+        targets: new SetField(new DocumentIdField())
+      }, { required: false, initial: null })
     };
   }
 }

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -7,12 +7,22 @@ import GroupSystemFlags from "./group-system-flags.mjs";
 const { ArrayField, ForeignDocumentField, HTMLField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
+ * @import { RestConfiguration, RestResult } from "../../documents/actor/actor.mjs";
+ */
+
+/**
  * Metadata associated with members in this group.
- * @typedef {object} GroupMemberData
+ * @typedef GroupMemberData
  * @property {Actor5e} actor              Associated actor document.
  * @property {object} quantity
  * @property {number} quantity.value      Number of this actor in the group (for encounter or crew types).
  * @property {string} [quantity.formula]  Formula used for re-rolling actor quantities in encounters.
+ */
+
+/**
+ * @typedef {RestConfiguration} GroupRestConfiguration
+ * @param {boolean} [autoRest]  Automatically perform rest for group members rather than creating request message.
+ * @param {string[]} [targets]  IDs of actors to rest. If not provided, then all group actors will be rested.
  */
 
 /**
@@ -265,18 +275,37 @@ export default class GroupActor extends ActorDataModel.mixin(CurrencyTemplate) {
 
   /**
    * Initiate a rest for all members of this group.
-   * @param {RestConfiguration} config  Configuration data for the rest.
-   * @param {RestResult} result         Results of the rest operation being built.
-   * @returns {boolean}                 Returns `false` to prevent regular rest process from completing.
+   * @param {GroupRestConfiguration} config  Configuration data for the rest.
+   * @param {RestResult} result              Results of the rest operation being built.
+   * @returns {boolean}                      Returns `false` to prevent regular rest process from completing.
    */
   async rest(config, result) {
+    const targets = this.members
+      .map(({ actor }) => !config.targets || config.targets.includes(actor.id) ? actor : null)
+      .filter(_ => _);
+
+    // Create a rest chat message
+    if ( !config.autoRest ) {
+      const messageData = {
+        flavor: this.parent.createRestFlavor(config),
+        speaker: ChatMessage.getSpeaker({ actor: this.parent, alias: this.parent.name }),
+        system: {
+          newDay: config.newDay === true,
+          targets: targets.map(t => ({ actor: t })),
+          type: config.type
+        },
+        type: "restRequest"
+      };
+      await ChatMessage.create(messageData);
+    }
+
     const results = new Map();
-    for ( const member of this.members ) {
+    for ( const actor of targets ) {
       results.set(
-        member.actor,
-        await member.actor[config.type === "short" ? "shortRest" : "longRest"]({
+        actor,
+        config.autoRest ? await actor[config.type === "short" ? "shortRest" : "longRest"]({
           ...config, dialog: false, advanceBastionTurn: false, advanceTime: false
-        }) ?? null
+        }) ?? null : null
       );
     }
 

--- a/module/data/chat-message/_module.mjs
+++ b/module/data/chat-message/_module.mjs
@@ -1,12 +1,16 @@
 import RestMessageData from "./rest-message-data.mjs";
+import RestRequestMessageData from "./rest-request-message-data.mjs";
 import TurnMessageData from "./turn-message-data.mjs";
 
 export {
+  RestMessageData,
+  RestRequestMessageData,
   TurnMessageData
 };
 export * as fields from "./fields/_module.mjs";
 
 export const config = {
   rest: RestMessageData,
+  restRequest: RestRequestMessageData,
   turn: TurnMessageData
 };

--- a/module/data/chat-message/rest-message-data.mjs
+++ b/module/data/chat-message/rest-message-data.mjs
@@ -2,7 +2,7 @@ import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
 import ActivationsField from "./fields/activations-field.mjs";
 import { ActorDeltasField } from "./fields/deltas-field.mjs";
 
-const { StringField } = foundry.data.fields;
+const { ForeignDocumentField, StringField } = foundry.data.fields;
 
 /**
  * @import ActivationsData from "./fields/activations-field.mjs";
@@ -14,6 +14,7 @@ const { StringField } = foundry.data.fields;
  *
  * @property {ActivationsData} activations  Activities that can be used after this rest, stored as relative UUIDs.
  * @property {ActorDeltasData} deltas       Actor/item recovery from this turn change.
+ * @property {ChatMessage5e} [request]      Rest request chat message for which this rest was performed.
  * @property {string} type                  Type of rest performed.
  */
 export default class RestMessageData extends ChatMessageDataModel {
@@ -27,6 +28,7 @@ export default class RestMessageData extends ChatMessageDataModel {
     return {
       activations: new ActivationsField(),
       deltas: new ActorDeltasField(),
+      request: new ForeignDocumentField(foundry.documents.BaseChatMessage),
       type: new StringField()
     };
   }

--- a/module/data/chat-message/rest-request-message-data.mjs
+++ b/module/data/chat-message/rest-request-message-data.mjs
@@ -1,0 +1,112 @@
+import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+
+const { ArrayField, BooleanField, ForeignDocumentField, SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * @typedef RestRequestTargetData
+ * @property {Actor5e} actor         Actor whose rest was requested.
+ * @property {ChatMessage5e} result  Rest chat message indicating the rest was completed for this actor.
+ */
+
+/**
+ * Data stored in a rest chat message.
+ *
+ * @property {boolean} newDay                   A new day has occurred during this rest.
+ * @property {RestRequestTargetData[]} targets  Actors that were the target of the rest request.
+ * @property {string} type                      Type of rest requested.
+ */
+export default class RestRequestMessageData extends ChatMessageDataModel {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {
+      newDay: new BooleanField(),
+      targets: new ArrayField(new SchemaField({
+        actor: new ForeignDocumentField(foundry.documents.BaseActor),
+        result: new ForeignDocumentField(foundry.documents.BaseChatMessage)
+      })),
+      type: new StringField()
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    actions: {
+      rest: RestRequestMessageData.#restActor
+    },
+    template: "systems/dnd5e/templates/chat/rest-request-card.hbs"
+  }, { inplace: false }));
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext() {
+    const restConfig = CONFIG.DND5E.restTypes[this.type];
+    if ( !restConfig ) return {};
+
+    const context = {
+      button: { icon: restConfig.icon, label: restConfig.label },
+      targets: this.targets.map(t => {
+        if ( !t.actor || (this.complete && !t.result) ) return null;
+        return { actor: t.actor, completed: t.result !== null };
+      }).filter(_ => _)
+    };
+
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle associating a newly created rest result message with an actor and updating this message.
+   * @param {ChatMessage5e} message
+   */
+  static onCreateRestMessage(message) {
+    if ( (message.type !== "rest") || (game.users.activeGM !== game.user) ) return;
+
+    const actor = message.system.actor;
+    const request = message.system.request;
+    const index = request?.system.targets?.findIndex(t => t.actor === actor);
+    const target = request.system.targets?.[index];
+    if ( !target || target.result ) return;
+
+    const targetsData = request?.system.toObject().targets ?? [];
+    targetsData[index].result = message.id;
+    request.update({ "system.targets": targetsData });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle resting an actor.
+   * @this {RestRequestMessageData}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static async #restActor(event, target) {
+    const actor = fromUuidSync(target.closest("[data-uuid]")?.dataset.uuid);
+    try {
+      target.disabled = true;
+      const config = {
+        newDay: this.newDay,
+        request: this.parent,
+        type: this.type
+      };
+      await actor[config.type === "short" ? "shortRest" : "longRest"]({
+        ...config, advanceBastionTurn: false, advanceTime: false
+      });
+    } finally {
+      target.disabled = false;
+    }
+  }
+}

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2235,6 +2235,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @property {boolean} [autoHD]              Should hit dice be spent automatically during a short rest?
    * @property {number} [autoHDThreshold]      How many hit points should be missing before hit dice are
    *                                           automatically spent during a short rest.
+   * @property {ChatMessage5e} [request]       Rest request chat message for which this rest was performed.
    */
 
   /**
@@ -2373,10 +2374,11 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
         hitPoints: 0,
         hitDice: 0
       },
-      updateData: {},
-      updateItems: [],
       newDay: config.newDay === true,
-      rolls: []
+      request: config.request,
+      rolls: [],
+      updateData: {},
+      updateItems: []
     }, result);
     result.clone ??= this.clone();
     if ( "dhp" in result ) result.deltas.hitPoints = result.dhp;
@@ -2441,18 +2443,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @protected
    */
   async _displayRestResultMessage(config, result) {
-    let { dhd, dhp, newDay } = result;
+    let { dhd, dhp } = result;
     if ( config.type === "short" ) dhd *= -1;
     const diceRestored = dhd !== 0;
     const healthRestored = dhp !== 0;
     const longRest = config.type === "long";
     const length = longRest ? "Long" : "Short";
-
     const typeConfig = CONFIG.DND5E.restTypes[config.type] ?? {};
-    const duration = convertTime(config.duration, "minute");
-    const parts = [formatTime(duration.value, duration.unit)];
-    if ( newDay ) parts.push(game.i18n.localize("DND5E.REST.NewDay.Label").toLowerCase());
-    const restFlavor = `${typeConfig.label} (${game.i18n.getListFormatter({ type: "unit" }).format(parts)})`;
 
     // Determine the chat message to display
     let message;
@@ -2469,18 +2466,35 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
         dice: game.i18n.format(`DND5E.HITDICE.Counted.${pr.select(dhd)}`, { number: formatNumber(dhd) }),
         health: game.i18n.format(`DND5E.HITPOINTS.Counted.${pr.select(dhp)}`, { number: formatNumber(dhp) })
       }),
-      flavor: game.i18n.localize(restFlavor),
+      flavor: this.createRestFlavor(config, result),
       type: "rest",
       rolls: result.rolls,
       speaker: ChatMessage.getSpeaker({ actor: this, alias: this.name }),
       system: {
         activations: ActivationsField.getActivations(this, typeConfig?.activationPeriods ?? []),
         deltas: ActorDeltasField.getDeltas(result.clone, { actor: result.updateData, item: result.updateItems }),
+        request: config.request,
         type: result.type
       }
     };
     ChatMessage.applyRollMode(chatData, game.settings.get("core", "rollMode"));
     return ChatMessage.create(chatData);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Generate rest flavor text based on the provided configuration.
+   * @param {RestConfiguration} config  Rest configuration.
+   * @param {RestResult} [result]       Result of the rest operation.
+   * @returns {string}
+   */
+  createRestFlavor(config, result) {
+    const typeConfig = CONFIG.DND5E.restTypes[config.type] ?? {};
+    const duration = convertTime(config.duration, "minute");
+    const parts = [formatTime(duration.value, duration.unit)];
+    if ( result?.newDay ?? config.newDay ) parts.push(game.i18n.localize("DND5E.REST.NewDay.Label").toLowerCase());
+    return `${typeConfig.label} (${game.i18n.getListFormatter({ type: "unit" }).format(parts)})`;
   }
 
   /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -854,6 +854,32 @@ function dataset(object, options) {
 /* -------------------------------------------- */
 
 /**
+ * Create an icon element dynamically based on the provided icon string, supporting FontAwesome class strings
+ * or paths to SVG or other image types.
+ * @param {string} icon           Icon class or path.
+ * @param {object} [options={}]
+ * @param {string} [options.alt]  Alt text for the icon.
+ * @returns {HTMLElement|null}
+ */
+export function generateIcon(icon, { alt }={}) {
+  let element;
+  if ( icon?.startsWith("fa") ) {
+    element = document.createElement("i");
+    element.className = icon;
+    element.ariaLabel = alt;
+  } else if ( icon ) {
+    element = document.createElement(icon.endsWith(".svg") ? "dnd5e-icon" : "img");
+    element.src = icon;
+  } else {
+    return null;
+  }
+  if ( alt ) element[element.tagName === "IMG" ? "alt" : "ariaLabel"] = alt;
+  return element;
+}
+
+/* -------------------------------------------- */
+
+/**
  * A helper to create a set of <option> elements in a <select> block grouped together
  * in <optgroup> based on the provided categories.
  *
@@ -970,6 +996,11 @@ export function registerHandlebarsHelpers() {
     getProperty: foundry.utils.getProperty,
     "dnd5e-concealSection": concealSection,
     "dnd5e-dataset": dataset,
+    "dnd5e-icon": (icon, { hash: options }) => {
+      let element = generateIcon(icon, options);
+      if ( !element && options.fallback ) element = generateIcon(options.fallback, options);
+      return element ? new Handlebars.SafeString(element.outerHTML) : "";
+    },
     "dnd5e-formatCR": formatCR,
     "dnd5e-formatModifier": formatModifier,
     "dnd5e-groupedSelectOptions": groupedSelectOptions,

--- a/system.json
+++ b/system.json
@@ -43,6 +43,7 @@
     },
     "ChatMessage": {
       "rest": {},
+      "restRequest": {},
       "turn": {}
     },
     "Item": {

--- a/templates/actors/rest/long-rest.hbs
+++ b/templates/actors/rest/long-rest.hbs
@@ -6,9 +6,11 @@
     {{#if fields.length}}
     <fieldset>
         <legend>{{ localize "DND5E.REST.Configuration" }}</legend>
-        {{#each fields}}
-        {{ formField field name=name value=value input=input options=options rootId=../partId }}
-        {{/each}}
+        {{> "dnd5e.fieldlist" fields }}
     </fieldset>
+    {{/if}}
+
+    {{#if request}}
+    {{> "systems/dnd5e/templates/actors/rest/rest-request.hbs" }}
     {{/if}}
 </section>

--- a/templates/actors/rest/rest-request.hbs
+++ b/templates/actors/rest/rest-request.hbs
@@ -1,0 +1,4 @@
+<fieldset>
+    <legend>{{ localize "DND5E.REST.Request.Label" }}</legend>
+    {{> "dnd5e.fieldlist" request }}
+</fieldset>

--- a/templates/actors/rest/short-rest.hbs
+++ b/templates/actors/rest/short-rest.hbs
@@ -6,9 +6,7 @@
     {{#if fields.length}}
     <fieldset>
         <legend>{{ localize "DND5E.REST.Configuration" }}</legend>
-        {{#each fields}}
-        {{ formField field name=name value=value input=input options=options rootId=../partId }}
-        {{/each}}
+        {{> "dnd5e.fieldlist" fields }}
     </fieldset>
     {{/if}}
 
@@ -32,5 +30,9 @@
         {{ localize "DND5E.REST.HitDice.None" }}
     </div>
     {{/if}}
+    {{/if}}
+
+    {{#if request}}
+    {{> "systems/dnd5e/templates/actors/rest/rest-request.hbs" }}
     {{/if}}
 </section>

--- a/templates/chat/parts/card-activities.hbs
+++ b/templates/chat/parts/card-activities.hbs
@@ -1,6 +1,6 @@
 <section class="activities">
     <strong class="roboto-condensed-upper">{{ localize "DND5E.CHATMESSAGE.Activities" }}</strong>
-    <ul class="unlist">
+    <ul class="action-list unlist">
         {{#each activities}}
         <li class="activity flexrow item-tooltip" data-activity-uuid="{{ uuid }}" data-item-uuid="{{ item.uuid }}">
             <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">

--- a/templates/chat/rest-request-card.hbs
+++ b/templates/chat/rest-request-card.hbs
@@ -1,0 +1,26 @@
+<div class="dnd5e2 chat-card rest-card">
+    <section class="targets">
+        <strong class="roboto-condensed-upper">{{ localize "DND5E.CHATMESSAGE.RESTREQUEST.PartyMembers" }}</strong>
+        <ul class="action-list unlist">
+            {{#each targets}}
+            <li class="flexrow" data-uuid="{{ actor.uuid }}">
+                <img class="gold-icon" src="{{ actor.img }}" alt="{{ actor.name }}">
+                <span class="name-stacked">
+                    <span class="title">{{ actor.name }}</span>
+                </span>
+                <div class="status">
+                    {{#if completed}}
+                    <i class="fa-solid fa-check" data-tooltip="DND5E.CHATMESSAGE.RESTREQUEST.Complete"
+                       aria-label="{{ localize 'DND5E.CHATMESSAGE.RESTREQUEST.Complete' }}"></i>
+                    {{else if actor.isOwner}}
+                    <button type="button" class="gold-button" data-tooltip="{{ @root.button.label }}"
+                            aria-label="{{ @root.button.label }}" data-action="rest">
+                        {{ dnd5e-icon @root.button.icon fallback="fa-solid fa-bed" }}
+                    </button>
+                    {{/if}}
+                </div>
+            </li>
+            {{/each}}
+        </ul>
+    </section>
+</div>

--- a/templates/shared/fields/fieldlist.hbs
+++ b/templates/shared/fields/fieldlist.hbs
@@ -1,3 +1,3 @@
 {{#each this}}
-{{ formField field name=name value=value input=input options=options rootId=@root.partId }}
+{{ formField field name=name value=value input=input options=options disabled=disabled rootId=@root.partId }}
 {{/each}}


### PR DESCRIPTION
Adds a new `restRequest` chat message type that contains a list of actors to be rested, details on the rest being performed, and links to the individual actor rest result messages. Players will see rest buttons allowing them to rest directly from the chat message which will be updated to show that actor has completed their rest.

The group rest dialogs have been expanded to include a button to specify whether the rest should be performed automatically or not, and options to control which group members are rested. For non-party groups all actors are automatically rested.

The rest configuration now takes an optional `request` option pointing to the rest request chat message. This is also stored in rest result messages to easily associate a rest result with its request.

### Possible Future Work
- [ ] Use V13's query system to show the dialog to players
- [ ] Improve handling of NPCs in party
- [ ] Add config option to disable resting from actor sheets
- [ ] Associate rests from sheet with recent request message

Closes #5129