### PR TITLE
Add journal navigation system from premium content to system sheets

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2774,6 +2774,14 @@
 "DND5E.ItemWeaponUsage": "Weapon Usage",
 "DND5E.JackOfAllTrades": "Jack of all Trades",
 
+"DND5E.JOURNALENTRY": {
+  "Navigation": {
+    "Next": "Next",
+    "Previous": "Previous",
+    "Up": "Up"
+  }
+},
+
 "DND5E.LAIR": {
   "Label": "Lair",
   "Action": {

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -78,6 +78,61 @@
     }
   }
 
+  /* Navigation */
+  &.journal-entry .book-navigation {
+    flex-grow: 0;
+    padding: 5px 0px;
+    margin: 0 10px 10px;
+    border: none;
+    opacity: 0.2;
+    transition: opacity 0.5s ease-out;
+
+    &:hover { opacity: 1; }
+
+    ul {
+      display: flex;
+      gap: 5px;
+      margin: 0;
+      padding-inline: 1rem;
+      list-style: none;
+    }
+    li { flex: 1 1 33%; }
+    a {
+      display: block;
+      border: none;
+      background: none;
+      text-align: center;
+      text-decoration: none;
+    }
+    a[rel="prev"] {
+      text-align: start;
+      &::before {
+        content: "\f060";
+        font-family: var(--font-awesome);
+        font-weight: bold;
+        padding-inline-end: 2px;
+      }
+    }
+    a[rel="next"] {
+      text-align: end;
+      &::after {
+        content: "\f061";
+        font-family: var(--font-awesome);
+        font-weight: bold;
+        padding-inline-start: 2px;
+      }
+    }
+    a.parent {
+      text-align: center;
+      &::before {
+        content: "\f062";
+        font-family: var(--font-awesome);
+        font-weight: bold;
+        padding-inline-end: 3px;
+      }
+    }
+  }
+
 }
 
 /* ----------------------------------------- */

--- a/module/applications/journal/journal-sheet.mjs
+++ b/module/applications/journal/journal-sheet.mjs
@@ -10,18 +10,8 @@ export default class JournalSheet5e extends (foundry.appv1?.sheets?.JournalSheet
   }
 
   /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  activateListeners(html) {
-    super.activateListeners(html);
-    html.on("pointerdown", event => {
-      if ( (event.button === 1) && document.getElementById("tooltip")?.classList.contains("active") ) {
-        event.preventDefault();
-      }
-    });
-  }
-
-  /* -------------------------------------------- */
+  /*  Rendering                                    */
+  /* --------------------------------------------- */
 
   /** @inheritDoc */
   _getPageData() {
@@ -41,6 +31,43 @@ export default class JournalSheet5e extends (foundry.appv1?.sheets?.JournalSheet
     }
 
     return pageData;
+  }
+
+  /* --------------------------------------------- */
+
+  /** @inheritdoc */
+  async _render(...args) {
+    await super._render(...args);
+    const [html] = this.element;
+    const header = html.querySelector(".journal-entry-content .journal-header");
+
+    // Insert navigation
+    const nav = this.document.getFlag("dnd5e", "navigation");
+    if ( nav ) {
+      const getDocument = id => {
+        if ( !this.document.pack ) return game.journal.get(id);
+        return game.packs.get(this.document.pack).getDocument(id);
+      };
+      const previous = nav.previous ? await getDocument(nav.previous) : null;
+      const up = nav.up ? await getDocument(nav.up) : null;
+      const next = nav.next ? await getDocument(nav.next) : null;
+      const element = document.createElement("nav");
+      element.classList.add("book-navigation");
+      element.innerHTML = `
+        <ul>
+          <li>${previous ? `<a class="content-link" data-uuid="${previous.uuid}" rel="prev" data-link
+            data-tooltip="DND5E.JOURNALENTRY.Navigation.Previous" data-tooltip-direction="LEFT"></a>` : ""}</li>
+          <li>${up ? `<a class="content-link parent" data-uuid="${up.uuid}" data-link
+            data-tooltip="DND5E.JOURNALENTRY.Navigation.Up"></a>` : ""}</li>
+          <li>${next ? `<a class="content-link" data-uuid="${next.uuid}" rel="next" data-link
+            data-tooltip="DND5E.JOURNALENTRY.Navigation.Next" data-tooltip-direction="RIGHT"></a>` : ""}</li>
+        </ul>
+      `;
+      if ( previous ) element.querySelector("[rel=prev]").innerText = previous.name;
+      if ( up ) element.querySelector(".parent").innerText = up.name;
+      if ( next ) element.querySelector("[rel=next]").innerText = next.name;
+      header.after(element);
+    }
   }
 
   /* -------------------------------------------- */
@@ -73,5 +100,19 @@ export default class JournalSheet5e extends (foundry.appv1?.sheets?.JournalSheet
     if ( page.document.parent.sheet instanceof JournalSheet5e ) {
       element.classList.add("dnd5e2-journal", "themed", "theme-light");
     }
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  activateListeners(html) {
+    super.activateListeners(html);
+    html.on("pointerdown", event => {
+      if ( (event.button === 1) && document.getElementById("tooltip")?.classList.contains("active") ) {
+        event.preventDefault();
+      }
+    });
   }
 }


### PR DESCRIPTION
Adds support for a series of flags on journal sheets that allow displaying next, previous, and up links at the top of an entry for navigating through a book.

```json
"flags": {
  "dnd5e": {
    "navigation": {
      "previous": "journalLinkPrevi",
      "next": "journalLinkNext0",
      "up": "journalLinkUp000"
    }
  }
}
```