### PR TITLE
[#5129] Add setting to disallow resting from individual sheets

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3225,6 +3225,9 @@
       "Full": "{name} takes a short rest spending {dice} to recover {health}.",
       "Short": "{name} takes a short rest."
     }
+  },
+  "Warning": {
+    "OnlyByRequest": "Rests can only be performed at the request of the GM."
   }
 },
 
@@ -5059,6 +5062,10 @@
     "Hint": "Theme that will apply to the UI and all sheets by default. Automatic will be determined by your browser or operating system settings."
   },
   "PERMISSIONS": {
+    "AllowRests": {
+      "Hint": "Allow players to rest directly from their character's sheets. When disabled, players will only be able to rest when the GM makes a request from the party.",
+      "Name": "Allow Individual Rests"
+    },
     "AllowSummoning": {
       "Hint": "Allow players to use summoning abilities to summon actors. Players must also have the Create Token core permission for this to work.",
       "Name": "Allow Summoning"

--- a/lang/en.json
+++ b/lang/en.json
@@ -5063,7 +5063,7 @@
   },
   "PERMISSIONS": {
     "AllowRests": {
-      "Hint": "Allow players to rest directly from their character's sheets. When disabled, players will only be able to rest when the GM makes a request from the party.",
+      "Hint": "Allow players to rest directly from their characters' sheets. When disabled, players will only be able to rest when the GM makes a request from the party.",
       "Name": "Allow Individual Rests"
     },
     "AllowSummoning": {

--- a/less/v2/npc.less
+++ b/less/v2/npc.less
@@ -279,6 +279,7 @@
             flex-direction: column;
             gap: 4px;
             align-items: center;
+            justify-content: space-between;
           }
         }
       }

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -482,7 +482,10 @@ export default class CharacterActorSheet extends BaseActorSheet {
         { number: formatNumber(context.system.details.xp.boonsEarned ?? 0, { signDisplay: "always" }) }
       );
     }
+
+    // Visibility
     context.showExperience = game.settings.get("dnd5e", "levelingMode") !== "noxp";
+    context.showRests = game.user.isGM || (this.actor.isOwner && game.settings.get("dnd5e", "allowRests"));
 
     return context;
   }

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -296,6 +296,7 @@ export default class NPCActorSheet extends BaseActorSheet {
       context.showInitiativeScore = game.settings.get("dnd5e", "rulesVersion") === "modern";
     }
     context.showLoyalty = context.important && game.settings.get("dnd5e", "loyaltyScore") && game.user.isGM;
+    context.showRests = game.user.isGM || (this.actor.isOwner && game.settings.get("dnd5e", "allowRests"));
 
     return context;
   }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2075,8 +2075,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   async shortRest(config={}) {
     if ( this.type === "vehicle" ) return;
-    const clone = this.clone();
+    if ( !game.user.isGM && !game.settings.get("dnd5e", "allowRests") && !config.request ) {
+      ui.notifications.warn("DND5E.REST.Warning.OnlyByRequest", { localize: true, log: false });
+      return;
+    }
 
+    const clone = this.clone();
     const restConfig = CONFIG.DND5E.restTypes.short;
     config = foundry.utils.mergeObject({
       type: "short", dialog: true, chat: true, newDay: false, advanceTime: false, autoHD: false, autoHDThreshold: 3,
@@ -2133,8 +2137,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   async longRest(config={}) {
     if ( this.type === "vehicle" ) return;
-    const clone = this.clone();
+    if ( !game.user.isGM && !game.settings.get("dnd5e", "allowRests") && !config.request ) {
+      ui.notifications.warn("DND5E.REST.Warning.OnlyByRequest", { localize: true, log: false });
+      return;
+    }
 
+    const clone = this.clone();
     const restConfig = CONFIG.DND5E.restTypes.long;
     config = foundry.utils.mergeObject({
       type: "long", dialog: true, chat: true, newDay: true, advanceTime: false,

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -144,6 +144,16 @@ export function registerSystemSettings() {
     }
   });
 
+  // Allow Rests from Sheet
+  game.settings.register("dnd5e", "allowRests", {
+    name: "SETTINGS.DND5E.PERMISSIONS.AllowRests.Name",
+    hint: "SETTINGS.DND5E.PERMISSIONS.AllowRests.Hint",
+    scope: "world",
+    config: true,
+    default: true,
+    type: Boolean
+  });
+
   // Allow Polymorphing
   game.settings.register("dnd5e", "allowPolymorphing", {
     name: "SETTINGS.DND5E.PERMISSIONS.AllowTransformation.Name",

--- a/templates/actors/character-header.hbs
+++ b/templates/actors/character-header.hbs
@@ -36,7 +36,7 @@
 
         <div>
             {{!-- Resting & Special Traits --}}
-            {{#if actor.isOwner}}
+            {{#if showRests}}
             <div class="sheet-header-buttons">
                 <button type="button" class="short-rest gold-button" data-action="rest" data-type="short"
                         data-tooltip="DND5E.REST.Short.Label" aria-label="{{ localize 'DND5E.REST.Short.Label' }}">

--- a/templates/actors/npc-header.hbs
+++ b/templates/actors/npc-header.hbs
@@ -241,6 +241,7 @@
                 <div class="left">
 
                     <div class="sheet-header-buttons">
+                        {{#if showRests}}
                         <button type="button" class="gold-button" data-action="rest" data-type="short"
                                 data-tooltip="DND5E.REST.Short.Label"
                                 aria-label="{{ localize 'DND5E.REST.Short.Label' }}">
@@ -251,6 +252,7 @@
                                 aria-label="{{ localize 'DND5E.REST.Long.Label' }}">
                             <i class="fas fa-campground" inert></i>
                         </button>
+                        {{/if}}
                     </div>
 
                     <div class="proficiency">


### PR DESCRIPTION
Adds a new setting that controls whether the rest buttons appear on character sheets for players. When unchecked, players will only be able to rest their characters at the request of the GM. The setting is on by default so there is no behavior change.