### PR TITLE
[#5744] If `type` is provided to `Item5e.createDialog`, pre-select that type in the creation dialog

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1535,7 +1535,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const title = game.i18n.format("DOCUMENT.Create", { type: label });
     const name = data.name || game.i18n.format("DOCUMENT.New", { type: label });
     let type = data.type || CONFIG[this.documentName]?.defaultType;
-    if ( !types.includes(type) ) type = types[0];
     const content = await foundry.applications.handlebars.renderTemplate(
       "systems/dnd5e/templates/apps/document-create.hbs",
       {

--- a/templates/apps/document-create.hbs
+++ b/templates/apps/document-create.hbs
@@ -19,7 +19,8 @@
                 <img src="{{ icon }}" alt="{{ label }}">
                 {{/if}}
                 <span>{{ label }}</span>
-                <input type="radio" name="type" value="{{ type }}" required {{ disabled disabled }}>
+                <input type="radio" name="type" value="{{ type }}" required {{checked (eq type ../type)}}
+                       {{ disabled disabled }}>
             </label>
         </li>
         {{/each}}


### PR DESCRIPTION
Closes #5744 
Added a check in the hbs to appropriately check the radio input. Also remove a line which set a type by default, as that doesn't seem to be necessary/useful now. Otherwise would always default to having some radio checked, if that's desired.