### PR TITLE
[#4576] Add description to activities

### DIFF
--- a/less/v2/activities.less
+++ b/less/v2/activities.less
@@ -87,6 +87,11 @@
       }
     }
   }
+
+  .editor.prosemirror.slim {
+    margin-inline: -10px;
+    menu { border-radius: 0; }
+  }
 }
 
 /* ----------------------------------------- */

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -2,6 +2,8 @@ import { ConsumptionTargetData } from "../../data/activity/fields/consumption-ta
 import UsesField from "../../data/shared/uses-field.mjs";
 import PseudoDocumentSheet from "../api/pseudo-document-sheet.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * Default sheet for activities.
  */
@@ -341,6 +343,9 @@ export default class ActivitySheet extends PseudoDocumentSheet {
       field: context.fields.target.fields.prompt,
       value: context.source.target.prompt,
       input: context.inputs.createCheckboxInput
+    });
+    context.enriched = await TextEditor.enrichHTML(this.activity.description.value, {
+      relativeTo: this.activity, rollData: this.activity.getRollData(), secrets: this.activity.item.isOwner
     });
     context.placeholder = {
       name: game.i18n.localize(this.activity.metadata.title),

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -345,7 +345,7 @@ export default class ActivitySheet extends PseudoDocumentSheet {
       input: context.inputs.createCheckboxInput
     });
     context.enriched = await TextEditor.enrichHTML(this.activity.description.value, {
-      relativeTo: this.activity, rollData: this.activity.getRollData(), secrets: this.activity.item.isOwner
+      relativeTo: this.activity.item, rollData: this.activity.getRollData(), secrets: this.activity.item.isOwner
     });
     context.placeholder = {
       name: game.i18n.localize(this.activity.metadata.title),

--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -200,7 +200,7 @@ export default class ItemDataModel extends SystemDataModel {
     uses = this.hasLimitedUses && (game.user.isGM || identified) ? uses : null;
     price = game.user.isGM || identified ? price : null;
 
-    enrichmentOptions = { rollData, ...enrichmentOptions };
+    enrichmentOptions = { rollData, relative: this.parent, ...enrichmentOptions };
     const context = {
       name, type, img, price, weight, uses, school, materials,
       config: CONFIG.DND5E,
@@ -211,12 +211,13 @@ export default class ItemDataModel extends SystemDataModel {
       description: {
         value: await TextEditor.enrichHTML(
           (game.user.isGM || isIdentified ? description.value : unidentified?.description) ?? "",
-          { relativeTo: this.parent, ...enrichmentOptions }
+          enrichmentOptions
         ),
         chat: await TextEditor.enrichHTML(
-          activity?.description?.value || (isIdentified ? description.chat || (activity ? "" : description.value)
-            : unidentified?.description) || "",
-          { relativeTo: activity?.description?.value ? activity : this.parent, ...enrichmentOptions }
+          activity?.description?.value
+            || (isIdentified ? description.chat || description.value : unidentified?.description)
+            || "",
+          enrichmentOptions
         ),
         concealed: game.user.isGM && game.settings.get("dnd5e", "concealItemDescriptions") && !description.chat
       }

--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -200,7 +200,7 @@ export default class ItemDataModel extends SystemDataModel {
     uses = this.hasLimitedUses && (game.user.isGM || identified) ? uses : null;
     price = game.user.isGM || identified ? price : null;
 
-    enrichmentOptions = { rollData, relative: this.parent, ...enrichmentOptions };
+    enrichmentOptions = { rollData, relativeTo: this.parent, ...enrichmentOptions };
     const context = {
       name, type, img, price, weight, uses, school, materials,
       config: CONFIG.DND5E,

--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -214,7 +214,7 @@ export default class ItemDataModel extends SystemDataModel {
           { relativeTo: this.parent, ...enrichmentOptions }
         ),
         chat: await TextEditor.enrichHTML(
-          activity?.description?.value || (isIdentified ? description.chat || description.value
+          activity?.description?.value || (isIdentified ? description.chat || (activity ? "" : description.value)
             : unidentified?.description) || "",
           { relativeTo: activity?.description?.value ? activity : this.parent, ...enrichmentOptions }
         ),

--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -197,11 +197,10 @@ export default class ItemDataModel extends SystemDataModel {
     } = this;
     const rollData = (activity ?? this.parent).getRollData();
     const isIdentified = identified !== false;
-    const chat = isIdentified ? description.chat || description.value : unidentified?.description;
-    const desc = game.user.isGM || isIdentified ? description.value : unidentified?.description;
     uses = this.hasLimitedUses && (game.user.isGM || identified) ? uses : null;
     price = game.user.isGM || identified ? price : null;
 
+    enrichmentOptions = { rollData, ...enrichmentOptions };
     const context = {
       name, type, img, price, weight, uses, school, materials,
       config: CONFIG.DND5E,
@@ -210,12 +209,15 @@ export default class ItemDataModel extends SystemDataModel {
       tags: this.parent.labels?.components?.tags,
       subtitle: this.tooltipSubtitle.filterJoin(" • "),
       description: {
-        value: await TextEditor.enrichHTML(desc ?? "", {
-          rollData, relativeTo: this.parent, ...enrichmentOptions
-        }),
-        chat: await TextEditor.enrichHTML(chat ?? "", {
-          rollData, relativeTo: this.parent, ...enrichmentOptions
-        }),
+        value: await TextEditor.enrichHTML(
+          (game.user.isGM || isIdentified ? description.value : unidentified?.description) ?? "",
+          { relativeTo: this.parent, ...enrichmentOptions }
+        ),
+        chat: await TextEditor.enrichHTML(
+          activity?.description?.value || (isIdentified ? description.chat || description.value
+            : unidentified?.description) || "",
+          { relativeTo: activity?.description?.value ? activity : this.parent, ...enrichmentOptions }
+        ),
         concealed: game.user.isGM && game.settings.get("dnd5e", "concealItemDescriptions") && !description.chat
       }
     };

--- a/module/data/activity/_types.mjs
+++ b/module/data/activity/_types.mjs
@@ -21,6 +21,7 @@
  * @property {ConsumptionTargetData[]} consumption.targets  Collection of consumption targets.
  * @property {object} description
  * @property {string} description.chatFlavor     Extra text displayed in the activation chat message.
+ * @property {string} description.value          Full activity description displayed in chat.
  * @property {DurationData} duration             Duration of the effect.
  * @property {boolean} duration.concentration    Does this effect require concentration?
  * @property {boolean} duration.override         Override duration values inferred from item.

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -12,8 +12,8 @@ import AppliedEffectField from "./fields/applied-effect-field.mjs";
 import ConsumptionTargetsField from "./fields/consumption-targets-field.mjs";
 
 const {
-  ArrayField, BooleanField, DocumentFlagsField, DocumentIdField,
-  FilePathField, IntegerSortField, NumberField, SchemaField, StringField
+  ArrayField, BooleanField, DocumentFlagsField, DocumentIdField, FilePathField,
+  HTMLField, IntegerSortField, NumberField, SchemaField, StringField
 } = foundry.data.fields;
 
 /**
@@ -63,7 +63,8 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
         targets: new ConsumptionTargetsField()
       }),
       description: new SchemaField({
-        chatFlavor: new StringField()
+        chatFlavor: new StringField(),
+        value: new HTMLField()
       }),
       duration: new DurationField({
         concentration: new BooleanField(),

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -449,8 +449,8 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async getCardData(enrichmentOptions={}) {
-    const context = await super.getCardData(enrichmentOptions);
+  async getCardData(options) {
+    const context = await super.getCardData(options);
     context.isSpell = true;
     const { activation, components, duration, range, target } = this.parent.labels;
     context.properties = [components?.vsm, activation, duration, range, target].filter(_ => _);

--- a/system.json
+++ b/system.json
@@ -57,25 +57,33 @@
         "filePathFields": {
           "activities.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "activities.*.description.value", "description.value", "description.chat", "unidentified.description"
+        ]
       },
       "equipment": {
         "filePathFields": {
           "activities.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "activities.*.description.value", "description.value", "description.chat", "unidentified.description"
+        ]
       },
       "consumable": {
         "filePathFields": {
           "activities.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "activities.*.description.value", "description.value", "description.chat", "unidentified.description"
+        ]
       },
       "tool": {
         "filePathFields": {
           "activities.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "activities.*.description.value", "description.value", "description.chat", "unidentified.description"
+        ]
       },
       "loot": {
         "htmlFields": ["description.value", "description.chat", "unidentified.description"]
@@ -108,14 +116,14 @@
         "filePathFields": {
           "activities.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.chat"]
+        "htmlFields": ["activities.*.description.value", "description.value", "description.chat"]
       },
       "feat": {
         "filePathFields": {
           "activities.*.img": ["IMAGE"],
           "advancement.*.icon": ["IMAGE"]
         },
-        "htmlFields": ["advancement.*.hint", "description.value", "description.chat"]
+        "htmlFields": ["activities.*.description.value", "advancement.*.hint", "description.value", "description.chat"]
       },
       "container": {
         "htmlFields": ["description.value", "description.chat", "unidentified.description"]
@@ -127,7 +135,7 @@
         "filePathFields": {
           "activities.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.chat"]
+        "htmlFields": ["activities.*.description.value", "description.value", "description.chat"]
       }
     },
     "JournalEntryPage": {

--- a/templates/activity/parts/activity-identity.hbs
+++ b/templates/activity/parts/activity-identity.hbs
@@ -3,4 +3,13 @@
     {{ formField fields.name value=source.name placeholder=placeholder.name rootId=partId }}
     {{ formField fields.img value=source.img placeholder=placeholder.img rootId=partId }}
     {{ formField fields.description.fields.chatFlavor value=source.description.chatFlavor rootId=partId }}
+
+    {{!-- Description --}}
+    {{#if editable}}
+    <hr>
+    <prose-mirror name="description.value" value="{{ source.description.value }}" compact></prose-mirror>
+    {{else if enriched}}
+    <hr>
+    <div class="editor"><div class="editor-content">{{{ enriched }}}</div></div>
+    {{/if}}
 </fieldset>

--- a/templates/activity/parts/activity-identity.hbs
+++ b/templates/activity/parts/activity-identity.hbs
@@ -3,13 +3,12 @@
     {{ formField fields.name value=source.name placeholder=placeholder.name rootId=partId }}
     {{ formField fields.img value=source.img placeholder=placeholder.img rootId=partId }}
     {{ formField fields.description.fields.chatFlavor value=source.description.chatFlavor rootId=partId }}
-
     {{!-- Description --}}
     {{#if editable}}
     <hr>
-    <prose-mirror name="description.value" value="{{ source.description.value }}" compact></prose-mirror>
+    <prose-mirror class="slim" name="description.value" value="{{ source.description.value }}" compact></prose-mirror>
     {{else if enriched}}
     <hr>
-    <div class="editor"><div class="editor-content">{{{ enriched }}}</div></div>
+    <div class="editor editor-content">{{{ enriched }}}</div>
     {{/if}}
 </fieldset>

--- a/templates/chat/activity-card.hbs
+++ b/templates/chat/activity-card.hbs
@@ -1,5 +1,6 @@
 <div class="chat-card activation-card">
-    <section class="card-header description collapsible" {{#if description.concealed}}data-concealed{{/if}}>
+    <section class="card-header description {{~#if description.chat}} collapsible{{/if}}"
+             {{~#if description.concealed}} data-concealed{{/if}}>
         <header class="summary">
             <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
             <div class="name-stacked border">
@@ -8,11 +9,13 @@
                 <span class="subtitle">{{{ subtitle }}}</span>
                 {{/if}}
             </div>
-            <i class="fa-solid fa-chevron-down fa-fw" inert></i>
+            {{#if description.chat}}<i class="fa-solid fa-chevron-down fa-fw" inert></i>{{/if}}
         </header>
+        {{#if description.chat}}
         <section class="details collapsible-content card-content">
             <div class="wrapper">{{{ description.chat }}}</div>
         </section>
+        {{/if}}
     </section>
 
     {{#if buttons}}


### PR DESCRIPTION
Adds a new HTML description field to activities that is properly sanitized. When an activity is used this description is used in the chat if provided before the system fall back to the chat description and then the full description. Using the "Display in Chat" context option allows the normal item description to be shown rather than an activity description.

### Possible Future Work
- [ ] Add activity tooltips with description to actor inventory

Closes #4576