### PR TITLE
SRD: Remaining wand fixes

### DIFF
--- a/packs/_source/items/wand/wand-of-binding.yml
+++ b/packs/_source/items/wand/wand-of-binding.yml
@@ -5,22 +5,20 @@ img: icons/weapons/wands/wand-gem-green.webp
 system:
   description:
     value: >-
-      <p><em>(Requires attunement by a spellcaster)</em></p>
-
-      <p>This wand has 7 charges for the following properties. It regains 1d6 +
-      1 expended charges daily at dawn. If you expend the wand's last charge,
-      roll a d20. On a 1, the wand crumbles into ashes and is destroyed.</p>
-
-      <p><strong>Spells</strong>. While holding the wand, you can use an action
-      to expend some of its charges to cast one of the following spells (save DC
-      17): @UUID[Compendium.dnd5e.spells.Item.l9Ju5KE7bbn3WpTm]{Hold Monster} (5
+      <p><em>Wand (requires attunement by a spellcaster)</em></p><p>This wand
+      has 7 charges for the following properties. It regains 1d6 + 1 expended
+      charges daily at dawn. If you expend the wand's last charge, roll a d20.
+      On a 1, the wand crumbles into ashes and is
+      destroyed.</p><p><strong>Spells</strong>. While holding the wand, you can
+      use an action to expend some of its charges to cast one of the following
+      spells (save DC 17):
+      @UUID[Compendium.dnd5e.spells.Item.l9Ju5KE7bbn3WpTm]{Hold Monster} (5
       charges) or @UUID[Compendium.dnd5e.spells.Item.3Lo9boi7P2ro6QV4]{Hold
-      Person} (2 charges).</p>
-
-      <p><strong>Assisted Escape</strong>. While holding the wand, you can use
-      your reaction to expend 1 charge and gain advantage on a saving throw you
-      make to avoid being paralyzed or restrained, or you can expend 1 charge
-      and gain advantage on any check you make to escape a grapple.</p>
+      Person} (2 charges).</p><p><strong>Assisted Escape</strong>. While holding
+      the wand, you can use your reaction to expend 1 charge and gain advantage
+      on a saving throw you make to avoid being paralyzed or restrained, or you
+      can expend 1 charge and gain advantage on any check you make to escape a
+      grapple.</p>
     chat: ''
   source:
     custom: ''
@@ -42,7 +40,7 @@ system:
   uses:
     max: '7'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d6 + 1
     autoDestroy: false
@@ -236,7 +234,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037109504
   modifiedTime: 1730323638379
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-enemy-detection.yml
+++ b/packs/_source/items/wand/wand-of-enemy-detection.yml
@@ -5,18 +5,15 @@ img: icons/weapons/wands/wand-simple-eye.webp
 system:
   description:
     value: >-
-      <p><em>(Requires attunement)</em></p>
-
-      <p>This wand has 7 charges. While holding it, you can use an action and
-      expend 1 charge to speak its command word. For the next minute, you know
-      the direction of the nearest creature hostile to you within 60 feet, but
-      not its distance from you. The wand can sense the presence of hostile
-      creatures that are ethereal, invisible, disguised, or hidden, as well as
-      those in plain sight. The effect ends if you stop holding the wand.</p>
-
-      <p>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend
-      the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes
-      and is destroyed.</p>
+      <p><em>Wand (requires attunement)</em></p><p>This wand has 7 charges.
+      While holding it, you can use an action and expend 1 charge to speak its
+      command word. For the next minute, you know the direction of the nearest
+      creature hostile to you within 60 feet, but not its distance from you. The
+      wand can sense the presence of hostile creatures that are ethereal,
+      invisible, disguised, or hidden, as well as those in plain sight. The
+      effect ends if you stop holding the wand.</p><p>The wand regains 1d6 + 1
+      expended charges daily at dawn. If you expend the wand's last charge, roll
+      a d20. On a 1, the wand crumbles into ashes and is destroyed.</p>
     chat: ''
   source:
     custom: ''
