### PR TITLE
[#5824] Add option to use skills with tool in line with 2024 rules

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4900,6 +4900,7 @@
   "AwardEach": "{award} each",
   "CheckShort": "{check}",
   "CheckLong": "{check} check",
+  "CheckUsing": "{check} using {tool}",
   "DamageExtended": "<em>Hit:</em> {damage} damage",
   "DamageDouble": "{first} plus {second}",
   "DamageShort": "{formula} {type}",


### PR DESCRIPTION
Adds support for passing a tool into `rollSkill` alongside the skill to support gaining proficiency if the tool has it and not the skill and gaining advantage if both have proficiency.

This then extends the check enricher when using the modern rules to support rolling a skill check with an associated tool:

```
// Produces Dexterity (Sleight of Hand) check using Thieves' Tools
[[/check slt thief]]
[[/check skill=slt tool=thief]]
```

When the 2014 rules are used, or when more than one tool is used, the enricher will use the older style of specifying multiple different checks.

This also adds support for explicitly setting the rules version in an enricher using `rule=2014` or `rule=2024`.