### PR TITLE
[#5746] Make initial value of `source.rules` on items/actors respect current `rulesVersion` setting

### DIFF
--- a/module/data/shared/source-field.mjs
+++ b/module/data/shared/source-field.mjs
@@ -21,7 +21,9 @@ export default class SourceField extends SchemaField {
       custom: new StringField(),
       license: new StringField(),
       revision: new NumberField({ initial: 1 }),
-      rules: new StringField({ initial: "2024" }),
+      rules: new StringField({
+        initial: () => game.settings.get("dnd5e", "rulesVersion") === "modern" ? "2024" : "2014"
+      }),
       ...fields
     };
     Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);


### PR DESCRIPTION
Closes #5746 
Changing `SourceField`'s `rules`'s `initial` to a function rather than string should accomplish this.