### PR TITLE
Miscellaneous SRD upgrades

### DIFF
--- a/packs/_source/items/trinket/talisman-of-the-sphere.yml
+++ b/packs/_source/items/trinket/talisman-of-the-sphere.yml
@@ -1,18 +1,17 @@
 _id: 46ikeR4RrSim6DsN
 name: Talisman of the Sphere
-type: consumable
+type: equipment
 img: icons/commodities/treasure/broach-jeweled-pink.webp
 system:
   description:
     value: >-
-      <p><em>Wondrous item, (requires attunement)</em></p>
-
-      <p>When you make an Intelligence (Arcana) check to control a Sphere of
-      Annihilation while you are holding this talisman, you double your
-      proficiency bonus on the check. In addition, when you start your turn with
-      control over a Sphere of Annihilation, you can use an action to levitate
-      it 10 feet plus a number of additional feet equal to 10 × your
-      Intelligence modifier.</p>
+      <p><em>Wondrous item, (requires attunement)</em></p><p>When you make an
+      Intelligence (Arcana) check to control a Sphere of Annihilation while you
+      are holding this talisman, you double your proficiency bonus on the check.
+      In addition, when you start your turn with control over a Sphere of
+      Annihilation, you can use an action to levitate it 10 feet plus a number
+      of additional feet equal to 10 × your Intelligence modifier.</p><p>[[10 +
+      10 * @abilities.int.mod]]{Total distance} feet</p>
     chat: ''
   source:
     custom: ''
@@ -51,7 +50,7 @@ system:
         formula: ''
     replace: false
   type:
-    value: trinket
+    value: wondrous
     subtype: ''
   unidentified:
     description: ''
@@ -79,7 +78,7 @@ system:
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
@@ -106,11 +105,19 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: '25'
+        associated:
+          - arc
       uses:
         spent: 0
         recovery: []
+        max: ''
       sort: 0
+      name: Control Check
+      img: ''
+      appliedEffects: []
   attuned: false
   identifier: talisman-of-the-sphere
 effects: []
@@ -118,13 +125,17 @@ folder: UnUwTG4YIgd0kaUJ
 sort: 1100000
 ownership:
   default: 0
-flags: {}
+flags:
+  dnd5e:
+    riders:
+      activity: []
+      effect: []
 _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1725037098121
-  modifiedTime: 1725992483211
+  modifiedTime: 1744317421044
   lastModifiedBy: dnd5ebuilder0000
 _key: '!items!46ikeR4RrSim6DsN'

--- a/packs/_source/monsterfeatures/legendary-resistance.yml
+++ b/packs/_source/monsterfeatures/legendary-resistance.yml
@@ -30,16 +30,13 @@ system:
       activation:
         type: special
         value: null
-        condition: ''
+        condition: fails a saving throw
         override: false
       consumption:
         targets:
           - type: attribute
-            target: ''
             value: '1'
-            scaling:
-              mode: ''
-              formula: ''
+            target: resources.legres.value
         scaling:
           allowed: false
           max: ''
@@ -49,12 +46,12 @@ system:
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -68,7 +65,7 @@ system:
           units: ''
         affects:
           count: ''
-          type: ''
+          type: self
           choice: false
           special: ''
         prompt: true
@@ -83,12 +80,20 @@ system:
         prompt: false
         visible: false
       sort: 0
+      name: Expend Use
+      img: systems/dnd5e/icons/svg/monster.svg
+      appliedEffects: []
   enchant: {}
   prerequisites:
     level: null
-  properties: []
+  properties:
+    - trait
   identifier: legendary-resistance
-flags: {}
+flags:
+  dnd5e:
+    riders:
+      activity: []
+      effect: []
 img: icons/equipment/shield/kite-wooden-oak-glow.webp
 effects: []
 folder: null
@@ -97,8 +102,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1725304968656
-  modifiedTime: 1725992571943
+  modifiedTime: 1744318649828
   lastModifiedBy: dnd5ebuilder0000
 _key: '!items!J1NxNTJ2qi05iAFF'

--- a/packs/_source/monsters/celestial/couatl.yml
+++ b/packs/_source/monsters/celestial/couatl.yml
@@ -55,7 +55,7 @@ system:
       value: 97
       max: 97
       temp: null
-      tempmax: 0
+      tempmax: null
       formula: 13d8 + 39
     init:
       ability: ''
@@ -371,7 +371,7 @@ system:
       override: null
   bonuses:
     mwak:
-      attack: ''
+      attack: '1'
       damage: ''
     rwak:
       attack: ''
@@ -490,12 +490,11 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+8 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>8 (1d6 + 5) <em>piercing
-          damage</em></strong>.</p><p>The target must succeed on a  <strong>DC
-          13 Constitution</strong> saving throw or be poisoned for 24 hours.
-          Until this poison ends, the target is unconscious. Another creature
-          can use an action to shake the target awake.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          succeed on a [[/save]] saving throw or be &amp;Reference[poisoned
+          apply=false] for 24 hours. Until this poison ends, the target is
+          &amp;Reference[unconscious apply=false]. Another creature can use an
+          action to shake the target awake.</p>
         chat: >-
           <p>The Couatl attacks with its Bite. The target must make a
           <strong>Constitution</strong> saving throw.</p>
@@ -519,7 +518,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -562,6 +561,7 @@ items:
         conditions: ''
       properties:
         - fin
+        - mgc
       proficient: 1
       unidentified:
         description: ''
@@ -590,7 +590,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -620,13 +620,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -634,11 +634,14 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
           activation:
-            type: action
+            type: special
             value: 1
             condition: ''
             override: false
@@ -653,10 +656,11 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: GLxzcYW1p5BO6Tdt
           range:
             value: '5'
             units: ft
@@ -683,31 +687,64 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
-            parts:
-              - number: 1
-                denomination: 6
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            onSave: none
+            parts: []
           save:
             ability: con
             dc:
-              calculation: ''
+              calculation: con
               formula: '13'
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects:
+            - GLxzcYW1p5BO6Tdt
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
-    effects: []
+      mastery: ''
+    effects:
+      - name: Poisoned
+        img: systems/dnd5e/icons/svg/statuses/unconscious.svg
+        origin: Compendium.dnd5e.monsters.Actor.ZaP1H91t4FzbRqR5.Item.7M1OrMoMMTCEKxta
+        transfer: false
+        _id: GLxzcYW1p5BO6Tdt
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          seconds: 86400
+          combat: null
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>Until this poison ends, the target is unconscious. Another creature
+          can use an action to shake the target awake.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+          - unconscious
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          coreVersion: '12.331'
+          systemId: dnd5e
+          systemVersion: 4.3.8
+          createdTime: 1744076654091
+          modifiedTime: 1744076734676
+          lastModifiedBy: dnd5ebuilder0000
+        _key: >-
+          !actors.items.effects!ZaP1H91t4FzbRqR5.7M1OrMoMMTCEKxta.GLxzcYW1p5BO6Tdt
     folder: null
     sort: 0
     ownership:
@@ -715,14 +752,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676688
+      modifiedTime: 1744076855445
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!ZaP1H91t4FzbRqR5.7M1OrMoMMTCEKxta'
   - _id: 8LkzioyaScFxfst7
@@ -732,11 +773,10 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>,
-          <strong>10 ft.,</strong> one Medium or smaller creature. Hit:
-          <strong>10 (2d6 + 3) <em>bludgeoning damage</em></strong>.</p><p>The
-          target is grappled (escape DC 15). Until this grapple ends, the target
-          is restrained, and the couatl can't constrict another target.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
+          grappled (escape [[/check]]). Until this grapple ends, the target is
+          restrained, and the [[lookup @name lowercase]] can't constrict another
+          target.</p>
         chat: >-
           <p>The Couatl attacks with its Constrict. The target is grappled.
           Until this grapple ends, the target is restrained, and the couatl
@@ -761,10 +801,10 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -803,7 +843,7 @@ items:
         dt: null
         conditions: ''
       properties:
-        - fin
+        - mgc
       proficient: 1
       unidentified:
         description: ''
@@ -832,10 +872,11 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: bT77MKZEyBFGGrrW
           range:
             value: '5'
             units: ft
@@ -862,7 +903,7 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
@@ -876,24 +917,118 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
+        qSVi3BwrAoCnPpjk:
+          type: check
+          name: Escape Check
+          _id: qSVi3BwrAoCnPpjk
+          sort: 0
+          activation:
+            type: ''
+            value: null
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          range:
+            override: false
+          target:
+            template:
+              contiguous: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          check:
+            associated:
+              - acr
+              - ath
+            dc:
+              calculation: dex
+              formula: ''
+            ability: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: constrict
-    effects: []
+      mastery: ''
+    effects:
+      - name: Restrained
+        img: systems/dnd5e/icons/svg/statuses/restrained.svg
+        origin: Compendium.dnd5e.monsters.Actor.ZaP1H91t4FzbRqR5.Item.8LkzioyaScFxfst7
+        transfer: false
+        _id: bT77MKZEyBFGGrrW
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          seconds: null
+          combat: null
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: <p>Until this grapple ends, the target is restrained.</p>
+        tint: '#ffffff'
+        statuses:
+          - grappled
+          - restrained
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          coreVersion: '12.331'
+          systemId: dnd5e
+          systemVersion: 4.3.8
+          createdTime: 1744077355795
+          modifiedTime: 1744077412495
+          lastModifiedBy: dnd5ebuilder0000
+        _key: >-
+          !actors.items.effects!ZaP1H91t4FzbRqR5.8LkzioyaScFxfst7.bT77MKZEyBFGGrrW
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676688
+      modifiedTime: 1744077425336
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!ZaP1H91t4FzbRqR5.8LkzioyaScFxfst7'
   - _id: iw2q07K1D0X01DZO
@@ -1017,16 +1152,19 @@ items:
     system:
       description:
         value: >-
