### PR TITLE
[#5338] Add modifier combinations for forcing advantage mode

### DIFF
--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -118,11 +118,15 @@ export default class D20Roll extends BasicRoll {
 
     // Determine advantage mode
     for ( const roll of config.rolls ?? [] ) {
-      const advantage = roll.options.advantage || config.advantage || keys.advantage;
-      const disadvantage = roll.options.disadvantage || config.disadvantage || keys.disadvantage;
-      if ( advantage && !disadvantage ) roll.options.advantageMode = this.ADV_MODE.ADVANTAGE;
-      else if ( !advantage && disadvantage ) roll.options.advantageMode = this.ADV_MODE.DISADVANTAGE;
-      else roll.options.advantageMode = this.ADV_MODE.NORMAL;
+      if ( keys.normal && keys.advantage ) roll.options.advantageMode = this.ADV_MODE.ADVANTAGE;
+      else if ( keys.normal && keys.disadvantage ) roll.options.advantageMode = this.ADV_MODE.DISADVANTAGE;
+      else {
+        const advantage = roll.options.advantage || config.advantage || keys.advantage;
+        const disadvantage = roll.options.disadvantage || config.disadvantage || keys.disadvantage;
+        if ( advantage && !disadvantage ) roll.options.advantageMode = this.ADV_MODE.ADVANTAGE;
+        else if ( !advantage && disadvantage ) roll.options.advantageMode = this.ADV_MODE.DISADVANTAGE;
+        else roll.options.advantageMode = this.ADV_MODE.NORMAL;
+      }
     }
   }
 


### PR DESCRIPTION
Adds two new combinations of modifier keys to support forcing a roll to be with advantage or disadvantage, leading to six final combinations:
- `shift`: Fast forward with current advantage mode
- `alt`: Fast forward with added source of advantage
- `control`: Fast forward with added source of disadvantage
- `shift` + `alt`: Fast forward with forced advantage **(new)**
- `shift` + `control`: Fast forward with forced disadvantage **(new)**
- `alt` + `control`: Fast forward with flat roll

Closes #5338