### PR TITLE
[#5719] Add new utility method to improve plural language fallback

### DIFF
--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -1,4 +1,4 @@
-import { filteredKeys, formatNumber, simplifyBonus } from "../../utils.mjs";
+import { filteredKeys, formatNumber, getPluralLocalizationKey, simplifyBonus } from "../../utils.mjs";
 import Dialog5e from "../api/dialog.mjs";
 
 const { BooleanField, NumberField, StringField } = foundry.data.fields;
@@ -253,7 +253,6 @@ export default class ActivityUsageDialog extends Dialog5e {
       });
       const current = foundry.utils.getProperty(this.actor.system, property);
       if ( current && !containsConsumption ) {
-        const plurals = new Intl.PluralRules(game.i18n.lang);
         const value = (this.config.consume !== false) && (this.config.consume?.action !== false);
         const warn = (current.value < this.activity.activation.value) && value;
         context.fields.push({
@@ -263,12 +262,14 @@ export default class ActivityUsageDialog extends Dialog5e {
               type: activationConfig.label
             }),
             hint: _loc("DND5E.CONSUMPTION.Type.Action.PromptHint", {
-              available: _loc(`${activationConfig.counted}.${plurals.select(current.value)}`, {
-                number: `<strong>${formatNumber(current.value)}</strong>`
-              }),
-              cost: _loc(`${activationConfig.counted}.${plurals.select(this.activity.activation.value)}`, {
-                number: `<strong>${formatNumber(this.activity.activation.value)}</strong>`
-              })
+              available: _loc(
+                getPluralLocalizationKey(current.value, pr => `${activationConfig.counted}.${pr}`),
+                { number: `<strong>${formatNumber(current.value)}</strong>` }
+              ),
+              cost: _loc(
+                getPluralLocalizationKey(this.activity.activation.value, pr => `${activationConfig.counted}.${pr}`),
+                { number: `<strong>${formatNumber(this.activity.activation.value)}</strong>` }
+              )
             })
           }),
           input: context.inputs.createCheckboxInput,

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -1,4 +1,4 @@
-import { filteredKeys, formatNumber, simplifyBonus } from "../../utils.mjs";
+import { filteredKeys, formatNumber, getPluralLocalizationKey, simplifyBonus } from "../../utils.mjs";
 import Dialog5e from "../api/dialog.mjs";
 
 const { BooleanField, NumberField, StringField } = foundry.data.fields;
