### PR TITLE
Tool Expertise

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2489,7 +2489,7 @@
 "DND5E.FlagsMeleeCriticalDice": "Melee Critical Damage Dice",
 "DND5E.FlagsMeleeCriticalDiceHint": "A number of additional damage dice added to melee weapon critical hits.",
 "DND5E.FlagsToolExpertise": "Tool Expertise",
-"DND5E.FlagsToolExpertiseHint": "Your proficiency bonus is now doubled for any ability check you make that uses your proficiency with a tool.",
+"DND5E.FlagsToolExpertiseHint": "Doubles your proficiency bonus for any ability check you make that uses your proficiency with a tool.",
 "DND5E.Flat": "Flat",
 "DND5E.Formula": "Formula",
 "DND5E.FormulaMalformedError": "Problem preparing the {property} formula within {name}.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2488,6 +2488,8 @@
 "DND5E.FlagsSpellCritThresholdHint": "An expanded critical hit threshold for spell attacks.",
 "DND5E.FlagsMeleeCriticalDice": "Melee Critical Damage Dice",
 "DND5E.FlagsMeleeCriticalDiceHint": "A number of additional damage dice added to melee weapon critical hits.",
+"DND5E.FlagsToolExpertise": "Tool Expertise",
+"DND5E.FlagsToolExpertiseHint": "Your proficiency bonus is now doubled for any ability check you make that uses your proficiency with a tool.",
 "DND5E.Flat": "Flat",
 "DND5E.Formula": "Formula",
 "DND5E.FormulaMalformedError": "Problem preparing the {property} formula within {name}.",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4490,6 +4490,12 @@ DND5E.characterFlags = {
     section: "DND5E.Feats",
     type: Boolean
   },
+  toolExpertise: {
+    name: "DND5E.FlagsToolExpertise",
+    hint: "DND5E.FlagsToolExpertiseHint",
+    section: "DND5E.Feats",
+    type: Boolean
+  },
   weaponCriticalThreshold: {
     name: "DND5E.FlagsWeaponCritThreshold",
     hint: "DND5E.FlagsWeaponCritThresholdHint",

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -205,6 +205,13 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
   calculateToolProficiency(multiplier, ability) {
     let roundDown = true;
     if ( multiplier == 1 && this.parent.flags.dnd5e?.toolExpertise) multiplier = 2;
+	if ( multiplier < 1 ) {
+      if ( this.parent._isRemarkableAthlete(ability) ) {
+        multiplier = .5;
+        roundDown = false;
+      }
+      else if ( this.parent.flags.dnd5e?.jackOfAllTrades ) multiplier = .5;
+    }
     return new Proficiency(this.attributes.prof, multiplier, roundDown);
   }
 }

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -198,4 +198,10 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
     }
     return new Proficiency(this.attributes.prof, multiplier, roundDown);
   }
+  
+  calculateToolProficiency(multiplier, ability) {
+    let roundDown = true;
+    if ( multiplier == 1 && this.parent.flags.dnd5e?.toolExpertise) multiplier = 2;
+    return new Proficiency(this.attributes.prof, multiplier, roundDown);
+  }
 }

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -199,6 +199,9 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
     return new Proficiency(this.attributes.prof, multiplier, roundDown);
   }
   
+
+  /* -------------------------------------------- */
+
   calculateToolProficiency(multiplier, ability) {
     let roundDown = true;
     if ( multiplier == 1 && this.parent.flags.dnd5e?.toolExpertise) multiplier = 2;

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -260,7 +260,7 @@ export default class CreatureTemplate extends CommonTemplate {
       tool.effectValue = tool.value;
       tool.bonus = baseBonus + globalCheckBonus + checkBonusAbl;
       tool.mod = ability?.mod ?? 0;
-      tool.prof = this.calculateAbilityCheckProficiency(tool.value, tool.ability);
+      tool.prof = this.calculateToolProficiency(tool.value, tool.ability);
       tool.total = tool.mod + tool.bonus;
       if ( Number.isNumeric(tool.prof.term) ) tool.total += tool.prof.flat;
       tool.value = tool.prof.multiplier;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1248,7 +1248,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const rollData = this.getRollData();
     const abilityId = formData?.get("ability") ?? process.ability;
     const ability = this.system.abilities?.[abilityId];
-    const prof = this.system.calculateAbilityCheckProficiency(relevant?.effectValue ?? 0, abilityId);
+    const prof = type === "skill" ? this.system.calculateAbilityCheckProficiency(relevant?.effectValue ?? 0, abilityId) : this.system.calculateToolProficiency(relevant?.effectValue ?? 0, abilityId);
 
     let { parts, data } = CONFIG.Dice.BasicRoll.constructParts({
       mod: ability?.mod,


### PR DESCRIPTION
Introduces a flag `toolExpertise` to automate the tool expertise from artificer and fire rune, replicating the behavior of the existing `jackofalltrades` flag. Add's a new function `calculateToolProficiency` and points `prepareTools` to this function.

closes one part of https://github.com/foundryvtt/dnd5e/issues/4644 and https://github.com/foundryvtt/dnd5e/issues/3230