### PR TITLE
[#5445] Add Scaling References to Activities Configuration Section

### DIFF
--- a/wiki/Activities.md
+++ b/wiki/Activities.md
@@ -30,7 +30,12 @@ There are a variety of activity types offered by the DnD5e system, and modules c
 
 ## Configuring Activities
 
-While parts of the activity sheet change based on the selected activity type, many parts are shared.
+While parts of the activity sheet change based on the selected activity type, many parts are shared. Some configurations, such as those in the **Consumption** or **Effect** tabs, allow for the use of scaling to dynamically adjust an activity's behavior based on contextual factors like spell level or item properties.
+
+For more information and examples of how scaling can be used, see:
+- [Roll Formulas - Scaling](Roll-Formulas.md#scale)
+- [Roll Formulas - Item Properties](Roll-Formulas.md#item-properties)
+- [Scale Value Advancements](Advancement-Type-Scale-Value.md)
 
 ### Identity
 


### PR DESCRIPTION
### **Description**

#### **What Prompted the Issue**
An issue #5445 was raised regarding the lack of clarity in the Activities.md wiki page about how scaling can be used in activity configurations. While the page mentions scaling in certain contexts, it does not provide sufficient guidance or references for users to understand how to implement scaling effectively. This led to confusion, requiring users to search through other documentation or external resources (e.g., Discord) to find the necessary information.

#### **How We Addressed It**
To resolve this, we updated the **Configuring Activities** section of the Activities.md file to include references to relevant documentation that explains scaling in detail. Specifically:
- Added a note that some configurations, such as those in the **Consumption** or **Effect** tabs, allow for the use of scaling.
- Provided direct links to the following resources for more information and examples:
  - Roll Formulas - Scaling
  - Roll Formulas - Item Properties
  - Scale Value Advancements

This approach avoids duplicating content while ensuring users can easily find the information they need to understand and use scaling effectively.