### PR TITLE
[#5332] Migrate to core's `CompendiumArt` system

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -527,6 +527,8 @@ Hooks.on("renderSettings", (app, html) => applications.settings.sidebar.renderSe
 /*  Other Hooks                                 */
 /* -------------------------------------------- */
 
+Hooks.on("applyCompendiumArt", (documentClass, ...args) => documentClass.applyCompendiumArt?.(...args));
+
 Hooks.on("renderChatPopout", documents.ChatMessage5e.onRenderChatPopout);
 Hooks.on("getChatLogEntryContext", documents.ChatMessage5e.addChatMessageContextOptions);
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -180,20 +180,33 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /** @inheritDoc */
   _initializeSource(source, options={}) {
     source = super._initializeSource(source, options);
-    if ( !source._id || !options.pack || dnd5e.moduleArt.suppressArt ) return source;
-    const uuid = `Compendium.${options.pack}.${source._id}`;
+    const pack = game.packs.get(options.pack);
+    if ( !source._id || !pack || !game.compendiumArt.enabled ) return source;
+    const uuid = pack.getUuid(source._id);
     const art = game.dnd5e.moduleArt.map.get(uuid);
     if ( art?.actor || art?.token ) {
       if ( art.actor ) source.img = art.actor;
       if ( typeof art.token === "string" ) source.prototypeToken.texture.src = art.token;
       else if ( art.token ) foundry.utils.mergeObject(source.prototypeToken, art.token);
-      const biography = source.system.details?.biography;
-      if ( art.credit && biography ) {
-        if ( typeof biography.value !== "string" ) biography.value = "";
-        biography.value += `<p>${art.credit}</p>`;
-      }
+      Actor5e.applyCompendiumArt(source, pack, art);
     }
     return source;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Apply package-provided art to a compendium Document.
+   * @param {object} source                  The Document's source data.
+   * @param {CompendiumCollection} pack      The Document's compendium.
+   * @param {CompendiumArtInfo} art          The art being applied.
+   */
+  static applyCompendiumArt(source, pack, art) {
+    const biography = source.system.details?.biography;
+    if ( art.credit && biography ) {
+      if ( typeof biography.value !== "string" ) biography.value = "";
+      biography.value += `<p>${art.credit}</p>`;
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -193,7 +193,7 @@ export async function migrateCompendium(pack, { bypassVersionCheck=false, strict
   const wasLocked = pack.locked;
   try {
     await pack.configure({locked: false});
-    dnd5e.moduleArt.suppressArt = true;
+    game.compendiumArt.enabled = false;
 
     // Begin by requesting server-side data model migration and get the migrated content
     const documents = await pack.getDocuments();
@@ -243,7 +243,7 @@ export async function migrateCompendium(pack, { bypassVersionCheck=false, strict
   } finally {
     // Apply the original locked status for the pack
     await pack.configure({locked: wasLocked});
-    dnd5e.moduleArt.suppressArt = false;
+    game.compendiumArt.enabled = true;
   }
 }
 
@@ -322,7 +322,7 @@ export async function refreshCompendium(pack, { bypassVersionCheck, migrate=true
     }
   }
 
-  dnd5e.moduleArt.suppressArt = true;
+  game.compendiumArt.enabled = false;
   const DocumentClass = CONFIG[pack.documentName].documentClass;
   const wasLocked = pack.locked;
   await pack.configure({locked: false});
@@ -335,7 +335,7 @@ export async function refreshCompendium(pack, { bypassVersionCheck, migrate=true
     await DocumentClass.create(data, {keepId: true, keepEmbeddedIds: true, pack: pack.collection});
   }
   await pack.configure({locked: wasLocked});
-  dnd5e.moduleArt.suppressArt = false;
+  game.compendiumArt.enabled = true;
   ui.notifications.info(`Refreshed all documents from Compendium ${pack.collection}`);
 }
 

--- a/module/module-art.mjs
+++ b/module/module-art.mjs
@@ -23,7 +23,13 @@ export default class ModuleArt {
    * Set to true to temporarily prevent actors from loading module art.
    * @type {boolean}
    */
-  suppressArt = false;
+  get suppressArt() {
+    return !game.compendiumArt.enabled;
+  }
+
+  set suppressArt(value) {
+    game.compendiumArt.enabled = !value;
+  }
 
   /* -------------------------------------------- */
 
@@ -35,6 +41,10 @@ export default class ModuleArt {
     this.map.clear();
     // Load art modules in reverse order so that higher-priority modules overwrite lower-priority ones.
     for ( const { id, mapping, credit } of this.constructor.getArtModules().reverse() ) {
+      foundry.utils.logCompatibilityWarning(
+        "The dnd5e `ModuleArt` system has been deprecated and replaced with core's `CompendiumArt` system.",
+        { since: "DnD5e 5.0", until: "DnD5e 6.0", once: true }
+      );
       try {
         const json = await foundry.utils.fetchJsonWithTimeout(mapping);
         await this.#parseArtMapping(id, json, credit);
@@ -67,9 +77,9 @@ export default class ModuleArt {
         else delete info.actor;
         if ( !settings.tokens ) delete info.token;
         if ( credit ) info.credit = credit;
-        const uuid = `Compendium.${packName}.${actorId}`;
+        const uuid = pack.getUuid(actorId);
         info = foundry.utils.mergeObject(this.map.get(uuid) ?? {}, info, {inplace: false});
-        this.map.set(`Compendium.${packName}.${actorId}`, info);
+        this.map.set(uuid, info);
       }
     }
   }
@@ -120,18 +130,7 @@ export default class ModuleArt {
   static getArtModules() {
     const settings = game.settings.get("dnd5e", "moduleArtConfiguration");
     const unsorted = [];
-    const configs = [{
-      id: game.system.id,
-      label: game.system.title,
-      mapping: "systems/dnd5e/json/fa-token-mapping.json",
-      priority: settings.dnd5e?.priority ?? CONST.SORT_INTEGER_DENSITY,
-      credit: `
-        <em>
-          Token artwork by
-          <a href="https://www.forgotten-adventures.net/" target="_blank" rel="noopener">Forgotten Adventures</a>.
-        </em>
-      `
-    }];
+    const configs = [];
 
     for ( const module of game.modules ) {
       const flags = module.flags?.[module.id];

--- a/system.json
+++ b/system.json
@@ -350,6 +350,12 @@
   "primaryTokenAttribute": "attributes.hp",
   "background": "systems/dnd5e/ui/official/dnd5e-background.webp",
   "flags": {
+    "compendiumArtMappings": {
+      "dnd5e": {
+        "mapping": "systems/dnd5e/json/fa-token-mapping.json",
+        "credit": "<em>Token artwork by <a href=\"https://www.forgotten-adventures.net/\" target=\"_blank\" rel=\"noopener\">Forgotten Adventures</a>.</em>"
+      }
+    },
     "dnd5e": {
       "sourceBooks": {
         "SRD 5.1": "SOURCE.BOOK.SRD"


### PR DESCRIPTION
Adjusts the system's art mapping to use core's system rather than the system's. Add handling to the system to ensure credit is added to actor descriptions when using the core's system.

Deprecates the `ModuleArt` system while ensure it continues to work in tandem with core's system until the deprecation period ends. The removal version is set to `6.0` to give premium modules plenty of time to move over.

Closes #5332