### PR TITLE
More legacy SRD updates: Belts (and an amulet)

### DIFF
--- a/packs/_source/items/equipment/amulet-of-health.yml
+++ b/packs/_source/items/equipment/amulet-of-health.yml
@@ -58,7 +58,49 @@ system:
   activities: {}
   attuned: false
   identifier: amulet-of-health
-effects: []
+effects:
+  - name: Amulet of Health
+    img: icons/equipment/neck/pendant-faceted-red.webp
+    origin: Compendium.dnd5e.items.Item.iiQxTvDOhPGW5spF
+    _id: EDhQAxztAvrCtTMV
+    type: base
+    system: {}
+    changes:
+      - key: system.abilities.con.value
+        mode: 4
+        value: '19'
+        priority: null
+    disabled: false
+    duration:
+      startTime: null
+      combat: null
+      seconds: null
+      rounds: null
+      turns: null
+      startRound: null
+      startTurn: null
+    description: >-
+      <p>Your Constitution score is 19 while you wear this amulet. It has no
+      effect on you if your Constitution is already 19 or higher without it.</p>
+    tint: '#ffffff'
+    transfer: true
+    statuses: []
+    sort: 0
+    flags:
+      dnd5e:
+        riders:
+          statuses: []
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.340'
+      systemId: dnd5e
+      systemVersion: 5.0.0
+      createdTime: 1745428281095
+      modifiedTime: 1745428312509
+      lastModifiedBy: dnd5ebuilder0000
+    _key: '!items.effects!iiQxTvDOhPGW5spF.EDhQAxztAvrCtTMV'
 folder: aJgMxnZED9XdoN2W
 sort: 0
 ownership:

--- a/packs/_source/items/equipment/belt-of-cloud-giant-strength.yml
+++ b/packs/_source/items/equipment/belt-of-cloud-giant-strength.yml
@@ -5,11 +5,9 @@ img: icons/equipment/waist/belt-thick-gemmed-steel-grey.webp
 system:
   description:
     value: >-
-      <p><em>Wondrous item, (requires attunement)</em></p>
-
-      <p>While wearing this belt, your Strength score changes to 27. If your
-      Strength is already equal to or greater than the belt's score, the item
-      has no effect on you.</p>
+      <p><em>Wondrous item (requires attunement)</em></p><p>While wearing this
+      belt, your Strength score changes to 27. If your Strength is already equal
+      to or greater than the belt's score, the item has no effect on you.</p>
     chat: ''
   source:
     custom: ''
@@ -49,7 +47,7 @@ system:
   strength: null
   proficient: null
   type:
-    value: clothing
+    value: wondrous
     baseItem: ''
   unidentified:
     description: ''

--- a/packs/_source/items/equipment/belt-of-dwarvenkind.yml
+++ b/packs/_source/items/equipment/belt-of-dwarvenkind.yml
@@ -5,35 +5,18 @@ img: icons/equipment/waist/belt-armored-steel.webp
 system:
   description:
     value: >-
-      <p><em>Wondrous item, (requires attunement)</em></p>
-
-      <p>While wearing this belt, you gain the following benefits:</p>
-
-      <ul>
-
-      <li>Your Constitution score increases by 2, to a maximum of 20.</li>
-
-      <li>You have advantage on Charisma (Persuasion) checks made to interact
-      with dwarves.</li>
-
-      </ul>
-
-      <p>In addition, while attuned to the belt, you have a 50 percent chance
-      each day at dawn of growing a full beard if you're capable of growing one,
-      or a visibly thicker beard if you already have one.<br />If you aren't a
-      dwarf, you gain the following additional benefits while wearing the
-      belt:</p>
-
-      <ul>
-
-      <li>You have advantage on saving throws against poison, and you have
-      resistance against poison damage.</li>
-
-      <li>You have darkvision out to a range of 60 feet.</li>
-
-      <li>You can speak, read, and write Dwarvish.</li>
-
-      </ul>
+      <p><em>Wondrous item (requires attunement)</em></p><p>While wearing this
+      belt, you gain the following benefits:</p><ul><li>Your Constitution score
+      increases by 2, to a maximum of 20.</li><li>You have advantage on Charisma
+      (Persuasion) checks made to interact with dwarves.</li></ul><p>In
+      addition, while attuned to the belt, you have a 50 percent chance each day
+      at dawn of growing a full beard if you're capable of growing one, or a
+      visibly thicker beard if you already have one.<br />If you aren't a dwarf,
+      you gain the following additional benefits while wearing the
+      belt:</p><ul><li>You have advantage on saving throws against poison, and
+      you have resistance against poison damage.</li><li>You have darkvision out
+      to a range of 60 feet.</li><li>You can speak, read, and write
+      Dwarvish.</li></ul>
     chat: ''
   source:
     custom: ''
