### PR TITLE
[#5304] Add "Never Collapse" collapse tray option, which only collapses if explicitly told to collapse

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5002,7 +5002,8 @@
     "Hint": "Automatically collapse damage, hit, and effect trays that appear in chat cards.",
     "Always": "Collapse All",
     "Older": "Collapse Older Trays",
-    "Never": "Expand All"
+    "Never": "Collapse After Use",
+    "Manual": "Never Collapse"
   },
   "COMBAT": {
     "Hint": "Various configuration options that affect combat.",

--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -279,7 +279,9 @@ export default class DamageApplicationElement extends TargetedApplicationMixin(C
       const options = this.getTargetOptions(target.dataset.targetUuid);
       await token?.applyDamage(this.damages, { ...options, isDelta: true });
     }
-    this.open = false;
+    if ( game.settings.get("dnd5e", "autoCollapseChatTrays") !== "manual" ) {
+      this.open = false;
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -219,7 +219,9 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
         Hooks.onError("EffectApplicationElement._applyEffectToToken", err, { notify: "warn", log: "warn" });
       }
     }
-    this.querySelector(".collapsible").dispatchEvent(new PointerEvent("click", { bubbles: true, cancelable: true }));
+    if ( game.settings.get("dnd5e", "autoCollapseChatTrays") !== "manual" ) {
+      this.querySelector(".collapsible").dispatchEvent(new PointerEvent("click", { bubbles: true, cancelable: true }));
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -156,7 +156,8 @@ export default class ChatMessage5e extends ChatMessage {
     let collapse;
     switch ( game.settings.get("dnd5e", "autoCollapseChatTrays") ) {
       case "always": collapse = true; break;
-      case "never": collapse = false; break;
+      case "never":
+      case "manual": collapse = false; break;
       // Collapse chat message trays older than 5 minutes
       case "older": collapse = this.timestamp < Date.now() - (5 * 60 * 1000); break;
     }

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -138,6 +138,7 @@ export function registerSystemSettings() {
     default: "older",
     type: String,
     choices: {
+      manual: "SETTINGS.DND5E.COLLAPSETRAYS.Manual",
       never: "SETTINGS.DND5E.COLLAPSETRAYS.Never",
       older: "SETTINGS.DND5E.COLLAPSETRAYS.Older",
       always: "SETTINGS.DND5E.COLLAPSETRAYS.Always"


### PR DESCRIPTION
Closes #5304 
Changed name of previous "never" option from "Expand All" to "Collapse After Use", added new "Never Collapse."