### PR TITLE
Add support for rotation region shapes with rotate region behavior

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3116,6 +3116,11 @@
           }
         }
       },
+      "regions": {
+        "ids": {
+          "label": "Regions"
+        }
+      },
       "sounds": {
         "ids": {
           "label": "Ambient Sounds"
@@ -3149,6 +3154,9 @@
     "SpeedMode": {
       "Fixed": "Fixed (total rotation time)",
       "Variable": "Variable (time to rotate 90˚)"
+    },
+    "Warning": {
+      "RecursiveRegion": "Cannot rotate same region that contains the behavior."
     }
   }
 },

--- a/module/applications/region-behavior/rotate-area-config.mjs
+++ b/module/applications/region-behavior/rotate-area-config.mjs
@@ -100,4 +100,17 @@ export default class RotateAreaConfig extends foundry.applications.sheets.Region
     const position = Number(target.closest("[data-index]")?.dataset.index);
     this.document.system.rotateTo({ position });
   }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _prepareSubmitData(event, form, formData, updateData) {
+    const submitData = super._prepareSubmitData(event, form, formData, updateData);
+    if ( submitData.system?.regions?.ids?.includes(this.document.parent.id) ) {
+      throw new Error(game.i18n.localize("DND5E.REGIONBEHAVIORS.ROTATEAREA.Warning.RecursiveRegion"));
+    }
+    return submitData;
+  }
 }

--- a/module/data/region-behavior/rotate-area.mjs
+++ b/module/data/region-behavior/rotate-area.mjs
@@ -178,8 +178,7 @@ export default class RotateAreaRegionBehaviorType extends foundry.data.regionBeh
       lights: Array.from(this.lights.ids).map(l => calculateRotationUpdate(this.scene.lights.get(l))).filter(_ => _),
       regions: [this.region.id, ...this.regions.ids].map(r => {
         const region = this.scene.regions.get(r);
-        return region
-          ? RotateAreaRegionBehaviorType.#rotateRegionShapes(this.scene.regions.get(r), angle, radians, pivot) : null;
+        return region ? RotateAreaRegionBehaviorType.#rotateRegionShapes(region, angle, radians, pivot) : null;
       }).filter(_ => _),
       sounds: Array.from(this.sounds.ids).map(l => calculateRotationUpdate(this.scene.sounds.get(l))).filter(_ => _)
     };
@@ -196,8 +195,8 @@ export default class RotateAreaRegionBehaviorType extends foundry.data.regionBeh
     });
 
     // Handle tile and token updates immediately to allow animation
-    await canvas.scene.updateEmbeddedDocuments("Tile", updates.tiles, { dnd5e: { animate: { ...animateFlags } } });
-    await canvas.scene.updateEmbeddedDocuments("Token", updates.tokens, {
+    await this.scene.updateEmbeddedDocuments("Tile", updates.tiles, { dnd5e: { animate: { ...animateFlags } } });
+    await this.scene.updateEmbeddedDocuments("Token", updates.tokens, {
       animate: false,
       dnd5e: { animate: { ...animateFlags } },
       movement: updates.tokens.reduce((obj, { _id }) => {
@@ -211,10 +210,10 @@ export default class RotateAreaRegionBehaviorType extends foundry.data.regionBeh
 
     // Delay light, sound, and wall updates until the halfway point of the animation
     setTimeout(() => {
-      canvas.scene.updateEmbeddedDocuments("AmbientLight", updates.lights);
-      canvas.scene.updateEmbeddedDocuments("AmbientSound", updates.sounds);
-      canvas.scene.updateEmbeddedDocuments("Region", updates.regions);
-      canvas.scene.updateEmbeddedDocuments("Wall", updates.walls);
+      this.scene.updateEmbeddedDocuments("AmbientLight", updates.lights);
+      this.scene.updateEmbeddedDocuments("AmbientSound", updates.sounds);
+      this.scene.updateEmbeddedDocuments("Region", updates.regions);
+      this.scene.updateEmbeddedDocuments("Wall", updates.walls);
     }, duration / 2);
     // TODO: See how performant it is to animate wall movement
 


### PR DESCRIPTION
Rotates the primary region's shapes when the rotate region behavior is activated, and adds support for rotating other linked regions at the same time. The region shape updates are performed at the middle of the animation time along with walls, lights, & sounds.