### PR TITLE
[#5633] Add standard calendar HUD

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -457,8 +457,14 @@ Hooks.once("i18nInit", () => {
     });
   }
   utils.performPreLocalization(CONFIG.DND5E);
+  CONFIG.DND5E.calendar.formatters.forEach(f => {
+    f.label = game.i18n.localize(f.label);
+    f.group = game.i18n.localize(f.group);
+  });
   Object.values(CONFIG.DND5E.activityTypes).forEach(c => c.documentClass.localize());
   Object.values(CONFIG.DND5E.advancementTypes).forEach(c => c.documentClass.localize());
+  foundry.helpers.Localization.localizeDataModel(dataModels.settings.CalendarConfigSetting);
+  foundry.helpers.Localization.localizeDataModel(dataModels.settings.CalendarPreferencesSetting);
   foundry.helpers.Localization.localizeDataModel(dataModels.settings.TransformationSetting);
 });
 
@@ -489,6 +495,13 @@ Hooks.once("ready", function() {
 
   // Bastion initialization
   game.dnd5e.bastion.initializeUI();
+
+  // Display the calendar HUD
+  if ( CONFIG.DND5E.calendar.application ) {
+    CONFIG.DND5E.calendar.instance = new CONFIG.DND5E.calendar.application();
+    CONFIG.DND5E.calendar.instance.render({ force: true });
+    Hooks.on("updateWorldTime", CONFIG.DND5E.calendar.application.onUpdateWorldTime);
+  }
 
   // Determine whether a system migration is required and feasible
   if ( !game.user.isGM ) return;

--- a/lang/en.json
+++ b/lang/en.json
@@ -1000,6 +1000,77 @@
   }
 },
 
