### PR TITLE
[#1824] Adjust how merged skills/saves are handled in transform

### DIFF
--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -159,8 +159,13 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
 
       if ( !Number.isFinite(abl.max) ) abl.max = CONFIG.DND5E.maxAbilityScore;
 
-      // If we merged saves when transforming, take the highest bonus here.
-      if ( originalSaves && abl.proficient ) abl.save.value = Math.max(abl.save, originalSaves[id].save.value);
+      // If we merged saves when transforming, take the highest bonus
+      const difference = (originalSaves?.[id].save.value ?? 0) - abl.save.value;
+      if ( originalSaves && (difference > 0) ) {
+        abl.bonuses.save = `${abl.bonuses.save ?? ""} + ${difference}`;
+        abl.saveBonus += difference;
+        abl.save.value += difference;
+      }
 
       // Deprecations.
       abl.save.toString = function() {

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -223,9 +223,6 @@ export default class CreatureTemplate extends CommonTemplate {
     skillData.ability = ability;
     const baseBonus = simplifyBonus(skillData.bonuses?.check, rollData);
 
-    // Polymorph Skill Proficiencies
-    if ( originalSkills ) skillData.value = Math.max(skillData.value, originalSkills[skillId].value);
-
     // Compute modifier
     const checkBonusAbl = simplifyBonus(abilityData?.bonuses?.check, rollData);
     skillData.effectValue = skillData.value;
@@ -235,6 +232,14 @@ export default class CreatureTemplate extends CommonTemplate {
     skillData.value = skillData.proficient = skillData.prof.multiplier;
     skillData.total = skillData.mod + skillData.bonus;
     if ( Number.isNumeric(skillData.prof.term) ) skillData.total += skillData.prof.flat;
+
+    // If we merged skills when transforming, take the highest bonus
+    const difference = (originalSkills?.[skillId].total ?? 0) - skillData.total;
+    if ( originalSkills && (difference > 0) ) {
+      skillData.bonuses.check = `${skillData.bonuses.check ?? ""} + ${difference}`;
+      skillData.bonus += difference;
+      skillData.total += difference;
+    }
 
     // Compute passive bonus
     const passive = flags.observantFeat && CONFIG.DND5E.characterFlags.observantFeat.skills.includes(skillId) ? 5 : 0;


### PR DESCRIPTION
Modifies how skills and saves are handled when they are merged during transformation to ensure the source actor's modifier is always used if it is higher than the target's modifier. This is done by calculating the difference between the two final modifiers and adding that to the save/skill bonus.

Will not take into account dice-based bonuses such as those from the Dragonmarked races in Eberron.

Closes #1824