### PR TITLE
[#5612] Add ability to specify source books on a per-pack basis

### DIFF
--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -38,8 +38,9 @@ export default class SourceField extends SchemaField {
    * @param {string} uuid  Compendium source or document UUID.
    */
   static prepareData(uuid) {
-    const { pkg, flags } = SourceField.getPackage(uuid) ?? {};
-    this.bookPlaceholder = flags?.dnd5e?.sourceBook ?? SourceField.getModuleBook(pkg) ?? "";
+    const collection = foundry.utils.parseUuid(uuid)?.collection;
+    const pkg = SourceField.getPackage(collection);
+    this.bookPlaceholder = collection?.metadata?.flags?.dnd5e?.sourceBook ?? SourceField.getModuleBook(pkg) ?? "";
     if ( !this.book ) this.book = this.bookPlaceholder;
 
     if ( this.custom ) this.label = this.custom;
@@ -79,16 +80,16 @@ export default class SourceField extends SchemaField {
 
   /**
    * Get the package associated with the given UUID, if any.
-   * @param {string} uuid  The UUID.
-   * @returns {{ pkg: ClientPackage, [flags]: object }|null}
+   * @param {CompendiumCollection|string} uuidOrCollection  The document UUID or its collection.
+   * @returns {ClientPackage|null}
    */
-  static getPackage(uuid) {
-    if ( !uuid ) return null;
-    const pack = foundry.utils.parseUuid(uuid)?.collection?.metadata;
+  static getPackage(uuidOrCollection) {
+    const pack = typeof uuidOrCollection === "string" ? foundry.utils.parseUuid(uuidOrCollection)?.collection?.metadata
+      : uuidOrCollection?.metadata;
     switch ( pack?.packageType ) {
-      case "module": return { pkg: game.modules.get(pack.packageName), flags: pack.flags };
-      case "system": return { pkg: game.system, flags: pack.flags };
-      case "world": return { pkg: game.world, flags: pack.flags };
+      case "module": return game.modules.get(pack.packageName);
+      case "system": return game.system;
+      case "world": return game.world;
     }
     return null;
   }

--- a/system.json
+++ b/system.json
@@ -119,6 +119,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sourceBook": "SRD 5.1",
           "types": ["character"]
         }
       }
@@ -132,6 +133,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sourceBook": "SRD 5.1",
           "types": ["npc"]
         }
       }
@@ -145,6 +147,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sourceBook": "SRD 5.1",
           "types": ["weapon", "equipment", "consumable", "tool", "loot", "feat", "container"]
         }
       }
@@ -158,6 +161,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sourceBook": "SRD 5.1",
           "types": ["loot"]
         }
       }
@@ -172,6 +176,7 @@
       "flags": {
         "dnd5e": {
           "sorting": "m",
+          "sourceBook": "SRD 5.1",
           "types": ["spell"]
         }
       }
@@ -185,6 +190,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sourceBook": "SRD 5.1",
           "types": ["background", "feat"]
         }
       }
@@ -198,6 +204,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sourceBook": "SRD 5.1",
           "types": ["class"]
         }
       }
@@ -211,6 +218,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sourceBook": "SRD 5.1",
           "types": ["subclass"]
         }
       }
@@ -224,6 +232,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sourceBook": "SRD 5.1",
           "types": ["feat", "weapon"]
         }
       }
@@ -237,6 +246,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sourceBook": "SRD 5.1",
           "types": ["race", "feat"]
         }
       }
@@ -250,6 +260,7 @@
       "private": false,
       "flags": {
         "dnd5e": {
+          "sourceBook": "SRD 5.1",
           "types": ["feat", "weapon"]
         }
       }
@@ -299,7 +310,13 @@
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e"
+      "system": "dnd5e",
+      "flags": {
+        "dnd5e": {
+          "sourceBook": "SRD 5.2",
+          "types": ["class", "subclass", "feat"]
+        }
+      }
     },
     {
       "name": "origins24",
@@ -310,7 +327,13 @@
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e"
+      "system": "dnd5e",
+      "flags": {
+        "dnd5e": {
+          "sourceBook": "SRD 5.2",
+          "types": ["race", "background", "feat"]
+        }
+      }
     },
     {
       "name": "feats24",
@@ -321,7 +344,13 @@
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e"
+      "system": "dnd5e",
+      "flags": {
+        "dnd5e": {
+          "sourceBook": "SRD 5.2",
+          "types": ["feat"]
+        }
+      }
     },
     {
       "name": "spells24",
@@ -335,7 +364,9 @@
       "system": "dnd5e",
       "flags": {
         "dnd5e": {
-          "sorting": "m"
+          "sorting": "m",
+          "sourceBook": "SRD 5.2",
+          "types": ["spell"]
         }
       }
     },
@@ -348,7 +379,13 @@
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e"
+      "system": "dnd5e",
+      "flags": {
+        "dnd5e": {
+          "sourceBook": "SRD 5.2",
+          "types": ["weapon", "equipment", "consumable", "tool", "loot", "feat", "container"]
+        }
+      }
     },
     {
       "name": "tables24",
@@ -373,7 +410,8 @@
       "system": "dnd5e",
       "flags": {
         "dnd5e": {
-          "sorting": "m"
+          "sorting": "m",
+          "sourceBook": "SRD 5.2"
         }
       }
     }


### PR DESCRIPTION
Adds support for the `dnd5e.sourceBook` flag in compendium packs in the manifest. If specified, this value will be used by default when inferring the source book before falling back to a single source book defined in the `dnd5e.sourceBooks` flag on the package manifest.

This reverts the change made earlier that changed the process to infer even if more than one source book is defined by the package at the root level.

Closes #5612