### PR TITLE
[#5522] Added a hook to BaseActorSheet#_filterItem and ContainerSheet#_filterItem

### DIFF
--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1911,7 +1911,18 @@ export default class BaseActorSheet extends PrimarySheetMixin(
    * @returns {boolean|void}
    * @protected
    */
-  _filterItem(item, filters) {}
+  _filterItem(item, filters) {
+    /**
+     * A hook event that fires when an Actor sheet filters an item
+     * @function dnd5e.filterItem
+     * @memberof hookEvents
+     * @param {BaseActorSheet} actorSheet The actor sheet.
+     * @param {Item5e} item               The item being filtered.
+     * @param {Set<string>} filters       Filters applied to the Item.
+     * @returns {false|void} Return false to hide the item, otherwise other filters will continue to apply.
+     */
+    if (Hooks.call("dnd5e.filterItem", this, item, filters) === false) return false;
+  }
 
   /* -------------------------------------------- */
   /*  Sorting                                     */

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1915,15 +1915,15 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     /** @import ContainerSheet from "../../item/container-sheet.mjs" */
 
     /**
-     * A hook event that fires when an sheet filters an item
+     * A hook event that fires when a sheet filters an item.
      * @function dnd5e.filterItem
      * @memberof hookEvents
-     * @param {BaseActorSheet | ContainerSheet} sheet   The sheet the item is being rendered on.
+     * @param {BaseActorSheet|ContainerSheet} sheet     The sheet the item is being rendered on.
      * @param {Item5e} item                             The item being filtered.
      * @param {Set<string>} filters                     Filters applied to the Item.
      * @returns {false|void} Return false to hide the item, otherwise other filters will continue to apply.
      */
-    if (Hooks.call("dnd5e.filterItem", this, item, filters) === false) return false;
+    if ( Hooks.call("dnd5e.filterItem", this, item, filters) === false ) return false;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1912,13 +1912,15 @@ export default class BaseActorSheet extends PrimarySheetMixin(
    * @protected
    */
   _filterItem(item, filters) {
+    /** @import ContainerSheet from "../../item/container-sheet.mjs" */
+
     /**
-     * A hook event that fires when an Actor sheet filters an item
+     * A hook event that fires when an sheet filters an item
      * @function dnd5e.filterItem
      * @memberof hookEvents
-     * @param {BaseActorSheet} actorSheet The actor sheet.
-     * @param {Item5e} item               The item being filtered.
-     * @param {Set<string>} filters       Filters applied to the Item.
+     * @param {BaseActorSheet | ContainerSheet} sheet   The sheet the item is being rendered on.
+     * @param {Item5e} item                             The item being filtered.
+     * @param {Set<string>} filters                     Filters applied to the Item.
      * @returns {false|void} Return false to hide the item, otherwise other filters will continue to apply.
      */
     if (Hooks.call("dnd5e.filterItem", this, item, filters) === false) return false;

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -1291,8 +1291,10 @@ export default class CharacterActorSheet extends BaseActorSheet {
   /*  Filtering                                   */
   /* -------------------------------------------- */
 
-  /** @override */
-  _filterItem(item) {
+  /** @inheritDoc */
+  _filterItem(item, filters) {
+    const allowed = super._filterItem(item, filters);
+    if (allowed !== undefined) return allowed;
     if ( item.type === "container" ) return true;
   }
 

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -1294,7 +1294,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
   /** @inheritDoc */
   _filterItem(item, filters) {
     const allowed = super._filterItem(item, filters);
-    if (allowed !== undefined) return allowed;
+    if ( allowed !== undefined ) return allowed;
     if ( item.type === "container" ) return true;
   }
 

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -373,15 +373,15 @@ export default class ContainerSheet extends ItemSheet5e {
     /** @import BaseActorSheet from "../actor/api/base-actor-sheet.mjs" */
 
     /**
-     * A hook event that fires when an sheet filters an item
+     * A hook event that fires when a sheet filters an item.
      * @function dnd5e.filterItem
      * @memberof hookEvents
-     * @param {BaseActorSheet | ContainerSheet} sheet   The sheet the item is being rendered on.
+     * @param {BaseActorSheet|ContainerSheet} sheet     The sheet the item is being rendered on.
      * @param {Item5e} item                             The item being filtered.
      * @param {Set<string>} filters                     Filters applied to the Item.
      * @returns {false|void} Return false to hide the item, otherwise other filters will continue to apply.
      */
-    if (Hooks.call("dnd5e.filterItem", this, item, filters) === false) return false;
+    if ( Hooks.call("dnd5e.filterItem", this, item, filters) === false ) return false;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -369,7 +369,20 @@ export default class ContainerSheet extends ItemSheet5e {
    * @returns {boolean|void}
    * @protected
    */
-  _filterItem(item, filters) {}
+  _filterItem(item, filters) {
+    /** @import BaseActorSheet from "../actor/api/base-actor-sheet.mjs" */
+
+    /**
+     * A hook event that fires when an sheet filters an item
+     * @function dnd5e.filterItem
+     * @memberof hookEvents
+     * @param {BaseActorSheet | ContainerSheet} sheet   The sheet the item is being rendered on.
+     * @param {Item5e} item                             The item being filtered.
+     * @param {Set<string>} filters                     Filters applied to the Item.
+     * @returns {false|void} Return false to hide the item, otherwise other filters will continue to apply.
+     */
+    if (Hooks.call("dnd5e.filterItem", this, item, filters) === false) return false;
+  }
 
   /* -------------------------------------------- */
   /*  Sorting                                     */


### PR DESCRIPTION
Small & simple hook; I double checked `Hooks.call` and it will default to returning `true`, so there's no good way to have a "return true if this filter is an always show" kind of deal. But this at least generalizes the implementation for stuff like Power Specializations or any other novel additions.

Closes #5522 
