### PR TITLE
[#5483] Add stat blocks formatted for 2014 rules

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1132,6 +1132,7 @@
     "FastForwardHint": "<kbd>Shift</kbd> + <left-click> the item to skip this dialog"
   }
 },
+"DND5E.Challenge": "Challenge",
 "DND5E.ChallengeRating": "Challenge Rating",
 "DND5E.Charged": "Charged",
 "DND5E.Charges": "Charges",

--- a/less/v2/typography.less
+++ b/less/v2/typography.less
@@ -178,19 +178,39 @@
   }
 
   /* NPC Stat Blocks */
-  .double-column .statblock {
+  .double-column .statblock.npc {
     max-width: calc(var(--dnd5e-statblock-column-width) * 2);
     .statblock-content { columns: 2; }
   }
 
   .statblock {
     max-width: var(--dnd5e-statblock-column-width);
-    background: var(--dnd5e-statblock-background);
+    background: var(--dnd5e-statblock-background-plain);
     border: 3px double var(--dnd5e-statblock-border);
     border-radius: 8px;
     padding-block: 4px;
     padding-inline: 8px;
     box-shadow: 2px 2px 2px var(--dnd5e-shadow-15);
+
+    &.rules-2014 {
+      position: relative;
+      margin-inline: 2px;
+      border: none;
+      border-radius: 0;
+      background: var(--dnd5e-statblock-background-parchment);
+      box-shadow: 0 0 6px var(--dnd5e-shadow-15);
+
+      &::before, &::after {
+        content: "";
+        position: absolute;
+        background: var(--dnd5e-statblock-scroll);
+        border: 1px solid var(--dnd5e-statblock-border);
+        inset-inline: -2px;
+        block-size: 5px;
+      }
+      &::before { inset-block-start: -5px; }
+      &::after { inset-block-end: -5px; }
+    }
 
     .statblock-title,
     .statblock-actions-title {
@@ -214,6 +234,13 @@
         text-decoration: none;
       }
     }
+    &.rules-2014 .statblock-title {
+      margin-block-end: 0;
+      border: none;
+      color: var(--dnd5e-statblock-text-header);
+      font-size: var(--font-size-24);
+      font-weight: normal;
+    }
     .statblock-actions-title {
       margin-block-start: 8px;
       color: var(--dnd5e-statblock-text-header);
@@ -223,6 +250,10 @@
     .statblock-tags {
       color: var(--dnd5e-statblock-text-secondary);
       font-style: italic;
+    }
+    &.rules-2014 .statblock-tags {
+      color: var(--dnd5e-statblock-text-primary);
+      font-size: var(--font-size-13);
     }
 
     .statblock-content { column-width: var(--dnd5e-statblock-column-width); }
@@ -250,45 +281,77 @@
           font-weight: bold;
         }
       }
