### PR TITLE
[#5787] Automatically create advancement on classes & backgrounds

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -374,6 +374,13 @@
     "AnyLevel": "Any",
     "Details": "Advancement Details"
   },
+  "Defaults": {
+    "BackgroundFeat": "Background Feat",
+    "BackgroundFeature": "Background Feature",
+    "BackgroundProficiencies": "Background Proficiencies",
+    "ChooseLanguages": "Choose Languages",
+    "ClassFeatures": "Class Features"
+  },
   "HitPoints": {
     "Action": {
       "Roll": "Roll {die}"

--- a/lang/en.json
+++ b/lang/en.json
@@ -378,8 +378,7 @@
     "BackgroundFeat": "Background Feat",
     "BackgroundFeature": "Background Feature",
     "BackgroundProficiencies": "Background Proficiencies",
-    "ChooseLanguages": "Choose Languages",
-    "ClassFeatures": "Class Features"
+    "ChooseLanguages": "Choose Languages"
   },
   "HitPoints": {
     "Action": {

--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -1,18 +1,17 @@
 import ItemDataModel from "../abstract/item-data-model.mjs";
-import AdvancementField from "../fields/advancement-field.mjs";
+import AdvancementTemplate from "./templates/advancement.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import StartingEquipmentTemplate from "./templates/starting-equipment.mjs";
 
-const { ArrayField } = foundry.data.fields;
-
 /**
  * Data definition for Background items.
+ * @mixes AdvancementTemplate
  * @mixes ItemDescriptionTemplate
  * @mixes StartingEquipmentTemplate
- *
- * @property {object[]} advancement  Advancement objects for this background.
  */
-export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionTemplate, StartingEquipmentTemplate) {
+export default class BackgroundData extends ItemDataModel.mixin(
+  AdvancementTemplate, ItemDescriptionTemplate, StartingEquipmentTemplate
+) {
 
   /* -------------------------------------------- */
   /*  Model Configuration                         */
@@ -20,15 +19,6 @@ export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionT
 
   /** @override */
   static LOCALIZATION_PREFIXES = ["DND5E.SOURCE"];
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  static defineSchema() {
-    return this.mergeSchema(super.defineSchema(), {
-      advancement: new ArrayField(new AdvancementField(), {label: "DND5E.AdvancementTitle"})
-    });
-  }
 
   /* -------------------------------------------- */
 
@@ -58,6 +48,36 @@ export default class BackgroundData extends ItemDataModel.mixin(ItemDescriptionT
 
   /* -------------------------------------------- */
   /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _advancementToCreate(options) {
+    if ( game.settings.get("dnd5e", "rulesVersion") === "legacy" ) return [
+      { type: "Trait", title: game.i18n.localize("DND5E.ADVANCEMENT.Defaults.BackgroundProficiencies") },
+      { type: "Trait", title: game.i18n.localize("DND5E.ADVANCEMENT.Defaults.ChooseLanguages") },
+      { type: "ItemGrant", title: game.i18n.localize("DND5E.ADVANCEMENT.Defaults.BackgroundFeature") }
+    ];
+
+    return [
+      { type: "AbilityScoreImprovement", configuration: { points: 3 } },
+      { type: "Trait", title: game.i18n.localize("DND5E.ADVANCEMENT.Defaults.BackgroundProficiencies") },
+      {
+        type: "Trait",
+        title: game.i18n.localize("DND5E.ADVANCEMENT.Defaults.ChooseLanguages"),
+        configuration: { grants: ["languages:standard:common"] }
+      },
+      { type: "ItemGrant", title: game.i18n.localize("DND5E.ADVANCEMENT.Defaults.BackgroundFeat") }
+    ];
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preCreate(data, options, user) {
+    if ( (await super._preCreate(data, options, user)) === false ) return false;
+    await this.preCreateAdvancement(data, options);
+  }
+
   /* -------------------------------------------- */
 
   /** @inheritDoc */

--- a/module/data/item/background.mjs
+++ b/module/data/item/background.mjs
@@ -54,7 +54,6 @@ export default class BackgroundData extends ItemDataModel.mixin(
   _advancementToCreate(options) {
     if ( game.settings.get("dnd5e", "rulesVersion") === "legacy" ) return [
       { type: "Trait", title: game.i18n.localize("DND5E.ADVANCEMENT.Defaults.BackgroundProficiencies") },
-      { type: "Trait", title: game.i18n.localize("DND5E.ADVANCEMENT.Defaults.ChooseLanguages") },
       { type: "ItemGrant", title: game.i18n.localize("DND5E.ADVANCEMENT.Defaults.BackgroundFeature") }
     ];
 

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -251,12 +251,12 @@ export default class ClassData extends ItemDataModel.mixin(
   _advancementToCreate(options) {
     return [
       { type: "HitPoints" },
+      { type: "Subclass", level: 3 },
       { type: "AbilityScoreImprovement", level: 4 },
       { type: "AbilityScoreImprovement", level: 8 },
       { type: "AbilityScoreImprovement", level: 12 },
       { type: "AbilityScoreImprovement", level: 16 },
-      { type: "AbilityScoreImprovement", level: 19 },
-      { type: "ItemGrant", title: game.i18n.localize("DND5E.ADVANCEMENT.Defaults.ClassFeatures"), level: 1 }
+      { type: "AbilityScoreImprovement", level: 19 }
     ];
   }
 

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -1,13 +1,13 @@
 import ItemDataModel from "../abstract/item-data-model.mjs";
-import AdvancementField from "../fields/advancement-field.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import IdentifierField from "../fields/identifier-field.mjs";
 import ActivitiesTemplate from "./templates/activities.mjs";
+import AdvancementTemplate from "./templates/advancement.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ItemTypeTemplate from "./templates/item-type.mjs";
 import ItemTypeField from "./fields/item-type-field.mjs";
 
-const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { ItemTypeData } from "./fields/item-type-field.mjs";
@@ -16,10 +16,10 @@ const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringFiel
 /**
  * Data definition for Feature items.
  * @mixes ActivitiesTemplate
+ * @mixes AdvancementTemplate
  * @mixes ItemDescriptionTemplate
  * @mixes ItemTypeTemplate
  *
- * @property {Advancement[]} advancement            Advancement objects for this feature.
  * @property {number} cover                         Amount of cover this feature affords to its crew on a vehicle.
  * @property {boolean} crewed                       Is this vehicle feature currently crewed?
  * @property {object} enchant
@@ -34,7 +34,7 @@ const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringFiel
  * @property {Omit<ItemTypeData, "baseItem">} type  Feature type and subtype.
  */
 export default class FeatData extends ItemDataModel.mixin(
-  ActivitiesTemplate, ItemDescriptionTemplate, ItemTypeTemplate
+  ActivitiesTemplate, AdvancementTemplate, ItemDescriptionTemplate, ItemTypeTemplate
 ) {
 
   /* -------------------------------------------- */
@@ -49,7 +49,6 @@ export default class FeatData extends ItemDataModel.mixin(
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" }),
       cover: new NumberField({ min: 0, max: 1 }),
       crewed: new BooleanField(),
       enchant: new SchemaField({

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -163,14 +163,13 @@ export default class RaceData extends ItemDataModel.mixin(AdvancementTemplate, I
 
   /** @override */
   _advancementToCreate(options) {
-    const toCreate = [
+    if ( game.settings.get("dnd5e", "rulesVersion") === "legacy" ) return [
+      { type: "AbilityScoreImprovement" },
       { type: "Size" },
       { type: "Trait", configuration: { grants: ["languages:standard:common"] } }
     ];
-    if ( game.settings.get("dnd5e", "rulesVersion") === "legacy" ) {
-      toCreate.unshift({ type: "AbilityScoreImprovement" });
-    }
-    return toCreate;
+
+    return [{ type: "Size" }];
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -1,20 +1,17 @@
 import ItemDataModel from "../abstract/item-data-model.mjs";
-import AdvancementField from "../fields/advancement-field.mjs";
 import IdentifierField from "../fields/identifier-field.mjs";
 import SpellcastingField from "./fields/spellcasting-field.mjs";
+import AdvancementTemplate from "./templates/advancement.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
-
-const { ArrayField } = foundry.data.fields;
 
 /**
  * Data definition for Subclass items.
  * @mixes ItemDescriptionTemplate
  *
- * @property {object[]} advancement    Advancement objects for this subclass.
  * @property {string} classIdentifier  Identifier slug for the class with which this subclass should be associated.
  * @property {SpellcastingField} spellcasting  Details on subclass's spellcasting ability.
  */
-export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTemplate) {
+export default class SubclassData extends ItemDataModel.mixin(AdvancementTemplate, ItemDescriptionTemplate) {
 
   /* -------------------------------------------- */
   /*  Model Configuration                         */
@@ -28,7 +25,6 @@ export default class SubclassData extends ItemDataModel.mixin(ItemDescriptionTem
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" }),
       classIdentifier: new IdentifierField({
         required: true, label: "DND5E.ClassIdentifier", hint: "DND5E.ClassIdentifierHint"
       }),

--- a/module/data/item/templates/advancement.mjs
+++ b/module/data/item/templates/advancement.mjs
@@ -1,0 +1,53 @@
+import SystemDataModel from "../../abstract/system-data-model.mjs";
+import AdvancementField from "../../fields/advancement-field.mjs";
+
+const { ArrayField } = foundry.data.fields;
+
+/**
+ * Data model template for items with advancement.
+ *
+ * @property {Advancement[]} advancement  Advancement objects for this item.
+ * @mixin
+ */
+export default class AdvancementTemplate extends SystemDataModel {
+
+  /** @inheritDoc */
+  static defineSchema() {
+    return {
+      advancement: new ArrayField(new AdvancementField(), { label: "DND5E.AdvancementTitle" })
+    };
+  }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /**
+   * If no advancement data exists on the item, create some default advancement.
+   * @param {object} data     The initial data object provided to the document creation request.
+   * @param {object} options  Additional options which modify the creation request.
+   */
+  async preCreateAdvancement(data, options) {
+    if ( data._id || foundry.utils.hasProperty(data, "system.advancement") ) return;
+    const toCreate = this._advancementToCreate(options)
+    if ( toCreate.length ) this.parent.updateSource({
+      "system.advancement": toCreate.map(c => {
+        const config = CONFIG.DND5E.advancementTypes[c.type];
+        const cls = config.documentClass ?? config;
+        return new cls(c, { parent: this.parent }).toObject();
+      })
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create a list of advancement data to be created on new items of this type.
+   * @param {object} options  Additional options which modify the creation request.
+   * @returns {object[]}
+   * @protected
+   */
+  _advancementToCreate(options) {
+    return [];
+  }
+}


### PR DESCRIPTION
In addition to the default advancement created on Species, this adds Trait & Grant Item advancement to backgrounds (and ASI with the modern rules) and Hit Points, ASI, and a single Grant Items advancement for classes.

Creates a new `AdvancementTemplate` for item data models that encapsulates the default creation code so that individual types just need to override `_advancementToCreate` to indicate what should be created and call `preCreateAdvancement` during the `_preCreate` method.

Closes #5787