-          <p>The couatl's spellcasting ability is Charisma (spell save DC 14).
-          It can innately cast the following spells, requiring only verbal
-          components:</p>
-
-          <p>At will: detect evil and good, detect magic, detect thoughts</p>
-
-          <p>3/day each: bless, create food and water, cure wounds, lesser
-          restoration, protection from poison, sanctuary, shield</p>
-
-          <p>1/day each: dream, greater restoration, scrying</p>
+          <p>The [[lookup @name lowercase]]'s spellcasting ability is Charisma
+          (spell save DC [[lookup @abilities.cha.dc]]). It can innately cast the
+          following spells, requiring only verbal components:</p><p>At will: 
+          [[/item .Mzh95utKDPIrjiH8]]{detect evil and good}, [[/item
+          .ghXTfe7sgCbgf1Q8]]{detect magic}, [[/item .ppWAAEul0QHtm4er]]{detect
+          thoughts}</p><p>3/day each: [[/item .8dzaICjGy6mTUaUr]]{bless},
+          [[/item .BV0mpbHh29IbbIj5]]{create food and water}, [[/item
+          .uUWb1wZgtMou0TVP]]{cure wounds}, [[/item .F0GsG0SJzsIOacwV]]{lesser
+          restoration}, [[/item .MAxM77CDUu8dgIRQ]]{protection from poison},
+          [[/item .gvdA9nPuWLck4tBl]]{sanctuary}, [[/item
+          .z1mx84ONwkXKUZd7]]{shield}</p><p>1/day each: [[/item
+          .kSPRpeIx3w3nihrF]]{dream}, [[/item .WzvJ7G3cqvIubsLk]]{greater
+          restoration}, [[/item .fVbCxFRaORalHB20]]{scrying}</p>
         chat: ''
       source:
         custom: ''
@@ -1040,10 +1178,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -1062,10 +1201,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744076493164
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!ZaP1H91t4FzbRqR5.J40yeoOnwpvtVpHt'
   - _id: 3qE2LLHPANSEPmIN
     name: Magic Weapons
@@ -1087,10 +1226,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -1109,10 +1249,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744076521424
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!ZaP1H91t4FzbRqR5.3qE2LLHPANSEPmIN'
   - _id: MGh9IkfXNn7FmwL5
     name: Shielded Mind
@@ -1139,7 +1279,8 @@ items:
         value: ''
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -1158,10 +1299,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744076561380
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!ZaP1H91t4FzbRqR5.MGh9IkfXNn7FmwL5'
   - _id: Mzh95utKDPIrjiH8
     name: Detect Evil and Good
@@ -3035,8 +3176,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171239772
-  modifiedTime: 1726171446294
+  modifiedTime: 1744077277605
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!ZaP1H91t4FzbRqR5'

--- a/packs/_source/monsters/fiend/succubus-incubus.yml
+++ b/packs/_source/monsters/fiend/succubus-incubus.yml
@@ -55,7 +55,7 @@ system:
       value: 66
       max: 66
       temp: null
-      tempmax: 0
+      tempmax: null
       formula: 12d8 + 12
     init:
       ability: ''
@@ -508,10 +508,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -530,10 +531,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744058659464
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!VmdyZDjqAc8vdncY.P3P1EukfOip32dtd'
   - _id: ZVMVqd01HraMcenH
     name: Shapechanger
@@ -566,7 +567,8 @@ items:
         value: ''
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
@@ -638,9 +640,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676927
+      modifiedTime: 1744059611427
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!VmdyZDjqAc8vdncY.ZVMVqd01HraMcenH'
   - _id: oSlFzVMu0fdEfYt1
@@ -649,10 +651,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Succubus/Incubus attacks with its Claw.</p>
       source:
         custom: ''
@@ -674,7 +673,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -715,7 +714,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
+      properties:
+        - fin
       proficient: 1
       unidentified:
         description: ''
@@ -744,7 +744,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -774,13 +774,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -788,24 +788,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw-fiend-form-only
+      mastery: ''
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676927
+      modifiedTime: 1744058885337
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!VmdyZDjqAc8vdncY.oSlFzVMu0fdEfYt1'
   - _id: 2bFCfFfjRNmhyE8A
@@ -816,15 +824,14 @@ items:
       description:
         value: >-
           <p>One humanoid the fiend can see within 30 feet of it must make a
-          <strong>DC 15</strong> <strong>Wisdom</strong> saving throw or be
-          magically charmed for 1 day. The charmed target obeys the fiend's
-          verbal or telepathic commands.</p><p>If the target suffers any harm or
-          receives a suicidal command, it can repeat the saving throw, ending
-          the effect on a success. If the target successfully saves against the
-          effect, or if the effect on it ends, the target is immune to this
-          fiend's Charm for the next 24 hours.The fiend can have only one target
-          charmed at a time. If it charms another, the effect on the previous
-          target ends.</p>
+          [[/save]] saving throw or be magically charmed for 1 day. The charmed
+          target obeys the fiend's verbal or telepathic commands.</p><p>If the
+          target suffers any harm or receives a suicidal command, it can repeat
+          the saving throw, ending the effect on a success. If the target
+          successfully saves against the effect, or if the effect on it ends,
+          the target is immune to this fiend's Charm for the next 24 hours.The
+          fiend can have only one target charmed at a time. If it charms
+          another, the effect on the previous target ends.</p>
         chat: >-
           <p>One humanoid the fiend can see within 30 feet of it must make a
           <strong>Wisdom</strong> saving throw.</p>
@@ -840,10 +847,11 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
@@ -867,7 +875,8 @@ items:
             units: day
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: iuVbm8rd6UWg36yg
           range:
             value: '30'
             units: ft
@@ -883,10 +892,10 @@ items:
               height: ''
               units: ''
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
-              special: ''
+              special: Humanoid
             prompt: true
             override: false
           uses:
@@ -894,20 +903,66 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability: wis
             dc:
-              calculation: ''
+              calculation: cha
               formula: '15'
           sort: 0
           name: ''
+          img: ''
+          appliedEffects:
+            - iuVbm8rd6UWg36yg
       enchant: {}
       prerequisites:
         level: null
       identifier: charm
-    effects: []
+    effects:
+      - name: Charmed
+        img: systems/dnd5e/icons/svg/statuses/charmed.svg
+        origin: Compendium.dnd5e.monsters.Actor.VmdyZDjqAc8vdncY.Item.2bFCfFfjRNmhyE8A
+        transfer: false
+        _id: iuVbm8rd6UWg36yg
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          seconds: 86400
+          combat: null
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>The charmed target obeys the fiend's verbal or telepathic
+          commands.</p><p>If the target suffers any harm or receives a suicidal
+          command, it can repeat the saving throw, ending the effect on a
+          success. If the target successfully saves against the effect, or if
+          the effect on it ends, the target is immune to this fiend's Charm for
+          the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - charmed
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          coreVersion: '12.331'
+          systemId: dnd5e
+          systemVersion: 4.3.8
+          createdTime: 1744059005231
+          modifiedTime: 1744059080198
+          lastModifiedBy: dnd5ebuilder0000
+        _key: >-
+          !actors.items.effects!VmdyZDjqAc8vdncY.2bFCfFfjRNmhyE8A.iuVbm8rd6UWg36yg
     folder: null
     sort: 0
     ownership:
@@ -915,14 +970,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.ykoo88OJOdfYH7mH
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.ykoo88OJOdfYH7mH
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676927
+      modifiedTime: 1744059148476
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!VmdyZDjqAc8vdncY.2bFCfFfjRNmhyE8A'
   - _id: eb0O9cQ8N6lovLyI
@@ -933,11 +992,10 @@ items:
       description:
         value: >-
           <p>The fiend kisses a creature charmed by it or a willing creature.
-          The target must make a  <strong>DC 15 Constitution</strong> saving
-          throw against this magic, taking <strong>32 (5d10 + 5) <em>psychic
-          damage</em></strong> on a failed save, or half as much damage on a
-          successful one. </p><p>The target's hit point maximum is reduced by an
-          amount equal to the damage taken. This reduction lasts until the
+          The target must make a [[/save]] saving throw against this magic,
+          taking [[/damage]] damage on a failed save, or half as much damage on
+          a successful one.</p><p>The target's hit point maximum is reduced by
+          an amount equal to the damage taken. This reduction lasts until the
           target finishes a long rest. The target dies if this effect reduces
           its hit point maximum to 0.</p>
         chat: >-
@@ -955,10 +1013,11 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
-      requirements: ''
-      properties: []
+      requirements: Targets a charmed or willing creature
+      properties:
+        - mgc
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
@@ -984,7 +1043,7 @@ items:
             override: false
           effects: []
           range:
-            units: self
+            units: touch
             special: ''
             override: false
           target:
@@ -997,10 +1056,10 @@ items:
               height: ''
               units: ''
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
-              special: ''
+              special: charmed or willing creature
             prompt: true
             override: false
           uses:
@@ -1014,19 +1073,19 @@ items:
                   enabled: false
                   formula: ''
                 number: 5
-                denomination: 10
+                denomination: '10'
                 bonus: '@mod'
                 types:
                   - psychic
-                scaling:
-                  number: 1
           save:
             ability: con
             dc:
-              calculation: ''
+              calculation: cha
               formula: '15'
           sort: 0
           name: ''
+          img: ''
+          appliedEffects: []
       enchant: {}
       prerequisites:
         level: null
@@ -1039,14 +1098,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.iq0J225DCbHYU2hU
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.iq0J225DCbHYU2hU
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676927
+      modifiedTime: 1744059474380
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!VmdyZDjqAc8vdncY.eb0O9cQ8N6lovLyI'
   - _id: s1s5asgUorljP7SV
@@ -1055,10 +1118,10 @@ items:
     img: icons/magic/unholy/barrier-shield-glowing-pink.webp
     system:
       description:
-        value: ''
-        chat: >-
-          <section class="secret"><p></p></section><p>The fiend magically enters
-          the Ethereal Plane from the Material Plane, or vice versa.</p>
+        value: >-
+          <p>The fiend magically enters the Ethereal Plane from the Material
+          Plane, or vice versa.</p>
+        chat: ''
       source:
         custom: ''
         book: ''
@@ -1071,10 +1134,11 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
@@ -1095,12 +1159,13 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: perm
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: 1Bd78CAdilT57jFe
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1114,7 +1179,7 @@ items:
               units: ''
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1129,11 +1194,51 @@ items:
             prompt: false
             visible: false
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       enchant: {}
       prerequisites:
         level: null
       identifier: etherealness
