### PR TITLE
Fix setting NPC skills.

### DIFF
--- a/module/applications/actor/config/traits-config.mjs
+++ b/module/applications/actor/config/traits-config.mjs
@@ -117,7 +117,7 @@ export default class TraitsConfig extends BaseConfigSheet {
    * @protected
    */
   _processChoice(data, key, choice, categoryChosen=false) {
-    if ( (data.value?.includes("ALL") && (key !== "ALL")) || categoryChosen ) {
+    if ( (data.value?.includes?.("ALL") && (key !== "ALL")) || categoryChosen ) {
       choice.chosen = true;
       choice.disabled = true;
     }
@@ -130,7 +130,7 @@ export default class TraitsConfig extends BaseConfigSheet {
   /** @inheritDoc */
   _processFormData(event, form, formData) {
     const submitData = super._processFormData(event, form, formData);
-    if ( CONFIG.DND5E.traits[this.options.trait].dataType !== Number ) {
+    if ( !CONFIG.DND5E.traits[this.options.trait].dataType ) {
       this._filterData(submitData, `${Trait.actorKeyPath(this.options.trait)}.value`);
     }
     return submitData;

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4,6 +4,7 @@ import TransformationSetting from "./data/settings/transformation-setting.mjs";
 import * as activities from "./documents/activity/_module.mjs";
 import * as advancement from "./documents/advancement/_module.mjs";
 import { preLocalize } from "./utils.mjs";
+import MappingField from "./data/fields/mapping-field.mjs";
 
 // Namespace Configuration Values
 const DND5E = {};
@@ -4272,7 +4273,8 @@ DND5E.traits = {
     icon: "icons/tools/instruments/harp-yellow-teal.webp",
     actorKeyPath: "system.skills",
     labelKeyPath: "label",
-    expertise: true
+    expertise: true,
+    dataType: MappingField
   },
   languages: {
     labels: {
@@ -4314,7 +4316,8 @@ DND5E.traits = {
     subtypes: { keyPath: "toolType", ids: ["tools"] },
     children: { vehicle: "vehicleTypes" },
     sortCategories: true,
-    expertise: true
+    expertise: true,
+    dataType: MappingField
   },
   di: {
     labels: {


### PR DESCRIPTION
Two adjustments here:
* Add a `dataType` to `CONFIG.DND5E.traits.skills` in order to prevent an extraneous `value` being appended to the `actor.system.skills` source.
* Made `TraitsConfig` more resilient to bad data in order to fix NPCs that have this extraneous `value` already. In theory this wouldn't be needed with the above fix, but we do have some bad data in the wild there now.