@@ -72,7 +55,7 @@ system:
   strength: null
   proficient: null
   type:
-    value: clothing
+    value: wondrous
     baseItem: ''
   unidentified:
     description: ''
@@ -83,7 +66,55 @@ system:
   activities: {}
   attuned: false
   identifier: belt-of-dwarvenkind
-effects: []
+effects:
+  - name: Belt of Dwarvenkind
+    img: icons/equipment/waist/belt-armored-steel.webp
+    origin: Compendium.dnd5e.items.Item.j2ZGEwx8MhHZXds4
+    _id: uuh2qSmWVNoHcqTc
+    type: base
+    system: {}
+    changes:
+      - key: system.abilities.con.value
+        mode: 2
+        value: '2'
+        priority: null
+      - key: system.attributes.senses.darkvision
+        mode: 4
+        value: '60'
+        priority: null
+      - key: system.traits.languages.value
+        mode: 2
+        value: dwarvish
+        priority: null
+    disabled: false
+    duration:
+      startTime: null
+      combat: null
+      seconds: null
+      rounds: null
+      turns: null
+      startRound: null
+      startTurn: null
+    description: ''
+    tint: '#ffffff'
+    transfer: true
+    statuses: []
+    sort: 0
+    flags:
+      dnd5e:
+        riders:
+          statuses: []
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.340'
+      systemId: dnd5e
+      systemVersion: 5.0.0
+      createdTime: 1745428424759
+      modifiedTime: 1745428481635
+      lastModifiedBy: dnd5ebuilder0000
+    _key: '!items.effects!j2ZGEwx8MhHZXds4.uuh2qSmWVNoHcqTc'
 folder: aJgMxnZED9XdoN2W
 sort: 0
 ownership:

--- a/packs/_source/items/equipment/belt-of-fire-giant-strength.yml
+++ b/packs/_source/items/equipment/belt-of-fire-giant-strength.yml
@@ -5,11 +5,9 @@ img: icons/equipment/waist/belt-coiled-leather-steel.webp
 system:
   description:
     value: >-
-      <p><em>Wondrous item, (requires attunement)</em></p>
-
-      <p>While wearing this belt, your Strength score changes to 25. If your
-      Strength is already equal to or greater than the belt's score, the item
-      has no effect on you.</p>
+      <p><em>Wondrous item (requires attunement)</em></p><p>While wearing this
+      belt, your Strength score changes to 25. If your Strength is already equal
+      to or greater than the belt's score, the item has no effect on you.</p>
     chat: ''
   source:
     custom: ''
@@ -49,7 +47,7 @@ system:
   strength: null
   proficient: null
   type:
-    value: clothing
+    value: wondrous
     baseItem: ''
   unidentified:
     description: ''

--- a/packs/_source/items/equipment/belt-of-frost-giant-strength.yml
+++ b/packs/_source/items/equipment/belt-of-frost-giant-strength.yml
@@ -5,14 +5,11 @@ img: icons/equipment/waist/cloth-sash-purple.webp
 system:
   description:
     value: >-
-      <p><em>Wondrous item, (requires attunement)</em></p>
-
-      <p>While wearing this belt, your Strength score changes to 23. If your
-      Strength is already equal to or greater than the belt's score, the item
-      has no effect on you.</p>
-
-      <p>The Belt of Stone Giant Strength and the Belt of Frost Giant Strength
-      look different, but they have the same effect.</p>
+      <p><em>Wondrous item (requires attunement)</em></p><p>While wearing this
+      belt, your Strength score changes to 23. If your Strength is already equal
+      to or greater than the belt's score, the item has no effect on
+      you.</p><p>The Belt of Stone Giant Strength and the Belt of Frost Giant
+      Strength look different, but they have the same effect.</p>
     chat: ''
   source:
     custom: ''
@@ -52,7 +49,7 @@ system:
   strength: null
   proficient: null
   type:
-    value: clothing
+    value: wondrous
     baseItem: ''
   unidentified:
     description: ''

--- a/packs/_source/items/equipment/belt-of-hill-giant-strength.yml
+++ b/packs/_source/items/equipment/belt-of-hill-giant-strength.yml
@@ -5,11 +5,9 @@ img: icons/equipment/waist/belt-buckle-square-leather-brown.webp
 system:
   description:
     value: >-
