### PR TITLE
[#5847] Add `identifier` to unlinked spells on spell list page

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -68,7 +68,7 @@ Hooks.once("init", function() {
   CONFIG.Combatant.documentClass = documents.Combatant5e;
   CONFIG.CombatantGroup.documentClass = documents.CombatantGroup5e;
   CONFIG.Item.collection = dataModels.collection.Items5e;
-  CONFIG.Item.compendiumIndexFields.push("system.container");
+  CONFIG.Item.compendiumIndexFields.push("system.container", "system.identifier");
   CONFIG.Item.documentClass = documents.Item5e;
   CONFIG.JournalEntryPage.documentClass = documents.JournalEntryPage5e;
   CONFIG.Token.documentClass = documents.TokenDocument5e;

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -106,16 +106,16 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
           for ( const [k, v] of Object.entries(value ?? {}) ) {
             const list = dnd5e.registry.spellLists.forType(...k.split(":"));
             if ( !list || (v === 0) ) continue;
-            if ( v === 1 ) include = include.union(list.uuids);
-            else if ( v === -1 ) exclude = exclude.union(list.uuids);
+            if ( v === 1 ) include = include.union(list.identifiers);
+            else if ( v === -1 ) exclude = exclude.union(list.identifiers);
           }
-          if ( include.size ) filters.push({ k: "uuid", o: "in", v: include });
-          if ( exclude.size ) filters.push({ o: "NOT", v: { k: "uuid", o: "in", v: exclude } });
+          if ( include.size ) filters.push({ k: "system.identifier", o: "in", v: include });
+          if ( exclude.size ) filters.push({ o: "NOT", v: { k: "system.identifier", o: "in", v: exclude } });
         },
         config: {
           choices: dnd5e.registry.spellLists.options.reduce((obj, entry) => {
             const list = dnd5e.registry.spellLists.forType(...entry.value.split(":"));
-            if ( list?.uuids.size ) obj[entry.value] = entry.label;
+            if ( list?.identifiers.size ) obj[entry.value] = entry.label;
             return obj;
           }, {})
         }

--- a/module/data/journal/spells.mjs
+++ b/module/data/journal/spells.mjs
@@ -9,6 +9,7 @@ const { ArrayField, DocumentIdField, HTMLField, NumberField, SchemaField, SetFie
  *
  * @typedef {object} UnlinkedSpellConfiguration
  * @property {string} _id            Unique ID for this entry.
+ * @property {string} identifier     Identifier of this spell.
  * @property {string} name           Name of the spell.
  * @property {object} system
  * @property {number} system.level   Spell level.
@@ -38,25 +39,26 @@ export default class SpellListJournalPageData extends foundry.abstract.TypeDataM
       type: new StringField({
         initial: "class", label: "JOURNALENTRYPAGE.DND5E.SpellList.Type.Label"
       }),
-      identifier: new IdentifierField({label: "DND5E.Identifier"}),
+      identifier: new IdentifierField({ label: "DND5E.Identifier" }),
       grouping: new StringField({
         initial: "level", choices: this.GROUPING_MODES,
         label: "JOURNALENTRYPAGE.DND5E.SpellList.Grouping.Label",
         hint: "JOURNALENTRYPAGE.DND5E.SpellList.Grouping.Hint"
       }),
       description: new SchemaField({
-        value: new HTMLField({textSearch: true, label: "DND5E.Description"})
+        value: new HTMLField({ textSearch: true, label: "DND5E.Description" })
       }),
-      spells: new SetField(new StringField(), {label: "DND5E.ItemTypeSpellPl"}),
+      spells: new SetField(new StringField(), { label: "DND5E.ItemTypeSpellPl" }),
       unlinkedSpells: new ArrayField(new SchemaField({
-        _id: new DocumentIdField({initial: () => foundry.utils.randomID()}),
-        name: new StringField({required: true, label: "Name"}),
+        _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
+        identifier: new IdentifierField({ label: "DND5E.Identifier" }),
+        name: new StringField({ required: true, label: "Name" }),
         system: new SchemaField({
-          level: new NumberField({min: 0, integer: true, label: "DND5E.Level"}),
-          school: new StringField({label: "DND5E.School"})
+          level: new NumberField({ min: 0, integer: true, label: "DND5E.Level" }),
+          school: new StringField({ label: "DND5E.School" })
         }),
         source: new SourceField({license: false, revision: false, rules: false, uuid: new StringField()})
-      }), {label: "JOURNALENTRYPAGE.DND5E.SpellList.UnlinkedSpells.Label"})
+      }), { label: "JOURNALENTRYPAGE.DND5E.SpellList.UnlinkedSpells.Label" })
     };
   }
 
