### PR TITLE
[#5503] Add `dnd5e.postBuildRollConfig` hook for skipped rolls

### DIFF
--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -304,17 +304,6 @@ export default class RollConfigurationDialog extends Dialog5e {
   _buildConfig(config, formData, index) {
     config = foundry.utils.mergeObject({ parts: [], data: {}, options: {} }, config);
 
-    /**
-     * A hook event that fires when a roll config is built using the roll prompt.
-     * @function dnd5e.buildRollConfig
-     * @memberof hookEvents
-     * @param {RollConfigurationDialog} app    Roll configuration dialog.
-     * @param {BasicRollConfiguration} config  Roll configuration data.
-     * @param {FormDataExtended} [formData]    Any data entered into the rolling prompt.
-     * @param {number} index                   Index of the roll within all rolls being prepared.
-     */
-    Hooks.callAll("dnd5e.buildRollConfig", this, config, formData, index);
-
     const situational = formData?.get(`roll.${index}.situational`);
     if ( situational && (config.situational !== false) ) {
       config.parts.push("@situational");
@@ -324,6 +313,21 @@ export default class RollConfigurationDialog extends Dialog5e {
     }
 
     this.options.buildConfig?.(this.config, config, formData, index);
+
+    /**
+     * A hook event that fires when a roll config is built using the roll prompt. Multiple hooks may be called depending
+     * on the rolling method (e.g. `dnd5e.buildSkillRollConfig`, `dnd5e.buildAbilityCheckRollConfig`,
+     * `dnd5e.buildRollConfig`).
+     * @function dnd5e.buildRollConfig
+     * @memberof hookEvents
+     * @param {RollConfigurationDialog|object} app  Roll configuration dialog or object that simulates it.
+     * @param {BasicRollConfiguration} config       Roll configuration data.
+     * @param {FormDataExtended} [formData]         Any data entered into the rolling prompt.
+     * @param {number} index                        Index of the roll within all rolls being prepared.
+     */
+    for ( const hookName of this.#config.hookNames ?? [""] ) {
+      Hooks.callAll(`dnd5e.build${hookName.capitalize()}RollConfig`, this, config, formData, index);
+    }
 
     return config;
   }

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -304,6 +304,21 @@ export default class RollConfigurationDialog extends Dialog5e {
   _buildConfig(config, formData, index) {
     config = foundry.utils.mergeObject({ parts: [], data: {}, options: {} }, config);
 
+    /**
+     * A hook event that fires when a roll config is built using the roll prompt. Multiple hooks may be called depending
+     * on the rolling method (e.g. `dnd5e.buildSkillRollConfig`, `dnd5e.buildAbilityCheckRollConfig`,
+     * `dnd5e.buildRollConfig`).
+     * @function dnd5e.buildRollConfig
+     * @memberof hookEvents
+     * @param {RollConfigurationDialog} app    Roll configuration dialog.
+     * @param {BasicRollConfiguration} config  Roll configuration data.
+     * @param {FormDataExtended} [formData]    Any data entered into the rolling prompt.
+     * @param {number} index                   Index of the roll within all rolls being prepared.
+     */
+    for ( const hookName of this.#config.hookNames ?? [""] ) {
+      Hooks.callAll(`dnd5e.build${hookName.capitalize()}RollConfig`, this, config, formData, index);
+    }
+
     const situational = formData?.get(`roll.${index}.situational`);
     if ( situational && (config.situational !== false) ) {
       config.parts.push("@situational");
@@ -315,18 +330,22 @@ export default class RollConfigurationDialog extends Dialog5e {
     this.options.buildConfig?.(this.config, config, formData, index);
 
     /**
-     * A hook event that fires when a roll config is built using the roll prompt. Multiple hooks may be called depending
-     * on the rolling method (e.g. `dnd5e.buildSkillRollConfig`, `dnd5e.buildAbilityCheckRollConfig`,
-     * `dnd5e.buildRollConfig`).
-     * @function dnd5e.buildRollConfig
+     * A hook event that fires after a roll config has been built using the roll prompt. Multiple hooks may be called
+     * depending on the rolling method (e.g. `dnd5e.postBuildSkillRollConfig`, `dnd5e.postBuildAbilityCheckRollConfig`,
+     * `dnd5e.postBuildRollConfig`).
+     * @function dnd5e.postBuildRollConfig
      * @memberof hookEvents
-     * @param {RollConfigurationDialog|object} app  Roll configuration dialog or object that simulates it.
-     * @param {BasicRollConfiguration} config       Roll configuration data.
-     * @param {FormDataExtended} [formData]         Any data entered into the rolling prompt.
-     * @param {number} index                        Index of the roll within all rolls being prepared.
+     * @param {BasicRollProcessConfiguration} process  Full process configuration data.
+     * @param {BasicRollConfiguration} config          Roll configuration data.
+     * @param {number} index                           Index of the roll within all rolls being prepared.
+     * @param {object} [options]
+     * @param {RollConfigurationDialog} [options.app]  Roll configuration dialog.
+     * @param {FormDataExtended} [options.formData]    Any data entered into the rolling prompt.
      */
     for ( const hookName of this.#config.hookNames ?? [""] ) {
-      Hooks.callAll(`dnd5e.build${hookName.capitalize()}RollConfig`, this, config, formData, index);
+      Hooks.callAll(`dnd5e.postBuild${hookName.capitalize()}RollConfig`, this.config, config, index, {
+        app: this, formData
+      });
     }
 
     return config;

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -152,11 +152,10 @@ export default class BasicRoll extends Roll {
 
     let rolls;
     if ( dialog.configure === false ) {
-      const appStub = { config, message, rolls: config.rolls, rollType: this.constructor };
       rolls = config.rolls?.map((r, index) => {
         dialog.options?.buildConfig?.(config, r, null, index);
-        for ( const hookName of config.hookNames ?? [""] ) {
-          Hooks.callAll(`dnd5e.build${hookName.capitalize()}RollConfig`, appStub, r, null, index);
+        for ( const hookName of config.hookNames ) {
+          Hooks.callAll(`dnd5e.postBuild${hookName.capitalize()}RollConfig`, config, r, index);
         }
         return this.fromConfig(r, config);
       }) ?? [];

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -152,8 +152,12 @@ export default class BasicRoll extends Roll {
 
     let rolls;
     if ( dialog.configure === false ) {
+      const appStub = { config, message, rolls: config.rolls, rollType: this.constructor };
       rolls = config.rolls?.map((r, index) => {
         dialog.options?.buildConfig?.(config, r, null, index);
+        for ( const hookName of config.hookNames ?? [""] ) {
+          Hooks.callAll(`dnd5e.build${hookName.capitalize()}RollConfig`, appStub, r, null, index);
+        }
         return this.fromConfig(r, config);
       }) ?? [];
     } else {


### PR DESCRIPTION
Makes three changes to the `dnd5e.buildRollConfig` hook to make it more useful:
- Moves it after `options.buildConfig` is called so it has the fully-built data to work on
- Calls multiple hooks using `hookNames` to dial down on specific roll types
- Calls it in `buildConfigure` if the dialog is skipped to give a chance to modify the config

This can be potentially a breaking change in two ways:
- Any callers relying on the hook being called before `buildConfig` is called
- Any callers expecting the full application to be passed to the hook might get issues with fast-forwarded rolls. A stub version of the application is passed that has all of the key public properties available, but if the caller is using the hook to modify the rendered application itself this may cause an issue.

Closes #5503