### PR TITLE
[#2147] Add options to retain gear prof, languages, & resistances

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -120,6 +120,7 @@ Hooks.once("init", function() {
 
     // Adjust Wild Shape and Polymorph presets.
     DND5E.transformation.presets.wildshape.settings.keep.delete("hp");
+    DND5E.transformation.presets.wildshape.settings.keep.delete("languages");
     DND5E.transformation.presets.wildshape.settings.keep.delete("type");
     delete DND5E.transformation.presets.polymorph.settings.addTemp;
     DND5E.transformation.presets.polymorph.settings.keep.delete("hp");

--- a/lang/en.json
+++ b/lang/en.json
@@ -4042,10 +4042,16 @@
       "Features": {
         "Label": "Features"
       },
+      "GearProficiency": {
+        "Label": "Gear Proficiency"
+      },
       "Health": {
         "Label": "Hit Points & Hit Dice"
       },
       "Hint": "These details will be retained from the source actor.",
+      "Languages": {
+        "Label": "Languages"
+      },
       "Mental": {
         "Hint": "Keep intelligence, wisdom, and charisma scores.",
         "Label": "Mental Abilities"
@@ -4056,6 +4062,9 @@
       },
       "Proficiency": {
         "Label": "Proficiency Bonus"
+      },
+      "Resistances": {
+        "Label": "Damage Resistances"
       },
       "Saves": {
         "Label": "Save Proficiencies"

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3460,6 +3460,12 @@ DND5E.transformation = {
       label: "DND5E.TRANSFORM.Setting.Keep.Skills.Label",
       disables: ["merge.skills"]
     },
+    gearProf: {
+      label: "DND5E.TRANSFORM.Setting.Keep.GearProficiency.Label"
+    },
+    languages: {
+      label: "DND5E.TRANSFORM.Setting.Keep.Languages.Label"
+    },
     class: {
       label: "DND5E.TRANSFORM.Setting.Keep.Proficiency.Label"
     },
@@ -3480,6 +3486,9 @@ DND5E.transformation = {
     },
     hp: {
       label: "DND5E.TRANSFORM.Setting.Keep.Health.Label"
+    },
+    resistances: {
+      label: "DND5E.TRANSFORM.Setting.Keep.Resistances.Label"
     },
     vision: {
       label: "DND5E.TRANSFORM.Setting.Keep.Vision.Label",
@@ -3513,7 +3522,7 @@ DND5E.transformation = {
       label: "DND5E.TRANSFORM.Preset.WildShape.Label",
       settings: {
         effects: new Set(["otherOrigin", "origin", "feat", "spell", "class", "background"]),
-        keep: new Set(["bio", "class", "feats", "hp", "mental", "type"]),
+        keep: new Set(["bio", "class", "feats", "hp", "languages", "mental", "type"]),
         merge: new Set(["saves", "skills"])
       }
     },

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2951,6 +2951,16 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
         }
       }
 
+      // Keep armor, weapon, & tool proficiencies
+      if ( settings.keep.has("gearProf") ) {
+        d.system.traits.armorProf = o.system.traits.armorProf;
+        d.system.traits.weaponProf = o.system.traits.weaponProf;
+        d.system.tools = o.system.tools;
+      }
+
+      // Keep languages
+      if ( settings.keep.has("languages") ) d.system.traits.languages = o.system.traits.languages;
+
       // Keep specific items from the original data
       d.items = d.items.concat(o.items.filter(i => {
         switch ( i.type ) {
@@ -3000,6 +3010,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
       // Keep HP & HD
       if ( settings.keep.has("hp") ) d.system.attributes.hp = { ...this.system.attributes.hp };
+
+      // Keep damage resistances
+      if ( settings.keep.has("resistances") ) {
+        d.system.traits.di = o.system.traits.di;
+        d.system.traits.dr = o.system.traits.dr;
+        d.system.traits.dv = o.system.traits.dv;
+        d.system.traits.dm = o.system.traits.dm;
+      }
 
       // Add temporary hit points
       if ( settings.other.has("addTemp") ) d.system.attributes.hp.temp = target.system.attributes.hp.max;


### PR DESCRIPTION
Adds three new transformation options:
- "Gear Proficiencies": Retains armor, weapon, and tool prof
- "Languages": Retains languages and communication information
- "Resistances": Retains damage resistances, immunities, etc.

The modern Wild Shape preset gains the `languages` option.

Closes #2147