+"DND5E.CALENDAR": {
+  "Action": {
+    "AdvanceTime": "Advance by {amount}",
+    "OpenCharacterSheet": "Open Character Sheet",
+    "OpenPartySheet": "Open Party Sheet",
+    "ReverseTime": "Reverse by {amount}"
+  },
+  "Configuration": {
+    "DisabledMessage": "The DM must enable the calendar interface before it can be used by players.",
+    "Hint": "Control whether the calendar HUD is displayed and how it functions.",
+    "Label": "Configure Calendar",
+    "Name": "Calendar",
+    "Preferences": "Calendar Preferences"
+  },
+  "FIELDS": {
+    "buttons": {
+      "advanceFar": {
+        "label": "Advance Far Button"
+      },
+      "advanceShort": {
+        "label": "Advance Short Button"
+      },
+      "hint": "Amount of time changed when using the time control buttons in the HUD.",
+      "label": "Time Control Buttons",
+      "reverseFar": {
+        "label": "Reverse Far Button"
+      },
+      "reverseShort": {
+        "label": "Reverse Short Button"
+      },
+      "units": "Units",
+      "value": "Value"
+    },
+    "enabled": {
+      "hint": "Allow the calendar UI to be used by all users.",
+      "label": "Enabled"
+    },
+    "formatters": {
+      "date": {
+        "label": "Date Format"
+      },
+      "time": {
+        "label": "Time Format"
+      }
+    },
+    "visible": {
+      "label": "Display Calendar HUD"
+    }
+  },
+  "Formatters": {
+    "Date": "Date Formatters",
+    "MonthDay": {
+      "Format": "{B} {D}",
+      "Label": "Month & Day"
+    },
+    "MonthDayYear": {
+      "Format": "{B} {D}, {Y}",
+      "Label": "Month, Day, & Year"
+    },
+    "HoursMinutes": {
+      "Format": "{H}:{M}",
+      "Label": "Hours & Minutes"
+    },
+    "HoursMinutesSeconds": {
+      "Format": "{H}:{M}:{S}",
+      "Label": "Hours, Minutes, & Seconds"
+    },
+    "Time": "Time Formatters"
+  }
+},
+
 "DND5E.CAST": {
   "Title": "Cast",
   "FIELDS": {
@@ -3941,23 +4012,6 @@
   "NoneTargeted": "No Tokens Targeted",
   "Selected": "Selected",
   "Targeted": "Targeted"
-},
-"DND5E.TokenRings": {
-  "BackgroundColor": "Background Color",
-  "Effects": {
-    "Label": "Effects",
-    "BackgroundWave": "Background Wave",
-    "RingGradient": "Ring Gradient",
-    "RingPulse": "Ring Pulse"
-  },
-  "Enabled": "Use Dynamic Ring",
-  "RingColor": "Ring Color",
-  "ScaleCorrection": "Scale Correction",
-  "Subject": {
-    "Label": "Subject Path",
-    "Hint": "Explicitly specify a path for the artwork placed over the dynamic token ring. If not provided, the subject image will be set to the normal token artwork."
-  },
-  "Title": "Dynamic Ring"
 },
 "DND5E.ToggleDescription": "Toggle Description",
 

--- a/less/dnd5e.less
+++ b/less/dnd5e.less
@@ -28,6 +28,7 @@
 @import "v2/items.less";
 @import "v2/character.less";
 @import "v2/npc.less";
+@import "v2/calendar-hud.less";
 @import "v2/compendium-browser.less";
 @import "v2/inventory.less";
 @import "v2/chat.less";

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1054,7 +1054,7 @@
     padding-inline: 14px;
     overflow-y: auto;
 
-    > section > .note {
+    > :is(section, fieldset) > .note {
       --note-color: var(--dnd5e-color-note-info);
       position: relative;
       margin-block-end: 0;

--- a/less/v2/calendar-hud.less
+++ b/less/v2/calendar-hud.less
@@ -1,0 +1,139 @@
+@property --calendar-day-progress {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 0;
+}
+@property --calendar-night-progress {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 0;
+}
+
+#calendar-hud {
+  --calendar-animation-time: 250ms;
+  --calendar-animation: var(--calendar-animation-time) ease-in-out;
+  --calendar-gap: .5rem;
+  --calendar-sun-size: 6px;
+
+  display: flex;
+  gap: var(--calendar-gap);
+  block-size: var(--control-size);
+  margin-block-start: 16px;
+  margin-inline: 16px;
+
+  align-content: center;
+  color: var(--control-icon-color);
+  font-size: var(--font-size-12);
+  pointer-events: all;
+
+  .calendar-core, .calendar-button {
+    background: var(--control-bg-color);
+    border: 1px solid var(--control-border-color);
+    border-radius: 4px;
+  }
+
+  .calendar-buttons {
+    display: flex;
+    gap: var(--calendar-gap);
+    align-items: center;
+  }
+  .calendar-button {
+    width: 24px;
+    height: 24px;
+
+    button {
+      block-size: 100%;
+      inline-size: 100%;
+      background: none;
+      border: none;
+      color: inherit;
+    }
+  }
+
+  .calendar-core {
+    display: grid;
+    grid-template-columns: 1fr 80px 1fr;
+    align-items: center;
+    gap: 6px;
+  }
+  .calendar-date, .calendar-time {
+    padding: 6px;
+    text-align: center;
+  }
+  .calendar-widget {
+    --sky-top-color: rgb(0 115 188);
+    --sky-bottom-color: rgb(161 176 209);
+
+    position: relative;
+    margin-block: 2px;
+    align-self: stretch;
+    border: 1px solid var(--control-icon-color);
+    border-radius: 2px;
+    overflow: hidden;
+    isolation: isolate;
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(to bottom, var(--sky-top-color), var(--sky-bottom-color));
+      z-index: -1;
+      opacity: ~"calc(.75 + sin((var(--calendar-day-progress) * pi)))";
+      transition: opacity var(--calendar-animation);
+    }
+  }
+  .calendar-stars, .calendar-sun {
+    position: absolute;
+    block-size: 100px;
+    inline-size: 100px;
+    top: 6px;
+    left: -10px;
+    border-radius: 100%;
+    transition: rotate var(--calendar-animation);
+  }
+  .calendar-stars {
+    rotate: calc(var(--calendar-night-progress) * -.5turn);
+    z-index: -2;
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: -20px;
+      border-radius: 100%;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cfilter id='filter'%3E%3CfeTurbulence baseFrequency='0.3'/%3E%3CfeColorMatrix values='0 0 0 9 -4 0 0 0 9 -4 0 0 0 9 -4 0 0 0 0 1'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23filter)'/%3E%3C/svg%3E%0A");
+    }
+  }
+  .calendar-sun {
+    rotate: calc(var(--calendar-day-progress) * -.28turn);
+    opacity: ~"calc(1 + sin((var(--calendar-day-progress) * pi)))";
+    transition: opacity var(--calendar-animation), rotate var(--calendar-animation);
+
+    &::before, &::after {
+      content: "";
+      position: absolute;
+    }
+    &::before {
+      block-size: 120px;
+      inline-size: 120px;
+      inset-inline-end: -50px;
+      inset-block-start: -43px;
+      background:
+        radial-gradient(20px 10px, rgb(252 249 214 / .7), transparent),
+        radial-gradient(30px 20px, rgb(248 243 161 / .5), transparent),
+        radial-gradient(35px 25px, rgb(250 188 90 / .3), transparent),
+        radial-gradient(40px 30px, rgb(234 158 111 / .2), transparent);
+      opacity: ~"calc(1 - sin((var(--calendar-day-progress) * pi)))";
+      rotate: calc(var(--calendar-day-progress) * .28turn);
+      transition: opacity var(--calendar-animation), rotate var(--calendar-animation);
+    }
+    &::after {
+      block-size: var(--calendar-sun-size);
+      inline-size: var(--calendar-sun-size);
+      right: 8.5px;
+      top: 15px;
+      background: yellow;
+      border-radius: 100%;
+      outline-offset: 5px;
+    }
+  }
+}

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -2,6 +2,7 @@ export * as activity from "./activity/_module.mjs";
 export * as actor from "./actor/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";
 export * as api from "./api/_module.mjs";
+export * as calendar from "./calendar/_module.mjs";
 export * as combat from "./combat/_module.mjs";
 export * as components from "./components/_module.mjs";
 export * as dice from "./dice/_module.mjs";

--- a/module/applications/calendar/_module.mjs
+++ b/module/applications/calendar/_module.mjs
@@ -1,0 +1,2 @@
+export {default as BaseCalendarHUD} from "./base-calendar-hud.mjs";
+export {default as CalendarHUD} from "./calendar-hud.mjs";

