### PR TITLE
[#4604] [#5408] Divorce spellcasting method from preparation state.

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -204,9 +204,6 @@ Hooks.once("init", function() {
     label: "DND5E.SheetClass.Token"
   });
 
-  // Spellcasting
-  dataModels.spellcasting.SpellcastingModel.fromConfig();
-
   // Preload Handlebars helpers & partials
   utils.registerHandlebarsHelpers();
   utils.preloadHandlebarsTemplates();
@@ -483,6 +480,9 @@ Hooks.once("i18nInit", () => {
   Object.values(CONFIG.DND5E.activityTypes).forEach(c => c.documentClass.localize());
   Object.values(CONFIG.DND5E.advancementTypes).forEach(c => c.documentClass.localize());
   foundry.helpers.Localization.localizeDataModel(dataModels.settings.TransformationSetting);
+
+  // Spellcasting
+  dataModels.spellcasting.SpellcastingModel.fromConfig();
 });
 
 /* -------------------------------------------- */

--- a/lang/en.json
+++ b/lang/en.json
@@ -583,8 +583,11 @@
         "ability": {
           "label": "Ability"
         },
-        "preparation": {
-          "label": "Preparation Mode"
+        "method": {
+          "label": "Spellcasting Method"
+        },
+        "prepared": {
+          "label": "Preparation"
         },
         "uses": {
           "max": {
@@ -2935,6 +2938,7 @@
 "DND5E.MaxClassLevelMinimumWarn": "Class must have at least one level.",
 "DND5E.Maximum": "Maximum",
 "DND5E.Minimum": "Minimum",
+"DND5E.Method": "Method",
 "DND5E.Modifier": "Modifier",
 "DND5E.ModuleArtConfigH": "Configure which module-provided art should be used.",
 "DND5E.ModuleArtConfigL": "Configure Art",
@@ -3004,6 +3008,7 @@
 "DND5E.PersonalityTraits": "Personality Traits",
 "DND5E.Portrait": "Portrait",
 "DND5E.Prepared": "Prepared",
+"DND5E.Preparation": "Preparation",
 "DND5E.Prerequisites": {
   "Header": "Feature Prerequisites",
   "FIELDS": {
@@ -3529,6 +3534,60 @@
 "DND5E.SpellcasterLevel": "Spellcaster Level",
 "DND5E.SpellCastingHeader": "Spell Casting",
 "DND5E.Spellcasting": "Spellcasting",
+
+"DND5E.SPELLCASTING": {
+  "METHODS": {
+    "AtWill": {
+      "label": "At-Will"
+    },
+    "Innate": {
+      "label": "Innate Spellcasting"
+    },
+    "Ritual": {
+      "label": "Ritual Only"
+    },
+    "Spell": {
+      "label": "Class Spellcasting",
+      "Full": {
+        "label": "Full Caster"
+      },
+      "Half": {
+        "label": "Half Caster"
+      },
+      "Third": {
+        "label": "Third Caster"
+      },
+      "Artificer": {
+        "label": "Artificer"
+      }
+    },
+    "Pact": {
+      "abbr": "Pact",
+      "label": "Pact Magic",
+      "Full": {
+        "label": "Pact Magic"
+      }
+    }
+  },
+  "SLOTS": {
+    "spell0": "Cantrips",
+    "spell1": "1st Level",
+    "spell2": "2nd Level",
+    "spell3": "3rd Level",
+    "spell4": "4th Level",
+    "spell5": "5th Level",
+    "spell6": "6th Level",
+    "spell7": "7th Level",
+    "spell8": "8th Level",
+    "spell9": "9th Level"
+  },
+  "STATES": {
+    "Unprepared": "Not Prepared",
+    "Prepared": "Prepared",
+    "AlwaysPrepared": "Always Prepared"
+  }
+},
+
 "DND5E.SpellcastingClass": "{class} Spellcasting",
 "DND5E.SpellComponent": "Spell Component",
 "DND5E.SpellComponents": "Spell Components",
@@ -3556,7 +3615,7 @@
 "DND5E.SpellLevel7": "7th Level",
 "DND5E.SpellLevel8": "8th Level",
 "DND5E.SpellLevel9": "9th Level",
-"DND5E.SpellLevelSlot": "{level} ({n} Slots)",
+"DND5E.SpellLevelSpell": "{level} ({n} Slots)",
 "DND5E.SpellLevelPact": "Pact Slot [Level {level}] ({n} Slots)",
 "DND5E.SpellMaterials": "Spellcasting Materials",
 "DND5E.SpellMaterialsConsumed": "Consume Materials",
@@ -3573,7 +3632,7 @@
 "DND5E.SpellPreparation": {
   "Label": "Spell Preparation",
   "Formula": "Preparation Formula",
-  "Mode": "Spell Preparation Mode"
+  "Method": "Spellcasting Method"
 },
 "DND5E.SpellSourceClass": "Source Class",
 "DND5E.SpellPrepared": "Prepared",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3547,7 +3547,7 @@
       "label": "Ritual Only"
     },
     "Spell": {
-      "label": "Class Spellcasting",
+      "label": "Spellcasting",
       "Full": {
         "label": "Full Caster"
       },

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -391,13 +391,12 @@ export default class ActivityUsageDialog extends Dialog5e {
       let spellSlotValue = this.actor.system.spells[this.config.spell?.slot]?.value || !consumeSlot
         ? this.config.spell.slot : null;
       const spellSlotOptions = Object.entries(this.actor.system.spells).map(([value, slot]) => {
-        if ( (slot.level < minimumLevel) || (slot.level > maximumLevel) || !slot.type ) return null;
-        let label;
-        if ( slot.type === "leveled" ) {
-          label = game.i18n.format("DND5E.SpellLevelSlot", { level: slot.label, n: slot.value });
-        } else {
-          label = game.i18n.format(`DND5E.SpellLevel${slot.type.capitalize()}`, { level: slot.level, n: slot.value });
-        }
+        if ( !slot.max || (slot.level < minimumLevel) || (slot.level > maximumLevel) || !slot.type ) return null;
+        const model = CONFIG.DND5E.spellcasting[slot.type];
+        const label = game.i18n.format(`DND5E.SpellLevel${slot.type.capitalize()}`, {
+          level: model?.isSingleLevel ? slot.level : slot.label,
+          n: slot.value
+        });
         // Set current value if applicable.
         const disabled = (slot.value === 0) && consumeSlot;
         if ( !disabled && !spellSlotValue ) spellSlotValue = value;

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -560,34 +560,36 @@ export default class BaseActorSheet extends PrimarySheetMixin(
    */
   _prepareSpellbook(context) {
     const spellbook = {};
-
-    // Define section and label mappings
-    const sections = Object.entries(CONFIG.DND5E.spellPreparationModes).reduce((acc, [k, {order}]) => {
-      if ( Number.isNumeric(order) ) acc[k] = Number(order);
-      return acc;
-    }, {});
-
-    const levels = context.actor.system.spells;
     const columns = customElements.get(this.options.elements.inventory).mapColumns([
       "school", "time", "range", "target", "roll", { id: "uses", order: 650, priority: 300 },
       { id: "formula", priority: 200 }, "controls"
     ]);
 
-    // Format a spellbook entry for a certain indexed level
-    const registerSection = (slot, i, label, { prepMode="prepared" }={}) => {
-      const section = spellbook[i] = {
-        label, slot, columns,
-        id: slot,
-        dataset: { type: "spell", level: prepMode in sections ? 1 : i, preparationMode: prepMode },
-        draggable: true,
-        order: i,
+    /**
+     * Register a section in the spellbook.
+     * @param {string} key                  The section's unique identifier.
+     * @param {number} [level]              The level of spells in this section. Only relevant for spellcasting methods
+     *                                      that provide multi-level slots.
+     * @param {SpellcastingModel} [config]  The spellcasting model, if any.
+     */
+    const registerSection = (key, level, config) => {
+      level = config?.slots ? level : 1;
+      if ( key in spellbook ) return;
+      const label = config?.getLabel({ level }) ?? game.i18n.localize("DND5E.CAST.SECTIONS.Spellbook");
+      const method = config?.key ?? key;
+      const order = level === 0 ? 0 : (config?.order ?? 1000);
+      const usesSlots = config?.slots && level;
+      const section = spellbook[key] = {
+        label, columns, order, usesSlots,
+        id: method,
+        slot: key,
         items: [],
-        usesSlots: i > 0,
-        minWidth: 220
+        minWidth: 220,
+        draggable: true,
+        dataset: { level, method, type: "spell" }
       };
-      if ( !section.usesSlots ) return;
-
-      const spells = foundry.utils.getProperty(this.actor.system.spells, section.slot);
+      if ( !usesSlots ) return;
+      const spells = foundry.utils.getProperty(this.actor.system.spells, key);
       const maxSlots = spells.override ?? spells.max ?? 0;
       section.pips = Array.fromRange(Math.max(maxSlots, spells.value ?? 0), 1).map(n => {
         const filled = spells.value >= n;
@@ -604,62 +606,33 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       });
     };
 
-    // Determine the maximum spell level which has a slot
-    const maxLevel = Array.fromRange(Object.keys(CONFIG.DND5E.spellLevels).length - 1, 1).reduce((max, i) => {
-      const level = levels[`spell${i}`];
-      if ( level && (level.max || level.override ) && ( i > max ) ) max = i;
-      return max;
-    }, 0);
-
-    // Level-based spellcasters have cantrips and leveled slots
-    if ( maxLevel > 0 ) {
-      registerSection("spell0", 0, CONFIG.DND5E.spellLevels[0]);
-      for ( let lvl = 1; lvl <= maxLevel; lvl++ ) {
-        const sl = `spell${lvl}`;
-        registerSection(sl, lvl, CONFIG.DND5E.spellLevels[lvl], levels[sl]);
-      }
-    }
-
-    // Create spellbook sections for all alternative spell preparation modes that have spell slots.
-    for ( const [k, v] of Object.entries(CONFIG.DND5E.spellPreparationModes) ) {
-      if ( !(k in levels) || !v.upcast || !levels[k].max ) continue;
-      if ( !spellbook["0"] && v.cantrips ) registerSection("spell0", 0, CONFIG.DND5E.spellLevels[0]);
-      const l = levels[k];
-      const level = game.i18n.localize(`DND5E.SpellLevel${l.level}`);
-      const label = `${v.label} — ${level}`;
-      registerSection(k, sections[k], label, { prepMode: k });
+    // Register sections for the available spellcasting methods this character has.
+    for ( const spellcasting of Object.values(CONFIG.DND5E.spellcasting) ) {
+      const levels = spellcasting.getAvailableLevels?.(this.actor) ?? [];
+      if ( !levels.length ) continue;
+      if ( spellcasting.cantrips ) registerSection("spell0", 0, CONFIG.DND5E.spellcasting.spell);
+      levels.forEach(l => registerSection(spellcasting.getSpellSlotKey(l), l, spellcasting));
     }
 
     // Iterate over every spell item, adding spells to the spellbook by section
     (context.itemCategories.spells ?? []).forEach(spell => {
-      const mode = spell.system.preparation.mode || "prepared";
-      let s = spell.system.level || 0;
-      const sl = `spell${s}`;
+      let method = spell.system.method;
+      if ( !(method in CONFIG.DND5E.spellcasting) ) method = "innate";
+      const spellcasting = CONFIG.DND5E.spellcasting[method];
+      const level = spell.system.level || 0;
+      method = spellcasting?.getSpellSlotKey?.(level) ?? method;
 
       // Spells from items
       if ( spell.getFlag("dnd5e", "cachedFor") ) {
-        s = "item";
-        if ( !spell.system.linkedActivity?.displayInSpellbook ) return;
-        if ( !spellbook[s] ) {
-          registerSection(null, s, game.i18n.localize("DND5E.CAST.SECTIONS.Spellbook"));
-          spellbook[s].order = 1000;
-        }
-      }
-
-      // Specialized spellcasting modes (if they exist)
-      else if ( mode in sections ) {
-        s = sections[mode];
-        if ( !spellbook[s] ) {
-          const config = CONFIG.DND5E.spellPreparationModes[mode];
-          registerSection(mode, s, config.label, { prepMode: mode });
-        }
+        method = "item";
+        registerSection(method);
       }
 
       // Sections for higher-level spells which the caster does not have any slots for.
-      else if ( !spellbook[s] ) registerSection(sl, s, CONFIG.DND5E.spellLevels[s]);
+      else registerSection(method, level, spellcasting);
 
       // Add the spell to the relevant heading
-      spellbook[s].items.push(spell);
+      spellbook[method].items.push(spell);
     });
 
     // Sort the spellbook by section level
@@ -979,21 +952,16 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     }
 
     // Prepared
-    const mode = item.system.preparation?.mode;
-    const config = CONFIG.DND5E.spellPreparationModes[mode] ?? {};
-    if ( config.prepares && !linked ) {
-      const isAlways = mode === "always";
-      const prepared = isAlways || item.system.preparation.prepared;
+    const { method, prepared } = item.system;
+    const config = CONFIG.DND5E.spellcasting[method];
+    if ( config?.prepares && !linked ) {
+      const isAlways = prepared === CONFIG.DND5E.spellPreparationStates.always.value;
       ctx.preparation = {
         applicable: true,
         disabled: !item.isOwner || isAlways,
         cls: prepared ? "active" : "",
-        icon: `<i class="fa-${prepared ? "solid" : "regular"} fa-${isAlways ? "certificate" : "sun"}"></i>`,
-        title: isAlways
-          ? CONFIG.DND5E.spellPreparationModes.always.label
-          : prepared
-            ? CONFIG.DND5E.spellPreparationModes.prepared.label
-            : game.i18n.localize("DND5E.SpellUnprepared")
+        icon: `<i class="fa-${prepared ? "solid" : "regular"} fa-${isAlways ? "certificate" : "sun"}" inert></i>`,
+        title: CONFIG.DND5E.spellPreparationStates[isAlways ? "always" : prepared ? "prepared" : "unprepared"].label
       };
     }
     else ctx.preparation = { applicable: false };
@@ -1050,7 +1018,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     for ( const { usesSlots, pips, slot, dataset } of Object.values(context.spellbook) ) {
       if ( !usesSlots ) continue;
       const query = `[data-application-part="spells"] .items-section[data-level="${
-        dataset.level}"][data-preparation-mode="${dataset.preparationMode}"] .items-header`;
+        dataset.level}"][data-method="${dataset.method}"] .items-header`;
       const header = this.element.querySelector(query);
       if ( !header ) continue;
       if ( context.editable ) {
@@ -1822,7 +1790,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
    */
   _onDropResetData(event, itemData) {
     if ( !itemData.system ) return;
-    ["attuned", "equipped", "preparation.prepared"].forEach(k => foundry.utils.deleteProperty(itemData.system, k));
+    ["attuned", "equipped", "prepared"].forEach(k => foundry.utils.deleteProperty(itemData.system, k));
   }
 
   /* -------------------------------------------- */
@@ -1888,7 +1856,6 @@ export default class BaseActorSheet extends PrimarySheetMixin(
    * @protected
    */
   _filterItems(items, filters) {
-    const alwaysPrepared = ["innate", "always"];
     const actions = ["action", "bonus", "reaction"];
     const recoveries = ["lr", "sr"];
     const spellSchools = new Set(Object.keys(CONFIG.DND5E.spellSchools));
@@ -1918,10 +1885,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       if ( filters.has("concentration") && !item.system.properties?.has("concentration") ) return false;
       if ( schoolFilter.size && !schoolFilter.has(item.system.school) ) return false;
       if ( classFilter.size && !classFilter.has(item.system.sourceClass) ) return false;
-      if ( filters.has("prepared") ) {
-        if ( alwaysPrepared.includes(item.system.preparation?.mode) ) return true;
-        return item.system.preparation?.prepared;
-      }
+      if ( filters.has("prepared") ) return item.system.canPrepare && item.system.prepared;
 
       // Equipment-specific filters
       if ( filters.has("equipped") && (item.system.equipped !== true) ) return false;

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -721,9 +721,8 @@ export default class CharacterActorSheet extends BaseActorSheet {
   async _getFavoriteData(type, id) {
     // Spell slots
     if ( type === "slots" ) {
-      const [method] = id.match(/^\D+/) ?? [];
+      const { value, max, level, type: method } = this.actor.system.spells?.[id] ?? {};
       const model = CONFIG.DND5E.spellcasting[method];
-      const { value, max, level } = this.actor.system.spells[id] ?? {};
       const uses = { value, max, name: `system.spells.${id}.value` };
       if ( !model || model.isSingleLevel ) return {
         uses, level, method,

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -697,7 +697,6 @@ export default class CharacterActorSheet extends BaseActorSheet {
         effectId: type === "effect" ? favorite.id : null,
         parentId: (type === "effect") && (favorite.parent !== favorite.target) ? favorite.parent.id: null,
         activityId: type === "activity" ? favorite.id : null,
-        preparationMode: (type === "slots") ? (/spell\d+/.test(id) ? "prepared" : id) : null,
         key: (type === "skill") || (type === "tool") ? id : null,
         toggle: toggle === undefined ? null : { applicable: true, value: toggle },
         quantity: quantity > 1 ? quantity : "",
@@ -722,25 +721,26 @@ export default class CharacterActorSheet extends BaseActorSheet {
   async _getFavoriteData(type, id) {
     // Spell slots
     if ( type === "slots" ) {
+      const [method] = id.match(/^\D+/) ?? [];
+      const model = CONFIG.DND5E.spellcasting[method];
       const { value, max, level } = this.actor.system.spells[id] ?? {};
       const uses = { value, max, name: `system.spells.${id}.value` };
-      if ( !/spell\d+/.test(id) ) return {
-        uses, level,
+      if ( !model || model.isSingleLevel ) return {
+        uses, level, method,
         title: game.i18n.localize(`DND5E.SpellSlots${id.capitalize()}`),
         subtitle: [
           game.i18n.localize(`DND5E.SpellLevel${level}`),
-          game.i18n.localize(`DND5E.Abbreviation${CONFIG.DND5E.spellcastingTypes[id]?.shortRest ? "SR" : "LR"}`)
+          game.i18n.localize(`DND5E.Abbreviation${model?.isSR ? "SR" : "LR"}`)
         ],
-        img: CONFIG.DND5E.spellcastingTypes[id]?.img || CONFIG.DND5E.spellcastingTypes.pact.img
+        img: model?.img || CONFIG.DND5E.spellcasting.pact.img
       };
 
       const plurals = new Intl.PluralRules(game.i18n.lang, { type: "ordinal" });
-      const isSR = CONFIG.DND5E.spellcastingTypes.leveled.shortRest;
       return {
-        uses, level,
+        uses, level, method,
         title: game.i18n.format(`DND5E.SpellSlotsN.${plurals.select(level)}`, { n: level }),
-        subtitle: game.i18n.localize(`DND5E.Abbreviation${isSR ? "SR" : "LR"}`),
-        img: CONFIG.DND5E.spellcastingTypes.leveled.img.replace("{id}", id)
+        subtitle: game.i18n.localize(`DND5E.Abbreviation${model.isSR ? "SR" : "LR"}`),
+        img: model.img.replace("{id}", id)
       };
     }
 
@@ -1123,14 +1123,14 @@ export default class CharacterActorSheet extends BaseActorSheet {
 
   /** @inheritDoc */
   _onDragStart(event) {
-    const modes = CONFIG.DND5E.spellPreparationModes;
+    const methods = CONFIG.DND5E.spellcasting;
     const { key } = event.target.closest("[data-key]")?.dataset ?? {};
-    const { level, preparationMode } = event.target.closest("[data-level]")?.dataset ?? {};
+    const { level, method } = event.target.closest("[data-level]")?.dataset ?? {};
     const isSlots = event.target.closest("[data-favorite-id]") || event.target.classList.contains("items-header");
     let type;
     if ( key in CONFIG.DND5E.skills ) type = "skill";
     else if ( key in CONFIG.DND5E.tools ) type = "tool";
-    else if ( modes[preparationMode]?.upcast && (level !== "0") && isSlots ) type = "slots";
+    else if ( methods[method]?.slots && (level !== "0") && isSlots ) type = "slots";
     if ( !type ) return super._onDragStart(event);
 
     // Add another deferred deactivation to catch the second pointerenter event that seems to be fired on Firefox.
@@ -1138,7 +1138,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
     game.tooltip.deactivate();
 
     const dragData = { dnd5e: { action: "favorite", type } };
-    if ( type === "slots" ) dragData.dnd5e.id = (preparationMode === "prepared") ? `spell${level}` : preparationMode;
+    if ( type === "slots" ) dragData.dnd5e.id = methods[method].getSpellSlotKey(Number(level));
     else dragData.dnd5e.id = key;
     event.dataTransfer.setData("application/json", JSON.stringify(dragData));
     event.dataTransfer.effectAllowed = "link";

--- a/module/applications/actor/config/spell-slots-config.mjs
+++ b/module/applications/actor/config/spell-slots-config.mjs
@@ -37,24 +37,29 @@ export default class SpellSlotsConfig extends BaseConfigSheet {
   async _preparePartContext(partId, context, options) {
     context = await super._preparePartContext(partId, context, options);
 
-    const source = this.document._source.system.spells;
     const { spells } = this.document.system;
-    context.overrides = Array.fromRange(Object.keys(CONFIG.DND5E.spellLevels).length - 1, 1).map(level => ({
-      value: source[`spell${level}`]?.override,
-      label: CONFIG.DND5E.spellLevels[level],
-      name: `system.spells.spell${level}.override`,
-      placeholder: spells[`spell${level}`]?.max ?? 0
-    }));
+    const source = this.document._source.system.spells;
+    const maxLevel = Object.keys(CONFIG.DND5E.spellLevels).length - 1;
+    const spellcastingMethods = new Set(["spell", ...Object.values(this.document.spellcastingClasses).map(cls => {
+      return cls.system.spellcasting.type;
+    })]);
 
-    for ( const k of Object.keys(CONFIG.DND5E.spellcastingTypes) ) {
-      const hasSpell = this.document.items.some(i => i.type === "spell" && i.system.preparation.mode === k);
-      if ( parseInt(spells[k]?.level) || hasSpell ) context.overrides.push({
-        label: CONFIG.DND5E.spellPreparationModes[k].label,
-        value: source[k]?.override,
-        name: `system.spells.${k}.override`,
-        placeholder: spells[k]?.max ?? 0
-      });
-    }
+    const models = Object.entries(CONFIG.DND5E.spellcasting).sort(([a]) => a === "spell" ? -1 : 0);
+    context.overrides = models.reduce((arr, [method, model]) => {
+      if ( !model.slots || !spellcastingMethods.has(method) ) return arr;
+      for ( let i = model.isSingleLevel ? maxLevel : 1; i <= maxLevel; i++ ) {
+        const key = model.getSpellSlotKey(i);
+        arr.push({
+          label: model.isSingleLevel
+            ? game.i18n.localize(`DND5E.SPELLCASTING.METHODS.${method.capitalize()}.abbr`)
+            : model.getLabel({ level: i }),
+          name: `system.spells.${key}.override`,
+          placeholder: spells[key]?.max ?? 0,
+          value: source[key]?.override
+        });
+      }
+      return arr;
+    }, []);
 
     return context;
   }

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -78,6 +78,9 @@ export default class ItemChoiceConfig extends AdvancementConfig {
     context.spellcastingMethods = Object.values(CONFIG.DND5E.spellcasting).map(({ key, label }) => {
       return { label, value: key };
     });
+    if ( spell?.method && !(spell.method in CONFIG.DND5E.spellcasting) ) {
+      context.spellcastingMethods.push({ label: spell.method, value: spell.method });
+    }
 
     context.typeOptions = [
       { value: "", label: game.i18n.localize("DND5E.ADVANCEMENT.ItemChoice.FIELDS.type.Any") },

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -70,8 +70,15 @@ export default class ItemChoiceConfig extends AdvancementConfig {
     context.listRestrictionOptions = dnd5e.registry.spellLists.options;
     context.showContainerWarning = context.items.some(i => i.index?.type === "container");
     context.showSpellConfig = this.advancement.configuration.type === "spell";
-    context.showRequireSpellSlot = !this.advancement.configuration.spell?.preparation
-      || CONFIG.DND5E.spellPreparationModes[this.advancement.configuration.spell?.preparation]?.upcast;
+
+    const { spell } = this.advancement.configuration;
+    const model = CONFIG.DND5E.spellcasting[spell?.method];
+    context.showRequireSpellSlot = !spell?.method || model?.slots;
+    context.canPrepare = model?.prepares;
+    context.spellcastingMethods = Object.values(CONFIG.DND5E.spellcasting).map(({ key, label }) => {
+      return { label, value: key };
+    });
+
     context.typeOptions = [
       { value: "", label: game.i18n.localize("DND5E.ADVANCEMENT.ItemChoice.FIELDS.type.Any") },
       { rule: true },

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -258,7 +258,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     // For advancements on classes or subclasses, use the largest slot available for that class
     if ( spellcasting?.type ) {
       const progression = { slot: 0, pact: 0 };
-      const maxSpellLevel = CONFIG.DND5E.SPELL_SLOT_TABLE[CONFIG.DND5E.SPELL_SLOT_TABLE.length - 1].length;
+      const maxSpellLevel = Object.keys(CONFIG.DND5E.spellLevels).length - 1;
       spells = Object.fromEntries(Array.fromRange(maxSpellLevel, 1).map(l => [`spell${l}`, {}]));
       Actor5e.computeClassProgression(progression, this.advancement.item, { spellcasting });
       Actor5e.prepareSpellcastingSlots(spells, spellcasting.type, progression);

--- a/module/applications/advancement/item-grant-config.mjs
+++ b/module/applications/advancement/item-grant-config.mjs
@@ -51,6 +51,9 @@ export default class ItemGrantConfig extends AdvancementConfig {
     context.spellcastingMethods = Object.values(CONFIG.DND5E.spellcasting).map(({ key, label }) => {
       return { label, value: key };
     });
+    if ( spell?.method && !(spell.method in CONFIG.DND5E.spellcasting) ) {
+      context.spellcastingMethods.push({ label: spell.method, value: spell.method });
+    }
 
     return context;
   }

--- a/module/applications/advancement/item-grant-config.mjs
+++ b/module/applications/advancement/item-grant-config.mjs
@@ -43,8 +43,14 @@ export default class ItemGrantConfig extends AdvancementConfig {
     context.abilityOptions = Object.entries(CONFIG.DND5E.abilities).map(([value, { label }]) => ({ value, label }));
     context.showContainerWarning = context.items.some(i => i.index?.type === "container");
     context.showSpellConfig = context.items.some(i => i.index?.type === "spell");
-    context.showRequireSpellSlot = !this.advancement.configuration.spell?.preparation
-      || CONFIG.DND5E.spellPreparationModes[this.advancement.configuration.spell?.preparation]?.upcast;
+
+    const { spell } = this.advancement.configuration;
+    const model = CONFIG.DND5E.spellcasting[spell?.method];
+    context.showRequireSpellSlot = !spell?.method || model?.slots;
+    context.canPrepare = model?.prepares;
+    context.spellcastingMethods = Object.values(CONFIG.DND5E.spellcasting).map(({ key, label }) => {
+      return { label, value: key };
+    });
 
     return context;
   }

--- a/module/applications/api/primary-sheet-mixin.mjs
+++ b/module/applications/api/primary-sheet-mixin.mjs
@@ -503,8 +503,8 @@ export default function PrimarySheetMixin(Base) {
     static sortItemsPriority(a, b) {
       return a.system.linkedActivity?.item?.name.localeCompare(b.system.linkedActivity?.item?.name, game.i18n.lang)
         || ((a.system.level ?? 0) - (b.system.level ?? 0))
-        || (a.system.method ?? "").compare(b.system.method ?? "")
         || ((a.system.prepared ?? 0) - (b.system.prepared ?? 0))
+        || (a.system.method ?? "").compare(b.system.method ?? "")
         || a.name.localeCompare(b.name, game.i18n.lang);
     }
 

--- a/module/applications/api/primary-sheet-mixin.mjs
+++ b/module/applications/api/primary-sheet-mixin.mjs
@@ -503,8 +503,8 @@ export default function PrimarySheetMixin(Base) {
     static sortItemsPriority(a, b) {
       return a.system.linkedActivity?.item?.name.localeCompare(b.system.linkedActivity?.item?.name, game.i18n.lang)
         || ((a.system.level ?? 0) - (b.system.level ?? 0))
-        || a.system.preparation?.mode?.localeCompare(b.system.preparation?.mode, "en")
-        || ((b.system.preparation?.prepared ?? 0) - (a.system.preparation?.prepared ?? 0))
+        || (a.system.method ?? "").compare(b.system.method ?? "")
+        || ((a.system.prepared ?? 0) - (b.system.prepared ?? 0))
         || a.name.localeCompare(b.name, game.i18n.lang);
     }
 

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -397,12 +397,13 @@ export default class InventoryElement extends HTMLElement {
       callback: li => this._onAction(li, "toggleCharge"),
       group: "state"
     }, {
-      name: `DND5E.ContextMenuAction${item.system.preparation?.prepared ? "Unprepare" : "Prepare"}`,
+      name: `DND5E.ContextMenuAction${item.system.prepared ? "Unprepare" : "Prepare"}`,
       icon: '<i class="fa-solid fa-sun fa-fw"></i>',
       condition: () => {
-        const isPrepared = ("preparation" in item.system) && (item.system.preparation.mode === "prepared");
+        const isPrepared = CONFIG.DND5E.spellcasting[item.system.method]?.prepares;
+        const isAlways = item.system.prepared === CONFIG.DND5E.spellPreparationStates.always.value;
         const canEdit = item.isOwner && !compendiumLocked;
-        return !item.hasRecharge && isPrepared && canEdit && !item.getFlag("dnd5e", "cachedFor");
+        return !item.hasRecharge && isPrepared && !isAlways && canEdit && !item.getFlag("dnd5e", "cachedFor");
       },
       callback: li => this._onAction(li, "prepare"),
       group: "state"
@@ -459,7 +460,7 @@ export default class InventoryElement extends HTMLElement {
     const { itemId } = target.closest("[data-item-id]")?.dataset ?? {};
     const { activityId } = target.closest("[data-activity-id]")?.dataset ?? {};
     const item = await this.getItem(itemId);
-    if ( !item ) return;
+    if ( !item || (target.ariaDisabled === "true") ) return;
     const activity = item.system.activities?.get(activityId);
 
     switch ( action ) {
@@ -786,7 +787,7 @@ export default class InventoryElement extends HTMLElement {
    * @protected
    */
   _onTogglePrepared(item) {
-    return item.update({ "system.preparation.prepared": !item.system.preparation?.prepared });
+    return item.update({ "system.prepared": Boolean(!item.system.prepared) });
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -787,7 +787,7 @@ export default class InventoryElement extends HTMLElement {
    * @protected
    */
   _onTogglePrepared(item) {
-    return item.update({ "system.prepared": Boolean(!item.system.prepared) });
+    return item.update({ "system.prepared": Number(!item.system.prepared) });
   }
 
   /* -------------------------------------------- */

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -322,7 +322,10 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
     context.spellProgression = { ...CONFIG.DND5E.spellProgression };
     if ( (game.settings.get("dnd5e", "rulesVersion") === "modern")
       && (this.item.system.spellcasting?.progression !== "artificer") ) delete context.spellProgression.artificer;
-    context.spellProgression = Object.entries(context.spellProgression).map(([value, label]) => ({ value, label }));
+    context.spellProgression = Object.entries(context.spellProgression).map(([value, config]) => {
+      const group = CONFIG.DND5E.spellcasting[config.type]?.label ?? "";
+      return { group, value, label: config.label };
+    });
 
     // Limited Uses
     context.data = { uses: context.source.uses };

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -326,6 +326,10 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
       const group = CONFIG.DND5E.spellcasting[config.type]?.label ?? "";
       return { group, value, label: config.label };
     });
+    const { progression } = this.item.system.spellcasting ?? {};
+    if ( progression && !(progression in CONFIG.DND5E.spellProgression) ) {
+      context.spellProgression.push({ value: progression, label: progression });
+    }
 
     // Limited Uses
     context.data = { uses: context.source.uses };

--- a/module/applications/journal/class-page-sheet.mjs
+++ b/module/applications/journal/class-page-sheet.mjs
@@ -332,7 +332,7 @@ export default class JournalClassPageSheet extends JournalEntryPageHandlebarsShe
 
       let largestSlot;
       for ( const level of Array.fromRange(CONFIG.DND5E.maxLevel, 1).reverse() ) {
-        const progression = { slot: 0 };
+        const progression = { [spellcasting.type]: 0 };
         spellcasting.levels = level;
         Actor5e.computeClassProgression(progression, item, { spellcasting });
         Actor5e.prepareSpellcastingSlots(spells, spellcasting.type, progression);
@@ -361,7 +361,7 @@ export default class JournalClassPageSheet extends JournalEntryPageHandlebarsShe
     }
 
     /**
-     * A hook event that fires to generate the table for custom spellcasting types.
+     * A hook event that fires to generate the table for spellcasting types.
      * The actual hook names include the spellcasting type (e.g. `dnd5e.buildPsionicSpellcastingTable`).
      * @param {object} table                          Table definition being built. *Will be mutated.*
      * @param {Item5e} item                           Class for which the spellcasting table is being built.

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3312,7 +3312,7 @@ DND5E.spellProgression = new Proxy({}, {
   set() {
     foundry.utils.logCompatibilityWarning("CONFIG.DND5E.spellProgression is read-only. Spell progressions must be set "
       + "on CONFIG.DND5E.spellcasting instead.", { since: "DnD5e 5.1", until: "DnD5e 5.4" });
-    return false;
+    return true;
   }
 });
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3111,6 +3111,13 @@ const pactCastingProgression = DND5E.pactCastingProgression = {
  *                                                                       actor sheet's spells tab, ascending.
  * @property {boolean} [cantrips]                                        Whether this spellcasting method includes
  *                                                                       cantrips.
+ * @property {object} [exclusive]                                        Exclusivity options.
+ * @property {boolean} [exclusive.slots]                                 Whether the slots provided by this spellcasting
+ *                                                                       method may only be used to cast spells that use
+ *                                                                       this spellcasting method.
+ * @property {boolean} [exclusive.spells]                                Whether spells that use this spellcasting
+ *                                                                       method may only be cast with slots provided by
+ *                                                                       this spellcasting method.
  * @property {boolean} [prepares]                                        Whether spells using this method are variably
  *                                                                       available for casting. In 2024 this term was
  *                                                                       unified to 'prepares', but 2014 uses different

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2961,7 +2961,7 @@ DND5E.restTypes = {
     recoverHitDice: true,
     recoverHitPoints: true,
     recoverPeriods: ["lr", "sr"],
-    recoverSpellSlotTypes: new Set(["leveled", "pact"]),
+    recoverSpellSlotTypes: new Set(["spell", "pact"]),
     recoverTemp: true,
     recoverTempMax: true
   }
@@ -3052,28 +3052,11 @@ preLocalize("attackTypes", { key: "label" });
 /* -------------------------------------------- */
 
 /**
- * Spell lists that will be registered by the system during init.
- * @type {string[]}
- */
-DND5E.SPELL_LISTS = Object.freeze([
-  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.wwia6Wwo4BgE9GSI",
-  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.SkHptN2PTzFGDaEj",
-  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.LhvuDQEyrCdg5EfU",
-  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.8yD9Jgp404hfZ9ie",
-  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.5HnIk6HsrSxkvkz5",
-  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.VfZ5mH2ZuyFq82Ga",
-  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.sSzagq8GvYXpfmfs",
-  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.6AnqLUowgdsqMFvz"
-]);
-
-/* -------------------------------------------- */
-
-/**
  * Define the standard slot progression by character level.
  * The entries of this array represent the spell slot progression for a full spell-caster.
- * @type {number[][]}
+ * @type {SpellcastingTable5e}
  */
-DND5E.SPELL_SLOT_TABLE = [
+const SPELL_SLOT_TABLE = DND5E.SPELL_SLOT_TABLE = [
   [2],
   [3],
   [4, 2],
@@ -3099,18 +3082,10 @@ DND5E.SPELL_SLOT_TABLE = [
 /* -------------------------------------------- */
 
 /**
- * Configuration data for pact casting progression.
- *
- * @typedef {object} PactProgressionConfig
- * @property {number} slots  Number of spell slots granted.
- * @property {number} level  Level of spells that can be cast.
- */
-
-/**
  * Define the pact slot & level progression by pact caster level.
- * @enum {PactProgressionConfig}
+ * @type {SpellcastingTableSingle5e}
  */
-DND5E.pactCastingProgression = {
+const pactCastingProgression = DND5E.pactCastingProgression = {
   1: { slots: 1, level: 1 },
   2: { slots: 2, level: 1 },
   3: { slots: 2, level: 2 },
@@ -3124,126 +3099,216 @@ DND5E.pactCastingProgression = {
 /* -------------------------------------------- */
 
 /**
- * Configuration data for spell preparation modes.
- *
- * @typedef {object} SpellPreparationModeConfiguration
- * @property {string} label           Localized name of this spell preparation type.
- * @property {boolean} [upcast]       Whether this preparation mode allows for upcasting.
- * @property {boolean} [cantrips]     Whether this mode allows for cantrips in a spellbook.
- * @property {number} [order]         The sort order of this mode in a spellbook.
- * @property {boolean} [prepares]     Whether this preparation mode prepares spells.
+ * @typedef SpellcastingMethod5e
+ * @property {string} label                                              The human-readable label.
+ * @property {"none"|"single"|"multi"} [type="none"]                     "none" - No spell slots.
+ *                                                                       "single" - Spell slots of a single level only.
+ *                                                                       "multi" - Spell slots of multiple levels.
+ * @property {SpellcastingTable5e|SpellcastingTableSingle5e} [table]     The spell slot progression table.
+ * @property {string} [img]                                              The icon to use if this spellcasting method is
+ *                                                                       favorited.
+ * @property {number} order                                              The ordering of this spellcasting method on an
+ *                                                                       actor sheet's spells tab, ascending.
+ * @property {boolean} [cantrips]                                        Whether this spellcasting method includes
+ *                                                                       cantrips.
+ * @property {boolean} [prepares]                                        Whether spells using this method are variably
+ *                                                                       available for casting. In 2024 this term was
+ *                                                                       unified to 'prepares', but 2014 uses different
+ *                                                                       nomenclature for different classes.
+ * @property {Record<string, SpellcastingProgression5e>} [progression]   Spell slot progressions available for this
+ *                                                                       method.
  */
 
 /**
- * Various different ways a spell can be prepared.
- * @enum {SpellPreparationModeConfiguration}
+ * @typedef {number[][]} SpellcastingTable5e
  */
-DND5E.spellPreparationModes = {
-  prepared: {
-    label: "DND5E.SpellPrepPrepared",
-    upcast: true,
-    prepares: true
-  },
-  pact: {
-    label: "DND5E.PactMagic",
-    upcast: true,
-    cantrips: true,
-    order: 0.5
-  },
-  always: {
-    label: "DND5E.SpellPrepAlways",
-    upcast: true,
-    prepares: true
-  },
+
+/**
+ * @typedef {Record<number, SpellcastingTableEntry5e>} SpellcastingTableSingle5e
+ */
+
+/**
+ * @typedef SpellcastingTableEntry5e
+ * @property {number} slots  The number of slots available.
+ * @property {number} level  The level of the slots.
+ */
+
+/**
+ * @typedef SpellcastingProgression5e
+ * @property {string} label       The human-readable label.
+ * @property {number} divisor     How much this progression mode contributes to the base progression of the spellcasting
+ *                                method.
+ * @property {boolean} [roundUp]  Whether to round up or down when determining contribution.
+ */
+
+/**
+ * Available spellcasting methods.
+ * @type {Record<string, SpellcastingMethod5e>}
+ */
+DND5E.spellcasting = {
   atwill: {
-    label: "DND5E.SpellPrepAtWill",
+    label: "DND5E.SPELLCASTING.METHODS.AtWill.label",
     order: -30
   },
   innate: {
-    label: "DND5E.SpellPrepInnate",
+    label: "DND5E.SPELLCASTING.METHODS.Innate.label",
     order: -20
   },
   ritual: {
-    label: "DND5E.SpellPrepRitual",
+    label: "DND5E.SPELLCASTING.METHODS.Ritual.label",
     order: -10
-  }
-};
-preLocalize("spellPreparationModes", { key: "label" });
-
-/* -------------------------------------------- */
-
-/**
- * Configuration data for different types of spellcasting supported.
- *
- * @typedef {object} SpellcastingTypeConfiguration
- * @property {string} label                               Localized label.
- * @property {string} img                                 Image used when rendered as a favorite on the sheet.
- * @property {boolean} [shortRest]                        Are these spell slots additionally restored on a short rest?
- * @property {Object<string, SpellcastingProgressionConfiguration>} [progression]  Any progression modes for this type.
- */
-
-/**
- * Configuration data for a spellcasting progression mode.
- *
- * @typedef {object} SpellcastingProgressionConfiguration
- * @property {string} label             Localized label.
- * @property {number} [divisor=1]       Value by which the class levels are divided to determine spellcasting level.
- * @property {boolean} [roundUp=false]  Should fractional values should be rounded up by default?
- */
-
-/**
- * Different spellcasting types and their progression.
- * @type {SpellcastingTypeConfiguration}
- */
-DND5E.spellcastingTypes = {
-  leveled: {
-    label: "DND5E.SpellProgLeveled",
+  },
+  pact: {
+    label: "DND5E.SPELLCASTING.METHODS.Pact.label",
+    type: "single",
+    cantrips: true,
+    prepares: true,
+    order: 10,
+    img: "icons/magic/unholy/silhouette-robe-evil-power.webp",
+    table: pactCastingProgression,
+    progression: {
+      pact: {
+        label: "DND5E.SPELLCASTING.METHODS.Pact.Full.label",
+        divisor: 1
+      }
+    }
+  },
+  spell: {
+    label: "DND5E.SPELLCASTING.METHODS.Spell.label",
+    type: "multi",
+    cantrips: true,
+    prepares: true,
+    order: 20,
     img: "systems/dnd5e/icons/spell-tiers/{id}.webp",
+    table: SPELL_SLOT_TABLE,
     progression: {
       full: {
-        label: "DND5E.SpellProgFull",
+        label: "DND5E.SPELLCASTING.METHODS.Spell.Full.label",
         divisor: 1
       },
       half: {
-        label: "DND5E.SpellProgHalf",
+        label: "DND5E.SPELLCASTING.METHODS.Spell.Half.label",
         divisor: 2,
         roundUp: true
       },
       third: {
-        label: "DND5E.SpellProgThird",
+        label: "DND5E.SPELLCASTING.METHODS.Spell.Third.label",
         divisor: 3
       },
       artificer: {
-        label: "DND5E.SpellProgArt",
+        label: "DND5E.SPELLCASTING.METHODS.Spell.Artificer.label",
         divisor: 2,
         roundUp: true
       }
     }
-  },
-  pact: {
-    label: "DND5E.SpellProgPact",
-    img: "icons/magic/unholy/silhouette-robe-evil-power.webp",
-    shortRest: true
   }
 };
-preLocalize("spellcastingTypes", { key: "label", sort: true });
-preLocalize("spellcastingTypes.leveled.progression", { key: "label" });
+preLocalize("spellcasting", { key: "label" });
+preLocalize("spellcasting.spell.progression", { key: "label" });
+preLocalize("spellcasting.pact.progression", { key: "label" });
 
 /* -------------------------------------------- */
 
 /**
- * Ways in which a class can contribute to spellcasting levels.
- * @enum {string}
+ * @typedef SpellcastingPreparationState5e
+ * @property {string} label  The human-readable label.
+ * @property {number} value  A unique number representing this state.
  */
-DND5E.spellProgression = {
-  none: "DND5E.SpellNone",
-  full: "DND5E.SpellProgFull",
-  half: "DND5E.SpellProgHalf",
-  third: "DND5E.SpellProgThird",
-  pact: "DND5E.SpellProgPact",
-  artificer: "DND5E.SpellProgArt"
+
+/**
+ * Spell preparation states.
+ * @type {Record<string, SpellcastingPreparationState5e>}
+ */
+DND5E.spellPreparationStates = {
+  unprepared: {
+    label: "DND5E.SPELLCASTING.STATES.Unprepared",
+    value: 0
+  },
+  prepared: {
+    label: "DND5E.SPELLCASTING.STATES.Prepared",
+    value: 1
+  },
+  always: {
+    label: "DND5E.SPELLCASTING.STATES.AlwaysPrepared",
+    value: 2
+  }
 };
-preLocalize("spellProgression", { key: "label" });
+preLocalize("spellPreparationStates", { key: "label" });
+
+/* -------------------------------------------- */
+
+/**
+ * Spell lists that will be registered by the system during init.
+ * @type {string[]}
+ */
+DND5E.SPELL_LISTS = Object.freeze([
+  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.wwia6Wwo4BgE9GSI",
+  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.SkHptN2PTzFGDaEj",
+  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.LhvuDQEyrCdg5EfU",
+  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.8yD9Jgp404hfZ9ie",
+  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.5HnIk6HsrSxkvkz5",
+  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.VfZ5mH2ZuyFq82Ga",
+  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.sSzagq8GvYXpfmfs",
+  "Compendium.dnd5e.content24.JournalEntry.phbSpells0000000.JournalEntryPage.6AnqLUowgdsqMFvz"
+]);
+
+/* -------------------------------------------- */
+
+/**
+ * @deprecated since 5.1
+ * @ignore
+ */
+DND5E.spellPreparationModes = new Proxy(DND5E.spellcasting, {
+  get(target, prop, receiver) {
+    foundry.utils.logCompatibilityWarning("CONFIG.DND5E.spellPreparationModes is deprecated, use CONFIG.DND5E.spellcasting"
+      + " instead.", { since: "DnD5e 5.1", until: "DnD5e 5.4" });
+    if ( (prop === "prepared") || (prop === "always") ) prop = "spell";
+    return Reflect.get(target, prop, receiver);
+  },
+
+  set(target, prop, value, receiver) {
+    foundry.utils.logCompatibilityWarning("CONFIG.DND5E.spellPreparationModes is deprecated, use CONFIG.DND5E.spellcasting"
+      + " instead.", { since: "DnD5e 5.1", until: "DnD5e 5.4" });
+    if ( (prop === "prepared") || (prop === "always") ) prop = "spell";
+    return Reflect.set(target, prop, value, receiver);
+  }
+});
+
+/* -------------------------------------------- */
+
+/**
+ * @deprecated since 5.1
+ * @ignore
+ */
+DND5E.spellcastingTypes = new Proxy(DND5E.spellcasting, {
+  get(target, prop, receiver) {
+    foundry.utils.logCompatibilityWarning("CONFIG.DND5E.spellcastingTypes is deprecated, use CONFIG.DND5E.spellcasting"
+      + " instead.", { since: "DnD5e 5.1", until: "DnD5e 5.4" });
+    if ( prop === "leveled" ) prop = "spell";
+    return Reflect.get(target, prop, receiver);
+  },
+
+  set(target, prop, value, receiver) {
+    foundry.utils.logCompatibilityWarning("CONFIG.DND5E.spellcastingTypes is deprecated, use CONFIG.DND5E.spellcasting"
+      + " instead.", { since: "DnD5e 5.1", until: "DnD5e 5.4" });
+    if ( prop === "leveled" ) prop = "spell";
+    return Reflect.set(target, prop, value, receiver);
+  }
+});
+
+/* -------------------------------------------- */
+
+/**
+ * @ignore
+ */
+DND5E.spellProgression = new Proxy({}, {
+  set() {
+    foundry.utils.logCompatibilityWarning("CONFIG.DND5E.spellProgression is read-only. Spell progressions must be set "
+      + "on CONFIG.DND5E.spellcasting instead.", { since: "DnD5e 5.1", until: "DnD5e 5.4" });
+    return false;
+  }
+});
+
 
 /* -------------------------------------------- */
 

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -13,4 +13,5 @@ export * as journal from "./journal/_module.mjs";
 export * as regionBehavior from "./region-behavior/_module.mjs";
 export * as settings from "./settings/_module.mjs";
 export * as shared from "./shared/_module.mjs";
+export * as spellcasting from "./spellcasting/_module.mjs";
 export * as user from "./user/_module.mjs";

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -92,7 +92,7 @@ export default class EnchantmentData extends foundry.abstract.TypeDataModel {
       /** @deprecated since 5.1 */
       case "system.preparation.mode":
         foundry.utils.logCompatibilityWarning("system.preparation.mode is deprecated. Please instead use "
-          + "system.method to set the spellcasting method, or system.prepared to set the preparation state..",
+          + "system.method to set the spellcasting method, or system.prepared to set the preparation state.",
         { since: "DnD5e 5.1", until: "DnD5e 5.4", once: true });
         change.key = "system.method";
         if ( change.value === "always" ) {

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -60,8 +60,8 @@ export default class EnchantmentData extends foundry.abstract.TypeDataModel {
               activity, { ...change, key: keyPath, value }
             );
           }
-          return false;
         } catch(err) {}
+        return false;
       case "system.damage.types":
         const adjust = (damage, keyPath) =>
           ActiveEffect.implementation.applyField(damage, { ...change, key: "types", value: change.value });
@@ -88,6 +88,25 @@ export default class EnchantmentData extends foundry.abstract.TypeDataModel {
           );
         }
         return false;
+
+      /** @deprecated since 5.1 */
+      case "system.preparation.mode":
+        foundry.utils.logCompatibilityWarning("system.preparation.mode is deprecated. Please instead use "
+          + "system.method to set the spellcasting method, or system.prepared to set the preparation state..",
+        { since: "DnD5e 5.1", until: "DnD5e 5.4", once: true });
+        change.key = "system.method";
+        if ( change.value === "always" ) {
+          change.key = "system.prepared";
+          change.value = "2";
+        }
+        break;
+
+      /** @deprecated since 5.1 */
+      case "system.preparation.prepared":
+        foundry.utils.logCompatibilityWarning("system.preparation.prepared is deprecated. "
+          + "Please use system.prepared instead.", { since: "DnD5e 5.1", until: "DnD5e 5.4", once: true });
+        change.key = "system.prepared";
+        break;
     }
   }
 }

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -163,8 +163,8 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * @type {boolean}
    */
   get canScale() {
-    return this.consumption.scaling.allowed || (this.isSpell && this.item.system.level > 0
-      && CONFIG.DND5E.spellPreparationModes[this.item.system.preparation.mode]?.upcast);
+    return this.consumption.scaling.allowed || (this.isSpell && (this.item.system.level > 0)
+      && CONFIG.DND5E.spellcasting[this.item.system.method]?.slots);
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -489,7 +489,7 @@ export default class NPCData extends CreatureTemplate {
    * @returns {number}
    */
   cantripLevel(spell) {
-    if ( spell.system.preparation.mode === "innate" ) return this.details.cr;
+    if ( spell.system.method === "innate" ) return this.details.cr;
     return this.details.level ? this.details.level : this.attributes.spell.level;
   }
 

--- a/module/data/advancement/item-choice.mjs
+++ b/module/data/advancement/item-choice.mjs
@@ -77,6 +77,7 @@ export class ItemChoiceConfigurationData extends foundry.abstract.DataModel {
     if ( "pool" in source ) {
       source.pool = source.pool.map(i => foundry.utils.getType(i) === "string" ? { uuid: i } : i);
     }
+    if ( source.spell ) SpellConfigurationData.migrateData(source.spell);
     return source;
   }
 }

--- a/module/data/advancement/item-grant.mjs
+++ b/module/data/advancement/item-grant.mjs
@@ -49,6 +49,7 @@ export default class ItemGrantConfigurationData extends foundry.abstract.DataMod
     if ( "items" in source ) {
       source.items = source.items.map(i => foundry.utils.getType(i) === "string" ? { uuid: i } : i);
     }
+    if ( source.spell ) SpellConfigurationData.migrateData(source.spell);
     return source;
   }
 }

--- a/module/data/advancement/spell-config.mjs
+++ b/module/data/advancement/spell-config.mjs
@@ -1,13 +1,14 @@
 import FormulaField from "../fields/formula-field.mjs";
 
-const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 export default class SpellConfigurationData extends foundry.abstract.DataModel {
   /** @inheritDoc */
   static defineSchema() {
     return {
       ability: new SetField(new StringField()),
-      preparation: new StringField(),
+      method: new StringField(),
+      prepared: new NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 0 }),
       uses: new SchemaField({
         max: new FormulaField({ deterministic: true }),
         per: new StringField(),
@@ -34,9 +35,20 @@ export default class SpellConfigurationData extends foundry.abstract.DataModel {
 
   /** @inheritDoc */
   static migrateData(source) {
-    if ( foundry.utils.getType(source.ability) === "string" ) {
-      source.ability = source.ability ? [source.ability] : [];
+    if ( foundry.utils.getType(source.ability) === "string" ) source.ability = source.ability ? [source.ability] : [];
+    if ( !("preparation" in source) ) return;
+    const { preparation } = source;
+    if ( preparation === "always" ) {
+      if ( !("method" in source) ) source.method = "spell";
+      if ( !("prepared" in source) ) source.prepared = 2;
+    } else {
+      if ( !("method" in source) ) {
+        if ( preparation === "prepared" ) source.method = "spell";
+        else if ( preparation ) source.method = preparation;
+      }
+      if ( !("prepared" in source) ) source.prepared = 0;
     }
+    delete source.preparation;
   }
 
   /* -------------------------------------------- */
@@ -53,13 +65,14 @@ export default class SpellConfigurationData extends foundry.abstract.DataModel {
     ability = this.ability.size ? this.ability.has(ability) ? ability : this.ability.first() : null;
     if ( ability ) foundry.utils.setProperty(itemData, "system.ability", ability);
 
-    if ( this.preparation ) {
-      foundry.utils.setProperty(itemData, "system.preparation.mode", this.preparation);
-      const notAtWill = (this.preparation !== "atwill") && (this.preparation !== "innate");
+    if ( this.method ) {
+      foundry.utils.setProperty(itemData, "system.method", this.method);
+      foundry.utils.setProperty(itemData, "system.prepared", this.prepared);
+      const model = CONFIG.DND5E.spellcasting[this.method];
       const hasClass = (this.item?.type === "class") || (this.item?.type === "subclass");
 
       // Set source class.
-      if ( notAtWill && hasClass ) {
+      if ( model.slots && hasClass ) {
         const identifier = this.item.type === "class" ? this.item.identifier : this.item.system.classIdentifier;
         if ( identifier ) foundry.utils.setProperty(itemData, "system.sourceClass", identifier);
       }
@@ -70,8 +83,8 @@ export default class SpellConfigurationData extends foundry.abstract.DataModel {
       itemData.system.uses.recovery ??= [];
       itemData.system.uses.recovery.push({ period: this.uses.per, type: "recoverAll" });
 
-      const preparationConfig = CONFIG.DND5E.spellPreparationModes[itemData.system.preparation?.mode];
-      const createForwardActivity = !this.uses.requireSlot && preparationConfig?.upcast;
+      const spellcasting = CONFIG.DND5E.spellcasting[itemData.system.method];
+      const createForwardActivity = !this.uses.requireSlot && spellcasting?.slots;
 
       for ( const activity of Object.values(itemData.system.activities ?? {}) ) {
         if ( !activity.consumption?.spellSlot ) continue;

--- a/module/data/item/fields/spellcasting-field.mjs
+++ b/module/data/item/fields/spellcasting-field.mjs
@@ -43,11 +43,8 @@ export default class SpellcastingField extends SchemaField {
     this.spellcasting.preparation.max = simplifyBonus(this.spellcasting.preparation.formula, rollData);
 
     // Temp method for determining spellcasting type until this data is available directly using advancement
-    if ( CONFIG.DND5E.spellcastingTypes[this.spellcasting.progression] ) {
-      this.spellcasting.type = this.spellcasting.progression;
-    } else this.spellcasting.type = Object.entries(CONFIG.DND5E.spellcastingTypes).find(([, { progression }]) =>
-      progression?.[this.spellcasting.progression]
-    )?.[0];
+    this.spellcasting.type = CONFIG.DND5E.spellProgression[this.spellcasting.progression]?.type;
+    this.spellcasting.slots = CONFIG.DND5E.spellcasting[this.spellcasting.type]?.slots;
 
     const actor = this.parent.actor;
     if ( !actor ) return;

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -139,8 +139,8 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
       + "place of preparation.mode and SpellData#prepared in place of preparation.prepared.",
     { since: "DnD5e 5.1", until: "DnD5e 5.4" });
     if ( this.prepared === 2 ) return { mode: "always", prepared: 1 };
-    if ( this.method === "spell" ) return { mode: "prepared", prepared: this.prepared };
-    return { mode: this.method, prepared: this.prepared };
+    if ( this.method === "spell" ) return { mode: "prepared", prepared: Boolean(this.prepared) };
+    return { mode: this.method, prepared: Boolean(this.prepared) };
   }
 
   /* -------------------------------------------- */
@@ -207,7 +207,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
 
   /**
    * Migrate preparation data.
-   * @since 5.1
+   * @since 5.1.0
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
   static #migratePreparation(source) {

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -388,6 +388,9 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     context.spellcastingMethods = Object.values(CONFIG.DND5E.spellcasting).map(({ key, label }) => {
       return { label, value: key };
     });
+    if ( this.method && !(this.method in CONFIG.DND5E.spellcasting) ) {
+      context.spellcastingMethods.push({ label: this.method, value: this.method });
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -257,12 +257,10 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     const uuid = this.parent._stats.compendiumSource ?? this.parent.uuid;
     Object.defineProperty(labels, "classes", {
       get() {
-        return game.i18n.getListFormatter({ style: "narrow" }).format(
-          Array.from(dnd5e.registry.spellLists.forSpell(uuid))
-            .filter(list => list.metadata.type === "class")
-            .map(list => list.name)
-            .sort((lhs, rhs) => lhs.localeCompare(rhs, game.i18n.lang))
-        );
+        return Array.from(dnd5e.registry.spellLists.forSpell(uuid))
+          .filter(list => list.metadata.type === "class")
+          .map(list => list.name)
+          .sort((lhs, rhs) => lhs.localeCompare(rhs, game.i18n.lang));
       },
       configurable: true
     });
@@ -318,12 +316,11 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
 
   /** @inheritDoc */
   async getSheetData(context) {
-    context.properties.active = this.parent.labels?.components?.tags;
+    context.properties.active = [...(this.parent.labels?.components?.tags ?? []), ...(context.labels.classes ?? [])];
     context.subtitles = [
       { label: context.labels.level },
       { label: context.labels.school },
-      { label: CONFIG.DND5E.spellcasting[this.method]?.label },
-      { label: context.labels.classes, classes: "full-width" }
+      { label: CONFIG.DND5E.spellcasting[this.method]?.label }
     ];
 
     context.parts = ["dnd5e.details-spell", "dnd5e.field-uses"];

--- a/module/data/spellcasting/_module.mjs
+++ b/module/data/spellcasting/_module.mjs
@@ -1,0 +1,1 @@
+export * from "./spellcasting-model.mjs";

--- a/module/data/spellcasting/spellcasting-model.mjs
+++ b/module/data/spellcasting/spellcasting-model.mjs
@@ -120,6 +120,10 @@ export class SlotSpellcasting extends SpellcastingModel {
     return {
       ...super.defineSchema(),
       cantrips: new BooleanField(),
+      exclusive: new SchemaField({
+        slots: new BooleanField(),
+        spells: new BooleanField()
+      }),
       prepares: new BooleanField(),
       progression: new TypedObjectField(new SchemaField({
         divisor: new NumberField({ required: true, nullable: false, integer: true, positive: true, initial: 1 }),

--- a/module/data/spellcasting/spellcasting-model.mjs
+++ b/module/data/spellcasting/spellcasting-model.mjs
@@ -79,10 +79,7 @@ export class SpellcastingModel extends foundry.abstract.DataModel {
   static fromConfig() {
     const { spellcasting } = CONFIG.DND5E;
 
-    // Give other packages a chance to define spellcasting.
-    Hooks.callAll("dnd5e.initSpellcasting", spellcasting);
-
-    // Map progressions to spellcasting for faster lookup;
+    // Map progressions to spellcasting for faster lookup.
     CONFIG.DND5E.spellProgression = { none: { label: "DND5E.SpellNone" } };
 
     // Initialize models.
@@ -206,7 +203,7 @@ export class SlotSpellcasting extends SpellcastingModel {
    * @param {number} [count]                          Number of classes with this type of spellcasting.
    */
   computeProgression(progression, actor, cls, spellcasting, count) {
-    const prog = this.progression[spellcasting.progression];
+    const prog = this.progression?.[spellcasting?.progression];
     if ( !prog ) return;
     const rounding = prog.roundUp ? Math.ceil : Math.floor;
     progression[this.key] += rounding(spellcasting.levels / (prog.divisor ?? 1));
@@ -300,7 +297,7 @@ export class SingleLevelSpellcasting extends SlotSpellcasting {
    * @returns {boolean}
    */
   static #validateTableKey(k) {
-    return Number.isNumeric(k);
+    return Number.isNumeric(k) && (Number(k) > 0);
   }
 
   /* -------------------------------------------- */

--- a/module/data/spellcasting/spellcasting-model.mjs
+++ b/module/data/spellcasting/spellcasting-model.mjs
@@ -1,0 +1,420 @@
+const {
+  ArrayField, BooleanField, FilePathField, NumberField, SchemaField, StringField, TypedObjectField
+} = foundry.data.fields;
+
+/**
+ * A DataModel that represents a spellcasting method.
+ * @extends {foundry.abstract.DataModel}
+ */
+export class SpellcastingModel extends foundry.abstract.DataModel {
+  constructor(data={}, { key, ...options }={}) {
+    super(data, options);
+    this.#key = key;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {
+      img: new FilePathField({
+        required: true, categories: ["IMAGE"], initial: "icons/magic/unholy/silhouette-robe-evil-power.webp"
+      }),
+      label: new StringField({ required: true, initial: () => game.i18n.localize("DND5E.SPELLCASTING.Unlabeled") }),
+      order: new NumberField({ required: true, integer: true, nullable: false, initial: 0 }),
+      type: new StringField({ required: true, readonly: true, initial: () => this.TYPE })
+    };
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Available spellcasting methods.
+   * @type {Record<string, typeof SpellcastingModel>}
+   */
+  static get TYPES() {
+    Object.defineProperty(this, "TYPES", {
+      value: {
+        base: this,
+        [SingleLevelSpellcasting.TYPE]: SingleLevelSpellcasting,
+        [MultiLevelSpellcasting.TYPE]: MultiLevelSpellcasting
+      },
+      writable: false,
+      configurable: false
+    });
+    return this.TYPES;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The spellcasting method type.
+   * @type {string}
+   */
+  static get TYPE() {
+    return "none";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The internal key of the spellcasting method.
+   * @type {string}
+   */
+  get key() {
+    return this.#key;
+  }
+
+  #key;
+
+  /* -------------------------------------------- */
+  /*  Public API                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Initialize data models from global config.
+   */
+  static fromConfig() {
+    const { spellcasting } = CONFIG.DND5E;
+
+    // Give other packages a chance to define spellcasting.
+    Hooks.callAll("dnd5e.initSpellcasting", spellcasting);
+
+    // Map progressions to spellcasting for faster lookup;
+    CONFIG.DND5E.spellProgression = { none: { label: "DND5E.SpellNone" } };
+
+    // Initialize models.
+    Object.entries(spellcasting).forEach(([key, config]) => {
+      const Model = this.TYPES[config.type ?? "base"];
+      if ( !Model ) return delete spellcasting[key];
+      spellcasting[key] = new Model(config, { key });
+      Object.entries(config.progression ?? {}).forEach(([k, v]) => {
+        if ( k in CONFIG.DND5E.spellProgression ) console.warn(`Duplicate spell progression key '${k}' detected.`);
+        CONFIG.DND5E.spellProgression[k] = { ...v, type: key };
+      });
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the human-readable label for this spellcasting method.
+   * @param {object} [options]
+   * @param {number} [options.level]                  The spell slot level.
+   * @param {"long"|"short"} [options.format="long"]  The verbosity level.
+   * @returns {string}
+   */
+  getLabel(options={}) {
+    return this.label;
+  }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * An abstract class that defines spellcasting methods that provide spell slots.
+ * @extends {SpellcastingModel}
+ */
+export class SlotSpellcasting extends SpellcastingModel {
+  /** @inheritDoc */
+  static defineSchema() {
+    return {
+      ...super.defineSchema(),
+      cantrips: new BooleanField(),
+      prepares: new BooleanField(),
+      progression: new TypedObjectField(new SchemaField({
+        divisor: new NumberField({ required: true, nullable: false, integer: true, positive: true, initial: 1 }),
+        label: new StringField({ required: true, initial: () => game.i18n.localize("DND5E.SPELLCASTING.Unlabeled") }),
+        roundUp: new BooleanField()
+      }))
+    };
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Are spell slots recovered on a long rest?
+   * @type {boolean}
+   */
+  get isLR() {
+    return this.recovery.has("long");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Are spell slots recovered on a short rest?
+   * @type {boolean}
+   */
+  get isSR() {
+    return this.recovery.has("short");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Rest types that fully restore the spell slots of this spellcasting method.
+   * @type {Set<string>}
+   */
+  get recovery() {
+    if ( this.#recovery ) return this.#recovery;
+    return this.#recovery = Object.entries(CONFIG.DND5E.restTypes).reduce((acc, [k, v]) => {
+      if ( v.recoverSpellSlotTypes?.has(this.key) ) acc.add(k);
+      return acc;
+    }, new Set());
+  }
+
+  #recovery;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Whether this spellcasting method provides spell slots.
+   * @type {boolean}
+   */
+  get slots() {
+    return true;
+  }
+
+  /* -------------------------------------------- */
+  /*  Public API                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Calculate the slots made available by this spellcasting method at the given character level.
+   * @param {number} level              The character level, adjusted for different progression speeds and
+   *                                    multi-classing.
+   * @returns {Record<number, number>}  A mapping of slot level to the number of slots.
+   * @abstract
+   */
+  calculateSlots(level) {
+    return {};
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Contribute to the actor's spellcasting progression for a spellcasting method that provides slots.
+   * @param {object} progression                      Spellcasting progression data. *Will be mutated.*
+   * @param {Actor5e|void} actor                      Actor for whom the data is being prepared, if any.
+   * @param {Item5e} [cls]                            Class for whom this progression is being computed.
+   * @param {SpellcastingDescription} [spellcasting]  Spellcasting descriptive object.
+   * @param {number} [count]                          Number of classes with this type of spellcasting.
+   */
+  computeProgression(progression, actor, cls, spellcasting, count) {
+    const prog = this.progression[spellcasting.progression];
+    if ( !prog ) return;
+    const rounding = prog.roundUp ? Math.ceil : Math.floor;
+    progression[this.key] += rounding(spellcasting.levels / (prog.divisor ?? 1));
+    // Single-classed, non-full progression rounds up, rather than down.
+    if ( (count === 1) && (prog.divisor > 1) && progression[this.key] ) {
+      progression[this.key] = Math.ceil(spellcasting.levels / prog.divisor);
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * When being considered as a single-classed caster, retrieve the available levels which can be prepared via this
+   * spellcasting method, in ascending order.
+   * @param {Actor5e} actor  The caster.
+   * @returns {number[]}
+   */
+  getAvailableLevels(actor) {
+    const spells = foundry.utils.getProperty(actor, `system.spells.${this.getSpellSlotKey()}`);
+    return spells?.max ? [spells.level] : [];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the internal actor model key for spell slots provided by the spellcasting method.
+   * @param {number} [level]  The spell slot level.
+   * @returns {string}
+   */
+  getSpellSlotKey(level) {
+    if ( level === 0 ) return "spell0";
+    return this.key;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare slots provided by this spellcasting method.
+   * @param {object} spells        The `data.spells` object within actor's data. *Will be mutated.*
+   * @param {Actor5e|null} actor   Actor for whom the data is being prepared, if any.
+   * @param {object} progression   Spellcasting progression data.
+   * @abstract
+   */
+  prepareSlots(spells, actor, progression) {}
+}
+
+/* -------------------------------------------- */
+
+/**
+ * A spellcasting model that represents spellcasting methods that provide spell slots that are all the same level.
+ * @extends {SlotSpellcasting}
+ */
+export class SingleLevelSpellcasting extends SlotSpellcasting {
+  /** @inheritDoc */
+  static defineSchema() {
+    return {
+      ...super.defineSchema(),
+      table: new TypedObjectField(new SchemaField({
+        slots: new NumberField({ required: true, nullable: false, integer: true, positive: true, initial: 1 }),
+        level: new NumberField({ required: true, nullable: false, integer: true, positive: true, initial: 1 })
+      }, { validateKey: SingleLevelSpellcasting.#validateTableKey }))
+    };
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static get TYPE() {
+    return "single";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Whether this spellcasting method only provides a single level of spell slots.
+   * @returns {boolean}
+   */
+  get isSingleLevel() {
+    return true;
+  }
+
+  /* -------------------------------------------- */
+  /*  Validation                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Ensure spell slot table keys are numeric.
+   * @param {any} k  The key.
+   * @returns {boolean}
+   */
+  static #validateTableKey(k) {
+    return Number.isNumeric(k);
+  }
+
+  /* -------------------------------------------- */
+  /*  Public API                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  calculateSlots(level) {
+    const [, slots] = Object.entries(this.table).reverse().find(([l]) => Number(l) <= level) ?? [];
+    const available = {};
+    if ( slots ) available[slots.level] = slots.slots;
+    return available;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  getLabel({ level, format }={}) {
+    if ( !(level in CONFIG.DND5E.spellLevels) ) return this.label;
+    const short = format === "short";
+    return [this.label, short ? "" : "—", short ? "" : CONFIG.DND5E.spellLevels[level]].filterJoin(" ");
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  prepareSlots(spells, actor, progression) {
+    let level = Math.clamp(progression[this.key], 0, CONFIG.DND5E.maxLevel);
+    const slot = spells[this.key] ??= { value: 0 };
+    slot.type = this.key;
+    slot.label = this.label;
+    const override = Number.isNumeric(slot.override) ? Math.max(parseInt(slot.override), 0) : null;
+    if ( (level === 0) && (actor.type === "npc") && (override !== null) ) level = actor.system.attributes.spell.level;
+    const slots = this.calculateSlots(level);
+    if ( foundry.utils.isEmpty(slots) && !override ) return;
+    const [[slotLevel, slotAmount]=[]] = Object.entries(slots);
+    slot.max = Number.isFinite(override) ? override : (slotAmount || 0);
+    slot.level = slot.max ? slotLevel ? parseInt(slotLevel) : 1 : 0;
+    slot.value = Math.clamp(slot.value, 0, slot.max) || 0;
+  }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * A spellcasting model that represents spellcasting methods that provide slots of different levels.
+ * @extends {SlotSpellcasting}
+ */
+export class MultiLevelSpellcasting extends SlotSpellcasting {
+  /** @inheritDoc */
+  static defineSchema() {
+    return {
+      ...super.defineSchema(),
+      table: new ArrayField(new ArrayField(new NumberField({
+        required: true, nullable: false, integer: true, positive: true, initial: 1
+      })))
+    };
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static get TYPE() {
+    return "multi";
+  }
+
+  /* -------------------------------------------- */
+  /*  Public API                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  calculateSlots(level) {
+    const slots = this.table[Math.min(level, this.table.length) - 1] ?? [];
+    return Object.fromEntries(slots.map((n, i) => [i + 1, n]));
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  getAvailableLevels(actor) {
+    return Array.fromRange(Object.keys(CONFIG.DND5E.spellLevels).length - 1, 1).reduce((arr, l) => {
+      const spells = foundry.utils.getProperty(actor, `system.spells.${this.getSpellSlotKey(l)}`);
+      if ( spells?.max ) arr.push(l);
+      return arr;
+    }, []);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  getLabel({ level }={}) {
+    return game.i18n.localize(`DND5E.SPELLCASTING.SLOTS.${this.getSpellSlotKey(level)}`);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  getSpellSlotKey(level) {
+    return `${this.key}${level}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  prepareSlots(spells, actor, progression) {
+    const slots = this.calculateSlots(progression[this.key]);
+    for ( const level of Array.fromRange(Object.keys(CONFIG.DND5E.spellLevels).length - 1, 1) ) {
+      const slot = spells[this.getSpellSlotKey(level)] ??= { value: 0 };
+      slot.label = this.getLabel({ level });
+      slot.level = level;
+      slot.max = Number.isNumeric(slot.override) ? Math.max(parseInt(slot.override), 0) : slots[level] ?? 0;
+      slot.type = this.key;
+    }
+  }
+}

--- a/module/data/spellcasting/spellcasting-model.mjs
+++ b/module/data/spellcasting/spellcasting-model.mjs
@@ -80,7 +80,7 @@ export class SpellcastingModel extends foundry.abstract.DataModel {
     const { spellcasting } = CONFIG.DND5E;
 
     // Map progressions to spellcasting for faster lookup.
-    CONFIG.DND5E.spellProgression = { none: { label: "DND5E.SpellNone" } };
+    CONFIG.DND5E.spellProgression = { none: { label: game.i18n.localize("DND5E.SpellNone") } };
 
     // Initialize models.
     Object.entries(spellcasting).forEach(([key, config]) => {

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -514,10 +514,12 @@ export default function ActivityMixin(Base) {
         else if ( Number.isFinite(linkedDelta) ) config.scaling ??= linkedDelta;
 
         if ( this.requiresSpellSlot ) {
-          const mode = this.item.system.preparation.mode;
+          const { level, method } = this.item.system;
+          const model = CONFIG.DND5E.spellcasting[method];
           config.spell ??= {};
-          config.spell.slot ??= linked?.spell?.level ? `spell${linked.spell.level}`
-            : (mode in this.actor.system.spells) ? mode : `spell${this.item.system.level}`;
+          config.spell.slot ??= linked?.spell?.level
+            ? `spell${linked.spell.level}`
+            : (model?.getSpellSlotKey(level) ?? `spell${level}`);
           const scaling = (this.actor.system.spells?.[config.spell.slot]?.level ?? 0) - this.item.system.level;
           if ( scaling > 0 ) config.scaling ??= scaling;
         }
@@ -671,10 +673,10 @@ export default function ActivityMixin(Base) {
       // Handle spell slot consumption
       else if ( ((config.consume === true) || config.consume.spellSlot)
         && this.requiresSpellSlot && this.consumption.spellSlot ) {
-        const mode = this.item.system.preparation.mode;
-        const isLeveled = ["always", "prepared"].includes(mode);
+        const { method } = this.item.system.preparation;
+        const spellcasting = CONFIG.DND5E.spellcasting[method];
         const effectiveLevel = this.item.system.level + (config.scaling ?? 0);
-        const slot = config.spell?.slot ?? (isLeveled ? `spell${effectiveLevel}` : mode);
+        const slot = config.spell?.slot ?? spellcasting?.getSpellSlotKey(effectiveLevel) ?? method;
         const slotData = this.actor.system.spells?.[slot];
         if ( slotData ) {
           if ( slotData.value ) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -94,6 +94,20 @@ export default class Item5e extends SystemDocumentMixin(Item) {
      */
     if ( options.pack || options.parent?.pack ) Hooks.callAll("dnd5e.initializeItemSource", this, data, options);
 
+    if ( data.type === "spell" ) {
+      return super._initializeSource(new Proxy(data, {
+        set(target, prop, value, receiver) {
+          if ( prop === "preparation" ) console.trace(value);
+          return Reflect.set(target, prop, value, receiver);
+        },
+
+        defineProperty(target, prop, attributes) {
+          if ( prop === "preparation" ) console.trace(attributes);
+          return Reflect.defineProperty(target, prop, attributes);
+        }
+      }), options);
+    }
+
     return super._initializeSource(data, options);
   }
 
@@ -366,25 +380,10 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /**
-   * Does this item scale with any kind of consumption?
-   * @type {string|null}
-   */
-  get usageScaling() {
-    // TODO: Re-implement on activity
-    const { level, preparation, consume } = this.system;
-    const isLeveled = (this.type === "spell") && (level > 0);
-    if ( isLeveled && CONFIG.DND5E.spellPreparationModes[preparation.mode]?.upcast ) return "slot";
-    else if ( isLeveled && this.hasResource && consume.scale ) return "resource";
-    return null;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
    * Spellcasting details for a class or subclass.
    *
    * @typedef {object} SpellcastingDescription
-   * @property {string} type              Spellcasting type as defined in ``CONFIG.DND5E.spellcastingTypes`.
+   * @property {string} type              Spellcasting method as defined in ``CONFIG.DND5E.spellcasting`.
    * @property {string|null} progression  Progression within the specified spellcasting type if supported.
    * @property {string} ability           Ability used when casting spells from this class or subclass.
    * @property {number|null} levels       Number of levels of this class or subclass's class if embedded.

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -383,7 +383,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * Spellcasting details for a class or subclass.
    *
    * @typedef {object} SpellcastingDescription
-   * @property {string} type              Spellcasting method as defined in ``CONFIG.DND5E.spellcasting`.
+   * @property {string} type              Spellcasting method as defined in `CONFIG.DND5E.spellcasting`.
    * @property {string|null} progression  Progression within the specified spellcasting type if supported.
    * @property {string} ability           Ability used when casting spells from this class or subclass.
    * @property {number|null} levels       Number of levels of this class or subclass's class if embedded.

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -483,7 +483,7 @@ export function migrateActorData(actor, actorData, migrationData, flags={}, { ac
 
     // Prepared, Equipped, and Proficient for NPC actors
     if ( actorData.type === "npc" ) {
-      if (foundry.utils.getProperty(itemData.system, "preparation.prepared") === false) itemUpdate["system.preparation.prepared"] = true;
+      if (foundry.utils.getProperty(itemData.system, "prepared") === false) itemUpdate["system.prepared"] = 1;
       if (foundry.utils.getProperty(itemData.system, "equipped") === false) itemUpdate["system.equipped"] = true;
     }
 

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -601,7 +601,7 @@ export function applyLegacyRules() {
   const DND5E = CONFIG.DND5E;
 
   // Set half-casters to round down.
-  delete DND5E.spellcastingTypes.leveled.progression.half.roundUp;
+  delete DND5E.spellcasting.leveled.progressions.half.roundUp;
 
   // Adjust Wild Shape and Polymorph presets.
   for ( const preset of ["polymorph", "wildshape"] ) {

--- a/templates/actors/character-sidebar.hbs
+++ b/templates/actors/character-sidebar.hbs
@@ -244,7 +244,7 @@
                 {{#if parentId}}data-parent-id="{{ parentId }}"{{/if}}
                 {{#if activityId}}data-activity-id="{{ activityId }}" data-action="useFavorite"{{/if}}
                 {{#if reference}}data-reference-tooltip="{{ reference }}"{{/if}}
-                {{#if preparationMode}}data-preparation-mode="{{ preparationMode }}"{{/if}}
+                {{#if method}}data-method="{{ method }}"{{/if}}
                 {{#if level}}data-level="{{ level }}"{{/if}}>
 
                 {{!-- Icon --}}

--- a/templates/advancement/advancement-spell-config-section.hbs
+++ b/templates/advancement/advancement-spell-config-section.hbs
@@ -6,9 +6,13 @@
         {{#with @root.configuration.data as |data|}}
         {{ formGroup fields.ability name="configuration.spell.ability" value=data.spell.ability
                      options=@root.abilityOptions rootId=@root.partId }}
-        {{ formGroup fields.preparation name="configuration.spell.preparation"
-                     value=data.spell.preparation choices=@root.CONFIG.spellPreparationModes
-                     labelAttr="label" blank="" rootId=@root.partId }}
+        {{ formGroup fields.method name="configuration.spell.method"
+                     value=data.spell.method options=@root.spellcastingMethods rootId=@root.partId }}
+        {{#if @root.canPrepare}}
+        {{ formGroup fields.prepared name="configuration.spell.prepared" value=data.spell.prepared
+                     choices=@root.CONFIG.spellPreparationStates labelAttr="label" valueAttr="value"
+                     rootId=@root.partId }}
+        {{/if}}
         <div class="form-group split-group">
             <label>{{ localize "DND5E.LimitedUses" }}</label>
             <div class="form-fields">

--- a/templates/inventory/columns/controls.hbs
+++ b/templates/inventory/columns/controls.hbs
@@ -40,7 +40,7 @@
     {{#with ctx.preparation}}
     {{#if applicable}}
     <button type="button" class="unbutton config-button item-control item-action {{ cls }}" data-action="prepare"
-            data-tooltip aria-label="{{ title }}" aria-disabled="{{ this.disabled }}">
+            data-tooltip aria-label="{{ localize title }}" aria-disabled="{{ this.disabled }}">
         {{{ icon }}}
     </button>
     {{/if}}

--- a/templates/items/details/details-spell.hbs
+++ b/templates/items/details/details-spell.hbs
@@ -43,21 +43,20 @@
     </div>
     {{/if}}
 
-    {{!-- Preparation Mode --}}
+    {{!-- Spellcasting --}}
     <div class="form-group">
-        <label>{{ localize "DND5E.SpellPreparation.Mode" }}</label>
+        <label>{{ localize "DND5E.SpellPreparation.Method" }}</label>
         <div class="form-fields">
 
-            {{!-- Prepared --}}
-            {{#if (eq source.preparation.mode "prepared")}}
-            {{ formInput fields.preparation.fields.prepared value=source.preparation.prepared
-                         dataset=(dnd5e-object tooltip="DND5E.Prepared") input=inputs.createCheckboxInput
-                         ariaLabel=(localize "DND5E.Prepared") }}
-            {{/if}}
+            {{!-- Method --}}
+            {{ formField fields.method value=source.method options=spellcastingMethods label="DND5E.Method"
+                         classes="label-top" localize=true }}
 
-            {{!-- Mode --}}
-            {{ formInput fields.preparation.fields.mode value=source.preparation.mode
-                         choices=CONFIG.spellPreparationModes labelAttr="label" }}
+            {{!-- Prepared --}}
+            {{#if canPrepare}}
+            {{ formField fields.prepared value=source.prepared choices=CONFIG.spellPreparationStates labelAttr="label"
+                         valueAttr="value" label="DND5E.Preparation" classes="label-top" localize=true }}
+            {{/if}}
         </div>
     </div>
 


### PR DESCRIPTION
- Closes #4604 
- Closes #5408 

Based on the most recent commit of yours I could find @krbz999 with additional refactoring and compatibility with the latest system changes.

- Separates the concept of a spellcasting method from its preparation state.
- Allows for definitions of arbitrary spellcasting methods with their own sub-progressions, or progressions based on character level rather than class level.
- Allows for spellcasting methods to indicate that their slots may only be used for spells that use the same method, or that spells that use the spellcasting method may only be cast with spells provided by that method.
- Moves spell slot progression and preparation logic out of `Actor5e` and into `SpellcastingModel`s.

### Breaking Changes
- `CONFIG.DND5E.spellPreparationModes` removed with deprecation.
- `CONFIG.DND5E.spellcastingTypes` removed with deprecation.
- `CONFIG.DND5E.spellProgression` read-only with no deprecation path.
- `SpellData#preparation#mode` deprecated in favour of `SpellData#method`.
- `SpellData#preparation#prepared` deprecated in favour of `SpellData#prepared`.
- `SpellConfigurationData#preparation` deprecated in favour of `SpellConfigurationData#method` and `SpellConfigurationData#prepared`.
- `Actor5e.computePactProgression` removed with deprecation.
- `Actor5e.computeLeveledProgression` removed with deprecation.
- `Actor5e.preparePactSlots` removed with deprecation.
- `Actor5e.prepareLeveledSlots` removed with deprecation.
- `Actor5e.prepareAltSlots` removed with deprecation.
- Spell item `labels#classes` type changed from `string` to `string[]`.