### PR TITLE
[#5072] Improvements to subclass summary table generation.

### DIFF
--- a/module/applications/journal/class-page-sheet.mjs
+++ b/module/applications/journal/class-page-sheet.mjs
@@ -279,6 +279,7 @@ export default class JournalClassPageSheet extends (foundry.appv1?.sheets?.Journ
         spellcasting.levels = level;
         Actor5e.computeClassProgression(progression, item, { spellcasting });
         Actor5e.prepareSpellcastingSlots(spells, "leveled", progression);
+
         if ( !largestSlot ) largestSlot = Object.values(spells).reduce((slot, { max, level }) => {
           if ( !max ) return slot;
           return Math.max(slot, level || -1);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -484,7 +484,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * A hook event that fires to convert the provided spellcasting progression into spell slots.
      * The actual hook names include the spellcasting type (e.g. `dnd5e.prepareLeveledSlots`).
      * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-     * @param {Actor5e} actor        Actor for whom the data is being prepared.
+     * @param {Actor5e} [actor]        Actor for whom the data is being prepared, if any.
      * @param {object} progression   Spellcasting progression data.
      * @returns {boolean}            Explicitly return false to prevent default preparation from being performed.
      * @function dnd5e.prepareSpellcastingSlots
@@ -501,7 +501,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Prepare leveled spell slots using progression data.
    * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-   * @param {Actor5e} actor        Actor for whom the data is being prepared.
+   * @param {Actor5e} [actor]        Actor for whom the data is being prepared, if any.
    * @param {object} progression   Spellcasting progression data.
    */
   static prepareLeveledSlots(spells, actor, progression) {
@@ -521,7 +521,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Prepare non-leveled spell slots using progression data.
    * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-   * @param {Actor5e} actor        Actor for whom the data is being prepared.
+   * @param {Actor5e} [actor]        Actor for whom the data is being prepared, if any.
    * @param {object} progression   Spellcasting progression data.
    * @param {string} key           The internal key for these spell slots on the actor.
    * @param {object} table         The table used for determining the progression of slots.
@@ -539,7 +539,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const override = Number.isNumeric(spells[key].override) ? parseInt(spells[key].override) : null;
 
     // Slot override
-    if ( (keyLevel === 0) && (actor.type === "npc") && (override !== null) ) {
+    if ( (keyLevel === 0) && (actor?.type === "npc") && (override !== null) ) {
       keyLevel = actor.system.attributes.spell.level;
     }
 
@@ -562,7 +562,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Convenience method for preparing pact slots specifically.
    * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-   * @param {Actor5e} actor        Actor for whom the data is being prepared.
+   * @param {Actor5e} [actor]        Actor for whom the data is being prepared, if any.
    * @param {object} progression   Spellcasting progression data.
    */
   static preparePactSlots(spells, actor, progression) {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -403,7 +403,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @param {object} progression                             Spellcasting progression data. *Will be mutated.*
    * @param {Item5e} cls                                     Class for whom this progression is being computed.
    * @param {object} [config={}]
-   * @param {Actor5e} [config.actor]                    Actor for whom the data is being prepared.
+   * @param {Actor5e} [config.actor]                         Actor for whom the data is being prepared.
    * @param {SpellcastingDescription} [config.spellcasting]  Spellcasting descriptive object.
    * @param {number} [config.count=1]                        Number of classes with this type of spellcasting.
    */
@@ -415,7 +415,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * A hook event that fires while computing the spellcasting progression for each class on each actor.
      * The actual hook names include the spellcasting type (e.g. `dnd5e.computeLeveledProgression`).
      * @param {object} progression                    Spellcasting progression data. *Will be mutated.*
-     * @param {Actor5e|void} actor                  Actor for whom the data is being prepared.
+     * @param {Actor5e|void} actor                    Actor for whom the data is being prepared.
      * @param {Item5e} cls                            Class for whom this progression is being computed.
      * @param {SpellcastingDescription} spellcasting  Spellcasting descriptive object.
      * @param {number} count                          Number of classes with this type of spellcasting.
@@ -439,7 +439,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Contribute to the actor's spellcasting progression for a class with leveled spellcasting.
    * @param {object} progression                    Spellcasting progression data. *Will be mutated.*
-   * @param {Actor5e|void} actor                         Actor for whom the data is being prepared, if any.
+   * @param {Actor5e|void} actor                    Actor for whom the data is being prepared, if any.
    * @param {Item5e} cls                            Class for whom this progression is being computed.
    * @param {SpellcastingDescription} spellcasting  Spellcasting descriptive object.
    * @param {number} count                          Number of classes with this type of spellcasting.
@@ -460,7 +460,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Contribute to the actor's spellcasting progression for a class with pact spellcasting.
    * @param {object} progression                    Spellcasting progression data. *Will be mutated.*
-   * @param {Actor5e|void} actor                         Actor for whom the data is being prepared, if any.
+   * @param {Actor5e|void} actor                    Actor for whom the data is being prepared, if any.
    * @param {Item5e} cls                            Class for whom this progression is being computed.
    * @param {SpellcastingDescription} spellcasting  Spellcasting descriptive object.
    * @param {number} count                          Number of classes with this type of spellcasting.
@@ -484,7 +484,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * A hook event that fires to convert the provided spellcasting progression into spell slots.
      * The actual hook names include the spellcasting type (e.g. `dnd5e.prepareLeveledSlots`).
      * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-     * @param {Actor5e|void} actor        Actor for whom the data is being prepared, if any.
+     * @param {Actor5e|void} actor   Actor for whom the data is being prepared, if any.
      * @param {object} progression   Spellcasting progression data.
      * @returns {boolean}            Explicitly return false to prevent default preparation from being performed.
      * @function dnd5e.prepareSpellcastingSlots
@@ -501,7 +501,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Prepare leveled spell slots using progression data.
    * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-   * @param {Actor5e|void} actor        Actor for whom the data is being prepared, if any.
+   * @param {Actor5e|void} actor   Actor for whom the data is being prepared, if any.
    * @param {object} progression   Spellcasting progression data.
    */
   static prepareLeveledSlots(spells, actor, progression) {
@@ -521,7 +521,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Prepare non-leveled spell slots using progression data.
    * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-   * @param {Actor5e|void} actor        Actor for whom the data is being prepared, if any.
+   * @param {Actor5e|void} actor   Actor for whom the data is being prepared, if any.
    * @param {object} progression   Spellcasting progression data.
    * @param {string} key           The internal key for these spell slots on the actor.
    * @param {object} table         The table used for determining the progression of slots.
@@ -562,7 +562,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Convenience method for preparing pact slots specifically.
    * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-   * @param {Actor5e|void} actor        Actor for whom the data is being prepared, if any.
+   * @param {Actor5e|void} actor   Actor for whom the data is being prepared, if any.
    * @param {object} progression   Spellcasting progression data.
    */
   static preparePactSlots(spells, actor, progression) {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -403,7 +403,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @param {object} progression                             Spellcasting progression data. *Will be mutated.*
    * @param {Item5e} cls                                     Class for whom this progression is being computed.
    * @param {object} [config={}]
-   * @param {Actor5e|null} [config.actor]                    Actor for whom the data is being prepared.
+   * @param {Actor5e} [config.actor]                    Actor for whom the data is being prepared.
    * @param {SpellcastingDescription} [config.spellcasting]  Spellcasting descriptive object.
    * @param {number} [config.count=1]                        Number of classes with this type of spellcasting.
    */
@@ -415,7 +415,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * A hook event that fires while computing the spellcasting progression for each class on each actor.
      * The actual hook names include the spellcasting type (e.g. `dnd5e.computeLeveledProgression`).
      * @param {object} progression                    Spellcasting progression data. *Will be mutated.*
-     * @param {Actor5e|null} [actor]                  Actor for whom the data is being prepared.
+     * @param {Actor5e|void} actor                  Actor for whom the data is being prepared.
      * @param {Item5e} cls                            Class for whom this progression is being computed.
      * @param {SpellcastingDescription} spellcasting  Spellcasting descriptive object.
      * @param {number} count                          Number of classes with this type of spellcasting.
@@ -439,7 +439,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Contribute to the actor's spellcasting progression for a class with leveled spellcasting.
    * @param {object} progression                    Spellcasting progression data. *Will be mutated.*
-   * @param {Actor5e} actor                         Actor for whom the data is being prepared.
+   * @param {Actor5e|void} actor                         Actor for whom the data is being prepared, if any.
    * @param {Item5e} cls                            Class for whom this progression is being computed.
    * @param {SpellcastingDescription} spellcasting  Spellcasting descriptive object.
    * @param {number} count                          Number of classes with this type of spellcasting.
@@ -460,7 +460,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Contribute to the actor's spellcasting progression for a class with pact spellcasting.
    * @param {object} progression                    Spellcasting progression data. *Will be mutated.*
-   * @param {Actor5e} actor                         Actor for whom the data is being prepared.
+   * @param {Actor5e|void} actor                         Actor for whom the data is being prepared, if any.
    * @param {Item5e} cls                            Class for whom this progression is being computed.
    * @param {SpellcastingDescription} spellcasting  Spellcasting descriptive object.
    * @param {number} count                          Number of classes with this type of spellcasting.
@@ -484,7 +484,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * A hook event that fires to convert the provided spellcasting progression into spell slots.
      * The actual hook names include the spellcasting type (e.g. `dnd5e.prepareLeveledSlots`).
      * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-     * @param {Actor5e} [actor]        Actor for whom the data is being prepared, if any.
+     * @param {Actor5e|void} actor        Actor for whom the data is being prepared, if any.
      * @param {object} progression   Spellcasting progression data.
      * @returns {boolean}            Explicitly return false to prevent default preparation from being performed.
      * @function dnd5e.prepareSpellcastingSlots
@@ -501,7 +501,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Prepare leveled spell slots using progression data.
    * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-   * @param {Actor5e} [actor]        Actor for whom the data is being prepared, if any.
+   * @param {Actor5e|void} actor        Actor for whom the data is being prepared, if any.
    * @param {object} progression   Spellcasting progression data.
    */
   static prepareLeveledSlots(spells, actor, progression) {
@@ -521,7 +521,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Prepare non-leveled spell slots using progression data.
    * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-   * @param {Actor5e} [actor]        Actor for whom the data is being prepared, if any.
+   * @param {Actor5e|void} actor        Actor for whom the data is being prepared, if any.
    * @param {object} progression   Spellcasting progression data.
    * @param {string} key           The internal key for these spell slots on the actor.
    * @param {object} table         The table used for determining the progression of slots.
@@ -562,7 +562,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Convenience method for preparing pact slots specifically.
    * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
-   * @param {Actor5e} [actor]        Actor for whom the data is being prepared, if any.
+   * @param {Actor5e|void} actor        Actor for whom the data is being prepared, if any.
    * @param {object} progression   Spellcasting progression data.
    */
   static preparePactSlots(spells, actor, progression) {


### PR DESCRIPTION
Subclass progression tables now properly 'ignore' pre-subclass levels when the subclass grants a casting progression.

Subclass pact-style casters now render (previously errored out due to a pact slot computation checking for being an NPC when no actor is supplied).

I want to specifically call out the change to the `spellCell` retrieval change [here]( https://github.com/trioderegion/dnd5e/blob/1f757e3ca2108bc211ec0d35ce0e74325a54465b/module/applications/journal/class-page-sheet.mjs#L238) for review. Previously, when a subclass "skipped" this row (line 248), the next iteration would retrieve the same set of spellCells (now for the *previous* level) since the length was not modified.

Leveled subclass caster BEFORE
![image](https://github.com/user-attachments/assets/9e4becdd-0c52-45a2-b679-ec8adc6abeed)

Leveled subclass caster AFTER
![image](https://github.com/user-attachments/assets/b6440fe9-aba3-430b-ad99-674a51d869ac)

Pact subclass caster BEFORE (error at `actor.type`)
![image](https://github.com/user-attachments/assets/b55be821-d25f-413c-ac80-0695a1c965be)

Pact subclass caster AFTER
![image](https://github.com/user-attachments/assets/fc44d97b-0ee3-4cbc-b097-9a058575607d)

Closes #5072 