### PR TITLE
Bring ActiveEffect5e#isSuppressed in line with core expectations

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -77,7 +77,12 @@ export default class ActiveEffect5e extends ActiveEffect {
    * Is this active effect currently suppressed?
    * @type {boolean}
    */
-  isSuppressed = false;
+  get isSuppressed() {
+    if ( super.isSuppressed ) return true;
+    if ( this.type === "enchantment" ) return false;
+    if ( this.parent instanceof dnd5e.documents.Item5e ) return this.parent.areEffectsSuppressed;
+    return false;
+  }
 
   /* -------------------------------------------- */
 
@@ -282,17 +287,6 @@ export default class ActiveEffect5e extends ActiveEffect {
       else change.value = Boolean(value);
     }
     return change;
-  }
-
-  /* --------------------------------------------- */
-
-  /**
-   * Determine whether this Active Effect is suppressed or not.
-   */
-  determineSuppression() {
-    this.isSuppressed = false;
-    if ( this.type === "enchantment" ) return;
-    if ( this.parent instanceof dnd5e.documents.Item5e ) this.isSuppressed = this.parent.areEffectsSuppressed;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -73,10 +73,7 @@ export default class ActiveEffect5e extends ActiveEffect {
 
   /* -------------------------------------------- */
 
-  /**
-   * Is this active effect currently suppressed?
-   * @type {boolean}
-   */
+  /** @inheritDoc */
   get isSuppressed() {
     if ( super.isSuppressed ) return true;
     if ( this.type === "enchantment" ) return false;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -289,7 +289,8 @@ export default class ActiveEffect5e extends ActiveEffect {
   /* --------------------------------------------- */
 
   /**
-   * Previously, determined whether this Active Effect is suppressed or not.
+   * @deprecated
+   * @ignore
    */
   determineSuppression() {
     foundry.utils.logCompatibilityWarning(

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -286,6 +286,17 @@ export default class ActiveEffect5e extends ActiveEffect {
     return change;
   }
 
+  /* --------------------------------------------- */
+
+  /**
+   * Previously, determined whether this Active Effect is suppressed or not.
+   */
+  determineSuppression() {
+    foundry.utils.logCompatibilityWarning(
+      "The `ActiveEffect5e#determineSuppression` method has been deprecated and is no longer necessary to call.",
+      { since: "DnD5e 5.1", until: "DnD5e 5.3" }
+    );
+  }
   /* -------------------------------------------- */
   /*  Lifecycle                                   */
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -246,11 +246,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /** @inheritDoc */
   applyActiveEffects() {
     if ( this.system?.prepareEmbeddedData instanceof Function ) this.system.prepareEmbeddedData();
-    // The Active Effects do not have access to their parent at preparation time, so we wait until this stage to
-    // determine whether they are suppressed or not.
-    for ( const effect of this.allApplicableEffects() ) {
-      effect.determineSuppression();
-    }
     return super.applyActiveEffects();
   }
 


### PR DESCRIPTION
`ActiveEffect#isSuppressed` has existed in core as a getter for a little while now. With V13, systems which extend `ActiveEffect` should reference its `isSuppressed`, as now `ActiveEffect#isSuppressed` checks any effect subtypes' `system.isSuppressed` implementation. This PR gets rid of the now-unnecessary `ActiveEffect5e#determineSuppression` in favor of making `ActiveEffect5e#isSuppressed` a getter, and ensures the getter respects the super implementation.