@@ -38,7 +35,7 @@ system:
   uses:
     max: '7'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d6 + 1
     autoDestroy: false
@@ -134,7 +131,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037100973
   modifiedTime: 1731015765246
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-fear.yml
+++ b/packs/_source/items/wand/wand-of-fear.yml
@@ -5,28 +5,25 @@ img: icons/weapons/staves/staff-animal-skull-horned.webp
 system:
   description:
     value: >-
-      <p><em>(Requires attunement)</em></p>
-
-      <p>This wand has 7 charges for the following properties. It regains 1d6 +
-      1 expended charges daily at dawn. If you expend the wand's last charge,
-      roll a d20. On a 1, the wand crumbles into ashes and is destroyed.</p>
-
-      <p><strong>Command</strong>. While holding the wand, you can use an action
-      to expend 1 charge and command another creature to flee or grovel, as with
-      the @UUID[Compendium.dnd5e.spells.Item.arzCrMRgcNiQuh43]{Command} spell
-      (save DC 15).</p>
-
-      <p><strong>Cone of Fear</strong>. While holding the wand, you can use an
-      action to expend 2 charges, causing the wand's tip to emit a 60-foot cone
-      of amber light. Each creature in the cone must succeed on a DC 15 Wisdom
-      saving throw or become frightened of you for 1 minute. While it is
-      frightened in this way, a creature must spend its turns trying to move as
-      far away from you as it can, and it can't willingly move to a space within
-      30 feet of you. It also can't take reactions. For its action, it can use
-      only the Dash action or try to escape from an effect that prevents it from
-      moving. If it has nowhere it can move, the creature can use the Dodge
-      action. At the end of each of its turns, a creature can repeat the saving
-      throw, ending the effect on itself on a success.</p>
+      <p><em>Wand (requires attunement)</em></p><p>This wand has 7 charges for
+      the following properties. It regains 1d6 + 1 expended charges daily at
+      dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand
+      crumbles into ashes and is destroyed.</p><p><strong>Command</strong>.
+      While holding the wand, you can use an action to expend 1 charge and
+      command another creature to flee or grovel, as with the
+      @UUID[Compendium.dnd5e.spells.Item.arzCrMRgcNiQuh43]{Command} spell (save
+      DC 15).</p><p><strong>Cone of Fear</strong>. While holding the wand, you
+      can use an action to expend 2 charges, causing the wand's tip to emit a
+      60-foot cone of amber light. Each creature in the cone must succeed on a
+      DC 15 Wisdom saving throw or become &amp;reference[frightened] of you for
+      1 minute. While it is frightened in this way, a creature must spend its
+      turns trying to move as far away from you as it can, and it can't
+      willingly move to a space within 30 feet of you. It also can't take
+      reactions. For its action, it can use only the Dash action or try to
+      escape from an effect that prevents it from moving. If it has nowhere it
+      can move, the creature can use the Dodge action. At the end of each of its
+      turns, a creature can repeat the saving throw, ending the effect on itself
+      on a success.</p>
     chat: ''
   source:
     custom: ''
@@ -48,7 +45,7 @@ system:
   uses:
     max: '7'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d6 + 1
     autoDestroy: false
@@ -204,7 +201,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037136851
   modifiedTime: 1731015855536
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-fireballs.yml
+++ b/packs/_source/items/wand/wand-of-fireballs.yml
@@ -5,18 +5,15 @@ img: icons/weapons/staves/staff-obsidian.webp
 system:
   description:
     value: >-
-      <p><em>(Requires attunement by a spellcaster)</em></p>
-
-      <p>This wand has 7 charges. While holding it, you can use an action to
-      expend 1 or more of its charges to cast the
+      <p><em>Wand (requires attunement by a spellcaster)</em></p><p>This wand
+      has 7 charges. While holding it, you can use an action to expend 1 or more
+      of its charges to cast the
       @UUID[Compendium.dnd5e.spells.Item.ztgcdrWPshKRpFd0]{Fireball} spell (save
       DC 15) from it. For 1 charge, you cast the 3rd-level version of the spell.
       You can increase the spell slot level by one for each additional charge
