### PR TITLE
[#5740] Disable Compendium Browser's Submit button if fewer than min/more than max documents are selected

### DIFF
--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -481,11 +481,16 @@ export default class CompendiumBrowser extends Application5e {
     const { max, min } = this.options.selection;
 
     context.displaySelection = this.displaySelection;
-    context.invalid = (value < (min || -Infinity)) || (value > (max || Infinity)) ? "invalid" : "";
+    context.invalid = (value < (min || -Infinity)) || (value > (max || Infinity));
     const suffix = this.#selectionLocalizationSuffix;
     context.summary = suffix ? game.i18n.format(
       `DND5E.CompendiumBrowser.Selection.Summary.${suffix}`, { max, min, value }
     ) : value;
+    const pr = new Intl.PluralRules(game.i18n.lang);
+    context.invalidTooltip = game.i18n.format(`DND5E.CompendiumBrowser.Selection.Warning.${suffix}`, {
+      max, min, value,
+      document: game.i18n.localize(`DND5E.CompendiumBrowser.Selection.Warning.Document.${pr.select(max || min)}`)
+    });
     return context;
   }
 

--- a/templates/compendium/browser-footer.hbs
+++ b/templates/compendium/browser-footer.hbs
@@ -1,9 +1,9 @@
 <div class="flexrow">
     {{~#if displaySelection}}
-    <div class="count {{ invalid }}">
+    <div class="count {{#if invalid}}invalid {{/if}}">
         {{{ localize "DND5E.CompendiumBrowser.Selection.Label" summary=summary }}}
     </div>
-    <button type="submit">
+    <button type="submit"{{#if invalid}} disabled data-tooltip aria-label="{{invalidTooltip}}" {{/if}}>
         {{ localize "DND5E.CompendiumBrowser.Selection.Select" }}
     </button>
     {{/if~}}


### PR DESCRIPTION
Closes #5740 
Made `invalid` a boolean instead of a string, since now it's being checked in a second spot and `{{#if (eq invalid "invalid")}}` felt wrong.
Can _probably_ get rid of most of `#onHandleSubmit`, since it shouldn't be possible to trigger that at a time when it'd throw an error, but left it in for now just in case.