### PR TITLE
[#5510] Add SRD 5.2 to source books, adjust book selection behavior

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5085,6 +5085,7 @@
   }
 },
 
-"SOURCE.BOOK.SRD": "System Reference Document 5.1",
+"SOURCE.BOOK.SRD51": "System Reference Document 5.1",
+"SOURCE.BOOK.SRD52": "System Reference Document 5.2",
 "SIDEBAR.SortModePriority": "Sort by priority"
 }

--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -62,8 +62,7 @@ export default class SourceField extends SchemaField {
   /* -------------------------------------------- */
 
   /**
-   * Check if the provided package has any source books registered in its manifest. If it has only one, then return
-   * that book's key.
+   * Check if the provided package has any source books registered in its manifest and returns the first listed book.
    * @param {ClientPackage} pkg  The package.
    * @returns {string|null}
    */
@@ -71,7 +70,6 @@ export default class SourceField extends SchemaField {
     if ( !pkg ) return null;
     const sourceBooks = pkg.flags?.dnd5e?.sourceBooks;
     const keys = Object.keys(sourceBooks ?? {});
-    if ( keys.length !== 1 ) return null;
     return keys[0];
   }
 

--- a/system.json
+++ b/system.json
@@ -352,7 +352,8 @@
   "flags": {
     "dnd5e": {
       "sourceBooks": {
-        "SRD 5.1": "SOURCE.BOOK.SRD"
+        "SRD 5.1": "SOURCE.BOOK.SRD51",
+        "SRD 5.2": "SOURCE.BOOK.SRD52"
       },
       "spellLists": [
         "Compendium.dnd5e.rules.JournalEntry.QvPDSUsAiEn3hD8s.JournalEntryPage.ziBzRlrpBm1KVV0j",


### PR DESCRIPTION
Adds the SRD 5.2 to the book provided by the module. Because the old SRD content didn't have a book listed, this also adjust the default book selection behavior to select the first book regardless of how many are present in the manifest so that existing SRD content will have the correct source listed.