-      you expend.</p>
-
-      <p>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend
-      the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes
-      and is destroyed.</p>
+      you expend.</p><p>The wand regains 1d6 + 1 expended charges daily at dawn.
+      If you expend the wand's last charge, roll a d20. On a 1, the wand
+      crumbles into ashes and is destroyed.</p>
     chat: ''
   source:
     custom: ''
@@ -38,7 +35,7 @@ system:
   uses:
     max: '7'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d6 + 1
     autoDestroy: false
@@ -138,7 +135,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 5.0.0
   createdTime: 1725037134840
   modifiedTime: 1731015872768
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-lightning-bolts.yml
+++ b/packs/_source/items/wand/wand-of-lightning-bolts.yml
@@ -5,18 +5,15 @@ img: icons/weapons/staves/staff-ornate-jeweled-blue.webp
 system:
   description:
     value: >-
-      <p><em>(Requires attunement by a spellcaster)</em></p>
-
-      <p>This wand has 7 charges. While holding it, you can use an action to
-      expend 1 or more of its charges to cast the
+      <p><em>Wand (requires attunement by a spellcaster)</em></p><p>This wand
+      has 7 charges. While holding it, you can use an action to expend 1 or more
+      of its charges to cast the
       @UUID[Compendium.dnd5e.spells.Item.IyikgTEOTv701jgQ]{Lightning Bolt} spell
       (save DC 15) from it. For 1 charge, you cast the 3rd-level version of the
       spell. You can increase the spell slot level by one for each additional
-      charge you expend.</p>
-
-      <p>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend
-      the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes
-      and is destroyed.</p>
+      charge you expend.</p><p>The wand regains 1d6 + 1 expended charges daily
+      at dawn. If you expend the wand's last charge, roll a d20. On a 1, the
+      wand crumbles into ashes and is destroyed.</p>
     chat: ''
   source:
     custom: ''
@@ -38,7 +35,7 @@ system:
   uses:
     max: '7'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d6 + 1
     autoDestroy: false
@@ -138,7 +135,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037227490
   modifiedTime: 1731015885452
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-magic-detection.yml
+++ b/packs/_source/items/wand/wand-of-magic-detection.yml
@@ -5,8 +5,8 @@ img: icons/weapons/wands/wand-gem-purple.webp
 system:
   description:
     value: >-
-      <p>This wand has 3 charges. While holding it, you can expend 1 charge as
-      an action to cast the
+      <p><em>Wand</em></p><p>This wand has 3 charges. While holding it, you can
+      expend 1 charge as an action to cast the
       @UUID[Compendium.dnd5e.spells.Item.ghXTfe7sgCbgf1Q8]{Detect Magic} spell
       from it. The wand regains 1d3 expended charges daily at dawn.</p>
     chat: ''
@@ -30,7 +30,7 @@ system:
   uses:
     max: '3'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d3
     autoDestroy: false
@@ -121,7 +121,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037084495
   modifiedTime: 1731015893978
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-magic-missiles.yml
+++ b/packs/_source/items/wand/wand-of-magic-missiles.yml
@@ -5,16 +5,14 @@ img: icons/weapons/wands/wand-gem-pink.webp
 system:
   description:
     value: >-
-      <p>This wand has 7 charges. While holding it, you can use an action to
-      expend 1 or more of its charges to cast the
+      <p><em>Wand</em></p><p>This wand has 7 charges. While holding it, you can
+      use an action to expend 1 or more of its charges to cast the
       @UUID[Compendium.dnd5e.spells.Item.41JIhpDyM9Anm7cs]{Magic Missile} spell
       from it. For 1 charge, you cast the 1st-level version of the spell. You
       can increase the spell slot level by one for each additional charge you
-      expend.</p>
-
-      <p>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend
-      the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes
-      and is destroyed.</p>
+      expend.</p><p>The wand regains 1d6 + 1 expended charges daily at dawn. If
+      you expend the wand's last charge, roll a d20. On a 1, the wand crumbles
+      into ashes and is destroyed.</p>
     chat: ''
   source:
     custom: ''
