### PR TITLE
Deprecation Warning for `instanceof Token` in `blindsight.testVisibility()`

### DIFF
--- a/module/canvas/detection-modes/blindsight.mjs
+++ b/module/canvas/detection-modes/blindsight.mjs
@@ -28,7 +28,7 @@ export class DetectionModeBlindsight extends foundry.canvas.perception.Detection
   /** @override */
   _canDetect(visionSource, target) {
     if ( visionSource.object.document.hasStatusEffect(CONFIG.specialStatusEffects.BURROW) ) return false;
-    if ( target instanceof Token ) {
+    if ( target instanceof foundry.canvas.placeables.Token ) {
       if ( target.document.hasStatusEffect(CONFIG.specialStatusEffects.BURROW) ) return false;
     }
     return true;


### PR DESCRIPTION
Error: You are accessing the global "Token" which is now namespaced under foundry.canvas.placeables.Token Deprecated since Version 13

Closes #5683 