### PR TITLE
[#5508] Fix transforming unlinked actors in V13

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3049,13 +3049,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( this.isToken ) {
       const tokenData = d.prototypeToken;
       delete d.prototypeToken;
-      tokenData.delta = d;
       tokenData.elevation = this.token.elevation;
       tokenData.rotation = this.token.rotation;
       const previousActorData = this.token.delta.toObject();
       foundry.utils.setProperty(tokenData, "flags.dnd5e.previousActorData", previousActorData);
       await this.sheet?.close();
       const update = await this.token.update(tokenData);
+      await this.token.actor.update(d);
       if ( options.renderSheet ) this.sheet?.render(true);
       return update;
     }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3055,6 +3055,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       foundry.utils.setProperty(tokenData, "flags.dnd5e.previousActorData", previousActorData);
       await this.sheet?.close();
       const update = await this.token.update(tokenData);
+      if ( game.release.generation > 12 ) {
+        d["==items"] = d.items;
+        d["==effects"] = d.effects;
+        delete d.items;
+        delete d.effects;
+      }
       await this.token.actor.update(d);
       if ( options.renderSheet ) this.sheet?.render(true);
       return update;


### PR DESCRIPTION
Applies the unlinked actor changes as an updated directly to the synthetic actor rather than to the `ActorDelta` to avoid an issue with unlinked actors not immediately showing delta changes in V13.

See https://github.com/foundryvtt/foundryvtt/issues/12611

Closes #5508