### PR TITLE
Allow specifying limited set of currencies and their order in `CurrencyManager` when converting

### DIFF
--- a/module/applications/_types.mjs
+++ b/module/applications/_types.mjs
@@ -14,10 +14,12 @@
 
 /**
  * @typedef CurrencyUpdateOptions
- * @property {boolean} [exact=true]           Prioritize deducting the requested denomination first.
- * @property {boolean} [makeChange=true]      Convert higher denominations to fulfill the request if needed.
- * @property {"high"|"low"} [priority="low"]  Prioritize higher denominations before lower, or vice-versa.
- * @property {boolean} [recursive=false]      Deduct currency from containers as well as the base Actor. TODO
+ * @property {boolean} [exact=true]                    Prioritize deducting the requested denomination first.
+ * @property {boolean} [makeChange=true]               Convert higher denominations to fulfill the request if needed.
+ * @property {"high"|"low"|string[]} [priority="low"]  Prioritize higher denominations before lower, or vice-versa. If
+ *                                                     an array of denominations is passed, this exact order is used,
+ *                                                     skipping any denominations that are omitted.
+ * @property {boolean} [recursive=false]               Deduct currency from containers as well as the base Actor. TODO
  */
 
 /* -------------------------------------------- */

--- a/module/applications/currency-manager.mjs
+++ b/module/applications/currency-manager.mjs
@@ -275,10 +275,17 @@ export default class CurrencyManager extends Application5e {
     const { currency } = actor.system;
     if ( amount <= 0 ) return { system: { currency: { ...currency } }, remainder: amount, item: [] };
 
-    const currencies = Object.entries(CONFIG.DND5E.currencies)
-      .filter(([denom]) => !exact || (denom !== denomination))
-      .map(([denom, { conversion }]) => [denom, conversion])
-      .sort(([, a], [, b]) => priority === "high" ? a - b : b - a);
+    let currencies;
+    if ( Array.isArray(priority) ) {
+      // Use only the supplied denominations.
+      currencies = priority.map(denom => [denom, CONFIG.DND5E.currencies[denom].conversion]);
+    } else {
+      // Use all currencies from lowest to highest or highest to lowest.
+      currencies = Object.entries(CONFIG.DND5E.currencies)
+        .filter(([denom]) => !exact || (denom !== denomination))
+        .map(([denom, { conversion }]) => [denom, conversion])
+        .sort(([, a], [, b]) => priority === "high" ? a - b : b - a);
+    }
     const baseConversion = CONFIG.DND5E.currencies[denomination].conversion;
     if ( exact ) currencies.unshift([denomination, baseConversion]);
 

--- a/module/applications/currency-manager.mjs
+++ b/module/applications/currency-manager.mjs
@@ -282,12 +282,15 @@ export default class CurrencyManager extends Application5e {
     } else {
       // Use all currencies from lowest to highest or highest to lowest.
       currencies = Object.entries(CONFIG.DND5E.currencies)
-        .filter(([denom]) => !exact || (denom !== denomination))
         .map(([denom, { conversion }]) => [denom, conversion])
         .sort(([, a], [, b]) => priority === "high" ? a - b : b - a);
     }
     const baseConversion = CONFIG.DND5E.currencies[denomination].conversion;
-    if ( exact ) currencies.unshift([denomination, baseConversion]);
+    if ( exact ) {
+      // Prioritize the requested denomination.
+      currencies = currencies.filter(([denom]) => denom !== denomination);
+      currencies.unshift([denomination, baseConversion]);
+    }
 
     let passes = currencies.length;
     let updates;


### PR DESCRIPTION
So I'd been messing with this same exact concept of converting currency, then noticed the methods already existed in the `CurrencyManager` class, yay...

Except I needed the ability to specify a custom order of denominations, or even leaving out some. Reusing the `priority` option to allow for an array of strings as an alternative, this change should be non-breaking as it only adds an additional option that is API-only.

This would allow for, say, determining the currency update for games where the GM decides that Electrum is often not a valid currency for bartering in modern society.