### PR TITLE
[#5382] Reduce exhaustion when resting

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2977,6 +2977,7 @@ DND5E.hitDieTypes = ["d4", "d6", "d8", "d10", "d12"];
  * @property {string} icon                          Icon representing this rest type. Can be either a set of FontAwesome
  *                                                  classes or an image path.
  * @property {string[]} [activationPeriods]         Activation types that should be displayed in the chat card.
+ * @property {number} [exhaustionDelta]             The number of levels of exhaustion to deduct during this rest.
  * @property {boolean} [recoverHitDice]             Should hit dice be recovered during this rest?
  * @property {boolean} [recoverHitPoints]           Should hit points be recovered during this rest?
  * @property {string[]} [recoverPeriods]            What recovery periods should be applied when this rest is taken. The
@@ -3008,6 +3009,7 @@ DND5E.restTypes = {
       gritty: 10_080,
       epic: 60
     },
+    exhaustionDelta: 1,
     label: "DND5E.REST.Long.Label",
     icon: "fa-solid fa-campground",
     activationPeriods: ["longRest"],
@@ -4082,6 +4084,7 @@ DND5E.conditionEffects = {
   crawl: new Set(["prone", "exceedingCarryingCapacity"]),
   petrification: new Set(["petrified"]),
   halfHealth: new Set(["exhaustion-4"]),
+  malnourished: new Set(["malnutrition"]),
   abilityCheckDisadvantage: new Set(["poisoned", "exhaustion-1"]),
   abilitySaveDisadvantage: new Set(["exhaustion-3"]),
   attackDisadvantage: new Set(["poisoned", "exhaustion-3"]),

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2977,7 +2977,7 @@ DND5E.hitDieTypes = ["d4", "d6", "d8", "d10", "d12"];
  * @property {string} icon                          Icon representing this rest type. Can be either a set of FontAwesome
  *                                                  classes or an image path.
  * @property {string[]} [activationPeriods]         Activation types that should be displayed in the chat card.
- * @property {number} [exhaustionDelta]             The number of levels of exhaustion to deduct during this rest.
+ * @property {number} [exhaustionDelta]             Delta exhaustion to apply to creatures undergoing the rest.
  * @property {boolean} [recoverHitDice]             Should hit dice be recovered during this rest?
  * @property {boolean} [recoverHitPoints]           Should hit points be recovered during this rest?
  * @property {string[]} [recoverPeriods]            What recovery periods should be applied when this rest is taken. The
@@ -3009,7 +3009,7 @@ DND5E.restTypes = {
       gritty: 10_080,
       epic: 60
     },
-    exhaustionDelta: 1,
+    exhaustionDelta: -1,
     label: "DND5E.REST.Long.Label",
     icon: "fa-solid fa-campground",
     activationPeriods: ["longRest"],
@@ -4084,6 +4084,7 @@ DND5E.conditionEffects = {
   crawl: new Set(["prone", "exceedingCarryingCapacity"]),
   petrification: new Set(["petrified"]),
   halfHealth: new Set(["exhaustion-4"]),
+  dehydrated: new Set(["dehydration"]),
   malnourished: new Set(["malnutrition"]),
   abilityCheckDisadvantage: new Set(["poisoned", "exhaustion-1"]),
   abilitySaveDisadvantage: new Set(["exhaustion-3"]),

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2199,6 +2199,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     result.dhd = result.deltas.hitDice;
     result.longRest = result.type === "long";
 
+    if ( CONFIG.DND5E.restTypes[result.type]?.exhaustionDelta && !result.clone.hasConditionEffect("malnourished") ) {
+      const path = "system.attributes.exhaustion";
+      const value = foundry.utils.getProperty(result.clone, path) ?? 0;
+      const delta = CONFIG.DND5E.restTypes[result.type].exhaustionDelta;
+      foundry.utils.mergeObject(result.updateData, { [path]: Math.max(0, value - delta) });
+    }
+
     /**
      * A hook event that fires after rest result is calculated, but before any updates are performed.
      * @function dnd5e.preRestCompleted


### PR DESCRIPTION
- ~~Migrates `attributes.exhaustion` to an object with `value` and `delta` (null).~~
- Adds `exhaustionDelta` to `DND5E.restTypes`.
- Reduces levels of exhaustion on a long rest by an amount equal to ~~`delta` or~~ `exhaustionDelta` ~~(in that order).~~
- ~~`delta` isn't in the schema or shown anywhere, can only be modified by AEs.~~
- ~~Migrates `ActiveEffect#changes` that have `system.attributes.exhaustion` to append `.value` (unsure why anyone would do this).~~
- The Malnutrition status causes the `malnourished` condition effect, which prevents exhaustion reduction on rests entirely (which should be in accordance with both '14 and '24 rules).