### PR TITLE
Hit/Miss icon in "Targets" section of attack card properly reflects hit/miss if attack visibility is set to "hideAC"

### DIFF
--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -455,8 +455,8 @@ export default class ChatMessage5e extends ChatMessage {
     `;
     const evaluation = tray.querySelector("ul");
     const rows = targets.map(({ name, ac, uuid }) => {
-      if ( !game.user.isGM && (visibility !== "all") ) ac = "";
       const isMiss = !attackRoll.isCritical && ((attackRoll.total < ac) || attackRoll.isFumble);
+      if ( !game.user.isGM && (visibility !== "all") ) ac = "";
       const li = document.createElement("li");
       Object.assign(li.dataset, { uuid, miss: isMiss });
       li.className = `target ${isMiss ? "miss" : "hit"}`;


### PR DESCRIPTION
`isMiss` should be calculated prior to wiping the AC for non-GMs.