### PR TITLE
[#5507] Include `isDelta` in passed `options `for `dnd5e.preApplyDamage` and `dnd5e.applyDamage` hooks

### DIFF
--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -277,7 +277,7 @@ export default class DamageApplicationElement extends TargetedApplicationMixin(C
     for ( const target of this.targetList.querySelectorAll("[data-target-uuid]") ) {
       const token = fromUuidSync(target.dataset.targetUuid);
       const options = this.getTargetOptions(target.dataset.targetUuid);
-      await token?.applyDamage(this.damages, options);
+      await token?.applyDamage(this.damages, { ...options, isDelta: true });
     }
     this.open = false;
   }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -665,7 +665,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( attribute === "attributes.hp" ) {
       const hp = this.system.attributes.hp;
       const delta = isDelta ? (-1 * value) : (hp.value + hp.temp) - value;
-      return this.applyDamage(delta);
+      return this.applyDamage(delta, { isDelta });
     } else if ( attribute.startsWith(".") ) {
       const item = fromUuidSync(attribute, { relative: this });
       let newValue = item?.system.uses?.value ?? 0;
@@ -711,6 +711,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @property {boolean|Set<string>} [ignore.modification]   Should this actor's damage modification be ignored?
    * @property {boolean} [invertHealing=true]  Automatically invert healing types to it heals, rather than damages.
    * @property {"damage"|"healing"} [only]     Apply only damage or healing parts. Untyped rolls will always be applied.
+   * @property {boolean} [isDelta]             Whether the damage is coming from a relative change.
    */
 
   /**

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -830,7 +830,7 @@ export default class ChatMessage5e extends ChatMessage {
       properties: new Set(roll.options.properties ?? [])
     }));
     return Promise.all(canvas.tokens.controlled.map(t => {
-      return t.actor?.applyDamage(damages, { multiplier });
+      return t.actor?.applyDamage(damages, { multiplier, isDelta: true });
     }));
   }
 


### PR DESCRIPTION
Closes #5507 
For damage tray or chat card context menu applications, `isDelta` is always `true`. Otherwise, pass along the existing value.