### PR TITLE
[#5605] Prevent blank values in duration & range units

### DIFF
--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -14,7 +14,7 @@ export default class DurationField extends SchemaField {
   constructor(fields={}, options={}) {
     fields = {
       value: new FormulaField({ deterministic: true }),
-      units: new StringField({ initial: "inst" }),
+      units: new StringField({ required: true, blank: false, initial: "inst" }),
       special: new StringField(),
       ...fields
     };

--- a/module/data/shared/range-field.mjs
+++ b/module/data/shared/range-field.mjs
@@ -14,7 +14,7 @@ export default class RangeField extends SchemaField {
   constructor(fields={}, options={}) {
     fields = {
       value: new FormulaField({ deterministic: true }),
-      units: new StringField(),
+      units: new StringField({ required: true, blank: false, initial: "self" }),
       special: new StringField(),
       ...fields
     };


### PR DESCRIPTION
These fields weren't allowing blank values in V12, but a change in how V13 generates fields was adding a blank option. This change to the data models will prevent blank values from being entered and fix the generated inputs.

Closes #5605