-    effects: []
+    effects:
+      - name: Etherealness
+        img: icons/magic/unholy/barrier-shield-glowing-pink.webp
+        origin: Compendium.dnd5e.monsters.Actor.VmdyZDjqAc8vdncY.Item.s1s5asgUorljP7SV
+        transfer: true
+        _id: 1Bd78CAdilT57jFe
+        type: base
+        system: {}
+        changes: []
+        disabled: true
+        duration:
+          startTime: null
+          seconds: null
+          combat: null
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: ''
+        tint: '#ffffff'
+        statuses:
+          - ethereal
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          coreVersion: '12.331'
+          systemId: dnd5e
+          systemVersion: 4.3.8
+          createdTime: 1744059571494
+          modifiedTime: 1744059585380
+          lastModifiedBy: dnd5ebuilder0000
+        _key: >-
+          !actors.items.effects!VmdyZDjqAc8vdncY.s1s5asgUorljP7SV.1Bd78CAdilT57jFe
     folder: null
     sort: 0
     ownership:
@@ -1141,14 +1246,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.rDoNJnKdY47x8MD4
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.rDoNJnKdY47x8MD4
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676927
+      modifiedTime: 1744059571510
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!VmdyZDjqAc8vdncY.s1s5asgUorljP7SV'
 effects: []
@@ -1161,8 +1270,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171236478
-  modifiedTime: 1726171445682
+  modifiedTime: 1744059282250
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!VmdyZDjqAc8vdncY'

--- a/packs/_source/monsters/humanoid/assassin.yml
+++ b/packs/_source/monsters/humanoid/assassin.yml
@@ -55,7 +55,7 @@ system:
       value: 78
       max: 78
       temp: null
-      tempmax: 0
+      tempmax: null
       formula: 12d8 + 24
     init:
       ability: ''
@@ -579,10 +579,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -601,10 +602,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744049608086
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!EMvcuOpu7ABCmBWi.Ld00NpZe8Zl4J4Pi'
   - _id: crRphULq6iIdlq88
     name: Evasion
@@ -630,10 +631,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -652,10 +654,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744049652244
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!EMvcuOpu7ABCmBWi.crRphULq6iIdlq88'
   - _id: EcECOhaJIpCtN2o7
     name: Sneak Attack
@@ -663,13 +665,13 @@ items:
     img: icons/skills/melee/blade-tip-chipped-blood-red.webp
     system:
       description:
-        value: ''
-        chat: >-
+        value: >-
           <p>The assassin deals an extra 13 (4d6) damage when it hits a target
           with a weapon attack and has advantage on the attack roll, or when the
           target is within 5 ft. of an ally of the assassin that isn't
           incapacitated and the assassin doesn't have disadvantage on the attack
           roll.</p>
+        chat: ''
       source:
         custom: ''
         book: ''
@@ -682,10 +684,11 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
@@ -706,12 +709,12 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -739,18 +742,18 @@ items:
               allow: false
               bonus: ''
             parts:
-              - number: 4
-                denomination: 6
-                bonus: ''
-                types: []
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 4
+                denomination: '6'
+                bonus: ''
+                types:
+                  - piercing
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       enchant: {}
       prerequisites:
         level: null
@@ -763,14 +766,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.9uKShqfuA73duQsT
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.9uKShqfuA73duQsT
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676773
+      modifiedTime: 1744049774607
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!EMvcuOpu7ABCmBWi.EcECOhaJIpCtN2o7'
   - _id: zaYTSI1nKtzBnQwf
@@ -779,7 +786,7 @@ items:
     img: icons/skills/melee/blade-tips-triple-steel.webp
     system:
       description:
-        value: <p>The assassin makes two shortsword attacks.</p>
+        value: <p>The assassin makes two [[/item .Kbg12IJ0YW79vP06]] attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -868,10 +875,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744050115773
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!EMvcuOpu7ABCmBWi.zaYTSI1nKtzBnQwf'
   - _id: Kbg12IJ0YW79vP06
     name: Shortsword
@@ -880,15 +887,11 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+6 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>piercing
-          damage</em></strong>.</p><p>The target must make a  <strong>DC 15
-          Constitution</strong> saving throw, taking <strong>24 (7d6) <em>poison
-          damage</em></strong> on a failed save, or half as much damage on a
-          successful one.</p>
-        chat: >-
-          <p>The Assassin attacks with their Shortsword. The target must make a
-          <strong>Constitution</strong> saving throw.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          make a [[/save]] saving throw, taking [[/damage
+          activity=dnd5eactivity100]] damage on a failed save, or half as much
+          damage on a successful one.</p>
+        chat: ''
       source:
         custom: ''
         book: ''
@@ -981,7 +984,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1011,13 +1014,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -1025,6 +1028,9 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
@@ -1044,7 +1050,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1076,98 +1082,47 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 1
-                denomination: 6
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                number: 7
+                denomination: '6'
+                bonus: ''
+                types:
+                  - poison
           save:
             ability: con
             dc:
               calculation: ''
               formula: '15'
           sort: 0
-        dnd5eactivity300:
-          _id: dnd5eactivity300
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '5'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: 7d6
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: shortsword
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
       core:
         sourceId: Compendium.dnd5e.items.osLzOwQdPtrK3rQH
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.items.osLzOwQdPtrK3rQH
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676773
+      modifiedTime: 1744050091759
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!EMvcuOpu7ABCmBWi.Kbg12IJ0YW79vP06'
   - _id: rNQK7okIBNZ2zDvD
@@ -1177,11 +1132,10 @@ items:
     system:
       description:
         value: >-
-          <p>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit:
-          <strong>7 (1d8 + 3) <em>piercing damage</em></strong>.</p><p>The
-          target must make a  <strong>DC 15 Constitution</strong> saving throw,
-          taking <strong>24 (7d6) <em>poison damage</em></strong> on a failed
-          save, or half as much damage on a successful one.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
+          make a [[/save]] saving throw, taking [[/damage
+          activity=qt3tGFCRiYgaiWQ3]] damage on a failed save, or half as much
+          damage on a successful one.</p>
         chat: >-
           <p>The Assassin attacks with its Light Crossbow. The target must make
           a <strong>Constitution</strong> saving throw.</p>
@@ -1247,9 +1201,9 @@ items:
         dt: null
         conditions: ''
       properties:
-        - lgt
-        - two
         - amm
+        - lod
+        - two
       proficient: 1
       unidentified:
         description: ''
@@ -1259,8 +1213,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        FOPIJT58E21wGaqM:
           type: attack
           activation:
             type: action
@@ -1278,12 +1231,12 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            value: '80'
+            value: '5'
             units: ft
             special: ''
             override: false
@@ -1308,13 +1261,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: ranged
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -1322,8 +1275,9 @@ items:
             includeBase: true
             parts: []
           sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+          name: ''
+          _id: FOPIJT58E21wGaqM
+        qt3tGFCRiYgaiWQ3:
           type: save
           activation:
             type: action
@@ -1341,12 +1295,12 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            value: '80'
+            value: '5'
             units: ft
             special: ''
             override: false
@@ -1373,98 +1327,51 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 1
-                denomination: 8
-                bonus: '@mod'
-                types:
-                  - piercing
-                custom:
+              - custom:
                   enabled: false
                   formula: ''
+                number: 7
+                denomination: 6
+                bonus: ''
+                types:
+                  - poison
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '15'
           sort: 0
-        dnd5eactivity300:
-          _id: dnd5eactivity300
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '80'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: 7d6
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+          name: ''
+          _id: qt3tGFCRiYgaiWQ3
       attuned: false
-      ammunition: {}
+      ammunition:
+        type: crossbowBolt
       magicalBonus: null
       identifier: light-crossbow
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags:
       core:
         sourceId: Compendium.dnd5e.items.ddWvQRLmnnIS0eLF
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.items.ddWvQRLmnnIS0eLF
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676773
+      modifiedTime: 1744050413943
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!EMvcuOpu7ABCmBWi.rNQK7okIBNZ2zDvD'
 effects: []
@@ -1477,8 +1384,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171214988
-  modifiedTime: 1726171441681
+  modifiedTime: 1744051382560
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!EMvcuOpu7ABCmBWi'

--- a/packs/_source/monsters/humanoid/berserker.yml
+++ b/packs/_source/monsters/humanoid/berserker.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 67
       max: 67
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 9d8 + 27
     init:
       ability: ''
@@ -577,16 +577,55 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
         level: null
       identifier: reckless
-    effects: []
+    effects:
+      - name: Reckless
+        img: icons/skills/social/intimidation-impressing.webp
+        origin: Compendium.dnd5e.monsters.Actor.kz1t6xeXVwODpYb2.Item.Qzj9HKnvRGhYoggC
+        _id: WqXUqzRbXoMjF2MJ
+        type: base
+        system: {}
+        changes: []
+        disabled: true
+        duration:
+          startTime: null
+          seconds: null
+          combat: null
+          rounds: 1
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>Attack rolls against it have advantage until the start of its next
+          turn.</p>
+        tint: '#ffffff'
+        transfer: true
+        statuses: []
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          coreVersion: '12.331'
+          systemId: dnd5e
+          systemVersion: 4.3.8
+          createdTime: 1744135358115
+          modifiedTime: 1744135431645
+          lastModifiedBy: dnd5ebuilder0000
+        _key: >-
+          !actors.items.effects!kz1t6xeXVwODpYb2.Qzj9HKnvRGhYoggC.WqXUqzRbXoMjF2MJ
     folder: null
     sort: 0
     ownership:
@@ -599,10 +638,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744135320648
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!kz1t6xeXVwODpYb2.Qzj9HKnvRGhYoggC'
   - _id: RrHhFZOd6QT75V3W
     name: Greataxe
@@ -610,10 +649,7 @@ items:
     img: icons/weapons/axes/axe-double.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>9 (1d12 + 3) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Berserker attacks with their Greataxe.</p>
       source:
         custom: ''
