### PR TITLE
[#5108] Preserve hidden state of token across transformation

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2854,6 +2854,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       const tokenData = d.prototypeToken;
       delete d.prototypeToken;
       tokenData.elevation = this.token.elevation;
+      tokenData.hidden = this.token.hidden;
       tokenData.rotation = this.token.rotation;
       const previousActorData = this.token.delta.toObject();
       foundry.utils.setProperty(tokenData, "flags.dnd5e.previousActorData", previousActorData);
@@ -2905,6 +2906,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       newTokenData.actorId = newActor.id;
       newTokenData.actorLink = true;
       newTokenData.elevation = t.document.elevation;
+      newTokenData.hidden = t.document.hidden;
       newTokenData.rotation = t.document.rotation;
 
       const dOriginalActor = foundry.utils.getProperty(d, "flags.dnd5e.originalActor");
@@ -3004,6 +3006,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
         const update = foundry.utils.deepClone(tokenData);
         update._id = t.id;
         update.elevation = t.document.elevation;
+        update.hidden = t.document.hidden;
         update.rotation = t.document.rotation;
         delete update.x;
         delete update.y;


### PR DESCRIPTION
Previously hidden was being applied correctly to the transformed tokens but lost when the token was reverted, and it wasn't applied to unlinked tokens during transformation.

Closes #5108