@@ -36,7 +34,7 @@ system:
   uses:
     max: '7'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d6 + 1
     autoDestroy: false
@@ -135,7 +133,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037087123
   modifiedTime: 1731015902317
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-paralysis.yml
+++ b/packs/_source/items/wand/wand-of-paralysis.yml
@@ -5,18 +5,15 @@ img: icons/weapons/wands/wand-gem-violet.webp
 system:
   description:
     value: >-
-      <p><em>(Requires attunement by a spellcaster)</em></p>
-
-      <p>This wand has 7 charges. While holding it, you can use an action to
-      expend 1 of its charges to cause a thin blue ray to streak from the tip
-      toward a creature you can see within 60 feet of you. The target must
-      succeed on a DC 15 Constitution saving throw or be paralyzed for 1 minute.
-      At the end of each of the target's turns, it can repeat the saving throw,
-      ending the effect on itself on a success.</p>
-
-      <p>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend
-      the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes
-      and is destroyed.</p>
+      <p><em>Wand (requires attunement by a spellcaster)</em></p><p>This wand
+      has 7 charges. While holding it, you can use an action to expend 1 of its
+      charges to cause a thin blue ray to streak from the tip toward a creature
+      you can see within 60 feet of you. The target must succeed on a DC 15
+      Constitution saving throw or be paralyzed for 1 minute. At the end of each
+      of the target's turns, it can repeat the saving throw, ending the effect
+      on itself on a success.</p><p>The wand regains 1d6 + 1 expended charges
+      daily at dawn. If you expend the wand's last charge, roll a d20. On a 1,
+      the wand crumbles into ashes and is destroyed.</p>
     chat: ''
   source:
     custom: ''
@@ -38,7 +35,7 @@ system:
   uses:
     max: '7'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d6 + 1
     autoDestroy: false
@@ -177,7 +174,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037147741
   modifiedTime: 1731015947250
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-polymorph.yml
+++ b/packs/_source/items/wand/wand-of-polymorph.yml
@@ -5,16 +5,13 @@ img: icons/weapons/wands/wand-gem-red.webp
 system:
   description:
     value: >-
-      <p><em>(Requires attunement by a spellcaster)</em></p>
-
-      <p>This wand has 7 charges. While holding it, you can use an action to
-      expend 1 of its charges to cast the
+      <p><em>Wand (requires attunement by a spellcaster)</em></p><p>This wand
+      has 7 charges. While holding it, you can use an action to expend 1 of its
+      charges to cast the
       @UUID[Compendium.dnd5e.spells.Item.04nMsTWkIFvkbXlY]{Polymorph} spell
-      (save DC 15) from it.</p>
-
-      <p>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend
-      the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes
-      and is destroyed.</p>
+      (save DC 15) from it.</p><p>The wand regains 1d6 + 1 expended charges
+      daily at dawn. If you expend the wand's last charge, roll a d20. On a 1,
+      the wand crumbles into ashes and is destroyed.</p>
     chat: ''
   source:
     custom: ''
@@ -36,7 +33,7 @@ system:
   uses:
     max: '7'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d6 + 1
     autoDestroy: false
@@ -128,7 +125,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037269467
   modifiedTime: 1731015960717
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-secrets.yml
+++ b/packs/_source/items/wand/wand-of-secrets.yml
@@ -5,10 +5,10 @@ img: icons/weapons/staves/staff-ornate-orb-steel-red.webp
 system:
   description:
     value: >-
-      <p>The wand has 3 charges. While holding it, you can use an action to
-      expend 1 of its charges, and if a secret door or trap is within 30 feet of
-      you, the wand pulses and points at the one nearest to you. The wand
-      regains 1d3 expended charges daily at dawn.</p>
+      <p><em>Wand</em></p><p>The wand has 3 charges. While holding it, you can
+      use an action to expend 1 of its charges, and if a secret door or trap is
+      within 30 feet of you, the wand pulses and points at the one nearest to
+      you. The wand regains 1d3 expended charges daily at dawn.</p>
     chat: ''
   source:
     custom: ''
