### PR TITLE
Miscellaneous SRD upgrades

### DIFF
--- a/packs/_source/items/trinket/talisman-of-the-sphere.json
+++ b/packs/_source/items/trinket/talisman-of-the-sphere.json
@@ -1,11 +1,11 @@
 {
   "_id": "46ikeR4RrSim6DsN",
   "name": "Talisman of the Sphere",
-  "type": "consumable",
+  "type": "equipment",
   "img": "icons/commodities/treasure/broach-jeweled-pink.webp",
   "system": {
     "description": {
-      "value": "<p><em>Wondrous item, (requires attunement)</em></p>\n<p>When you make an Intelligence (Arcana) check to control a Sphere of Annihilation while you are holding this talisman, you double your proficiency bonus on the check. In addition, when you start your turn with control over a Sphere of Annihilation, you can use an action to levitate it 10 feet plus a number of additional feet equal to 10 × your Intelligence modifier.</p>",
+      "value": "<p><em>Wondrous item, (requires attunement)</em></p><p>When you make an Intelligence (Arcana) check to control a Sphere of Annihilation while you are holding this talisman, you double your proficiency bonus on the check. In addition, when you start your turn with control over a Sphere of Annihilation, you can use an action to levitate it 10 feet plus a number of additional feet equal to 10 × your Intelligence modifier.</p><p>[[10 + 10 * @abilities.int.mod]]{Total distance} feet</p>",
       "chat": ""
     },
     "source": {
@@ -53,7 +53,7 @@
       "replace": false
     },
     "type": {
-      "value": "trinket",
+      "value": "wondrous",
       "subtype": ""
     },
     "unidentified": {
@@ -88,7 +88,7 @@
         "duration": {
           "concentration": false,
           "value": "",
-          "units": "",
+          "units": "inst",
           "special": "",
           "override": false
         },
@@ -120,13 +120,23 @@
         },
         "check": {
           "ability": "int",
-          "dc": {}
+          "dc": {
+            "calculation": "",
+            "formula": "25"
+          },
+          "associated": [
+            "arc"
+          ]
         },
         "uses": {
           "spent": 0,
-          "recovery": []
+          "recovery": [],
+          "max": ""
         },
-        "sort": 0
+        "sort": 0,
+        "name": "Control Check",
+        "img": "",
+        "appliedEffects": []
       }
     },
     "attuned": false,
@@ -138,14 +148,21 @@
   "ownership": {
     "default": 0
   },
-  "flags": {},
+  "flags": {
+    "dnd5e": {
+      "riders": {
+        "activity": [],
+        "effect": []
+      }
+    }
+  },
   "_stats": {
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1725037098121,
-    "modifiedTime": 1725992483211,
+    "modifiedTime": 1744317421044,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!46ikeR4RrSim6DsN"

--- a/packs/_source/monsterfeatures/legendary-resistance.json
+++ b/packs/_source/monsterfeatures/legendary-resistance.json
@@ -34,19 +34,15 @@
         "activation": {
           "type": "special",
           "value": null,
-          "condition": "",
+          "condition": "fails a saving throw",
           "override": false
         },
         "consumption": {
           "targets": [
             {
               "type": "attribute",
-              "target": "",
               "value": "1",
-              "scaling": {
-                "mode": "",
-                "formula": ""
-              }
+              "target": "resources.legres.value"
             }
           ],
           "scaling": {
@@ -61,13 +57,13 @@
         "duration": {
           "concentration": false,
           "value": "",
-          "units": "",
+          "units": "inst",
           "special": "",
           "override": false
         },
         "effects": [],
         "range": {
-          "units": "",
+          "units": "self",
           "special": "",
           "override": false
         },
@@ -83,7 +79,7 @@
           },
           "affects": {
             "count": "",
-            "type": "",
+            "type": "self",
             "choice": false,
             "special": ""
           },
@@ -101,17 +97,29 @@
           "prompt": false,
           "visible": false
         },
-        "sort": 0
+        "sort": 0,
+        "name": "Expend Use",
+        "img": "systems/dnd5e/icons/svg/monster.svg",
+        "appliedEffects": []
       }
     },
     "enchant": {},
     "prerequisites": {
       "level": null
     },
-    "properties": [],
+    "properties": [
+      "trait"
+    ],
     "identifier": "legendary-resistance"
   },
-  "flags": {},
+  "flags": {
+    "dnd5e": {
+      "riders": {
+        "activity": [],
+        "effect": []
+      }
+    }
+  },
   "img": "icons/equipment/shield/kite-wooden-oak-glow.webp",
   "effects": [],
   "folder": null,
@@ -120,9 +128,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1725304968656,
-    "modifiedTime": 1725992571943,
+    "modifiedTime": 1744318649828,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!items!J1NxNTJ2qi05iAFF"

