### PR TITLE
[#5680] Ensure `config.isCritical` matches `isCritical`s of roll options for damage rolls

### DIFF
--- a/module/applications/dice/damage-configuration-dialog.mjs
+++ b/module/applications/dice/damage-configuration-dialog.mjs
@@ -81,8 +81,10 @@ export default class DamageRollConfigurationDialog extends RollConfigurationDial
 
   /** @override */
   _finalizeRolls(action) {
+    const isCritical = action === "critical";
+    this.config.isCritical = isCritical;
     return this.rolls.map(roll => {
-      roll.options.isCritical = action === "critical";
+      roll.options.isCritical = isCritical;
       roll.configureDamage({ critical: this.config.critical });
       return roll;
     });

--- a/module/applications/dice/damage-configuration-dialog.mjs
+++ b/module/applications/dice/damage-configuration-dialog.mjs
@@ -81,10 +81,9 @@ export default class DamageRollConfigurationDialog extends RollConfigurationDial
 
   /** @override */
   _finalizeRolls(action) {
-    const isCritical = action === "critical";
-    this.config.isCritical = isCritical;
+    this.config.isCritical = action === "critical";
     return this.rolls.map(roll => {
-      roll.options.isCritical = isCritical;
+      roll.options.isCritical = this.config.isCritical;
       roll.configureDamage({ critical: this.config.critical });
       return roll;
     });

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -106,9 +106,11 @@ export default class DamageRoll extends BasicRoll {
     dialog.configure ??= Object.values(keys).every(k => !k);
 
     // Determine critical mode
+    config.isCritical ||= keys.critical;
+    config.isCritical &&= !keys.normal;
     for ( const roll of config.rolls ) {
       roll.options ??= {};
-      roll.options.isCritical ??= (config.isCritical || keys.critical) && !keys.normal;
+      roll.options.isCritical ??= config.isCritical;
     }
   }
 


### PR DESCRIPTION
Closes #5680 
Modify `config.isCritical` in two places:
1. `DamageRoll.applyKeybindings`: If advantage key held, `config.isCritical` is `true`, but if disadvantage key held, it's `false`
2. `DamageRollConfigurationDialog#_finalizeRolls`: If critical is clicked, `config.isCritical` is `true`, otherwise it's `false`
This ensures regardless of fast-forwarding, `config.isCritical` will always be accurate by the time it's passed in the `dnd5e.postRollConfiguration` hook