### PR TITLE
Ensure elevation is considered for tokens blocking movement

### DIFF
--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -76,7 +76,7 @@ export default class Token5e extends foundry.canvas.placeables.Token {
       for ( let i = 1; i < completePath.length; i++ ) {
         const waypoint = completePath[i];
         const occupiedGridSpaces = this.document.getOccupiedGridSpaceOffsets(waypoint);
-        const elevationOffset = Math.floor(waypoint.elevation / canvas.grid.distance);
+        const elevationOffset = Math.floor((waypoint.elevation / canvas.grid.distance) + 1e-8);
         if ( occupiedGridSpaces.some(space =>
           this.layer.isOccupiedGridSpaceBlocking({...space, k: elevationOffset}, this, {preview}))
         ) {

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -76,7 +76,10 @@ export default class Token5e extends foundry.canvas.placeables.Token {
       for ( let i = 1; i < completePath.length; i++ ) {
         const waypoint = completePath[i];
         const occupiedGridSpaces = this.document.getOccupiedGridSpaceOffsets(waypoint);
-        if ( occupiedGridSpaces.some(space => this.layer.isOccupiedGridSpaceBlocking(space, this, {preview})) ) {
+        const elevationOffset = Math.floor(waypoint.elevation / canvas.grid.distance);
+        if ( occupiedGridSpaces.some(space =>
+          this.layer.isOccupiedGridSpaceBlocking({...space, k: elevationOffset}, this, {preview}))
+        ) {
           blockedIndex = i;
           break;
         }


### PR DESCRIPTION
`TokenDocument#getOccupiedGridSpaceOffsets` returns 2D offsets (`{i, j}`), need to account for elevation. 

~~Note: Core would do `Math.floor((waypoint.elevation / canvas.grid.distance) + 1e-8)` if we were using `SquareGrid#getOffset` (and would also add `1e-8` prior to `Math.floor`-ing in a hexagonal grid, inside `HexagonalGrid#cubeRound`) so it's entirely possible that we should add it here as well. I haven't, because it's not "pretty," but verifying in the dev-support discord channel whether I should.~~ Added.