@@ -707,7 +743,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -737,13 +773,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -751,10 +787,14 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: greataxe
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -763,14 +803,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.items.1Lxk6kmoRhG8qQ0u
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.items.1Lxk6kmoRhG8qQ0u
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676494
+      modifiedTime: 1744135489725
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!kz1t6xeXVwODpYb2.RrHhFZOd6QT75V3W'
 effects: []
@@ -783,8 +827,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171252938
-  modifiedTime: 1726171448945
+  modifiedTime: 1744135509959
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!kz1t6xeXVwODpYb2'

--- a/packs/_source/monsters/humanoid/druid.yml
+++ b/packs/_source/monsters/humanoid/druid.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 27
       max: 27
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d8 + 5
     init:
       ability: ''
@@ -106,7 +106,7 @@ system:
     biography:
       value: ''
       public: ''
-    alignment: any
+    alignment: any alignment
     race: null
     type:
       value: humanoid
@@ -488,11 +488,14 @@ items:
         value: >-
           <p>The druid is a 4th-level spellcaster. Its spellcasting ability is
           Wisdom (spell save DC 12, +4 to hit with spell attacks).</p><p>It has
-          the following druid spells prepared:</p><p><strong>Cantrips
-          </strong>(at will): druidcraft, produce flame,
-          shillelagh</p><p><strong> 1st level</strong> (4 slots): entangle,
-          longstrider, speak with animals, thunderwave</p><p><strong>2nd
-          level</strong> (3 slots): animal messenger, barkskin</p>
+          the following druid spells prepared:</p><p>Cantrips (at will): [[/item
+          .SbSvZKkJASyk8jKo]]{druidcraft}, [[/item .eCPQuQkIabFKTl9u]]{produce
+          flame}, [[/item .VzgFzcmocr1X1cp4]]{shillelagh}</p><p>1st level (4
+          slots): [[/item .gMrWeG8fMDPRFiVe]]{entangle}, [[/item
+          .B0pnIcc52O6G8hi8]]{longstrider}, [[/item .aL1F8fvYLtNzUbKu]]{speak
+          with animals}, [[/item .WTbOQBsarsL1LuXJ]]{thunderwave}</p><p>2nd
+          level (3 slots): [[/item .X8w9EzYLGc4vQ1H2]]{animal messenger},
+          [[/item .JPwIEfgUPVebr5AH]]{barkskin}</p>
         chat: <p>The druid is a spellcaster. Its spellcasting ability is Wisdom.</p>
       source:
         custom: ''
@@ -528,9 +531,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676552
+      modifiedTime: 1744141612084
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!K15Yl8JmB5iPircc.07sdy4qaaW4MaB8W'
   - _id: KUP8WEfLxlcY7K2x
@@ -540,10 +543,11 @@ items:
     system:
       description:
         value: >-
-          <p>Melee Weapon Attack: +2 to hit (+4 to hit with shillelagh), reach 5
-          ft., one target. Hit: <strong>3 (1d6) <em>bludgeoning
-          damage</em></strong>, or <strong>6 (1d8 + 2) <em>bludgeoning
-          damage</em></strong> with shillelagh or if wielded with two hands.</p>
+          <p>[[/attack extended]]. [[/damage extended]] or [[/damage twoHanded]]
+          if wielded with two hands.</p><p>With
+          @UUID[.udSiVp4nSrGBSvG1]{shillelagh}, [[/attack extended
+          activity=J8RgDbtkXvXUJDuD]]. [[/damage extended
+          activity=J8RgDbtkXvXUJDuD]].</p>
         chat: <p>The Druid attacks with its Quarterstaff.</p>
       source:
         custom: ''
@@ -607,6 +611,7 @@ items:
         dt: null
         conditions: ''
       properties:
+        - foc
         - ver
       proficient: 1
       unidentified:
@@ -636,7 +641,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -666,7 +671,7 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: str
             bonus: ''
             critical:
               threshold: null
@@ -679,12 +684,145 @@ items:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: -200000
+          name: ''
+          img: ''
+          appliedEffects: []
+        J8RgDbtkXvXUJDuD:
+          type: attack
+          activation:
+            type: action
+            value: null
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+          duration:
+            value: ''
+            units: inst
+            special: ''
+            override: false
+            concentration: false
+          effects: []
+          range:
+            units: ''
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ''
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          attack:
+            ability: spellcasting
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: weapon
+          damage:
+            critical:
+              bonus: ''
+            includeBase: false
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: '8'
+                bonus: '@mod'
+                types:
+                  - bludgeoning
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: -100000
+          _id: J8RgDbtkXvXUJDuD
+          name: Spellcasting Attack
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: quarterstaff
-    effects: []
+      mastery: ''
+    effects:
+      - type: enchantment
+        name: Shillelagh
+        img: icons/magic/fire/dagger-rune-enchant-teal.webp
+        disabled: true
+        _id: siLjGctswI3gx3B2
+        system: {}
+        changes:
+          - key: name
+            mode: 2
+            value: ', Shillelagh'
+            priority: null
+          - key: system.damage.base.number
+            mode: 5
+            value: '1'
+            priority: null
+          - key: system.damage.base.denomination
+            mode: 5
+            value: '8'
+            priority: null
+          - key: system.properties
+            mode: 2
+            value: mgc
+            priority: null
+        duration:
+          startTime: null
+          seconds: 60
+          combat: null
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: ''
+        origin: Compendium.dnd5e.monsters.Actor.K15Yl8JmB5iPircc.Item.udSiVp4nSrGBSvG1
+        tint: '#ffffff'
+        transfer: false
+        statuses: []
+        sort: 0
+        flags:
+          dnd5e:
+            dependents:
+              - uuid: >-
+                  Compendium.dnd5e.monsters.Actor.K15Yl8JmB5iPircc.Item.KUP8WEfLxlcY7K2x.Activity.J8RgDbtkXvXUJDuD
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: >-
+            Compendium.dnd5e.monsters.Actor.K15Yl8JmB5iPircc.Item.udSiVp4nSrGBSvG1.ActiveEffect.QPsqj6jfS0iXSrTs
+          duplicateSource: null
+          coreVersion: '12.331'
+          systemId: dnd5e
+          systemVersion: 4.3.8
+          createdTime: 1744141902433
+          modifiedTime: 1744142295936
+          lastModifiedBy: dnd5ebuilder0000
+        _key: >-
+          !actors.items.effects!K15Yl8JmB5iPircc.KUP8WEfLxlcY7K2x.siLjGctswI3gx3B2
     folder: null
     sort: 0
     ownership:
@@ -692,14 +830,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.items.g2dWN7PQiMRYWzyk
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.items.g2dWN7PQiMRYWzyk
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676552
+      modifiedTime: 1744142941675
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!K15Yl8JmB5iPircc.KUP8WEfLxlcY7K2x'
   - _id: SbSvZKkJASyk8jKo
@@ -1587,134 +1729,6 @@ items:
       modifiedTime: null
       lastModifiedBy: null
     _key: '!actors.items!K15Yl8JmB5iPircc.X8w9EzYLGc4vQ1H2'
-  - _id: VzgFzcmocr1X1cp4
-    name: Shillelagh
-    ownership:
-      default: 0
-    type: spell
-    system:
-      description:
-        value: >-
-          <p>The wood of a club or quarterstaff you are holding is imbued with
-          nature's power. For the duration, you can use your spellcasting
-          ability instead of Strength for the attack and damage rolls of melee
-          attacks using that weapon, and the weapon's damage die becomes a d8.
-          The weapon also becomes magical, if it isn't already. The spell ends
-          if you cast it again or if you let go of the weapon.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      activation:
-        type: bonus
-        condition: ''
-        value: 1
-      duration:
-        value: '1'
-        units: minute
-      target:
-        affects:
-          type: object
-          count: '1'
-          choice: false
-        template:
-          units: spec
-          contiguous: false
-      range:
-        units: touch
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      level: 0
-      school: trs
-      materials:
-        value: A shamrock leaf, and a club or quarterstaff
-        consumed: false
-        cost: 0
-        supply: 0
-      preparation:
-        mode: prepared
-        prepared: true
-      properties:
-        - vocal
-        - somatic
-        - material
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: damage
-          activation:
-            type: action
-            value: null
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            concentration: false
-            override: false
-          effects: []
-          range:
-            override: false
-          target:
-            prompt: true
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            critical:
-              allow: false
-              bonus: ''
-            parts:
-              - number: 1
-                denomination: 8
-                bonus: '@mod'
-                types:
-                  - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: ''
-                  number: null
-                  formula: ''
-          sort: 0
-      identifier: shillelagh
-    sort: 0
-    flags:
-      core:
-        sourceId: Compendium.dnd5e.spells.VzgFzcmocr1X1cp4
-    img: icons/magic/fire/dagger-rune-enchant-teal.webp
-    effects: []
-    folder: null
-    _stats:
-      compendiumSource: Compendium.dnd5e.spells.VzgFzcmocr1X1cp4
-      duplicateSource: null
-      coreVersion: '12.331'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-    _key: '!actors.items!K15Yl8JmB5iPircc.VzgFzcmocr1X1cp4'
   - _id: JPwIEfgUPVebr5AH
     name: Barkskin
     type: spell
@@ -1870,6 +1884,251 @@ items:
       modifiedTime: null
       lastModifiedBy: null
     _key: '!actors.items!K15Yl8JmB5iPircc.JPwIEfgUPVebr5AH'
