### PR TITLE
[#5129] Add dialog for sending requests to certain players

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1568,10 +1568,13 @@
   },
   "REQUEST": {
     "Action": {
-      "Handle": "Handle Request"
+      "Handle": "Handle Request",
+      "Post": "Post Request"
     },
+    "AnyOwner": "Any Owner",
     "Complete": "Request Fulfilled",
-    "PartyMembers": "Party Members"
+    "PartyMembers": "Party Members",
+    "Title": "Request"
   },
   "TURN": {
     "NoCombatant": "Combatant no longer exists!"

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1889,6 +1889,21 @@ dialog.dnd5e2.application {
 }
 
 /* ---------------------------------- */
+/*  Request Dialog                    */
+/* ---------------------------------- */
+
+.party-request {
+  .recipients { gap: 4px; }
+  .recipient {
+    align-items: center;
+    gap: 4px;
+
+    label { display: contents; }
+    .name { flex: 2; }
+  }
+}
+
+/* ---------------------------------- */
 /*  Rest Dialogs                      */
 /* ---------------------------------- */
 

--- a/module/applications/actor/_module.mjs
+++ b/module/applications/actor/_module.mjs
@@ -3,6 +3,7 @@ export {default as CharacterActorSheet} from "./character-sheet.mjs";
 export {default as EncounterActorSheet} from "./encounter-sheet.mjs";
 export {default as GroupActorSheet} from "./group-sheet.mjs";
 export {default as NPCActorSheet} from "./npc-sheet.mjs";
+export {default as PartyRequestDialog} from "./party-request-dialog.mjs";
 export {default as TransformDialog} from "./transform-dialog.mjs";
 export {default as VehicleActorSheet} from "./vehicle-sheet.mjs";
 

--- a/module/applications/actor/_types.mjs
+++ b/module/applications/actor/_types.mjs
@@ -1,3 +1,20 @@
 /**
  * @typedef {"crew"|"draft"|"passengers"} CrewArea5e
  */
+
+/* -------------------------------------------- */
+
+/**
+ * @type PartyRequestDialogOptions
+ * @property {object}                     request
+ * @property {PartyRequestCondition|null} request.condition  Callback used to determine if an actor should be included.
+ * @property {Actor5e|null}               request.group      Group actor to fetch the actor list from, otherwise uses
+ *                                                           the primary party if one is set or falls back to the
+ *                                                           assigned characters.
+ */
+
+/**
+ * @callback PartyRequestCondition
+ * @param {Actor5e} actor  An actor that might be able to receive the request.
+ * @returns {boolean}      Should the actor be shown in the dialog?
+ */

--- a/module/applications/actor/party-request-dialog.mjs
+++ b/module/applications/actor/party-request-dialog.mjs
@@ -1,0 +1,168 @@
+import Dialog5e from "../api/dialog.mjs";
+
+/**
+ * @type PartyRequestDialogOptions
+ * @property {object}                     request
+ * @property {PartyRequestCondition|null} request.condition  Callback used to determine if an actor should be included.
+ * @property {Actor5e|null}               request.group      Group actor to fetch the actor list from, otherwise uses
+ *                                                           the primary party if one is set or falls back to the
+ *                                                           assigned characters.
+ */
+
+/**
+ * @callback PartyRequestCondition
+ * @param {Actor5e} actor  An actor that might be able to receive the request.
+ * @returns {boolean}      Should the actor be shown in the dialog?
+ */
+
+/**
+ * Dialog that allows GM to select party members to receive a roll request.
+ */
+export default class PartyRequestDialog extends Dialog5e {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["party-request"],
+    form: {
+      closeOnSubmit: true,
+      handler: PartyRequestDialog.#handleFormSubmission
+    },
+    position: {
+      width: 420
+    },
+    request: {
+      condition: null,
+      group: null
+    },
+    window: {
+      title: "DND5E.CHATMESSAGE.REQUEST.Title"
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static emittedEvents = [...super.emittedEvents, "resolve"];
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    ...super.PARTS,
+    content: {
+      template: "systems/dnd5e/templates/apps/party-request-dialog.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  #users;
+
+  /**
+   * Mapping of selected actors and their requested users.
+   * @type {Map<Actor5e, User>}
+   */
+  get users() {
+    return this.#users;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const group = this.options.request.group ?? game.settings.get("dnd5e", "primaryParty")?.actor;
+    const allActors = group?.system.members.map(m => m.actor) ?? game.users.map(u => u.character).filter(_ => _);
+    context.recipients = allActors
+      .filter(actor => !this.options.request.condition || this.options.request.condition(actor))
+      .map(actor => {
+        const owners = game.users
+          .filter(u => actor.testUserPermission(u, CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER))
+          .map(u => ({ value: u.id, label: u.name }));
+        return {
+          actor,
+          checked: true, // TODO: Save checked state?
+          defaultUser: null, // TODO: Save requested user?
+          icon: '<i class="fa-solid fa-user fa-fw" inert></i>',
+          users: [{ rule: true }, ...owners].filter(_ => _)
+        };
+      });
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle submission of the dialog using the form buttons.
+   * @this {PartyRequestDialog}
+   * @param {Event|SubmitEvent} event    The form submission event.
+   * @param {HTMLFormElement} form       The submitted form.
+   * @param {FormDataExtended} formData  Data from the dialog.
+   */
+  static async #handleFormSubmission(event, form, formData) {
+    const data = foundry.utils.expandObject(formData.object);
+    this.#users = Object.entries(data).reduce((map, [id, { request, user }]) => {
+      if ( request ) map.set(game.actors.get(id), game.users.get(user));
+      return map;
+    }, new Map());
+    this.dispatchEvent(new CustomEvent("resolve", { bubbles: true, detail: this.#users }));
+  }
+
+  /* -------------------------------------------- */
+  /*  Factory Methods                             */
+  /* -------------------------------------------- */
+
+  /**
+   * A helper to handle displaying and responding to the dialog.
+   * @param {object} [options={}]                Additional options passed to the dialog.
+   * @returns {Promise<Map<Actor5e, User>>}      Promise that resolves to a map of actors and the users who should
+   *                                             handle the request for that actor.
+   */
+  static async getRecipients(options={}) {
+    const app = new PartyRequestDialog(foundry.utils.mergeObject({
+      buttons: [{
+        default: true,
+        icon: "fa-solid fa-bullhorn",
+        label: game.i18n.localize("DND5E.CHATMESSAGE.REQUEST.Action.Post"),
+        type: "submit"
+      }]
+    }, options));
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const closeListener = app.addEventListener("close", () => reject(), { once: true });
+    app.addEventListener("resolve", event => {
+      app.removeEventListener("close", closeListener);
+      resolve(event.detail);
+    }, { once: true });
+    app.render({ force: true });
+    return promise;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * A helper to handle displaying and responding to the dialog.
+   * @param {string} handler            Specific rest handler as defined in `CONFIG.DND5E.requests`.
+   * @param {object} [messageData={}]   Additional data used to create the chat message.
+   * @param {object} [options={}]       Additional options passed to the dialog.
+   * @returns {Promise<ChatMessage5e>}  Promise that resolves to the created request chat message.
+   * @throws if dialog is closed
+   */
+  static async sendRequest(handler, messageData={}, options={}) {
+    const recipients = await this.getRecipients(options);
+
+    messageData = foundry.utils.mergeObject({
+      system: {
+        handler,
+        targets: Array.from(recipients.entries()).map(([actor, user]) => ({ actor: actor.id, user: user?.id }))
+      },
+      type: "request"
+    }, messageData);
+
+    return getDocumentClass("ChatMessage").create(messageData);
+  }
+}

--- a/module/applications/actor/party-request-dialog.mjs
+++ b/module/applications/actor/party-request-dialog.mjs
@@ -120,7 +120,7 @@ export default class PartyRequestDialog extends Dialog5e {
   /**
    * A helper to handle displaying and responding to the dialog.
    * @param {object} [options={}]                Additional options passed to the dialog.
-   * @returns {Promise<Map<Actor5e, User>>}      Promise that resolves to a map of actors and the users who should
+   * @returns {Promise<Map<Actor5e, User5e>>}    Promise that resolves to a map of actors and the users who should
    *                                             handle the request for that actor.
    */
   static async getRecipients(options={}) {
@@ -128,7 +128,7 @@ export default class PartyRequestDialog extends Dialog5e {
       buttons: [{
         default: true,
         icon: "fa-solid fa-bullhorn",
-        label: game.i18n.localize("DND5E.CHATMESSAGE.REQUEST.Action.Post"),
+        label: _loc("DND5E.CHATMESSAGE.REQUEST.Action.Post"),
         type: "submit"
       }]
     }, options));

--- a/module/applications/actor/party-request-dialog.mjs
+++ b/module/applications/actor/party-request-dialog.mjs
@@ -1,22 +1,12 @@
 import Dialog5e from "../api/dialog.mjs";
 
 /**
- * @type PartyRequestDialogOptions
- * @property {object}                     request
- * @property {PartyRequestCondition|null} request.condition  Callback used to determine if an actor should be included.
- * @property {Actor5e|null}               request.group      Group actor to fetch the actor list from, otherwise uses
- *                                                           the primary party if one is set or falls back to the
- *                                                           assigned characters.
- */
-
-/**
- * @callback PartyRequestCondition
- * @param {Actor5e} actor  An actor that might be able to receive the request.
- * @returns {boolean}      Should the actor be shown in the dialog?
+ * @import { PartyRequestDialogOptions } from "./_types.mjs";
  */
 
 /**
  * Dialog that allows GM to select party members to receive a roll request.
+ * @extends Dialog5e<ApplicationConfiguration & PartyRequestDialogOptions>
  */
 export default class PartyRequestDialog extends Dialog5e {
   /** @override */
@@ -61,7 +51,7 @@ export default class PartyRequestDialog extends Dialog5e {
 
   /**
    * Mapping of selected actors and their requested users.
-   * @type {Map<Actor5e, User>}
+   * @type {Map<Actor5e, User5e>}
    */
   get users() {
     return this.#users;
@@ -74,7 +64,7 @@ export default class PartyRequestDialog extends Dialog5e {
   /** @inheritDoc */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    const group = this.options.request.group ?? game.settings.get("dnd5e", "primaryParty")?.actor;
+    const group = this.options.request.group ?? game.actors.party;
     const allActors = group?.system.members.map(m => m.actor) ?? game.users.map(u => u.character).filter(_ => _);
     context.recipients = allActors
       .filter(actor => !this.options.request.condition || this.options.request.condition(actor))
@@ -158,7 +148,7 @@ export default class PartyRequestDialog extends Dialog5e {
     messageData = foundry.utils.mergeObject({
       system: {
         handler,
-        targets: Array.from(recipients.entries()).map(([actor, user]) => ({ actor: actor.id, user: user?.id }))
+        targets: Array.from(recipients.entries()).map(([actor, user]) => ({ actor: actor.uuid, user: user?.id }))
       },
       type: "request"
     }, messageData);

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -1,3 +1,4 @@
+import PartyRequestDialog from "../../applications/actor/party-request-dialog.mjs";
 import { defaultUnits } from "../../utils.mjs";
 import TravelField from "./fields/travel-field.mjs";
 import GroupSystemFlags from "./group-system-flags.mjs";
@@ -302,6 +303,21 @@ export default class GroupData extends GroupTemplate {
       type: "request"
     });
     return false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Send a request to the members of this group.
+   * @param {string} handler            Specific rest handler as defined in `CONFIG.DND5E.requests`.
+   * @param {object} [messageData={}]   Additional data used to create the chat message.
+   * @param {object} [options={}]       Additional options passed to the dialog.
+   * @returns {Promise<ChatMessage5e>}  Promise that resolves to the created request chat message.
+   * @throws if dialog is closed
+   */
+  sendRequest(handler, messageData={}, options={}) {
+    foundry.utils.setProperty(options, "request.group", this.parent);
+    return PartyRequestDialog.sendRequest(handler, messageData, options);
   }
 
   /* -------------------------------------------- */

--- a/templates/apps/party-request-dialog.hbs
+++ b/templates/apps/party-request-dialog.hbs
@@ -1,0 +1,14 @@
+<div class="recipients flexcol">
+    {{#each recipients}}
+    <div class="recipient flexrow" data-actor-id="{{ actor.id }}">
+        <label>
+            <dnd5e-checkbox name="{{ actor.id }}.request" {{ checked checked }}></dnd5e-checkbox>
+            {{{ icon }}}
+            <span class="name">{{ actor.name }}</span>
+        </label>
+        <select name="{{ actor.id}}.user">
+            {{ selectOptions users selected=defaultUser blank=(localize "DND5E.CHATMESSAGE.REQUEST.AnyOwner") }}
+        </select>
+    </div>
+    {{/each}}
+</div>


### PR DESCRIPTION
Adds a new `PartyRequestDialog` that can be used to prompt for which characters/players should receive a request. This dialog can be invoked from a specific group, in which case it will list the actors in that group, or it can use the primary party/assigned characters.

<img width="436" alt="Party Request Dialog" src="https://github.com/user-attachments/assets/4e0474da-b3ae-447c-862b-29528e793c01" />

The dialog presents the user with a list of actors that can be checked or unchecked as well as a list of owners for each actor. This list can be pre-filtered with the provided condition.

When the dialog is submitted a new `request` chat message will be created with the selected actors and users as well as any other provided data.