### PR TITLE
Added option to not reset temp max hp during long rest

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3115,7 +3115,7 @@
     "Hint": "Recover limited use abilities which recharge at dusk, dawn, or on a new day.",
     "Label": "New Day"
   },
-  "ResetTempMaxHP":{
+  "RecoverTempMaxHP":{
     "Hint": "Recover the character's temporary maximum hit points.",
     "Label": "Recover Temp Max HP"
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -3115,6 +3115,10 @@
     "Hint": "Recover limited use abilities which recharge at dusk, dawn, or on a new day.",
     "Label": "New Day"
   },
+  "ResetTempMaxHP":{
+    "Hint": "Reset character's temporary maximum hit points.",
+    "Label": "Reset Temporary max HP"
+  },
   "Short": {
     "Abbreviation": "SR",
     "Hint": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -3115,9 +3115,12 @@
     "Hint": "Recover limited use abilities which recharge at dusk, dawn, or on a new day.",
     "Label": "New Day"
   },
-  "RecoverTempMaxHP":{
-    "Hint": "Recover the character's temporary maximum hit points.",
-    "Label": "Recover Temp Max HP"
+  "RecoverTempHP": {
+    "Label": "Remove Temp HP"
+  },
+  "RecoverTempMaxHP": {
+    "Hint": "Remove any adjustments to a character's maximum Hit Points.",
+    "Label": "Recover Max HP"
   },
   "Short": {
     "Abbreviation": "SR",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3116,8 +3116,8 @@
     "Label": "New Day"
   },
   "ResetTempMaxHP":{
-    "Hint": "Reset character's temporary maximum hit points.",
-    "Label": "Reset Temporary max HP"
+    "Hint": "Recover the character's temporary maximum hit points.",
+    "Label": "Recover Temp Max HP"
   },
   "Short": {
     "Abbreviation": "SR",

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -64,13 +64,12 @@ export default class BaseRestDialog extends Dialog5e {
 
   /* -------------------------------------------- */
 
-  /* -------------------------------------------- */
-
   /**
    * Should the user be prompted as to whether reset the actor's temporary max hit points?
    * @returns {boolean}
    */
-  get promptResetTempMaxHP() {
+  get promptRecoverTempMaxHP() {
+    if (this.#config.type !== "long") return false;
     if (this.actor.type==="group") {
       const members = this.actor.system.members;
       for (var i = 0;i<members.length;i++){
@@ -120,10 +119,10 @@ export default class BaseRestDialog extends Dialog5e {
       name: "newDay",
       value: context.config.newDay
     });
-    if(this.promptResetTempMaxHP) context.fields.push({
+    if(this.promptRecoverTempMaxHP) context.fields.push({
       field: new BooleanField({
-        label: game.i18n.localize("DND5E.REST.ResetTempMaxHP.Label"),
-        hint: game.i18n.localize("DND5E.REST.ResetTempMaxHP.Hint")
+        label: game.i18n.localize("DND5E.REST.RecoverTempMaxHP.Label"),
+        hint: game.i18n.localize("DND5E.REST.RecoverTempMaxHP.Hint")
       }),
       input: context.inputs.createCheckboxInput,
       name: "recoverTempMax",

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -65,22 +65,6 @@ export default class BaseRestDialog extends Dialog5e {
   /* -------------------------------------------- */
 
   /**
-   * Should the user be prompted as to whether reset the actor's temporary max hit points?
-   * @returns {boolean}
-   */
-  get promptRecoverTempMaxHP() {
-    if (this.#config.type !== "long") return false;
-    if (this.actor.type==="group") {
-      const members = this.actor.system.members;
-      return members.some(member => member.actor.system.attributes.hp.tempmax !== 0);
-    }
-    return this.actor.system.attributes.hp.tempmax !== 0;
-  }
-
-  /* -------------------------------------------- */
-
-
-  /**
    * Was the rest button pressed?
    * @type {boolean}
    */
@@ -101,6 +85,7 @@ export default class BaseRestDialog extends Dialog5e {
       actor: this.actor,
       config: this.config,
       fields: [],
+      hitPoints: [],
       result: this.result,
       hd: this.actor.system.attributes?.hd,
       hp: this.actor.system.attributes?.hp,
@@ -116,16 +101,25 @@ export default class BaseRestDialog extends Dialog5e {
       name: "newDay",
       value: context.config.newDay
     });
-    if(this.promptRecoverTempMaxHP) context.fields.push({
+
+    const rest = CONFIG.DND5E.restTypes[this.config.type];
+    if ( "recoverTemp" in rest ) context.hitPoints.push({
+      field: new BooleanField({
+        label: game.i18n.localize("DND5E.REST.RecoverTempHP.Label")
+      }),
+      input: context.inputs.createCheckboxInput,
+      name: "recoverTemp",
+      value: rest.recoverTemp
+    });
+    if ( "recoverTempMax" in rest ) context.hitPoints.push({
       field: new BooleanField({
         label: game.i18n.localize("DND5E.REST.RecoverTempMaxHP.Label"),
         hint: game.i18n.localize("DND5E.REST.RecoverTempMaxHP.Hint")
       }),
       input: context.inputs.createCheckboxInput,
       name: "recoverTempMax",
-      value: true
+      value: rest.recoverTempMax
     });
-
 
     return context;
   }

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -64,6 +64,20 @@ export default class BaseRestDialog extends Dialog5e {
 
   /* -------------------------------------------- */
 
+    /* -------------------------------------------- */
+
+  /**
+   * Should the user be prompted as to whether reset the actor's temporary max hit points?
+   * @type {boolean}
+   */
+  get promptResetTempMaxHP() {
+    if (this.actor.system.attributes.hp.tempmax > 0) return true;
+    return false;
+  }
+
+  /* -------------------------------------------- */
+
+
   /**
    * Was the rest button pressed?
    * @type {boolean}
@@ -100,6 +114,17 @@ export default class BaseRestDialog extends Dialog5e {
       name: "newDay",
       value: context.config.newDay
     });
+    if(this.promptResetTempMaxHP) context.fields.push({
+      field: new BooleanField({
+        label: game.i18n.localize("DND5E.REST.ResetTempMaxHP.Label"),
+        hint: game.i18n.localize("DND5E.REST.ResetTempMaxHP.Hint")
+      }),
+      input: context.inputs.createCheckboxInput,
+      name: "recoverTempMax",
+      value: true
+    });
+
+
     return context;
   }
 

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -72,10 +72,7 @@ export default class BaseRestDialog extends Dialog5e {
     if (this.#config.type !== "long") return false;
     if (this.actor.type==="group") {
       const members = this.actor.system.members;
-      for (var i = 0;i<members.length;i++){
-        if (members[i].actor.system.attributes.hp.tempmax !== 0) return true;
-      }
-      return false;
+      return members.some(member => member.actor.system.attributes.hp.tempmax !== 0);
     }
     return this.actor.system.attributes.hp.tempmax !== 0;
   }

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -64,7 +64,7 @@ export default class BaseRestDialog extends Dialog5e {
 
   /* -------------------------------------------- */
 
-    /* -------------------------------------------- */
+  /* -------------------------------------------- */
 
   /**
    * Should the user be prompted as to whether reset the actor's temporary max hit points?

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -68,11 +68,17 @@ export default class BaseRestDialog extends Dialog5e {
 
   /**
    * Should the user be prompted as to whether reset the actor's temporary max hit points?
-   * @type {boolean}
+   * @returns {boolean}
    */
   get promptResetTempMaxHP() {
-    if (this.actor.system.attributes.hp.tempmax > 0) return true;
-    return false;
+    if (this.actor.type==="group") {
+      const members = this.actor.system.members;
+      for (var i = 0;i<members.length;i++){
+        if (members[i].actor.system.attributes.hp.tempmax !== 0) return true;
+      }
+      return false;
+    }
+    return this.actor.system.attributes.hp.tempmax !== 0;
   }
 
   /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2951,7 +2951,9 @@ DND5E.restTypes = {
     recoverHitDice: true,
     recoverHitPoints: true,
     recoverPeriods: ["lr", "sr"],
-    recoverSpellSlotTypes: new Set(["leveled", "pact"])
+    recoverSpellSlotTypes: new Set(["leveled", "pact"]),
+    recoverTemp: true,
+    recoverTempMax: true
   }
 };
 preLocalize("restTypes", { key: "label" });

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2365,8 +2365,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @protected
    */
   _getRestHitPointRecovery({ recoverTemp, recoverTempMax, ...config }={}, result={}) {
-    console.warn(config);
-    console.warn(recoverTemp);
     const restConfig = CONFIG.DND5E.restTypes[config.type ?? "long"];
     const hp = this.system.attributes?.hp;
     if ( !hp || !restConfig.recoverHitPoints ) return;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2188,7 +2188,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       updateData: {},
       updateItems: [],
       newDay: config.newDay === true,
-      rolls: []
+      rolls: [],
+      recoverTempMax: config.resetTempMaxHP === true
     }, result);
     result.clone ??= this.clone();
     if ( "dhp" in result ) result.deltas.hitPoints = result.dhp;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2133,7 +2133,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     config = foundry.utils.mergeObject({
       type: "long", dialog: true, chat: true, newDay: true, advanceTime: false,
-      duration: CONFIG.DND5E.restTypes.long.duration[game.settings.get("dnd5e", "restVariant")]
+      duration: CONFIG.DND5E.restTypes.long.duration[game.settings.get("dnd5e", "restVariant")], recoverTemp: true
     }, config);
 
     /**
@@ -2365,6 +2365,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @protected
    */
   _getRestHitPointRecovery({ recoverTemp, recoverTempMax, ...config }={}, result={}) {
+    console.warn(config);
+    console.warn(recoverTemp);
     const restConfig = CONFIG.DND5E.restTypes[config.type ?? "long"];
     const hp = this.system.attributes?.hp;
     if ( !hp || !restConfig.recoverHitPoints ) return;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2133,7 +2133,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     config = foundry.utils.mergeObject({
       type: "long", dialog: true, chat: true, newDay: true, advanceTime: false,
-      duration: CONFIG.DND5E.restTypes.long.duration[game.settings.get("dnd5e", "restVariant")], recoverTemp: true
+      duration: CONFIG.DND5E.restTypes.long.duration[game.settings.get("dnd5e", "restVariant")]
     }, config);
 
     /**
@@ -2188,8 +2188,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       updateData: {},
       updateItems: [],
       newDay: config.newDay === true,
-      rolls: [],
-      recoverTempMax: config.RecoverTempMaxHP === true
+      rolls: []
     }, result);
     result.clone ??= this.clone();
     if ( "dhp" in result ) result.deltas.hitPoints = result.dhp;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2189,7 +2189,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       updateItems: [],
       newDay: config.newDay === true,
       rolls: [],
-      recoverTempMax: config.resetTempMaxHP === true
+      recoverTempMax: config.RecoverTempMaxHP === true
     }, result);
     result.clone ??= this.clone();
     if ( "dhp" in result ) result.deltas.hitPoints = result.dhp;

--- a/templates/actors/rest/long-rest.hbs
+++ b/templates/actors/rest/long-rest.hbs
@@ -11,4 +11,13 @@
         {{/each}}
     </fieldset>
     {{/if}}
+
+    {{#if hitPoints.length}}
+    <fieldset>
+        <legend>{{ localize "DND5E.HitPoints" }}</legend>
+        {{#each hitPoints}}
+        {{ formField field name=name value=value input=input options=options rootId=../partId }}
+        {{/each}}
+    </fieldset>
+    {{/if}}
 </section>

--- a/templates/actors/rest/short-rest.hbs
+++ b/templates/actors/rest/short-rest.hbs
@@ -12,6 +12,15 @@
     </fieldset>
     {{/if}}
 
+    {{#if hitPoints.length}}
+    <fieldset>
+        <legend>{{ localize "DND5E.HitPoints" }}</legend>
+        {{#each hitPoints}}
+        {{ formField field name=name value=value input=input options=options rootId=../partId }}
+        {{/each}}
+    </fieldset>
+    {{/if}}
+
     {{#if hitDice}}
     {{#if hitDice.canRoll}}
     <fieldset>


### PR DESCRIPTION
- Closes #3386
- Closes #5707 

The user sees a checkbox whether to reset the actor's temp max hp if the actor has any temp max hp, negative or positive. Group sheet long rest sees this checkbox if at least 1 actor has any temp max hp.
Also added that temp hp always resets on long rest. Not sure if this was a bug or intentional but as per the rules temp hp should reset on every long rest.