+  - _id: udSiVp4nSrGBSvG1
+    name: Shillelagh
+    ownership:
+      default: 0
+    type: spell
+    system:
+      description:
+        value: >-
+          <p>The wood of a club or quarterstaff you are holding is imbued with
+          nature's power. For the duration, you can use your spellcasting
+          ability instead of Strength for the attack and damage rolls of melee
+          attacks using that weapon, and the weapon's damage die becomes a d8.
+          The weapon also becomes magical, if it isn't already. The spell ends
+          if you cast it again or if you let go of the weapon.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: SRD 5.1
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      activation:
+        type: bonus
+        condition: ''
+        value: 1
+      duration:
+        value: '1'
+        units: minute
+      target:
+        affects:
+          type: object
+          count: '1'
+          choice: false
+          special: ''
+        template:
+          units: spec
+          contiguous: false
+          type: ''
+      range:
+        units: touch
+        special: ''
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      level: 0
+      school: trs
+      materials:
+        value: A shamrock leaf, and a club or quarterstaff
+        consumed: false
+        cost: 0
+        supply: 0
+      preparation:
+        mode: prepared
+        prepared: true
+      properties:
+        - vocal
+        - somatic
+        - material
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: enchant
+          sort: 0
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: QPsqj6jfS0iXSrTs
+              level:
+                min: null
+                max: null
+              riders:
+                activity:
+                  - ONVab5lmTqJwwMBC
+                effect: []
+                item: []
+          range:
+            override: false
+          target:
+            template:
+              contiguous: false
+              units: ft
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          enchant: {}
+          restrictions:
+            allowMagical: true
+            categories:
+              - simpleM
+            properties: []
+            type: weapon
+          name: Imbue Weapon
+        ONVab5lmTqJwwMBC:
+          type: attack
+          activation:
+            type: action
+            value: null
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+          duration:
+            value: ''
+            units: ''
+            special: ''
+            override: false
+            concentration: false
+          effects: []
+          range:
+            units: ''
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ''
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          attack:
+            ability: spellcasting
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: melee
+              classification: weapon
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 0
+          _id: ONVab5lmTqJwwMBC
+          name: Spellcasting Attack
+      identifier: shillelagh
+    sort: 0
+    flags:
+      dnd5e:
+        riders:
+          activity:
+            - ONVab5lmTqJwwMBC
+          effect: []
+    img: icons/magic/fire/dagger-rune-enchant-teal.webp
+    effects:
+      - type: enchantment
+        name: Shillelagh
+        img: icons/magic/fire/dagger-rune-enchant-teal.webp
+        disabled: false
+        _id: QPsqj6jfS0iXSrTs
+        system: {}
+        changes:
+          - key: name
+            mode: 2
+            value: ', Shillelagh'
+            priority: null
+          - key: system.damage.base.number
+            mode: 5
+            value: '1'
+            priority: null
+          - key: system.damage.base.denomination
+            mode: 5
+            value: '8'
+            priority: null
+          - key: system.properties
+            mode: 2
+            value: mgc
+            priority: null
+        duration:
+          startTime: null
+          seconds: 60
+          combat: null
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: ''
+        origin: null
+        tint: '#ffffff'
+        transfer: false
+        statuses: []
+        sort: 0
+        flags: {}
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          coreVersion: '12.331'
+          systemId: dnd5e
+          systemVersion: 4.3.8
+          createdTime: null
+          modifiedTime: null
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!K15Yl8JmB5iPircc.udSiVp4nSrGBSvG1.QPsqj6jfS0iXSrTs
+    folder: Z8kZlnggh1PtuF3Y
+    _stats:
+      duplicateSource: null
+      compendiumSource: Compendium.dnd5e.spells.Item.VzgFzcmocr1X1cp4
+      coreVersion: '12.331'
+      systemId: dnd5e
+      systemVersion: 4.3.8
+      createdTime: 1744141670539
+      modifiedTime: 1744141670539
+      lastModifiedBy: dnd5ebuilder0000
+    _key: '!actors.items!K15Yl8JmB5iPircc.udSiVp4nSrGBSvG1'
 effects: []
 folder: pEyqIq8DYb21xia3
 sort: 0
@@ -1880,8 +2139,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171221276
-  modifiedTime: 1726171442924
+  modifiedTime: 1744141765490
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!K15Yl8JmB5iPircc'

--- a/packs/_source/monsters/humanoid/gladiator.yml
+++ b/packs/_source/monsters/humanoid/gladiator.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 112
       max: 112
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 15d8 + 45
     init:
       ability: ''
@@ -652,10 +652,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -674,10 +675,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744043376665
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!fsPruAIDOg4tVrgb.YbB6EsBwNaEzVlxU'
   - _id: NPTnV9YupSeKJrQ0
     name: Brute
@@ -701,10 +702,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -723,10 +725,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744043390559
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!fsPruAIDOg4tVrgb.NPTnV9YupSeKJrQ0'
   - _id: QuVUb9i809rjJWcL
     name: Multiattack
@@ -734,7 +736,10 @@ items:
     img: icons/skills/melee/blade-tips-triple-steel.webp
     system:
       description:
-        value: <p>The gladiator makes three melee attacks or two ranged attacks.</p>
+        value: >-
+          <p>The gladiator makes three melee attacks or two ranged
+          attacks.</p><p>Melee: [[/item .eL15erXXE9EuXWSB]], [[/item
+          .GrUneCbXCYngdpjf]]</p><p>Ranged: [[/item .eL15erXXE9EuXWSB]]</p>
         chat: ''
       source:
         custom: ''
@@ -748,7 +753,7 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -823,10 +828,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744044307584
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!fsPruAIDOg4tVrgb.QuVUb9i809rjJWcL'
   - _id: eL15erXXE9EuXWSB
     name: Spear
@@ -834,12 +839,7 @@ items:
     img: icons/weapons/polearms/spear-flared-worn-grey.webp
     system:
       description:
-        value: >-
-          <p>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. and range
-          20/60 ft., one target. Hit: <strong>11 (2d6 + 4) <em>piercing
-          damage</em></strong>, or <strong>13 (2d8 + 4) <em>piercing
-          damage</em></strong> if used with two hands to make a melee
-          attack.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Gladiator attacks with their Spear.</p>
       source:
         custom: ''
@@ -933,7 +933,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -963,13 +963,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -977,26 +977,33 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: spear
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
       core:
         sourceId: Compendium.dnd5e.items.OG4nBBydvmfWYXIk
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.items.OG4nBBydvmfWYXIk
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676808
+      modifiedTime: 1744044179160
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!fsPruAIDOg4tVrgb.eL15erXXE9EuXWSB'
   - _id: GrUneCbXCYngdpjf
@@ -1006,11 +1013,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+7 to hit,</strong>, <strong>5
-          ft.,</strong> one creature. Hit: <strong>9 (2d4 + 4) <em>bludgeoning
-          damage</em></strong>.</p><p>If the target is a Medium or smaller
-          creature, it must succeed on a  <strong>DC 15 Strength</strong> saving
-          throw or be knocked prone.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a Medium or smaller creature, it must succeed on a [[/save]] saving
+          throw or be knocked &amp;Reference[prone].</p><p></p>
         chat: >-
           <p>The Gladiator attacks with their Shield Bash. If the target is a
           Medium or smaller creature, it must make a <strong>Strength</strong>
@@ -1081,7 +1086,7 @@ items:
       unidentified:
         description: ''
       type:
-        value: martialM
+        value: natural
         baseItem: ''
       container: null
       crewed: false
@@ -1105,7 +1110,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1124,8 +1129,8 @@ items:
               height: ''
               units: ''
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1135,13 +1140,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -1149,13 +1154,16 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
           activation:
-            type: action
+            type: ''
             value: 1
-            condition: ''
+            condition: On hit
             override: false
           consumption:
             targets: []
@@ -1168,10 +1176,11 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: e0KniuDngw2shi5N
           range:
             value: '5'
             units: ft
@@ -1187,8 +1196,8 @@ items:
               height: ''
               units: ''
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1198,44 +1207,77 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
-            parts:
-              - number: 2
-                denomination: 4
-                bonus: '@mod'
-                types:
-                  - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+            onSave: none
+            parts: []
           save:
             ability: str
             dc:
-              calculation: ''
+              calculation: str
               formula: '15'
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: shield-bash
-    effects: []
+      mastery: ''
+    effects:
+      - name: Prone
+        img: systems/dnd5e/icons/svg/statuses/prone.svg
+        origin: Compendium.dnd5e.monsters.Actor.fsPruAIDOg4tVrgb.Item.GrUneCbXCYngdpjf
+        transfer: false
+        _id: e0KniuDngw2shi5N
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          seconds: null
+          combat: null
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: ''
+        tint: '#ffffff'
+        statuses:
+          - prone
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          coreVersion: '12.331'
+          systemId: dnd5e
+          systemVersion: 4.3.8
+          createdTime: 1744043946552
+          modifiedTime: 1744043988419
+          lastModifiedBy: dnd5ebuilder0000
+        _key: >-
+          !actors.items.effects!fsPruAIDOg4tVrgb.GrUneCbXCYngdpjf.e0KniuDngw2shi5N
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676808
+      modifiedTime: 1744044179160
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!fsPruAIDOg4tVrgb.GrUneCbXCYngdpjf'
   - _id: AwP14Hu6dPdnSbQt
@@ -1263,7 +1305,7 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -1274,7 +1316,7 @@ items:
           activation:
             type: reaction
             value: 1
-            condition: ''
+            condition: when a melee attack would hit this creature
             override: false
           consumption:
             targets: []
@@ -1292,7 +1334,7 @@ items:
             override: false
           effects: []
           range:
-            units: none
+            units: self
             special: ''
             override: false
           target:
@@ -1321,6 +1363,9 @@ items:
             prompt: false
             visible: false
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       enchant: {}
       prerequisites:
         level: null
@@ -1333,14 +1378,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.kfi26Jy0VLXv9TTm
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.kfi26Jy0VLXv9TTm
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676808
+      modifiedTime: 1744044417544
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!fsPruAIDOg4tVrgb.AwP14Hu6dPdnSbQt'
 effects: []
@@ -1353,8 +1402,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171246985
-  modifiedTime: 1726171447697
+  modifiedTime: 1744044640004
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!fsPruAIDOg4tVrgb'

--- a/packs/_source/monsters/humanoid/mage.yml
+++ b/packs/_source/monsters/humanoid/mage.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 40
       max: 40
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 9d8
     init:
       ability: ''
@@ -486,12 +486,21 @@ items:
         value: >-
           <p>The mage is a 9th-level spellcaster. Its spellcasting ability is
           Intelligence (spell save DC 14, +6 to hit with spell attacks). The