-      .abilities {
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
-        gap: 6px;
+    }
+    &.rules-2014 .statblock-header { margin-block-start: 8px;}
+    &.rules-2024 .abilities {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 6px;
 
-        table, thead, tbody, tr, th, td { all: revert; }
-        table { border-collapse: collapse; }
+      table, thead, tbody, tr, th, td { all: revert; }
+      table { border-collapse: collapse; }
 
-        thead th {
-          color: var(--dnd5e-statblock-text-secondary);
-          font-family: var(--dnd5e-font-roboto);
-          font-size: var(--font-size-10);
-          font-weight: normal;
-          text-transform: uppercase;
+      thead th {
+        color: var(--dnd5e-statblock-text-secondary);
+        font-family: var(--dnd5e-font-roboto);
+        font-size: var(--font-size-10);
+        font-weight: normal;
+        text-transform: uppercase;
 
-          &.visually-hidden {
-            clip: rect(0 0 0 0);
-            clip-path: inset(50%);
-            font-size: 1px;
-            overflow: hidden;
-            white-space: nowrap;
-          }
-        }
-        tbody {
-          tr {
-            border-block: 1px solid var(--dnd5e-statblock-ability-border);
-            &:nth-of-type(odd) {
-              th, .score { background: var(--dnd5e-statblock-ability-header-1st); }
-              td { background: var(--dnd5e-statblock-ability-stat-1st); }
-            }
-            &:nth-of-type(even) {
-              th, .score { background: var(--dnd5e-statblock-ability-header-2nd); }
-              td { background: var(--dnd5e-statblock-ability-stat-2nd); }
-            }
-          }
-          th { font-variant: small-caps; }
-          td { text-align: center; }
+        &.visually-hidden {
+          clip: rect(0 0 0 0);
+          clip-path: inset(50%);
+          font-size: 1px;
+          overflow: hidden;
+          white-space: nowrap;
         }
       }
+      tbody {
+        tr {
+          border-block: 1px solid var(--dnd5e-statblock-ability-border);
+          &:nth-of-type(odd) {
+            th, .score { background: var(--dnd5e-statblock-ability-header-1st); }
+            td { background: var(--dnd5e-statblock-ability-stat-1st); }
+          }
+          &:nth-of-type(even) {
+            th, .score { background: var(--dnd5e-statblock-ability-header-2nd); }
+            td { background: var(--dnd5e-statblock-ability-stat-2nd); }
+          }
+        }
+        th { font-variant: small-caps; }
+        td { text-align: center; }
+      }
+    }
+    &.rules-2014 .abilities {
+      display: flex;
+      > .ability {
+        flex: 1 0;
+        display: flex;
+        flex-direction: column;
+        text-align: center;
+        .name {
+          text-transform: uppercase;
+          font-weight: bold;
+        }
+      }
+    }
+    &.rules-2014 :is(.statblock-header, .abilities) {
+      position: relative;
+      padding-block: 4px;
+
+      &::before, &::after {
+        content: "";
+        position: absolute;
+        display: block;
+        height: 6px;
+        inset-inline: 0;
+        background: var(--dnd5e-statblock-separator);
+        clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+      }
+      &::before { inset-block-start: 0; }
+      &::after { inset-block-end: 0; }
+
+      &.abilities { padding-block: 12px; }
     }
 
     .statblock-actions {

--- a/less/v2/typography.less
+++ b/less/v2/typography.less
@@ -265,7 +265,9 @@
       dl {
         display: flex;
         flex-wrap: wrap;
+        margin: 0.5em 0;
 
+        dd { margin-inline-start: 4px; }
         > div {
           flex: 1 0 100%;
           &.half-width { flex: 1 0 50%; }

--- a/less/variables/dark.less
+++ b/less/variables/dark.less
@@ -186,13 +186,16 @@
   table { --table-background-color: var(--dnd5e-color-blue-gray-1); }
 
   /* Statblocks */
-  --dnd5e-statblock-background: rgb(0 0 0 / .35);
+  --dnd5e-statblock-background-plain: rgb(0 0 0 / .35);
+  --dnd5e-statblock-background-parchment: rgb(0 0 0 / .35);
   --dnd5e-statblock-ability-border: black;
   --dnd5e-statblock-ability-header-1st: rgb(83, 73, 50);
   --dnd5e-statblock-ability-header-2nd: rgb(62, 68, 48);
   --dnd5e-statblock-ability-stat-1st: rgb(89, 63, 63);
   --dnd5e-statblock-ability-stat-2nd: rgb(89, 67, 87);
   --dnd5e-statblock-border: var(--dnd5e-color-blue-gray-1);
+  --dnd5e-statblock-scroll: rgb(135 51 44);
+  --dnd5e-statblock-separator: rgb(135 51 44);
   --dnd5e-statblock-text-header: var(--color-text-primary);
   --dnd5e-statblock-text-primary: var(--color-text-primary);
   --dnd5e-statblock-text-secondary: color-mix(in oklab, var(--color-text-primary), transparent 25%);

--- a/less/variables/light.less
+++ b/less/variables/light.less
@@ -180,13 +180,16 @@
   table { --table-background-color: var(--dnd5e-color-card); }
 
   /* Statblocks */
-  --dnd5e-statblock-background: rgb(235 228 214 / .35);
+  --dnd5e-statblock-background-plain: rgb(235 228 214 / .35);
+  --dnd5e-statblock-background-parchment: rgb(253 242 205 / .5);
   --dnd5e-statblock-ability-border: white;
   --dnd5e-statblock-ability-header-1st: rgb(234 229 217);
   --dnd5e-statblock-ability-header-2nd: rgb(215 217 208);
   --dnd5e-statblock-ability-stat-1st: rgb(218 211 203);
   --dnd5e-statblock-ability-stat-2nd: rgb(205 201 201);
   --dnd5e-statblock-border: rgb(78 76 74);
+  --dnd5e-statblock-scroll: rgb(237 191 100);
+  --dnd5e-statblock-separator: rgb(135 51 44);
   --dnd5e-statblock-text-header: rgb(79 29 21);
   --dnd5e-statblock-text-primary: rgb(31, 30, 30);
   --dnd5e-statblock-text-secondary: rgb(73 72 73 / .75);

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -180,6 +180,8 @@ export default class AttributesFields {
       AdvantageModeField.setMode(this, "skills.ste.roll.mode", -1);
     }
 
+    ac.label = !["custom", "flat"].includes(ac.calc) ? CONFIG.DND5E.armorClasses[ac.calc]?.label : null;
+
     // Determine base AC
     switch ( ac.calc ) {
 
@@ -206,6 +208,8 @@ export default class AttributesFields {
           ac.equippedArmor = armors[0];
         }
         else ac.dex = this.abilities.dex?.mod ?? 0;
+
+        if ( !ac.equippedArmor ) ac.label = null;
 
         rollData.attributes.ac = ac;
         try {

--- a/templates/actors/embeds/npc-embed.hbs
+++ b/templates/actors/embeds/npc-embed.hbs
@@ -1,28 +1,9 @@
-<div class="statblock npc">
+<div class="statblock npc rules-{{ rulesVersion }}">
     <h4 class="statblock-title">{{#if anchor}}{{{ anchor }}}{{else}}{{ name }}{{/if}}</h4>
     <span class="statblock-tags">{{ summary.tag }}</span>
     <div class="statblock-content">
         <div class="statblock-header">
-            <dl>
-                <div class="half-width">
-                    <dt>{{ localize "DND5E.AC" }}</dt>
-                    <dd>{{ system.attributes.ac.value }}</dd>
-                </div>
-                <div class="half-width">
-                    <dt>{{ localize "DND5E.Initiative" }}</dt>
-                    <dd>{{ summary.initiative }}</dd>
-                </div>
-                <div>
-                    <dt>{{ localize "DND5E.HP" }}</dt><dd>{{ system.attributes.hp.max }}</dd>
-                    {{~#if system.attributes.hp.formula~}}
-                    <dd>({{ system.attributes.hp.formula }})</dd>
-                    {{~/if~}}
-                </div>
-                <div>
-                    <dt>{{ localize "DND5E.Speed" }}</dt>
-                    <dd>{{ summary.speed }}</dd>
-                </div>
-            </dl>
+            {{> ".definitionList" entries=definitions.upper }}
             <div class="abilities">
                 {{#each abilityTables}}
                 <table>
@@ -45,56 +26,20 @@
                         {{/each}}
                     </tbody>
                 </table>
+                {{else}}
+                {{#each system.abilities}}
+                <div class="ability">
+                    <span class="name">{{ lookup (lookup @root.CONFIG.abilities @key) "abbreviation" }}</span>
+                    <span class="score">{{ dnd5e-numberFormat value }} ({{ dnd5e-numberFormat mod signDisplay="always" }})</span>
+                </div>
+                {{/each}}
                 {{/each}}
             </div>
-            <dl>
-                {{#if summary.skills}}
-                <div>
-                    <dt>{{ localize "DND5E.Skills" }}</dt>
-                    <dd>{{ summary.skills }}</dd>
-                </div>
-                {{/if}}
-                {{#if summary.gear}}
-                <div>
-                    <dt>{{ localize "DND5E.Gear" }}</dt>
-                    <dd>{{ summary.gear }}</dd>
-                </div>
-                {{/if}}
-                {{#if summary.vulnerabilities}}
-                <div>
-                    <dt>{{ localize "DND5E.Vulnerabilities" }}</dt>
-                    <dd>{{ summary.vulnerabilities }}</dd>
-                </div>
-                {{/if}}
-                {{#if summary.resistances}}
-                <div>
-                    <dt>{{ localize "DND5E.Resistances" }}</dt>
-                    <dd>{{ summary.resistances }}</dd>
-                </div>
-                {{/if}}
-                {{#if summary.immunities}}
-                <div>
-                    <dt>{{ localize "DND5E.Immunities" }}</dt>
-                    <dd>{{ summary.immunities }}</dd>
-                </div>
-                {{/if}}
-                <div>
-                    <dt>{{ localize "DND5E.Senses" }}</dt>
-                    <dd>{{ summary.senses }}</dd>
-                </div>
-                <div>
-                    <dt>{{ localize "DND5E.Languages" }}</dt>
-                    <dd>{{ summary.languages }}</dd>
-                </div>
-                <div>
-                    <dt>{{ localize "DND5E.AbbreviationCR" }}</dt>
-                    <dd>{{ summary.cr }}</dd>
-                </div>
-            </dl>
+            {{> ".definitionList" entries=definitions.lower }}
         </div>
         {{#each actionSections}}
         <div class="statblock-actions {{ @key }}">
-            <h5 class="statblock-actions-title">{{ label }}</h5>
+            {{#unless hideLabel}}<h5 class="statblock-actions-title">{{ label }}</h5>{{/unless}}
             {{{ description }}}
             {{#each actions}}
             <div class="statblock-action">
@@ -107,3 +52,14 @@
         {{/each}}
     </div>
 </div>
+
+{{#*inline ".definitionList" }}
+<dl>
+    {{#each entries}}
+    <div {{~#if classes}} class="{{ classes }}"{{/if}}>
+        <dt>{{ localize label }}</dt>
+        {{~#each definitions}}{{#unless (eq this undefined)}}<dd>{{ this }}</dd>{{/unless}}{{/each}}
+    </div>
+    {{/each}}
+</dl>
+{{/inline}}


### PR DESCRIPTION
Modifies the embed template to move the definition lists into the context rather than the template to support different lists on the two different styles of stat blocks. Then apply different styling depending on what rules version is selected.

<img width="842" alt="Stat Block 2014 vs 2024" src="https://github.com/user-attachments/assets/059aa056-4b6c-4a30-a267-5b59f69ae945" />

The styling is near the 2014 versions, but the background and borders are missing some of the texture that is present in the official designs.

Also adds `attributes.ac.label` which is used when displaying the stat block.

Closes #5483