### PR TITLE
[#4895] Add automatic self enchanting option for Enchant activity

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1936,6 +1936,10 @@
       "identifier": {
         "label": "Class Identifier",
         "hint": "Identifier used to determine whether the character level or a specific class level should be used for enchantment level limits."
+      },
+      "self": {
+        "label": "Automatically Enchant Self",
+        "hint": "Automatically apply selected enchantment to the item containing this activity when it is used, and remove it when the activity is used again."
       }
     },
     "restrictions": {
@@ -1972,6 +1976,7 @@
       "Create": "Create Enchantment",
       "Delete": "Delete Enchantment"
     },
+    "Active": "{name} (active)",
     "Empty": "No associated enchantments. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing enchantment from the drop-down."
   },
   "Warning": {
@@ -4741,11 +4746,11 @@
       },
       "prompt": {
         "label": "Roll Prompt",
-        "hint": "Should the roll configuration dialog be displayed when rolling?"
+        "hint": "Display the roll configuration dialog when rolling."
       },
       "visible": {
         "label": "Visible to All",
-        "hint": "Should the rolling button be visible to all players?"
+        "hint": "Display the rolling button in chat for all players."
       }
     }
   }

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -322,6 +322,12 @@ export default class ActivitySheet extends PseudoDocumentSheet {
    */
   async _prepareIdentityContext(context) {
     context.tab = context.tabs.identity;
+    context.behaviorFields = [];
+    if ( context.fields.target?.fields?.prompt ) context.behaviorFields.push({
+      field: context.fields.target.fields.prompt,
+      value: context.source.target.prompt,
+      input: context.inputs.createCheckboxInput
+    });
     context.placeholder = {
       name: game.i18n.localize(this.activity.metadata.title),
       img: this.activity.metadata.img

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -153,7 +153,9 @@ export default class ActivityUsageDialog extends Dialog5e {
 
   /** @inheritDoc */
   async _prepareContext(options) {
-    if ( "scaling" in this.config ) this.#item = this.#item.clone({ "flags.dnd5e.scaling": this.config.scaling });
+    if ( "scaling" in this.config ) {
+      this.#item = this.#item.clone({ "flags.dnd5e.scaling": this.config.scaling }, { keepId: true });
+    }
     return {
       ...await super._prepareContext(options),
       activity: this.activity,

--- a/module/applications/activity/cast-sheet.mjs
+++ b/module/applications/activity/cast-sheet.mjs
@@ -18,10 +18,6 @@ export default class CastSheet extends ActivitySheet {
   /** @inheritDoc */
   static PARTS = {
     ...super.PARTS,
-    identity: {
-      template: "systems/dnd5e/templates/activity/cast-identity.hbs",
-      templates: super.PARTS.identity.templates
-    },
     effect: {
       template: "systems/dnd5e/templates/activity/cast-effect.hbs",
       templates: [
@@ -73,6 +69,11 @@ export default class CastSheet extends ActivitySheet {
   /** @inheritDoc */
   async _prepareIdentityContext(context) {
     context = await super._prepareIdentityContext(context);
+    context.behaviorFields = [{
+      field: context.fields.spell.fields.spellbook,
+      value: context.source.spell.spellbook,
+      input: context.inputs.createCheckboxInput
+    }];
     if ( context.spell ) context.placeholder = { name: context.spell.name, img: context.spell.img };
     return context;
   }

--- a/module/applications/activity/enchant-sheet.mjs
+++ b/module/applications/activity/enchant-sheet.mjs
@@ -85,6 +85,19 @@ export default class EnchantSheet extends ActivitySheet {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  async _prepareIdentityContext(context) {
+    context = await super._prepareIdentityContext(context);
+    context.behaviorFields.unshift({
+      field: context.fields.enchant.fields.self,
+      value: context.source.enchant.self,
+      input: context.inputs.createCheckboxInput
+    });
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   _getTabs() {
     const tabs = super._getTabs();
     tabs.effect.label = "DND5E.ENCHANT.SECTIONS.Enchanting";

--- a/module/applications/activity/enchant-usage-dialog.mjs
+++ b/module/applications/activity/enchant-usage-dialog.mjs
@@ -25,12 +25,18 @@ export default class EnchantUsageDialog extends ActivityUsageDialog {
 
     const enchantments = this.activity.availableEnchantments;
     if ( (enchantments.length > 1) && this._shouldDisplay("create.enchantment") ) {
+      const existingProfile = this.activity.existingEnchantment?.flags.dnd5e?.enchantmentProfile;
       context.hasCreation = true;
       context.enchantment = {
-        field: new StringField({ label: game.i18n.localize("DND5E.ENCHANTMENT.Label") }),
+        field: new StringField({ required: true, blank: false, label: game.i18n.localize("DND5E.ENCHANTMENT.Label") }),
         name: "enchantmentProfile",
         value: this.config.enchantmentProfile,
-        options: enchantments.map(e => ({ value: e._id, label: e.effect.name }))
+        options: enchantments.map(e => ({
+          value: e._id,
+          label: e._id === existingProfile
+            ? game.i18n.format("DND5E.ENCHANT.Enchantment.Active", { name: e.effect.name })
+            : e.effect.name
+        }))
       };
     } else if ( enchantments.length ) {
       context.enchantment = enchantments[0]?._id ?? false;

--- a/module/applications/activity/forward-sheet.mjs
+++ b/module/applications/activity/forward-sheet.mjs
@@ -15,10 +15,6 @@ export default class ForwardSheet extends ActivitySheet {
   /** @inheritDoc */
   static PARTS = {
     ...super.PARTS,
-    identity: {
-      template: "systems/dnd5e/templates/activity/forward-identity.hbs",
-      templates: super.PARTS.identity.templates
-    },
     activation: {
       template: "systems/dnd5e/templates/activity/forward-activation.hbs",
       templates: [
@@ -53,6 +49,15 @@ export default class ForwardSheet extends ActivitySheet {
         .filter(a => (a.type !== "forward") && (CONFIG.DND5E.activityTypes[a.type] !== false))
         .map(activity => ({ value: activity.id, label: activity.name }))
     ];
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareIdentityContext(context) {
+    context = await super._prepareIdentityContext(context);
+    context.behaviorFields = [];
     return context;
   }
 

--- a/module/applications/activity/summon-sheet.mjs
+++ b/module/applications/activity/summon-sheet.mjs
@@ -19,10 +19,6 @@ export default class SummonSheet extends ActivitySheet {
   /** @inheritDoc */
   static PARTS = {
     ...super.PARTS,
-    identity: {
-      template: "systems/dnd5e/templates/activity/summon-identity.hbs",
-      templates: super.PARTS.identity.templates
-    },
     effect: {
       template: "systems/dnd5e/templates/activity/summon-effect.hbs",
       templates: [
@@ -86,6 +82,19 @@ export default class SummonSheet extends ActivitySheet {
       (lhs.name || lhs.document?.name || "").localeCompare(rhs.name || rhs.document?.name || "", game.i18n.lang)
     );
 
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareIdentityContext(context) {
+    context = await super._prepareIdentityContext(context);
+    context.behaviorFields.push({
+      field: context.fields.summon.fields.prompt,
+      value: context.source.summon.prompt,
+      input: context.inputs.createCheckboxInput
+    });
     return context;
   }
 

--- a/module/applications/activity/utility-sheet.mjs
+++ b/module/applications/activity/utility-sheet.mjs
@@ -15,13 +15,24 @@ export default class UtilitySheet extends ActivitySheet {
   /** @inheritDoc */
   static PARTS = {
     ...super.PARTS,
-    identity: {
-      template: "systems/dnd5e/templates/activity/utility-identity.hbs",
-      templates: super.PARTS.identity.templates
-    },
     effect: {
       template: "systems/dnd5e/templates/activity/utility-effect.hbs",
       templates: super.PARTS.effect.templates
     }
   };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareIdentityContext(context) {
+    context = await super._prepareIdentityContext(context);
+    context.behaviorFields.push({
+      field: context.fields.roll.fields.prompt,
+      value: context.source.roll.prompt,
+      input: context.inputs.createCheckboxInput
+    });
+    return context;
+  }
 }

--- a/module/applications/components/enchantment-application.mjs
+++ b/module/applications/components/enchantment-application.mjs
@@ -137,35 +137,22 @@ export default class EnchantmentApplicationElement extends HTMLElement {
   async _onDrop(event) {
     event.preventDefault();
     const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
-    const effect = this.enchantmentItem.effects.get(this.chatMessage.getFlag("dnd5e", "use.enchantmentProfile"));
-    if ( (data.type !== "Item") || !effect ) return;
     const droppedItem = await Item.implementation.fromDropData(data);
-
-    // Validate against the enchantment's restraints on the origin item
-    const errors = this.enchantmentActivity.canEnchant(droppedItem);
-    if ( errors?.length ) {
-      errors.forEach(err => ui.notifications.error(err.message, { console: false }));
-      return;
-    }
+    if ( !droppedItem ) return;
 
     // If concentration is required, ensure it is still being maintained & GM is present
     const concentrationId = this.chatMessage.getFlag("dnd5e", "use.concentrationId");
-    const concentration = effect.parent.actor.effects.get(concentrationId);
+    const concentration = this.enchantmentActivity.actor.effects.get(concentrationId);
     if ( concentrationId && !concentration ) {
       ui.notifications.error("DND5E.ENCHANT.Warning.ConcentrationEnded", { console: false, localize: true });
       return;
     }
-    if ( !game.user.isGM && concentration && !concentration.isOwner ) {
-      ui.notifications.error("DND5E.EffectApplyWarningConcentration", { console: false, localize: true });
-      return;
-    }
 
-    const effectData = effect.toObject();
-    effectData.origin = this.enchantmentActivity.uuid;
-    const applied = await ActiveEffect.create(effectData, {
-      parent: droppedItem, keepOrigin: true, chatMessageOrigin: this.chatMessage.id
-    });
-    if ( concentration ) await concentration.addDependent(applied);
+    this.enchantmentActivity.applyEnchantment(
+      this.chatMessage.getFlag("dnd5e", "use.enchantmentProfile"),
+      droppedItem,
+      { chatMessage: this.chatMessage, concentration }
+    );
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/enchant-data.mjs
+++ b/module/data/activity/enchant-data.mjs
@@ -22,6 +22,7 @@ const {
  *
  * @property {object} enchant
  * @property {string} enchant.identifier    Class identifier that will be used to determine applicable level.
+ * @property {string} enchant.self          Automatically apply enchantment to item containing this activity when used.
  * @property {object} restrictions
  * @property {boolean} restrictions.allowMagical    Allow enchantments to be applied to items that are already magical.
  * @property {Set<string>} restrictions.categories  Item categories to restrict to.
@@ -45,7 +46,8 @@ export default class EnchantActivityData extends BaseActivityData {
         })
       })),
       enchant: new SchemaField({
-        identifier: new IdentifierField()
+        identifier: new IdentifierField(),
+        self: new BooleanField()
       }),
       restrictions: new SchemaField({
         allowMagical: new BooleanField(),

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -321,7 +321,7 @@ export default class ActiveEffect5e extends ActiveEffect {
   prepareDerivedData() {
     super.prepareDerivedData();
     if ( this.id === this.constructor.ID.EXHAUSTION ) this._prepareExhaustionLevel();
-    if ( this.isAppliedEnchantment ) dnd5e.registry.enchantments.track(this.origin, this.uuid);
+    if ( this.isAppliedEnchantment && this.uuid ) dnd5e.registry.enchantments.track(this.origin, this.uuid);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -122,13 +122,13 @@ export default class EnchantActivity extends ActivityMixin(EnchantActivityData) 
 
   /**
    * Apply an enchantment to the provided item.
-   * @param {string} profile            ID of the enchantment profile to apply.
-   * @param {Item5e} item               Item to which to apply the enchantment.
+   * @param {string} profile                  ID of the enchantment profile to apply.
+   * @param {Item5e} item                     Item to which to apply the enchantment.
    * @param {object} [options={}]
    * @param {ChatMessage5e} [options.chatMessage]     Chat message used to make the enchantment, if applicable.
    * @param {ActiveEffect5e} [options.concentration]  Concentration active effect to associate with this enchantment.
-   * @param {boolean} [options.strict]  Display UI errors and prevent creation if enchantment isn't allowed.
-   * @returns {ActiveEffect5e|null}     Created enchantment effect if the process was successful.
+   * @param {boolean} [options.strict]        Display UI errors and prevent creation if enchantment isn't allowed.
+   * @returns {Promise<ActiveEffect5e|null>}  Created enchantment effect if the process was successful.
    */
   async applyEnchantment(profile, item, { chatMessage, concentration, strict=true }={}) {
     const effect = this.item.effects.get(profile);

--- a/templates/activity/attack-identity.hbs
+++ b/templates/activity/attack-identity.hbs
@@ -3,6 +3,6 @@
     {{> "systems/dnd5e/templates/activity/parts/attack-identity.hbs" }}
     <fieldset>
         <legend>{{ localize "DND5E.ACTIVITY.SECTIONS.Behavior" }}</legend>
-        {{ formField fields.target.fields.prompt value=source.target.prompt input=inputs.createCheckboxInput }}
+        {{> "dnd5e.fieldlist" behaviorFields }}
     </fieldset>
 </section>

--- a/templates/activity/cast-identity.hbs
+++ b/templates/activity/cast-identity.hbs
@@ -1,7 +1,0 @@
-<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
-    {{> "systems/dnd5e/templates/activity/parts/activity-identity.hbs" }}
-    <fieldset>
-        <legend>{{ localize "DND5E.ACTIVITY.SECTIONS.Behavior" }}</legend>
-        {{ formField fields.spell.fields.spellbook value=source.spell.spellbook input=inputs.createCheckboxInput }}
-    </fieldset>
-</section>

--- a/templates/activity/forward-identity.hbs
+++ b/templates/activity/forward-identity.hbs
@@ -1,3 +1,0 @@
-<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
-    {{> "systems/dnd5e/templates/activity/parts/activity-identity.hbs" }}
-</section>

--- a/templates/activity/identity.hbs
+++ b/templates/activity/identity.hbs
@@ -1,7 +1,9 @@
 <section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
     {{> "systems/dnd5e/templates/activity/parts/activity-identity.hbs" }}
+    {{#if behaviorFields.length}}
     <fieldset>
         <legend>{{ localize "DND5E.ACTIVITY.SECTIONS.Behavior" }}</legend>
-        {{ formField fields.target.fields.prompt value=source.target.prompt input=inputs.createCheckboxInput }}
+        {{> "dnd5e.fieldlist" behaviorFields }}
     </fieldset>
+    {{/if}}
 </section>

--- a/templates/activity/summon-identity.hbs
+++ b/templates/activity/summon-identity.hbs
@@ -1,8 +1,0 @@
-<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
-    {{> "systems/dnd5e/templates/activity/parts/activity-identity.hbs" }}
-    <fieldset>
-        <legend>{{ localize "DND5E.ACTIVITY.SECTIONS.Behavior" }}</legend>
-        {{ formField fields.target.fields.prompt value=source.target.prompt input=inputs.createCheckboxInput }}
-        {{ formField fields.summon.fields.prompt value=source.summon.prompt input=inputs.createCheckboxInput }}
-    </fieldset>
-</section>

--- a/templates/activity/utility-identity.hbs
+++ b/templates/activity/utility-identity.hbs
@@ -1,8 +1,0 @@
-<section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
-    {{> "systems/dnd5e/templates/activity/parts/activity-identity.hbs" }}
-    <fieldset>
-        <legend>{{ localize "DND5E.ACTIVITY.SECTIONS.Behavior" }}</legend>
-        {{ formField fields.target.fields.prompt value=source.target.prompt input=inputs.createCheckboxInput }}
-        {{ formField fields.roll.fields.prompt value=source.roll.prompt input=inputs.createCheckboxInput }}
-    </fieldset>
-</section>


### PR DESCRIPTION
Adds an option to the Behavior section of Enchant activities that allows them to automatically enchant their parent item when used. When activated with this option, the Enchant activity will check to see if an enchantment from this item is already on its item. If one is found, it will be removed. If one isn't found, or the profile of the found enchantment doesn't match the configured profile, then a new enchantment will be created. This allows for easy toggling of an enchantment on an item, or swapping between multiple enchantments on a single item.

<img width="511" height="419" alt="Enchant - Self Enchant Config" src="https://github.com/user-attachments/assets/dc2a3071-4177-470d-9f12-4f8443bec817" />

When multiple profiles are available, the usage dialog will select the currently applied one by default and indicate that it is active in the list.

<img width="432" height="196" alt="Enchant - Self Enchant Selection" src="https://github.com/user-attachments/assets/0a5e9735-3714-4864-a8c3-0f595f4bae5d" />

To avoid code duplication, some of the enchantment application code has been moved from `EnchantmentApplicationElement` into the `EnchantActivity`.

There is also some changes to how the behavior section of the activity sheets are created to avoid having to create a new template every time a new behavior option is required.

Closes #4895