### PR TITLE
Resolve some deprecation warnings for moved implementations

### DIFF
--- a/module/applications/activity/order-usage-dialog.mjs
+++ b/module/applications/activity/order-usage-dialog.mjs
@@ -292,7 +292,7 @@ export default class OrderUsageDialog extends ActivityUsageDialog {
    * @protected
    */
   _onDrop(event) {
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     if ( (data.type !== "Actor") || !data.uuid ) return;
     const { trade } = this.item.system;
     if ( !this.config.trade?.creatures?.buy ) {

--- a/module/applications/activity/summon-sheet.mjs
+++ b/module/applications/activity/summon-sheet.mjs
@@ -155,7 +155,7 @@ export default class SummonSheet extends ActivitySheet {
    */
   async #onDrop(event) {
     // Try to extract the data
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
 
     // Handle dropping linked items
     if ( data?.type !== "Actor" ) return;

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -5,6 +5,8 @@ import ContextMenu5e from "../context-menu.mjs";
 import BaseActorSheet from "./api/base-actor-sheet.mjs";
 import Item5e from "../../documents/item.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * Extension of base actor sheet for characters.
  */

--- a/module/applications/actor/deprecated/base-sheet.mjs
+++ b/module/applications/actor/deprecated/base-sheet.mjs
@@ -31,6 +31,8 @@ import TraitsConfig from "../config/traits-config.mjs";
 import TreasureConfig from "../config/treasure-config.mjs";
 import WeaponsConfig from "../config/weapons-config.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * @import { DropEffectValue } from "../../../drag-drop.mjs"
  * @import { FilterState5e } from "../../components/item-list-controls.mjs";

--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -4,6 +4,8 @@ import Award from "../award.mjs";
 import MovementSensesConfig from "../shared/movement-senses-config.mjs";
 import ActorSheetMixin from "./deprecated/sheet-mixin.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * A character sheet for group-type Actors.
  * The functionality of this sheet is sufficiently different from other Actor types that we extend the base

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -4,6 +4,8 @@ import BaseActorSheet from "./api/base-actor-sheet.mjs";
 import HabitatConfig from "./config/habitat-config.mjs";
 import TreasureConfig from "./config/treasure-config.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * Extension of base actor sheet for NPCs.
  */

--- a/module/applications/advancement/advancement-config-v2.mjs
+++ b/module/applications/advancement/advancement-config-v2.mjs
@@ -195,7 +195,7 @@ export default class AdvancementConfig extends PseudoDocumentSheet {
     if ( !this.options.dropKeyPath ) return;
 
     // Try to extract the data
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
 
     if ( data?.type !== "Item" ) return;
     const item = await Item.implementation.fromDropData(data);

--- a/module/applications/advancement/advancement-config.mjs
+++ b/module/applications/advancement/advancement-config.mjs
@@ -202,7 +202,7 @@ export default class AdvancementConfig extends FormApplication {
     );
 
     // Try to extract the data
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
 
     if ( data?.type !== "Item" ) return false;
     const item = await Item.implementation.fromDropData(data);

--- a/module/applications/advancement/advancement-flow.mjs
+++ b/module/applications/advancement/advancement-flow.mjs
@@ -40,6 +40,11 @@ export default class AdvancementFlow extends FormApplication {
 
   /* -------------------------------------------- */
 
+  /** @override */
+  static _warnedAppV1 = true;
+
+  /* --------------------------------------------- */
+
   /** @inheritDoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {

--- a/module/applications/advancement/advancement-migration-dialog.mjs
+++ b/module/applications/advancement/advancement-migration-dialog.mjs
@@ -70,7 +70,7 @@ export default class AdvancementMigrationDialog extends Dialog5e {
           label: game.i18n.localize("DND5E.ADVANCEMENT.Migration.Action.Confirm")
         }
       ],
-      content: await renderTemplate(
+      content: await foundry.applications.handlebars.renderTemplate(
         "systems/dnd5e/templates/advancement/advancement-migration-dialog.hbs",
         { item, advancements: advancementContext }
       ),

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -650,7 +650,9 @@ export default class CompendiumBrowser extends Application5e {
       displaySelection: this.displaySelection,
       selected: this.#selected.has(uuid)
     };
-    const html = await renderTemplate("systems/dnd5e/templates/compendium/browser-entry.hbs", context);
+    const html = await foundry.applications.handlebars.renderTemplate(
+      "systems/dnd5e/templates/compendium/browser-entry.hbs", context
+    );
     const template = document.createElement("template");
     template.innerHTML = html;
     const element = template.content.firstElementChild;
@@ -709,13 +711,16 @@ export default class CompendiumBrowser extends Application5e {
       obj[k.slugify({ strict: true })] = v;
       return obj;
     }, {});
-    const filter = await renderTemplate("systems/dnd5e/templates/compendium/browser-sidebar-filter-set.hbs", {
-      locked,
-      value: locked,
-      key: "source",
-      label: "DND5E.SOURCE.FIELDS.source.label",
-      config: { choices: this.#sources }
-    });
+    const filter = await foundry.applications.handlebars.renderTemplate(
+      "systems/dnd5e/templates/compendium/browser-sidebar-filter-set.hbs",
+      {
+        locked,
+        value: locked,
+        key: "source",
+        label: "DND5E.SOURCE.FIELDS.source.label",
+        config: { choices: this.#sources }
+      }
+    );
     filters.insertAdjacentHTML("beforeend", filter);
   }
 

--- a/module/applications/components/enchantment-application.mjs
+++ b/module/applications/components/enchantment-application.mjs
@@ -136,7 +136,7 @@ export default class EnchantmentApplicationElement extends HTMLElement {
    */
   async _onDrop(event) {
     event.preventDefault();
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     const effect = this.enchantmentItem.effects.get(this.chatMessage.getFlag("dnd5e", "use.enchantmentProfile"));
     if ( (data.type !== "Item") || !effect ) return;
     const droppedItem = await Item.implementation.fromDropData(data);

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -703,7 +703,9 @@ export default class InventoryElement extends HTMLElement {
         this.app._expanded.delete(item.id);
       } else {
         const chatData = await item.getChatData({secrets: this.document.isOwner});
-        const summary = $(await renderTemplate("systems/dnd5e/templates/items/parts/item-summary.hbs", chatData));
+        const summary = $(await foundry.applications.handlebars.renderTemplate(
+          "systems/dnd5e/templates/items/parts/item-summary.hbs", chatData
+        ));
         $(li).append(summary.hide());
         summary.slideDown(200);
         this.app._expanded.add(item.id);

--- a/module/applications/item/config/starting-equipment-config.mjs
+++ b/module/applications/item/config/starting-equipment-config.mjs
@@ -176,7 +176,7 @@ export default class StartingEquipmentConfig extends DocumentSheet5e {
   /** @inheritDoc */
   async _onDrop(event) {
     // Try to extract the data
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
 
     // Handle re-ordering of list
     if ( data?.entryId && (data.uuid === this.document.uuid) ) return this._onSortEntry(event, data);

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -166,7 +166,7 @@ export default class ContainerSheet extends ItemSheet5e {
 
   /** @inheritDoc */
   _onDrop(event) {
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     if ( !["Item", "Folder"].includes(data.type) ) return super._onDrop(event, data);
 
     if ( Hooks.call("dnd5e.dropItemSheetData", this.item, this, data) === false ) return;

--- a/module/applications/item/item-directory.mjs
+++ b/module/applications/item/item-directory.mjs
@@ -5,9 +5,7 @@ import ItemSheet5e from "./item-sheet.mjs";
 /**
  * Items sidebar with added support for item containers.
  */
-export default class ItemDirectory5e extends DragDropApplicationMixin(
-  foundry.applications?.sidebar?.tabs?.ItemDirectory ?? ItemDirectory
-) {
+export default class ItemDirectory5e extends DragDropApplicationMixin(foundry.applications.sidebar.tabs.ItemDirectory) {
 
   /** @override */
   _allowedDropBehaviors(event, data) {
@@ -34,7 +32,7 @@ export default class ItemDirectory5e extends DragDropApplicationMixin(
 
   /** @override */
   _onDrop(event) {
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     if ( !data.type ) return;
     const target = event.target.closest(".directory-item") || null;
 
@@ -75,11 +73,11 @@ export default class ItemDirectory5e extends DragDropApplicationMixin(
   /* -------------------------------------------- */
 
   /** @override */
-  async _onClickEntryName(event) {
-    const { entryId } = event.target.closest("[data-entry-id]")?.dataset ?? {};
-    const item = this.collection.get(entryId);
-    if ( !item ) return;
+  async _onClickEntry(event, target) {
+    const { entryId } = target.closest("[data-entry-id]")?.dataset ?? {};
+    const item = this.collection.get(entryId) ?? await this.collection.getDocument(entryId);
+    if ( !item ) return super._onClickEntry(event, target);
     const mode = item.sheet?._mode ?? (this.collection.locked ? ItemSheet5e.MODES.PLAY : ItemSheet5e.MODES.EDIT);
-    item.sheet.render(true, { mode });
+    item.sheet.render({ force: true, mode });
   }
 }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -12,6 +12,8 @@ import MovementSensesConfig from "../shared/movement-senses-config.mjs";
 import SourceConfig from "../source-config.mjs";
 import StartingEquipmentConfig from "./config/starting-equipment-config.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * Base item sheet built on ApplicationV2.
  */

--- a/module/applications/journal/class-page-sheet.mjs
+++ b/module/applications/journal/class-page-sheet.mjs
@@ -4,10 +4,17 @@ import Proficiency from "../../documents/actor/proficiency.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
 import JournalEditor from "./journal-editor.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * Journal entry page that displays an automatically generated summary of a class along with additional description.
  */
 export default class JournalClassPageSheet extends foundry.appv1.sheets.JournalPageSheet {
+
+  /** @override */
+  static _warnedAppV1 = true;
+
+  /* --------------------------------------------- */
 
   /** @inheritDoc */
   static get defaultOptions() {

--- a/module/applications/journal/journal-editor.mjs
+++ b/module/applications/journal/journal-editor.mjs
@@ -1,5 +1,7 @@
 import DocumentSheet5e from "../api/document-sheet.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * @typedef JournalEditorConfiguration
  * @property {string} textKeyPath  The path to the specific HTML field being edited.

--- a/module/applications/journal/journal-sheet.mjs
+++ b/module/applications/journal/journal-sheet.mjs
@@ -2,6 +2,12 @@
  * Variant of the standard journal sheet to handle custom TOC numbering.
  */
 export default class JournalSheet5e extends foundry.appv1.sheets.JournalSheet {
+
+  /** @override */
+  static _warnedAppV1 = true;
+
+  /* --------------------------------------------- */
+
   /** @inheritDoc */
   static get defaultOptions() {
     const options = super.defaultOptions;

--- a/module/applications/journal/map-page-sheet.mjs
+++ b/module/applications/journal/map-page-sheet.mjs
@@ -3,6 +3,11 @@
  */
 export default class JournalMapLocationPageSheet extends foundry.appv1.sheets.JournalTextPageSheet {
 
+  /** @override */
+  static _warnedAppV1 = true;
+
+  /* --------------------------------------------- */
+
   /** @inheritDoc */
   static get defaultOptions() {
     const options = super.defaultOptions;

--- a/module/applications/journal/rule-page-sheet.mjs
+++ b/module/applications/journal/rule-page-sheet.mjs
@@ -1,7 +1,14 @@
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * Journal entry page that displays a controls for editing rule page tooltip & type.
  */
 export default class JournalRulePageSheet extends foundry.appv1.sheets.JournalTextPageSheet {
+
+  /** @override */
+  static _warnedAppV1 = true;
+
+  /* --------------------------------------------- */
 
   /** @inheritDoc */
   static get defaultOptions() {

--- a/module/applications/journal/spells-page-sheet.mjs
+++ b/module/applications/journal/spells-page-sheet.mjs
@@ -2,10 +2,17 @@ import { linkForUuid, sortObjectEntries } from "../../utils.mjs";
 import Items5e from "../../data/collection/items-collection.mjs";
 import SpellsUnlinkedConfig from "./spells-unlinked-config.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * Journal entry page the displays a list of spells for a class, subclass, background, or something else.
  */
 export default class JournalSpellListPageSheet extends foundry.appv1.sheets.JournalPageSheet {
+
+  /** @override */
+  static _warnedAppV1 = true;
+
+  /* --------------------------------------------- */
 
   /** @inheritDoc */
   static get defaultOptions() {

--- a/module/applications/mixins/sheet-v2-mixin.mjs
+++ b/module/applications/mixins/sheet-v2-mixin.mjs
@@ -279,7 +279,9 @@ export default function DocumentSheetV2Mixin(Base) {
         this._expanded.delete(item.id);
       } else {
         const context = await item.getChatData({ secrets: item.isOwner });
-        const content = await renderTemplate("systems/dnd5e/templates/items/parts/item-summary.hbs", context);
+        const content = await foundry.applications.handlebars.renderTemplate(
+          "systems/dnd5e/templates/items/parts/item-summary.hbs", context
+        );
         summary.querySelectorAll(".item-summary").forEach(el => el.remove());
         summary.insertAdjacentHTML("beforeend", content);
         await new Promise(resolve => requestAnimationFrame(resolve));

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -1,6 +1,8 @@
 import Proficiency from "../documents/actor/proficiency.mjs";
 import * as Trait from "../documents/actor/trait.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * Data Model variant with some extra methods to support template mix-ins.
  *
@@ -533,7 +535,7 @@ export class ItemDataModel extends SystemDataModel {
    */
   async richTooltip(enrichmentOptions={}) {
     return {
-      content: await renderTemplate(
+      content: await foundry.applications.handlebars.renderTemplate(
         this.constructor.ITEM_TOOLTIP_TEMPLATE, await this.getCardData(enrichmentOptions)
       ),
       classes: ["dnd5e2", "dnd5e-tooltip", "item-tooltip"]

--- a/module/data/abstract/chat-message-data-model.mjs
+++ b/module/data/abstract/chat-message-data-model.mjs
@@ -64,7 +64,7 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
    */
   async render(options) {
     if ( !this.template ) return "";
-    return renderTemplate(this.template, await this._prepareContext(options));
+    return foundry.applications.handlebars.renderTemplate(this.template, await this._prepareContext(options));
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -11,6 +11,7 @@ import CreatureTemplate from "./templates/creature.mjs";
 import DetailsFields from "./templates/details.mjs";
 import TraitsFields from "./templates/traits.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
 const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
@@ -565,7 +566,9 @@ export default class NPCData extends CreatureTemplate {
       context.anchor = this.parent.toAnchor({ name: context.name }).outerHTML;
     }
     const template = document.createElement("template");
-    template.innerHTML = await renderTemplate("systems/dnd5e/templates/actors/embeds/npc-embed.hbs", context);
+    template.innerHTML = await foundry.applications.handlebars.renderTemplate(
+      "systems/dnd5e/templates/actors/embeds/npc-embed.hbs", context
+    );
 
     /**
      * A hook event that fires after an embedded NPC stat block rendered.

--- a/module/data/chat-message/rest-message-data.mjs
+++ b/module/data/chat-message/rest-message-data.mjs
@@ -2,6 +2,7 @@ import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
 import ActivationsField from "./fields/activations-field.mjs";
 import { ActorDeltasField } from "./fields/deltas-field.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
 const { StringField } = foundry.data.fields;
 
 /**

--- a/module/data/journal/rule.mjs
+++ b/module/data/journal/rule.mjs
@@ -1,3 +1,4 @@
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
 const { HTMLField, StringField } = foundry.data.fields;
 
 /**
@@ -32,7 +33,9 @@ export default class RuleJournalPageData extends foundry.abstract.TypeDataModel 
       })
     };
     return {
-      content: await renderTemplate("systems/dnd5e/templates/journal/page-rule-tooltip.hbs", context),
+      content: await foundry.applications.handlebars.renderTemplate(
+        "systems/dnd5e/templates/journal/page-rule-tooltip.hbs", context
+      ),
       classes: ["dnd5e-tooltip", "rule-tooltip"]
     };
   }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -2,6 +2,7 @@ import FormulaField from "../data/fields/formula-field.mjs";
 import MappingField from "../data/fields/mapping-field.mjs";
 import { parseOrString, staticID } from "../utils.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
 const { ObjectField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
@@ -826,7 +827,7 @@ export default class ActiveEffect5e extends ActiveEffect {
     if ( this.type === "enchantment" ) properties.push("DND5E.ENCHANTMENT.Label");
 
     return {
-      content: await renderTemplate(
+      content: await foundry.applications.handlebars.renderTemplate(
         "systems/dnd5e/templates/effects/parts/effect-tooltip.hbs", {
           effect: this,
           description: await TextEditor.enrichHTML(this.description ?? "", { relativeTo: this, ...enrichmentOptions }),

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -856,7 +856,7 @@ export default function ActivityMixin(Base) {
       const messageConfig = foundry.utils.mergeObject({
         rollMode: game.settings.get("core", "rollMode"),
         data: {
-          content: await renderTemplate(this.metadata.usage.chatCard, context),
+          content: await foundry.applications.handlebars.renderTemplate(this.metadata.usage.chatCard, context),
           speaker: ChatMessage.getSpeaker({ actor: this.item.actor }),
           flags: {
             core: { canPopout: true }

--- a/module/documents/activity/order.mjs
+++ b/module/documents/activity/order.mjs
@@ -318,7 +318,7 @@ export default class OrderActivity extends ActivityMixin(OrderActivityData) {
     }
     foundry.utils.setProperty(config, "data.flags.dnd5e.order.costs.paid", true);
     const context = await this._usageChatContext(config);
-    const content = await renderTemplate(this.metadata.usage.chatCard, context);
+    const content = await foundry.applications.handlebars.renderTemplate(this.metadata.usage.chatCard, context);
     await message.update({ content, flags: config.data.flags });
   }
 }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1041,7 +1041,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     };
 
     return ChatMessage.implementation.create({
-      content: await renderTemplate("systems/dnd5e/templates/chat/request-card.hbs", {
+      content: await foundry.applications.handlebars.renderTemplate("systems/dnd5e/templates/chat/request-card.hbs", {
         buttons: [{
           dataset: { ...dataset, type: "concentration", visbility: "all" },
           buttonLabel: createRollLabel({ ...dataset, ...config }),

--- a/module/documents/actor/bastion.mjs
+++ b/module/documents/actor/bastion.mjs
@@ -467,7 +467,7 @@ export default class Bastion {
         link: facility.toAnchor().outerHTML
       });
     }
-    return renderTemplate(this.constructor.ATTACK_TEMPLATE, context);
+    return foundry.applications.handlebars.renderTemplate(this.constructor.ATTACK_TEMPLATE, context);
   }
 
   /* -------------------------------------------- */
@@ -513,7 +513,7 @@ export default class Bastion {
         dataset: { action: "claim" }
       });
     }
-    return renderTemplate(this.constructor.TURN_TEMPLATE, context);
+    return foundry.applications.handlebars.renderTemplate(this.constructor.TURN_TEMPLATE, context);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -16,6 +16,8 @@ import SelectChoices from "./actor/select-choices.mjs";
 import Advancement from "./advancement/advancement.mjs";
 import SystemDocumentMixin from "./mixins/document.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * Override and extend the basic Item implementation.
  */
@@ -716,7 +718,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const messageConfig = foundry.utils.mergeObject({
       create: message?.createMessage ?? true,
       data: {
-        content: await renderTemplate("systems/dnd5e/templates/chat/item-card.hbs", context),
+        content: await foundry.applications.handlebars.renderTemplate(
+          "systems/dnd5e/templates/chat/item-card.hbs", context
+        ),
         flags: {
           "core.canPopout": true,
           "dnd5e.item": { id: this.id, uuid: this.uuid, type: this.type }
@@ -1529,21 +1533,24 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const name = data.name || game.i18n.format("DOCUMENT.New", { type: label });
     let type = data.type || CONFIG[this.documentName]?.defaultType;
     if ( !types.includes(type) ) type = types[0];
-    const content = await renderTemplate("systems/dnd5e/templates/apps/document-create.hbs", {
-      folders, name, type,
-      folder: data.folder,
-      hasFolders: folders.length > 0,
-      types: types.map(type => {
-        const label = CONFIG[this.documentName]?.typeLabels?.[type] ?? type;
-        const data = {
-          type,
-          label: game.i18n.has(label) ? game.i18n.localize(label) : type,
-          icon: this.getDefaultArtwork({ type })?.img ?? "icons/svg/item-bag.svg"
-        };
-        data.svg = data.icon?.endsWith(".svg");
-        return data;
-      }).sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang))
-    });
+    const content = await foundry.applications.handlebars.renderTemplate(
+      "systems/dnd5e/templates/apps/document-create.hbs",
+      {
+        folders, name, type,
+        folder: data.folder,
+        hasFolders: folders.length > 0,
+        types: types.map(type => {
+          const label = CONFIG[this.documentName]?.typeLabels?.[type] ?? type;
+          const data = {
+            type,
+            label: game.i18n.has(label) ? game.i18n.localize(label) : type,
+            icon: this.getDefaultArtwork({ type })?.img ?? "icons/svg/item-bag.svg"
+          };
+          data.svg = data.icon?.endsWith(".svg");
+          return data;
+        }).sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang))
+      }
+    );
     return Dialog.prompt({
       title, content,
       label: title,

--- a/module/documents/mixins/pseudo-document.mjs
+++ b/module/documents/mixins/pseudo-document.mjs
@@ -276,14 +276,17 @@ export default function PseudoDocumentMixin(Base) {
       let type = data.type;
 
       if ( !types.includes(type) ) type = types[0];
-      const content = await renderTemplate("systems/dnd5e/templates/apps/document-create.hbs", {
-        name, type,
-        types: types.map(t => {
-          const data = this._createDialogData(t, parent);
-          data.svg = data.icon?.endsWith(".svg");
-          return data;
-        }).sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang))
-      });
+      const content = await foundry.applications.handlebars.renderTemplate(
+        "systems/dnd5e/templates/apps/document-create.hbs",
+        {
+          name, type,
+          types: types.map(t => {
+            const data = this._createDialogData(t, parent);
+            data.svg = data.icon?.endsWith(".svg");
+            return data;
+          }).sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang))
+        }
+      );
       return Dialog.prompt({
         title, content,
         label: title,

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -130,7 +130,7 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
    * @returns {string[]}
    */
   getRingEffects() {
-    const e = foundry.canvas.tokens.TokenRing.effects;
+    const e = foundry.canvas.placeables.tokens.TokenRing.effects;
     const effects = [];
     if ( this.hasStatusEffect(CONFIG.specialStatusEffects.INVISIBLE) ) effects.push(e.INVISIBILITY);
     else if ( this === game.combat?.combatant?.token ) effects.push(e.RING_GRADIENT);
@@ -150,7 +150,7 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     const options = {};
     if ( type === "damage" ) {
       options.duration = 500;
-      options.easing = foundry.canvas.tokens.TokenRing.easeTwoPeaks;
+      options.easing = foundry.canvas.placeables.tokens.TokenRing.easeTwoPeaks;
     }
     this.object.ring?.flashColor(Color.from(color), options);
   }

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -1396,7 +1396,9 @@ async function rollAction(event) {
 
     const chatData = {
       user: game.user.id,
-      content: await renderTemplate("systems/dnd5e/templates/chat/request-card.hbs", { buttons }),
+      content: await foundry.applications.handlebars.renderTemplate(
+        "systems/dnd5e/templates/chat/request-card.hbs", { buttons }
+      ),
       flavor: game.i18n.localize("EDITOR.DND5E.Inline.RollRequest"),
       speaker: MessageClass.getSpeaker({user: game.user})
     };

--- a/module/tooltips.mjs
+++ b/module/tooltips.mjs
@@ -1,3 +1,5 @@
+const TooltipManager = foundry.helpers.interaction.TooltipManager.implementation;
+
 /**
  * A class responsible for orchestrating tooltips in the system.
  */
@@ -164,7 +166,9 @@ export default class Tooltips5e {
     }
 
     this.tooltip.classList.add("dnd5e-tooltip", "passive-tooltip");
-    this.tooltip.innerHTML = await renderTemplate("systems/dnd5e/templates/journal/passive-tooltip.hbs", context);
+    this.tooltip.innerHTML = await foundry.applications.handlebars.renderTemplate(
+      "systems/dnd5e/templates/journal/passive-tooltip.hbs", context
+    );
     game.tooltip._setAnchor(TooltipManager.TOOLTIP_DIRECTIONS.DOWN);
   }
 


### PR DESCRIPTION
- Resolved `renderTemplate` warnings
- Resolved `TextEditor` warnings
- Resolved `TooltipManager` warnings
- Suppressed `AppV1` warnings for remaining legacy applications
- Renamed `_onClickEntryName` to `_onClickEntry` in item directory