### PR TITLE
Add Free Rules integration to build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,6 @@ jobs:
 
 
     - name: Integrate Free Rules
-      id: test
       uses: ./utils/integrate
       continue-on-error: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4
 
 
-    - name: Load project details
+    - name: Load package type
       id: type
       uses: ActionsTools/read-json-action@main
       with:
@@ -43,11 +46,12 @@ jobs:
         file_path: "./foundryvtt.json"
 
 
-    - name: Load system manifest
-      id: manifest
+    - name: Load package ID
+      id: package-id
       uses: ActionsTools/read-json-action@main
       with:
         file_path: "./${{ steps.type.outputs.value }}.json"
+        prop_path: "id"
 
 
     # Set up our some variables for future use
@@ -60,7 +64,7 @@ jobs:
       id: get_vars
       run: |
         TAG=${GITHUB_REF/refs\/tags\//}
-        PACKAGE_ID=${{ steps.manifest.outputs.id }}
+        PACKAGE_ID=${{ steps.package-id.outputs.value }}
         PACKAGE_TYPE=${{ steps.type.outputs.value }}
         echo "TAG_NAME=$TAG" >> $GITHUB_ENV
         echo "PACKAGE_ID=$PACKAGE_ID" >> $GITHUB_ENV
@@ -70,8 +74,39 @@ jobs:
         echo "RELEASE_INSTALL_URL=https://github.com/${{ github.repository }}/releases/download/$TAG/$PACKAGE_TYPE.json" >> $GITHUB_ENV
 
 
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: 'npm'
+
+
+    # `npm ci` is recommended:
+    # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+    - name: Install Dependencies
+      run: npm ci --ignore-scripts
+
+
+    - name: Integrate Free Rules
+      id: test
+      uses: ./utils/integrate
+      continue-on-error: true
+
+
+    - name: Build All
+      run: |
+        npm run build
+        mv --force dnd5e-compiled.mjs dnd5e.mjs
+
+
+    - name: Load Manifest
+      id: manifest
+      uses: ActionsTools/read-json-action@main
+      with:
+        file_path: "./${{ steps.type.outputs.value }}.json"
+
+
     # Run some tests to make sure our `system.json` is correct
-    # Exit before setting up node if not
     - name: Verify correct naming
       env:
         TAG_NAME: ${{ env.TAG_NAME }}
@@ -114,25 +149,6 @@ jobs:
         files: "${{ env.PACKAGE_TYPE }}.json"
       env:
         protected: true
-
-
-    - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-        cache: 'npm'
-
-
-    # `npm ci` is recommended:
-    # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-    - name: Install Dependencies
-      run: npm ci
-
-
-    - name: Build All
-      run: |
-        npm run build:code --if-present
-        mv --force dnd5e-compiled.mjs dnd5e.mjs
 
 
     - name: Determine archive contents

--- a/package-lock.json
+++ b/package-lock.json
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -4108,9 +4108,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "peer": true,
       "requires": {

--- a/utils/integrate/action.yml
+++ b/utils/integrate/action.yml
@@ -1,0 +1,25 @@
+name: Integrate Free Rules
+description: Integrate free rules from private repo into public dnd5e repo during build
+runs:
+  using: composite
+  steps:
+    - name: Generate Access Token
+      uses: qoomon/actions--access-token@v3
+      id: access-token
+      with:
+        repository: dnd-free-rules
+        permissions: |
+          contents: read
+
+    - name: Checkout Free Rules Repo
+      uses: actions/checkout@v4
+      with:
+        path: _free/
+        repository: foundryvtt/dnd-free-rules
+        ref: main
+        token: ${{ steps.access-token.outputs.token }}
+
+    - name: Complete Integration
+      uses: ./_free/integrate
+      with:
+        token: ${{ steps.access-token.outputs.token }}


### PR DESCRIPTION
Modifies the release build script to integrate content into the final build artifact from a private repo. The build script now calls the `integrate` action, a composite action that does three things:

1) Generate private access token to the private repo
2) Checks out the private repo into the `_free` folder
3) Runs the repo's `integrate` action that copies compendium content and images into the system and modifies the system manifest slightly

Because the integration script modifies the manifest, the ordering in the build script has been adjusted so the full manifest isn't loaded until after this is completed. Instead only the module `id` is loaded earlier.

The free rules integration will fail if the build script is run on a fork outside the `foundryvtt` organization, so it is marked as `continue-on-error` to avoid breaking any builds.