### PR TITLE
[#5589] Changed to getChatMessageContextOptions hook and changed addChatMessageContextOptions function accordingly

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -529,7 +529,7 @@ Hooks.on("renderSettings", (app, html) => applications.settings.sidebar.renderSe
 Hooks.on("applyCompendiumArt", (documentClass, ...args) => documentClass.applyCompendiumArt?.(...args));
 
 Hooks.on("renderChatPopout", documents.ChatMessage5e.onRenderChatPopout);
-Hooks.on("getChatLogEntryContext", documents.ChatMessage5e.addChatMessageContextOptions);
+Hooks.on("getChatMessageContextOptions", documents.ChatMessage5e.addChatMessageContextOptions);
 
 Hooks.on("renderChatLog", (app, html, data) => {
   documents.Item5e.chatListeners(html);

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -696,8 +696,8 @@ export default class ChatMessage5e extends ChatMessage {
    * @returns {object[]}          The extended options Array including new context choices
    */
   static addChatMessageContextOptions(html, options) {
-    const canApply = (li) => game.messages.get(li.dataset.messageId)?.canApplyDamage;
-    const canTarget = (li) => game.messages.get(li.dataset.messageId)?.canSelectTargets;
+    const canApply = li => game.messages.get(li.dataset.messageId)?.canApplyDamage;
+    const canTarget = li => game.messages.get(li.dataset.messageId)?.canSelectTargets;
     options.push(
       {
         name: game.i18n.localize("DND5E.ChatContextDamage"),
@@ -738,14 +738,14 @@ export default class ChatMessage5e extends ChatMessage {
         name: game.i18n.localize("DND5E.ChatContextSelectHit"),
         icon: '<i class="fas fa-bullseye"></i>',
         condition: canTarget,
-        callback: ([li]) => game.messages.get(li.dataset.messageId)?.selectTargets(li, "hit"),
+        callback: li => game.messages.get(li.dataset.messageId)?.selectTargets(li, "hit"),
         group: "attack"
       },
       {
         name: game.i18n.localize("DND5E.ChatContextSelectMiss"),
         icon: '<i class="fas fa-bullseye"></i>',
         condition: canTarget,
-        callback: ([li]) => game.messages.get(li.dataset.messageId)?.selectTargets(li, "miss"),
+        callback: li => game.messages.get(li.dataset.messageId)?.selectTargets(li, "miss"),
         group: "attack"
       }
     );

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -696,42 +696,42 @@ export default class ChatMessage5e extends ChatMessage {
    * @returns {object[]}          The extended options Array including new context choices
    */
   static addChatMessageContextOptions(html, options) {
-    const canApply = ([li]) => game.messages.get(li.dataset.messageId)?.canApplyDamage;
-    const canTarget = ([li]) => game.messages.get(li.dataset.messageId)?.canSelectTargets;
+    const canApply = (li) => game.messages.get(li.dataset.messageId)?.canApplyDamage;
+    const canTarget = (li) => game.messages.get(li.dataset.messageId)?.canSelectTargets;
     options.push(
       {
         name: game.i18n.localize("DND5E.ChatContextDamage"),
         icon: '<i class="fas fa-user-minus"></i>',
         condition: canApply,
-        callback: li => game.messages.get(li.data("messageId"))?.applyChatCardDamage(li, 1),
+        callback: li => game.messages.get(li.dataset.messageId)?.applyChatCardDamage(li, 1),
         group: "damage"
       },
       {
         name: game.i18n.localize("DND5E.ChatContextHealing"),
         icon: '<i class="fas fa-user-plus"></i>',
         condition: canApply,
-        callback: li => game.messages.get(li.data("messageId"))?.applyChatCardDamage(li, -1),
+        callback: li => game.messages.get(li.dataset.messageId)?.applyChatCardDamage(li, -1),
         group: "damage"
       },
       {
         name: game.i18n.localize("DND5E.ChatContextTempHP"),
         icon: '<i class="fas fa-user-clock"></i>',
         condition: canApply,
-        callback: li => game.messages.get(li.data("messageId"))?.applyChatCardTemp(li),
+        callback: li => game.messages.get(li.dataset.messageId)?.applyChatCardTemp(li),
         group: "damage"
       },
       {
         name: game.i18n.localize("DND5E.ChatContextDoubleDamage"),
         icon: '<i class="fas fa-user-injured"></i>',
         condition: canApply,
-        callback: li => game.messages.get(li.data("messageId"))?.applyChatCardDamage(li, 2),
+        callback: li => game.messages.get(li.dataset.messageId)?.applyChatCardDamage(li, 2),
         group: "damage"
       },
       {
         name: game.i18n.localize("DND5E.ChatContextHalfDamage"),
         icon: '<i class="fas fa-user-shield"></i>',
         condition: canApply,
-        callback: li => game.messages.get(li.data("messageId"))?.applyChatCardDamage(li, 0.5),
+        callback: li => game.messages.get(li.dataset.messageId)?.applyChatCardDamage(li, 0.5),
         group: "damage"
       },
       {


### PR DESCRIPTION
When right clicking a damage type dice roll message it now shows the proper context menu.

Fixes issue #5589