### PR TITLE
[#5376] Improve conversion functions, auto-convert weights

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -750,7 +750,10 @@ Hooks.on("preCreateScene", (doc, createData, options, userId) => {
   if ( (units !== dnd5e.grid.units) && !foundry.utils.getProperty(createData, "grid.distance")
     && !foundry.utils.getProperty(createData, "grid.units") ) {
     doc.updateSource({
-      grid: { distance: utils.convertLength(dnd5e.grid.distance, dnd5e.grid.units, units, { strict: false }), units }
+      grid: {
+        distance: utils.convertLength( dnd5e.grid.distance, dnd5e.grid.units, { legacy: false, to: units }).value,
+        units
+      }
     });
   }
 });

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -751,7 +751,7 @@ Hooks.on("preCreateScene", (doc, createData, options, userId) => {
     && !foundry.utils.getProperty(createData, "grid.units") ) {
     doc.updateSource({
       grid: {
-        distance: utils.convertLength( dnd5e.grid.distance, dnd5e.grid.units, { legacy: false, to: units }).value,
+        distance: utils.convertLength( dnd5e.grid.distance, dnd5e.grid.units, { to: units, legacy: false }).value,
         units
       }
     });

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -648,7 +648,10 @@ Hooks.on("preCreateScene", (doc, createData, options, userId) => {
   if ( (units !== dnd5e.grid.units) && !foundry.utils.getProperty(createData, "grid.distance")
     && !foundry.utils.getProperty(createData, "grid.units") ) {
     doc.updateSource({
-      grid: { distance: utils.convertLength(dnd5e.grid.distance, dnd5e.grid.units, units, { strict: false }), units }
+      grid: {
+        distance: utils.convertLength( dnd5e.grid.distance, dnd5e.grid.units, { legacy: false, to: units }).value,
+        units
+      }
     });
   }
 });

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -762,7 +762,7 @@
  *                                 the largest unit that can represent the value as an integer.
  * @property {boolean} [truncate]  Select the largest unit that can represent the value, discarding any
  *                                 remainder, rather than the largest that represents it exactly.
- * @property {string} [type]       Target measurement system. If provided without target unit then the value will be
+ * @property {string} [system]     Target measurement system. If provided without target unit then the value will be
  *                                 converted to the closest equivalent unit in the specified measurement system
  *                                 (e.g. "mi" > "km").
  */

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -756,6 +756,20 @@
 /* -------------------------------------------- */
 
 /**
+ * @typedef UnitConversionOptions
+ * @property {boolean} [strict]    Throw an error if either unit isn't found.
+ * @property {string} [to]         The final unit. If neither this nor the unit system is provided then will convert to
+ *                                 the largest unit that can represent the value as an integer.
+ * @property {boolean} [truncate]  Select the largest unit that can represent the value, discarding any
+ *                                 remainder, rather than the largest that represents it exactly.
+ * @property {string} [type]       Target measurement system. If provided without target unit then the value will be
+ *                                 converted to the closest equivalent unit in the specified measurement system
+ *                                 (e.g. "mi" > "km").
+ */
+
+/* -------------------------------------------- */
+
+/**
  * @typedef UnitValue5e
  * @property {string} units
  * @property {number} value

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -1077,7 +1077,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
     if ( !target.classList.contains("rollable") ) return;
     const { facilityId } = target.closest("[data-facility-id]")?.dataset ?? {};
     const facility = this.actor.items.get(facilityId);
-    facility?.use({ legacy: false, chooseActivity: true, event });
+    facility?.use({ chooseActivity: true, event });
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -194,7 +194,7 @@ export default class BaseRestDialog extends Dialog5e {
     });
 
     if ( context.isGroup && dnd5e.settings.calendarConfig.enabled ) {
-      const duration = convertTime(this.duration, "minute", { strict: false });
+      const duration = convertTime(this.duration, "minute");
       context.duration = {
         fields: [
           {
@@ -256,7 +256,7 @@ export default class BaseRestDialog extends Dialog5e {
       this.actor.setFlag("dnd5e", "restSettings", data);
     }
     if ( foundry.utils.isPlainObject(data.duration) ) {
-      data.duration = convertTime(data.duration.value, data.duration.unit, { strict: false, to: "minute" }).value;
+      data.duration = convertTime(data.duration.value, data.duration.unit, { to: "minute" }).value;
     }
     foundry.utils.mergeObject(this.config, data);
     this.#rested = true;

--- a/module/canvas/template-placement.mjs
+++ b/module/canvas/template-placement.mjs
@@ -92,11 +92,11 @@ export default class TemplatePlacement extends BasePlacement {
     const templateData = {
       type: templateShape,
       size: target.size
-        ? convertLength(target.size, target.units, canvas.scene.grid.units, { strict: false }) : undefined,
+        ? convertLength(target.size, target.units, { to: canvas.scene.grid.units, legacy: false }).value : undefined,
       width: target.width
-        ? convertLength(target.width, target.units, canvas.scene.grid.units, { strict: false }) : undefined,
+        ? convertLength(target.width, target.units, { to: canvas.scene.grid.units, legacy: false }).value : undefined,
       height: target.height
-        ? convertLength(target.height, target.units, canvas.scene.grid.units, { strict: false }) : undefined
+        ? convertLength(target.height, target.units, { to: canvas.scene.grid.units, legacy: false }).value : undefined
     };
 
     const config = foundry.utils.mergeObject({

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -361,7 +361,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
     // Add reach for melee weapons, unless the activity is explicitly specified as a ranged attack
     if ( this.validAttackTypes.has("melee") ) {
       let { reach, units } = this.item.system.range;
-      if ( !reach ) reach = convertLength(5, "ft", units);
+      if ( !reach ) reach = convertLength(5, "ft", { to: units, legacy: false }).value;
       parts.push(_loc("DND5E.RANGE.Formatted.Reach", {
         reach: formatLength(reach, units, { strict: false })
       }));

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -344,7 +344,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
     // Add reach for melee weapons, unless the activity is explicitly specified as a ranged attack
     if ( this.validAttackTypes.has("melee") ) {
       let { reach, units } = this.item.system.range;
-      if ( !reach ) reach = convertLength(5, "ft", units);
+      if ( !reach ) reach = convertLength(5, "ft", { to: units, legacy: false }).value;
       parts.push(_loc("DND5E.RANGE.Formatted.Reach", {
         reach: formatLength(reach, units, { strict: false })
       }));

--- a/module/data/actor/fields/travel-field.mjs
+++ b/module/data/actor/fields/travel-field.mjs
@@ -118,10 +118,10 @@ export default class TravelField extends foundry.data.fields.SchemaField {
     const fromConfig = CONFIG.DND5E.movementUnits[initialUnit];
     const toConfig = CONFIG.DND5E.movementUnits[finalUnit];
     if ( (fromConfig?.type === "metric") && (toConfig?.type === "metric") ) {
-      value = convertLength(value, initialUnit, "m", { strict: false });
+      value = convertLength(value, initialUnit, { legacy: false, strict: false, to: "m" }).value;
       return convertTravelSpeed(value / 2, "kph", { strict: false, to: finalUnit }).value;
     } else {
-      value = convertLength(value, initialUnit, "ft", { strict: false });
+      value = convertLength(value, initialUnit, { legacy: false, strict: false, to: "ft" }).value;
       return convertTravelSpeed(value / 10, "mph", { strict: false, to: finalUnit }).value;
     }
   }

--- a/module/data/actor/fields/travel-field.mjs
+++ b/module/data/actor/fields/travel-field.mjs
@@ -118,11 +118,11 @@ export default class TravelField extends foundry.data.fields.SchemaField {
     const fromConfig = CONFIG.DND5E.movementUnits[initialUnit];
     const toConfig = CONFIG.DND5E.movementUnits[finalUnit];
     if ( (fromConfig?.type === "metric") && (toConfig?.type === "metric") ) {
-      value = convertLength(value, initialUnit, { legacy: false, strict: false, to: "m" }).value;
-      return convertTravelSpeed(value / 2, "kph", { strict: false, to: finalUnit }).value;
+      value = convertLength(value, initialUnit, { to: "m", legacy: false }).value;
+      return convertTravelSpeed(value / 2, "kph", { to: finalUnit }).value;
     } else {
-      value = convertLength(value, initialUnit, { legacy: false, strict: false, to: "ft" }).value;
-      return convertTravelSpeed(value / 10, "mph", { strict: false, to: finalUnit }).value;
+      value = convertLength(value, initialUnit, { to: "ft", legacy: false }).value;
+      return convertTravelSpeed(value / 10, "mph", { to: finalUnit }).value;
     }
   }
 

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -389,8 +389,8 @@ export default class AttributesFields {
       weight += convertWeight(
         numCoins / currencyPerWeight,
         config.baseUnits.default[unitSystem],
-        baseUnits[unitSystem]
-      );
+        { to: baseUnits[unitSystem], legacy: false }
+      ).value;
     }
 
     // Determine the Encumbrance size class
@@ -559,7 +559,7 @@ export default class AttributesFields {
       && !this.parent.flags.dnd5e?.ignoreArmorSpeedReduction && this.isCreature ) {
       reduction += CONFIG.DND5E.armorSpeedReduction;
     }
-    reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, units);
+    reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, { to: units, legacy: false }).value;
     const bonus = simplifyBonus(this.attributes.movement.bonus, rollData);
     const multiplier = this.attributes.movement.multiplier * (halfMovement ? 0.5 : 1);
     this.attributes.movement.max = 0;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -411,7 +411,7 @@ export default class AttributesFields {
       if ( threshold === "maximum" ) maximumMultiplier = multiplier;
       if ( this.isVehicle ) {
         const { cargo } = attributes.capacity;
-        base = convertWeight(cargo.value || Infinity, cargo.units, baseUnits[unitSystem]);
+        base = convertWeight(cargo.value || Infinity, cargo.units, { legacy: false, to: baseUnits[unitSystem] }).value;
       }
       else multiplier *= (config.threshold[threshold]?.[unitSystem] ?? 1) * sizeMod;
       return (base * multiplier).toNearest(0.1) + bonus;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -411,7 +411,7 @@ export default class AttributesFields {
       if ( threshold === "maximum" ) maximumMultiplier = multiplier;
       if ( this.isVehicle ) {
         const { cargo } = attributes.capacity;
-        base = convertWeight(cargo.value || Infinity, cargo.units, { legacy: false, to: baseUnits[unitSystem] }).value;
+        base = convertWeight(cargo.value || Infinity, cargo.units, { to: baseUnits[unitSystem], legacy: false }).value;
       }
       else multiplier *= (config.threshold[threshold]?.[unitSystem] ?? 1) * sizeMod;
       return (base * multiplier).toNearest(0.1) + bonus;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -279,8 +279,8 @@ export default class AttributesFields {
       weight += convertWeight(
         numCoins / currencyPerWeight,
         config.baseUnits.default[unitSystem],
-        baseUnits[unitSystem]
-      );
+        { to: baseUnits[unitSystem], legacy: false }
+      ).value;
     }
 
     // Determine the Encumbrance size class
@@ -434,7 +434,7 @@ export default class AttributesFields {
       && !this.parent.flags.dnd5e?.ignoreArmorSpeedReduction && this.isCreature ) {
       reduction += CONFIG.DND5E.armorSpeedReduction;
     }
-    reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, units);
+    reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, { to: units, legacy: false }).value;
     const bonus = simplifyBonus(this.attributes.movement.bonus, rollData);
     this.attributes.movement.max = 0;
     for ( const type of Object.keys(CONFIG.DND5E.movementTypes) ) {

--- a/module/data/calendar/calendar-data.mjs
+++ b/module/data/calendar/calendar-data.mjs
@@ -455,7 +455,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
     // X days have passed
     if ( timePassageData.midnights > 1 ) {
       const pr = getPluralRules();
-      const { value, unit } = convertTime(timePassageData.midnights, "day", { strict: false });
+      const { value, unit } = convertTime(timePassageData.midnights, "day");
       const number = formatTime(value, unit, { words: true });
       message = _loc(`DND5E.CALENDAR.TimePassage.TimePassed.${pr.select(value)}`, {
         number: number.capitalize(), numberLc: number

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -242,6 +242,11 @@ export default class PhysicalItemTemplate extends SystemDataModel {
    * Prepare physical item properties.
    */
   preparePhysicalData() {
+    const unitSystem = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
+    Object.assign(
+      this.weight, convertWeight(this.weight.value, this.weight.units, { type: unitSystem, legacy: false })
+    );
+
     if ( !(CONFIG.DND5E.defaultCurrency in CONFIG.DND5E.currencies) ) return;
     const { value, denomination } = this.price;
     const { conversion } = CONFIG.DND5E.currencies[denomination] ?? {};
@@ -473,7 +478,9 @@ export default class PhysicalItemTemplate extends SystemDataModel {
    */
   totalWeightIn(units) {
     const weight = this.totalWeight;
-    if ( weight instanceof Promise ) return weight.then(w => convertWeight(w, this.weight.units, units));
-    return convertWeight(weight, this.weight.units, units);
+    if ( weight instanceof Promise ) {
+      return weight.then(w => convertWeight(w, this.weight.units, { to: units, legacy: false }).value);
+    }
+    return convertWeight(weight, this.weight.units, { to: units, legacy: false }).value;
   }
 }

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -244,7 +244,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
   preparePhysicalData() {
     const unitSystem = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
     Object.assign(
-      this.weight, convertWeight(this.weight.value, this.weight.units, { type: unitSystem, legacy: false })
+      this.weight, convertWeight(this.weight.value, this.weight.units, { system: unitSystem, legacy: false })
     );
 
     if ( !(CONFIG.DND5E.defaultCurrency in CONFIG.DND5E.currencies) ) return;

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -185,6 +185,11 @@ export default class PhysicalItemTemplate extends SystemDataModel {
    * Prepare physical item properties.
    */
   preparePhysicalData() {
+    const unitSystem = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
+    Object.assign(
+      this.weight, convertWeight(this.weight.value, this.weight.units, { type: unitSystem, legacy: false })
+    );
+
     if ( !(CONFIG.DND5E.defaultCurrency in CONFIG.DND5E.currencies) ) return;
     const { value, denomination } = this.price;
     const { conversion } = CONFIG.DND5E.currencies[denomination] ?? {};
@@ -390,7 +395,9 @@ export default class PhysicalItemTemplate extends SystemDataModel {
    */
   totalWeightIn(units) {
     const weight = this.totalWeight;
-    if ( weight instanceof Promise ) return weight.then(w => convertWeight(w, this.weight.units, units));
-    return convertWeight(weight, this.weight.units, units);
+    if ( weight instanceof Promise ) {
+      return weight.then(w => convertWeight(w, this.weight.units, { to: units, legacy: false }).value);
+    }
+    return convertWeight(weight, this.weight.units, { to: units, legacy: false }).value;
   }
 }

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -187,7 +187,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
   preparePhysicalData() {
     const unitSystem = game.settings.get("dnd5e", "metricWeightUnits") ? "metric" : "imperial";
     Object.assign(
-      this.weight, convertWeight(this.weight.value, this.weight.units, { type: unitSystem, legacy: false })
+      this.weight, convertWeight(this.weight.value, this.weight.units, { system: unitSystem, legacy: false })
     );
 
     if ( !(CONFIG.DND5E.defaultCurrency in CONFIG.DND5E.currencies) ) return;

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -486,7 +486,7 @@ export default class WeaponData extends ItemDataModel.mixin(
     if ( this.attackType === "ranged" ) this.range.reach = null;
     else if ( this.range.reach === null ) {
       this.range.reach = convertLength(
-        this.properties.has("rch") ? 10 : 5, "ft", { strict: false, to: this.range.units, legacy: false }
+        this.properties.has("rch") ? 10 : 5, "ft", { to: this.range.units, legacy: false }
       ).value;
     }
     if ( !this.hasRange ) this.range.value = this.range.long = null;

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -485,7 +485,9 @@ export default class WeaponData extends ItemDataModel.mixin(
 
     if ( this.attackType === "ranged" ) this.range.reach = null;
     else if ( this.range.reach === null ) {
-      this.range.reach = convertLength(this.properties.has("rch") ? 10 : 5, "ft", this.range.units, { strict: false });
+      this.range.reach = convertLength(
+        this.properties.has("rch") ? 10 : 5, "ft", { strict: false, to: this.range.units, legacy: false }
+      ).value;
     }
     if ( !this.hasRange ) this.range.value = this.range.long = null;
   }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -488,7 +488,9 @@ export default class WeaponData extends ItemDataModel.mixin(
 
     if ( this.attackType === "ranged" ) this.range.reach = null;
     else if ( this.range.reach === null ) {
-      this.range.reach = convertLength(this.properties.has("rch") ? 10 : 5, "ft", this.range.units, { strict: false });
+      this.range.reach = convertLength(
+        this.properties.has("rch") ? 10 : 5, "ft", { strict: false, to: this.range.units, legacy: false }
+      ).value;
     }
     if ( !this.hasRange ) this.range.value = this.range.long = null;
   }

--- a/module/rules/falling.mjs
+++ b/module/rules/falling.mjs
@@ -20,7 +20,7 @@ import { convertLength, formatLength } from "../utils.mjs";
  */
 export function getFallDamageFormula(distance, units) {
   const { damageDie, distancePerDie, maximumDice } = CONFIG.DND5E.falling;
-  const feet = convertLength(distance, units, "ft", { strict: false });
+  const feet = convertLength(distance, units, "ft");
   const dice = Math.min(maximumDice, Math.floor(feet / distancePerDie));
   return dice ? `${dice}${damageDie}` : null;
 }

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -337,7 +337,8 @@ export function registerSystemSettings() {
     scope: "world",
     config: true,
     type: Boolean,
-    default: false
+    default: false,
+    requiresReload: true
   });
 
   // Metric Volume Weights
@@ -347,7 +348,8 @@ export function registerSystemSettings() {
     scope: "world",
     config: true,
     type: Boolean,
-    default: false
+    default: false,
+    requiresReload: true
   });
 
   // Metric Unit Weights
@@ -357,7 +359,8 @@ export function registerSystemSettings() {
     scope: "world",
     config: true,
     type: Boolean,
-    default: false
+    default: false,
+    requiresReload: true
   });
 
   // Strict validation

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -201,7 +201,8 @@ export function registerSystemSettings() {
     scope: "world",
     config: true,
     type: Boolean,
-    default: false
+    default: false,
+    requiresReload: true
   });
 
   // Metric Volume Weights
@@ -211,7 +212,8 @@ export function registerSystemSettings() {
     scope: "world",
     config: true,
     type: Boolean,
-    default: false
+    default: false,
+    requiresReload: true
   });
 
   // Metric Unit Weights
@@ -221,7 +223,8 @@ export function registerSystemSettings() {
     scope: "world",
     config: true,
     type: Boolean,
-    default: false
+    default: false,
+    requiresReload: true
   });
 
   // Strict validation

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1,7 +1,7 @@
 import TargetsField from "./data/chat-message/fields/targets-field.mjs";
 
 /**
- * @import { TargetDescriptor5e, UnitConfiguration } from "./_types.mjs";
+ * @import { TargetDescriptor5e, UnitConfiguration, UnitConversionOptions } from "./_types.mjs";
  * @import { RollData } from "./documents/_types.mjs";
  */
 
@@ -813,16 +813,32 @@ export function getSceneTargets(actor, { checkBaseActor }={}) {
 
 /**
  * Convert the provided length to another unit.
- * @param {number} value                   The length being converted.
- * @param {string} from                    The initial units.
- * @param {string} to                      The final units.
- * @param {object} [options={}]
- * @param {boolean} [options.strict=true]  Throw an error if either unit isn't found.
- * @returns {number}
+ * @param {number} value                    The length being converted.
+ * @param {string} from                     The initial unit as defined in `CONFIG.DND5E.movementUnits`.
+ * @param {UnitConversionOptions} [options={}]
+ * @param {boolean} [options.legacy=true]   Only return converted value rather than value and units.
+ * @param {object} [_options]
+ * @returns {{ value: number, unit: string }|number}
  */
-export function convertLength(value, from, to, { strict=true }={}) {
+export function convertLength(value, from, options={}, _options={}) {
+  if ( foundry.utils.getType(options) !== "Object" ) {
+    foundry.utils.logCompatibilityWarning(
+      "The `to` parameter for `convertWeight` is now passed in to the options object.",
+      { since: "DnD5e 6.1", until: "DnD5e 6.3", once: true }
+    );
+    options = { ..._options, to: options };
+  }
+
   const message = unit => `Length unit ${unit} not defined in CONFIG.DND5E.movementUnits`;
-  return _convertSystemUnits(value, from, to, CONFIG.DND5E.movementUnits, { message, strict });
+  const result = _convertSystemUnits(value, from, CONFIG.DND5E.movementUnits, { ...options, message });
+  if ( options.legacy !== false ) {
+    foundry.utils.logCompatibilityWarning(
+      "The `convertLength` function has been altered to return value and units. Pass a `legacy` of `false` to the options to return the new value.",
+      { since: "DnD5e 6.1", until: "DnD5e 6.3", once: true }
+    );
+    return result.value;
+  }
+  return result;
 }
 
 /* -------------------------------------------- */
@@ -830,33 +846,17 @@ export function convertLength(value, from, to, { strict=true }={}) {
 /**
  * Convert the provided time value to another unit. If no final unit is provided, then will convert it to the largest
  * unit that can still represent the value as a whole number.
- * @param {number} value                      The time being converted.
- * @param {string} from                       The initial unit as defined in `CONFIG.DND5E.timeUnits`.
- * @param {object} [options={}]
- * @param {boolean} [options.combat=false]    Use combat units when auto-selecting units, rather than normal units.
- * @param {boolean} [options.strict=true]     Throw an error if from unit isn't found.
- * @param {string} [options.to]               The final units, if explicitly provided.
- * @param {boolean} [options.truncate=false]  Select the largest unit that can represent the value, discarding any
- *                                            remainder, rather than the largest that represents it exactly.
+ * @param {number} value                    The time being converted.
+ * @param {string} from                     The initial unit as defined in `CONFIG.DND5E.timeUnits`.
+ * @param {UnitConversionOptions} [options={}]
+ * @param {boolean} [options.combat=false]  Use combat units when auto-selecting units, rather than normal units.
  * @returns {{ value: number, unit: string }}
  */
-export function convertTime(value, from, { combat=false, strict=true, to, truncate=false }={}) {
-  const base = value * (CONFIG.DND5E.timeUnits[from]?.conversion ?? 1);
-  if ( !to ) {
-    // Find unit with largest conversion value that can still display the value
-    const unitOptions = Object.entries(CONFIG.DND5E.timeUnits)
-      .reduce((arr, [key, v]) => {
-        const fits = truncate ? base >= v.conversion : (base % v.conversion === 0) || (base >= v.conversion * 2);
-        if ( ((v.combat ?? false) === combat) && fits ) arr.push({ key, conversion: v.conversion });
-        return arr;
-      }, [])
-      .sort((lhs, rhs) => rhs.conversion - lhs.conversion);
-    to = unitOptions[0]?.key ?? from;
-  }
-
+export function convertTime(value, from, options={}) {
+  let config = CONFIG.DND5E.timeUnits;
+  if ( !options.combat ) config = Object.fromEntries(Object.entries(config).filter(([, v]) => !v.combat));
   const message = unit => `Time unit ${unit} not defined in CONFIG.DND5E.timeUnits`;
-  const converted = _convertSystemUnits(value, from, to, CONFIG.DND5E.timeUnits, { message, strict });
-  return { unit: to, value: truncate ? Math.floor(converted) : converted };
+  return _convertSystemUnits(value, from, config, { ...options, message });
 }
 
 /* -------------------------------------------- */
@@ -865,50 +865,99 @@ export function convertTime(value, from, { combat=false, strict=true, to, trunca
  * Convert the provided travel speed to another unit.
  * @param {number} value                    The travel speed being converted.
  * @param {string} from                     The initial unit.
- * @param {object} options
- * @param {boolean} [options.strict=false]  Throw an error if either unit isn't found.
- * @param {string} options.to               The final unit.
+ * @param {UnitConversionOptions} [options={}]
  * @returns {{ value: number, unit: string }}
  */
-export function convertTravelSpeed(value, from, { strict=false, to }) {
+export function convertTravelSpeed(value, from, options={}) {
   const message = unit => `Travel speed unit ${unit} not defined in CONFIG.DND5E.travelUnits`;
-  return { value: _convertSystemUnits(value, from, to, CONFIG.DND5E.travelUnits, { message, strict }), unit: to };
+  return _convertSystemUnits(value, from, CONFIG.DND5E.travelUnits, { ...options, message });
 }
 
 /* -------------------------------------------- */
 
 /**
  * Convert the provided weight to another unit.
- * @param {number} value                   The weight being converted.
- * @param {string} from                    The initial unit as defined in `CONFIG.DND5E.weightUnits`.
- * @param {string} to                      The final units.
- * @param {object} [options={}]
- * @param {boolean} [options.strict=true]  Throw an error if either unit isn't found.
- * @returns {number}      Weight in the specified units.
+ * @param {number} value                    The weight being converted.
+ * @param {string} from                     The initial unit as defined in `CONFIG.DND5E.weightUnits`.
+ * @param {UnitConversionOptions} [options={}]
+ * @param {boolean} [options.legacy=true]   Only return converted value rather than value and units.
+ * @param {object} [_options]
+ * @returns {{ value: number, unit: string }|number}
  */
-export function convertWeight(value, from, to, { strict=true }={}) {
+export function convertWeight(value, from, options={}, _options={}) {
+  if ( foundry.utils.getType(options) !== "Object" ) {
+    foundry.utils.logCompatibilityWarning(
+      "The `to` parameter for `convertWeight` is now passed in to the options object.",
+      { since: "DnD5e 6.1", until: "DnD5e 6.3", once: true }
+    );
+    options = { ..._options, to: options };
+  }
+
   const message = unit => `Weight unit ${unit} not defined in CONFIG.DND5E.weightUnits`;
-  return _convertSystemUnits(value, from, to, CONFIG.DND5E.weightUnits, { message, strict });
+  const result = _convertSystemUnits(value, from, CONFIG.DND5E.weightUnits, { ...options, message });
+  if ( options.legacy !== false ) {
+    foundry.utils.logCompatibilityWarning(
+      "The `convertWeight` function has been altered to return value and units. Pass a `legacy` of `false` to the options to return the new value.",
+      { since: "DnD5e 6.1", until: "DnD5e 6.3", once: true }
+    );
+    return result.value;
+  }
+  return result;
 }
 
 /* -------------------------------------------- */
 
 /**
+ * Cache of best unit conversions from one measurement system to another.
+ * @type {Record<string, string>}
+ */
+const _measurementSystemConversionCache = {};
+
+/**
  * Convert from one unit to another using one of core's built-in unit types.
  * @param {number} value                                Value to display.
  * @param {string} from                                 The initial unit.
- * @param {string} to                                   The final unit.
  * @param {UnitConfiguration} config                    Configuration data for the unit.
- * @param {object} options
+ * @param {UnitConversionOptions} options
  * @param {function(string): string} [options.message]  Method used to produce the error message if unit not found.
- * @param {boolean} [options.strict]                    Throw an error if either unit isn't found.
- * @returns {string}
+ * @returns {{ value: number, unit: string }}
  */
-function _convertSystemUnits(value, from, to, config, { message, strict }) {
-  if ( from === to ) return value;
+export function _convertSystemUnits(value, from, config, { message, strict, to, truncate, type }) {
+  if ( (from === to) || (!to && type && (config[from]?.type === type)) ) return { value, unit: from };
   if ( strict && !config[from] ) throw new Error(message(from));
-  if ( strict && !config[to] ) throw new Error(message(to));
-  return value * (config[from]?.conversion ?? 1) / (config[to]?.conversion ?? 1);
+  if ( strict && to && !config[to] ) throw new Error(message(to));
+
+  // If measurement system is provided and no target unit, convert to equivalent unit in other measurement system
+  if ( !to && type ) {
+    if ( !_measurementSystemConversionCache[from] ) {
+      const baseConversion = config[from]?.conversion ?? 1;
+      const unitOptions = Object.entries(config)
+        .reduce((arr, [key, v]) => {
+          if ( type === v.type ) arr.push({ key, difference: Math.abs(((v.conversion ?? 1) / baseConversion) - 1) });
+          return arr;
+        }, [])
+        .sort((lhs, rhs) => lhs.difference - rhs.difference);
+      to = unitOptions[0]?.key ?? from;
+      _measurementSystemConversionCache[from] = to;
+    }
+    to = _measurementSystemConversionCache[from];
+  }
+
+  // If no target unit available, find largest unit in current measurement system that can represent number
+  else if ( !to ) {
+    const base = value * (config[from]?.conversion ?? 1);
+    const unitOptions = Object.entries(config)
+      .reduce((arr, [key, v]) => {
+        const fits = truncate ? base >= v.conversion : (base % v.conversion === 0) || (base >= v.conversion * 2);
+        if ( fits && (config[from]?.type === v.type) ) arr.push({ key, conversion: v.conversion });
+        return arr;
+      }, [])
+      .sort((lhs, rhs) => rhs.conversion - lhs.conversion);
+    to = unitOptions[0]?.key ?? from;
+  }
+
+  const converted = value * (config[from]?.conversion ?? 1) / (config[to]?.conversion ?? 1);
+  return { value: truncate ? Math.floor(converted) : converted, unit: to };
 }
 
 /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -823,7 +823,7 @@ export function getSceneTargets(actor, { checkBaseActor }={}) {
 export function convertLength(value, from, options={}, _options={}) {
   if ( foundry.utils.getType(options) !== "Object" ) {
     foundry.utils.logCompatibilityWarning(
-      "The `to` parameter for `convertWeight` is now passed in to the options object.",
+      "The `to` parameter for `convertLength` is now passed in to the options object.",
       { since: "DnD5e 6.1", until: "DnD5e 6.3", once: true }
     );
     options = { ..._options, to: options };
@@ -908,47 +908,29 @@ export function convertWeight(value, from, options={}, _options={}) {
 /* -------------------------------------------- */
 
 /**
- * Cache of best unit conversions from one measurement system to another.
- * @type {Record<string, string>}
- */
-const _measurementSystemConversionCache = {};
-
-/**
  * Convert from one unit to another using one of core's built-in unit types.
  * @param {number} value                                Value to display.
  * @param {string} from                                 The initial unit.
- * @param {UnitConfiguration} config                    Configuration data for the unit.
+ * @param {Record<string, UnitConfiguration>} config    Configuration data for the available units.
  * @param {UnitConversionOptions} options
  * @param {function(string): string} [options.message]  Method used to produce the error message if unit not found.
  * @returns {{ value: number, unit: string }}
  */
-export function _convertSystemUnits(value, from, config, { message, strict, to, truncate, type }) {
-  if ( (from === to) || (!to && type && (config[from]?.type === type)) ) return { value, unit: from };
+export function _convertSystemUnits(value, from, config, { message, strict, system, truncate, to }) {
+  if ( (from === to) || (!to && system && (config[from]?.type === system)) ) return { value, unit: from };
   if ( strict && !config[from] ) throw new Error(message(from));
   if ( strict && to && !config[to] ) throw new Error(message(to));
+  if ( !config[from] ) return { value, unit: from ?? to };
 
   // If measurement system is provided and no target unit, convert to equivalent unit in other measurement system
-  if ( !to && type ) {
-    if ( !_measurementSystemConversionCache[from] ) {
-      const baseConversion = config[from]?.conversion ?? 1;
-      const unitOptions = Object.entries(config)
-        .reduce((arr, [key, v]) => {
-          if ( type === v.type ) arr.push({ key, difference: Math.abs(((v.conversion ?? 1) / baseConversion) - 1) });
-          return arr;
-        }, [])
-        .sort((lhs, rhs) => lhs.difference - rhs.difference);
-      to = unitOptions[0]?.key ?? from;
-      _measurementSystemConversionCache[from] = to;
-    }
-    to = _measurementSystemConversionCache[from];
-  }
+  if ( !to && system ) to = preferredUnit(from, { system, units: config });
 
   // If no target unit available, find largest unit in current measurement system that can represent number
   else if ( !to ) {
-    const base = value * (config[from]?.conversion ?? 1);
+    const base = value * (config[from].conversion ?? 1);
     const unitOptions = Object.entries(config)
       .reduce((arr, [key, v]) => {
-        const fits = truncate ? base >= v.conversion : (base % v.conversion === 0) || (base >= v.conversion * 2);
+        const fits = truncate ? base >= v.conversion : ((base % v.conversion === 0) || (base >= v.conversion * 2));
         if ( fits && (config[from]?.type === v.type) ) arr.push({ key, conversion: v.conversion });
         return arr;
       }, [])
@@ -956,7 +938,8 @@ export function _convertSystemUnits(value, from, config, { message, strict, to, 
     to = unitOptions[0]?.key ?? from;
   }
 
-  const converted = value * (config[from]?.conversion ?? 1) / (config[to]?.conversion ?? 1);
+  if ( !config[to] ) return { value, unit: from };
+  const converted = value * (config[from].conversion ?? 1) / (config[to].conversion ?? 1);
   return { value: truncate ? Math.floor(converted) : converted, unit: to };
 }
 
@@ -970,6 +953,48 @@ export function _convertSystemUnits(value, from, config, { message, strict, to, 
 export function defaultUnits(type) {
   const settingKey = type === "travel" ? "metricLengthUnits" : `metric${type.capitalize()}Units`;
   return CONFIG.DND5E.defaultUnits[type]?.[game.settings.get("dnd5e", settingKey) ? "metric" : "imperial"];
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Cache of best unit conversions from one measurement system to another.
+ * @type {Map<string, string>}
+ */
+const _measurementSystemConversionCache = new Map();
+
+/**
+ * Find the preferred unit from the config in the provided measurement system. Must provide either type or units.
+ * @param {string} from                                       Original unit to find closest unit in preferred system.
+ * @param {object} config
+ * @param {string} config.system                              Target measurement system.
+ * @param {string} [config.type]                              Type of unit to select.
+ * @param {Record<string, UnitConfiguration>} [config.units]  Configuration data for the available units.
+ * @returns {string}
+ */
+export function preferredUnit(from, { system, type, units }={}) {
+  if ( !units ) {
+    switch (type) {
+      case "length": units = CONFIG.DND5E.distanceUnits; break;
+      case "speed": units = CONFIG.DND5E.travelUnits; break;
+      case "time": units = CONFIG.DND5E.timeUnits; break;
+      case "weight": units = CONFIG.DND5E.weightUnits; break;
+    }
+  }
+
+  if ( !_measurementSystemConversionCache.has(from) ) {
+    const baseConversion = Math.log10(units[from].conversion ?? 1);
+    const unitOptions = Object.entries(units)
+      .reduce((arr, [key, v]) => {
+        if ( system === v.type ) {
+          arr.push({ key, difference: Math.abs(Math.log10(v.conversion ?? 1) - baseConversion) });
+        }
+        return arr;
+      }, [])
+      .sort((lhs, rhs) => lhs.difference - rhs.difference);
+    _measurementSystemConversionCache.set(from, unitOptions[0]?.key ?? from);
+  }
+  return _measurementSystemConversionCache.get(from);
 }
 
 /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -688,11 +688,11 @@ export function getSceneTargets(actor) {
 /**
  * @typedef UnitConversionOptions
  * @property {boolean} [strict]  Throw an error if either unit isn't found.
- * @property {string} [to]       The final unit. If neither this nor the unit system is provided then will convert to
- *                               the largest unit that can represent the value as an integer.
- * @property {string} [type]     Target measurement system. If provided without target unit then the value will be
+ * @property {string} [system]   Target measurement system. If provided without target unit then the value will be
  *                               converted to the closest equivalent unit in the specified measurement system
  *                               (e.g. "mi" > "km").
+ * @property {string} [to]       The final unit. If neither this nor the unit system is provided then will convert to
+ *                               the largest unit that can represent the value as an integer.
  */
 
 /**
@@ -707,7 +707,7 @@ export function getSceneTargets(actor) {
 export function convertLength(value, from, options={}, _options={}) {
   if ( foundry.utils.getType(options) !== "Object" ) {
     foundry.utils.logCompatibilityWarning(
-      "The `to` parameter for `convertWeight` is now passed in to the options object.",
+      "The `to` parameter for `convertLength` is now passed in to the options object.",
       { since: "DnD5e 5.1", until: "DnD5e 5.3", once: true }
     );
     options = { ..._options, to: options };
@@ -794,47 +794,29 @@ export function convertWeight(value, from, options={}, _options={}) {
 /* -------------------------------------------- */
 
 /**
- * Cache of best unit conversions from one measurement system to another.
- * @type {Record<string, string>}
- */
-const _measurementSystemConversionCache = {};
-
-/**
  * Convert from one unit to another using one of core's built-in unit types.
  * @param {number} value                                Value to display.
  * @param {string} from                                 The initial unit.
- * @param {UnitConfiguration} config                    Configuration data for the unit.
+ * @param {Record<string, UnitConfiguration>} config    Configuration data for the available units.
  * @param {UnitConversionOptions} options
  * @param {function(string): string} [options.message]  Method used to produce the error message if unit not found.
  * @returns {{ value: number, unit: string }}
  */
-export function _convertSystemUnits(value, from, config, { message, strict, to, type }) {
-  if ( (from === to) || (!to && type && (config[from]?.type === type)) ) return { value, unit: from };
+export function _convertSystemUnits(value, from, config, { message, strict, system, to }) {
+  if ( (from === to) || (!to && system && (config[from]?.type === system)) ) return { value, unit: from };
   if ( strict && !config[from] ) throw new Error(message(from));
   if ( strict && to && !config[to] ) throw new Error(message(to));
+  if ( !config[from] ) return { value, unit: from ?? to };
 
   // If measurement system is provided and no target unit, convert to equivalent unit in other measurement system
-  if ( !to && type ) {
-    if ( !_measurementSystemConversionCache[from] ) {
-      const baseConversion = config[from]?.conversion ?? 1;
-      const unitOptions = Object.entries(config)
-        .reduce((arr, [key, v]) => {
-          if ( type === v.type ) arr.push({ key, difference: Math.abs(((v.conversion ?? 1) / baseConversion) - 1) });
-          return arr;
-        }, [])
-        .sort((lhs, rhs) => lhs.difference - rhs.difference);
-      to = unitOptions[0]?.key ?? from;
-      _measurementSystemConversionCache[from] = to;
-    }
-    to = _measurementSystemConversionCache[from];
-  }
+  if ( !to && system ) to = preferredUnit(from, { system, units: config });
 
   // If no target unit available, find largest unit in current measurement system that can represent number
   else if ( !to ) {
-    const base = value * (config[from]?.conversion ?? 1);
+    const base = value * (config[from].conversion ?? 1);
     const unitOptions = Object.entries(config)
       .reduce((arr, [key, v]) => {
-        if ( ((base % v.conversion === 0) || (base >= v.conversion * 2)) && (config[from]?.type === v.type) ) {
+        if ( ((base % v.conversion === 0) || (base >= v.conversion * 2)) && (config[from].type === v.type) ) {
           arr.push({ key, conversion: v.conversion });
         }
         return arr;
@@ -843,7 +825,8 @@ export function _convertSystemUnits(value, from, config, { message, strict, to, 
     to = unitOptions[0]?.key ?? from;
   }
 
-  return { value: value * (config[from]?.conversion ?? 1) / (config[to]?.conversion ?? 1), unit: to };
+  if ( !config[to] ) return { value, unit: from };
+  return { value: value * (config[from].conversion ?? 1) / (config[to]?.conversion ?? 1), unit: to };
 }
 
 /* -------------------------------------------- */
@@ -856,6 +839,46 @@ export function _convertSystemUnits(value, from, config, { message, strict, to, 
 export function defaultUnits(type) {
   const settingKey = type === "travel" ? "metricLengthUnits" : `metric${type.capitalize()}Units`;
   return CONFIG.DND5E.defaultUnits[type]?.[game.settings.get("dnd5e", settingKey) ? "metric" : "imperial"];
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Cache of best unit conversions from one measurement system to another.
+ * @type {Map<string, string>}
+ */
+const _measurementSystemConversionCache = new Map();
+
+/**
+ * Find the preferred unit from the config in the provided measurement system. Must provide either type or units.
+ * @param {string} from                                       Original unit to find closest unit in preferred system.
+ * @param {object} config
+ * @param {string} config.system                              Target measurement system.
+ * @param {string} [config.type]                              Type of unit to select.
+ * @param {Record<string, UnitConfiguration>} [config.units]  Configuration data for the available units.
+ * @returns {string}
+ */
+export function preferredUnit(from, { system, type, units }={}) {
+  if ( !units ) {
+    switch (type) {
+      case "length": units = CONFIG.DND5E.distanceUnits; break;
+      case "weight": units = CONFIG.DND5E.weightUnits; break;
+    }
+  }
+
+  if ( !_measurementSystemConversionCache.has(from) ) {
+    const baseConversion = Math.log10(units[from].conversion ?? 1);
+    const unitOptions = Object.entries(units)
+      .reduce((arr, [key, v]) => {
+        if ( system === v.type ) {
+          arr.push({ key, difference: Math.abs(Math.log10(v.conversion ?? 1) - baseConversion) });
+        }
+        return arr;
+      }, [])
+      .sort((lhs, rhs) => lhs.difference - rhs.difference);
+    _measurementSystemConversionCache.set(from, unitOptions[0]?.key ?? from);
+  }
+  return _measurementSystemConversionCache.get(from);
 }
 
 /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -686,17 +686,43 @@ export function getSceneTargets(actor) {
 /* -------------------------------------------- */
 
 /**
- * Convert the provided length to another unit.
- * @param {number} value                   The length being converted.
- * @param {string} from                    The initial units.
- * @param {string} to                      The final units.
- * @param {object} [options={}]
- * @param {boolean} [options.strict=true]  Throw an error if either unit isn't found.
- * @returns {number}
+ * @typedef UnitConversionOptions
+ * @property {boolean} [strict]  Throw an error if either unit isn't found.
+ * @property {string} [to]       The final unit. If neither this nor the unit system is provided then will convert to
+ *                               the largest unit that can represent the value as an integer.
+ * @property {string} [type]     Target measurement system. If provided without target unit then the value will be
+ *                               converted to the closest equivalent unit in the specified measurement system
+ *                               (e.g. "mi" > "km").
  */
-export function convertLength(value, from, to, { strict=true }={}) {
+
+/**
+ * Convert the provided length to another unit.
+ * @param {number} value                    The length being converted.
+ * @param {string} from                     The initial unit as defined in `CONFIG.DND5E.movementUnits`.
+ * @param {UnitConversionOptions} [options={}]
+ * @param {boolean} [options.legacy=true]   Only return converted value rather than value and units.
+ * @param {object} [_options]
+ * @returns {{ value: number, unit: string }|number}
+ */
+export function convertLength(value, from, options={}, _options={}) {
+  if ( foundry.utils.getType(options) !== "Object" ) {
+    foundry.utils.logCompatibilityWarning(
+      "The `to` parameter for `convertWeight` is now passed in to the options object.",
+      { since: "DnD5e 5.1", until: "DnD5e 5.3", once: true }
+    );
+    options = { ..._options, to: options };
+  }
+
   const message = unit => `Length unit ${unit} not defined in CONFIG.DND5E.movementUnits`;
-  return _convertSystemUnits(value, from, to, CONFIG.DND5E.movementUnits, { message, strict });
+  const result = _convertSystemUnits(value, from, CONFIG.DND5E.movementUnits, { ...options, message });
+  if ( options.legacy !== false ) {
+    foundry.utils.logCompatibilityWarning(
+      "The `convertLength` function has been altered to return value and units. Pass a `legacy` of `false` to the options to return the new value.",
+      { since: "DnD5e 5.1", until: "DnD5e 5.3", once: true }
+    );
+    return result.value;
+  }
+  return result;
 }
 
 /* -------------------------------------------- */
@@ -706,29 +732,15 @@ export function convertLength(value, from, to, { strict=true }={}) {
  * unit that can still represent the value as a whole number.
  * @param {number} value                    The time being converted.
  * @param {string} from                     The initial unit as defined in `CONFIG.DND5E.timeUnits`.
- * @param {object} [options={}]
+ * @param {UnitConversionOptions} [options={}]
  * @param {boolean} [options.combat=false]  Use combat units when auto-selecting units, rather than normal units.
- * @param {boolean} [options.strict=true]   Throw an error if from unit isn't found.
- * @param {string} [options.to]             The final units, if explicitly provided.
  * @returns {{ value: number, unit: string }}
  */
-export function convertTime(value, from, { combat=false, strict=true, to }={}) {
-  const base = value * (CONFIG.DND5E.timeUnits[from]?.conversion ?? 1);
-  if ( !to ) {
-    // Find unit with largest conversion value that can still display the value
-    const unitOptions = Object.entries(CONFIG.DND5E.timeUnits)
-      .reduce((arr, [key, v]) => {
-        if ( ((v.combat ?? false) === combat) && ((base % v.conversion === 0) || (base >= v.conversion * 2)) ) {
-          arr.push({ key, conversion: v.conversion });
-        }
-        return arr;
-      }, [])
-      .sort((lhs, rhs) => rhs.conversion - lhs.conversion);
-    to = unitOptions[0]?.key ?? from;
-  }
-
+export function convertTime(value, from, options={}) {
+  let config = CONFIG.DND5E.timeUnits;
+  if ( !options.combat ) config = Object.fromEntries(Object.entries(config).filter(([, v]) => !v.combat));
   const message = unit => `Time unit ${unit} not defined in CONFIG.DND5E.timeUnits`;
-  return { value: _convertSystemUnits(value, from, to, CONFIG.DND5E.timeUnits, { message, strict }), unit: to };
+  return _convertSystemUnits(value, from, config, { ...options, message });
 }
 
 /* -------------------------------------------- */
@@ -751,36 +763,87 @@ export function convertTravelSpeed(value, from, { strict=false, to }) {
 
 /**
  * Convert the provided weight to another unit.
- * @param {number} value                   The weight being converted.
- * @param {string} from                    The initial unit as defined in `CONFIG.DND5E.weightUnits`.
- * @param {string} to                      The final units.
- * @param {object} [options={}]
- * @param {boolean} [options.strict=true]  Throw an error if either unit isn't found.
- * @returns {number}      Weight in the specified units.
+ * @param {number} value                    The weight being converted.
+ * @param {string} from                     The initial unit as defined in `CONFIG.DND5E.weightUnits`.
+ * @param {UnitConversionOptions} [options={}]
+ * @param {boolean} [options.legacy=true]   Only return converted value rather than value and units.
+ * @param {object} [_options]
+ * @returns {{ value: number, unit: string }|number}
  */
-export function convertWeight(value, from, to, { strict=true }={}) {
+export function convertWeight(value, from, options={}, _options={}) {
+  if ( foundry.utils.getType(options) !== "Object" ) {
+    foundry.utils.logCompatibilityWarning(
+      "The `to` parameter for `convertWeight` is now passed in to the options object.",
+      { since: "DnD5e 5.1", until: "DnD5e 5.3", once: true }
+    );
+    options = { ..._options, to: options };
+  }
+
   const message = unit => `Weight unit ${unit} not defined in CONFIG.DND5E.weightUnits`;
-  return _convertSystemUnits(value, from, to, CONFIG.DND5E.weightUnits, { message, strict });
+  const result = _convertSystemUnits(value, from, CONFIG.DND5E.weightUnits, { ...options, message });
+  if ( options.legacy !== false ) {
+    foundry.utils.logCompatibilityWarning(
+      "The `convertWeight` function has been altered to return value and units. Pass a `legacy` of `false` to the options to return the new value.",
+      { since: "DnD5e 5.1", until: "DnD5e 5.3", once: true }
+    );
+    return result.value;
+  }
+  return result;
 }
 
 /* -------------------------------------------- */
 
 /**
+ * Cache of best unit conversions from one measurement system to another.
+ * @type {Record<string, string>}
+ */
+const _measurementSystemConversionCache = {};
+
+/**
  * Convert from one unit to another using one of core's built-in unit types.
  * @param {number} value                                Value to display.
  * @param {string} from                                 The initial unit.
- * @param {string} to                                   The final unit.
  * @param {UnitConfiguration} config                    Configuration data for the unit.
- * @param {object} options
+ * @param {UnitConversionOptions} options
  * @param {function(string): string} [options.message]  Method used to produce the error message if unit not found.
- * @param {boolean} [options.strict]                    Throw an error if either unit isn't found.
- * @returns {string}
+ * @returns {{ value: number, unit: string }}
  */
-function _convertSystemUnits(value, from, to, config, { message, strict }) {
-  if ( from === to ) return value;
+export function _convertSystemUnits(value, from, config, { message, strict, to, type }) {
+  if ( (from === to) || (!to && type && (config[from]?.type === type)) ) return { value, unit: from };
   if ( strict && !config[from] ) throw new Error(message(from));
-  if ( strict && !config[to] ) throw new Error(message(to));
-  return value * (config[from]?.conversion ?? 1) / (config[to]?.conversion ?? 1);
+  if ( strict && to && !config[to] ) throw new Error(message(to));
+
+  // If measurement system is provided and no target unit, convert to equivalent unit in other measurement system
+  if ( !to && type ) {
+    if ( !_measurementSystemConversionCache[from] ) {
+      const baseConversion = config[from]?.conversion ?? 1;
+      const unitOptions = Object.entries(config)
+        .reduce((arr, [key, v]) => {
+          if ( type === v.type ) arr.push({ key, difference: Math.abs(((v.conversion ?? 1) / baseConversion) - 1) });
+          return arr;
+        }, [])
+        .sort((lhs, rhs) => lhs.difference - rhs.difference);
+      to = unitOptions[0]?.key ?? from;
+      _measurementSystemConversionCache[from] = to;
+    }
+    to = _measurementSystemConversionCache[from];
+  }
+
+  // If no target unit available, find largest unit in current measurement system that can represent number
+  else if ( !to ) {
+    const base = value * (config[from]?.conversion ?? 1);
+    const unitOptions = Object.entries(config)
+      .reduce((arr, [key, v]) => {
+        if ( ((base % v.conversion === 0) || (base >= v.conversion * 2)) && (config[from]?.type === v.type) ) {
+          arr.push({ key, conversion: v.conversion });
+        }
+        return arr;
+      }, [])
+      .sort((lhs, rhs) => rhs.conversion - lhs.conversion);
+    to = unitOptions[0]?.key ?? from;
+  }
+
+  return { value: value * (config[from]?.conversion ?? 1) / (config[to]?.conversion ?? 1), unit: to };
 }
 
 /* -------------------------------------------- */


### PR DESCRIPTION
Extends `convertLength` and `convertWeight` to support automatic target unit selection similar to `convertTime`, and adds the ability for all three of those methods to automatically select the equivalent unit in another measurement system (e.g. mi => km).

This change is then used during item preparation to automatically convert item weights into the proper measurement system depending on the "Use Metric Weight Units" option. Since this is done at data preparation rather than sheet rendering, this setting now requires a restart.

 ### Todo
- [ ] Automatically convert length units