### PR TITLE
Corrects white "border" on some darkmode tables.

### DIFF
--- a/less/v2/dark/journal.less
+++ b/less/v2/dark/journal.less
@@ -10,6 +10,7 @@
     table {
       --row-color: var(--dnd5e-color-iron-gray);
       border-color: var(--dnd5e-color-blue-gray-1);
+      background: var(--dnd5e-color-blue-gray-1);
 
       thead {
         border-color: var(--dnd5e-color-blue-gray-1);


### PR DESCRIPTION
Done via setting the background color of the table to the same background blue-gray-1 color.

Before
![image](https://github.com/user-attachments/assets/19583cd2-3b7c-4a7b-a633-36459802f607)

After
![image](https://github.com/user-attachments/assets/4d22b85c-2604-4242-8f96-1328b3290d8a)

