### PR TITLE
[#933] Add special field to actor movement

### DIFF
--- a/less/v1/apps.less
+++ b/less/v1/apps.less
@@ -651,7 +651,7 @@ h5 {
     + .row { margin-top: 4px; }
     .value { font-weight: bold; }
     .label { flex: 1; }
-    .units {
+    .units, .unit {
       opacity: .6;
       font-weight: normal;
     }

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -354,15 +354,18 @@ export default class NPCActorSheet extends BaseActorSheet {
     context.tools = this._prepareSkillsTools(context, "tools");
 
     // Speed
-    context.speed = Object.entries(CONFIG.DND5E.movementTypes).map(([k, label]) => {
-      const value = attributes.movement[k];
-      if ( !value ) return null;
-      const data = { label, value };
-      if ( (k === "fly") && attributes.movement.hover ) data.icons = [{
-        icon: "fas fa-cloud", label: game.i18n.localize("DND5E.MovementHover")
-      }];
-      return data;
-    }).filter(_ => _);
+    context.speed = [
+      ...Object.entries(CONFIG.DND5E.movementTypes).map(([k, label]) => {
+        const value = attributes.movement[k];
+        if ( !value ) return null;
+        const data = { label, value };
+        if ( (k === "fly") && attributes.movement.hover ) data.icons = [{
+          icon: "fas fa-cloud", label: game.i18n.localize("DND5E.MovementHover")
+        }];
+        return data;
+      }),
+      ...splitSemicolons(attributes.movement.special).map(label => ({ label }))
+    ].filter(_ => _);
 
     // Traits
     context.traits = this._prepareTraits(context);

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -600,6 +600,23 @@ export default class NPCData extends CreatureTemplate {
       ...splitSemicolons(custom ?? "")
     ].sort((lhs, rhs) => lhs.localeCompare(rhs, game.i18n.lang)));
 
+    const prepareSpeed = () => {
+      const standard = formatter.format([
+        prepareMeasured(this.attributes.movement.walk, this.attributes.movement.units),
+        ...Object.entries(CONFIG.DND5E.movementTypes)
+          .filter(([k]) => this.attributes.movement[k] && (k !== "walk"))
+          .map(([k, label]) => {
+            let prepared = prepareMeasured(this.attributes.movement[k], this.attributes.movement.units, label);
+            if ( (k === "fly") && this.attributes.movement.hover ) {
+              prepared = `${prepared} (${game.i18n.localize("DND5E.MovementHover").toLowerCase()})`;
+            }
+            return prepared;
+          })
+      ]);
+      const custom = formatter.format(splitSemicolons(this.attributes.movement.special));
+      return custom ? `${standard} (${custom})` : standard;
+    };
+
     const context = {
       abilityTables: Array.fromRange(3).map(_ => ({ abilities: [] })),
       actionSections: {
@@ -670,18 +687,7 @@ export default class NPCData extends CreatureTemplate {
         ),
 
         // Speed (e.g. `40 ft., Burrow 40 ft., Fly 80 ft.`)
-        speed: formatter.format([
-          prepareMeasured(this.attributes.movement.walk, this.attributes.movement.units),
-          ...Object.entries(CONFIG.DND5E.movementTypes)
-            .filter(([k]) => this.attributes.movement[k] && (k !== "walk"))
-            .map(([k, label]) => {
-              let prepared = prepareMeasured(this.attributes.movement[k], this.attributes.movement.units, label);
-              if ( (k === "fly") && this.attributes.movement.hover ) {
-                prepared = `${prepared} (${game.i18n.localize("DND5E.MovementHover").toLowerCase()})`;
-              }
-              return prepared;
-            })
-        ]),
+        speed: prepareSpeed(),
 
         // Tag (e.g. `Gargantuan Dragon, Lawful Evil`)
         tag: game.i18n.format("DND5E.CreatureTag", {

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -31,7 +31,7 @@ export default class RaceData extends ItemDataModel.mixin(ItemDescriptionTemplat
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
       advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" }),
-      movement: new MovementField({}, { initialUnits: defaultUnits("length") }),
+      movement: new MovementField({ special: false }, { initialUnits: defaultUnits("length") }),
       senses: new SensesField({}, { initialUnits: defaultUnits("length") }),
       type: new CreatureTypeField({ swarm: false }, { initial: { value: "humanoid" } })
     });

--- a/module/data/shared/movement-field.mjs
+++ b/module/data/shared/movement-field.mjs
@@ -2,13 +2,14 @@ const { BooleanField, NumberField, StringField } = foundry.data.fields;
 
 /**
  * @typedef {object} MovementData
- * @property {number} burrow  Actor burrowing speed.
- * @property {number} climb   Actor climbing speed.
- * @property {number} fly     Actor flying speed.
- * @property {number} swim    Actor swimming speed.
- * @property {number} walk    Actor walking speed.
- * @property {string} units   Movement used to measure the various speeds.
- * @property {boolean} hover  This flying creature able to hover in place.
+ * @property {number} burrow   Actor burrowing speed.
+ * @property {number} climb    Actor climbing speed.
+ * @property {number} fly      Actor flying speed.
+ * @property {number} swim     Actor swimming speed.
+ * @property {number} walk     Actor walking speed.
+ * @property {string} special  Semi-colon separated list of special movement information.
+ * @property {string} units    Movement used to measure the various speeds.
+ * @property {boolean} hover   This flying creature able to hover in place.
  */
 
 /**
@@ -23,6 +24,7 @@ export default class MovementField extends foundry.data.fields.SchemaField {
       fly: new NumberField({ ...numberConfig, label: "DND5E.MovementFly" }),
       swim: new NumberField({ ...numberConfig, label: "DND5E.MovementSwim" }),
       walk: new NumberField({ ...numberConfig, label: "DND5E.MovementWalk" }),
+      special: new StringField(),
       units: new StringField({
         required: true, nullable: true, blank: false, initial: initialUnits, label: "DND5E.MovementUnits"
       }),

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -6,7 +6,9 @@ import ActivationsField from "../../data/chat-message/fields/activations-field.m
 import { ActorDeltasField } from "../../data/chat-message/fields/deltas-field.mjs";
 import TransformationSetting from "../../data/settings/transformation-setting.mjs";
 import { createRollLabel } from "../../enrichers.mjs";
-import { convertTime, defaultUnits, formatNumber, formatTime, simplifyBonus, staticID } from "../../utils.mjs";
+import {
+  convertTime, defaultUnits, formatLength, formatNumber, formatTime, simplifyBonus, staticID
+} from "../../utils.mjs";
 import ActiveEffect5e from "../active-effect.mjs";
 import Item5e from "../item.mjs";
 import SystemDocumentMixin from "../mixins/document.mjs";
@@ -2540,12 +2542,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   _prepareMovementAttribution() {
     const { movement } = this.system.attributes;
     const units = movement.units || defaultUnits("length");
+    const unit = CONFIG.DND5E.movementUnits[units]?.formattingUnit;
+    const formatValue = value => `<span class="value">${
+      unit ? formatLength(value ?? 0, unit, { parts: true })
+        : `${value ?? 0} <span class="units">${units}</span>`
+    }</span>`;
     return Object.entries(CONFIG.DND5E.movementTypes).reduce((html, [k, label]) => {
       const value = movement[k];
       if ( value || (k === "walk") ) html += `
         <div class="row">
           <i class="fas ${k}"></i>
-          <span class="value">${value ?? 0} <span class="units">${units}</span></span>
+          ${formatValue(value)}
           <span class="label">${label}</span>
         </div>
       `;


### PR DESCRIPTION
Adds a semi-colon separrated special movement field to actor movement data for one-off values.

Also adds a small change to the movement attribution tooltip to use proper unit localization.

Closes #933