### PR TITLE
Swap to using cursor variables

### DIFF
--- a/less/elements.less
+++ b/less/elements.less
@@ -5,7 +5,7 @@
 copyable-text {
   text-decoration: underline;
   text-decoration-style: dashed;
-  cursor: pointer;
+  cursor: var(--cursor-pointer);
   &:hover, &:has(:focus-visible) {
     text-decoration-color: var(--color-shadow-primary);
     button { text-shadow: 0 0 4px var(--color-shadow-primary); }
@@ -71,7 +71,7 @@ filter-state {
   }
 
   &:not(:disabled) .indicator {
-    cursor: pointer;
+    cursor: var(--cursor-pointer);
   }
   &:focus-visible .indicator {
     outline: 2px solid var(--filter-state-focus-color);
@@ -96,7 +96,7 @@ slide-toggle {
   display: inline-block;
   width: var(--slide-toggle-width);
   height: var(--slide-toggle-height);
-  cursor: pointer;
+  cursor: var(--cursor-pointer);
 
   .slide-toggle-track {
     width: 100%;
@@ -246,7 +246,7 @@ dnd5e-icon.fa-fw {
 
 .dnd5e multi-select .tags {
   flex-wrap: wrap;
-  .tag { cursor: pointer; }
+  .tag { cursor: var(--cursor-pointer); }
 }
 
 /* ---------------------------------- */

--- a/less/v1/actors.less
+++ b/less/v1/actors.less
@@ -269,7 +269,7 @@
     font-size: var(--font-size-12);
 
     &.disabled {
-      cursor: default;
+      cursor: var(--cursor-default);
       text-shadow: none;
     }
   }
@@ -280,7 +280,7 @@
   .locked .proficiency-toggle {
     color: var(--dnd5e-color-beige);
     text-shadow: none;
-    cursor: default;
+    cursor: var(--cursor-default);
   }
 
   /* ----------------------------------------- */
@@ -385,7 +385,7 @@
       line-height: 20px;
 
       label {
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         align-items: center;
         input[type=checkbox] {
           top: unset;

--- a/less/v1/advancement.less
+++ b/less/v1/advancement.less
@@ -158,7 +158,7 @@
           padding: 0.5em;
           &:not([data-action]) {
             opacity: 33%;
-            cursor: default;
+            cursor: var(--cursor-default);
             &:hover {
               text-shadow: none;
             }

--- a/less/v1/apps.less
+++ b/less/v1/apps.less
@@ -192,7 +192,7 @@ h5 {
 
   // Rollable Titles
   .editable .rollable:hover {
-    cursor: pointer;
+    cursor: var(--cursor-pointer);
   }
   .editable h4.rollable:hover,
   .editable .rollable:hover > h4 {
@@ -723,7 +723,7 @@ h5 {
   }
 
   .item-name > label, .item-image, input {
-    cursor: pointer;
+    cursor: var(--cursor-pointer);
   }
 
   .item-name > label {
@@ -850,7 +850,7 @@ h5 {
 }
 
 .accordion-heading {
-  cursor: pointer;
+  cursor: var(--cursor-pointer);
   position: relative;
 }
 

--- a/less/v1/group.less
+++ b/less/v1/group.less
@@ -62,7 +62,7 @@
     .group-member {
       padding: 0 0.5rem;
       .name {
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         align-items: center;
         h4 {
           white-space: unset;

--- a/less/v1/inventory.less
+++ b/less/v1/inventory.less
@@ -52,7 +52,7 @@
       &[hidden] { display: none; }
 
       .item-name {
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         flex: auto;
         &.rollable:hover .item-image {
           background-image: url("../../icons/svg/d20-grey.svg") !important;

--- a/less/v1/items.less
+++ b/less/v1/items.less
@@ -41,7 +41,7 @@
         > input { display: none; }
 
         &:has(input:not([disabled])) {
-          cursor: pointer;
+          cursor: var(--cursor-pointer);
           &:hover, &:focus-visible {
             text-shadow: 0 0 4px color-mix(in oklab, var(--color-shadow-primary), transparent);
           }
@@ -612,7 +612,7 @@
     margin-block-start: 8px;
 
     > label {
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
       display: flex;
       justify-content: center;
       gap: .25rem;

--- a/less/v2/activities.less
+++ b/less/v2/activities.less
@@ -15,7 +15,7 @@
     }
 
     > label {
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
       display: flex;
       justify-content: center;
       gap: .25rem;
@@ -262,7 +262,7 @@
       border: var(--dnd5e-border-gold);
       border-radius: 3px;
       overflow: hidden;
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
 
       > img {
         pointer-events: none;

--- a/less/v2/actors.less
+++ b/less/v2/actors.less
@@ -89,7 +89,7 @@
         position: relative;
         display: flex;
         align-items: center;
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
 
         > input { position: relative; }
       }
@@ -135,7 +135,7 @@
         gap: .375rem;
 
         img {
-          cursor: pointer;
+          cursor: var(--cursor-pointer);
           flex: 0 0 32px;
           width: 32px;
           height: 32px;
@@ -332,6 +332,6 @@
   /* ---------------------------------- */
 
   &.locked {
-    .meter.sectioned > .hit-points { cursor: default; }
+    .meter.sectioned > .hit-points { cursor: var(--cursor-default); }
   }
 }

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -277,7 +277,7 @@
     .pill-lg {
       max-width: unset;
       &.empty:not(.disabled) {
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         transition: opacity 250ms ease;
         &:hover { opacity: .5; }
       }
@@ -285,7 +285,7 @@
       .name-stacked { flex: 1; }
       .control-button { padding-inline: 4px; }
       img[data-action] {
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         &:hover { box-shadow: 0 0 12px var(--dnd5e-color-gold); }
       }
     }
@@ -337,7 +337,7 @@
       align-items: baseline;
       &.selected { font-weight: bold; }
       &:not(.selected) {
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         &:hover { text-shadow: 0 0 8px var(--color-shadow-primary); }
       }
     }

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -659,7 +659,7 @@
       .deletion-control {
         width: unset;
         height: unset;
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         position: absolute;
         inset: -3px -3px 0 0;
       }
@@ -667,7 +667,7 @@
 
     .occupant-slot {
       overflow: visible;
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
 
       &.empty, &.pending {
         display: inline-grid;
@@ -897,7 +897,7 @@
     width: var(--players-width, 200px);
     background: rgb(0 0 0 / 80%);
     border: 1px solid var(--color-border-dark);
-    cursor: var(--cursor-pointer), pointer;
+    cursor: var(--cursor-pointer);
     height: 40px;
 
     &:hover {
@@ -956,7 +956,7 @@
 
 .dnd5e2.sheet {
   .locked a:not(.always-interactive) {
-    cursor: default;
+    cursor: var(--cursor-default);
     &:hover { text-shadow: unset; }
   }
 }
@@ -1406,7 +1406,7 @@ dialog.dnd5e2.application {
       justify-content: space-between;
       padding: 6px 10px;
       &:hover {
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         background: var(--dnd5e-background-parchment);
       }
     }
@@ -1750,7 +1750,7 @@ dialog.dnd5e2.application {
       display: flex;
       align-items: center;
       gap: 1rem;
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
 
       > span {
         flex: 1;
@@ -1814,7 +1814,7 @@ dialog.dnd5e2.application {
       gap: .5rem;
       padding: .5625rem .75rem;
       align-items: center;
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
       border: none;
       border-bottom: var(--border-style);
       border-right: var(--border-style);
@@ -1879,7 +1879,7 @@ dialog.dnd5e2.application {
     &.active:not(.collapsed)::after { border-color: color-mix(in oklab, var(--color-warm-2), transparent); }
 
     .group-children { padding: 0; }
-    .group-header { cursor: pointer; }
+    .group-header { cursor: var(--cursor-pointer); }
     .group-numbers {
       flex: 0 0 20px;
       color: var(--color-text-light-5);
@@ -1910,7 +1910,7 @@ dialog.dnd5e2.application {
     border: none;
     padding: 0 .75rem;
     margin: 0;
-    cursor: pointer;
+    cursor: var(--cursor-pointer);
     display: flex;
     align-items: baseline;
     line-height: 32px;

--- a/less/v2/character.less
+++ b/less/v2/character.less
@@ -272,7 +272,7 @@
           display: grid;
           place-content: center;
           background: var(--dnd5e-color-iron-gray);
-          cursor: pointer;
+          cursor: var(--cursor-pointer);
           box-shadow: 0 0 6px var(--color-shadow-dark);
 
           &:hover, &:focus { box-shadow: 0 0 6px var(--color-shadow-dark); }
@@ -308,7 +308,7 @@
         .portrait {
           position: relative;
           width: 100%;
-          cursor: pointer;
+          cursor: var(--cursor-pointer);
 
           > img {
             display: block;
@@ -421,7 +421,7 @@
               &:nth-child(2) { margin-top: 24px; }
 
               &.rollable:hover .value {
-                cursor: pointer;
+                cursor: var(--cursor-pointer);
 
                 > span { display: none; }
 
@@ -558,7 +558,7 @@
 
             &.effect {
               &:not(.suppressed){
-                cursor: pointer;
+                cursor: var(--cursor-pointer);
                 &:hover {
                   .title { text-shadow: 0 0 8px var(--color-shadow-primary); }
                   .primary i { text-shadow: 0 0 8px var(--color-shadow-primary); }
@@ -601,7 +601,7 @@
             .title { font-size: var(--font-size-13); }
 
             &.rollable {
-              cursor: pointer;
+              cursor: var(--cursor-pointer);
               &:hover .title { text-shadow: 0 0 8px var(--color-shadow-primary); }
             }
           }
@@ -824,12 +824,12 @@
       transition: box-shadow 250ms ease;
 
       &.race, &.background {
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         &:hover:not(:has(a:hover)) { box-shadow: 0 0 12px var(--dnd5e-color-gold); }
       }
 
       &.empty:not(.disabled) {
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         transition: opacity 250ms ease;
         &:hover { opacity: .5; }
       }
@@ -1163,7 +1163,7 @@
     }
   }
 
-  .spells-list .items-header .item-name { cursor: pointer; }
+  .spells-list .items-header .item-name { cursor: var(--cursor-pointer); }
 
   /* ---------------------------------- */
   /*  Biography                         */
@@ -1304,7 +1304,7 @@
     .roster ul li {
       width: 48px;
       height: 48px;
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
 
       &.empty {
         width: 100%;
@@ -1340,7 +1340,7 @@
       &.empty {
         min-height: 50px;
         color: var(--dnd5e-color-gold);
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         border-style: dashed;
         opacity: .5;
         transition: all 250ms ease;
@@ -1381,7 +1381,7 @@
         .title { font-size: var(--font-size-13); }
         .slots { flex: none; }
         .name-stacked.rollable {
-          cursor: pointer;
+          cursor: var(--cursor-pointer);
           &:hover .title { text-shadow: 0 0 8px var(--color-shadow-primary); }
         }
       }
@@ -1431,7 +1431,7 @@
       .deletion-control {
         width: unset;
         height: unset;
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         position: absolute;
         inset: -3px -3px 0 0;
       }

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -275,7 +275,7 @@
 }
 
 .dice-roll {
-  cursor: pointer;
+  cursor: var(--cursor-pointer);
 
   .dice-flavor { display: none; }
 
@@ -430,7 +430,7 @@
       }
     }
 
-    &.collapsible .summary { cursor: pointer; }
+    &.collapsible .summary { cursor: var(--cursor-pointer); }
     &.collapsed {
       .summary > i { transform: rotate(-90deg); }
       .details {
@@ -491,7 +491,7 @@
   }
 
   > label {
-    cursor: pointer;
+    cursor: var(--cursor-pointer);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -632,7 +632,7 @@
         padding: 2px;
         font-size: inherit;
         line-height: unset;
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
 
         &::after {
           content: "";
@@ -735,7 +735,7 @@ enchantment-application {
     align-items: center;
     gap: .5rem;
     padding: 0 8px;
-    cursor: pointer;
+    cursor: var(--cursor-pointer);
 
     > i { font-size: var(--font-size-14); }
 

--- a/less/v2/compendium-browser.less
+++ b/less/v2/compendium-browser.less
@@ -97,7 +97,7 @@
         align-items: center;
 
         label {
-          cursor: pointer;
+          cursor: var(--cursor-pointer);
           display: flex;
           gap: 4px;
           align-items: center;
@@ -114,7 +114,7 @@
       [data-action="toggleCollapse"] {
         width: 20px;
         margin-inline-start: auto;
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         text-align: center;
       }
     }
@@ -122,7 +122,7 @@
     [data-application-part="filters"] { gap: 8px; }
 
     .filter-header > label {
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
       display: flex;
       justify-content: center;
       gap: 4px;
@@ -161,7 +161,7 @@
 
       &.filter-set:has(> .collapsible-content > .wrapper:empty) { display: none; }
 
-      &.filter-set .filter-choice, &.filter-boolean > label { cursor: pointer; }
+      &.filter-set .filter-choice, &.filter-boolean > label { cursor: var(--cursor-pointer); }
 
       &.filter-set .wrapper {
         display: flex;
@@ -325,7 +325,7 @@
       font-family: var(--dnd5e-font-roboto-condensed);
       border: none;
       padding: 0;
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
 
       &:hover { text-shadow: 0 0 6px var(--color-shadow-primary); }
 

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -66,7 +66,7 @@
       font-weight: bold;
     }
     &:disabled {
-      cursor: default;
+      cursor: var(--cursor-default);
       color: var(--color-text-dark-inactive);
     }
     &:hover:not(:disabled), &:focus {
@@ -168,12 +168,12 @@
   }
 
   label.checkbox {
-    cursor: pointer;
+    cursor: var(--cursor-pointer);
     display: flex;
     align-items: center;
     gap: 4px;
 
-    &:has(input[type=checkbox]:disabled, dnd5e-checkbox[disabled]) { cursor: default; }
+    &:has(input[type=checkbox]:disabled, dnd5e-checkbox[disabled]) { cursor: var(--cursor-default); }
     > span { line-height: calc(var(--form-field-height) + 1px); }
   }
 
@@ -434,11 +434,11 @@
 
   select {
     height: var(--form-field-height);
-    &:not(:disabled) { cursor: pointer; }
+    &:not(:disabled) { cursor: var(--cursor-pointer); }
   }
 
   :is(document-tags, multi-select) .tags.input-element-tags .tag {
-    cursor: pointer;
+    cursor: var(--cursor-pointer);
     font-size: var(--font-size-10);
     border: var(--dnd5e-border-gold);
     background: var(--dnd5e-background-card);
@@ -447,8 +447,8 @@
   }
 
   :is(document-tags, multi-select):has(select:disabled) .tags.input-element-tags .tag {
-    cursor: default;
-    a { cursor: default; }
+    cursor: var(--cursor-default);
+    a { cursor: var(--cursor-default); }
     &:hover a { text-shadow: none; }
     .remove { display: unset; }
     .fa-xmark { display: none; }
@@ -554,7 +554,7 @@
     display: block;
 
     > input { display: none; }
-    &:has(input:not([disabled])) { cursor: pointer; }
+    &:has(input:not([disabled])) { cursor: var(--cursor-pointer); }
   }
 
   /* Control buttons */

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -118,7 +118,7 @@
         &:not(h3) { padding: .25rem; }
 
         &.rollable {
-          cursor: pointer;
+          cursor: var(--cursor-pointer);
           &:hover .title { text-shadow: 0 0 8px var(--color-shadow-primary); }
         }
 
@@ -592,7 +592,7 @@
       margin: 0;
       padding: 4px;
       align-items: center;
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
     }
     input {
       flex: unset;

--- a/less/v2/items.less
+++ b/less/v2/items.less
@@ -359,7 +359,7 @@
 
       &.collapsible {
         > .header {
-          cursor: pointer;
+          cursor: var(--cursor-pointer);
 
           &::before {
             content: "\f078";
@@ -658,7 +658,7 @@
       inset-block: 0;
       inset-inline-end: 0;
       inline-size: 16px;
-      cursor: grab;
+      cursor: var(--cursor-grab);
       color: var(--dnd5e-color-faint);
     }
     [data-action="delete-entry"] {

--- a/less/v2/npc.less
+++ b/less/v2/npc.less
@@ -120,7 +120,7 @@
         font-family: var(--dnd5e-font-roboto);
         font-size: var(--font-size-18);
         text-shadow: 0 0 4px var(--dnd5e-color-gold);
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
         border-radius: 100%;
         color: var(--color-text-light-0);
         border: 2px solid var(--dnd5e-color-gold);
@@ -414,7 +414,7 @@
         font-weight: bold;
 
         &.rollable {
-          cursor: pointer;
+          cursor: var(--cursor-pointer);
           &:hover .save { text-shadow: 0 0 8px var(--color-shadow-primary); }
         }
 
@@ -780,7 +780,7 @@
           display: grid;
           select {
             background: var(--dnd5e-background-5);
-            &:hover { cursor: pointer; }
+            &:hover { cursor: var(--cursor-pointer); }
           }
         }
 

--- a/module/applications/components/checkbox.mjs
+++ b/module/applications/components/checkbox.mjs
@@ -33,14 +33,14 @@ export default class CheckboxElement extends AdoptedStyleSheetMixin(
   /** @override */
   static CSS = `
     :host {
-      cursor: pointer;
+      cursor: var(--cursor-pointer);
       display: inline-block;
       width: var(--checkbox-size, 18px);
       height: var(--checkbox-size, 18px);
       aspect-ratio: 1;
     }
 
-    :host(:disabled) { cursor: default; }
+    :host(:disabled) { cursor: var(--cursor-default); }
 
     :host > div {
       width: 100%;

--- a/module/applications/components/proficiency-cycle.mjs
+++ b/module/applications/components/proficiency-cycle.mjs
@@ -21,7 +21,7 @@ export default class ProficiencyCycleElement extends AdoptedStyleSheetMixin(
     :host { display: inline-block; }
     div { --_fill: var(--proficiency-cycle-enabled-color, var(--dnd5e-color-blue)); }
     div:has(:disabled, :focus-visible) { --_fill: var(--proficiency-cycle-disabled-color, var(--dnd5e-color-gold)); }
-    div:not(:has(:disabled)) { cursor: pointer; }
+    div:not(:has(:disabled)) { cursor: var(--cursor-pointer); }
 
     div {
       position: relative;


### PR DESCRIPTION
Swaps out everything except for uses of `cursor: help` and `cursor: not-allowed` which aren't supported as custom types.