### PR TITLE
[#2187] Allow recovery periods to be set by uses scale value

### DIFF
--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -210,7 +210,6 @@ export default class ActivitySheet extends PseudoDocumentSheet {
     context.showScaling = !this.activity.isSpell || this.activity.isRider;
 
     // Uses recovery
-    context.recoveryPeriods = CONFIG.DND5E.limitedUsePeriods.recoveryOptions;
     context.recoveryTypes = [
       { value: "recoverAll", label: _loc("DND5E.USES.Recovery.Type.RecoverAll") },
       { value: "loseAll", label: _loc("DND5E.USES.Recovery.Type.LoseAll") },
@@ -221,7 +220,8 @@ export default class ActivitySheet extends PseudoDocumentSheet {
       fields: this.activity.schema.fields.uses.fields.recovery.element.fields,
       prefix: `uses.recovery.${index}.`,
       source: context.source.uses.recovery[index] ?? data,
-      formulaOptions: data.period === "recharge" ? UsesField.rechargeOptions : null
+      formulaOptions: data.period === "recharge" ? UsesField.rechargeOptions : null,
+      periodOptions: UsesField.recoveryOptions(this.item, data.period)
     }));
 
     // Template dimensions

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -358,7 +358,6 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
     // Limited Uses
     context.data = { uses: context.source.uses };
     context.hasLimitedUses = this.item.system.hasLimitedUses;
-    context.recoveryPeriods = CONFIG.DND5E.limitedUsePeriods.recoveryOptions;
     context.recoveryTypes = [
       { value: "recoverAll", label: "DND5E.USES.Recovery.Type.RecoverAll" },
       { value: "loseAll", label: "DND5E.USES.Recovery.Type.LoseAll" },
@@ -369,7 +368,8 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
       fields: context.fields.uses.fields.recovery.element.fields,
       prefix: `system.uses.recovery.${index}.`,
       source: context.source.uses.recovery[index] ?? data,
-      formulaOptions: data.period === "recharge" ? UsesField.rechargeOptions : null
+      formulaOptions: data.period === "recharge" ? UsesField.rechargeOptions : null,
+      periodOptions: UsesField.recoveryOptions(this.item, data.period)
     }));
 
     return context;

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -1,3 +1,4 @@
+import { ScaleValueTypeUsage } from "../../data/advancement/scale-value.mjs";
 import { formatNumber, formatRange, getPluralRules, prepareFormulaValue } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
@@ -46,6 +47,12 @@ export default class UsesField extends SchemaField {
 
     const periods = [];
     for ( const recovery of this.uses.recovery ) {
+      recovery.isScaleValue = recovery.period.startsWith("@scale");
+      if ( recovery.isScaleValue ) {
+        const scaleValue = foundry.utils.getProperty(rollData, recovery.period.replace("@", ""));
+        if ( scaleValue?.period ) recovery.period = scaleValue.period;
+      }
+
       if ( recovery.period === "recharge" ) {
         recovery.formula ??= "6";
         recovery.type = "recoverAll";
@@ -80,6 +87,48 @@ export default class UsesField extends SchemaField {
         range: min === 6 ? formatNumber(6) : formatRange(min, 6)
       })
     }));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Recovery options for an item.
+   * @param {Item5e} item   Item for which the recovery options will be created.
+   * @param {string} value  Current recovery value.
+   * @returns {FormSelectOption[]|null}
+   */
+  static recoveryOptions(item, value) {
+    // For non-embedded items with a scale value, just show text input
+    if ( !item.isEmbedded && value.startsWith("@scale") ) return null;
+    const recoveryOptions = CONFIG.DND5E.limitedUsePeriods.recoveryOptions;
+
+    // For embedded items, build a list of uses scale values to display
+    if ( item.isEmbedded ) {
+      const usesScaleValues = [];
+      for ( const [itemIdentifier, scaleValues] of Object.entries(item.actor.system.scale ?? {}) ) {
+        for ( const [scaleIdentifier, scaleValue] of Object.entries(scaleValues) ) {
+          if ( scaleValue instanceof ScaleValueTypeUsage ) usesScaleValues.push({
+            value: `@scale.${itemIdentifier}.${scaleIdentifier}`,
+            label: scaleValue.parent.title
+          });
+        }
+      }
+      if ( value.startsWith("@scale") && !usesScaleValues.find(s => s.value === value) ) return null;
+      recoveryOptions.push(
+        { rule: true },
+        ...usesScaleValues.sort((lhs, rhs) => lhs.label.localeCompare(rhs.label, game.i18n.lang))
+      );
+    }
+
+    // Not embedded, just show single Scale Value option that transform input into freeform text box
+    else {
+      recoveryOptions.push(
+        { rule: true },
+        { value: "@scale", label: game.i18n.localize("DND5E.ADVANCEMENT.ScaleValue.Title") }
+      );
+    }
+
+    return recoveryOptions;
   }
 
   /* -------------------------------------------- */

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -49,7 +49,7 @@ export default class UsesField extends SchemaField {
     for ( const recovery of this.uses.recovery ) {
       recovery.isScaleValue = recovery.period.startsWith("@scale");
       if ( recovery.isScaleValue ) {
-        const scaleValue = foundry.utils.getProperty(rollData, recovery.period.replace("@", ""));
+        const scaleValue = foundry.utils.getProperty(rollData, recovery.period.slice(1));
         if ( scaleValue?.period ) recovery.period = scaleValue.period;
       }
 

--- a/templates/shared/fields/field-uses.hbs
+++ b/templates/shared/fields/field-uses.hbs
@@ -37,7 +37,7 @@
         <div class="form-fields">
 
             {{!-- Period --}}
-            {{ formField fields.period name=(concat prefix "period") value=source.period options=@root.recoveryPeriods
+            {{ formField fields.period name=(concat prefix "period") value=source.period options=periodOptions
                          label="DND5E.Period" localize=true hint=false classes="label-top" rootId=@root.partId }}
 
             {{!-- Type --}}


### PR DESCRIPTION
Adds a scale value option to the recovery periods on items or activities. For non-embedded items, selected the "Scale Value" option will swap the input to a freeform text input with `@scale` filled in, allowing for entering any scale value. For items on actors, the list will be filled with any scale values on the actor (unless the current value isn't found, in which case it will fall back to showing the text input).

<img width="520" height="355" alt="Uses Scale Value Options" src="https://github.com/user-attachments/assets/1aec84f6-688d-4f5f-8edf-eb7ce53531c0" />

<img width="517" height="100" alt="Uses Scale Value Text" src="https://github.com/user-attachments/assets/d31b5f87-5767-459f-a608-7a9aeac72936" />

<img width="521" height="718" alt="Uses Scale Value Rage" src="https://github.com/user-attachments/assets/c3608c43-19b7-42cc-9a9a-b6b81fa1ec8c" />

Closes #2187