@@ -255,7 +255,6 @@ export default class ActivityUsageDialog extends Dialog5e {
       });
       const current = foundry.utils.getProperty(this.actor.system, property);
       if ( current && !containsConsumption ) {
-        const plurals = new Intl.PluralRules(game.i18n.lang);
         const value = (this.config.consume !== false) && (this.config.consume?.action !== false);
         const warn = (current.value < this.activity.activation.value) && value;
         context.fields.push({
@@ -265,12 +264,14 @@ export default class ActivityUsageDialog extends Dialog5e {
               type: activationConfig.label
             }),
             hint: _loc("DND5E.CONSUMPTION.Type.Action.PromptHint", {
-              available: _loc(`${activationConfig.counted}.${plurals.select(current.value)}`, {
-                number: `<strong>${formatNumber(current.value)}</strong>`
-              }),
-              cost: _loc(`${activationConfig.counted}.${plurals.select(this.activity.activation.value)}`, {
-                number: `<strong>${formatNumber(this.activity.activation.value)}</strong>`
-              })
+              available: _loc(
+                getPluralLocalizationKey(current.value, pr => `${activationConfig.counted}.${pr}`),
+                { number: `<strong>${formatNumber(current.value)}</strong>` }
+              ),
+              cost: _loc(
+                getPluralLocalizationKey(this.activity.activation.value, pr => `${activationConfig.counted}.${pr}`),
+                { number: `<strong>${formatNumber(this.activity.activation.value)}</strong>` }
+              )
             })
           }),
           input: context.inputs.createCheckboxInput,

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -4,7 +4,7 @@ import Item5e from "../../../documents/item.mjs";
 import {
   formatLength,
   formatNumber,
-  getPluralRules,
+  getPluralLocalizationKey,
   loadingTooltip,
   parseInputDelta,
   simplifyBonus,
@@ -607,7 +607,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
         const label = temp
           ? _loc("DND5E.SpellSlotTemporary")
           : filled
-            ? _loc(`DND5E.SpellSlotN.${getPluralRules({ type: "ordinal" }).select(n)}`, { n })
+            ? _loc(getPluralLocalizationKey(n, pr => `DND5E.SpellSlotN.${pr}`, { type: "ordinal" }), { n })
             : _loc("DND5E.SpellSlotExpended");
         const classes = ["pip"];
         if ( filled ) classes.push("filled");

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1,7 +1,7 @@
 import * as Trait from "../../../documents/actor/trait.mjs";
 import Item5e from "../../../documents/item.mjs";
 import {
-  formatLength, formatNumber, getPluralRules, parseInputDelta, simplifyBonus, splitSemicolons, staticID
+  formatLength, formatNumber, getPluralLocalizationKey, parseInputDelta, simplifyBonus, splitSemicolons, staticID
 } from "../../../utils.mjs";
 
 import AdvancementConfirmationDialog from "../../advancement/advancement-confirmation-dialog.mjs";
@@ -580,7 +580,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
         const label = temp
           ? _loc("DND5E.SpellSlotTemporary")
           : filled
-            ? _loc(`DND5E.SpellSlotN.${getPluralRules({ type: "ordinal" }).select(n)}`, { n })
+            ? _loc(getPluralLocalizationKey(n, pr => `DND5E.SpellSlotN.${pr}`, { type: "ordinal" }), { n })
             : _loc("DND5E.SpellSlotExpended");
         const classes = ["pip"];
         if ( filled ) classes.push("filled");

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -1,4 +1,4 @@
-import { formatNumber } from "../../utils.mjs";
+import { formatNumber, getPluralLocalizationKey } from "../../utils.mjs";
 import AdvancementManager from "../advancement/advancement-manager.mjs";
 import CompendiumBrowser from "../compendium-browser.mjs";
 import ContextMenu5e from "../context-menu.mjs";
@@ -486,9 +486,8 @@ export default class CharacterActorSheet extends BaseActorSheet {
 
     // Experience & Epic Boons
     if ( context.system.details.xp.boonsEarned !== undefined ) {
-      const pluralRules = new Intl.PluralRules(game.i18n.lang);
       context.epicBoonsEarned = _loc(
-        `DND5E.ExperiencePoints.Boons.${pluralRules.select(context.system.details.xp.boonsEarned ?? 0)}`,
+        getPluralLocalizationKey(context.system.details.xp.boonsEarned, pr => `DND5E.ExperiencePoints.Boons.${pr}`),
         { number: formatNumber(context.system.details.xp.boonsEarned ?? 0, { signDisplay: "always" }) }
       );
     }
@@ -528,7 +527,6 @@ export default class CharacterActorSheet extends BaseActorSheet {
     context.portrait = await this._preparePortrait(context);
 
     // Death Saves
-    const plurals = new Intl.PluralRules(game.i18n.lang, { type: "ordinal" });
     context.death = {
       open: this._deathTrayOpen
     };
@@ -544,7 +542,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
         context.death[deathSave].push({
           n, filled,
           tooltip: i18nKey,
-          label: _loc(`${i18nKey}N.${plurals.select(n)}`),
+          label: _loc(getPluralLocalizationKey(n, pr => `${i18nKey}N.${pr}`, { type: "ordinal" })),
           classes: classes.join(" ")
         });
       }
@@ -736,10 +734,9 @@ export default class CharacterActorSheet extends BaseActorSheet {
         img: model?.img || CONFIG.DND5E.spellcasting.pact.img
       };
 
-      const plurals = new Intl.PluralRules(game.i18n.lang, { type: "ordinal" });
       return {
         uses, level, method,
-        title: _loc(`DND5E.SpellSlotsN.${plurals.select(level)}`, { n: level }),
+        title: _loc(getPluralLocalizationKey(level, pr => `DND5E.SpellSlotsN.${pr}`), { n: level }),
         subtitle: _loc(`DND5E.Abbreviation${model.isSR ? "SR" : "LR"}`),
         img: model.img.replace("{id}", id)
       };

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -1,4 +1,4 @@
-import { formatNumber } from "../../utils.mjs";
+import { formatNumber, getPluralLocalizationKey } from "../../utils.mjs";
 import AdvancementManager from "../advancement/advancement-manager.mjs";
 import CompendiumBrowser from "../compendium-browser.mjs";
 import ContextMenu5e from "../context-menu.mjs";
@@ -486,9 +486,8 @@ export default class CharacterActorSheet extends BaseActorSheet {
 
     // Experience & Epic Boons
     if ( context.system.details.xp.boonsEarned !== undefined ) {
-      const pluralRules = new Intl.PluralRules(game.i18n.lang);
       context.epicBoonsEarned = _loc(
-        `DND5E.ExperiencePoints.Boons.${pluralRules.select(context.system.details.xp.boonsEarned ?? 0)}`,
+        getPluralLocalizationKey(context.system.details.xp.boonsEarned, pr => `DND5E.ExperiencePoints.Boons.${pr}`),
         { number: formatNumber(context.system.details.xp.boonsEarned ?? 0, { signDisplay: "always" }) }
       );
     }
@@ -528,7 +527,6 @@ export default class CharacterActorSheet extends BaseActorSheet {
     context.portrait = await this._preparePortrait(context);
 
     // Death Saves
-    const plurals = new Intl.PluralRules(game.i18n.lang, { type: "ordinal" });
     context.death = {
       open: this._deathTrayOpen
     };
@@ -544,7 +542,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
         context.death[deathSave].push({
           n, filled,
           tooltip: i18nKey,
-          label: _loc(`${i18nKey}N.${plurals.select(n)}`),
+          label: _loc(getPluralLocalizationKey(n, pr => `${i18nKey}N.${pr}`, { type: "ordinal" })),
           classes: classes.join(" ")
         });
       }
@@ -733,10 +731,9 @@ export default class CharacterActorSheet extends BaseActorSheet {
         img: model?.img || CONFIG.DND5E.spellcasting.pact.img
       };
 
-      const plurals = new Intl.PluralRules(game.i18n.lang, { type: "ordinal" });
       return {
         uses, level, method,
-        title: _loc(`DND5E.SpellSlotsN.${plurals.select(level)}`, { n: level }),
+        title: _loc(getPluralLocalizationKey(level, pr => `DND5E.SpellSlotsN.${pr}`), { n: level }),
         subtitle: _loc(`DND5E.Abbreviation${model.isSR ? "SR" : "LR"}`),
         img: model.img.replace("{id}", id)
       };

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -1,4 +1,4 @@
-import { formatNumber, getPluralRules, simplifyBonus, splitSemicolons } from "../../utils.mjs";
+import { formatNumber, getPluralLocalizationKey, simplifyBonus, splitSemicolons } from "../../utils.mjs";
 import { createCheckboxInput } from "../fields.mjs";
 import BaseActorSheet from "./api/base-actor-sheet.mjs";
 import HabitatConfig from "./config/habitat-config.mjs";
@@ -269,7 +269,6 @@ export default class NPCActorSheet extends BaseActorSheet {
     context.classes = context.itemCategories.classes;
 
     // Legendary Actions & Resistances
-    const plurals = getPluralRules({ type: "ordinal" });
     const resources = context.source.resources;
     for ( const res of ["legact", "legres"] ) {
       const { max, value } = resources[res];
@@ -281,7 +280,7 @@ export default class NPCActorSheet extends BaseActorSheet {
         return {
           n: max - n, filled,
           tooltip: `DND5E.${i18n}.Label`,
-          label: _loc(`DND5E.${i18n}.Ordinal.${plurals.select(n)}`, { n }),
+          label: _loc(getPluralLocalizationKey(n, pr => `DND5E.${i18n}.Ordinal.${pr}`, { type: "ordinal" }), { n }),
           classes: classes.join(" ")
         };
       });

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -1,3 +1,4 @@
+import { getPluralLocalizationKey } from "../../utils.mjs";
 import CompendiumBrowser from "../compendium-browser.mjs";
 import AdvancementFlow from "./advancement-flow-v2.mjs";
 
@@ -131,11 +132,13 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
     const modernRules = dnd5e.settings.rulesVersion === "modern";
     const pluralRules = new Intl.PluralRules(game.i18n.lang);
     context.pointCap = _loc(
-      `DND5E.ADVANCEMENT.AbilityScoreImprovement.CapDisplay.${pluralRules.select(context.points.cap)}`,
+      getPluralLocalizationKey(context.points.cap, pr => `DND5E.ADVANCEMENT.AbilityScoreImprovement.CapDisplay.${pr}`),
       { points: context.points.cap }
     );
     context.pointsRemaining = _loc(
-      `DND5E.ADVANCEMENT.AbilityScoreImprovement.PointsRemaining.${pluralRules.select(context.points.available)}`,
+      getPluralLocalizationKey(context.points.available, pr =>
+        `DND5E.ADVANCEMENT.AbilityScoreImprovement.PointsRemaining.${pr}`
+      ),
       { points: context.points.available }
     );
     context.showASIFeat = modernRules && this.advancement.allowFeat;

--- a/module/applications/combat/combat-tracker.mjs
+++ b/module/applications/combat/combat-tracker.mjs
@@ -1,4 +1,4 @@
-import { formatNumber, getPluralRules } from "../../utils.mjs";
+import { formatNumber, getPluralLocalizationKey } from "../../utils.mjs";
 
 /**
  * @import { CombatGroupData } from "./_types.mjs";
@@ -67,7 +67,7 @@ export default class CombatTracker5e extends foundry.applications.sidebar.tabs.C
       for ( const [index, element] of children.entries() ) {
         if ( element.classList.contains("active") ) activeEntry = index;
       }
-      let count = _loc(`DND5E.COMBATANT.Counted.${getPluralRules().select(children.length)}`, {
+      let count = _loc(getPluralLocalizationKey(children.length, pr => `DND5E.COMBATANT.Counted.${pr}`), {
         number: formatNumber(children.length)
       });
       if ( activeEntry !== undefined ) {

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -1,6 +1,6 @@
 import * as Filter from "../filter.mjs";
 import SourceField from "../data/shared/source-field.mjs";
-import {bulkFromUuid, formatIdentifier, getPluralRules, loadingTooltip} from "../utils.mjs";
+import {bulkFromUuid, formatIdentifier, getPluralLocalizationKey, loadingTooltip} from "../utils.mjs";
 import Application5e from "./api/application.mjs";
 import CompendiumBrowserSettingsConfig from "./settings/compendium-browser-settings.mjs";
 
@@ -455,10 +455,11 @@ export default class CompendiumBrowser extends Application5e {
     context.summary = suffix ? _loc(
       `DND5E.CompendiumBrowser.Selection.Summary.${suffix}`, { max, min, value }
     ) : value;
-    const pr = getPluralRules();
     context.invalidTooltip = _loc(`DND5E.CompendiumBrowser.Selection.Warning.${suffix}`, {
       max, min, value,
-      document: _loc(`DND5E.CompendiumBrowser.Selection.Warning.Document.${pr.select(max || min)}`)
+      document: _loc(getPluralLocalizationKey(max || min, pr =>
+        `DND5E.CompendiumBrowser.Selection.Warning.Document.${pr}`
+      ))
     });
     return context;
   }
@@ -1001,10 +1002,11 @@ export default class CompendiumBrowser extends Application5e {
     const { max, min } = this.options.selection;
     if ( (value < (min || -Infinity)) || (value > (max || Infinity)) ) {
       const suffix = this.#selectionLocalizationSuffix;
-      const pr = getPluralRules();
       throw new Error(_loc(`DND5E.CompendiumBrowser.Selection.Warning.${suffix}`, {
         max, min, value,
-        document: _loc(`DND5E.CompendiumBrowser.Selection.Warning.Document.${pr.select(max || min)}`)
+        document: _loc(getPluralLocalizationKey(max || min, pr =>
+          `DND5E.CompendiumBrowser.Selection.Warning.Document.${pr}`
+        ))
       }));
     }
 

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -1,6 +1,6 @@
 import * as Filter from "../filter.mjs";
 import SourceField from "../data/shared/source-field.mjs";
-import { getPluralRules } from "../utils.mjs";
+import { getPluralLocalizationKey } from "../utils.mjs";
 import Application5e from "./api/application.mjs";
 import CompendiumBrowserSettingsConfig from "./settings/compendium-browser-settings.mjs";
 
@@ -440,10 +440,11 @@ export default class CompendiumBrowser extends Application5e {
     context.summary = suffix ? _loc(
       `DND5E.CompendiumBrowser.Selection.Summary.${suffix}`, { max, min, value }
     ) : value;
-    const pr = getPluralRules();
     context.invalidTooltip = _loc(`DND5E.CompendiumBrowser.Selection.Warning.${suffix}`, {
       max, min, value,
-      document: _loc(`DND5E.CompendiumBrowser.Selection.Warning.Document.${pr.select(max || min)}`)
+      document: _loc(getPluralLocalizationKey(max || min, pr =>
+        `DND5E.CompendiumBrowser.Selection.Warning.Document.${pr}`
+      ))
     });
     return context;
   }
@@ -965,10 +966,11 @@ export default class CompendiumBrowser extends Application5e {
     const { max, min } = this.options.selection;
     if ( (value < (min || -Infinity)) || (value > (max || Infinity)) ) {
       const suffix = this.#selectionLocalizationSuffix;
-      const pr = getPluralRules();
       throw new Error(_loc(`DND5E.CompendiumBrowser.Selection.Warning.${suffix}`, {
         max, min, value,
-        document: _loc(`DND5E.CompendiumBrowser.Selection.Warning.Document.${pr.select(max || min)}`)
+        document: _loc(getPluralLocalizationKey(max || min, pr =>
+          `DND5E.CompendiumBrowser.Selection.Warning.Document.${pr}`
+        ))
       }));
     }
 

--- a/module/applications/welcome-screen.mjs
+++ b/module/applications/welcome-screen.mjs
@@ -1,4 +1,4 @@
-import { getPluralRules } from "../utils.mjs";
+import { getPluralLocalizationKey } from "../utils.mjs";
 import Application5e from "./api/application.mjs";
 import { createCheckboxInput } from "./fields.mjs";
 import BaseSettingsConfig from "./settings/base-settings.mjs";
@@ -307,10 +307,10 @@ export default class WelcomeScreen extends Application5e {
     for ( const { adventures, handler } of Object.values(importActions) ) await handler(adventures);
     await game.settings.set("core", "adventureImports", adventureImports);
 
-    const pr = getPluralRules();
-    ui.notifications.success(`DND5E.ADVENTURE.Finished.${pr.select(this.options.adventures.length)}`, {
-      format: { adventure: this.options.adventures[0].name, number: this.options.adventures.length }
-    });
+    ui.notifications.success(
+      getPluralLocalizationKey(this.options.adventures.length, pr => `DND5E.ADVENTURE.Finished.${pr}`),
+      { format: { adventure: this.options.adventures[0].name, number: this.options.adventures.length } }
+    );
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -1,5 +1,7 @@
 import simplifyRollFormula from "../../../dice/simplify-roll-formula.mjs";
-import { formatNumber, getHumanReadableAttributeLabel, simplifyBonus } from "../../../utils.mjs";
+import {
+  formatNumber, getHumanReadableAttributeLabel, getPluralLocalizationKey, simplifyBonus
+} from "../../../utils.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 
 const { ArrayField, EmbeddedDataField, SchemaField, StringField } = foundry.data.fields;
@@ -396,7 +398,6 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
   static consumptionLabelsActivityUses(config, { consumed }={}) {
     const { cost, simplifiedCost, increaseKey, pluralRule } = this._resolveHintCost(config);
     const uses = this.activity.uses;
-    const usesPluralRule = new Intl.PluralRules(game.i18n.lang).select(uses.value);
     return {
       label: _loc(`DND5E.CONSUMPTION.Type.ActivityUses.Prompt${increaseKey}`),
       hint: _loc(
@@ -405,7 +406,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
           cost,
           use: _loc(`DND5E.CONSUMPTION.Type.Use.${pluralRule}`),
           available: formatNumber(uses.value),
-          availableUse: _loc(`DND5E.CONSUMPTION.Type.Use.${usesPluralRule}`)
+          availableUse: _loc(getPluralLocalizationKey(uses.value, pr => `DND5E.CONSUMPTION.Type.Use.${pr}`))
         }
       ),
       warn: simplifiedCost > uses.value
@@ -486,7 +487,6 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
     const item = this.actor.items.get(this.target);
     const itemName = item ? item.name : _loc("DND5E.CONSUMPTION.Target.ThisItem").toLowerCase();
     const uses = (item ?? this.item).system.uses;
-    const usesPluralRule = new Intl.PluralRules(game.i18n.lang).select(uses.value);
 
     const notes = [];
     let warn = false;
@@ -504,7 +504,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
           cost,
           use: _loc(`DND5E.CONSUMPTION.Type.Use.${pluralRule}`),
           available: formatNumber(uses.value),
-          availableUse: _loc(`DND5E.CONSUMPTION.Type.Use.${usesPluralRule}`),
+          availableUse: _loc(getPluralLocalizationKey(uses.value, pr => `DND5E.CONSUMPTION.Type.Use.${pr}`)),
           item: item ? `<em>${itemName}</em>` : itemName
         }
       ),
@@ -591,7 +591,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
       else cost = simplifyRollFormula(costRoll.invert().formula);
     }
     let pluralRule;
-    if ( costRoll.isDeterministic ) pluralRule = new Intl.PluralRules(game.i18n.lang).select(Number(cost));
+    if ( costRoll.isDeterministic ) pluralRule = getPluralRules().select(Number(cost));
     else pluralRule = "other";
     return { cost, simplifiedCost, increaseKey: isNegative ? "Increase" : "Decrease", pluralRule };
   }

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -2,7 +2,9 @@ import Actor5e from "../../documents/actor/actor.mjs";
 import Proficiency from "../../documents/actor/proficiency.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
 import { getRulesVersion } from "../../enrichers.mjs";
-import { defaultUnits, formatCR, formatLength, formatNumber, getPluralRules, splitSemicolons } from "../../utils.mjs";
+import {
+  defaultUnits, formatCR, formatLength, formatNumber, getPluralLocalizationKey, splitSemicolons
+} from "../../utils.mjs";
 import { ActorDeltasField } from "../chat-message/fields/deltas-field.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
@@ -541,7 +543,6 @@ export default class NPCData extends CreatureTemplate {
   getLegendaryActionsDescription(name=this.parent.name) {
     const max = this._source.resources.legact.max;
     if ( !max ) return "";
-    const pr = getPluralRules().select(max);
     const rulesVersion = this.source?.rules
       || (dnd5e.settings.rulesVersion === "modern" ? "2024" : "2014");
     return _loc(`DND5E.LegendaryAction.Description${rulesVersion === "2014" ? "Legacy" : ""}`, {
@@ -549,7 +550,10 @@ export default class NPCData extends CreatureTemplate {
       uses: this.resources.lair.value ? _loc("DND5E.LegendaryAction.LairUses", {
         normal: formatNumber(max), lair: formatNumber(max + 1)
       }) : formatNumber(max),
-      usesNamed: _loc(`DND5E.ACTIVATION.Type.Legendary.Counted.${pr}`, { number: formatNumber(max) })
+      usesNamed: _loc(
+        getPluralLocalizationKey(max, pr => `DND5E.ACTIVATION.Type.Legendary.Counted.${pr}`),
+        { number: formatNumber(max) }
+      )
     });
   }
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -2,7 +2,9 @@ import Actor5e from "../../documents/actor/actor.mjs";
 import Proficiency from "../../documents/actor/proficiency.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
 import { getRulesVersion } from "../../enrichers.mjs";
-import { defaultUnits, formatCR, formatLength, formatNumber, getPluralRules, splitSemicolons } from "../../utils.mjs";
+import {
+  defaultUnits, formatCR, formatLength, formatNumber, getPluralLocalizationKey, splitSemicolons
+} from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
 import RollConfigField from "../shared/roll-config-field.mjs";
@@ -528,7 +530,6 @@ export default class NPCData extends CreatureTemplate {
   getLegendaryActionsDescription(name=this.parent.name) {
     const max = this._source.resources.legact.max;
     if ( !max ) return "";
-    const pr = getPluralRules().select(max);
     const rulesVersion = this.source?.rules
       || (dnd5e.settings.rulesVersion === "modern" ? "2024" : "2014");
     return _loc(`DND5E.LegendaryAction.Description${rulesVersion === "2014" ? "Legacy" : ""}`, {
@@ -536,7 +537,10 @@ export default class NPCData extends CreatureTemplate {
       uses: this.resources.lair.value ? _loc("DND5E.LegendaryAction.LairUses", {
         normal: formatNumber(max), lair: formatNumber(max + 1)
       }) : formatNumber(max),
-      usesNamed: _loc(`DND5E.ACTIVATION.Type.Legendary.Counted.${pr}`, { number: formatNumber(max) })
+      usesNamed: _loc(
+        getPluralLocalizationKey(max, pr => `DND5E.ACTIVATION.Type.Legendary.Counted.${pr}`),
+        { number: formatNumber(max) }
+      )
     });
   }
 

--- a/module/data/calendar/calendar-data.mjs
+++ b/module/data/calendar/calendar-data.mjs
@@ -1,4 +1,4 @@
-import { convertTime, formatNumber, formatTime, getPluralRules } from "../../utils.mjs";
+import { convertTime, formatNumber, formatTime, getPluralLocalizationKey } from "../../utils.mjs";
 import { IndividualDeltaField } from "../chat-message/fields/deltas-field.mjs";
 
 /**
@@ -454,12 +454,12 @@ export default class CalendarData5e extends foundry.data.CalendarData {
 
     // X days have passed
     if ( timePassageData.midnights > 1 ) {
-      const pr = getPluralRules();
       const { value, unit } = convertTime(timePassageData.midnights, "day", { strict: false });
       const number = formatTime(value, unit, { words: true });
-      message = _loc(`DND5E.CALENDAR.TimePassage.TimePassed.${pr.select(value)}`, {
-        number: number.capitalize(), numberLc: number
-      });
+      message = _loc(
+        getPluralLocalizationKey(value, pr => `DND5E.CALENDAR.TimePassage.TimePassed.${pr}`),
+        { number: number.capitalize(), numberLc: number }
+      );
     }
 
     // Sun has set and risen again

--- a/module/data/chat-message/bastion-attack-message-data.mjs
+++ b/module/data/chat-message/bastion-attack-message-data.mjs
@@ -77,10 +77,11 @@ export default class BastionAttackMessageData extends ChatMessageDataModel {
   /** @override */
   async _prepareContext() {
     const context = {};
-    const plurals = new Intl.PluralRules(game.i18n.lang);
-    const key = this.undefended ? "Undefended" : this.deaths ? `Deaths.${plurals.select(this.deaths)}` : "NoDeaths";
+    let key = this.undefended ? "Undefended" : this.deaths ? null : "NoDeaths";
+    if ( key ) key = `DND5E.Bastion.Attack.Result.${key}`;
+    else key = getPluralLocalizationKey(deaths, pr => `DND5E.Bastion.Attack.Result.${pr}`);
     const isPrivate = !this.parent.isContentVisible;
-    context.description = _loc(`DND5E.Bastion.Attack.Result.${key}`, { deaths: this.deaths });
+    context.description = _loc(key, { deaths: this.deaths });
     context.rolls = await Promise.all(this.parent.rolls.map(roll => roll.render({
       isPrivate, message: this.parent, template: this.constructor.ROLL_TEMPLATE
     })));

--- a/module/data/chat-message/bastion-attack-message-data.mjs
+++ b/module/data/chat-message/bastion-attack-message-data.mjs
@@ -57,8 +57,10 @@ export default class BastionAttackMessageData extends ChatMessageDataModel {
   async _prepareContext() {
     const context = {};
     const plurals = new Intl.PluralRules(game.i18n.lang);
-    const key = this.undefended ? "Undefended" : this.deaths ? `Deaths.${plurals.select(this.deaths)}` : "NoDeaths";
-    context.description = _loc(`DND5E.Bastion.Attack.Result.${key}`, { deaths: this.deaths });
+    let key = this.undefended ? "Undefended" : this.deaths ? null : "NoDeaths";
+    if ( key ) key = `DND5E.Bastion.Attack.Result.${key}`;
+    else key = getPluralLocalizationKey(deaths, pr => `DND5E.Bastion.Attack.Result.${pr}`);
+    context.description = _loc(key, { deaths: this.deaths });
     context.roll = await this.parent.rolls[0].render();
     context.buttons = [];
     if ( !this.resolved && (this.deaths || this.undefended) ) {

--- a/module/data/shared/activation-field.mjs
+++ b/module/data/shared/activation-field.mjs
@@ -1,4 +1,4 @@
-import { formatNumber, formatTime, getPluralRules } from "../../utils.mjs";
+import { formatNumber, formatTime, getPluralLocalizationKey } from "../../utils.mjs";
 
 const { NumberField, SchemaField, StringField } = foundry.data.fields;
 
@@ -41,7 +41,7 @@ export default class ActivationField extends SchemaField {
     let scalar;
     if ( activation.type in CONFIG.DND5E.timeUnits ) scalar = formatTime(value ?? 1, activation.type);
     else if ( config?.counted ) scalar = _loc(
-      `${config.counted}.${getPluralRules().select(value ?? 1)}`,
+      getPluralLocalizationKey(value ?? 1, pr => `${config.counted}.${pr}`),
       { number: formatNumber(value ?? 1) }
     );
     else scalar = `${formatNumber(value ?? 1)} ${config?.label ?? ""}`;

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -1,4 +1,6 @@
-import { defaultUnits, formatLength, formatNumber, getPluralRules, prepareFormulaValue } from "../../utils.mjs";
+import {
+  defaultUnits, formatLength, formatNumber, getPluralLocalizationKey, prepareFormulaValue
+} from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { BooleanField, SchemaField, StringField } = foundry.data.fields;
@@ -49,8 +51,6 @@ export default class TargetField extends SchemaField {
    * @returns {TargetLabels}
    */
   static getLabels({ capitalize=false, dimensions, target }) {
-    const pr = getPluralRules();
-
     /**
      * Combine a count with its localized target type.
      * @param {string} count                        Formatted count.
@@ -77,7 +77,8 @@ export default class TargetField extends SchemaField {
         parts.push(formatLength(target.template.size, target.template.units));
       }
       template.statblock = fmt(
-        parts.filterJoin(" "), `${templateConfig.counted}.${pr.select(target.template.count || 1)}`,
+        parts.filterJoin(" "),
+        getPluralLocalizationKey(target.template.count || 1, pr => `${templateConfig.counted}.${pr}`),
         { capitalize }
       ).capitalize();
 
@@ -93,10 +94,10 @@ export default class TargetField extends SchemaField {
           })
         ));
 
-      template.description = _loc(`${templateConfig.counted}.${pr.select(target.template.count || 1)}Sized`, {
-        number: formatNumber(target.template.count, { words: true }),
-        sizes: template.size
-      });
+      template.description = _loc(
+        getPluralLocalizationKey(target.template.count || 1, pr => `${templateConfig.counted}.${pr}Sized`),
+        { number: formatNumber(target.template.count, { words: true }), sizes: template.size }
+      );
 
       template.type = templateConfig.label;
     }
@@ -108,13 +109,21 @@ export default class TargetField extends SchemaField {
     const described = special ? "DND5E.TARGET.Type.Special.Counted" : counted;
     const affects = {
       description: count
-        ? fmt(formatNumber(count, { words: true }), `${described}.${pr.select(count)}`, { special })
+        ? fmt(
+          formatNumber(count, { words: true }),
+          getPluralLocalizationKey(count, pr => `${described}.${pr}`),
+          { special }
+        )
         : _loc(`${described}.${target.template.type ? "each" : "any"}`, { special }),
       sheet: affectsConfig?.counted ? fmt(
         count ? formatNumber(count) : _loc(`DND5E.TARGET.Count.${target.template.type ? "Every" : "Any"}`),
-        `${affectsConfig.counted}.${count ? pr.select(count) : "other"}`, { capitalize }
+        getPluralLocalizationKey(count, pr => `${affectsConfig.counted}.${pr}`),
+        { capitalize }
       ).capitalize() : (affectsConfig?.label ?? ""),
-      statblock: fmt(formatNumber(count || 1, { words: true }), `${counted}.${pr.select(count || 1)}`)
+      statblock: fmt(
+        formatNumber(count || 1, { words: true }),
+        getPluralLocalizationKey(count || 1, pr => `${counted}.${pr}`)
+      )
     };
 
     return { affects, template };

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -1,4 +1,6 @@
-import { defaultUnits, formatLength, formatNumber, getPluralRules, prepareFormulaValue } from "../../utils.mjs";
+import {
+  defaultUnits, formatLength, formatNumber, getPluralLocalizationKey, prepareFormulaValue
+} from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { BooleanField, SchemaField, StringField } = foundry.data.fields;
@@ -68,8 +70,6 @@ export default class TargetField extends SchemaField {
       this.target.template.height = null;
     }
 
-    const pr = getPluralRules();
-
     // Generate the template labels
     const templateConfig = CONFIG.DND5E.areaTargetTypes[this.target.template.type];
     this.target.template.labels = {};
@@ -80,7 +80,8 @@ export default class TargetField extends SchemaField {
         parts.push(formatLength(this.target.template.size, this.target.template.units));
       }
       this.target.template.labels.statblock = this.target.template.label = _loc(
-        `${templateConfig.counted}.${pr.select(this.target.template.count || 1)}`, { number: parts.filterJoin(" ") }
+        getPluralLocalizationKey(this.target.template.count || 1, pr => `${templateConfig.counted}.${pr}`),
+        { number: parts.filterJoin(" ") }
       ).trim().capitalize();
 
       const sizeUnit = CONFIG.DND5E.movementUnits[this.target.template.units]?.template ?? "";
@@ -97,7 +98,7 @@ export default class TargetField extends SchemaField {
         ));
 
       this.target.template.labels.description = _loc(
-        `${templateConfig.counted}.${pr.select(this.target.template.count || 1)}Sized`,
+        getPluralLocalizationKey(this.target.template.count || 1, pr => `${templateConfig.counted}.${pr}Sized`),
         {
           number: formatNumber(this.target.template.count, { words: true }),
           sizes: this.target.template.labels.size
@@ -109,24 +110,30 @@ export default class TargetField extends SchemaField {
 
     // Generate the affects labels
     const affectsConfig = CONFIG.DND5E.individualTargetTypes[this.target.affects.type];
+    const affectsDescriptionBase = (this.target.affects.special ? "DND5E.TARGET.Type.Special.Counted"
+      : affectsConfig?.counted) ?? "DND5E.TARGET.Type.Target.Counted";
     this.target.affects.labels = {
       description: _loc(
-        `${this.target.affects.special ? "DND5E.TARGET.Type.Special.Counted"
-          : affectsConfig?.counted ?? "DND5E.TARGET.Type.Target.Counted"}.${this.target.affects.count
-          ? pr.select(this.target.affects.count) : this.target.template.type ? "each" : "any"}`,
+        this.target.affects.count
+          ? getPluralLocalizationKey(this.target.affects.count, pr => `${affectsDescriptionBase}.${pr}`)
+          : `${affectsDescriptionBase}.${this.target.template.type ? "each" : "any"}`,
         {
           number: formatNumber(this.target.affects.count, { words: true }),
           special: this.target.affects.special
         }
       ),
       sheet: affectsConfig?.counted ? _loc(
-        `${affectsConfig.counted}.${this.target.affects.count ? pr.select(this.target.affects.count) : "other"}`, {
+        this.target.affects.count
+          ? getPluralLocalizationKey(this.target.affects.count, pr => `${affectsConfig.counted}.${pr}`)
+          : `${affectsConfig.counted}.other`,
+        {
           number: this.target.affects.count ? formatNumber(this.target.affects.count)
             : _loc(`DND5E.TARGET.Count.${this.target.template.type ? "Every" : "Any"}`)
         }
       ).trim().capitalize() : (affectsConfig?.label ?? ""),
       statblock: _loc(
-        `${affectsConfig?.counted ?? "DND5E.TARGET.Type.Target.Counted"}.${pr.select(this.target.affects.count || 1)}`,
+        getPluralLocalizationKey(this.target.affects.count || 1, pr =>
+          `${affectsConfig?.counted ?? "DND5E.TARGET.Type.Target.Counted"}.${pr}`),
         { number: formatNumber(this.target.affects.count || 1, { words: true }) }
       )
     };

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -1,5 +1,5 @@
 import { ScaleValueTypeUsage } from "../../data/advancement/scale-value-data.mjs";
-import { formatNumber, formatRange, getPluralRules, prepareFormulaValue } from "../../utils.mjs";
+import { formatNumber, formatRange, getPluralLocalizationKey, prepareFormulaValue } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
@@ -143,10 +143,10 @@ export default class UsesField extends SchemaField {
     // Legendary/Mythic Actions
     if ( (this.activation?.type === "legendary") || (this.activation?.type === "mythic") ) {
       if ( this.activation.value < 2 ) return "";
-      const pr = getPluralRules();
-      return _loc(`DND5E.NPC.ActionCostCounted.${pr.select(this.activation.value)}`, {
-        number: formatNumber(this.activation.value)
-      });
+      return _loc(
+        getPluralLocalizationKey(this.activation.value, pr => `DND5E.NPC.ActionCostCounted.${pr}`),
+        { number: formatNumber(this.activation.value) }
+      );
     }
 
     if ( !this.uses.max || (this.uses.recovery.length !== 1) ) return "";

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -11,7 +11,7 @@ import D20RollModificationField from "../../data/shared/d20-roll-modification-fi
 import TransformationSetting from "../../data/settings/transformation-setting.mjs";
 import { Filter } from "../../filter.mjs";
 import {
-  convertTime, defaultUnits, formatLength, formatNumber, formatTime, simplifyBonus, staticID
+  convertTime, defaultUnits, formatLength, formatNumber, formatTime, getPluralLocalizationKey, simplifyBonus, staticID
 } from "../../utils.mjs";
 import ActiveEffect5e from "../active-effect.mjs";
 import Item5e from "../item.mjs";
@@ -2456,12 +2456,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     // Create a chat message
-    const pr = new Intl.PluralRules(game.i18n.lang);
     let chatData = {
       content: `<p>${_loc(message, {
         name: this.name,
-        dice: _loc(`DND5E.HITDICE.Counted.${pr.select(dhd)}`, { number: formatNumber(dhd) }),
-        health: _loc(`DND5E.HITPOINTS.Counted.${pr.select(dhp)}`, { number: formatNumber(dhp) })
+        dice: _loc(getPluralLocalizationKey(dhd, pr => `DND5E.HITDICE.Counted.${pr}`), { number: formatNumber(dhd) }),
+        health: _loc(
+          getPluralLocalizationKey(dhp, pr => `DND5E.HITPOINTS.Counted.${pr}`), { number: formatNumber(dhp) }
+        )
       })}</p>`,
       flavor: this.createRestFlavor(config, result),
       type: "rest",

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -9,7 +9,7 @@ import AdvantageModeField from "../../data/fields/advantage-mode-field.mjs";
 import TransformationSetting from "../../data/settings/transformation-setting.mjs";
 import { createRollLabel } from "../../enrichers.mjs";
 import {
-  convertTime, defaultUnits, formatLength, formatNumber, formatTime, simplifyBonus, staticID
+  convertTime, defaultUnits, formatLength, formatNumber, formatTime, getPluralLocalizationKey, simplifyBonus, staticID
 } from "../../utils.mjs";
 import ActiveEffect5e from "../active-effect.mjs";
 import Item5e from "../item.mjs";
@@ -2350,12 +2350,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     // Create a chat message
-    const pr = new Intl.PluralRules(game.i18n.lang);
     let chatData = {
       content: _loc(message, {
         name: this.name,
-        dice: _loc(`DND5E.HITDICE.Counted.${pr.select(dhd)}`, { number: formatNumber(dhd) }),
-        health: _loc(`DND5E.HITPOINTS.Counted.${pr.select(dhp)}`, { number: formatNumber(dhp) })
+        dice: _loc(getPluralLocalizationKey(dhd, pr => `DND5E.HITDICE.Counted.${pr}`), { number: formatNumber(dhd) }),
+        health: _loc(
+          getPluralLocalizationKey(dhp, pr => `DND5E.HITPOINTS.Counted.${pr}`), { number: formatNumber(dhp) }
+        )
       }),
       flavor: this.createRestFlavor(config, result),
       type: "rest",

--- a/module/documents/actor/trait.mjs
+++ b/module/documents/actor/trait.mjs
@@ -1,3 +1,4 @@
+import { getPluralLocalizationKey } from "../../utils.mjs";
 import SelectChoices from "./select-choices.mjs";
 
 /**
@@ -350,9 +351,9 @@ export function traitIndexFields() {
  */
 export function traitLabel(trait, count) {
   const traitConfig = CONFIG.DND5E.traits[trait];
-  const pluralRule = (count !== undefined) ? new Intl.PluralRules(game.i18n.lang).select(count) : "other";
-  if ( !traitConfig ) return _loc(`DND5E.TRAIT.Generic.${pluralRule}`);
-  return _loc(`${traitConfig.labels.localization}.${pluralRule}`);
+  return _loc(getPluralLocalizationKey(count, pr =>
+    `${traitConfig?.labels?.localization ?? "DND5E.TRAIT.Generic"}.${pr}`
+  ));
 }
 
 /* -------------------------------------------- */
@@ -434,16 +435,15 @@ export function keyIcon(key, { trait }={}) {
  */
 export function keyLabel(key, config={}) {
   let { count, trait, final } = config;
-
   let parts = key.split(":");
-  const pluralRules = new Intl.PluralRules(game.i18n.lang);
 
   if ( !trait ) trait = parts.shift();
   const traitConfig = CONFIG.DND5E.traits[trait];
   if ( !traitConfig ) return key;
   const traitData = CONFIG.DND5E[traitConfig.configKey ?? trait] ?? {};
-  let categoryLabel = _loc(`${traitConfig.labels.localization}.${
-    pluralRules.select(count ?? 1)}`);
+  let categoryLabel = _loc(getPluralLocalizationKey(count ?? 1, pr =>
+    `${traitConfig.labels.localization}.${pr}`
+  ));
 
   // Trait (e.g. "Tool Proficiency")
   const lastKey = parts.pop();

--- a/module/documents/actor/trait.mjs
+++ b/module/documents/actor/trait.mjs
@@ -1,3 +1,4 @@
+import { getPluralLocalizationKey } from "../../utils.mjs";
 import SelectChoices from "./select-choices.mjs";
 
 /**
@@ -350,9 +351,9 @@ export function traitIndexFields() {
  */
 export function traitLabel(trait, count) {
   const traitConfig = CONFIG.DND5E.traits[trait];
-  const pluralRule = (count !== undefined) ? new Intl.PluralRules(game.i18n.lang).select(count) : "other";
-  if ( !traitConfig ) return _loc(`DND5E.TraitGenericPlural.${pluralRule}`);
-  return _loc(`${traitConfig.labels.localization}.${pluralRule}`);
+  return _loc(getPluralLocalizationKey(count, pr =>
+    `${traitConfig?.labels?.localization ?? "DND5E.TraitGenericPlural"}.${pr}`
+  ));
 }
 
 /* -------------------------------------------- */
@@ -434,16 +435,15 @@ export function keyIcon(key, { trait }={}) {
  */
 export function keyLabel(key, config={}) {
   let { count, trait, final } = config;
-
   let parts = key.split(":");
-  const pluralRules = new Intl.PluralRules(game.i18n.lang);
 
   if ( !trait ) trait = parts.shift();
   const traitConfig = CONFIG.DND5E.traits[trait];
   if ( !traitConfig ) return key;
   const traitData = CONFIG.DND5E[traitConfig.configKey ?? trait] ?? {};
-  let categoryLabel = _loc(`${traitConfig.labels.localization}.${
-    pluralRules.select(count ?? 1)}`);
+  let categoryLabel = _loc(getPluralLocalizationKey(count ?? 1, pr =>
+    `${traitConfig.labels.localization}.${pr}`
+  ));
 
   // Trait (e.g. "Tool Proficiency")
   const lastKey = parts.pop();

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -325,8 +325,8 @@ export function formatTime(value, unit, options={}) {
     if ( (options.unitDisplay === "narrow") && game.i18n.has(`${config.counted}.narrow`) ) {
       return _loc(`${config.counted}.narrow`, { number: formatNumber(value, options) });
     } else {
-      const pr = new Intl.PluralRules(game.i18n.lang);
-      return _loc(`${config.counted}.${pr.select(value)}`, { number: formatNumber(value, options) });
+      const localizationKey = getPluralLocalizationKey(value, pr => `${config.counted}.${pr}`);
+      return _loc(localizationKey, { number: formatNumber(value, options) });
     }
   }
   try {
@@ -376,7 +376,7 @@ export function formatWeight(value, unit, options={}) {
 function _formatSystemUnits(value, unit, config, { parts=false, ...options }={}) {
   options.unitDisplay ??= "short";
   if ( config?.counted ) {
-    const localizationKey = `${config.counted}.${options.unitDisplay}.${getPluralRules().select(value)}`;
+    const localizationKey = getPluralLocalizationKey(value, pr => `${config.counted}.${options.unitDisplay}.${pr}`);
     return _loc(localizationKey, { number: formatNumber(value, options) });
   }
   unit = config?.formattingUnit ?? unit;
@@ -398,12 +398,30 @@ const _pluralRules = {};
 /**
  * Get a PluralRules object, fetching from cache if possible.
  * @param {object} [options={}]
+ * @param {string} [options.lang]
  * @param {string} [options.type=cardinal]
  * @returns {Intl.PluralRules}
  */
-export function getPluralRules({ type="cardinal" }={}) {
-  _pluralRules[type] ??= new Intl.PluralRules(game.i18n.lang, { type });
-  return _pluralRules[type];
+export function getPluralRules({ lang=game.i18n.lang, type="cardinal" }={}) {
+  const key = `${lang}_${type}`;
+  _pluralRules[key] ??= new Intl.PluralRules(lang, { type });
+  return _pluralRules[key];
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Get a pluralized localization key using the provided formatting function which properly falls back to English
+ * if the currently language is missing the key.
+ * @param {number} value         Counted value.
+ * @param {Function} format      Method that takes a plural rule value and returns the full localization key.
+ * @param {object} [options={}]  Options passed to `getPluralRules`.
+ * @returns {string}
+ */
+export function getPluralLocalizationKey(value, format, options={}) {
+  const localizationKey = format(getPluralRules(options).select(value ?? 0));
+  if ( game.i18n.has(localizationKey) ) return localizationKey;
+  return format(getPluralRules({ ...options, lang: "en" }).select(value ?? 0));
 }
 
 /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -234,8 +234,8 @@ export function formatTime(value, unit, options={}) {
     if ( (options.unitDisplay === "narrow") && game.i18n.has(`${config.counted}.narrow`) ) {
       return _loc(`${config.counted}.narrow`, { number: formatNumber(value, options) });
     } else {
-      const pr = new Intl.PluralRules(game.i18n.lang);
-      return _loc(`${config.counted}.${pr.select(value)}`, { number: formatNumber(value, options) });
+      const localizationKey = getPluralLocalizationKey(value, pr => `${config.counted}.${pr}`);
+      return _loc(localizationKey, { number: formatNumber(value, options) });
     }
   }
   try {
@@ -285,7 +285,7 @@ export function formatWeight(value, unit, options={}) {
 function _formatSystemUnits(value, unit, config, { parts=false, ...options }={}) {
   options.unitDisplay ??= "short";
   if ( config?.counted ) {
-    const localizationKey = `${config.counted}.${options.unitDisplay}.${getPluralRules().select(value)}`;
+    const localizationKey = getPluralLocalizationKey(value, pr => `${config.counted}.${options.unitDisplay}.${pr}`);
     return _loc(localizationKey, { number: formatNumber(value, options) });
   }
   unit = config?.formattingUnit ?? unit;
@@ -307,12 +307,30 @@ const _pluralRules = {};
 /**
  * Get a PluralRules object, fetching from cache if possible.
  * @param {object} [options={}]
+ * @param {string} [options.lang]
  * @param {string} [options.type=cardinal]
  * @returns {Intl.PluralRules}
  */
-export function getPluralRules({ type="cardinal" }={}) {
-  _pluralRules[type] ??= new Intl.PluralRules(game.i18n.lang, { type });
-  return _pluralRules[type];
+export function getPluralRules({ lang=game.i18n.lang, type="cardinal" }={}) {
+  const key = `${lang}_${type}`;
+  _pluralRules[key] ??= new Intl.PluralRules(lang, { type });
+  return _pluralRules[key];
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Get a pluralized localization key using the provided formatting function which properly falls back to English
+ * if the currently language is missing the key.
+ * @param {number} value         Counted value.
+ * @param {Function} format      Method that takes a plural rule value and returns the full localization key.
+ * @param {object} [options={}]  Options passed to `getPluralRules`.
+ * @returns {string}
+ */
+export function getPluralLocalizationKey(value, format, options={}) {
+  const localizationKey = format(getPluralRules(options).select(value ?? 0));
+  if ( game.i18n.has(localizationKey) ) return localizationKey;
+  return format(getPluralRules({ ...options, lang: "en" }).select(value ?? 0));
 }
 
 /* -------------------------------------------- */


### PR DESCRIPTION
Fixes a gap in how we handle localizing plurals that results from different languages having additional plural rules than English which would result in localization keys being displayed because English lacks the proper fallback string.

This new method takes the count as well as a function for producing the final localization key from the PR. It will check to ensure the produced string exists in the current language file, and if not it will re-determine the appropriate plural rule as if the language were set to English and return that localization key instead.

All places in the system where `getPluralRules` was used or a new `Intl.PluralRules` object was constructed have been replaced with calls to this new utility method (except for in consumption target data, where some additional work will need to be done because of how that code is structured).

Closes #5719