### PR TITLE
[#5736] Add separate ability maximum to ability score advancement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -314,24 +314,28 @@
     },
     "FIELDS": {
       "cap": {
-        "label": "Point Cap",
-        "hint": "Maximum number of points a player can assign to a single score."
+        "hint": "Maximum number of points a player can assign to a single score.",
+        "label": "Point Cap"
+      },
+      "fixed": {
+        "hint": "Abilities that are improved by a fixed amount and cannot be manually improved during the process.",
+        "label": "Fixed Improvement"
       },
       "locked": {
-        "label": "Locked",
         "hint": "Ability cannot be improved.",
+        "label": "Locked",
         "locked": "Ability cannot be improved.",
         "unlocked": "Ability may be improved."
       },
-      "fixed": {
-        "label": "Fixed Improvement",
-        "hint": "Abilities that are improved by a fixed amount and cannot be manually improved during the process."
+      "max": {
+        "hint": "Increase the maximum score from what is allowed on the actor.",
+        "label": "Maximum"
       },
       "points": {
-        "label": "Points",
-        "hint": "Number of points that can be assigned to any unlocked ability score.",
         "decrease": "Decrease Points",
-        "increase": "Increase Points"
+        "hint": "Number of points that can be assigned to any unlocked ability score.",
+        "increase": "Increase Points",
+        "label": "Points"
       }
     },
     "Hint": "Allow the player to increase one or more ability scores or take an optional feat.",

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -69,9 +69,10 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
       const assignment = this.assignments[key] ?? 0;
       const fixed = this.advancement.configuration.fixed[key] ?? 0;
       const locked = this.advancement.configuration.locked.has(key);
-      const value = Math.min(ability.value + fixed + assignment, ability.max);
-      const max = locked ? value : Math.min(value + points.available, ability.max);
-      const min = Math.min(ability.value + fixed, ability.max);
+      const abilityMax = Math.max(ability.max, this.advancement.configuration.max ?? -Infinity);
+      const value = Math.min(ability.value + fixed + assignment, abilityMax);
+      const max = locked ? value : Math.min(value + points.available, abilityMax);
+      const min = Math.min(ability.value + fixed, abilityMax);
       obj[key] = {
         key, max, min, value,
         name: `abilities.${key}`,
@@ -80,7 +81,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
         delta: (value - ability.value) ? formatter.format(value - ability.value) : null,
         showDelta: true,
         isDisabled: lockImprovement,
-        isLocked: !!locked || (ability.value >= ability.max),
+        isLocked: !!locked || (ability.value >= abilityMax),
         canIncrease: (value < max) && ((fixed + assignment) < points.cap) && !locked && !lockImprovement,
         canDecrease: (value > (ability.value + fixed)) && !locked && !lockImprovement
       };

--- a/module/data/advancement/ability-score-improvement.mjs
+++ b/module/data/advancement/ability-score-improvement.mjs
@@ -7,8 +7,9 @@ const { NumberField, SetField, StringField } = foundry.data.fields;
  * Data model for the Ability Score Improvement advancement configuration.
  *
  * @property {number} cap                    Maximum number of points that can be assigned to a single score.
- * @property {Set<string>} locked            Abilities that cannot be changed by this advancement.
  * @property {Object<string, number>} fixed  Number of points automatically assigned to a certain score.
+ * @property {Set<string>} locked            Abilities that cannot be changed by this advancement.
+ * @property {number} max                    Override for the maximum ability score.
  * @property {number} points                 Number of points that can be assigned to any score.
  */
 export class AbilityScoreImprovementConfigurationData extends foundry.abstract.DataModel {
@@ -24,6 +25,7 @@ export class AbilityScoreImprovementConfigurationData extends foundry.abstract.D
       cap: new NumberField({ integer: true, min: 1, initial: 2 }),
       fixed: new MappingField(new NumberField({ nullable: false, integer: true, initial: 0 })),
       locked: new SetField(new StringField()),
+      max: new NumberField({ integer: true, min: 1 }),
       points: new NumberField({ integer: true, min: 0, initial: 0 })
     };
   }

--- a/module/documents/advancement/ability-score-improvement.mjs
+++ b/module/documents/advancement/ability-score-improvement.mjs
@@ -147,7 +147,8 @@ export default class AbilityScoreImprovementAdvancement extends Advancement {
         const ability = this.actor.system.abilities[key];
         const source = this.actor.system.toObject().abilities[key] ?? {};
         if ( !ability || !this.canImprove(key) ) continue;
-        assignments[key] = Math.min(assignments[key], ability.max - source.value);
+        const max = Math.max(ability.max, this.configuration.max ?? -Infinity);
+        assignments[key] = Math.min(assignments[key], max - source.value);
         if ( assignments[key] ) updates[`system.abilities.${key}.value`] = source.value + assignments[key];
         else delete assignments[key];
       }

