### PR TITLE
[#5300] Add feature prerequisites on other items

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -347,7 +347,6 @@
     },
     "Title": "Ability Score Improvement",
     "Warning": {
-      "Level": "Must be at least level {level} to take this feat.",
       "Type": "Only features with the \"feat\" type can be selected."
     }
   },
@@ -433,10 +432,8 @@
     },
     "Title": "Choose Items",
     "Warning": {
-      "FeatureLevel": "Must be at least level {level} to take this feature.",
       "InvalidType": "Only {type} items can be selected for this choice.",
       "NoOriginal": "Previously selected choice no longer available for replacement.",
-      "PreviouslyChosen": "This item has already been chosen at a previous level.",
       "SpellLevelAvailable": "Only {level} or lower spells can be chosen for this advancement.",
       "SpellLevelSpecific": "Only {level} spells can be chosen for this advancement.",
       "SpellList": "Only spells available on the {lists} spell list can be chosen for this advancement."
@@ -3008,16 +3005,26 @@
   "Header": "Feature Prerequisites",
   "FIELDS": {
     "prerequisites": {
+      "items": {
+        "hint": "Identifiers for items that the character must have before selecting this item.",
+        "label": "Required Items"
+      },
       "label": "Prerequisites",
       "level": {
-        "label": "Required Level",
-        "hint": "Character or class level required to select this feature when levelling up."
+        "hint": "Character or class level required to select this feature when levelling up.",
+        "label": "Required Level"
       },
       "repeatable": {
         "hint": "This feature can be chosen more than once.",
         "label": "Repeatable"
       }
     }
+  },
+  "Warning": {
+    "InvalidLevel": "must be at least level {level}",
+    "Message": "{actor} {requirements} in order to take this {type}.",
+    "MissingItem": "must have previously taken {items}",
+    "NotRepeatable": "must not have taken this before"
   }
 },
 "DND5E.Price": "Price",

--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -109,6 +109,7 @@ export default class ItemDataModel extends SystemDataModel {
   /** @inheritDoc */
   prepareBaseData() {
     if ( this.parent.isEmbedded && this.parent.actor?.items.has(this.parent.id) ) {
+      if ( this.identifier ) this.parent.actor.identifiedItems?.set(this.identifier, this.parent);
       const sourceId = this.parent.flags.dnd5e?.sourceId ?? this.parent._stats.compendiumSource
         ?? this.parent.flags.core?.sourceId;
       if ( sourceId ) this.parent.actor.sourcedItems?.set(sourceId, this.parent);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -31,8 +31,16 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
+   * Mapping of item identifiers to the items.
+   * @type {IdentifiedItemsMap<string, Set<Item5e>>}
+   */
+  identifiedItems = this.identifiedItems;
+
+  /* -------------------------------------------- */
+
+  /**
    * Mapping of item compendium source UUIDs to the items.
-   * @type {Map<string, Item5e>}
+   * @type {SourcedItemsMap<string, Set<Item5e>>}
    */
   sourcedItems = this.sourcedItems;
 
@@ -237,6 +245,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
   /** @inheritDoc */
   prepareEmbeddedDocuments() {
+    this.identifiedItems = new IdentifiedItemsMap();
     this.sourcedItems = new SourcedItemsMap();
     this._embeddedPreparation = true;
     super.prepareEmbeddedDocuments();
@@ -3471,6 +3480,29 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const ids = new Set(documents.map(d => d.getRelativeUUID(this)));
     const favorites = this.system.favorites.filter(f => !ids.has(f.id));
     return this.update({ "system.favorites": favorites });
+  }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * @extends {Map<string, Set<Item5e>>}
+ */
+class IdentifiedItemsMap extends Map {
+  /** @inheritDoc */
+  get(key, { type }={}) {
+    const result = super.get(key);
+    if ( !result?.size || !type ) return result;
+    return result.filter(i => i.type === type);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  set(key, value) {
+    if ( !this.has(key) ) super.set(key, new Set());
+    this.get(key).add(value);
+    return this;
   }
 }
 

--- a/templates/items/details/details-feat.hbs
+++ b/templates/items/details/details-feat.hbs
@@ -17,6 +17,7 @@
 
     {{!-- Feature Prerequisites --}}
     {{ formField fields.prerequisites.fields.level value=source.prerequisites.level }}
+    {{ formField fields.prerequisites.fields.items value=source.prerequisites.items }}
     {{ formField fields.prerequisites.fields.repeatable value=source.prerequisites.repeatable
                  input=inputs.createCheckboxInput }}
 


### PR DESCRIPTION
Adds a list of identifiers to feature prerequisites and require at least one of those other items to be present on the actor to take that feature using an Choose Items or ASI advancement.

To support this functionality `identifiedItems` has been added to actors along side `sourcedItems`. This groups items by their identifiers and optionally allows getting only items with a matching identifier and of a certain type.

Moves the prerequisite validation code into a new method on the feature item itself to avoid code duplication between the two advancement types.

Closes #5300