-          mage has the following wizard spells prepared:</p><p>Cantrips (at
-          will): fire bolt, light, mage hand, prestidigitation</p><p>1st level
-          (4 slots): detect magic, mage armor, magic missile, shield</p><p>2nd
-          level (3 slots): misty step, suggestion</p><p>3rd level (3 slots):
-          counterspell, fireball, fly</p><p>4th level (3 slots): greater
-          invisibility, ice storm</p><p>5th level (1 slot): cone of cold</p>
+          mage has the following wizard spells prepared:</p><p>Cantrip (at
+          will): [[/item .EOmsUcFQJTfG2oio]]{fire bolt}, [[/item
+          .Bnn9Nzajixvow9xi]]{light}, [[/item .Utk1OQRwYkMkFRD3]]{mage hand},
+          [[/item .udsLtG0BugXHR2JQ]]{prestidigitation}</p><p>1st level (4
+          slots): [[/item .ghXTfe7sgCbgf1Q8]]{detect magic}, [[/item
+          .CKZTpZlxj7hjjo2H]]{mage armor}, [[/item .41JIhpDyM9Anm7cs]]{magic
+          missile}, [[/item .z1mx84ONwkXKUZd7]]{shield}</p><p>2nd level (3
+          slots): [[/item .wqfAVANuQonNBgnL]]{misty step}, [[/item
+          .zMAWdyc8UVb37BK4]]{suggestion}</p><p>3rd level (3 slots): [[/item
+          .Ek45cBpVXvJdv1Qy]]{counterspell}, [[/item
+          .ztgcdrWPshKRpFd0]]{fireball}, [[/item
+          .yfbK8gZqESlaoY5t]]{fly}</p><p>4th level (3 slots): [[/item
+          .tEpDmYZNGc9f5OhJ]]{greater invisibility}, [[/item
+          .WN2LWEljYU6QqnRH]]{ice storm}</p><p>5th level (1 slots): [[/item
+          .RpKjTlYASrfqUPVA]]{cone of cold}</p>
         chat: >-
           <p>The mage is a spellcaster. Its spellcasting ability is
           Intelligence.</p>
@@ -507,10 +516,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -529,181 +539,11 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676601
+      modifiedTime: 1744060239778
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!mQnsXanewsPiV7QE.tbKbwgcprUBciliF'
-  - _id: LcMdsxbtVEhUDXju
-    name: Dagger
-    type: weapon
-    img: icons/weapons/daggers/dagger-jeweled-purple.webp
-    system:
-      description:
-        value: >-
-          <p>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range
-          20/60 ft., one target. Hit: <strong>4 (1d4 + 2) <em>piercing
-          damage</em></strong>.</p>
-        chat: <p>The Mage attacks with its Dagger.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 1
-        units: lb
-      price:
-        value: 2
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: 5
-        long: null
-        units: ft
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 1
-          denomination: 4
-          bonus: ''
-          types:
-            - piercing
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties:
-        - fin
-        - lgt
-        - thr
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: simpleM
-        baseItem: dagger
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: attack
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '5'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: dex
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: dagger
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags:
-      core:
-        sourceId: Compendium.dnd5e.items.0E565kQUBmndJ1a2
-    _stats:
-      compendiumSource: Compendium.dnd5e.items.0E565kQUBmndJ1a2
-      duplicateSource: null
-      coreVersion: '12.331'
-      systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1736804676601
-      lastModifiedBy: dnd5ebuilder0000
-    _key: '!actors.items!mQnsXanewsPiV7QE.LcMdsxbtVEhUDXju'
   - _id: EOmsUcFQJTfG2oio
     name: Fire Bolt
     ownership:
@@ -2751,6 +2591,178 @@ items:
       modifiedTime: null
       lastModifiedBy: null
     _key: '!actors.items!mQnsXanewsPiV7QE.RpKjTlYASrfqUPVA'
+  - _id: rG6fb3lkjuxqEaDd
+    name: Dagger
+    type: weapon
+    img: icons/weapons/daggers/dagger-straight-blue.webp
+    system:
+      description:
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
+        chat: ''
+      source:
+        custom: ''
+        book: SRD 5.1
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      quantity: 1
+      weight:
+        value: 1
+        units: lb
+      price:
+        value: 2
+        denomination: gp
+      attunement: ''
+      rarity: ''
+      identified: true
+      cover: null
+      range:
+        value: 20
+        long: 60
+        units: ft
+        reach: null
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      damage:
+        versatile:
+          number: null
+          denomination: null
+          bonus: ''
+          types: []
+          custom:
+            enabled: false
+            formula: ''
+          scaling:
+            mode: ''
+            number: null
+            formula: ''
+        base:
+          number: 1
+          denomination: 4
+          bonus: ''
+          types:
+            - piercing
+          custom:
+            enabled: false
+            formula: ''
+          scaling:
+            mode: ''
+            number: null
+            formula: ''
+      armor:
+        value: 10
+      hp:
+        value: 0
+        max: 0
+        dt: null
+        conditions: ''
+      properties:
+        - fin
+        - lgt
+        - thr
+      proficient: null
+      type:
+        value: simpleM
+        baseItem: dagger
+      unidentified:
+        description: ''
+      container: null
+      crewed: false
+      magicalBonus: null
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: attack
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '20'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ''
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: weapon
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
+      ammunition: {}
+      identifier: dagger
+      attuned: false
+      equipped: true
+    effects: []
+    folder: MLMTCAvKsuFE3vYA
+    sort: 0
+    ownership:
+      default: 0
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
+    _stats:
+      duplicateSource: null
+      compendiumSource: Compendium.dnd5e.items.Item.0E565kQUBmndJ1a2
+      coreVersion: '12.331'
+      systemId: dnd5e
+      systemVersion: 4.3.8
+      createdTime: 1744060295689
+      modifiedTime: 1744060344403
+      lastModifiedBy: dnd5ebuilder0000
+    _key: '!actors.items!mQnsXanewsPiV7QE.rG6fb3lkjuxqEaDd'
 effects: []
 folder: pEyqIq8DYb21xia3
 sort: 0
@@ -2761,8 +2773,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171254943
-  modifiedTime: 1726171449301
+  modifiedTime: 1744060372156
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!mQnsXanewsPiV7QE'

--- a/packs/_source/monsters/humanoid/noble.yml
+++ b/packs/_source/monsters/humanoid/noble.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 9
       max: 9
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 2d8
     init:
       ability: ''
@@ -561,10 +561,7 @@ items:
     img: icons/weapons/swords/sword-guard-brown.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+3 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>5 (1d8 + 1) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Noble attacks with its Rapier.</p>
       source:
         custom: ''
@@ -657,7 +654,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -687,13 +684,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -701,10 +698,14 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: rapier
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -713,14 +714,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.items.Tobce1hexTnDk4sV
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.items.Tobce1hexTnDk4sV
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676544
+      modifiedTime: 1744048714751
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!GlaCGcgIP6YjBjGc.f12lOXuMaI21HDrz'
   - _id: HhLmdqeivyDnsemN
@@ -838,8 +843,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171217891
-  modifiedTime: 1726171442247
+  modifiedTime: 1744048738286
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!GlaCGcgIP6YjBjGc'

--- a/packs/_source/monsters/humanoid/priest.yml
+++ b/packs/_source/monsters/humanoid/priest.yml
@@ -104,10 +104,7 @@ system:
       failure: 0
   details:
     biography:
-      value: >-
-        <p><em>Token artwork by </em><a
-        href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener"><em>Forgotten Adventures</em></a><em>.</em></p>
+      value: ''
       public: ''
     alignment: Any Alignment
     race: null

--- a/packs/_source/monsters/humanoid/priest.yml
+++ b/packs/_source/monsters/humanoid/priest.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 27
       max: 27
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 5d8 + 5
     init:
       ability: ''
@@ -69,7 +69,7 @@ system:
       climb: 0
       fly: 0
       swim: 0
-      walk: 25
+      walk: 30
       units: ft
       hover: false
     attunement:
@@ -104,7 +104,10 @@ system:
       failure: 0
   details:
     biography:
-      value: ''
+      value: >-
+        <p><em>Token artwork by </em><a
+        href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener"><em>Forgotten Adventures</em></a><em>.</em></p>
       public: ''
     alignment: Any Alignment
     race: null
@@ -477,84 +480,6 @@ prototypeToken:
       scale: 1
       texture: null
 items:
-  - _id: bndaCEOeIP8RgbU1
-    name: Chain Shirt
-    type: equipment
-    img: icons/equipment/chest/breastplate-metal-scaled-grey.webp
-    system:
-      description:
-        value: >-
-          <p>Made of interlocking metal rings, a chain shirt is worn between
-          layers of clothing or leather. This armor offers modest protection to
-          the wearer's upper body and allows the sound of the rings rubbing
-          against one another to be muffled by outer layers.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 20
-        units: lb
-      price:
-        value: 50
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      armor:
-        value: 13
-        dex: null
-        magicalBonus: null
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      speed:
-        value: null
-        conditions: ''
-      strength: null
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: light
-        baseItem: chainshirt
-      container: null
-      crewed: false
-      properties: []
-      activities: {}
-      attuned: false
-      identifier: chain-shirt
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags:
-      core:
-        sourceId: Compendium.dnd5e.items.p2zChy24ZJdVqMSH
-    _stats:
-      compendiumSource: Compendium.dnd5e.items.p2zChy24ZJdVqMSH
-      duplicateSource: null
-      coreVersion: '12.331'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-    _key: '!actors.items!PVD5wRdyO7iCJPs1.bndaCEOeIP8RgbU1'
   - _id: J12x6xIwx1aCEm1e
     name: Spellcasting
     type: feat
@@ -562,17 +487,18 @@ items:
     system:
       description:
         value: >-