-      <p><em>Wondrous item, (requires attunement)</em></p>
-
-      <p>While wearing this belt, your Strength score changes to 21. If your
-      Strength is already equal to or greater than the belt's score, the item
-      has no effect on you.</p>
+      <p><em>Wondrous item (requires attunement)</em></p><p>While wearing this
+      belt, your Strength score changes to 21. If your Strength is already equal
+      to or greater than the belt's score, the item has no effect on you.</p>
     chat: ''
   source:
     custom: ''
@@ -49,7 +47,7 @@ system:
   strength: null
   proficient: null
   type:
-    value: clothing
+    value: wondrous
     baseItem: ''
   unidentified:
     description: ''

--- a/packs/_source/items/equipment/belt-of-stone-giant-strength.yml
+++ b/packs/_source/items/equipment/belt-of-stone-giant-strength.yml
@@ -5,14 +5,11 @@ img: icons/equipment/waist/belt-armored-steel.webp
 system:
   description:
     value: >-
-      <p><em>Wondrous item, (requires attunement)</em></p>
-
-      <p>While wearing this belt, your Strength score changes to 23. If your
-      Strength is already equal to or greater than the belt's score, the item
-      has no effect on you.</p>
-
-      <p>The Belt of Stone Giant Strength and the Belt of Frost Giant Strength
-      look different, but they have the same effect.</p>
+      <p><em>Wondrous item (requires attunement)</em></p><p>While wearing this
+      belt, your Strength score changes to 23. If your Strength is already equal
+      to or greater than the belt's score, the item has no effect on
+      you.</p><p>The Belt of Stone Giant Strength and the Belt of Frost Giant
+      Strength look different, but they have the same effect.</p>
     chat: ''
   source:
     custom: ''
@@ -51,7 +48,7 @@ system:
   strength: null
   proficient: null
   type:
-    value: clothing
+    value: wondrous
     baseItem: ''
   unidentified:
     description: ''
@@ -62,7 +59,47 @@ system:
   activities: {}
   attuned: false
   identifier: belt-of-stone-giant-strength
-effects: []
+effects:
+  - name: Belt of Stone Giant Strength
+    img: icons/equipment/waist/belt-armored-steel.webp
+    origin: Compendium.dnd5e.items.Item.fCUZ7h8YYrs16UhX
+    _id: lGoO7zq8A2ZphIVf
+    type: base
+    system: {}
+    changes:
+      - key: system.abilities.str.value
+        mode: 4
+        value: '23'
+        priority: null
+    disabled: false
+    duration:
+      startTime: null
+      combat: null
+      seconds: null
+      rounds: null
+      turns: null
+      startRound: null
+      startTurn: null
+    description: ''
+    tint: '#ffffff'
+    transfer: true
+    statuses: []
+    sort: 0
+    flags:
+      dnd5e:
+        riders:
+          statuses: []
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.340'
+      systemId: dnd5e
+      systemVersion: 5.0.0
+      createdTime: 1745428597042
+      modifiedTime: 1745428610665
+      lastModifiedBy: dnd5ebuilder0000
+    _key: '!items.effects!fCUZ7h8YYrs16UhX.lGoO7zq8A2ZphIVf'
 folder: aJgMxnZED9XdoN2W
 sort: 0
 ownership:

--- a/packs/_source/items/equipment/belt-of-storm-giant-strength.yml
+++ b/packs/_source/items/equipment/belt-of-storm-giant-strength.yml
@@ -5,11 +5,9 @@ img: icons/equipment/waist/sash-cloth-gold-purple.webp
 system:
   description:
     value: >-
-      <p><em>Wondrous item, (requires attunement)</em></p>
-
-      <p>While wearing this belt, your Strength score changes to 29. If your
-      Strength is already equal to or greater than the belt's score, the item
-      has no effect on you.</p>
+      <p><em>Wondrous item (requires attunement)</em></p><p>While wearing this
+      belt, your Strength score changes to 29. If your Strength is already equal
+      to or greater than the belt's score, the item has no effect on you.</p>
     chat: ''
   source:
     custom: ''
@@ -49,7 +47,7 @@ system:
   strength: null
   proficient: null
   type:
-    value: clothing
+    value: wondrous
     baseItem: ''
   unidentified:
     description: ''


### PR DESCRIPTION
- Added missing effect to Amulet of Health.
- Changes instances of `Wondrous item, (...)` to `Wondrous item (...)` (with no comma).
- Changed subtype of Belt of X Giant Strength to "Wondrous".
- Added missing effect to Belt of Dwarvenkind.
- Added missing effect to Belt of Stone Giant Strength.