--- a/packs/_source/monsters/beast/ape.json
+++ b/packs/_source/monsters/beast/ape.json
@@ -69,8 +69,8 @@
       "hp": {
         "value": 19,
         "max": 19,
-        "temp": 0,
-        "tempmax": 0,
+        "temp": null,
+        "tempmax": null,
         "formula": "3d8 + 6"
       },
       "init": {
@@ -132,7 +132,7 @@
     },
     "details": {
       "biography": {
-        "value": "",
+        "value": "<p><em>Token artwork by </em><a href=\"https://www.forgotten-adventures.net/\" target=\"_blank\" rel=\"noopener\"><em>Forgotten Adventures</em></a><em>.</em></p>",
         "public": ""
       },
       "alignment": "Unaligned",
@@ -1151,9 +1151,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171221697,
-    "modifiedTime": 1726171443008,
+    "modifiedTime": 1744056508684,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!K5cKmPoFkpuOotis"

--- a/packs/_source/monsters/celestial/couatl.json
+++ b/packs/_source/monsters/celestial/couatl.json
@@ -70,7 +70,7 @@
         "value": 97,
         "max": 97,
         "temp": null,
-        "tempmax": 0,
+        "tempmax": null,
         "formula": "13d8 + 39"
       },
       "init": {
@@ -480,7 +480,7 @@
     },
     "bonuses": {
       "mwak": {
-        "attack": "",
+        "attack": "1",
         "damage": ""
       },
       "rwak": {
@@ -624,7 +624,7 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>8 (1d6 + 5) <em>piercing damage</em></strong>.</p><p>The target must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be poisoned for 24 hours. Until this poison ends, the target is unconscious. Another creature can use an action to shake the target awake.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p><p>The target must succeed on a [[/save]] saving throw or be &amp;Reference[poisoned apply=false] for 24 hours. Until this poison ends, the target is &amp;Reference[unconscious apply=false]. Another creature can use an action to shake the target awake.</p>",
           "chat": "<p>The Couatl attacks with its Bite. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
@@ -650,7 +650,7 @@
         "identified": true,
         "cover": null,
         "range": {
-          "value": 5,
+          "value": null,
           "long": null,
           "units": "ft",
           "reach": null
@@ -704,7 +704,8 @@
           "conditions": ""
         },
         "properties": [
-          "fin"
+          "fin",
+          "mgc"
         ],
         "proficient": 1,
         "unidentified": {
@@ -740,7 +741,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -776,14 +777,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "dex",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -794,13 +795,16 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           },
           "dnd5eactivity100": {
             "_id": "dnd5eactivity100",
             "type": "save",
             "activation": {
-              "type": "action",
+              "type": "special",
               "value": 1,
               "condition": "",
               "override": false
@@ -819,11 +823,15 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
-            "effects": [],
+            "effects": [
+              {
+                "_id": "GLxzcYW1p5BO6Tdt"
+              }
+            ],
             "range": {
               "value": "5",
               "units": "ft",
@@ -855,43 +863,77 @@
               "recovery": []
             },
             "damage": {
-              "onSave": "half",
-              "parts": [
-                {
-                  "number": 1,
-                  "denomination": 6,
-                  "bonus": "@mod",
-                  "types": [
-                    "piercing"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "onSave": "none",
+              "parts": []
             },
             "save": {
               "ability": "con",
               "dc": {
-                "calculation": "",
+                "calculation": "con",
                 "formula": "13"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": [
+              "GLxzcYW1p5BO6Tdt"
+            ]
           }
         },
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "bite"
+        "identifier": "bite",
+        "mastery": ""
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Poisoned",
+          "img": "systems/dnd5e/icons/svg/statuses/unconscious.svg",
+          "origin": "Compendium.dnd5e.monsters.Actor.ZaP1H91t4FzbRqR5.Item.7M1OrMoMMTCEKxta",
+          "transfer": false,
+          "_id": "GLxzcYW1p5BO6Tdt",
+          "type": "base",
+          "system": {},
+          "changes": [],
+          "disabled": false,
+          "duration": {
+            "startTime": null,
+            "seconds": 86400,
+            "combat": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "<p>Until this poison ends, the target is unconscious. Another creature can use an action to shake the target awake.</p>",
+          "tint": "#ffffff",
+          "statuses": [
+            "poisoned",
+            "unconscious"
+          ],
+          "sort": 0,
+          "flags": {
+            "dnd5e": {
+              "riders": {
+                "statuses": []
+              }
+            }
+          },
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "coreVersion": "12.331",
+            "systemId": "dnd5e",
+            "systemVersion": "4.3.8",
+            "createdTime": 1744076654091,
+            "modifiedTime": 1744076734676,
+            "lastModifiedBy": "dnd5ebuilder0000"
+          },
+          "_key": "!actors.items.effects!ZaP1H91t4FzbRqR5.7M1OrMoMMTCEKxta.GLxzcYW1p5BO6Tdt"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "ownership": {
@@ -900,6 +942,12 @@
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -907,9 +955,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676688,
+        "modifiedTime": 1744076855445,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZaP1H91t4FzbRqR5.7M1OrMoMMTCEKxta"
@@ -921,7 +969,7 @@
       "img": "icons/creatures/reptiles/serpent-horned-green.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>10 ft.,</strong> one Medium or smaller creature. Hit: <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p><p>The target is grappled (escape DC 15). Until this grapple ends, the target is restrained, and the couatl can't constrict another target.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p><p>The target is grappled (escape [[/check]]). Until this grapple ends, the target is restrained, and the [[lookup @name lowercase]] can't constrict another target.</p>",
           "chat": "<p>The Couatl attacks with its Constrict. The target is grappled. Until this grapple ends, the target is restrained, and the couatl can't constrict another target.</p>"
         },
         "source": {
@@ -947,10 +995,10 @@
         "identified": true,
         "cover": null,
         "range": {
-          "value": 5,
+          "value": null,
           "long": null,
           "units": "ft",
-          "reach": null
+          "reach": 10
         },
         "uses": {
           "max": "",
@@ -1001,7 +1049,7 @@
           "conditions": ""
         },
         "properties": [
-          "fin"
+          "mgc"
         ],
         "proficient": 1,
         "unidentified": {
@@ -1037,11 +1085,15 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
-            "effects": [],
+            "effects": [
+              {
+                "_id": "bT77MKZEyBFGGrrW"
+              }
+            ],
             "range": {
               "value": "5",
               "units": "ft",
@@ -1073,7 +1125,7 @@
               "recovery": []
             },
             "attack": {
-              "ability": "str",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
@@ -1091,29 +1143,148 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
+          },
+          "qSVi3BwrAoCnPpjk": {
+            "type": "check",
+            "name": "Escape Check",
+            "_id": "qSVi3BwrAoCnPpjk",
+            "sort": 0,
+            "activation": {
+              "type": "",
+              "value": null,
+              "override": false,
+              "condition": ""
+            },
+            "consumption": {
+              "scaling": {
+                "allowed": false
+              },
+              "spellSlot": true,
+              "targets": []
+            },
+            "description": {
+              "chatFlavor": ""
+            },
+            "duration": {
+              "units": "inst",
+              "concentration": false,
+              "override": false
+            },
+            "effects": [],
+            "range": {
+              "override": false
+            },
+            "target": {
+              "template": {
+                "contiguous": false,
+                "units": "ft",
+                "type": ""
+              },
+              "affects": {
+                "choice": false,
+                "type": ""
+              },
+              "override": false,
+              "prompt": true
+            },
+            "uses": {
+              "spent": 0,
+              "recovery": [],
+              "max": ""
+            },
+            "check": {
+              "associated": [
+                "acr",
+                "ath"
+              ],
+              "dc": {
+                "calculation": "dex",
+                "formula": ""
+              },
+              "ability": ""
+            },
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "constrict"
+        "identifier": "constrict",
+        "mastery": ""
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Restrained",
+          "img": "systems/dnd5e/icons/svg/statuses/restrained.svg",
+          "origin": "Compendium.dnd5e.monsters.Actor.ZaP1H91t4FzbRqR5.Item.8LkzioyaScFxfst7",
+          "transfer": false,
+          "_id": "bT77MKZEyBFGGrrW",
+          "type": "base",
+          "system": {},
+          "changes": [],
+          "disabled": false,
+          "duration": {
+            "startTime": null,
+            "seconds": null,
+            "combat": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "<p>Until this grapple ends, the target is restrained.</p>",
+          "tint": "#ffffff",
+          "statuses": [
+            "grappled",
+            "restrained"
+          ],
+          "sort": 0,
+          "flags": {
+            "dnd5e": {
+              "riders": {
+                "statuses": []
+              }
+            }
+          },
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "coreVersion": "12.331",
+            "systemId": "dnd5e",
+            "systemVersion": "4.3.8",
+            "createdTime": 1744077355795,
+            "modifiedTime": 1744077412495,
+            "lastModifiedBy": "dnd5ebuilder0000"
+          },
+          "_key": "!actors.items.effects!ZaP1H91t4FzbRqR5.8LkzioyaScFxfst7.bT77MKZEyBFGGrrW"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "ownership": {
         "default": 0
       },
-      "flags": {},
+      "flags": {
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676688,
+        "modifiedTime": 1744077425336,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZaP1H91t4FzbRqR5.8LkzioyaScFxfst7"
@@ -1250,7 +1421,7 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<p>The couatl's spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring only verbal components:</p>\n<p>At will: detect evil and good, detect magic, detect thoughts</p>\n<p>3/day each: bless, create food and water, cure wounds, lesser restoration, protection from poison, sanctuary, shield</p>\n<p>1/day each: dream, greater restoration, scrying</p>",
+          "value": "<p>The [[lookup @name lowercase]]'s spellcasting ability is Charisma (spell save DC [[lookup @abilities.cha.dc]]). It can innately cast the following spells, requiring only verbal components:</p><p>At will:  [[/item .Mzh95utKDPIrjiH8]]{detect evil and good}, [[/item .ghXTfe7sgCbgf1Q8]]{detect magic}, [[/item .ppWAAEul0QHtm4er]]{detect thoughts}</p><p>3/day each: [[/item .8dzaICjGy6mTUaUr]]{bless}, [[/item .BV0mpbHh29IbbIj5]]{create food and water}, [[/item .uUWb1wZgtMou0TVP]]{cure wounds}, [[/item .F0GsG0SJzsIOacwV]]{lesser restoration}, [[/item .MAxM77CDUu8dgIRQ]]{protection from poison}, [[/item .gvdA9nPuWLck4tBl]]{sanctuary}, [[/item .z1mx84ONwkXKUZd7]]{shield}</p><p>1/day each: [[/item .kSPRpeIx3w3nihrF]]{dream}, [[/item .WzvJ7G3cqvIubsLk]]{greater restoration}, [[/item .fVbCxFRaORalHB20]]{scrying}</p>",
           "chat": ""
         },
         "source": {
@@ -1267,11 +1438,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -1295,10 +1468,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744076493164,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZaP1H91t4FzbRqR5.J40yeoOnwpvtVpHt"
     },
@@ -1326,11 +1499,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -1354,10 +1529,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744076521424,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZaP1H91t4FzbRqR5.3qE2LLHPANSEPmIN"
     },
@@ -1389,7 +1564,9 @@
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -1413,10 +1590,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744076561380,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!ZaP1H91t4FzbRqR5.MGh9IkfXNn7FmwL5"
     },
@@ -3598,9 +3775,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171239772,
-    "modifiedTime": 1726171446294,
+    "modifiedTime": 1744077277605,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!ZaP1H91t4FzbRqR5"

--- a/packs/_source/monsters/fiend/succubus-incubus.json
+++ b/packs/_source/monsters/fiend/succubus-incubus.json
@@ -70,7 +70,7 @@
         "value": 66,
         "max": 66,
         "temp": null,
-        "tempmax": 0,
+        "tempmax": null,
         "formula": "12d8 + 12"
       },
       "init": {
@@ -642,11 +642,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -670,10 +672,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744058659464,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.P3P1EukfOip32dtd"
     },
@@ -705,7 +707,9 @@
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {
           "dnd5eactivity000": {
             "_id": "dnd5eactivity000",
@@ -795,9 +799,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676927,
+        "modifiedTime": 1744059611427,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.ZVMVqd01HraMcenH"
@@ -809,7 +813,7 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
           "chat": "<p>The Succubus/Incubus attacks with its Claw.</p>"
         },
         "source": {
@@ -835,7 +839,7 @@
         "identified": true,
         "cover": null,
         "range": {
-          "value": 5,
+          "value": null,
           "long": null,
           "units": "ft",
           "reach": null
@@ -888,7 +892,9 @@
           "dt": null,
           "conditions": ""
         },
-        "properties": [],
+        "properties": [
+          "fin"
+        ],
         "proficient": 1,
         "unidentified": {
           "description": ""
@@ -923,7 +929,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -959,14 +965,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "dex",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -977,13 +983,17 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "claw-fiend-form-only"
+        "identifier": "claw-fiend-form-only",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -991,15 +1001,22 @@
       "ownership": {
         "default": 0
       },
-      "flags": {},
+      "flags": {
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676927,
+        "modifiedTime": 1744058885337,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.oSlFzVMu0fdEfYt1"
@@ -1011,7 +1028,7 @@
       "img": "icons/magic/air/wind-tornado-spiral-pink-purple.webp",
       "system": {
         "description": {
-          "value": "<p>One humanoid the fiend can see within 30 feet of it must make a <strong>DC 15</strong> <strong>Wisdom</strong> saving throw or be magically charmed for 1 day. The charmed target obeys the fiend's verbal or telepathic commands.</p><p>If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend's Charm for the next 24 hours.The fiend can have only one target charmed at a time. If it charms another, the effect on the previous target ends.</p>",
+          "value": "<p>One humanoid the fiend can see within 30 feet of it must make a [[/save]] saving throw or be magically charmed for 1 day. The charmed target obeys the fiend's verbal or telepathic commands.</p><p>If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend's Charm for the next 24 hours.The fiend can have only one target charmed at a time. If it charms another, the effect on the previous target ends.</p>",
           "chat": "<p>One humanoid the fiend can see within 30 feet of it must make a <strong>Wisdom</strong> saving throw.</p>"
         },
         "source": {
@@ -1028,11 +1045,13 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "mgc"
+        ],
         "activities": {
           "dnd5eactivity000": {
             "_id": "dnd5eactivity000",
@@ -1061,7 +1080,11 @@
               "special": "",
               "override": false
             },
-            "effects": [],
+            "effects": [
+              {
+                "_id": "iuVbm8rd6UWg36yg"
+              }
+            ],
             "range": {
               "value": "30",
               "units": "ft",
@@ -1079,10 +1102,10 @@
                 "units": ""
               },
               "affects": {
-                "count": "",
-                "type": "",
+                "count": "1",
+                "type": "creature",
                 "choice": false,
-                "special": ""
+                "special": "Humanoid"
               },
               "prompt": true,
               "override": false
@@ -1093,18 +1116,22 @@
               "recovery": []
             },
             "damage": {
-              "onSave": "half",
+              "onSave": "none",
               "parts": []
             },
             "save": {
               "ability": "wis",
               "dc": {
-                "calculation": "",
+                "calculation": "cha",
                 "formula": "15"
               }
             },
             "sort": 0,
-            "name": ""
+            "name": "",
+            "img": "",
+            "appliedEffects": [
+              "iuVbm8rd6UWg36yg"
+            ]
           }
         },
         "enchant": {},
@@ -1113,7 +1140,52 @@
         },
         "identifier": "charm"
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Charmed",
+          "img": "systems/dnd5e/icons/svg/statuses/charmed.svg",
+          "origin": "Compendium.dnd5e.monsters.Actor.VmdyZDjqAc8vdncY.Item.2bFCfFfjRNmhyE8A",
+          "transfer": false,
+          "_id": "iuVbm8rd6UWg36yg",
+          "type": "base",
+          "system": {},
+          "changes": [],
+          "disabled": false,
+          "duration": {
+            "startTime": null,
+            "seconds": 86400,
+            "combat": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "<p>The charmed target obeys the fiend's verbal or telepathic commands.</p><p>If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend's Charm for the next 24 hours.</p>",
+          "tint": "#ffffff",
+          "statuses": [
+            "charmed"
+          ],
+          "sort": 0,
+          "flags": {
+            "dnd5e": {
+              "riders": {
+                "statuses": []
+              }
+            }
+          },
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "coreVersion": "12.331",
+            "systemId": "dnd5e",
+            "systemVersion": "4.3.8",
+            "createdTime": 1744059005231,
+            "modifiedTime": 1744059080198,
+            "lastModifiedBy": "dnd5ebuilder0000"
+          },
+          "_key": "!actors.items.effects!VmdyZDjqAc8vdncY.2bFCfFfjRNmhyE8A.iuVbm8rd6UWg36yg"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "ownership": {
@@ -1122,6 +1194,12 @@
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.monsterfeatures.ykoo88OJOdfYH7mH"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -1129,9 +1207,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676927,
+        "modifiedTime": 1744059148476,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.2bFCfFfjRNmhyE8A"
@@ -1143,7 +1221,7 @@
       "img": "icons/magic/air/wind-vortex-swirl-purple.webp",
       "system": {
         "description": {
-          "value": "<p>The fiend kisses a creature charmed by it or a willing creature. The target must make a  <strong>DC 15 Constitution</strong> saving throw against this magic, taking <strong>32 (5d10 + 5) <em>psychic damage</em></strong> on a failed save, or half as much damage on a successful one. </p><p>The target's hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p>",
+          "value": "<p>The fiend kisses a creature charmed by it or a willing creature. The target must make a [[/save]] saving throw against this magic, taking [[/damage]] damage on a failed save, or half as much damage on a successful one.</p><p>The target's hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.</p>",
           "chat": "<p>The target must make a <strong>Constitution</strong> saving throw against this magic.</p>"
         },
         "source": {
@@ -1160,11 +1238,13 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
-        "requirements": "",
-        "properties": [],
+        "requirements": "Targets a charmed or willing creature",
+        "properties": [
+          "mgc"
+        ],
         "activities": {
           "dnd5eactivity000": {
             "_id": "dnd5eactivity000",
@@ -1195,7 +1275,7 @@
             },
             "effects": [],
             "range": {
-              "units": "self",
+              "units": "touch",
               "special": "",
               "override": false
             },
@@ -1210,10 +1290,10 @@
                 "units": ""
               },
               "affects": {
-                "count": "",
-                "type": "",
+                "count": "1",
+                "type": "creature",
                 "choice": false,
-                "special": ""
+                "special": "charmed or willing creature"
               },
               "prompt": true,
               "override": false
@@ -1232,26 +1312,25 @@
                     "formula": ""
                   },
                   "number": 5,
-                  "denomination": 10,
+                  "denomination": "10",
                   "bonus": "@mod",
                   "types": [
                     "psychic"
-                  ],
-                  "scaling": {
-                    "number": 1
-                  }
+                  ]
                 }
               ]
             },
             "save": {
               "ability": "con",
               "dc": {
-                "calculation": "",
+                "calculation": "cha",
                 "formula": "15"
               }
             },
             "sort": 0,
-            "name": ""
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1269,6 +1348,12 @@
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.monsterfeatures.iq0J225DCbHYU2hU"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -1276,9 +1361,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676927,
+        "modifiedTime": 1744059474380,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.eb0O9cQ8N6lovLyI"
@@ -1290,8 +1375,8 @@
       "img": "icons/magic/unholy/barrier-shield-glowing-pink.webp",
       "system": {
         "description": {
-          "value": "",
-          "chat": "<section class=\"secret\"><p></p></section><p>The fiend magically enters the Ethereal Plane from the Material Plane, or vice versa.</p>"
+          "value": "<p>The fiend magically enters the Ethereal Plane from the Material Plane, or vice versa.</p>",
+          "chat": ""
         },
         "source": {
           "custom": "",
@@ -1307,11 +1392,13 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "mgc"
+        ],
         "activities": {
           "dnd5eactivity000": {
             "_id": "dnd5eactivity000",
@@ -1336,13 +1423,17 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "perm",
               "special": "",
               "override": false
             },
-            "effects": [],
+            "effects": [
+              {
+                "_id": "1Bd78CAdilT57jFe"
+              }
+            ],
             "range": {
-              "units": "",
+              "units": "self",
               "special": "",
               "override": false
             },
@@ -1358,7 +1449,7 @@
               },
               "affects": {
                 "count": "",
-                "type": "",
+                "type": "self",
                 "choice": false,
                 "special": ""
               },
@@ -1376,7 +1467,10 @@
               "prompt": false,
               "visible": false
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1385,7 +1479,52 @@
         },
         "identifier": "etherealness"
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Etherealness",
+          "img": "icons/magic/unholy/barrier-shield-glowing-pink.webp",
+          "origin": "Compendium.dnd5e.monsters.Actor.VmdyZDjqAc8vdncY.Item.s1s5asgUorljP7SV",
+          "transfer": true,
+          "_id": "1Bd78CAdilT57jFe",
+          "type": "base",
+          "system": {},
+          "changes": [],
+          "disabled": true,
+          "duration": {
+            "startTime": null,
+            "seconds": null,
+            "combat": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "statuses": [
+            "ethereal"
+          ],
+          "sort": 0,
+          "flags": {
+            "dnd5e": {
+              "riders": {
+                "statuses": []
+              }
+            }
+          },
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "coreVersion": "12.331",
+            "systemId": "dnd5e",
+            "systemVersion": "4.3.8",
+            "createdTime": 1744059571494,
+            "modifiedTime": 1744059585380,
+            "lastModifiedBy": "dnd5ebuilder0000"
+          },
+          "_key": "!actors.items.effects!VmdyZDjqAc8vdncY.s1s5asgUorljP7SV.1Bd78CAdilT57jFe"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "ownership": {
@@ -1394,6 +1533,12 @@
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.monsterfeatures.rDoNJnKdY47x8MD4"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -1401,9 +1546,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676927,
+        "modifiedTime": 1744059571510,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!VmdyZDjqAc8vdncY.s1s5asgUorljP7SV"
@@ -1420,9 +1565,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171236478,
-    "modifiedTime": 1726171445682,
+    "modifiedTime": 1744059282250,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!VmdyZDjqAc8vdncY"

--- a/packs/_source/monsters/humanoid/assassin.json
+++ b/packs/_source/monsters/humanoid/assassin.json
@@ -70,7 +70,7 @@
         "value": 78,
         "max": 78,
         "temp": null,
-        "tempmax": 0,
+        "tempmax": null,
         "formula": "12d8 + 24"
       },
       "init": {
@@ -728,11 +728,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -756,10 +758,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744049608086,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EMvcuOpu7ABCmBWi.Ld00NpZe8Zl4J4Pi"
     },
@@ -787,11 +789,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -815,10 +819,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744049652244,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EMvcuOpu7ABCmBWi.crRphULq6iIdlq88"
     },
@@ -829,8 +833,8 @@
       "img": "icons/skills/melee/blade-tip-chipped-blood-red.webp",
       "system": {
         "description": {
-          "value": "",
-          "chat": "<p>The assassin deals an extra 13 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 ft. of an ally of the assassin that isn't incapacitated and the assassin doesn't have disadvantage on the attack roll.</p>"
+          "value": "<p>The assassin deals an extra 13 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 ft. of an ally of the assassin that isn't incapacitated and the assassin doesn't have disadvantage on the attack roll.</p>",
+          "chat": ""
         },
         "source": {
           "custom": "",
@@ -846,11 +850,13 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {
           "dnd5eactivity000": {
             "_id": "dnd5eactivity000",
@@ -875,13 +881,13 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
             "effects": [],
             "range": {
-              "units": "",
+              "units": "self",
               "special": "",
               "override": false
             },
@@ -916,23 +922,23 @@
               },
               "parts": [
                 {
-                  "number": 4,
-                  "denomination": 6,
-                  "bonus": "",
-                  "types": [],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 4,
+                  "denomination": "6",
+                  "bonus": "",
+                  "types": [
+                    "piercing"
+                  ]
                 }
               ]
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -950,6 +956,12 @@
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.monsterfeatures.9uKShqfuA73duQsT"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -957,9 +969,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676773,
+        "modifiedTime": 1744049774607,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EMvcuOpu7ABCmBWi.EcECOhaJIpCtN2o7"
@@ -971,7 +983,7 @@
       "img": "icons/skills/melee/blade-tips-triple-steel.webp",
       "system": {
         "description": {
-          "value": "<p>The assassin makes two shortsword attacks.</p>",
+          "value": "<p>The assassin makes two [[/item .Kbg12IJ0YW79vP06]] attacks.</p>",
           "chat": ""
         },
         "source": {
@@ -1082,10 +1094,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744050115773,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EMvcuOpu7ABCmBWi.zaYTSI1nKtzBnQwf"
     },
@@ -1096,8 +1108,8 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>24 (7d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
-          "chat": "<p>The Assassin attacks with their Shortsword. The target must make a <strong>Constitution</strong> saving throw.</p>"
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p><p>The target must make a [[/save]] saving throw, taking [[/damage activity=dnd5eactivity100]] damage on a failed save, or half as much damage on a successful one.</p>",
+          "chat": ""
         },
         "source": {
           "custom": "",
@@ -1213,7 +1225,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1249,14 +1261,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "dex",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -1267,7 +1279,10 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           },
           "dnd5eactivity100": {
             "_id": "dnd5eactivity100",
@@ -1292,7 +1307,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1331,21 +1346,16 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 1,
-                  "denomination": 6,
-                  "bonus": "@mod",
-                  "types": [
-                    "piercing"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
+                  "number": 7,
+                  "denomination": "6",
+                  "bonus": "",
+                  "types": [
+                    "poison"
+                  ]
                 }
               ]
             },
@@ -1356,73 +1366,10 @@
                 "formula": "15"
               }
             },
-            "sort": 0
-          },
-          "dnd5eactivity300": {
-            "_id": "dnd5eactivity300",
-            "type": "utility",
-            "activation": {
-              "type": "action",
-              "value": 1,
-              "condition": "",
-              "override": false
-            },
-            "consumption": {
-              "targets": [],
-              "scaling": {
-                "allowed": false,
-                "max": ""
-              },
-              "spellSlot": true
-            },
-            "description": {
-              "chatFlavor": ""
-            },
-            "duration": {
-              "concentration": false,
-              "value": "",
-              "units": "",
-              "special": "",
-              "override": false
-            },
-            "effects": [],
-            "range": {
-              "value": "5",
-              "units": "ft",
-              "special": "",
-              "override": false
-            },
-            "target": {
-              "template": {
-                "count": "",
-                "contiguous": false,
-                "type": "",
-                "size": "",
-                "width": "",
-                "height": "",
-                "units": ""
-              },
-              "affects": {
-                "count": "",
-                "type": "",
-                "choice": false,
-                "special": ""
-              },
-              "prompt": true,
-              "override": false
-            },
-            "uses": {
-              "spent": 0,
-              "max": "",
-              "recovery": []
-            },
-            "roll": {
-              "formula": "7d6",
-              "name": "",
-              "prompt": false,
-              "visible": false
-            },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
@@ -1432,13 +1379,19 @@
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 100000,
       "ownership": {
         "default": 0
       },
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.items.osLzOwQdPtrK3rQH"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -1446,9 +1399,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676773,
+        "modifiedTime": 1744050091759,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EMvcuOpu7ABCmBWi.Kbg12IJ0YW79vP06"
@@ -1460,7 +1413,7 @@
       "img": "icons/weapons/crossbows/crossbow-simple-brown.webp",
       "system": {
         "description": {
-          "value": "<p>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p><p>The target must make a  <strong>DC 15 Constitution</strong> saving throw, taking <strong>24 (7d6) <em>poison damage</em></strong> on a failed save, or half as much damage on a successful one.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p><p>The target must make a [[/save]] saving throw, taking [[/damage activity=qt3tGFCRiYgaiWQ3]] damage on a failed save, or half as much damage on a successful one.</p>",
           "chat": "<p>The Assassin attacks with its Light Crossbow. The target must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
@@ -1540,9 +1493,9 @@
           "conditions": ""
         },
         "properties": [
-          "lgt",
-          "two",
-          "amm"
+          "amm",
+          "lod",
+          "two"
         ],
         "proficient": 1,
         "unidentified": {
@@ -1555,8 +1508,7 @@
         "container": null,
         "crewed": false,
         "activities": {
-          "dnd5eactivity000": {
-            "_id": "dnd5eactivity000",
+          "FOPIJT58E21wGaqM": {
             "type": "attack",
             "activation": {
               "type": "action",
@@ -1578,13 +1530,13 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
             "effects": [],
             "range": {
-              "value": "80",
+              "value": "5",
               "units": "ft",
               "special": "",
               "override": false
@@ -1614,14 +1566,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "dex",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "ranged",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -1632,10 +1584,11 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "_id": "FOPIJT58E21wGaqM"
           },
-          "dnd5eactivity100": {
-            "_id": "dnd5eactivity100",
+          "qt3tGFCRiYgaiWQ3": {
             "type": "save",
             "activation": {
               "type": "action",
@@ -1657,13 +1610,13 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
             "effects": [],
             "range": {
-              "value": "80",
+              "value": "5",
               "units": "ft",
               "special": "",
               "override": false
@@ -1696,114 +1649,59 @@
               "onSave": "half",
               "parts": [
                 {
-                  "number": 1,
-                  "denomination": 8,
-                  "bonus": "@mod",
-                  "types": [
-                    "piercing"
-                  ],
                   "custom": {
                     "enabled": false,
                     "formula": ""
                   },
+                  "number": 7,
+                  "denomination": 6,
+                  "bonus": "",
+                  "types": [
+                    "poison"
+                  ],
                   "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
+                    "number": 1
                   }
                 }
               ]
             },
             "save": {
-              "ability": "con",
+              "ability": [
+                "con"
+              ],
               "dc": {
                 "calculation": "",
                 "formula": "15"
               }
             },
-            "sort": 0
-          },
-          "dnd5eactivity300": {
-            "_id": "dnd5eactivity300",
-            "type": "utility",
-            "activation": {
-              "type": "action",
-              "value": 1,
-              "condition": "",
-              "override": false
-            },
-            "consumption": {
-              "targets": [],
-              "scaling": {
-                "allowed": false,
-                "max": ""
-              },
-              "spellSlot": true
-            },
-            "description": {
-              "chatFlavor": ""
-            },
-            "duration": {
-              "concentration": false,
-              "value": "",
-              "units": "",
-              "special": "",
-              "override": false
-            },
-            "effects": [],
-            "range": {
-              "value": "80",
-              "units": "ft",
-              "special": "",
-              "override": false
-            },
-            "target": {
-              "template": {
-                "count": "",
-                "contiguous": false,
-                "type": "",
-                "size": "",
-                "width": "",
-                "height": "",
-                "units": ""
-              },
-              "affects": {
-                "count": "",
-                "type": "",
-                "choice": false,
-                "special": ""
-              },
-              "prompt": true,
-              "override": false
-            },
-            "uses": {
-              "spent": 0,
-              "max": "",
-              "recovery": []
-            },
-            "roll": {
-              "formula": "7d6",
-              "name": "",
-              "prompt": false,
-              "visible": false
-            },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "_id": "qt3tGFCRiYgaiWQ3"
           }
         },
         "attuned": false,
-        "ammunition": {},
+        "ammunition": {
+          "type": "crossbowBolt"
+        },
         "magicalBonus": null,
-        "identifier": "light-crossbow"
+        "identifier": "light-crossbow",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 300000,
       "ownership": {
         "default": 0
       },
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.items.ddWvQRLmnnIS0eLF"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -1811,9 +1709,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676773,
+        "modifiedTime": 1744050413943,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!EMvcuOpu7ABCmBWi.rNQK7okIBNZ2zDvD"
@@ -1830,9 +1728,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171214988,
-    "modifiedTime": 1726171441681,
+    "modifiedTime": 1744051382560,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!EMvcuOpu7ABCmBWi"

--- a/packs/_source/monsters/humanoid/berserker.json
+++ b/packs/_source/monsters/humanoid/berserker.json
@@ -69,8 +69,8 @@
       "hp": {
         "value": 67,
         "max": 67,
-        "temp": 0,
-        "tempmax": 0,
+        "temp": null,
+        "tempmax": null,
         "formula": "9d8 + 27"
       },
       "init": {
@@ -723,11 +723,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -735,7 +737,50 @@
         },
         "identifier": "reckless"
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Reckless",
+          "img": "icons/skills/social/intimidation-impressing.webp",
+          "origin": "Compendium.dnd5e.monsters.Actor.kz1t6xeXVwODpYb2.Item.Qzj9HKnvRGhYoggC",
+          "_id": "WqXUqzRbXoMjF2MJ",
+          "type": "base",
+          "system": {},
+          "changes": [],
+          "disabled": true,
+          "duration": {
+            "startTime": null,
+            "seconds": null,
+            "combat": null,
+            "rounds": 1,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "<p>Attack rolls against it have advantage until the start of its next turn.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "sort": 0,
+          "flags": {
+            "dnd5e": {
+              "riders": {
+                "statuses": []
+              }
+            }
+          },
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "coreVersion": "12.331",
+            "systemId": "dnd5e",
+            "systemVersion": "4.3.8",
+            "createdTime": 1744135358115,
+            "modifiedTime": 1744135431645,
+            "lastModifiedBy": "dnd5ebuilder0000"
+          },
+          "_key": "!actors.items.effects!kz1t6xeXVwODpYb2.Qzj9HKnvRGhYoggC.WqXUqzRbXoMjF2MJ"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "ownership": {
@@ -751,10 +796,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744135320648,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kz1t6xeXVwODpYb2.Qzj9HKnvRGhYoggC"
     },
@@ -765,7 +810,7 @@
       "img": "icons/weapons/axes/axe-double.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>9 (1d12 + 3) <em>slashing damage</em></strong>.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
           "chat": "<p>The Berserker attacks with their Greataxe.</p>"
         },
         "source": {
@@ -882,7 +927,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -918,14 +963,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "str",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -936,13 +981,17 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "greataxe"
+        "identifier": "greataxe",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -953,6 +1002,12 @@
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.items.1Lxk6kmoRhG8qQ0u"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -960,9 +1015,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676494,
+        "modifiedTime": 1744135489725,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!kz1t6xeXVwODpYb2.RrHhFZOd6QT75V3W"
@@ -979,9 +1034,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171252938,
-    "modifiedTime": 1726171448945,
+    "modifiedTime": 1744135509959,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!kz1t6xeXVwODpYb2"

--- a/packs/_source/monsters/humanoid/druid.json
+++ b/packs/_source/monsters/humanoid/druid.json
@@ -69,8 +69,8 @@
       "hp": {
         "value": 27,
         "max": 27,
-        "temp": 0,
-        "tempmax": 0,
+        "temp": null,
+        "tempmax": null,
         "formula": "5d8 + 5"
       },
       "init": {
@@ -135,7 +135,7 @@
         "value": "",
         "public": ""
       },
-      "alignment": "any",
+      "alignment": "any alignment",
       "race": null,
       "type": {
         "value": "humanoid",
@@ -618,7 +618,7 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<p>The druid is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks).</p><p>It has the following druid spells prepared:</p><p><strong>Cantrips </strong>(at will): druidcraft, produce flame, shillelagh</p><p><strong> 1st level</strong> (4 slots): entangle, longstrider, speak with animals, thunderwave</p><p><strong>2nd level</strong> (3 slots): animal messenger, barkskin</p>",
+          "value": "<p>The druid is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks).</p><p>It has the following druid spells prepared:</p><p>Cantrips (at will): [[/item .SbSvZKkJASyk8jKo]]{druidcraft}, [[/item .eCPQuQkIabFKTl9u]]{produce flame}, [[/item .VzgFzcmocr1X1cp4]]{shillelagh}</p><p>1st level (4 slots): [[/item .gMrWeG8fMDPRFiVe]]{entangle}, [[/item .B0pnIcc52O6G8hi8]]{longstrider}, [[/item .aL1F8fvYLtNzUbKu]]{speak with animals}, [[/item .WTbOQBsarsL1LuXJ]]{thunderwave}</p><p>2nd level (3 slots): [[/item .X8w9EzYLGc4vQ1H2]]{animal messenger}, [[/item .JPwIEfgUPVebr5AH]]{barkskin}</p>",
           "chat": "<p>The druid is a spellcaster. Its spellcasting ability is Wisdom.</p>"
         },
         "source": {
@@ -663,9 +663,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676552,
+        "modifiedTime": 1744141612084,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!K15Yl8JmB5iPircc.07sdy4qaaW4MaB8W"
@@ -677,7 +677,7 @@
       "img": "icons/weapons/staves/staff-simple-gold.webp",
       "system": {
         "description": {
-          "value": "<p>Melee Weapon Attack: +2 to hit (+4 to hit with shillelagh), reach 5 ft., one target. Hit: <strong>3 (1d6) <em>bludgeoning damage</em></strong>, or <strong>6 (1d8 + 2) <em>bludgeoning damage</em></strong> with shillelagh or if wielded with two hands.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]] or [[/damage twoHanded]] if wielded with two hands.</p><p>With @UUID[.udSiVp4nSrGBSvG1]{shillelagh}, [[/attack extended activity=J8RgDbtkXvXUJDuD]]. [[/damage extended activity=J8RgDbtkXvXUJDuD]].</p>",
           "chat": "<p>The Druid attacks with its Quarterstaff.</p>"
         },
         "source": {
@@ -757,6 +757,7 @@
           "conditions": ""
         },
         "properties": [
+          "foc",
           "ver"
         ],
         "proficient": 1,
@@ -793,7 +794,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -829,7 +830,7 @@
               "recovery": []
             },
             "attack": {
-              "ability": "dex",
+              "ability": "str",
               "bonus": "",
               "critical": {
                 "threshold": null
@@ -847,15 +848,186 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": -200000,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
+          },
+          "J8RgDbtkXvXUJDuD": {
+            "type": "attack",
+            "activation": {
+              "type": "action",
+              "value": null,
+              "condition": "",
+              "override": false
+            },
+            "consumption": {
+              "targets": [],
+              "scaling": {
+                "allowed": false,
+                "max": ""
+              },
+              "spellSlot": true
+            },
+            "description": {
+              "chatFlavor": ""
+            },
+            "duration": {
+              "value": "",
+              "units": "inst",
+              "special": "",
+              "override": false,
+              "concentration": false
+            },
+            "effects": [],
+            "range": {
+              "units": "",
+              "special": "",
+              "override": false
+            },
+            "target": {
+              "template": {
+                "count": "",
+                "contiguous": false,
+                "type": "",
+                "size": "",
+                "width": "",
+                "height": "",
+                "units": ""
+              },
+              "affects": {
+                "count": "",
+                "type": "",
+                "choice": false,
+                "special": ""
+              },
+              "prompt": true,
+              "override": false
+            },
+            "attack": {
+              "ability": "spellcasting",
+              "bonus": "",
+              "critical": {
+                "threshold": null
+              },
+              "flat": false,
+              "type": {
+                "value": "",
+                "classification": "weapon"
+              }
+            },
+            "damage": {
+              "critical": {
+                "bonus": ""
+              },
+              "includeBase": false,
+              "parts": [
+                {
+                  "custom": {
+                    "enabled": false,
+                    "formula": ""
+                  },
+                  "number": 1,
+                  "denomination": "8",
+                  "bonus": "@mod",
+                  "types": [
+                    "bludgeoning"
+                  ]
+                }
+              ]
+            },
+            "uses": {
+              "spent": 0,
+              "recovery": [],
+              "max": ""
+            },
+            "sort": -100000,
+            "_id": "J8RgDbtkXvXUJDuD",
+            "name": "Spellcasting Attack",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "quarterstaff"
+        "identifier": "quarterstaff",
+        "mastery": ""
       },
-      "effects": [],
+      "effects": [
+        {
+          "type": "enchantment",
+          "name": "Shillelagh",
+          "img": "icons/magic/fire/dagger-rune-enchant-teal.webp",
+          "disabled": true,
+          "_id": "siLjGctswI3gx3B2",
+          "system": {},
+          "changes": [
+            {
+              "key": "name",
+              "mode": 2,
+              "value": ", Shillelagh",
+              "priority": null
+            },
+            {
+              "key": "system.damage.base.number",
+              "mode": 5,
+              "value": "1",
+              "priority": null
+            },
+            {
+              "key": "system.damage.base.denomination",
+              "mode": 5,
+              "value": "8",
+              "priority": null
+            },
+            {
+              "key": "system.properties",
+              "mode": 2,
+              "value": "mgc",
+              "priority": null
+            }
+          ],
+          "duration": {
+            "startTime": null,
+            "seconds": 60,
+            "combat": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "",
+          "origin": "Compendium.dnd5e.monsters.Actor.K15Yl8JmB5iPircc.Item.udSiVp4nSrGBSvG1",
+          "tint": "#ffffff",
+          "transfer": false,
+          "statuses": [],
+          "sort": 0,
+          "flags": {
+            "dnd5e": {
+              "dependents": [
+                {
+                  "uuid": "Compendium.dnd5e.monsters.Actor.K15Yl8JmB5iPircc.Item.KUP8WEfLxlcY7K2x.Activity.J8RgDbtkXvXUJDuD"
+                }
+              ],
+              "riders": {
+                "statuses": []
+              }
+            }
+          },
+          "_stats": {
+            "compendiumSource": "Compendium.dnd5e.monsters.Actor.K15Yl8JmB5iPircc.Item.udSiVp4nSrGBSvG1.ActiveEffect.QPsqj6jfS0iXSrTs",
+            "duplicateSource": null,
+            "coreVersion": "12.331",
+            "systemId": "dnd5e",
+            "systemVersion": "4.3.8",
+            "createdTime": 1744141902433,
+            "modifiedTime": 1744142295936,
+            "lastModifiedBy": "dnd5ebuilder0000"
+          },
+          "_key": "!actors.items.effects!K15Yl8JmB5iPircc.KUP8WEfLxlcY7K2x.siLjGctswI3gx3B2"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "ownership": {
@@ -864,6 +1036,12 @@
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.items.g2dWN7PQiMRYWzyk"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -871,9 +1049,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676552,
+        "modifiedTime": 1744142941675,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!K15Yl8JmB5iPircc.KUP8WEfLxlcY7K2x"
@@ -1930,167 +2108,6 @@
       "_key": "!actors.items!K15Yl8JmB5iPircc.X8w9EzYLGc4vQ1H2"
     },
     {
-      "_id": "VzgFzcmocr1X1cp4",
-      "name": "Shillelagh",
-      "ownership": {
-        "default": 0
-      },
-      "type": "spell",
-      "system": {
-        "description": {
-          "value": "<p>The wood of a club or quarterstaff you are holding is imbued with nature's power. For the duration, you can use your spellcasting ability instead of Strength for the attack and damage rolls of melee attacks using that weapon, and the weapon's damage die becomes a d8. The weapon also becomes magical, if it isn't already. The spell ends if you cast it again or if you let go of the weapon.</p>",
-          "chat": ""
-        },
-        "source": {
-          "custom": "",
-          "book": "",
-          "page": "",
-          "license": "CC-BY-4.0",
-          "rules": "2014",
-          "revision": 1
-        },
-        "activation": {
-          "type": "bonus",
-          "condition": "",
-          "value": 1
-        },
-        "duration": {
-          "value": "1",
-          "units": "minute"
-        },
-        "target": {
-          "affects": {
-            "type": "object",
-            "count": "1",
-            "choice": false
-          },
-          "template": {
-            "units": "spec",
-            "contiguous": false
-          }
-        },
-        "range": {
-          "units": "touch"
-        },
-        "uses": {
-          "max": "",
-          "recovery": [],
-          "spent": 0
-        },
-        "level": 0,
-        "school": "trs",
-        "materials": {
-          "value": "A shamrock leaf, and a club or quarterstaff",
-          "consumed": false,
-          "cost": 0,
-          "supply": 0
-        },
-        "preparation": {
-          "mode": "prepared",
-          "prepared": true
-        },
-        "properties": [
-          "vocal",
-          "somatic",
-          "material"
-        ],
-        "activities": {
-          "dnd5eactivity000": {
-            "_id": "dnd5eactivity000",
-            "type": "damage",
-            "activation": {
-              "type": "action",
-              "value": null,
-              "override": false
-            },
-            "consumption": {
-              "targets": [],
-              "scaling": {
-                "allowed": false,
-                "max": ""
-              },
-              "spellSlot": true
-            },
-            "description": {
-              "chatFlavor": ""
-            },
-            "duration": {
-              "units": "inst",
-              "concentration": false,
-              "override": false
-            },
-            "effects": [],
-            "range": {
-              "override": false
-            },
-            "target": {
-              "prompt": true,
-              "template": {
-                "contiguous": false,
-                "units": "ft"
-              },
-              "affects": {
-                "choice": false
-              },
-              "override": false
-            },
-            "uses": {
-              "spent": 0,
-              "max": "",
-              "recovery": []
-            },
-            "damage": {
-              "critical": {
-                "allow": false,
-                "bonus": ""
-              },
-              "parts": [
-                {
-                  "number": 1,
-                  "denomination": 8,
-                  "bonus": "@mod",
-                  "types": [
-                    "bludgeoning"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
-            },
-            "sort": 0
-          }
-        },
-        "identifier": "shillelagh"
-      },
-      "sort": 0,
-      "flags": {
-        "core": {
-          "sourceId": "Compendium.dnd5e.spells.VzgFzcmocr1X1cp4"
-        }
-      },
-      "img": "icons/magic/fire/dagger-rune-enchant-teal.webp",
-      "effects": [],
-      "folder": null,
-      "_stats": {
-        "compendiumSource": "Compendium.dnd5e.spells.VzgFzcmocr1X1cp4",
-        "duplicateSource": null,
-        "coreVersion": "12.331",
-        "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
-        "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
-      },
-      "_key": "!actors.items!K15Yl8JmB5iPircc.VzgFzcmocr1X1cp4"
-    },
-    {
       "_id": "JPwIEfgUPVebr5AH",
       "name": "Barkskin",
       "type": "spell",
@@ -2282,6 +2299,315 @@
         "lastModifiedBy": null
       },
       "_key": "!actors.items!K15Yl8JmB5iPircc.JPwIEfgUPVebr5AH"
+    },
+    {
+      "_id": "udSiVp4nSrGBSvG1",
+      "name": "Shillelagh",
+      "ownership": {
+        "default": 0
+      },
+      "type": "spell",
+      "system": {
+        "description": {
+          "value": "<p>The wood of a club or quarterstaff you are holding is imbued with nature's power. For the duration, you can use your spellcasting ability instead of Strength for the attack and damage rolls of melee attacks using that weapon, and the weapon's damage die becomes a d8. The weapon also becomes magical, if it isn't already. The spell ends if you cast it again or if you let go of the weapon.</p>",
+          "chat": ""
+        },
+        "source": {
+          "custom": "",
+          "book": "SRD 5.1",
+          "page": "",
+          "license": "CC-BY-4.0",
+          "rules": "2014",
+          "revision": 1
+        },
+        "activation": {
+          "type": "bonus",
+          "condition": "",
+          "value": 1
+        },
+        "duration": {
+          "value": "1",
+          "units": "minute"
+        },
+        "target": {
+          "affects": {
+            "type": "object",
+            "count": "1",
+            "choice": false,
+            "special": ""
+          },
+          "template": {
+            "units": "spec",
+            "contiguous": false,
+            "type": ""
+          }
+        },
+        "range": {
+          "units": "touch",
+          "special": ""
+        },
+        "uses": {
+          "max": "",
+          "recovery": [],
+          "spent": 0
+        },
+        "level": 0,
+        "school": "trs",
+        "materials": {
+          "value": "A shamrock leaf, and a club or quarterstaff",
+          "consumed": false,
+          "cost": 0,
+          "supply": 0
+        },
+        "preparation": {
+          "mode": "prepared",
+          "prepared": true
+        },
+        "properties": [
+          "vocal",
+          "somatic",
+          "material"
+        ],
+        "activities": {
+          "dnd5eactivity000": {
+            "_id": "dnd5eactivity000",
+            "type": "enchant",
+            "sort": 0,
+            "activation": {
+              "type": "action",
+              "value": null,
+              "override": false
+            },
+            "consumption": {
+              "scaling": {
+                "allowed": false
+              },
+              "spellSlot": true,
+              "targets": []
+            },
+            "description": {
+              "chatFlavor": ""
+            },
+            "duration": {
+              "units": "inst",
+              "concentration": false,
+              "override": false
+            },
+            "effects": [
+              {
+                "_id": "QPsqj6jfS0iXSrTs",
+                "level": {
+                  "min": null,
+                  "max": null
+                },
+                "riders": {
+                  "activity": [
+                    "ONVab5lmTqJwwMBC"
+                  ],
+                  "effect": [],
+                  "item": []
+                }
+              }
+            ],
+            "range": {
+              "override": false
+            },
+            "target": {
+              "template": {
+                "contiguous": false,
+                "units": "ft"
+              },
+              "affects": {
+                "choice": false
+              },
+              "override": false,
+              "prompt": true
+            },
+            "uses": {
+              "spent": 0,
+              "recovery": [],
+              "max": ""
+            },
+            "enchant": {},
+            "restrictions": {
+              "allowMagical": true,
+              "categories": [
+                "simpleM"
+              ],
+              "properties": [],
+              "type": "weapon"
+            },
+            "name": "Imbue Weapon"
+          },
+          "ONVab5lmTqJwwMBC": {
+            "type": "attack",
+            "activation": {
+              "type": "action",
+              "value": null,
+              "condition": "",
+              "override": false
+            },
+            "consumption": {
+              "targets": [],
+              "scaling": {
+                "allowed": false,
+                "max": ""
+              },
+              "spellSlot": true
+            },
+            "description": {
+              "chatFlavor": ""
+            },
+            "duration": {
+              "value": "",
+              "units": "",
+              "special": "",
+              "override": false,
+              "concentration": false
+            },
+            "effects": [],
+            "range": {
+              "units": "",
+              "special": "",
+              "override": false
+            },
+            "target": {
+              "template": {
+                "count": "",
+                "contiguous": false,
+                "type": "",
+                "size": "",
+                "width": "",
+                "height": "",
+                "units": ""
+              },
+              "affects": {
+                "count": "",
+                "type": "",
+                "choice": false,
+                "special": ""
+              },
+              "prompt": true,
+              "override": false
+            },
+            "attack": {
+              "ability": "spellcasting",
+              "bonus": "",
+              "critical": {
+                "threshold": null
+              },
+              "flat": false,
+              "type": {
+                "value": "melee",
+                "classification": "weapon"
+              }
+            },
+            "damage": {
+              "critical": {
+                "bonus": ""
+              },
+              "includeBase": true,
+              "parts": []
+            },
+            "uses": {
+              "spent": 0,
+              "recovery": [],
+              "max": ""
+            },
+            "sort": 0,
+            "_id": "ONVab5lmTqJwwMBC",
+            "name": "Spellcasting Attack"
+          }
+        },
+        "identifier": "shillelagh"
+      },
+      "sort": 0,
+      "flags": {
+        "dnd5e": {
+          "riders": {
+            "activity": [
+              "ONVab5lmTqJwwMBC"
+            ],
+            "effect": []
+          }
+        }
+      },
+      "img": "icons/magic/fire/dagger-rune-enchant-teal.webp",
+      "effects": [
+        {
+          "type": "enchantment",
+          "name": "Shillelagh",
+          "img": "icons/magic/fire/dagger-rune-enchant-teal.webp",
+          "disabled": false,
+          "_id": "QPsqj6jfS0iXSrTs",
+          "system": {},
+          "changes": [
+            {
+              "key": "name",
+              "mode": 2,
+              "value": ", Shillelagh",
+              "priority": null
+            },
+            {
+              "key": "system.damage.base.number",
+              "mode": 5,
+              "value": "1",
+              "priority": null
+            },
+            {
+              "key": "system.damage.base.denomination",
+              "mode": 5,
+              "value": "8",
+              "priority": null
+            },
+            {
+              "key": "system.properties",
+              "mode": 2,
+              "value": "mgc",
+              "priority": null
+            }
+          ],
+          "duration": {
+            "startTime": null,
+            "seconds": 60,
+            "combat": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "",
+          "origin": null,
+          "tint": "#ffffff",
+          "transfer": false,
+          "statuses": [],
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "coreVersion": "12.331",
+            "systemId": "dnd5e",
+            "systemVersion": "4.3.8",
+            "createdTime": null,
+            "modifiedTime": null,
+            "lastModifiedBy": null
+          },
+          "_key": "!actors.items.effects!K15Yl8JmB5iPircc.udSiVp4nSrGBSvG1.QPsqj6jfS0iXSrTs"
+        }
+      ],
+      "folder": "Z8kZlnggh1PtuF3Y",
+      "_stats": {
+        "duplicateSource": null,
+        "compendiumSource": "Compendium.dnd5e.spells.Item.VzgFzcmocr1X1cp4",
+        "coreVersion": "12.331",
+        "systemId": "dnd5e",
+        "systemVersion": "4.3.8",
+        "createdTime": 1744141670539,
+        "modifiedTime": 1744141670539,
+        "lastModifiedBy": "dnd5ebuilder0000"
+      },
+      "_key": "!actors.items!K15Yl8JmB5iPircc.udSiVp4nSrGBSvG1"
     }
   ],
   "effects": [],
@@ -2295,9 +2621,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171221276,
-    "modifiedTime": 1726171442924,
+    "modifiedTime": 1744141765490,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!K15Yl8JmB5iPircc"

--- a/packs/_source/monsters/humanoid/gladiator.json
+++ b/packs/_source/monsters/humanoid/gladiator.json
@@ -69,8 +69,8 @@
       "hp": {
         "value": 112,
         "max": 112,
-        "temp": 0,
-        "tempmax": 0,
+        "temp": null,
+        "tempmax": null,
         "formula": "15d8 + 45"
       },
       "init": {
@@ -814,11 +814,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -842,10 +844,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744043376665,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fsPruAIDOg4tVrgb.YbB6EsBwNaEzVlxU"
     },
@@ -873,11 +875,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -901,10 +905,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744043390559,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fsPruAIDOg4tVrgb.NPTnV9YupSeKJrQ0"
     },
@@ -915,7 +919,7 @@
       "img": "icons/skills/melee/blade-tips-triple-steel.webp",
       "system": {
         "description": {
-          "value": "<p>The gladiator makes three melee attacks or two ranged attacks.</p>",
+          "value": "<p>The gladiator makes three melee attacks or two ranged attacks.</p><p>Melee: [[/item .eL15erXXE9EuXWSB]], [[/item .GrUneCbXCYngdpjf]]</p><p>Ranged: [[/item .eL15erXXE9EuXWSB]]</p>",
           "chat": ""
         },
         "source": {
@@ -932,7 +936,7 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
@@ -1026,10 +1030,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744044307584,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fsPruAIDOg4tVrgb.QuVUb9i809rjJWcL"
     },
@@ -1040,7 +1044,7 @@
       "img": "icons/weapons/polearms/spear-flared-worn-grey.webp",
       "system": {
         "description": {
-          "value": "<p>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. and range 20/60 ft., one target. Hit: <strong>11 (2d6 + 4) <em>piercing damage</em></strong>, or <strong>13 (2d8 + 4) <em>piercing damage</em></strong> if used with two hands to make a melee attack.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
           "chat": "<p>The Gladiator attacks with their Spear.</p>"
         },
         "source": {
@@ -1157,7 +1161,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1193,14 +1197,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "str",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -1211,7 +1215,10 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
@@ -1221,13 +1228,19 @@
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 100000,
       "ownership": {
         "default": 0
       },
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.items.OG4nBBydvmfWYXIk"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -1235,9 +1248,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676808,
+        "modifiedTime": 1744044179160,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fsPruAIDOg4tVrgb.eL15erXXE9EuXWSB"
@@ -1249,7 +1262,7 @@
       "img": "icons/equipment/shield/buckler-wooden-boss-glowing-blue.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5 ft.,</strong> one creature. Hit: <strong>9 (2d4 + 4) <em>bludgeoning damage</em></strong>.</p><p>If the target is a Medium or smaller creature, it must succeed on a  <strong>DC 15 Strength</strong> saving throw or be knocked prone.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is a Medium or smaller creature, it must succeed on a [[/save]] saving throw or be knocked &amp;Reference[prone].</p><p></p>",
           "chat": "<p>The Gladiator attacks with their Shield Bash. If the target is a Medium or smaller creature, it must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
@@ -1334,7 +1347,7 @@
           "description": ""
         },
         "type": {
-          "value": "martialM",
+          "value": "natural",
           "baseItem": ""
         },
         "container": null,
@@ -1363,7 +1376,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1385,8 +1398,8 @@
                 "units": ""
               },
               "affects": {
-                "count": "",
-                "type": "",
+                "count": "1",
+                "type": "creature",
                 "choice": false,
                 "special": ""
               },
@@ -1399,14 +1412,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "str",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -1417,15 +1430,18 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           },
           "dnd5eactivity100": {
             "_id": "dnd5eactivity100",
             "type": "save",
             "activation": {
-              "type": "action",
+              "type": "",
               "value": 1,
-              "condition": "",
+              "condition": "On hit",
               "override": false
             },
             "consumption": {
@@ -1442,11 +1458,15 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
-            "effects": [],
+            "effects": [
+              {
+                "_id": "e0KniuDngw2shi5N"
+              }
+            ],
             "range": {
               "value": "5",
               "units": "ft",
@@ -1464,8 +1484,8 @@
                 "units": ""
               },
               "affects": {
-                "count": "",
-                "type": "",
+                "count": "1",
+                "type": "creature",
                 "choice": false,
                 "special": ""
               },
@@ -1478,57 +1498,95 @@
               "recovery": []
             },
             "damage": {
-              "onSave": "half",
-              "parts": [
-                {
-                  "number": 2,
-                  "denomination": 4,
-                  "bonus": "@mod",
-                  "types": [
-                    "bludgeoning"
-                  ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
+              "onSave": "none",
+              "parts": []
             },
             "save": {
               "ability": "str",
               "dc": {
-                "calculation": "",
+                "calculation": "str",
                 "formula": "15"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "shield-bash"
+        "identifier": "shield-bash",
+        "mastery": ""
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Prone",
+          "img": "systems/dnd5e/icons/svg/statuses/prone.svg",
+          "origin": "Compendium.dnd5e.monsters.Actor.fsPruAIDOg4tVrgb.Item.GrUneCbXCYngdpjf",
+          "transfer": false,
+          "_id": "e0KniuDngw2shi5N",
+          "type": "base",
+          "system": {},
+          "changes": [],
+          "disabled": false,
+          "duration": {
+            "startTime": null,
+            "seconds": null,
+            "combat": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "statuses": [
+            "prone"
+          ],
+          "sort": 0,
+          "flags": {
+            "dnd5e": {
+              "riders": {
+                "statuses": []
+              }
+            }
+          },
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "coreVersion": "12.331",
+            "systemId": "dnd5e",
+            "systemVersion": "4.3.8",
+            "createdTime": 1744043946552,
+            "modifiedTime": 1744043988419,
+            "lastModifiedBy": "dnd5ebuilder0000"
+          },
+          "_key": "!actors.items.effects!fsPruAIDOg4tVrgb.GrUneCbXCYngdpjf.e0KniuDngw2shi5N"
+        }
+      ],
       "folder": null,
-      "sort": 0,
+      "sort": 300000,
       "ownership": {
         "default": 0
       },
-      "flags": {},
+      "flags": {
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676808,
+        "modifiedTime": 1744044179160,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fsPruAIDOg4tVrgb.GrUneCbXCYngdpjf"
@@ -1557,7 +1615,7 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
@@ -1569,7 +1627,7 @@
             "activation": {
               "type": "reaction",
               "value": 1,
-              "condition": "",
+              "condition": "when a melee attack would hit this creature",
               "override": false
             },
             "consumption": {
@@ -1592,7 +1650,7 @@
             },
             "effects": [],
             "range": {
-              "units": "none",
+              "units": "self",
               "special": "",
               "override": false
             },
@@ -1626,7 +1684,10 @@
               "prompt": false,
               "visible": false
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -1644,6 +1705,12 @@
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.monsterfeatures.kfi26Jy0VLXv9TTm"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -1651,9 +1718,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676808,
+        "modifiedTime": 1744044417544,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!fsPruAIDOg4tVrgb.AwP14Hu6dPdnSbQt"
@@ -1670,9 +1737,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171246985,
-    "modifiedTime": 1726171447697,
+    "modifiedTime": 1744044640004,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!fsPruAIDOg4tVrgb"

--- a/packs/_source/monsters/humanoid/mage.json
+++ b/packs/_source/monsters/humanoid/mage.json
@@ -69,8 +69,8 @@
       "hp": {
         "value": 40,
         "max": 40,
-        "temp": 0,
-        "tempmax": 0,
+        "temp": null,
+        "tempmax": null,
         "formula": "9d8"
       },
       "init": {
@@ -615,7 +615,7 @@
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<p>The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The mage has the following wizard spells prepared:</p><p>Cantrips (at will): fire bolt, light, mage hand, prestidigitation</p><p>1st level (4 slots): detect magic, mage armor, magic missile, shield</p><p>2nd level (3 slots): misty step, suggestion</p><p>3rd level (3 slots): counterspell, fireball, fly</p><p>4th level (3 slots): greater invisibility, ice storm</p><p>5th level (1 slot): cone of cold</p>",
+          "value": "<p>The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The mage has the following wizard spells prepared:</p><p>Cantrip (at will): [[/item .EOmsUcFQJTfG2oio]]{fire bolt}, [[/item .Bnn9Nzajixvow9xi]]{light}, [[/item .Utk1OQRwYkMkFRD3]]{mage hand}, [[/item .udsLtG0BugXHR2JQ]]{prestidigitation}</p><p>1st level (4 slots): [[/item .ghXTfe7sgCbgf1Q8]]{detect magic}, [[/item .CKZTpZlxj7hjjo2H]]{mage armor}, [[/item .41JIhpDyM9Anm7cs]]{magic missile}, [[/item .z1mx84ONwkXKUZd7]]{shield}</p><p>2nd level (3 slots): [[/item .wqfAVANuQonNBgnL]]{misty step}, [[/item .zMAWdyc8UVb37BK4]]{suggestion}</p><p>3rd level (3 slots): [[/item .Ek45cBpVXvJdv1Qy]]{counterspell}, [[/item .ztgcdrWPshKRpFd0]]{fireball}, [[/item .yfbK8gZqESlaoY5t]]{fly}</p><p>4th level (3 slots): [[/item .tEpDmYZNGc9f5OhJ]]{greater invisibility}, [[/item .WN2LWEljYU6QqnRH]]{ice storm}</p><p>5th level (1 slots): [[/item .RpKjTlYASrfqUPVA]]{cone of cold}</p>",
           "chat": "<p>The mage is a spellcaster. Its spellcasting ability is Intelligence.</p>"
         },
         "source": {
@@ -632,11 +632,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -660,222 +662,12 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676601,
+        "modifiedTime": 1744060239778,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!mQnsXanewsPiV7QE.tbKbwgcprUBciliF"
-    },
-    {
-      "_id": "LcMdsxbtVEhUDXju",
-      "name": "Dagger",
-      "type": "weapon",
-      "img": "icons/weapons/daggers/dagger-jeweled-purple.webp",
-      "system": {
-        "description": {
-          "value": "<p>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: <strong>4 (1d4 + 2) <em>piercing damage</em></strong>.</p>",
-          "chat": "<p>The Mage attacks with its Dagger.</p>"
-        },
-        "source": {
-          "custom": "",
-          "book": "",
-          "page": "",
-          "license": "CC-BY-4.0",
-          "rules": "2014",
-          "revision": 1
-        },
-        "quantity": 1,
-        "weight": {
-          "value": 1,
-          "units": "lb"
-        },
-        "price": {
-          "value": 2,
-          "denomination": "gp"
-        },
-        "attunement": "",
-        "equipped": true,
-        "rarity": "",
-        "identified": true,
-        "cover": null,
-        "range": {
-          "value": 5,
-          "long": null,
-          "units": "ft",
-          "reach": null
-        },
-        "uses": {
-          "max": "",
-          "recovery": [],
-          "spent": 0
-        },
-        "damage": {
-          "versatile": {
-            "number": null,
-            "denomination": null,
-            "bonus": "",
-            "types": [],
-            "custom": {
-              "enabled": false,
-              "formula": ""
-            },
-            "scaling": {
-              "mode": "",
-              "number": null,
-              "formula": ""
-            }
-          },
-          "base": {
-            "number": 1,
-            "denomination": 4,
-            "bonus": "",
-            "types": [
-              "piercing"
-            ],
-            "custom": {
-              "enabled": false,
-              "formula": ""
-            },
-            "scaling": {
-              "mode": "",
-              "number": null,
-              "formula": ""
-            }
-          }
-        },
-        "armor": {
-          "value": 10
-        },
-        "hp": {
-          "value": 0,
-          "max": 0,
-          "dt": null,
-          "conditions": ""
-        },
-        "properties": [
-          "fin",
-          "lgt",
-          "thr"
-        ],
-        "proficient": 1,
-        "unidentified": {
-          "description": ""
-        },
-        "type": {
-          "value": "simpleM",
-          "baseItem": "dagger"
-        },
-        "container": null,
-        "crewed": false,
-        "activities": {
-          "dnd5eactivity000": {
-            "_id": "dnd5eactivity000",
-            "type": "attack",
-            "activation": {
-              "type": "action",
-              "value": 1,
-              "condition": "",
-              "override": false
-            },
-            "consumption": {
-              "targets": [],
-              "scaling": {
-                "allowed": false,
-                "max": ""
-              },
-              "spellSlot": true
-            },
-            "description": {
-              "chatFlavor": ""
-            },
-            "duration": {
-              "concentration": false,
-              "value": "",
-              "units": "",
-              "special": "",
-              "override": false
-            },
-            "effects": [],
-            "range": {
-              "value": "5",
-              "units": "ft",
-              "special": "",
-              "override": false
-            },
-            "target": {
-              "template": {
-                "count": "",
-                "contiguous": false,
-                "type": "",
-                "size": "",
-                "width": "",
-                "height": "",
-                "units": ""
-              },
-              "affects": {
-                "count": "",
-                "type": "",
-                "choice": false,
-                "special": ""
-              },
-              "prompt": true,
-              "override": false
-            },
-            "uses": {
-              "spent": 0,
-              "max": "",
-              "recovery": []
-            },
-            "attack": {
-              "ability": "dex",
-              "bonus": "",
-              "critical": {
-                "threshold": null
-              },
-              "flat": false,
-              "type": {
-                "value": "melee",
-                "classification": "weapon"
-              }
-            },
-            "damage": {
-              "critical": {
-                "bonus": ""
-              },
-              "includeBase": true,
-              "parts": []
-            },
-            "sort": 0
-          }
-        },
-        "attuned": false,
-        "ammunition": {},
-        "magicalBonus": null,
-        "identifier": "dagger"
-      },
-      "effects": [],
-      "folder": null,
-      "sort": 0,
-      "ownership": {
-        "default": 0
-      },
-      "flags": {
-        "core": {
-          "sourceId": "Compendium.dnd5e.items.0E565kQUBmndJ1a2"
-        }
-      },
-      "_stats": {
-        "compendiumSource": "Compendium.dnd5e.items.0E565kQUBmndJ1a2",
-        "duplicateSource": null,
-        "coreVersion": "12.331",
-        "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
-        "createdTime": null,
-        "modifiedTime": 1736804676601,
-        "lastModifiedBy": "dnd5ebuilder0000"
-      },
-      "_key": "!actors.items!mQnsXanewsPiV7QE.LcMdsxbtVEhUDXju"
     },
     {
       "_id": "EOmsUcFQJTfG2oio",
@@ -3383,6 +3175,222 @@
         "lastModifiedBy": null
       },
       "_key": "!actors.items!mQnsXanewsPiV7QE.RpKjTlYASrfqUPVA"
+    },
+    {
+      "_id": "rG6fb3lkjuxqEaDd",
+      "name": "Dagger",
+      "type": "weapon",
+      "img": "icons/weapons/daggers/dagger-straight-blue.webp",
+      "system": {
+        "description": {
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
+          "chat": ""
+        },
+        "source": {
+          "custom": "",
+          "book": "SRD 5.1",
+          "page": "",
+          "license": "CC-BY-4.0",
+          "rules": "2014",
+          "revision": 1
+        },
+        "quantity": 1,
+        "weight": {
+          "value": 1,
+          "units": "lb"
+        },
+        "price": {
+          "value": 2,
+          "denomination": "gp"
+        },
+        "attunement": "",
+        "rarity": "",
+        "identified": true,
+        "cover": null,
+        "range": {
+          "value": 20,
+          "long": 60,
+          "units": "ft",
+          "reach": null
+        },
+        "uses": {
+          "max": "",
+          "recovery": [],
+          "spent": 0
+        },
+        "damage": {
+          "versatile": {
+            "number": null,
+            "denomination": null,
+            "bonus": "",
+            "types": [],
+            "custom": {
+              "enabled": false,
+              "formula": ""
+            },
+            "scaling": {
+              "mode": "",
+              "number": null,
+              "formula": ""
+            }
+          },
+          "base": {
+            "number": 1,
+            "denomination": 4,
+            "bonus": "",
+            "types": [
+              "piercing"
+            ],
+            "custom": {
+              "enabled": false,
+              "formula": ""
+            },
+            "scaling": {
+              "mode": "",
+              "number": null,
+              "formula": ""
+            }
+          }
+        },
+        "armor": {
+          "value": 10
+        },
+        "hp": {
+          "value": 0,
+          "max": 0,
+          "dt": null,
+          "conditions": ""
+        },
+        "properties": [
+          "fin",
+          "lgt",
+          "thr"
+        ],
+        "proficient": null,
+        "type": {
+          "value": "simpleM",
+          "baseItem": "dagger"
+        },
+        "unidentified": {
+          "description": ""
+        },
+        "container": null,
+        "crewed": false,
+        "magicalBonus": null,
+        "activities": {
+          "dnd5eactivity000": {
+            "_id": "dnd5eactivity000",
+            "type": "attack",
+            "activation": {
+              "type": "action",
+              "value": 1,
+              "condition": "",
+              "override": false
+            },
+            "consumption": {
+              "targets": [],
+              "scaling": {
+                "allowed": false,
+                "max": ""
+              },
+              "spellSlot": true
+            },
+            "description": {
+              "chatFlavor": ""
+            },
+            "duration": {
+              "concentration": false,
+              "value": "",
+              "units": "inst",
+              "special": "",
+              "override": false
+            },
+            "effects": [],
+            "range": {
+              "value": "20",
+              "units": "ft",
+              "special": "",
+              "override": false
+            },
+            "target": {
+              "template": {
+                "count": "",
+                "contiguous": false,
+                "type": "",
+                "size": "",
+                "width": "",
+                "height": "",
+                "units": ""
+              },
+              "affects": {
+                "count": "",
+                "type": "",
+                "choice": false,
+                "special": ""
+              },
+              "prompt": true,
+              "override": false
+            },
+            "attack": {
+              "ability": "",
+              "bonus": "",
+              "critical": {
+                "threshold": null
+              },
+              "flat": false,
+              "type": {
+                "value": "",
+                "classification": "weapon"
+              }
+            },
+            "damage": {
+              "critical": {
+                "bonus": ""
+              },
+              "includeBase": true,
+              "parts": []
+            },
+            "uses": {
+              "spent": 0,
+              "recovery": [],
+              "max": ""
+            },
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
+          }
+        },
+        "ammunition": {},
+        "identifier": "dagger",
+        "attuned": false,
+        "equipped": true
+      },
+      "effects": [],
+      "folder": "MLMTCAvKsuFE3vYA",
+      "sort": 0,
+      "ownership": {
+        "default": 0
+      },
+      "flags": {
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
+        }
+      },
+      "_stats": {
+        "duplicateSource": null,
+        "compendiumSource": "Compendium.dnd5e.items.Item.0E565kQUBmndJ1a2",
+        "coreVersion": "12.331",
+        "systemId": "dnd5e",
+        "systemVersion": "4.3.8",
+        "createdTime": 1744060295689,
+        "modifiedTime": 1744060344403,
+        "lastModifiedBy": "dnd5ebuilder0000"
+      },
+      "_key": "!actors.items!mQnsXanewsPiV7QE.rG6fb3lkjuxqEaDd"
     }
   ],
   "effects": [],
@@ -3396,9 +3404,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171254943,
-    "modifiedTime": 1726171449301,
+    "modifiedTime": 1744060372156,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!mQnsXanewsPiV7QE"

--- a/packs/_source/monsters/humanoid/noble.json
+++ b/packs/_source/monsters/humanoid/noble.json
@@ -69,8 +69,8 @@
       "hp": {
         "value": 9,
         "max": 9,
-        "temp": 0,
-        "tempmax": 0,
+        "temp": null,
+        "tempmax": null,
         "formula": "2d8"
       },
       "init": {
@@ -706,7 +706,7 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d8 + 1) <em>piercing damage</em></strong>.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
           "chat": "<p>The Noble attacks with its Rapier.</p>"
         },
         "source": {
@@ -822,7 +822,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -858,14 +858,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "dex",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -876,13 +876,17 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "rapier"
+        "identifier": "rapier",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
@@ -893,6 +897,12 @@
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.items.Tobce1hexTnDk4sV"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -900,9 +910,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676544,
+        "modifiedTime": 1744048714751,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!GlaCGcgIP6YjBjGc.f12lOXuMaI21HDrz"
@@ -1044,9 +1054,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171217891,
-    "modifiedTime": 1726171442247,
+    "modifiedTime": 1744048738286,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!GlaCGcgIP6YjBjGc"

--- a/packs/_source/monsters/humanoid/priest.json
+++ b/packs/_source/monsters/humanoid/priest.json
@@ -69,8 +69,8 @@
       "hp": {
         "value": 27,
         "max": 27,
-        "temp": 0,
-        "tempmax": 0,
+        "temp": null,
+        "tempmax": null,
         "formula": "5d8 + 5"
       },
       "init": {
@@ -87,7 +87,7 @@
         "climb": 0,
         "fly": 0,
         "swim": 0,
-        "walk": 25,
+        "walk": 30,
         "units": "ft",
         "hover": false
       },
@@ -132,7 +132,7 @@
     },
     "details": {
       "biography": {
-        "value": "",
+        "value": "<p><em>Token artwork by </em><a href=\"https://www.forgotten-adventures.net/\" target=\"_blank\" rel=\"noopener\"><em>Forgotten Adventures</em></a><em>.</em></p>",
         "public": ""
       },
       "alignment": "Any Alignment",
@@ -609,104 +609,13 @@
   },
   "items": [
     {
-      "_id": "bndaCEOeIP8RgbU1",
-      "name": "Chain Shirt",
-      "type": "equipment",
-      "img": "icons/equipment/chest/breastplate-metal-scaled-grey.webp",
-      "system": {
-        "description": {
-          "value": "<p>Made of interlocking metal rings, a chain shirt is worn between layers of clothing or leather. This armor offers modest protection to the wearer's upper body and allows the sound of the rings rubbing against one another to be muffled by outer layers.</p>",
-          "chat": ""
-        },
-        "source": {
-          "custom": "",
-          "book": "",
-          "page": "",
-          "license": "CC-BY-4.0",
-          "rules": "2014",
-          "revision": 1
-        },
-        "quantity": 1,
-        "weight": {
-          "value": 20,
-          "units": "lb"
-        },
-        "price": {
-          "value": 50,
-          "denomination": "gp"
-        },
-        "attunement": "",
-        "equipped": true,
-        "rarity": "",
-        "identified": true,
-        "cover": null,
-        "uses": {
-          "max": "",
-          "spent": 0,
-          "recovery": []
-        },
-        "armor": {
-          "value": 13,
-          "dex": null,
-          "magicalBonus": null
-        },
-        "hp": {
-          "value": 0,
-          "max": 0,
-          "dt": null,
-          "conditions": ""
-        },
-        "speed": {
-          "value": null,
-          "conditions": ""
-        },
-        "strength": null,
-        "proficient": 1,
-        "unidentified": {
-          "description": ""
-        },
-        "type": {
-          "value": "light",
-          "baseItem": "chainshirt"
-        },
-        "container": null,
-        "crewed": false,
-        "properties": [],
-        "activities": {},
-        "attuned": false,
-        "identifier": "chain-shirt"
-      },
-      "effects": [],
-      "folder": null,
-      "sort": 0,
-      "ownership": {
-        "default": 0
-      },
-      "flags": {
-        "core": {
-          "sourceId": "Compendium.dnd5e.items.p2zChy24ZJdVqMSH"
-        }
-      },
-      "_stats": {
-        "compendiumSource": "Compendium.dnd5e.items.p2zChy24ZJdVqMSH",
-        "duplicateSource": null,
-        "coreVersion": "12.331",
-        "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
-        "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
-      },
-      "_key": "!actors.items!PVD5wRdyO7iCJPs1.bndaCEOeIP8RgbU1"
-    },
-    {
       "_id": "J12x6xIwx1aCEm1e",
       "name": "Spellcasting",
       "type": "feat",
       "img": "icons/magic/light/projectiles-star-purple.webp",
       "system": {
         "description": {
-          "value": "<p>The priest is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The priest has the following cleric spells prepared:</p>\n<p>Cantrips (at will): light, sacred flame, thaumaturgy</p>\n<p>1st level (4 slots): cure wounds, guiding bolt, sanctuary</p>\n<p>2nd level (3 slots): lesser restoration, spiritual weapon</p>\n<p>3rd level (2 slots): dispel magic, spirit guardians</p>",
+          "value": "<p>The [[lookup @name lowercase]] is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The priest has the following cleric spells prepared:</p><p>Cantrip (at will): [[/item .Bnn9Nzajixvow9xi]]{light}, [[/item .n9pJzTDsAwQxJVRl]]{sacred flame}, [[/item .MUO1uYN7JR1hm4dR]]{thaumaturgy}</p><p>1st level (4 slots): [[/item .uUWb1wZgtMou0TVP]]{cure wounds}, [[/item .7buEm5KhI5lP8m1z]]{guiding bolt}, [[/item .gvdA9nPuWLck4tBl]]{sanctuary}</p><p>2nd level (3 slots): [[/item .F0GsG0SJzsIOacwV]]{lesser restoration}, [[/item .JbxsYXxSOTZbf9I0]]{spiritual weapon}</p><p>3rd level (2 slots): [[/item .15Fa6q1nH27XfbR8]]{dispel magic}, [[/item .uCud2s4TjMfjiXUb]]{spirit guardians}</p>",
           "chat": ""
         },
         "source": {
@@ -723,11 +632,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -751,10 +662,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744058046751,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PVD5wRdyO7iCJPs1.J12x6xIwx1aCEm1e"
     },
@@ -765,7 +676,7 @@
       "img": "icons/magic/symbols/cog-shield-white-blue.webp",
       "system": {
         "description": {
-          "value": "<p>As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra <strong>10 (3d6) <em>radiant damage</em></strong> to a target on a hit. </p><p>This benefit lasts until the end of the turn. If the priest expends a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each level above 1st.</p>",
+          "value": "<p>As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra [[/damage]] damage to a target on a hit.</p><p>This benefit lasts until the end of the turn. If the priest expends a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each level above 1st.</p>",
           "chat": "<p>As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra <em>radiant damage</em> to a target on a hit.</p>"
         },
         "source": {
@@ -782,11 +693,13 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "mgc"
+        ],
         "activities": {
           "dnd5eactivity000": {
             "_id": "dnd5eactivity000",
@@ -798,10 +711,20 @@
               "override": false
             },
             "consumption": {
-              "targets": [],
+              "targets": [
+                {
+                  "type": "spellSlots",
+                  "value": "1",
+                  "target": "1",
+                  "scaling": {
+                    "mode": "level",
+                    "formula": ""
+                  }
+                }
+              ],
               "scaling": {
-                "allowed": false,
-                "max": ""
+                "allowed": true,
+                "max": "3"
               },
               "spellSlot": true
             },
@@ -810,14 +733,14 @@
             },
             "duration": {
               "concentration": false,
-              "value": "",
-              "units": "",
+              "value": "1",
+              "units": "turn",
               "special": "",
               "override": false
             },
             "effects": [],
             "range": {
-              "units": "",
+              "units": "self",
               "special": "",
               "override": false
             },
@@ -847,112 +770,33 @@
             },
             "damage": {
               "critical": {
-                "allow": false,
+                "allow": true,
                 "bonus": ""
               },
               "parts": [
                 {
+                  "custom": {
+                    "enabled": false,
+                    "formula": ""
+                  },
                   "number": 3,
-                  "denomination": 6,
+                  "denomination": "6",
                   "bonus": "",
                   "types": [
                     "radiant"
                   ],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
                   "scaling": {
                     "mode": "whole",
-                    "number": null,
+                    "number": 1,
                     "formula": ""
                   }
                 }
               ]
             },
-            "sort": 0
-          },
-          "dnd5eactivity200": {
-            "_id": "dnd5eactivity200",
-            "type": "damage",
-            "activation": {
-              "type": "bonus",
-              "value": 1,
-              "condition": "",
-              "override": false
-            },
-            "consumption": {
-              "targets": [],
-              "scaling": {
-                "allowed": false,
-                "max": ""
-              },
-              "spellSlot": true
-            },
-            "description": {
-              "chatFlavor": ""
-            },
-            "duration": {
-              "concentration": false,
-              "value": "",
-              "units": "",
-              "special": "",
-              "override": false
-            },
-            "effects": [],
-            "range": {
-              "units": "",
-              "special": "",
-              "override": false
-            },
-            "target": {
-              "template": {
-                "count": "",
-                "contiguous": false,
-                "type": "",
-                "size": "",
-                "width": "",
-                "height": "",
-                "units": ""
-              },
-              "affects": {
-                "count": "",
-                "type": "",
-                "choice": false,
-                "special": ""
-              },
-              "prompt": true,
-              "override": false
-            },
-            "uses": {
-              "spent": 0,
-              "max": "",
-              "recovery": []
-            },
-            "damage": {
-              "critical": {
-                "allow": false,
-                "bonus": ""
-              },
-              "parts": [
-                {
-                  "number": 1,
-                  "denomination": 6,
-                  "bonus": "",
-                  "types": [],
-                  "custom": {
-                    "enabled": false,
-                    "formula": ""
-                  },
-                  "scaling": {
-                    "mode": "whole",
-                    "number": null,
-                    "formula": ""
-                  }
-                }
-              ]
-            },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -970,6 +814,12 @@
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.monsterfeatures.lVrnjqBrv90VH96d"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -977,9 +827,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676566,
+        "modifiedTime": 1744056004524,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PVD5wRdyO7iCJPs1.9LzZrzdWIZpjFIGV"
@@ -991,7 +841,7 @@
       "img": "icons/weapons/maces/mace-round-spiked-black.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>3 (1d6) <em>bludgeoning damage</em></strong>.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
           "chat": "<p>The Priest attacks with its Mace.</p>"
         },
         "source": {
@@ -1181,9 +1031,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676566,
+        "modifiedTime": 1744053508579,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!PVD5wRdyO7iCJPs1.B0jROhxuoqvfmz2B"
@@ -2732,6 +2582,93 @@
         "lastModifiedBy": null
       },
       "_key": "!actors.items!PVD5wRdyO7iCJPs1.uUWb1wZgtMou0TVP"
+    },
+    {
+      "_id": "pC1QJ005t6xVU8ZT",
+      "name": "Chain Shirt",
+      "type": "equipment",
+      "img": "icons/equipment/chest/breastplate-scale-grey.webp",
+      "system": {
+        "description": {
+          "value": "<p>Made of interlocking metal rings, a chain shirt is worn between layers of clothing or leather. This armor offers modest protection to the wearer's upper body and allows the sound of the rings rubbing against one another to be muffled by outer layers.</p>",
+          "chat": ""
+        },
+        "source": {
+          "custom": "",
+          "book": "SRD 5.1",
+          "page": "",
+          "license": "CC-BY-4.0",
+          "rules": "2014",
+          "revision": 1
+        },
+        "quantity": 1,
+        "weight": {
+          "value": 20,
+          "units": "lb"
+        },
+        "price": {
+          "value": 50,
+          "denomination": "gp"
+        },
+        "attunement": "",
+        "rarity": "",
+        "identified": true,
+        "cover": null,
+        "crewed": false,
+        "uses": {
+          "max": "",
+          "spent": 0,
+          "recovery": []
+        },
+        "armor": {
+          "value": 13,
+          "dex": 2,
+          "magicalBonus": null
+        },
+        "hp": {
+          "value": 0,
+          "max": 0,
+          "dt": null,
+          "conditions": ""
+        },
+        "speed": {
+          "value": null,
+          "conditions": ""
+        },
+        "strength": null,
+        "proficient": null,
+        "type": {
+          "value": "medium",
+          "baseItem": "chainshirt"
+        },
+        "unidentified": {
+          "description": ""
+        },
+        "container": null,
+        "properties": [],
+        "activities": {},
+        "identifier": "chain-shirt",
+        "attuned": false,
+        "equipped": true
+      },
+      "effects": [],
+      "folder": "JqTP017wj3uxDJ8g",
+      "sort": 0,
+      "ownership": {
+        "default": 0
+      },
+      "flags": {},
+      "_stats": {
+        "duplicateSource": null,
+        "compendiumSource": "Compendium.dnd5e.items.Item.p2zChy24ZJdVqMSH",
+        "coreVersion": "12.331",
+        "systemId": "dnd5e",
+        "systemVersion": "4.3.8",
+        "createdTime": 1744053591786,
+        "modifiedTime": 1744053591786,
+        "lastModifiedBy": "dnd5ebuilder0000"
+      },
+      "_key": "!actors.items!PVD5wRdyO7iCJPs1.pC1QJ005t6xVU8ZT"
     }
   ],
   "effects": [],
@@ -2745,9 +2682,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171229383,
-    "modifiedTime": 1726171444342,
+    "modifiedTime": 1744053772129,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!PVD5wRdyO7iCJPs1"

--- a/packs/_source/monsters/humanoid/scout.json
+++ b/packs/_source/monsters/humanoid/scout.json
@@ -69,8 +69,8 @@
       "hp": {
         "value": 16,
         "max": 16,
-        "temp": 0,
-        "tempmax": 0,
+        "temp": null,
+        "tempmax": null,
         "formula": "3d8 + 3"
       },
       "init": {
@@ -723,11 +723,13 @@
           "recovery": []
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -747,10 +749,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744052052908,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!O3ABqI55Ir1du1Xa.PQGwUNCJ7EkJAE8V"
     },
@@ -874,8 +876,8 @@
         "systemId": "dnd5e",
         "systemVersion": "4.0.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744132986913,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!O3ABqI55Ir1du1Xa.YO57HtdvpuGxJANB"
     },
@@ -886,7 +888,7 @@
       "img": "icons/weapons/swords/sword-guard-brown.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing damage</em></strong>.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
           "chat": "<p>The Scout attacks with their Shortsword.</p>"
         },
         "source": {
@@ -1003,7 +1005,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1039,14 +1041,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "dex",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -1057,7 +1059,10 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
@@ -1067,13 +1072,19 @@
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 100000,
       "ownership": {
         "default": 0
       },
       "flags": {
         "core": {
           "sourceId": "Compendium.dnd5e.items.osLzOwQdPtrK3rQH"
+        },
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
         }
       },
       "_stats": {
@@ -1081,9 +1092,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676671,
+        "modifiedTime": 1744132985302,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!O3ABqI55Ir1du1Xa.YDoOa6D6QDoR2Htu"
@@ -1095,7 +1106,7 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<p>Ranged Weapon Attack: +4 to hit, ranged 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
           "chat": "<p>The Scout attacks with their Longbow.</p>"
         },
         "source": {
@@ -1271,13 +1282,16 @@
           }
         },
         "attuned": false,
-        "ammunition": {},
+        "ammunition": {
+          "type": "arrow"
+        },
         "magicalBonus": null,
-        "identifier": "longbow"
+        "identifier": "longbow",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 300000,
       "ownership": {
         "default": 0
       },
@@ -1291,9 +1305,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676671,
+        "modifiedTime": 1744132985302,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!O3ABqI55Ir1du1Xa.E2fYrhLigMeVH09l"
@@ -1310,9 +1324,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171227806,
-    "modifiedTime": 1726171444090,
+    "modifiedTime": 1744052139226,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!O3ABqI55Ir1du1Xa"

--- a/packs/_source/monsters/humanoid/weretiger.json
+++ b/packs/_source/monsters/humanoid/weretiger.json
@@ -70,7 +70,7 @@
         "value": 120,
         "max": 120,
         "temp": null,
-        "tempmax": 0,
+        "tempmax": null,
         "formula": "16d8 + 48"
       },
       "init": {
@@ -641,7 +641,7 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
         "requirements": "",
@@ -721,7 +721,7 @@
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 600000,
       "ownership": {
         "default": 0
       },
@@ -735,9 +735,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676953,
+        "modifiedTime": 1744075307516,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.EjU9p4Wh1U2wsnFK"
@@ -770,7 +770,9 @@
           "subtype": ""
         },
         "requirements": "",
-        "properties": [],
+        "properties": [
+          "trait"
+        ],
         "activities": {},
         "enchant": {},
         "prerequisites": {
@@ -790,21 +792,21 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744074944805,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.2iPYXoxM2ZReuhSL"
     },
     {
       "_id": "jW4qHQ761qRLeWM8",
-      "name": "Pounce (Tiger or Hybrid Form Only)",
+      "name": "Pounce",
       "type": "feat",
       "img": "icons/creatures/abilities/cougar-pounce-stalk-black.webp",
       "system": {
         "description": {
-          "value": "<p>If the weretiger moves at <strong>least 15 feet</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a <strong>DC 14 Strength saving throw</strong> or be knocked prone. If the target is prone, the weretiger can make one bite attack against it as a bonus action.</p><p>If the target is prone, the panther can make one bite attack against it as a bonus action.</p>",
+          "value": "<p>If the [[lookup @name lowercase]] moves at <strong>least 15 feet</strong> straight toward a creature and then hits it with a [[/item .HPmjVRKpG08bgohb]]{claw} attack on the same turn, that target must succeed on a [[/save]] saving throw or be knocked &amp;Reference[prone]. If the target is prone, the weretiger can make one [[/item .FOkSL18gU0Sli5ZA]]{bite} attack against it as a bonus action.</p>",
           "chat": "<p>If the weretiger moves at <strong>least 15 feet</strong> straight toward a creature and then hits it with a claw attack on the same turn, that target must make a <strong>Strength</strong> saving throw or be knocked prone.</p>"
         },
         "source": {
@@ -821,85 +823,21 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
-        "requirements": "",
-        "properties": [],
+        "requirements": "Tiger or Hybrid Form",
+        "properties": [
+          "trait"
+        ],
         "activities": {
-          "dnd5eactivity000": {
-            "_id": "dnd5eactivity000",
-            "type": "utility",
-            "activation": {
-              "type": "",
-              "value": null,
-              "condition": "",
-              "override": false
-            },
-            "consumption": {
-              "targets": [],
-              "scaling": {
-                "allowed": false,
-                "max": ""
-              },
-              "spellSlot": true
-            },
-            "description": {
-              "chatFlavor": ""
-            },
-            "duration": {
-              "concentration": false,
-              "value": "",
-              "units": "",
-              "special": "",
-              "override": false
-            },
-            "effects": [],
-            "range": {
-              "value": "15",
-              "units": "ft",
-              "special": "",
-              "override": false
-            },
-            "target": {
-              "template": {
-                "count": "",
-                "contiguous": false,
-                "type": "",
-                "size": "",
-                "width": "",
-                "height": "",
-                "units": ""
-              },
-              "affects": {
-                "count": "",
-                "type": "",
-                "choice": false,
-                "special": ""
-              },
-              "prompt": true,
-              "override": false
-            },
-            "uses": {
-              "spent": 0,
-              "max": "",
-              "recovery": []
-            },
-            "roll": {
-              "formula": "",
-              "name": "",
-              "prompt": false,
-              "visible": false
-            },
-            "sort": 0
-          },
           "dnd5eactivity100": {
             "_id": "dnd5eactivity100",
             "type": "save",
             "activation": {
               "type": "",
               "value": null,
-              "condition": "",
+              "condition": "moves 15 feet and hits with a claw attack",
               "override": false
             },
             "consumption": {
@@ -916,11 +854,15 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
-            "effects": [],
+            "effects": [
+              {
+                "_id": "xx5oDVvttzxBUXpQ"
+              }
+            ],
             "range": {
               "value": "15",
               "units": "ft",
@@ -952,7 +894,7 @@
               "recovery": []
             },
             "damage": {
-              "onSave": "half",
+              "onSave": "none",
               "parts": []
             },
             "save": {
@@ -962,7 +904,10 @@
                 "formula": "14"
               }
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "enchant": {},
@@ -971,33 +916,85 @@
         },
         "identifier": "pounce-tiger-or-hybrid-form-only"
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Prone",
+          "img": "systems/dnd5e/icons/svg/statuses/prone.svg",
+          "origin": "Compendium.dnd5e.monsters.Actor.zIr3NaNF0mWz5Ahq.Item.jW4qHQ761qRLeWM8",
+          "transfer": false,
+          "_id": "xx5oDVvttzxBUXpQ",
+          "type": "base",
+          "system": {},
+          "changes": [],
+          "disabled": false,
+          "duration": {
+            "startTime": null,
+            "seconds": null,
+            "combat": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "statuses": [
+            "prone"
+          ],
+          "sort": 0,
+          "flags": {
+            "dnd5e": {
+              "riders": {
+                "statuses": []
+              }
+            }
+          },
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "coreVersion": "12.331",
+            "systemId": "dnd5e",
+            "systemVersion": "4.3.8",
+            "createdTime": 1744074885146,
+            "modifiedTime": 1744074906625,
+            "lastModifiedBy": "dnd5ebuilder0000"
+          },
+          "_key": "!actors.items.effects!zIr3NaNF0mWz5Ahq.jW4qHQ761qRLeWM8.xx5oDVvttzxBUXpQ"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "ownership": {
         "default": 0
       },
-      "flags": {},
+      "flags": {
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676953,
+        "modifiedTime": 1744074929043,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.jW4qHQ761qRLeWM8"
     },
     {
       "_id": "SmUCt79LtakgTJoa",
-      "name": "Multiattack (Humanoid or Hybrid Form Only)",
+      "name": "Multiattack",
       "type": "feat",
       "img": "icons/skills/melee/blade-tips-triple-steel.webp",
       "system": {
         "description": {
-          "value": "<p>In humanoid form, the weretiger makes two scimitar attacks or two longbow attacks. In hybrid form, it can attack like a humanoid or make two claw attacks.</p>",
+          "value": "<p>In humanoid form, the weretiger makes two [[/item .vtnEGCOptmp2bcqG]]{scimitar} attacks or two [[/item .onmNGMiE4AyvYxDQ]]{longbow} attacks.</p><p>In hybrid form, it can attack like a humanoid or make two [[/item .HPmjVRKpG08bgohb]]{claw} attacks.</p>",
           "chat": ""
         },
         "source": {
@@ -1014,10 +1011,10 @@
           "spent": 0
         },
         "type": {
-          "value": "",
+          "value": "monster",
           "subtype": ""
         },
-        "requirements": "",
+        "requirements": "Humanoid or Hybrid Form",
         "properties": [],
         "activities": {
           "dnd5eactivity000": {
@@ -1104,10 +1101,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.0.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1744075424301,
+        "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.SmUCt79LtakgTJoa"
     },
@@ -1118,7 +1115,7 @@
       "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing damage</em></strong>. </p><p>If the target is a humanoid, it must succeed on a  <strong>DC 13 Constitution</strong> saving throw or be cursed with weretiger lycanthropy.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is a humanoid, it must succeed on a [[/save]] saving throw or be cursed with weretiger lycanthropy.</p>",
           "chat": "<p>The Weretiger attacks with its Bite. If the target is a humanoid, it must make a <strong>Constitution</strong> saving throw.</p>"
         },
         "source": {
@@ -1144,7 +1141,7 @@
         "identified": true,
         "cover": null,
         "range": {
-          "value": 5,
+          "value": null,
           "long": null,
           "units": "ft",
           "reach": null
@@ -1232,7 +1229,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1268,14 +1265,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "str",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -1286,13 +1283,16 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           },
           "dnd5eactivity100": {
             "_id": "dnd5eactivity100",
             "type": "save",
             "activation": {
-              "type": "action",
+              "type": "special",
               "value": 1,
               "condition": "",
               "override": false
@@ -1358,7 +1358,9 @@
               }
             },
             "sort": 0,
-            "name": ""
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
@@ -1369,19 +1371,26 @@
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 100000,
       "ownership": {
         "default": 0
       },
-      "flags": {},
+      "flags": {
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676953,
+        "modifiedTime": 1744075307516,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.FOkSL18gU0Sli5ZA"
@@ -1393,7 +1402,7 @@
       "img": "icons/skills/melee/strike-slashes-red.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing damage</em></strong>.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
           "chat": "<p>The Weretiger attacks with its Claw.</p>"
         },
         "source": {
@@ -1419,7 +1428,7 @@
         "identified": true,
         "cover": null,
         "range": {
-          "value": 5,
+          "value": null,
           "long": null,
           "units": "ft",
           "reach": null
@@ -1507,7 +1516,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1543,14 +1552,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "str",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "melee",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -1561,29 +1570,40 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "claw-tiger-or-hybrid-form-only"
+        "identifier": "claw-tiger-or-hybrid-form-only",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 300000,
       "ownership": {
         "default": 0
       },
-      "flags": {},
+      "flags": {
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676953,
+        "modifiedTime": 1744075307516,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.HPmjVRKpG08bgohb"
@@ -1595,7 +1615,7 @@
       "img": "icons/weapons/swords/sword-katana.webp",
       "system": {
         "description": {
-          "value": "<p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5 ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing damage</em></strong>.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
           "chat": "<p>The Weretiger attacks with its Scimitar.</p>"
         },
         "source": {
@@ -1684,7 +1704,7 @@
         },
         "type": {
           "value": "martialM",
-          "baseItem": ""
+          "baseItem": "scimitar"
         },
         "container": null,
         "crewed": false,
@@ -1772,11 +1792,12 @@
         "attuned": false,
         "ammunition": {},
         "magicalBonus": null,
-        "identifier": "scimitar-humanoid-or-hybrid-form-only"
+        "identifier": "scimitar-humanoid-or-hybrid-form-only",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 400000,
       "ownership": {
         "default": 0
       },
@@ -1786,9 +1807,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676953,
+        "modifiedTime": 1744075307516,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.vtnEGCOptmp2bcqG"
@@ -1800,7 +1821,7 @@
       "img": "icons/weapons/bows/longbow-leather-green.webp",
       "system": {
         "description": {
-          "value": "<p>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>",
+          "value": "<p>[[/attack extended]]. [[/damage extended]].</p>",
           "chat": "<p>The Weretiger attacks with its Longbow.</p>"
         },
         "source": {
@@ -1890,7 +1911,7 @@
         },
         "type": {
           "value": "martialR",
-          "baseItem": ""
+          "baseItem": "longbow"
         },
         "container": null,
         "crewed": false,
@@ -1918,7 +1939,7 @@
             "duration": {
               "concentration": false,
               "value": "",
-              "units": "",
+              "units": "inst",
               "special": "",
               "override": false
             },
@@ -1954,14 +1975,14 @@
               "recovery": []
             },
             "attack": {
-              "ability": "str",
+              "ability": "",
               "bonus": "",
               "critical": {
                 "threshold": null
               },
               "flat": false,
               "type": {
-                "value": "ranged",
+                "value": "",
                 "classification": "weapon"
               }
             },
@@ -1972,29 +1993,42 @@
               "includeBase": true,
               "parts": []
             },
-            "sort": 0
+            "sort": 0,
+            "name": "",
+            "img": "",
+            "appliedEffects": []
           }
         },
         "attuned": false,
-        "ammunition": {},
+        "ammunition": {
+          "type": "arrow"
+        },
         "magicalBonus": null,
-        "identifier": "longbow-humanoid-or-hybrid-form-only"
+        "identifier": "longbow-humanoid-or-hybrid-form-only",
+        "mastery": ""
       },
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 500000,
       "ownership": {
         "default": 0
       },
-      "flags": {},
+      "flags": {
+        "dnd5e": {
+          "riders": {
+            "activity": [],
+            "effect": []
+          }
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "dnd5e",
-        "systemVersion": "4.2.0",
+        "systemVersion": "4.3.8",
         "createdTime": null,
-        "modifiedTime": 1736804676953,
+        "modifiedTime": 1744075307516,
         "lastModifiedBy": "dnd5ebuilder0000"
       },
       "_key": "!actors.items!zIr3NaNF0mWz5Ahq.onmNGMiE4AyvYxDQ"
@@ -2011,9 +2045,9 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "dnd5e",
-    "systemVersion": "4.0.0",
+    "systemVersion": "4.3.8",
     "createdTime": 1726171267537,
-    "modifiedTime": 1726171452250,
+    "modifiedTime": 1744075486015,
     "lastModifiedBy": "dnd5ebuilder0000"
   },
   "_key": "!actors!zIr3NaNF0mWz5Ahq"


### PR DESCRIPTION
Actors:
- Ape - FA credit line
- Couatl, Succubus/Incubus, Assassin, Berserker, Gladiator, Weretiger  - attack/damage/save enrichers and additional activities
- Druid - enrichers and shillelagh improvements
- Mage, Priest, Scout - enrichers and replaced natural weapons with equipment equivalents
- Noble - enrichers

Items:
- Talisman of the Sphere - changed item type to equipment (wondrous item) and added control check activity

Monster Features:
- Legendary Resistance - adds resource consumption, clarifies activity (expend use)