### PR TITLE
[#933, #5238] Add custom movement types

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3421,6 +3421,8 @@
 
 "DND5E.MOVEMENT": {
   "Action": {
+    "AddCustom": "Add Custom Movement",
+    "DeleteCustom": "Delete Custom Movement",
     "Configure": "Configure Movement Speed"
   },
   "FIELDS": {

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -450,6 +450,7 @@
     border-radius: 4px;
     background: var(--dnd5e-color-black);
     color: var(--dnd5e-color-gold);
+    flex: 0 0 30px;
     width: 30px;
     height: 30px;
     margin: 0;
@@ -1519,6 +1520,10 @@ dialog.dnd5e2.application {
     padding-block: 3px 2px;
     padding-inline: 10px;
     border-radius: 0;
+  }
+  fieldset > .gold-button {
+    align-self: flex-end;
+    margin-block-start: 4px;
   }
 }
 

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -623,7 +623,7 @@
   gap: 0;
 
   .form-group:not(.label-top, .checkbox) {
-    gap: 0;
+    gap: 2px;
 
     > label {
       flex: 2;

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -364,6 +364,7 @@ export default class NPCActorSheet extends BaseActorSheet {
         }];
         return data;
       }),
+      ...attributes.movement.custom,
       ...splitSemicolons(attributes.movement.special).map(label => ({ label }))
     ].filter(_ => _);
 

--- a/module/applications/shared/movement-senses-config.mjs
+++ b/module/applications/shared/movement-senses-config.mjs
@@ -7,12 +7,16 @@ import BaseConfigSheet from "../actor/api/base-config-sheet.mjs";
 export default class MovementSensesConfig extends BaseConfigSheet {
   /** @override */
   static DEFAULT_OPTIONS = {
-    type: null,
+    actions: {
+      addCustom: MovementSensesConfig.#addCustom,
+      deleteCustom: MovementSensesConfig.#deleteCustom
+    },
     keyPath: null,
     position: {
       width: 420
     },
-    withResolution: false
+    withResolution: false,
+    type: null
   };
 
   /* -------------------------------------------- */
@@ -84,6 +88,11 @@ export default class MovementSensesConfig extends BaseConfigSheet {
       value: context.data[key],
       placeholder: placeholderData?.[key] ?? ""
     }));
+    if ( context.fields.custom ) context.custom = (context.data.custom ?? []).map((data, index) => ({
+      data,
+      fields: context.fields.custom.element.fields,
+      prefix: `system.${this.keyPath}.custom.${index}`
+    }));
 
     context.unitsOptions = Object.entries(CONFIG.DND5E.movementUnits).map(([value, { label, travelResolution }]) => {
       if ( !this.options.withResolution || !travelResolution ) return { value, label };
@@ -143,5 +152,38 @@ export default class MovementSensesConfig extends BaseConfigSheet {
       localize: true
     });
     return extras;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle adding a new custom entry.
+   * @this {MovementSensesConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #addCustom(event, target) {
+    const custom = foundry.utils.getProperty(this.document.system.toObject(), `${this.keyPath}.custom`) ?? [];
+    this.submit({ updateData: {
+      [`system.${this.keyPath}.custom`]: [...custom, {}]
+    } });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle removing a custom entry.
+   * @this {MovementSensesConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #deleteCustom(event, target) {
+    const custom = foundry.utils.getProperty(this.document.system.toObject(), `${this.keyPath}.custom`) ?? [];
+    custom.splice(target.closest("[data-index]").dataset.index, 1);
+    this.submit({ updateData: {
+      [`system.${this.keyPath}.custom`]: custom
+    } });
   }
 }

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -630,7 +630,13 @@ export default class NPCData extends CreatureTemplate {
             return prepared;
           })
       ]);
-      const custom = formatter.format(splitSemicolons(this.attributes.movement.special));
+      const custom = formatter.format([
+        ...this.attributes.movement.custom.map(({ label, value }) => {
+          const prepared = prepareMeasured(value, this.attributes.movement.units);
+          return `${prepared} ${label.toLowerCase()}`;
+        }),
+        ...splitSemicolons(this.attributes.movement.special)
+      ]);
       return custom ? `${standard} (${custom})` : standard;
     };
 

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -28,7 +28,7 @@ export default class RaceData extends ItemDataModel.mixin(AdvancementTemplate, I
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      movement: new MovementField({ special: false }, { initialUnits: defaultUnits("length") }),
+      movement: new MovementField({ custom: false, special: false }, { initialUnits: defaultUnits("length") }),
       senses: new SensesField({}, { initialUnits: defaultUnits("length") }),
       type: new CreatureTypeField({ swarm: false }, { initial: { value: "humanoid" } })
     });

--- a/module/data/shared/movement-field.mjs
+++ b/module/data/shared/movement-field.mjs
@@ -1,6 +1,6 @@
 import { convertLength } from "../../utils.mjs";
 
