### PR TITLE
[#5530] Fix embedded Document marshalling in synthetic Actor transformations.

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3060,12 +3060,18 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       foundry.utils.setProperty(tokenData, "flags.dnd5e.previousActorData", previousActorData);
       await this.sheet?.close();
       const update = await this.token.update(tokenData);
-      if ( game.release.generation > 12 ) {
-        d["==items"] = d.items;
-        d["==effects"] = d.effects;
-        delete d.items;
-        delete d.effects;
-      }
+      // TODO: We have to make do with these extra server hits until #12768 or #12769 is resolved.
+      const itemIds = new Set(d.items.map(i => i._id));
+      const effectIds = new Set(d.effects.map(e => e._id));
+      // An invocation like this is the only thing that (currently) triggers correct tombstoning on the ActorDelta.
+      await this.token.actor.deleteEmbeddedDocuments("Item", o.items.reduce((ids, { _id: id }) => {
+        if ( !itemIds.has(id) ) ids.push(id);
+        return ids;
+      }, []));
+      await this.token.actor.deleteEmbeddedDocuments("ActiveEffect", o.effects.reduce((ids, { _id: id }) => {
+        if ( !effectIds.has(id) ) ids.push(id);
+        return ids;
+      }, []));
       await this.token.actor.update(d);
       if ( options.renderSheet ) this.sheet?.render(true);
       return update;


### PR DESCRIPTION
Related foundryvtt/foundryvtt#12768
Related foundryvtt/foundryvtt#12769

Seems this initial solution was never working and I did something wrong when I was testing it. I don't see any way to avoid the extra server round-trips here given the above issues. This solution does work in v12 as well though, which is something.

Given I'm not sure what happened with the testing of the original solution, I'd appreciate an extra party to verify that the `==` solution does indeed not work currently in v13, and that this new proposal does work.