--- a/packs/_source/feats24/epic-boon-feats/boon-of-combat-prowess.yml
+++ b/packs/_source/feats24/epic-boon-feats/boon-of-combat-prowess.yml
@@ -43,6 +43,7 @@ system:
           cha: 0
         locked: []
         points: 1
+        max: 30
       value:
         type: asi
       level: 0
@@ -63,11 +64,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.345'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.0
   createdTime: 1735865940774
-  modifiedTime: 1745256779807
+  modifiedTime: 1751410940615
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbBoonofCombatP'

--- a/packs/_source/feats24/epic-boon-feats/boon-of-dimensional-travel.yml
+++ b/packs/_source/feats24/epic-boon-feats/boon-of-dimensional-travel.yml
@@ -91,6 +91,7 @@ system:
           cha: 0
         locked: []
         points: 1
+        max: 30
       value:
         type: asi
       level: 0
@@ -111,11 +112,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.345'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.0
   createdTime: 1735865940774
-  modifiedTime: 1745256779887
+  modifiedTime: 1751410946432
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbBoonofDimensi'

--- a/packs/_source/feats24/epic-boon-feats/boon-of-fate.yml
+++ b/packs/_source/feats24/epic-boon-feats/boon-of-fate.yml
@@ -106,6 +106,7 @@ system:
           cha: 0
         locked: []
         points: 1
+        max: 30
       value:
         type: asi
       level: 0
@@ -126,11 +127,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.345'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.0
   createdTime: 1735865940774
-  modifiedTime: 1745256780034
+  modifiedTime: 1751410951759
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbBoonofFate000'

--- a/packs/_source/feats24/epic-boon-feats/boon-of-irresistible-offense.yml
+++ b/packs/_source/feats24/epic-boon-feats/boon-of-irresistible-offense.yml
@@ -53,6 +53,7 @@ system:
           - wis
           - cha
         points: 1
+        max: 30
       value:
         type: asi
       level: 0
@@ -73,11 +74,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.345'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.0
   createdTime: 1735865940774
-  modifiedTime: 1745256780098
+  modifiedTime: 1751410957023
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbBoonofIrresis'

--- a/packs/_source/feats24/epic-boon-feats/boon-of-spell-recall.yml
+++ b/packs/_source/feats24/epic-boon-feats/boon-of-spell-recall.yml
@@ -98,6 +98,7 @@ system:
           - dex
           - con
         points: 1
+        max: 30
       value:
         type: asi
       level: 0
@@ -113,11 +114,11 @@ folder: 7zo2bljGLQY3uwXI
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.345'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.0
   createdTime: 1745522919901
-  modifiedTime: 1745712692794
+  modifiedTime: 1751410962420
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/feats24/epic-boon-feats/boon-of-the-night-spirit.yml
+++ b/packs/_source/feats24/epic-boon-feats/boon-of-the-night-spirit.yml
@@ -100,6 +100,7 @@ system:
           cha: 0
         locked: []
         points: 1
+        max: 30
       value:
         type: asi
       level: 0
@@ -231,11 +232,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.345'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.0
   createdTime: 1735865940774
-  modifiedTime: 1745256780197
+  modifiedTime: 1751410971090
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbBoonoftheNigh'

--- a/packs/_source/feats24/epic-boon-feats/boon-of-truesight.yml
+++ b/packs/_source/feats24/epic-boon-feats/boon-of-truesight.yml
@@ -45,6 +45,7 @@ system:
           cha: 0
         locked: []
         points: 1
+        max: 30
       value:
         type: asi
       level: 0
@@ -102,11 +103,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.345'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.0
   createdTime: 1735865940774
-  modifiedTime: 1745256780148
+  modifiedTime: 1751410977677
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbBoonofTruesig'

--- a/templates/advancement/ability-score-improvement-config-details.hbs
+++ b/templates/advancement/ability-score-improvement-config-details.hbs
@@ -2,4 +2,6 @@
     <legend>{{ localize "DND5E.ADVANCEMENT.AbilityScoreImprovement.Details" }}</legend>
     {{ formField configuration.fields.cap name="configuration.cap" value=configuration.data.cap
                  placeholder=(localize "None") rootId=partId }}
+    {{ formField configuration.fields.max name="configuration.max" value=configuration.data.max
+                 rootId=partId }}
 </fieldset>


### PR DESCRIPTION
Adds a maximum field to the ability score improvement advancement to allow for specifying a higher maximum then is allowed by the actor.

Closes #5736