@@ -77,7 +79,10 @@ export default class SpellListJournalPageData extends foundry.abstract.TypeDataM
 
   /** @inheritDoc */
   prepareDerivedData() {
-    this.unlinkedSpells.forEach(s => SourceField.prepareData.call(s.source, s.source?.uuid));
+    this.unlinkedSpells.forEach(s => {
+      s.identifier ??= s.name.replaceAll(/(\w+)([\\|/])(\w+)/g, "$1-$3").slugify({ strict: true });
+      SourceField.prepareData.call(s.source, s.source?.uuid);
+    });
   }
 
   /* -------------------------------------------- */

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -277,7 +277,7 @@ class SpellListRegistry {
   /* -------------------------------------------- */
 
   /**
-   * UUIDs of spell lists in the process of being loaded.
+   * UUIDs of spell lists or IDs of compendiums in the process of being loaded.
    * @type {Set<string>}
    */
   static #loading = new Set();

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -386,17 +386,20 @@ export class SpellList {
 
   /**
    * Identifiers for all the available & unlinked spells in this list.
-   * @returns {Promise<string>}
+   * @type {Set<string>}
    */
   get identifiers() {
-    return [...this.indexes.map(s => s.system?.identifier), ...this.#unlinked.map(u => u.identifier)].filter(_ => _);
+    return new Set([
+      ...this.indexes.map(s => s.system?.identifier),
+      ...this.#unlinked.map(u => u.identifier)
+    ].filter(_ => _));
   }
 
   /* -------------------------------------------- */
 
   /**
    * Indexes for the available spells sorted by name.
-   * @returns {object[]}
+   * @type {object[]}
    */
   get indexes() {
     return Array.from(this.#spells.keys())

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -385,12 +385,23 @@ export class SpellList {
   /* -------------------------------------------- */
 
   /**
+   * Identifiers for all the available & unlinked spells in this list.
+   * @returns {Promise<string>}
+   */
+  get identifiers() {
+    return [...this.indexes.map(s => s.system?.identifier), ...this.#unlinked.map(u => u.identifier)].filter(_ => _);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Indexes for the available spells sorted by name.
    * @returns {object[]}
    */
   get indexes() {
     return Array.from(this.#spells.keys())
       .map(s => fromUuidSync(s))
+      .filter(_ => _)
       .sort((lhs, rhs) => lhs.name.localeCompare(rhs.name, game.i18n.lang));
   }
 

--- a/templates/journal/spell/unlinked-spell.hbs
+++ b/templates/journal/spell/unlinked-spell.hbs
@@ -1,6 +1,7 @@
 <fieldset>
     <legend>{{ localize "TYPES.Item.spell" }}</legend>
     {{ formField fields.name name="name" value=name rootId=partId }}
+    {{ formField fields.identifier name="identifier" value=identifier localize=true rootId=partId }}
     {{ formField fields.system.fields.level name="system.level" value=system.level options=spellLevelOptions
                  localize=true rootId=partId }}
     {{ formField fields.system.fields.school name="system.school" value=system.school options=spellSchoolOptions


### PR DESCRIPTION
Adds `identifier` on unlinked spells in the config and adds a new `identifiers` getter in the spell list registry that returns all the identifiers for linked & unlinked spells in the list.

Modifies the spell list filtering in the compendium browser to use identifiers rather than UUIDs to allow for finding spells from multiple sources. This would allow a module to create a single spell list referencing SRD spells, but still allow the PHB versions of those spells to appear if that module is present.

Closes #5847