### PR TITLE
[#5649] Enable highlight matches plugin for ProseMirror editors

### DIFF
--- a/module/applications/api/application-v2-mixin.mjs
+++ b/module/applications/api/application-v2-mixin.mjs
@@ -219,6 +219,26 @@ export default function ApplicationV2Mixin(Base) {
     /*  Event Listeners and Handlers                */
     /* -------------------------------------------- */
 
+    /** @inheritDoc */
+    _attachFrameListeners() {
+      super._attachFrameListeners();
+      this.element.addEventListener("plugins", this._onConfigurePlugins.bind(this));
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Configure plugins for the ProseMirror instance.
+     * @param {ProseMirrorPluginsEvent} event
+     * @protected
+     */
+    _onConfigurePlugins(event) {
+      event.plugins.highlightDocumentMatches =
+        ProseMirror.ProseMirrorHighlightMatchesPlugin.build(ProseMirror.defaultSchema);
+    }
+
+    /* -------------------------------------------- */
+
     /**
      * Handle toggling the collapsed state of collapsible sections.
      * @this {BaseApplication5e}


### PR DESCRIPTION
Automatically configures the highlihgt matches plugin for all `ApplicationV2` applications. Anything that inherits from our V2 mixin can disable this by overwriting `_onConfigurePlugins`.

Closes #5649