### PR TITLE
Color ruler segment & grid highlights according to movement speed

### DIFF
--- a/module/canvas/ruler.mjs
+++ b/module/canvas/ruler.mjs
@@ -101,8 +101,10 @@ export default class TokenRuler5e extends foundry.canvas.placeables.tokens.Token
 
     // Color `normal` if <= max speed, else `double` if <= double max speed, else `triple`
     const { normal, double, triple } = CONFIG.DND5E.tokenRulerColors;
-    const colors = [normal, double, triple];
-    style.color = colors[Math.clamp(Math.floor((waypoint.measurement.cost - 0.1) / currActionSpeed), 0, 2)];
+    const increment = (waypoint.measurement.cost - .1) / currActionSpeed;
+    if ( increment <= 1 ) style.color = normal;
+    else if ( increment <= 2 ) style.color = double;
+    else style.color = triple;
     return style;
   }
 }

--- a/module/canvas/ruler.mjs
+++ b/module/canvas/ruler.mjs
@@ -59,17 +59,23 @@ export default class TokenRuler5e extends foundry.canvas.placeables.tokens.Token
     return context;
   }
 
+  /* -------------------------------------------- */
+
   /** @override */
   _getSegmentStyle(waypoint) {
     const style = super._getSegmentStyle(waypoint);
     return this.#getSpeedBasedStyle(waypoint, style);
   }
 
+  /* -------------------------------------------- */
+
   /** @override */
   _getGridHighlightStyle(waypoint, offset) {
     const style = super._getGridHighlightStyle(waypoint, offset);
     return this.#getSpeedBasedStyle(waypoint, style);
   }
+
+  /* -------------------------------------------- */
 
   /**
    * Modify segment or grid-highlighting style based on movement speed
@@ -85,11 +91,11 @@ export default class TokenRuler5e extends foundry.canvas.placeables.tokens.Token
 
     // Get actor's movement speed for currently selected token movement action
     const movement = this.token.actor.system.attributes?.movement;
-    if (!movement) return style;
+    if ( !movement ) return style;
     let currActionSpeed = movement[waypoint.action] ?? 0;
 
     // If current action can fall back to walk, treat "max" speed as maximum between current & walk
-    if (CONFIG.DND5E.movementTypes[waypoint.action]?.walkFallback) {
+    if ( CONFIG.DND5E.movementTypes[waypoint.action]?.walkFallback ) {
       currActionSpeed = Math.max(currActionSpeed, movement.walk);
     }
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1323,6 +1323,18 @@ DND5E.tokenRingColors = {
 /* -------------------------------------------- */
 
 /**
+ * Colors used to denote movement speed on ruler segments & grid highlighting
+ * @enum {number}
+ */
+DND5E.tokenRulerColors = {
+  normal: 0x33BC4E,
+  double: 0xF1D836,
+  triple: 0xE72124
+};
+
+/* -------------------------------------------- */
+
+/**
  * Configuration data for a map marker style. Options not included will fall back to the value set in `default` style.
  * Any additional styling options added will be passed into the custom marker class and be available for rendering.
  *


### PR DESCRIPTION
If total movement cost is <= selected move speed, green. If <= double, yellow. Otherwise red. The colors themselves are configurable under `CONFIG.DND5E.tokenRulerColors`.

Implementation notes:
- Only shows on the client attempting the movement
- Can be disabled using the "Disable Movement Automation" setting
- Currently treats all `walkFallback` actions as the maximum between that action's speed and walk speed, for coloring purposes
- Only shows coloring when previewing a movement (i.e. actively dragging)
- Currently colors the entire segment the same color, so a single move going from "within max speed" to ">3x max speed" will be entirely red. (If on a gridded map, the grid highlighting will _not_ be a single color).