### PR TITLE
[#5130] Adjust passive skills based on roll mode

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -273,10 +273,14 @@ preLocalize("skills", { key: "label", sort: true });
 /* -------------------------------------------- */
 
 /**
- * Amount by which the passive skill scores are modified when that skill has advantage or disadvantage.
- * @type {number}
+ * Base passive score and the amount by which the passive skill scores are modified when that skill has
+ * advantage or disadvantage.
+ * @type {{ base: number, modifier: number }}
  */
-DND5E.skillAdvantageModifier = 5;
+DND5E.skillPassive = {
+  base: 10,
+  modifier: 5
+};
 
 /* -------------------------------------------- */
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -273,6 +273,14 @@ preLocalize("skills", { key: "label", sort: true });
 /* -------------------------------------------- */
 
 /**
+ * Amount by which the passive skill scores are modified when that skill has advantage or disadvantage.
+ * @type {number}
+ */
+DND5E.skillAdvantageModifier = 5;
+
+/* -------------------------------------------- */
+
+/**
  * Character alignment options.
  * @enum {string}
  */

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -400,7 +400,7 @@ export default class AttributesFields {
     init.total = init.mod + initBonus + abilityBonus + globalCheckBonus
       + (flags.initiativeAlert && isLegacy ? 5 : 0)
       + (Number.isNumeric(init.prof.term) ? init.prof.flat : 0);
-    init.score = 10 + init.total + (init.roll.mode * 5);
+    init.score = CONFIG.DND5E.skillPassive.base + init.total + (init.roll.mode * CONFIG.DND5E.skillPassive.modifier);
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -255,8 +255,8 @@ export default class CreatureTemplate extends CommonTemplate {
     const advantageMode = AdvantageModeField.combineFields(this, [
       `abilities.${ability}.check.roll.mode`, `skills.${skillId}.roll.mode`
     ])?.mode ?? 0;
-    skillData.passive = 10 + skillData.mod + skillData.bonus + skillData.prof.flat
-      + passive + passiveBonus + (advantageMode * CONFIG.DND5E.skillAdvantageModifier);
+    skillData.passive = CONFIG.DND5E.skillPassive.base + skillData.mod + skillData.bonus + skillData.prof.flat
+      + passive + passiveBonus + (advantageMode * CONFIG.DND5E.skillPassive.modifier);
 
     return skillData;
   }

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -1,4 +1,5 @@
 import { simplifyBonus } from "../../../utils.mjs";
+import AdvantageModeField from "../../fields/advantage-mode-field.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 import MappingField from "../../fields/mapping-field.mjs";
 import RollConfigField from "../../shared/roll-config-field.mjs";
@@ -251,7 +252,11 @@ export default class CreatureTemplate extends CommonTemplate {
     // Compute passive bonus
     const passive = flags.observantFeat && CONFIG.DND5E.characterFlags.observantFeat.skills.includes(skillId) ? 5 : 0;
     const passiveBonus = simplifyBonus(skillData.bonuses?.passive, rollData);
-    skillData.passive = 10 + skillData.mod + skillData.bonus + skillData.prof.flat + passive + passiveBonus;
+    const advantageMode = AdvantageModeField.combineFields(this, [
+      `abilities.${ability}.check.roll.mode`, `skills.${skillId}.roll.mode`
+    ])?.mode ?? 0;
+    skillData.passive = 10 + skillData.mod + skillData.bonus + skillData.prof.flat
+      + passive + passiveBonus + (advantageMode * CONFIG.DND5E.skillAdvantageModifier);
 
     return skillData;
   }


### PR DESCRIPTION
Increases or decreases passive ability scores by `5` depending on whether the skill has advantage or disadvantage. Adds an option to `CONFIG` to set this value.

### Todo
- [x] Adjust the initiative bonus to use the new config option once https://github.com/foundryvtt/dnd5e/pull/5128 is merged

Closes #5130