### PR TITLE
Fix activity deprecation warnings on vehicle sheet

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -267,7 +267,7 @@ export default class ActorSheet5e extends ActorSheetMixin(ActorSheet) {
     if ( largestPrimary ) {
       let primary = speeds.shift();
       return {
-        primary: `${primary?.[1]} ${units}`,
+        primary: primary ? `${primary?.[1]} ${units}` : formatLength(movement.walk ?? 0, units),
         special: speeds.map(s => s[1]).join(", ")
       };
     }

--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -52,7 +52,8 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
     context.toggleTitle = game.i18n.localize(`DND5E.${isCrewed ? "Crewed" : "Uncrewed"}`);
 
     // Handle crew actions
-    if ( (item.type === "feat") && (item.system.activation.type === "crew") ) {
+    const hasCrewedActivation = item.system.activities?.contents[0]?.activation.type === "crew";
+    if ( (item.type === "feat") && hasCrewedActivation ) {
       if ( item.system.cover === 1 ) context.cover = game.i18n.localize("DND5E.CoverTotal");
       else if ( item.system.cover === .5 ) context.cover = "½";
       else if ( item.system.cover === .75 ) context.cover = "¾";
@@ -205,10 +206,12 @@ export default class ActorSheet5eVehicle extends ActorSheet5e {
           features.equipment.items.push(item);
           break;
         case "feat":
-          const act = item.system.activation;
-          if ( !act.type || (act.type === "none") ) features.passive.items.push(item);
-          else if (act.type === "reaction") features.reactions.items.push(item);
+          const act = item.system.activities?.contents[0] ?? {};
+          if ( !act.activation?.type || (act.activation?.type === "none") ) features.passive.items.push(item);
+          else if (act.activation?.type === "reaction") features.reactions.items.push(item);
           else features.actions.items.push(item);
+          ctx.hasRecharge = item.system.uses?.recovery?.find(r => r.period === "recharge")
+            || act.uses?.recovery?.find(r => r.period === "recharge");
           break;
         case "spell":
           break;

--- a/templates/actors/parts/actor-features.hbs
+++ b/templates/actors/parts/actor-features.hbs
@@ -56,14 +56,14 @@
             <div class="item-detail item-uses">
                 {{#if item.isOnCooldown}}
                 <a class="item-action" data-action="recharge">{{item.labels.recharge}}</a>
-                {{else if item.system.recharge.value}}
+                {{else if ctx.hasRecharge}}
                 {{localize "DND5E.Charged"}}
                 {{else if ctx.hasUses}}
                 <input type="text" value="{{item.system.uses.value}}" placeholder="0" data-dtype="Number" data-name="system.uses.value">/ {{item.system.uses.max}}
                 {{/if}}
             </div>
             <div class="item-detail item-action">
-                {{#if item.system.activation.type}}
+                {{#if item.labels.activation}}
                     {{item.labels.activation}}
                 {{/if}}
             </div>


### PR DESCRIPTION
Fixes some deprecation warnings caused by vehicle sheets accessing pre-activity values. Also fixes a bug where vehicles without any movement speeds would show `undefined ft` as their movement.