-          <p>The priest is a 5th-level spellcaster. Its spellcasting ability is
-          Wisdom (spell save DC 13, +5 to hit with spell attacks). The priest
-          has the following cleric spells prepared:</p>
-
-          <p>Cantrips (at will): light, sacred flame, thaumaturgy</p>
-
-          <p>1st level (4 slots): cure wounds, guiding bolt, sanctuary</p>
-
-          <p>2nd level (3 slots): lesser restoration, spiritual weapon</p>
-
-          <p>3rd level (2 slots): dispel magic, spirit guardians</p>
+          <p>The [[lookup @name lowercase]] is a 5th-level spellcaster. Its
+          spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell
+          attacks). The priest has the following cleric spells
+          prepared:</p><p>Cantrip (at will): [[/item .Bnn9Nzajixvow9xi]]{light},
+          [[/item .n9pJzTDsAwQxJVRl]]{sacred flame}, [[/item
+          .MUO1uYN7JR1hm4dR]]{thaumaturgy}</p><p>1st level (4 slots): [[/item
+          .uUWb1wZgtMou0TVP]]{cure wounds}, [[/item .7buEm5KhI5lP8m1z]]{guiding
+          bolt}, [[/item .gvdA9nPuWLck4tBl]]{sanctuary}</p><p>2nd level (3
+          slots): [[/item .F0GsG0SJzsIOacwV]]{lesser restoration}, [[/item
+          .JbxsYXxSOTZbf9I0]]{spiritual weapon}</p><p>3rd level (2 slots):
+          [[/item .15Fa6q1nH27XfbR8]]{dispel magic}, [[/item
+          .uCud2s4TjMfjiXUb]]{spirit guardians}</p>
         chat: ''
       source:
         custom: ''
@@ -586,10 +512,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -608,10 +535,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744058046751
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!PVD5wRdyO7iCJPs1.J12x6xIwx1aCEm1e'
   - _id: 9LzZrzdWIZpjFIGV
     name: Divine Eminence
@@ -621,11 +548,10 @@ items:
       description:
         value: >-
           <p>As a bonus action, the priest can expend a spell slot to cause its
-          melee weapon attacks to magically deal an extra <strong>10 (3d6)
-          <em>radiant damage</em></strong> to a target on a hit. </p><p>This
-          benefit lasts until the end of the turn. If the priest expends a spell
-          slot of 2nd level or higher, the extra damage increases by 1d6 for
-          each level above 1st.</p>
+          melee weapon attacks to magically deal an extra [[/damage]] damage to
+          a target on a hit.</p><p>This benefit lasts until the end of the turn.
+          If the priest expends a spell slot of 2nd level or higher, the extra
+          damage increases by 1d6 for each level above 1st.</p>
         chat: >-
           <p>As a bonus action, the priest can expend a spell slot to cause its
           melee weapon attacks to magically deal an extra <em>radiant
@@ -642,10 +568,11 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
@@ -656,22 +583,28 @@ items:
             condition: ''
             override: false
           consumption:
-            targets: []
+            targets:
+              - type: spellSlots
+                value: '1'
+                target: '1'
+                scaling:
+                  mode: level
+                  formula: ''
             scaling:
-              allowed: false
-              max: ''
+              allowed: true
+              max: '3'
             spellSlot: true
           description:
             chatFlavor: ''
           duration:
             concentration: false
-            value: ''
-            units: ''
+            value: '1'
+            units: turn
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -696,86 +629,25 @@ items:
             recovery: []
           damage:
             critical:
-              allow: false
+              allow: true
               bonus: ''
             parts:
-              - number: 3
-                denomination: 6
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
+                denomination: '6'
                 bonus: ''
                 types:
                   - radiant
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
                   mode: whole
-                  number: null
+                  number: 1
                   formula: ''
           sort: 0
-        dnd5eactivity200:
-          _id: dnd5eactivity200
-          type: damage
-          activation:
-            type: bonus
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            critical:
-              allow: false
-              bonus: ''
-            parts:
-              - number: 1
-                denomination: 6
-                bonus: ''
-                types: []
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       enchant: {}
       prerequisites:
         level: null
@@ -788,14 +660,18 @@ items:
     flags:
       core:
         sourceId: Compendium.dnd5e.monsterfeatures.lVrnjqBrv90VH96d
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.lVrnjqBrv90VH96d
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676566
+      modifiedTime: 1744056004524
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!PVD5wRdyO7iCJPs1.9LzZrzdWIZpjFIGV'
   - _id: B0jROhxuoqvfmz2B
@@ -804,10 +680,7 @@ items:
     img: icons/weapons/maces/mace-round-spiked-black.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+2 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>3 (1d6) <em>bludgeoning
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Priest attacks with its Mace.</p>
       source:
         custom: ''
@@ -959,9 +832,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676566
+      modifiedTime: 1744053508579
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!PVD5wRdyO7iCJPs1.B0jROhxuoqvfmz2B'
   - _id: n9pJzTDsAwQxJVRl
@@ -2243,6 +2116,82 @@ items:
       modifiedTime: null
       lastModifiedBy: null
     _key: '!actors.items!PVD5wRdyO7iCJPs1.uUWb1wZgtMou0TVP'
+  - _id: pC1QJ005t6xVU8ZT
+    name: Chain Shirt
+    type: equipment
+    img: icons/equipment/chest/breastplate-scale-grey.webp
+    system:
+      description:
+        value: >-
+          <p>Made of interlocking metal rings, a chain shirt is worn between
+          layers of clothing or leather. This armor offers modest protection to
+          the wearer's upper body and allows the sound of the rings rubbing
+          against one another to be muffled by outer layers.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: SRD 5.1
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      quantity: 1
+      weight:
+        value: 20
+        units: lb
+      price:
+        value: 50
+        denomination: gp
+      attunement: ''
+      rarity: ''
+      identified: true
+      cover: null
+      crewed: false
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      armor:
+        value: 13
+        dex: 2
+        magicalBonus: null
+      hp:
+        value: 0
+        max: 0
+        dt: null
+        conditions: ''
+      speed:
+        value: null
+        conditions: ''
+      strength: null
+      proficient: null
+      type:
+        value: medium
+        baseItem: chainshirt
+      unidentified:
+        description: ''
+      container: null
+      properties: []
+      activities: {}
+      identifier: chain-shirt
+      attuned: false
+      equipped: true
+    effects: []
+    folder: JqTP017wj3uxDJ8g
+    sort: 0
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      duplicateSource: null
+      compendiumSource: Compendium.dnd5e.items.Item.p2zChy24ZJdVqMSH
+      coreVersion: '12.331'
+      systemId: dnd5e
+      systemVersion: 4.3.8
+      createdTime: 1744053591786
+      modifiedTime: 1744053591786
+      lastModifiedBy: dnd5ebuilder0000
+    _key: '!actors.items!PVD5wRdyO7iCJPs1.pC1QJ005t6xVU8ZT'
 effects: []
 folder: pEyqIq8DYb21xia3
 sort: 0
@@ -2253,8 +2202,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171229383
-  modifiedTime: 1726171444342
+  modifiedTime: 1744053772129
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!PVD5wRdyO7iCJPs1'

--- a/packs/_source/monsters/humanoid/scout.yml
+++ b/packs/_source/monsters/humanoid/scout.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 16
       max: 16
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 3d8 + 3
     init:
       ability: ''
@@ -576,10 +576,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -596,10 +597,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744052052908
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!O3ABqI55Ir1du1Xa.PQGwUNCJ7EkJAE8V'
   - _id: YO57HtdvpuGxJANB
     name: Multiattack
@@ -698,8 +699,8 @@ items:
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744132986913
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!O3ABqI55Ir1du1Xa.YO57HtdvpuGxJANB'
   - _id: YDoOa6D6QDoR2Htu
     name: Shortsword
@@ -707,10 +708,7 @@ items:
     img: icons/weapons/swords/sword-guard-brown.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+4 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>5 (1d6 + 2) <em>piercing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Scout attacks with their Shortsword.</p>
       source:
         custom: ''
@@ -804,7 +802,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -834,13 +832,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -848,26 +846,33 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: shortsword
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags:
       core:
         sourceId: Compendium.dnd5e.items.osLzOwQdPtrK3rQH
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: Compendium.dnd5e.items.osLzOwQdPtrK3rQH
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676671
+      modifiedTime: 1744132985302
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!O3ABqI55Ir1du1Xa.YDoOa6D6QDoR2Htu'
   - _id: E2fYrhLigMeVH09l
@@ -876,9 +881,7 @@ items:
     img: icons/weapons/bows/longbow-leather-green.webp
     system:
       description:
-        value: >-
-          <p>Ranged Weapon Attack: +4 to hit, ranged 150/600 ft., one target.
-          Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Scout attacks with their Longbow.</p>
       source:
         custom: ''
@@ -1018,12 +1021,14 @@ items:
             parts: []
           sort: 0
       attuned: false
-      ammunition: {}
+      ammunition:
+        type: arrow
       magicalBonus: null
       identifier: longbow
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags:
@@ -1034,9 +1039,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676671
+      modifiedTime: 1744132985302
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!O3ABqI55Ir1du1Xa.E2fYrhLigMeVH09l'
 effects: []
@@ -1049,8 +1054,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171227806
-  modifiedTime: 1726171444090
+  modifiedTime: 1744052139226
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!O3ABqI55Ir1du1Xa'

--- a/packs/_source/monsters/humanoid/weretiger.yml
+++ b/packs/_source/monsters/humanoid/weretiger.yml
@@ -55,7 +55,7 @@ system:
       value: 120
       max: 120
       temp: null
-      tempmax: 0
+      tempmax: null
       formula: 16d8 + 48
     init:
       ability: ''
@@ -510,7 +510,7 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -574,7 +574,7 @@ items:
       identifier: shapechanger
     effects: []
     folder: null
-    sort: 0
+    sort: 600000
     ownership:
       default: 0
     flags:
@@ -585,9 +585,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676953
+      modifiedTime: 1744075307516
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!zIr3NaNF0mWz5Ahq.EjU9p4Wh1U2wsnFK'
   - _id: 2iPYXoxM2ZReuhSL
@@ -615,7 +615,8 @@ items:
         value: ''
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -632,25 +633,25 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744074944805
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!zIr3NaNF0mWz5Ahq.2iPYXoxM2ZReuhSL'
   - _id: jW4qHQ761qRLeWM8
-    name: Pounce (Tiger or Hybrid Form Only)
+    name: Pounce
     type: feat
     img: icons/creatures/abilities/cougar-pounce-stalk-black.webp
     system:
       description:
         value: >-