--- a/module/applications/calendar/base-calendar-hud.mjs
+++ b/module/applications/calendar/base-calendar-hud.mjs
@@ -1,0 +1,206 @@
+import { formatNumber } from "../../utils.mjs";
+import Application5e from "../api/application.mjs";
+
+/**
+ * Base application that calendar HUDs should inherit from.
+ */
+export default class BaseCalendarHUD extends Application5e {
+  /** @inheritDoc */
+  static DEFAULT_OPTIONS = {
+    actions: {
+      advanceTime: BaseCalendarHUD.#advanceTime
+    },
+    id: "calendar-hud",
+    window: {
+      frame: false,
+      positioned: false
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Should the calendar HUD be displayed for the current user?
+   * @type {boolean}
+   */
+  static get shouldDisplay() {
+    return (game.settings.get("dnd5e", "calendarConfig")?.enabled || false)
+      && (game.settings.get("dnd5e", "calendarPreferences")?.visible || false);
+  }
+
+  /**
+   * Should the calendar HUD be displayed for the current user?
+   * @type {boolean}
+   */
+  get shouldDisplay() {
+    return this.constructor.shouldDisplay;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async render(options) {
+    if ( this.rendered || this.shouldDisplay ) await super.render(options);
+  }
+
+  /* -------------------------------------------- */
+  /*  Life-Cycle Handlers                         */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onFirstRender(context, options) {
+    this._placeHUD();
+    await super._onFirstRender(context, options);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Place the HUD application in the middle-top UI section.
+   * @protected
+   */
+  _placeHUD() {
+    const location = document.querySelector("#ui-middle #ui-top");
+    location.append(this.element);
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle moving between set amounts of time.
+   * @this {BaseCalendarHUD}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #advanceTime(event, target) {
+    const config = game.settings.get("dnd5e", "calendarConfig").buttons[target.dataset.amount];
+    game.time.advance({
+      [config.units]: target.dataset.amount.startsWith("reverse") ? -config.value : config.value
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Respond to changes in the calendar settings.
+   */
+  onUpdateSettings() {
+    if ( this.shouldDisplay ) this.render({ force: true });
+    else if ( this.rendered ) this.close({ animate: false });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Respond to changes in the world time.
+   * @param {number} worldTime
+   * @param {number} deltaTime
+   * @param {object} options
+   * @param {string} userId
+   */
+  static onUpdateWorldTime(worldTime, deltaTime, options, userId) {
+    if ( this.shouldDisplay ) CONFIG.DND5E.calendar.instance?.render();
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * @typedef CalendarFormattingContext
+   * @property {string} y  Year number with at least 4 digits.
+   * @property {string} b  Month abbreviation.
+   * @property {string} B  Full month name.
+   * @property {string} m  Month number with at least 2 digits.
+   * @property {string} d  Day of month with at least 2 digits.
+   * @property {string} D  Ordinal day of month (e.g. 1st, 2nd).
+   * @property {string} j  Day of year with at least 3 digits.
+   * @property {string} w  Day number in week.
+   * @property {string} H  Hours with at least 2 digits.
+   * @property {string} M  Minutes with at least 2 digits.
+   * @property {string} S  Seconds with at least 2 digits.
+   */
+
+  /**
+   * Prepared date parts passed to the localization.
+   * @param {CalendarData} calendar      The configured calendar
+   * @param {TimeComponents} components  Time components to format
+   * @returns {CalendarFormattingContext}
+   */
+  static dateFormattingParts(calendar, components) {
+    const month = calendar.months.values[components.month];
+    return {
+      // Year
+      Y: components.year.paddedString(4),
+
+      // Month
+      b: month.abbreviation,
+      B: game.i18n.localize(month.name),
+      m: month.ordinal.paddedString(2),
+
+      // Week
+      // a: Day of week abbreviation (e.g. Mon, Tue)
+      // A: Day of week full name (e.g. Monday, Tuesday)
+      // W: week number of the year
+
+      // Day
+      d: (components.dayOfMonth + 1).paddedString(2),
+      D: formatNumber(components.dayOfMonth + 1, { ordinal: true }),
+      j: (components.day + 1).paddedString(3),
+      w: String(components.dayOfWeek + 1),
+
+      // Hour
+      H: components.hour.paddedString(2),
+
+      // Minute
+      M: components.minute.paddedString(2),
+
+      // Second
+      S: components.second.paddedString(2)
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Format the date using the provided localization key and the default formatting parts.
+   * @param {string} localizationKey     Key to use for localization.
+   * @param {CalendarData} calendar      The configured calendar.
+   * @param {TimeComponents} components  Time components to format.
+   * @param {object} options             Additional formatting options.
+   * @returns {string}                   The returned string format.
+   */
+  static simpleFormat(localizationKey, calendar, components, options) {
+    return game.i18n.format(localizationKey, BaseCalendarHUD.dateFormattingParts(calendar, components));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Progress between sunrise and sunset assuming it is daylight half the day duration.
+   * @type {CalendarProgress}
+   */
+  static simpleProgressDay(time) {
+    const daylightHours = time.calendar.days.hoursPerDay / 2;
+    return (time.components.hour - (daylightHours / 2)) / daylightHours;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Progress between sunset and sunrise assuming it is night half the day duration.
+   * @type {CalendarProgress}
+   */
+  static simpleProgressNight(time) {
+    const daylightHours = time.calendar.days.hoursPerDay / 2;
+    let hour = time.components.hour;
+    if ( time.components.hour < daylightHours ) hour += time.calendar.days.hoursPerDay;
+    return (hour - (daylightHours * 1.5)) / daylightHours;
+  }
+}

--- a/module/applications/calendar/calendar-hud.mjs
+++ b/module/applications/calendar/calendar-hud.mjs
@@ -1,0 +1,226 @@
+import { formatTime } from "../../utils.mjs";
+import BaseCalendarHUD from "./base-calendar-hud.mjs";
+
+/**
+ * @typedef CalendarHUDButton
+ * @property {object} dataset
+ * @property {Function} display
+ * @property {string} label
+ * @property {string} icon
+ */
+
+/**
+ * Application for showing a date and time interface on the screen.
+ */
+export default class CalendarHUD extends BaseCalendarHUD {
+  /** @inheritDoc */
+  static DEFAULT_OPTIONS = {
+    actions: {
+      openCharacterSheet: CalendarHUD.#openCharacterSheet,
+      openPartySheet: CalendarHUD.#openPartySheet
+    },
+    classes: ["faded-ui", "ui-control"]
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    startButtons: {
+      classes: ["calendar-buttons"],
+      template: "systems/dnd5e/templates/apps/calendar-buttons.hbs"
+    },
+    core: {
+      classes: ["calendar-core"],
+      template: "systems/dnd5e/templates/apps/calendar-core.hbs"
+    },
+    endButtons: {
+      classes: ["calendar-buttons"],
+      template: "systems/dnd5e/templates/apps/calendar-buttons.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    this._prepareButtonsContext(context, options);
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the buttons that can be displayed around the calendar UI.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   */
+  async _prepareButtonsContext(context, options) {
+    const config = game.settings.get("dnd5e", "calendarConfig");
+
+    context.startButtons = [
+      {
+        dataset: {
+          action: "advanceTime",
+          amount: "reverseShort"
+        },
+        display: game.user.isGM,
+        label: game.i18n.format("DND5E.CALENDAR.Action.ReverseTime", {
+          amount: formatTime(config.buttons.reverseShort.value, config.buttons.reverseShort.units).titleCase()
+        }),
+        icon: "fa-solid fa-angle-left"
+      },
+      {
+        dataset: {
+          action: "advanceTime",
+          amount: "reverseFar"
+        },
+        display: game.user.isGM,
+        label: game.i18n.format("DND5E.CALENDAR.Action.ReverseTime", {
+          amount: formatTime(config.buttons.reverseFar.value, config.buttons.reverseFar.units).titleCase()
+        }),
+        icon: "fa-solid fa-angles-left"
+      },
+      {
+        dataset: {
+          action: "openCharacterSheet"
+        },
+        display: !!game.user.character,
+        label: game.i18n.localize("DND5E.CALENDAR.Action.OpenCharacterSheet"),
+        icon: "fa-solid fa-user"
+      }
+    ];
+
+    context.endButtons = [
+      {
+        dataset: {
+          action: "advanceTime",
+          amount: "advanceShort"
+        },
+        display: game.user.isGM,
+        label: game.i18n.format("DND5E.CALENDAR.Action.AdvanceTime", {
+          amount: formatTime(config.buttons.advanceShort.value, config.buttons.advanceShort.units).titleCase()
+        }),
+        icon: "fa-solid fa-angle-right"
+      },
+      {
+        dataset: {
+          action: "advanceTime",
+          amount: "advanceFar"
+        },
+        display: game.user.isGM,
+        label: game.i18n.format("DND5E.CALENDAR.Action.AdvanceTime", {
+          amount: formatTime(config.buttons.advanceFar.value, config.buttons.advanceFar.units).titleCase()
+        }),
+        icon: "fa-solid fa-angles-right"
+      },
+      {
+        dataset: {
+          action: "openPartySheet"
+        },
+        // TODO: Verify permission on group actor
+        display: !!game.settings.get("dnd5e", "primaryParty")?.actor,
+        label: game.i18n.localize("DND5E.CALENDAR.Action.OpenPartySheet"),
+        icon: "fa-solid fa-users"
+      }
+    ];
+
+    /**
+     * A hook event that fires when preparing the buttons displayed around the calendar HUD. Buttons in each list
+     * are sorted with those closest to the center first.
+     * @function dnd5e.prepareCalendarButtons
+     * @memberof hookEvents
+     * @param {CalendarHUD} app                   The Calendar HUD application being rendered.
+     * @param {CalendarHUDButton[]} startButtons  Buttons displayed before the calendar UI.
+     * @param {CalendarHUDButton[]} endButtons    Buttons displayed after the calendar UI.
+     */
+    Hooks.callAll("dnd5e.prepareCalendarButtons", this, context.startButtons, context.endButtons);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preparePartContext(partId, context, options) {
+    context = await super._preparePartContext(partId, context, options);
+    switch ( partId ) {
+      case "endButtons":
+        context.buttons = context.endButtons;
+        break;
+      case "startButtons":
+        context.buttons = context.startButtons.reverse();
+        break;
+    }
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Adjust the date, time, and progress in the core part without a full re-render to allow animation.
+   */
+  async renderCore() {
+    const prefs = game.settings.get("dnd5e", "calendarPreferences");
+    const dateFormatter = CONFIG.DND5E.calendar.formatters.find(f => f.value === prefs.formatters.date);
+    this.element.querySelector(".calendar-date").innerText = dateFormatter ? game.time.calendar.format(
+      game.time.components, dateFormatter.formatter
+    ) : "";
+    const timeFormatter = CONFIG.DND5E.calendar.formatters.find(f => f.value === prefs.formatters.time);
+    this.element.querySelector(".calendar-time").innerText = timeFormatter ? game.time.calendar.format(
+      game.time.components, timeFormatter.formatter
+    ) : "";
+
+    const widget = this.element.querySelector(".calendar-widget");
+    widget.style.setProperty("--calendar-day-progress", CONFIG.DND5E.calendar.dayProgress(game.time));
+    widget.style.setProperty("--calendar-night-progress", CONFIG.DND5E.calendar.nightProgress(game.time));
+  }
+
+  /* -------------------------------------------- */
+  /*  Life-Cycle Handlers                         */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    await this.renderCore();
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle opening the player's character sheet.
+   * @this {CalendarHUD}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #openCharacterSheet(event, target) {
+    game.user.character?.sheet.render({ force: true });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle opening the primary party's sheet.
+   * @this {CalendarHUD}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #openPartySheet(event, target) {
+    game.settings.get("dnd5e", "primaryParty")?.actor?.sheet.render({ force: true });
+  }
+
+  /* -------------------------------------------- */
+
+  // TODO: Respond to updates to primary party
+  // TODO: Respond to updates to player's character
+
+  /** @override */
+  static onUpdateWorldTime(worldTime, deltaTime, options, userId) {
+    CONFIG.DND5E.calendar.instance?.renderCore();
+    // TODO: Use the delta time to ensure the animation runs in the correct direction
+  }
+}

--- a/module/applications/settings/_module.mjs
+++ b/module/applications/settings/_module.mjs
@@ -2,6 +2,7 @@ export * as sidebar from "./sidebar.mjs";
 
 export {default as BaseSettingsConfig} from "./base-settings.mjs";
 export {default as BastionSettingsConfig} from "./bastion-settings.mjs";
+export {default as CalendarSettingsConfig} from "./calendar-settings.mjs";
 export {default as CompendiumBrowserSettingsConfig} from "./compendium-browser-settings.mjs";
 export {default as ModuleArtSettingsConfig} from "./module-art-settings.mjs";
 export {default as VisibilitySettingsConfig} from "./visibility-settings.mjs";

--- a/module/applications/settings/calendar-settings.mjs
+++ b/module/applications/settings/calendar-settings.mjs
@@ -1,0 +1,138 @@
+import { CalendarConfigSetting, CalendarPreferencesSetting } from "../../data/settings/calendar-setting.mjs";
+import { createCheckboxInput } from "../fields.mjs";
+import BaseSettingsConfig from "./base-settings.mjs";
+
+const { BooleanField } = foundry.data.fields;
+
+/**
+ * An application for configuring calendar settings.
+ */
+export default class CalendarSettingsConfig extends BaseSettingsConfig {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    window: {
+      title: "DND5E.CALENDAR.Configuration.Label"
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    config: {
+      template: "systems/dnd5e/templates/settings/calendar-config.hbs"
+    },
+    preferences: {
+      template: "systems/dnd5e/templates/settings/calendar-preferences.hbs"
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _configureRenderParts(options) {
+    const parts = super._configureRenderParts(options);
+    if ( !game.user.isGM ) delete parts.config;
+    return parts;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preparePartContext(partId, context, options) {
+    context = await super._preparePartContext(partId, context, options);
+    switch ( partId ) {
+      case "config": return this._prepareConfigContext(context, options);
+      case "preferences": return this._preparePreferencesContext(context, options);
+    }
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the DM configuration section
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {ApplicationRenderContext}
+   * @protected
+   */
+  async _prepareConfigContext(context, options) {
+    const data = game.settings.get("dnd5e", "calendarConfig");
+    context.fields = Object.entries(CalendarConfigSetting.schema.fields)
+      .filter(([name]) => name !== "buttons")
+      .map(([name, field]) => ({
+        field,
+        input: field instanceof BooleanField ? createCheckboxInput : undefined,
+        name: `calendarConfig.${name}`,
+        value: data[name]
+      }));
+    const timeOptions = Object.entries(CONFIG.DND5E.timeUnits)
+      .filter(([, config]) => config.timeComponent)
+      .map(([value, { label }]) => ({ value, label }));
+    context.buttons = Object.entries(CalendarConfigSetting.schema.fields.buttons.fields).map(([name, field]) => ({
+      fields: [
+        {
+          classes: "label-top",
+          field: field.fields.value,
+          label: game.i18n.localize("DND5E.CALENDAR.FIELDS.buttons.value"),
+          name: `calendarConfig.buttons.${name}.value`,
+          value: data.buttons[name].value
+        },
+        {
+          classes: "label-top",
+          field: field.fields.units,
+          label: game.i18n.localize("DND5E.CALENDAR.FIELDS.buttons.units"),
+          name: `calendarConfig.buttons.${name}.units`,
+          options: timeOptions,
+          value: data.buttons[name].units
+        }
+      ],
+      label: field.label,
+      prefix: `calendarConfig.${name}.`
+    }));
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the player preferences section
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {ApplicationRenderContext}
+   * @protected
+   */
+  async _preparePreferencesContext(context, options) {
+    const data = game.settings.get("dnd5e", "calendarPreferences");
+    const fields = CalendarPreferencesSetting.schema.fields;
+    context.fields = [
+      {
+        field: fields.visible,
+        input: createCheckboxInput,
+        name: "calendarPreferences.visible",
+        value: data.visible
+      },
+      {
+        field: fields.formatters.fields.date,
+        name: "calendarPreferences.formatters.date",
+        options: CONFIG.DND5E.calendar.formatters,
+        value: data.formatters.date
+      },
+      {
+        field: fields.formatters.fields.time,
+        name: "calendarPreferences.formatters.time",
+        options: CONFIG.DND5E.calendar.formatters,
+        value: data.formatters.time
+      }
+    ];
+    context.showMessage = !game.settings.get("dnd5e", "calendarConfig")?.enabled;
+    context.disabled = context.showMessage && !game.user.isGM;
+    return context;
+  }
+}

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1,3 +1,4 @@
+import CalenderHUD from "./applications/calendar/calendar-hud.mjs";
 import MapLocationControlIcon from "./canvas/map-location-control-icon.mjs";
 import { ConsumptionTargetData } from "./data/activity/fields/consumption-targets-field.mjs";
 import TransformationSetting from "./data/settings/transformation-setting.mjs";
@@ -864,6 +865,7 @@ DND5E.toolIds = new Proxy(DND5E.tools, {
  * @property {number} conversion       Conversion multiplier used to converting between units.
  * @property {boolean} [combat=false]  Is this a combat-specific time unit?
  * @property {boolean} [option=true]   Should this be available when users can select from a list of units?
+ * @property {string} [timeComponent]  Mapping of this unit to a `TimeComponent` provided by core's calendar system.
  */
 
 /**
@@ -886,19 +888,23 @@ DND5E.timeUnits = {
   second: {
     label: "DND5E.UNITS.TIME.Second.Label",
     conversion: 1 / 60,
-    option: false
+    option: false,
+    timeComponent: "second"
   },
   minute: {
     label: "DND5E.UNITS.TIME.Minute.Label",
-    conversion: 1
+    conversion: 1,
+    timeComponent: "minute"
   },
   hour: {
     label: "DND5E.UNITS.TIME.Hour.Label",
-    conversion: 60
+    conversion: 60,
+    timeComponent: "hour"
   },
   day: {
     label: "DND5E.UNITS.TIME.Day.Label",
-    conversion: 1_440
+    conversion: 1_440,
+    timeComponent: "day"
   },
   week: {
     label: "DND5E.UNITS.TIME.Week.Label",
@@ -911,7 +917,8 @@ DND5E.timeUnits = {
   },
   year: {
     label: "DND5E.UNITS.TIME.Year.Label",
-    conversion: 525_600
+    conversion: 525_600,
+    timeComponent: "year"
   }
 };
 preLocalize("timeUnits", { key: "label" });
@@ -4660,6 +4667,68 @@ DND5E.defaultArtwork = {
 };
 
 /* -------------------------------------------- */
+/*  Calendar                                    */
+/* -------------------------------------------- */
+
+/**
+ * @typedef CalendarHUDConfiguration
+ * @property {typeof ApplicationV2|null} application  HUD application to display, or `null` to not display one.
+ * @property {ApplicationV2|null} instance            Currently instantiated calendar application.
+ * @property {CalendarTimeFormatter[]} formatters     Formatters that can be used to display the date or time.
+ * @property {CalendarProgress} dayProgress           Method for calculating progress through the day.
+ * @property {CalendarProgress} nightProgress         Method for calculating progress through the night.
+ */
+
+/**
+ * @typedef {FormSelectOption} CalendarTimeFormatter
+ * @property {string|TimeFormatter} formatter  The formatter name on the current calendar or a formatter function.
+ */
+
+/**
+ * @callback CalendarProgress
+ * @param {GameTime} time  Game time to use in the calculation.
+ * @returns {number}       Progress through day period. For day progress 0 represents sunrise and 1 sunset. For night
+ *                         progress 0 represents sunset and 1 sunrise. Values outside that range are valid.
+ */
+
+/**
+ * Configuration information for the calendar UI.
+ * @type {CalendarHUDConfiguration}
+ */
+DND5E.calendar = {
+  application: CalenderHUD,
+  instance: null,
+  formatters: [
+    {
+      value: "monthDay",
+      label: "DND5E.CALENDAR.Formatters.MonthDay.Label",
+      formatter: CalenderHUD.simpleFormat.bind(null, "DND5E.CALENDAR.Formatters.MonthDay.Format"),
+      group: "DND5E.CALENDAR.Formatters.Date"
+    },
+    {
+      value: "monthDayYear",
+      label: "DND5E.CALENDAR.Formatters.MonthDayYear.Label",
+      formatter: CalenderHUD.simpleFormat.bind(null, "DND5E.CALENDAR.Formatters.MonthDayYear.Format"),
+      group: "DND5E.CALENDAR.Formatters.Date"
+    },
+    {
+      value: "hoursMinutes",
+      label: "DND5E.CALENDAR.Formatters.HoursMinutes.Label",
+      formatter: CalenderHUD.simpleFormat.bind(null, "DND5E.CALENDAR.Formatters.HoursMinutes.Format"),
+      group: "DND5E.CALENDAR.Formatters.Time"
+    },
+    {
+      value: "hoursMinutesSeconds",
+      label: "DND5E.CALENDAR.Formatters.HoursMinutesSeconds.Label",
+      formatter: CalenderHUD.simpleFormat.bind(null, "DND5E.CALENDAR.Formatters.HoursMinutesSeconds.Format"),
+      group: "DND5E.CALENDAR.Formatters.Time"
+    }
+  ],
+  dayProgress: CalenderHUD.simpleProgressDay,
+  nightProgress: CalenderHUD.simpleProgressNight
+};
+
+/* -------------------------------------------- */
 /*  Rules                                       */
 /* -------------------------------------------- */
 
@@ -4899,33 +4968,6 @@ DND5E.rules = {
   jumping: "Compendium.dnd5e.content24.JournalEntry.phbAppendixCRule.JournalEntryPage.aaJOlRhI1H6vAxt9",
   resistance: "Compendium.dnd5e.content24.JournalEntry.phbAppendixCRule.JournalEntryPage.Uk3xhCTvEfx8BN1O"
 };
-
-/* -------------------------------------------- */
-/*  Token Rings Framework                       */
-/* -------------------------------------------- */
-
-/**
- * Token Rings configuration data
- *
- * @typedef {object} TokenRingsConfiguration
- * @property {Record<string, string>} effects        Localized names of the configurable ring effects.
- * @property {string} spriteSheet                    The sprite sheet json source.
- * @property {typeof BaseSamplerShader} shaderClass  The shader class definition associated with the token ring.
- */
-
-/**
- * @type {TokenRingsConfiguration}
- */
-DND5E.tokenRings = {
-  effects: {
-    RING_PULSE: "DND5E.TokenRings.Effects.RingPulse",
-    RING_GRADIENT: "DND5E.TokenRings.Effects.RingGradient",
-    BKG_WAVE: "DND5E.TokenRings.Effects.BackgroundWave"
-  },
-  spriteSheet: "systems/dnd5e/tokens/composite/token-rings.json",
-  shaderClass: null
-};
-preLocalize("tokenRings.effects");
 
 /* -------------------------------------------- */
 /*  Sources                                     */

--- a/module/data/settings/_module.mjs
+++ b/module/data/settings/_module.mjs
@@ -1,3 +1,4 @@
 export {default as BastionSetting} from "./bastion-setting.mjs";
+export * from "./calendar-setting.mjs";
 export {default as PrimaryPartySetting} from "./primary-party-setting.mjs";
 export {default as TransformationSetting} from "./transformation-setting.mjs";

--- a/module/data/settings/calendar-setting.mjs
+++ b/module/data/settings/calendar-setting.mjs
@@ -1,0 +1,51 @@
+const { BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * A data model that represents the GM-specific calendar settings.
+ */
+export class CalendarConfigSetting extends foundry.abstract.DataModel {
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.CALENDAR"];
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    const buttonSchema = (value, units) => ({
+      value: new NumberField({ required: true, integer: true, initial: value }),
+      units: new StringField({ required: true, initial: units })
+    });
+    return {
+      enabled: new BooleanField({ required: true }),
+      buttons: new SchemaField({
+        reverseFar: new SchemaField(buttonSchema(8, "hour")),
+        reverseShort: new SchemaField(buttonSchema(1, "hour")),
+        advanceShort: new SchemaField(buttonSchema(1, "hour")),
+        advanceFar: new SchemaField(buttonSchema(8, "hour"))
+      })
+    };
+  }
+}
+
+/**
+ * A data model that represents the player visible calendar settings.
+ */
+export class CalendarPreferencesSetting extends foundry.abstract.DataModel {
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.CALENDAR"];
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {
+      formatters: new SchemaField({
+        date: new StringField({ required: true, initial: "monthDay" }),
+        time: new StringField({ required: true, initial: "hoursMinutes" })
+      }),
+      visible: new BooleanField({ required: true, initial: true })
+    };
+  }
+}

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -1,10 +1,12 @@
 import BastionSettingsConfig from "./applications/settings/bastion-settings.mjs";
+import CalendarSettingsConfig from "./applications/settings/calendar-settings.mjs";
 import CombatSettingsConfig from "./applications/settings/combat-settings.mjs";
 import CompendiumBrowserSettingsConfig from "./applications/settings/compendium-browser-settings.mjs";
 import ModuleArtSettingsConfig from "./applications/settings/module-art-settings.mjs";
 import VariantRulesSettingsConfig from "./applications/settings/variant-rules-settings.mjs";
 import VisibilitySettingsConfig from "./applications/settings/visibility-settings.mjs";
 import BastionSetting from "./data/settings/bastion-setting.mjs";
+import { CalendarConfigSetting, CalendarPreferencesSetting } from "./data/settings/calendar-setting.mjs";
 import PrimaryPartySetting from "./data/settings/primary-party-setting.mjs";
 import TransformationSetting from "./data/settings/transformation-setting.mjs";
 import * as LEGACY from "./config-legacy.mjs";
@@ -264,6 +266,31 @@ export function registerSystemSettings() {
       duration: 7
     },
     onChange: () => game.dnd5e.bastion.initializeUI()
+  });
+
+  // Calendar Settings
+  game.settings.registerMenu("dnd5e", "calendarConfiguration", {
+    name: "DND5E.CALENDAR.Configuration.Name",
+    label: "DND5E.CALENDAR.Configuration.Label",
+    hint: "DND5E.CALENDAR.Configuration.Hint",
+    icon: "fas fa-calendar-days",
+    type: CalendarSettingsConfig
+  });
+
+  game.settings.register("dnd5e", "calendarConfig", {
+    name: "Calendar Configuration",
+    scope: "world",
+    config: false,
+    type: CalendarConfigSetting,
+    onChange: () => CONFIG.DND5E.calendar.instance?.onUpdateSettings?.()
+  });
+
+  game.settings.register("dnd5e", "calendarPreferences", {
+    name: "Calendar Preferences",
+    scope: "user",
+    config: false,
+    type: CalendarPreferencesSetting,
+    onChange: () => CONFIG.DND5E.calendar.instance?.onUpdateSettings?.()
   });
 
   // Combat Settings

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -841,6 +841,32 @@ function dataset(object, options) {
 /* -------------------------------------------- */
 
 /**
+ * Create an icon element dynamically based on the provided icon string, supporting FontAwesome class strings
+ * or paths to SVG or other image types.
+ * @param {string} icon           Icon class or path.
+ * @param {object} [options={}]
+ * @param {string} [options.alt]  Alt text for the icon.
+ * @returns {HTMLElement|null}
+ */
+export function generateIcon(icon, { alt }={}) {
+  let element;
+  if ( icon?.startsWith("fa") ) {
+    element = document.createElement("i");
+    element.className = icon;
+    element.ariaLabel = alt;
+  } else if ( icon ) {
+    element = document.createElement(icon.endsWith(".svg") ? "dnd5e-icon" : "img");
+    element.src = icon;
+  } else {
+    return null;
+  }
+  if ( alt ) element[element.tagName === "IMG" ? "alt" : "ariaLabel"] = alt;
+  return element;
+}
+
+/* -------------------------------------------- */
+
+/**
  * A helper to create a set of <option> elements in a <select> block grouped together
  * in <optgroup> based on the provided categories.
  *
@@ -957,6 +983,11 @@ export function registerHandlebarsHelpers() {
     getProperty: foundry.utils.getProperty,
     "dnd5e-concealSection": concealSection,
     "dnd5e-dataset": dataset,
+    "dnd5e-icon": (icon, { hash: options }) => {
+      let element = generateIcon(icon, options);
+      if ( !element && options.fallback ) element = generateIcon(options.fallback, options);
+      return element ? new Handlebars.SafeString(element.outerHTML) : "";
+    },
     "dnd5e-formatCR": formatCR,
     "dnd5e-formatModifier": formatModifier,
     "dnd5e-groupedSelectOptions": groupedSelectOptions,

--- a/templates/apps/calendar-buttons.hbs
+++ b/templates/apps/calendar-buttons.hbs
@@ -1,0 +1,11 @@
+<menu>
+    {{#each buttons}}
+    {{#if display}}
+    <li class="calendar-button">
+        <button type="button" {{ dnd5e-dataset dataset }} data-tooltip aria-label="{{ label }}">
+            {{ dnd5e-icon icon }}
+        </button>
+    </li>
+    {{/if}}
+    {{/each}}
+</menu>

--- a/templates/apps/calendar-core.hbs
+++ b/templates/apps/calendar-core.hbs
@@ -1,0 +1,8 @@
+<div>
+    <div class="calendar-date"></div>
+    <div class="calendar-widget">
+        <span class="calendar-sun"></span>
+        <span class="calendar-stars"></span>
+    </div>
+    <div class="calendar-time"></div>
+</div>

--- a/templates/settings/calendar-config.hbs
+++ b/templates/settings/calendar-config.hbs
@@ -1,0 +1,16 @@
+<fieldset>
+    <legend>{{ localize "SETUP.Configuration" }}</legend>
+    {{> "dnd5e.fieldlist" fields}}
+    <hr>
+    <div class="form-group">
+        <p class="hint">{{ localize "DND5E.CALENDAR.FIELDS.buttons.hint" }}</p>
+    </div>
+    {{#each buttons}}
+    <div class="form-group split-group">
+        <label>{{ label }}</label>
+        <div class="form-fields">
+            {{> "dnd5e.fieldlist" fields}}
+        </div>
+    </div>
+    {{/each}}
+</fieldset>

--- a/templates/settings/calendar-preferences.hbs
+++ b/templates/settings/calendar-preferences.hbs
@@ -1,0 +1,5 @@
+<fieldset {{ disabled disabled }}>
+    <legend>{{ localize "DND5E.CALENDAR.Configuration.Preferences" }}</legend>
+    {{#if showMessage}}<p class="note warn">{{ localize "DND5E.CALENDAR.Configuration.DisabledMessage" }}</p>{{/if}}
+    {{> "dnd5e.fieldlist" fields}}
+</fieldset>

--- a/templates/shared/fields/fieldlist.hbs
+++ b/templates/shared/fields/fieldlist.hbs
@@ -1,3 +1,4 @@
 {{#each this}}
-{{ formField field name=name value=value input=input options=options disabled=disabled rootId=@root.partId }}
+{{ formField field name=name value=value label=label hint=hint input=input options=options disabled=disabled
+             classes=classes rootId=@root.partId }}
 {{/each}}


### PR DESCRIPTION
Introduces a new calendar HUD UI element that displays at the top of the screen and is styled like the rest of the core UI. This element includes buttons for advancing and reversing time, opening the player's assigned character sheet, and opening the party group sheet. Between that it displays the current date and time along with a day visualizer to indicate the progress of the day.

<img width="548" alt="Calendar HUD GM Dark" src="https://github.com/user-attachments/assets/7f373b92-4d5b-48cc-bc2b-93bc98cf8550" />

<img width="353" alt="Calendar HUD Player Light" src="https://github.com/user-attachments/assets/3343c150-842e-43e0-a3ff-cc763fd85092" />

The calendar interface is set by a `CONFIG.DND5E.calendar` object that defines the application used to render the calendar, the current HUD instance if rendered, a list of formatters that can be used to display the date and time, and a pair of methods for tracking the progress through the day & night. This makes it easy to completely disable the native HUD (setting `application` to `null`) or to customize it to whatever calendar is being used.

<img width="519" alt="Calendar Settings GM" src="https://github.com/user-attachments/assets/a5096bdb-4971-4af0-b3cc-20b34311adc6" />

The settings offer two sets of calendar options, one visible only to GM users and the other available to all users. The GM settings allow for enabling the calendar for all users and for customizing the time change provided by each of the advance/reverse buttons.

<img width="525" alt="Calendar Settings Player" src="https://github.com/user-attachments/assets/18bab964-68f7-451d-b673-46ed3f103507" />

The preferences have a control to toggle the display of the HUD for each user and options to customize what formatter is used to display the date or time on each side of the widget.

<img width="1725" alt="Calendar HUD In Context" src="https://github.com/user-attachments/assets/2de5b17b-e09a-4348-b3c6-bb10305166f0" />

## Todo
- [ ] Show/hide sheet buttons based on sheet changes
- [ ] Improve animation when advancing over large periods of time
- [ ] Give GMs more control over what formatters players can use
- [ ] Add UI for changing to specific date/time