### PR TITLE
[#5172] Apply disadvantage based on certain conditions

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3954,6 +3954,10 @@ DND5E.conditionEffects = {
   crawl: new Set(["prone", "exceedingCarryingCapacity"]),
   petrification: new Set(["petrified"]),
   halfHealth: new Set(["exhaustion-4"]),
+  abilityCheckDisadvantage: new Set(["poisoned", "exhaustion-1"]),
+  abilitySaveDisadvantage: new Set(["exhaustion-3"]),
+  attackDisadvantage: new Set(["poisoned", "exhaustion-3"]),
+  dexteritySaveDisadvantage: new Set(["restrained"]),
   initiativeAdvantage: new Set(["invisible"]),
   initiativeDisadvantage: new Set(["incapacitated", "surprised"])
 };

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -175,6 +175,11 @@ export default class AttributesFields {
       return obj;
     }, { armors: [], shields: [] });
 
+    // Set stealth disadvantage
+    if ( armors[0]?.system.properties.has("stealthDisadvantage") ) {
+      AdvantageModeField.setMode(this, "skills.ste.roll.mode", -1);
+    }
+
     // Determine base AC
     switch ( ac.calc ) {
 


### PR DESCRIPTION
Adds disadvantage based on system conditions:
- Checks: Exhaustion 1 (legacy only) & poisoned
- Saves: Exhaustion 3 (legacy only)
- Attacks: Exhaustion 3 (legacy only) & poisoned (attack roll mode isn't currently functional pending #5176)
- Dex Saves: Restrained

Also applies disadvantage to stealth checks if the equipped armor has the "Stealth Disadvantage" flag.

Closes #5172