-          <p>If the weretiger moves at <strong>least 15 feet</strong> straight
-          toward a creature and then hits it with a claw attack on the same
-          turn, that target must succeed on a <strong>DC 14 Strength saving
-          throw</strong> or be knocked prone. If the target is prone, the
-          weretiger can make one bite attack against it as a bonus
-          action.</p><p>If the target is prone, the panther can make one bite
-          attack against it as a bonus action.</p>
+          <p>If the [[lookup @name lowercase]] moves at <strong>least 15
+          feet</strong> straight toward a creature and then hits it with a
+          [[/item .HPmjVRKpG08bgohb]]{claw} attack on the same turn, that target
+          must succeed on a [[/save]] saving throw or be knocked
+          &amp;Reference[prone]. If the target is prone, the weretiger can make
+          one [[/item .FOkSL18gU0Sli5ZA]]{bite} attack against it as a bonus
+          action.</p>
         chat: >-
           <p>If the weretiger moves at <strong>least 15 feet</strong> straight
           toward a creature and then hits it with a claw attack on the same
@@ -668,72 +669,19 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
-      requirements: ''
-      properties: []
+      requirements: Tiger or Hybrid Form
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: ''
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '15'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
           activation:
             type: ''
             value: null
-            condition: ''
+            condition: moves 15 feet and hits with a claw attack
             override: false
           consumption:
             targets: []
@@ -746,10 +694,11 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: xx5oDVvttzxBUXpQ
           range:
             value: '15'
             units: ft
@@ -776,7 +725,7 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability: str
@@ -784,36 +733,82 @@ items:
               calculation: ''
               formula: '14'
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       enchant: {}
       prerequisites:
         level: null
       identifier: pounce-tiger-or-hybrid-form-only
-    effects: []
+    effects:
+      - name: Prone
+        img: systems/dnd5e/icons/svg/statuses/prone.svg
+        origin: Compendium.dnd5e.monsters.Actor.zIr3NaNF0mWz5Ahq.Item.jW4qHQ761qRLeWM8
+        transfer: false
+        _id: xx5oDVvttzxBUXpQ
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          seconds: null
+          combat: null
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: ''
+        tint: '#ffffff'
+        statuses:
+          - prone
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          coreVersion: '12.331'
+          systemId: dnd5e
+          systemVersion: 4.3.8
+          createdTime: 1744074885146
+          modifiedTime: 1744074906625
+          lastModifiedBy: dnd5ebuilder0000
+        _key: >-
+          !actors.items.effects!zIr3NaNF0mWz5Ahq.jW4qHQ761qRLeWM8.xx5oDVvttzxBUXpQ
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676953
+      modifiedTime: 1744074929043
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!zIr3NaNF0mWz5Ahq.jW4qHQ761qRLeWM8'
   - _id: SmUCt79LtakgTJoa
-    name: Multiattack (Humanoid or Hybrid Form Only)
+    name: Multiattack
     type: feat
     img: icons/skills/melee/blade-tips-triple-steel.webp
     system:
       description:
         value: >-
-          <p>In humanoid form, the weretiger makes two scimitar attacks or two
-          longbow attacks. In hybrid form, it can attack like a humanoid or make
-          two claw attacks.</p>
+          <p>In humanoid form, the weretiger makes two [[/item
+          .vtnEGCOptmp2bcqG]]{scimitar} attacks or two [[/item
+          .onmNGMiE4AyvYxDQ]]{longbow} attacks.</p><p>In hybrid form, it can
+          attack like a humanoid or make two [[/item .HPmjVRKpG08bgohb]]{claw}
+          attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -827,9 +822,9 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
-      requirements: ''
+      requirements: Humanoid or Hybrid Form
       properties: []
       activities:
         dnd5eactivity000:
@@ -900,10 +895,10 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1744075424301
+      lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!zIr3NaNF0mWz5Ahq.SmUCt79LtakgTJoa'
   - _id: FOkSL18gU0Sli5ZA
     name: Bite (Tiger or Hybrid Form Only)
@@ -912,11 +907,9 @@ items:
     system:
       description:
         value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>8 (1d10 + 3) <em>piercing
-          damage</em></strong>. </p><p>If the target is a humanoid, it must
-          succeed on a  <strong>DC 13 Constitution</strong> saving throw or be
-          cursed with weretiger lycanthropy.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a humanoid, it must succeed on a [[/save]] saving throw or be cursed
+          with weretiger lycanthropy.</p>
         chat: >-
           <p>The Weretiger attacks with its Bite. If the target is a humanoid,
           it must make a <strong>Constitution</strong> saving throw.</p>
@@ -940,7 +933,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -1010,7 +1003,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1040,13 +1033,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -1054,11 +1047,14 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
         dnd5eactivity100:
           _id: dnd5eactivity100
           type: save
           activation:
-            type: action
+            type: special
             value: 1
             condition: ''
             override: false
@@ -1112,6 +1108,8 @@ items:
               formula: '13'
           sort: 0
           name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1119,18 +1117,22 @@ items:
       identifier: bite-tiger-or-hybrid-form-only
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676953
+      modifiedTime: 1744075307516
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!zIr3NaNF0mWz5Ahq.FOkSL18gU0Sli5ZA'
   - _id: HPmjVRKpG08bgohb
@@ -1139,10 +1141,7 @@ items:
     img: icons/skills/melee/strike-slashes-red.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>7 (1d8 + 3) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Weretiger attacks with its Claw.</p>
       source:
         custom: ''
@@ -1164,7 +1163,7 @@ items:
       identified: true
       cover: null
       range:
-        value: 5
+        value: null
         long: null
         units: ft
         reach: null
@@ -1234,7 +1233,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1264,13 +1263,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -1278,24 +1277,32 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw-tiger-or-hybrid-form-only
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676953
+      modifiedTime: 1744075307516
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!zIr3NaNF0mWz5Ahq.HPmjVRKpG08bgohb'
   - _id: vtnEGCOptmp2bcqG
@@ -1304,10 +1311,7 @@ items:
     img: icons/weapons/swords/sword-katana.webp
     system:
       description:
-        value: >-
-          <p><em>Melee Weapon Attack:</em><strong>+5 to hit,</strong>, <strong>5
-          ft.,</strong> one target. Hit: <strong>6 (1d6 + 3) <em>slashing
-          damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Weretiger attacks with its Scimitar.</p>
       source:
         custom: ''
@@ -1378,7 +1382,7 @@ items:
         description: ''
       type:
         value: martialM
-        baseItem: ''
+        baseItem: scimitar
       container: null
       crewed: false
       activities:
@@ -1449,9 +1453,10 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: scimitar-humanoid-or-hybrid-form-only
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 400000
     ownership:
       default: 0
     flags: {}
@@ -1460,9 +1465,9 @@ items:
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676953
+      modifiedTime: 1744075307516
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!zIr3NaNF0mWz5Ahq.vtnEGCOptmp2bcqG'
   - _id: onmNGMiE4AyvYxDQ
@@ -1471,9 +1476,7 @@ items:
     img: icons/weapons/bows/longbow-leather-green.webp
     system:
       description:
-        value: >-
-          <p>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target.
-          Hit: <strong>6 (1d8 + 2) <em>piercing damage</em></strong>.</p>
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
         chat: <p>The Weretiger attacks with its Longbow.</p>
       source:
         custom: ''
@@ -1545,7 +1548,7 @@ items:
         description: ''
       type:
         value: martialR
-        baseItem: ''
+        baseItem: longbow
       container: null
       crewed: false
       activities:
@@ -1568,7 +1571,7 @@ items:
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1598,13 +1601,13 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: ranged
+              value: ''
               classification: weapon
           damage:
             critical:
@@ -1612,24 +1615,33 @@ items:
             includeBase: true
             parts: []
           sort: 0
+          name: ''
+          img: ''
+          appliedEffects: []
       attuned: false
-      ammunition: {}
+      ammunition:
+        type: arrow
       magicalBonus: null
       identifier: longbow-humanoid-or-hybrid-form-only
+      mastery: ''
     effects: []
     folder: null
-    sort: 0
+    sort: 500000
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
     _stats:
       compendiumSource: null
       duplicateSource: null
       coreVersion: '12.331'
       systemId: dnd5e
-      systemVersion: 4.2.0
+      systemVersion: 4.3.8
       createdTime: null
-      modifiedTime: 1736804676953
+      modifiedTime: 1744075307516
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!zIr3NaNF0mWz5Ahq.onmNGMiE4AyvYxDQ'
 effects: []
@@ -1642,8 +1654,8 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.3.8
   createdTime: 1726171267537
-  modifiedTime: 1726171452250
+  modifiedTime: 1744075486015
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!zIr3NaNF0mWz5Ahq'

--- a/packs/_source/monsters/humanoid/weretiger.yml
+++ b/packs/_source/monsters/humanoid/weretiger.yml
@@ -639,7 +639,7 @@ items:
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!zIr3NaNF0mWz5Ahq.2iPYXoxM2ZReuhSL'
   - _id: jW4qHQ761qRLeWM8
-    name: Pounce
+    name: Pounce (Tiger or Hybrid Form Only)
     type: feat
     img: icons/creatures/abilities/cougar-pounce-stalk-black.webp
     system:
@@ -798,7 +798,7 @@ items:
       lastModifiedBy: dnd5ebuilder0000
     _key: '!actors.items!zIr3NaNF0mWz5Ahq.jW4qHQ761qRLeWM8'
   - _id: SmUCt79LtakgTJoa
-    name: Multiattack
+    name: Multiattack (Humanoid or Hybrid Form Only)
     type: feat
     img: icons/skills/melee/blade-tips-triple-steel.webp
     system:


### PR DESCRIPTION
Actors:
- Couatl, Succubus/Incubus, Assassin, Berserker, Gladiator, Weretiger  - attack/damage/save enrichers and additional activities
- Druid - enrichers and shillelagh improvements
- Mage, Priest, Scout - enrichers and replaced natural weapons with equipment equivalents
- Noble - enrichers

Items:
- Talisman of the Sphere - changed item type to equipment (wondrous item) and added control check activity
- Legendary Resistance - adds resource consumption, clarifies activity (expend use)