### PR TITLE
[#5806] Alleviate chat forced reflow/target selection performance issues

### DIFF
--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -494,9 +494,6 @@
     margin-top: 6px;
     &:not(.collapsed) > label { padding-bottom: 4px; }
   }
-  &.collapsed {
-    content-visibility: auto;
-  }
 
   > label {
     cursor: var(--cursor-pointer);

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -483,12 +483,19 @@
 }
 
 /* Damage & Effects Trays */
+.message.dnd5e2:not(:nth-last-child(-n + 5)) :is(.card-tray, .effects-tray, .targets-tray) {
+  content-visibility: auto;
+}
+
 .dnd5e2 :is(.card-tray, .effects-tray, .targets-tray) {
   margin-top: .125rem;
   &.damage-tray, &.effects-tray { margin-block-start: 8px; }
   &.targets-tray {
     margin-top: 6px;
     &:not(.collapsed) > label { padding-bottom: 4px; }
+  }
+  &.collapsed {
+    content-visibility: auto;
   }
 
   > label {

--- a/module/applications/chat-log.mjs
+++ b/module/applications/chat-log.mjs
@@ -4,6 +4,25 @@ import ChatMessage5e from "../documents/chat-message.mjs";
  * Custom implementation of the chat log to support saving tray states.
  */
 export default class ChatLog5e extends foundry.applications.sidebar.tabs.ChatLog {
+  /**
+   * The active intersection observer.
+   * @type {IntersectionObserver}
+   */
+  #intersections;
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onFirstRender(context, options) {
+    const scroll = this.element.querySelector(".chat-scroll");
+    const log = this.element.querySelector(".chat-log");
+    new MutationObserver(this.#onLogMutated.bind(this)).observe(log, { childList: true });
+    this.#intersections = new IntersectionObserver(this.#onCardIntersects.bind(this), { root: scroll });
+    return super._onFirstRender(context, options);
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   async updateMessage(message, notify=false) {
     const card = this.element.querySelector(`.message[data-message-id="${message.id}"]`);
@@ -13,5 +32,31 @@ export default class ChatLog5e extends foundry.applications.sidebar.tabs.ChatLog
       ...Array.from(card.querySelectorAll(ChatMessage5e.TRAY_TYPES.join(", "))).map(t => [t.tagName, t.open])
     ]);
     await super.updateMessage(message, notify);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Record visibility of cards as they intersect the viewport.
+   * @param {IntersectionObserverEntry[]} entries  The observed elements that have entered or left the viewport.
+   */
+  #onCardIntersects(entries) {
+    for ( const { isIntersecting, target } of entries ) {
+      const tray = target.querySelector("damage-application, effect-application");
+      if ( tray ) tray.visible = isIntersecting;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * React to changes in the chat log.
+   * @param {MutationRecord[]} records  The change list.
+   */
+  #onLogMutated(records) {
+    for ( const { addedNodes, removedNodes } of records ) {
+      for ( const node of addedNodes ) this.#intersections.observe(node);
+      for ( const node of removedNodes ) this.#intersections.unobserve(node);
+    }
   }
 }

--- a/module/applications/components/chat-tray-element.mjs
+++ b/module/applications/components/chat-tray-element.mjs
@@ -18,8 +18,22 @@ export default class ChatTrayElement extends HTMLElement {
   }
 
   set open(open) {
-    if ( open ) this.setAttribute("open", "");
-    else this.removeAttribute("open");
+    this.toggleAttribute("open", open);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Whether the tray is visible in the chat log.
+   * @returns {boolean}
+   */
+  get visible() {
+    return this.hasAttribute("visible");
+  }
+
+  set visible(visible) {
+    this.toggleAttribute("visible", visible);
+    if ( visible ) this._onVisible();
   }
 
   /* -------------------------------------------- */
@@ -51,6 +65,7 @@ export default class ChatTrayElement extends HTMLElement {
    */
   _handleToggleOpen(open) {
     this.dispatchEvent(new Event("toggle"));
+    if ( open ) this._onOpen();
 
     this.querySelector(".collapsible")?.classList.toggle("collapsed", !open);
 
@@ -58,4 +73,20 @@ export default class ChatTrayElement extends HTMLElement {
     const popout = this.closest(".chat-popout");
     if ( popout ) popout.style.height = "";
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Optionally perform some action when this element is toggled open.
+   * @protected
+   */
+  _onOpen() {}
+
+  /* -------------------------------------------- */
+
+  /**
+   * Optionally perform some action when this element becomes visible.
+   * @protected
+   */
+  _onVisible() {}
 }

--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -41,6 +41,13 @@ export default class DamageApplicationElement extends TargetedApplicationMixin(C
 
   /* -------------------------------------------- */
 
+  /** @override */
+  get shouldBuildTargetList() {
+    return this.open && this.visible;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Options for each application target.
    * @type {Map<string, DamageApplicationOptions>}
@@ -62,7 +69,6 @@ export default class DamageApplicationElement extends TargetedApplicationMixin(C
   /* -------------------------------------------- */
 
   connectedCallback() {
-    super.connectedCallback();
     // Fetch the associated chat message
     const messageId = this.closest("[data-message-id]")?.dataset.messageId;
     this.chatMessage = game.messages.get(messageId);
@@ -331,5 +337,19 @@ export default class DamageApplicationElement extends TargetedApplicationMixin(C
     const token = fromUuidSync(uuid);
     const entry = this.targetList.querySelector(`[data-target-uuid="${token.uuid}"]`);
     this.refreshListEntry(token, entry, options);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onOpen() {
+    this.buildTargetsList();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onVisible() {
+    this.buildTargetsList();
   }
 }

--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -62,6 +62,7 @@ export default class DamageApplicationElement extends TargetedApplicationMixin(C
   /* -------------------------------------------- */
 
   connectedCallback() {
+    super.connectedCallback();
     // Fetch the associated chat message
     const messageId = this.closest("[data-message-id]")?.dataset.messageId;
     this.chatMessage = game.messages.get(messageId);

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -55,6 +55,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
   /* -------------------------------------------- */
 
   connectedCallback() {
+    super.connectedCallback();
     // Fetch the associated chat message
     const messageId = this.closest("[data-message-id]")?.dataset.messageId;
     this.chatMessage = game.messages.get(messageId);

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -34,6 +34,13 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
 
   /* -------------------------------------------- */
 
+  /** @override */
+  get shouldBuildTargetList() {
+    return this.open && this.visible;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Checked status for application targets.
    * @type {Map<string, boolean>}
@@ -55,7 +62,6 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
   /* -------------------------------------------- */
 
   connectedCallback() {
-    super.connectedCallback();
     // Fetch the associated chat message
     const messageId = this.closest("[data-message-id]")?.dataset.messageId;
     this.chatMessage = game.messages.get(messageId);
@@ -235,5 +241,19 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     const uuid = event.target.closest("[data-target-uuid]")?.dataset.targetUuid;
     if ( !uuid ) return;
     this.#targetOptions.set(uuid, event.target.checked);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onOpen() {
+    this.buildTargetsList();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onVisible() {
+    this.buildTargetsList();
   }
 }

--- a/module/applications/components/targeted-application-mixin.mjs
+++ b/module/applications/components/targeted-application-mixin.mjs
@@ -1,4 +1,3 @@
-import ChatTrayElement from "./chat-tray-element.mjs";
 /**
  * Adds functionality to a custom HTML element for displaying a target selector and displaying targets.
  * @param {typeof HTMLElement} Base  The base class being mixed.
@@ -6,12 +5,6 @@ import ChatTrayElement from "./chat-tray-element.mjs";
  */
 export default function TargetedApplicationMixin(Base) {
   return class TargetedApplicationElement extends Base {
-    connectedCallback() {
-      if (this instanceof ChatTrayElement) {
-        this.addEventListener("toggle", this.buildTargetsList.bind(this));
-      }
-    }
-
     /* -------------------------------------------- */
     /*  Properties                                  */
     /* -------------------------------------------- */
@@ -21,6 +14,16 @@ export default function TargetedApplicationMixin(Base) {
      * @type {number|null}
      */
     selectedTokensHook = null;
+
+    /* -------------------------------------------- */
+
+    /**
+     * Whether to rebuild the target list.
+     * @type {boolean|void}
+     * @abstract
+     */
+    // eslint-disable-next-line getter-return
+    get shouldBuildTargetList() {}
 
     /* -------------------------------------------- */
 
@@ -101,7 +104,7 @@ export default function TargetedApplicationMixin(Base) {
      * Build a list of targeted tokens based on current mode & replace any existing targets.
      */
     buildTargetsList() {
-      if ( this.open === false ) return;
+      if ( this.shouldBuildTargetList === false ) return;
       if ( !this.targetList ) throw new Error("Must create a element to contain the target list.");
       const targetedTokens = new Map();
       switch ( this.targetingMode ) {

--- a/module/applications/components/targeted-application-mixin.mjs
+++ b/module/applications/components/targeted-application-mixin.mjs
@@ -8,7 +8,7 @@ export default function TargetedApplicationMixin(Base) {
   return class TargetedApplicationElement extends Base {
     connectedCallback() {
       if (this instanceof ChatTrayElement) {
-        this.addEventListener('toggle', this.buildTargetsList.bind(this));
+        this.addEventListener("toggle", this.buildTargetsList.bind(this));
       }
     }
 

--- a/module/applications/components/targeted-application-mixin.mjs
+++ b/module/applications/components/targeted-application-mixin.mjs
@@ -1,3 +1,4 @@
+import ChatTrayElement from "./chat-tray-element.mjs";
 /**
  * Adds functionality to a custom HTML element for displaying a target selector and displaying targets.
  * @param {typeof HTMLElement} Base  The base class being mixed.
@@ -5,6 +6,11 @@
  */
 export default function TargetedApplicationMixin(Base) {
   return class TargetedApplicationElement extends Base {
+    connectedCallback() {
+      if (this instanceof ChatTrayElement) {
+        this.addEventListener('toggle', this.buildTargetsList.bind(this));
+      }
+    }
 
     /* -------------------------------------------- */
     /*  Properties                                  */
@@ -95,6 +101,7 @@ export default function TargetedApplicationMixin(Base) {
      * Build a list of targeted tokens based on current mode & replace any existing targets.
      */
     buildTargetsList() {
+      if ( this.open === false ) return;
       if ( !this.targetList ) throw new Error("Must create a element to contain the target list.");
       const targetedTokens = new Map();
       switch ( this.targetingMode ) {


### PR DESCRIPTION
This proposes a two-pronged approach to alleviate the performance issues with target selection while there are a lot of chat messages:

1. Applies [`content-visibility: auto`](https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility) to the chat message card/effect/target trays on all but the most recent 5 chat messages. 
2. `buildTargetsList` will only run when the chat tray is open. Also registers an event listener for the `toggled` event so any expanded sections are correctly updated.

Each change on its own made a noticable difference. The second is the bigger performance boost as long as you don't have too many expanded target selections in chat, and the first helps alleviate the rest.

I don't have a ton of experience with Mixins, but I suspect my changes to `TargetedApplicationMixin` are an anti-pattern and Mixins shouldn't be concerned with implementation details of their parent class. I considered a separate `TargetedApplicationChatTrayElement` but I wanted to keep changes minimal for easier review and any potential refactoring.

Closes #5806