### PR TITLE
[#5410] Add minimum armor class formula during transformation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4167,6 +4167,10 @@
         "hint": "Merge these proficiencies, keeping whichever has the higher modifier.",
         "label": "Merge"
       },
+      "minimumAC": {
+        "hint": "Formula defining the armor class for the transformed creature, if the target actor's AC is not already higher.",
+        "label": "Minimum Armor Class"
+      },
       "other": {
         "label": "Other Options"
       },

--- a/module/applications/actor/transform-dialog.mjs
+++ b/module/applications/actor/transform-dialog.mjs
@@ -177,10 +177,11 @@ export default class TransformDialog extends Dialog5e {
       const config = foundry.utils.getProperty(CONFIG.DND5E.transformation, field.name);
       if ( !config?.disables?.length ) return;
       const names = config.disables.map(d => d.includes("*") ? `[name^="${d.replace("*", "")}"]` : `[name="${d}"]`);
-      const selector = `dnd5e-checkbox:is(${names.join(",")}):not([name="${field.name}"])`;
+      const selector = `:is(${names.join(",")}):not([name="${field.name}"])`;
       this.element.querySelectorAll(selector).forEach(element => {
         element.disabled = field.value;
-        if ( element.disabled ) element.checked = false;
+        if ( element.disabled && element.tagName === "DND5E-CHECKBOX" ) element.checked = false;
+        else if ( element.disabled ) element.value = "";
       });
     };
     if ( changed ) handleDisable(changed);

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3519,7 +3519,7 @@ DND5E.transformation = {
     self: {
       label: "DND5E.TRANSFORM.Setting.Keep.Self.Label",
       hint: "DND5E.TRANSFORM.Setting.Keep.Self.Hint",
-      disables: ["keep.*", "merge.*"]
+      disables: ["keep.*", "merge.*", "minimumAC", "tempFormula"]
     }
   },
   merge: {
@@ -3541,6 +3541,7 @@ DND5E.transformation = {
         effects: new Set(["otherOrigin", "origin", "feat", "spell", "class", "background"]),
         keep: new Set(["bio", "class", "feats", "hp", "mental", "type"]),
         merge: new Set(["saves", "skills"]),
+        minimumAC: "(13 + @abilities.wis.mod) * sign(@subclasses.moon.levels)",
         tempFormula: "max(@classes.druid.levels, @subclasses.moon.levels * 3)"
       }
     },

--- a/module/data/settings/transformation-setting.mjs
+++ b/module/data/settings/transformation-setting.mjs
@@ -8,6 +8,7 @@ const { BooleanField, SetField, StringField } = foundry.data.fields;
  * @property {Set<string>} effects
  * @property {Set<string>} keep
  * @property {Set<string>} merge
+ * @property {string} [minimumAC]         Formula for minimum armor class for transformed creature.
  * @property {Set<string>} other
  * @property {string} [preset]
  * @property {string} [tempFormula]       Formula for temp HP that will be added during transformation.
@@ -30,6 +31,7 @@ export default class TransformationSetting extends foundry.abstract.DataModel {
       effects: new SetField(new StringField(), { initial: () => TransformationSetting.#initial("effects") }),
       keep: new SetField(new StringField(), { initial: () => TransformationSetting.#initial("keep") }),
       merge: new SetField(new StringField(), { initial: () => TransformationSetting.#initial("merge") }),
+      minimumAC: new FormulaField({ deterministic: true }),
       other: new SetField(new StringField(), { initial: () => TransformationSetting.#initial("other") }),
       preset: new StringField({ initial: null, nullable: true }),
       tempFormula: new FormulaField({ determinstic: true }),

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2800,6 +2800,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       const tempHp = simplifyBonus(settings.tempFormula, rollData);
       if ( tempHp ) d.system.attributes.hp.temp = tempHp;
 
+      // Set armor class
+      const minimumAC = simplifyBonus(settings.minimumAC, rollData);
+      if ( minimumAC > target.system.attributes.ac.value ) {
+        d.system.attributes.ac.calc = "natural";
+        d.system.attributes.ac.flat = minimumAC;
+      }
+
       // Remove active effects
       const oEffects = foundry.utils.deepClone(d.effects);
       const originEffectIds = new Set(oEffects.filter(effect => {


### PR DESCRIPTION
Adds a formula for the minimum armor class when transforming to support Circle of the Moon Druids. For Wild Shape this formula is set to `(13 + @abilities.wis.mod) * @subclasses.moon`, which means it only applies if the character has the right subclass.

<img width="391" alt="Wild Shape Minimum AC" src="https://github.com/user-attachments/assets/5fa4bbed-63a9-41c3-994a-1c636623c893" />

Closes #5410