-const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @typedef {"slow"|"normal"|"fast"} TravelPace5e
@@ -13,10 +13,17 @@ const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields
  * @property {number} fly                           Actor flying speed.
  * @property {number} swim                          Actor swimming speed.
  * @property {number} walk                          Actor walking speed.
+ * @property {CustomMovementData[]} custom          Custom movement types.
  * @property {string} special                       Semi-colon separated list of special movement information.
  * @property {string} units                         Movement used to measure the various speeds.
  * @property {boolean} hover                        This flying creature able to hover in place.
  * @property {Set<string>} ignoredDifficultTerrain  Types of difficult terrain ignored.
+ */
+
+/**
+ * @typedef CustomMovementData
+ * @property {string} label  Label for custom movement.
+ * @property {number} value  Movement speed.
  */
 
 /**
@@ -31,6 +38,10 @@ export default class MovementField extends foundry.data.fields.SchemaField {
       fly: new NumberField({ ...numberConfig, label: "DND5E.MOVEMENT.Type.Fly", speed: true }),
       swim: new NumberField({ ...numberConfig, label: "DND5E.MOVEMENT.Type.Swim", speed: true }),
       walk: new NumberField({ ...numberConfig, label: "DND5E.MOVEMENT.Type.Walk", speed: true }),
+      custom: new ArrayField(new SchemaField({
+        label: new StringField(),
+        value: new NumberField({ ...numberConfig })
+      })),
       special: new StringField({ label: "DND5E.MOVEMENT.FIELDS.special.label" }),
       units: new StringField({
         required: true, nullable: true, blank: false, initial: initialUnits, label: "DND5E.MOVEMENT.FIELDS.units.label"

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2603,17 +2603,27 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       unit ? formatLength(value ?? 0, unit, { parts: true })
         : `${value ?? 0} <span class="units">${units}</span>`
     }</span>`;
-    return Object.entries(CONFIG.DND5E.movementTypes).reduce((html, [k, { label }]) => {
+    let html = Object.entries(CONFIG.DND5E.movementTypes).reduce((html, [k, { label }]) => {
       const value = movement[k];
       if ( value || (k === "walk") ) html += `
         <div class="row">
           <i class="fas ${k}"></i>
-          ${formatValue(value)}
+          ${formatValue(movement[k])}
           <span class="label">${label}</span>
         </div>
       `;
       return html;
     }, "");
+    for ( const { label, value } of movement.custom ) {
+      html += `
+        <div class="row">
+          <i class="fas"></i>
+          ${formatValue(value)}
+          <span class="label">${label}</span>
+        </div>
+      `;
+    }
+    return html;
   }
 
   /* -------------------------------------------- */

--- a/templates/shared/config/movement-senses-config.hbs
+++ b/templates/shared/config/movement-senses-config.hbs
@@ -1,5 +1,6 @@
 <section class="flexcol">
     <fieldset class="card">
+        {{!-- Standard Types --}}
         {{#each types}}
         {{#if (eq field.name "fly")}}
         <div class="form-group split-group">
@@ -15,6 +16,29 @@
         {{ formField field value=value placeholder=placeholder localize=true }}
         {{/if}}
         {{/each}}
+
+        {{!-- Custom Types --}}
+        {{#if fields.custom}}
+        {{#each custom}}
+        <div class="form-group" data-index="{{ @index }}">
+            <div class="form-label-field">
+                {{ formInput fields.label name=(concat prefix ".label") value=data.label }}
+            </div>
+            <div class="form-fields">
+                {{ formInput fields.value name=(concat prefix ".value") value=data.value }}
+                <button type="button" class="control-button middle unbutton" data-action="deleteCustom" data-tooltip
+                        aria-label="{{ localize 'DND5E.MOVEMENT.Action.DeleteCustom' }}">
+                    <i class="fa-solid fa-trash" inert></i>
+                </button>
+            </div>
+        </div>
+        {{/each}}
+        <button type="button" class="gold-button" data-action="addCustom" data-tooltip
+                aria-label="{{ localize 'DND5E.MOVEMENT.Action.AddCustom' }}">
+            <i class="fa-solid fa-plus" inert></i>
+        </button>
+        {{/if}}
+
         {{#if (or fields.units extras.length)}}<hr>{{/if}}
         {{#if fields.units}}
         {{ formField fields.units value=data.units options=unitsOptions localize=true blank=unitsOptions.blank }}


### PR DESCRIPTION
Adds custom movement which allows adding new movement types with distances in addition to the standard types. These custom types are displayed on the sheet like the others and in parentheses in the NPC stat block.

<img width="1167" alt="Movement Custom" src="https://github.com/user-attachments/assets/fe9227bc-7e01-4d2c-a95a-a76d13d655c9" />

### Possible Future Work
- [ ] Add custom types to senses to match movement
- [ ] Support formulas in custom movement types once added to normal types

Closes #933
Closes #5238