@@ -133,7 +133,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037201319
   modifiedTime: 1730323660772
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-web.yml
+++ b/packs/_source/items/wand/wand-of-web.yml
@@ -5,16 +5,13 @@ img: icons/weapons/staves/staff-crescent-purple.webp
 system:
   description:
     value: >-
-      <p><em>(Requires attunement by a spellcaster)</em></p>
-
-      <p>This wand has 7 charges. While holding it, you can use an action to
-      expend 1 of its charges to cast the
+      <p><em>Wand (requires attunement by a spellcaster)</em></p><p>This wand
+      has 7 charges. While holding it, you can use an action to expend 1 of its
+      charges to cast the
       @UUID[Compendium.dnd5e.spells.Item.UJJu9c2UvCzVljiP]{Web} spell (save DC
-      15) from it.</p>
-
-      <p>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend
-      the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes
-      and is destroyed.</p>
+      15) from it.</p><p>The wand regains 1d6 + 1 expended charges daily at
+      dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand
+      crumbles into ashes and is destroyed.</p>
     chat: ''
   source:
     custom: ''
@@ -36,7 +33,7 @@ system:
   uses:
     max: '7'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d6 + 1
     autoDestroy: false
@@ -128,7 +125,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037099540
   modifiedTime: 1731015972951
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/wand/wand-of-wonder.yml
+++ b/packs/_source/items/wand/wand-of-wonder.yml
@@ -5,24 +5,19 @@ img: icons/weapons/wands/wand-totem.webp
 system:
   description:
     value: >-
-      <p><em>(Requires attunement by a spellcaster)</em></p>
-
-      <p>This wand has 7 charges. While holding it, you can use an action to
-      expend 1 of its charges and choose a target within 120 feet of you. The
-      target can be a creature, an object, or a point in space. Roll on the
+      <p><em>Wand (requires attunement by a spellcaster)</em></p><p>This wand
+      has 7 charges. While holding it, you can use an action to expend 1 of its
+      charges and choose a target within 120 feet of you. The target can be a
+      creature, an object, or a point in space. Roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.X03rbSjVcNNJNqa8]{Wand of Wonder}
-      table to discover what happens.</p>
-
-      <p>If the effect causes you to cast a spell from the wand, the spell's
-      save DC is 15. If the spell normally has a range expressed in feet, its
-      range becomes 120 feet if it isn't already. If an effect covers an area,
-      you must center the spell on and include the target. If an effect has
-      multiple possible subjects, the GM randomly determines which ones are
-      affected.</p>
-
-      <p>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend
-      the wand's last charge, roll a d20. On a 1, the wand crumbles into dust
-      and is destroyed.</p>
+      table to discover what happens.</p><p>If the effect causes you to cast a
+      spell from the wand, the spell's save DC is 15. If the spell normally has
+      a range expressed in feet, its range becomes 120 feet if it isn't already.
+      If an effect covers an area, you must center the spell on and include the
+      target. If an effect has multiple possible subjects, the GM randomly
+      determines which ones are affected.</p><p>The wand regains 1d6 + 1
+      expended charges daily at dawn. If you expend the wand's last charge, roll
+      a d20. On a 1, the wand crumbles into dust and is destroyed.</p>
     chat: ''
   source:
     custom: ''
@@ -44,7 +39,7 @@ system:
   uses:
     max: '7'
     recovery:
-      - period: lr
+      - period: dawn
         type: formula
         formula: 1d6 + 1
     autoDestroy: false
@@ -591,7 +586,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 4.4.0
   createdTime: 1725037273704
   modifiedTime: 1731016531254
   lastModifiedBy: dnd5ebuilder0000


### PR DESCRIPTION
Fixed remaining wands in the SRD.
- Added the missing word "Wand" for consistency.
- Single one of them now has a missing enricher for "Frightened".
- Updated recovery being set to Long Rest instead of Dawn (they all explicitly say dawn).