### PR TITLE
SRD 5.1: Poisons

### DIFF
--- a/packs/_source/items/poison/basic-poison.yml
+++ b/packs/_source/items/poison/basic-poison.yml
@@ -7,8 +7,8 @@ system:
     value: >-
       <p>You can use the poison in this vial to coat one slashing or piercing
       weapon or up to three pieces of ammunition. Applying the poison takes an
-      action. A creature hit by the poisoned weapon or ammunition must make a DC
-      10 Constitution saving throw or take 1d4 poison damage. Once applied, the
+      action. A creature hit by the poisoned weapon or ammunition must make a
+      [[/save]] saving throw or take [[/damage]] damage. Once applied, the
       poison retains potency for 1 minute before drying.</p>
     chat: ''
   source:
@@ -49,8 +49,8 @@ system:
         formula: ''
     replace: false
   type:
-    value: potion
-    subtype: ''
+    value: poison
+    subtype: injury
   unidentified:
     description: ''
   container: null
@@ -142,7 +142,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1725037241703
   modifiedTime: 1725992531189
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/poison/potion-of-poison.yml
+++ b/packs/_source/items/poison/potion-of-poison.yml
@@ -8,16 +8,16 @@ system:
       <p><em>This concoction looks, smells, and tastes like a potion of healing
       or other beneficial potion.</em></p><p>However, it is actually poison
       masked by illusion magic. An identify spell reveals its true
-      nature.</p><p>If you drink it, you take 3d6 poison damage, and you must
-      succeed on a DC 13 Constitution saving throw or be poisoned. At the start
-      of each of your turns while you are poisoned in this way, you take 3d6
-      poison damage. At the end of each of your turns, you can repeat the saving
-      throw. On a successful save, the poison damage you take on your subsequent
-      turns decreases by 1d6. The poison ends when the damage decreases to
-      0.</p><section class="secret foundry-note"
-      id="secret-lK9L9LydgGgQJzNL"><p><strong>Foundry Note</strong></p><p>To
-      apply the reduced damage from a successful Constitution save, please use
-      the Other Formula (set at 1d6) as required.</p></section>
+      nature.</p><p>If you drink it, you take [[/damage 3d6 poison]] damage, and
+      you must succeed on a [[/save]] saving throw or be
+      &amp;reference[poisoned]. At the start of each of your turns while you are
+      poisoned in this way, you take [[/damage 3d6 poison]] damage. At the end
+      of each of your turns, you can repeat the saving throw. On a successful
+      save, the poison damage you take on your subsequent turns decreases by
+      1d6. The poison ends when the damage decreases to 0.</p><section
+      class="secret" id="secret-zrLCcwvOwukVWTvT"><p>For convenience, you can
+      use these enrichers ([[/damage 2d6 poison]] or [[/damage 1d6 poison]]) to
+      perform the damage roll for the reduced damage.</p></section>
     chat: ''
   source:
     custom: ''
@@ -58,7 +58,7 @@ system:
     replace: false
   type:
     value: poison
-    subtype: ''
+    subtype: ingested
   unidentified:
     description: ''
   container: null
@@ -117,19 +117,7 @@ system:
         override: false
       damage:
         onSave: half
-        parts:
-          - number: 3
-            denomination: 6
-            bonus: ''
-            types:
-              - poison
-            custom:
-              enabled: false
-              formula: ''
-            scaling:
-              mode: whole
-              number: null
-              formula: ''
+        parts: []
       save:
         ability: con
         dc:
@@ -151,7 +139,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1725037292318
   modifiedTime: 1725992548354
   lastModifiedBy: dnd5ebuilder0000

--- a/packs/_source/items/poison/truth-serum.yml
+++ b/packs/_source/items/poison/truth-serum.yml
@@ -4,14 +4,9 @@ img: icons/consumables/potions/bottle-bulb-corked-labeled-blue.webp
 system:
   description:
     value: >-
-      <p><em>(ingested)</em></p>
-
-      <p>A creature subjected to this poison must succeed on a <strong>DC 11
-      Constitution saving throw</strong> or become
-      @UUID[Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.lq3TRI6ZlED8ABMx]{Poisoned}
-      for <strong>1 hour</strong>. The
-      @UUID[Compendium.dnd5e.rules.JournalEntry.w7eitkpD7QQTB6j0.JournalEntryPage.lq3TRI6ZlED8ABMx]{Poisoned}
-      creature can't knowingly speak a lie, as if under the effect of a
+      <p>A creature subjected to this poison must succeed on a [[/save]] saving
+      throw or become &amp;Reference[poisoned] for 1 hour. The poisoned creature
+      can't knowingly speak a lie, as if under the effect of a
       @UUID[Compendium.dnd5e.spells.Item.CylBa7jR8DSbo8Z3]{Zone of Truth}
       spell.</p>
     chat: ''
@@ -49,7 +44,7 @@ system:
     replace: false
   type:
     value: poison
-    subtype: ''
+    subtype: ingested
   unidentified:
     description: ''
   container: null
@@ -120,7 +115,7 @@ _stats:
   duplicateSource: null
   coreVersion: '12.331'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 4.4.0
   createdTime: 1725037220965
   modifiedTime: 1725992524337
   lastModifiedBy: dnd5ebuilder0000


### PR DESCRIPTION
- Fixed 'Basic Poison' being a potion and added enrichers and subtype.
- Added missing subtype for Potion of Poison, and added enrichers, replacing the old Secret block that no longer made sense.
- Added convenience "Poisoned" enricher and save enricher to 'Truth Serum' and a subtype.

![image](https://github.com/user-attachments/assets/3554f32d-91cc-4be4-bc03-caead4bd99d7)
