### PR TITLE
[#5422] Allow referencing target CR in Transform activity

### DIFF
--- a/module/documents/activity/transform.mjs
+++ b/module/documents/activity/transform.mjs
@@ -190,7 +190,7 @@ export default class TransformActivity extends ActivityMixin(TransformActivityDa
   getRollData(options) {
     const rollData = super.getRollData(options);
     if ( game.user.targets.size ) {
-      foundry.utils.setProperty(rollData, "target.cr", game.user.targets.reduce((final, token) => {
+      foundry.utils.setProperty(rollData, "target.details.cr", game.user.targets.reduce((final, token) => {
         const details = token.actor?.system.details ?? {};
         const cr = Math.max(details.cr ?? -Infinity, details.level ?? -Infinity);
         return Number.isFinite(cr) ? Math.min(cr, final) : final;

--- a/module/documents/activity/transform.mjs
+++ b/module/documents/activity/transform.mjs
@@ -181,4 +181,21 @@ export default class TransformActivity extends ActivityMixin(TransformActivityDa
       // TODO: Create message for transformed actors
     }
   }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  getRollData(options) {
+    const rollData = super.getRollData(options);
+    if ( game.user.targets.size ) {
+      foundry.utils.setProperty(rollData, "target.cr", game.user.targets.reduce((final, token) => {
+        const details = token.actor?.system.details ?? {};
+        const cr = Math.max(details.cr ?? -Infinity, details.level ?? -Infinity);
+        return Number.isFinite(cr) ? Math.min(cr, final) : final;
+      }, Infinity));
+    }
+    return rollData;
+  }
 }

--- a/packs/_source/spells/4th-level/polymorph.yml
+++ b/packs/_source/spells/4th-level/polymorph.yml
@@ -150,7 +150,7 @@ system:
         recovery: []
         max: ''
       profiles:
-        - cr: '@target.cr'
+        - cr: '@target.details.cr'
           name: ''
           _id: LHLfS5BSpourwoiO
           sizes: []

--- a/packs/_source/spells/4th-level/polymorph.yml
+++ b/packs/_source/spells/4th-level/polymorph.yml
@@ -115,9 +115,64 @@ system:
         spent: 0
         recovery: []
       sort: 0
+    X06AwuyyIsMYwCIh:
+      type: transform
+      sort: 0
+      activation:
+        type: ''
+        override: true
+        condition: ''
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: false
+        targets: []
+      description:
+        chatFlavor: ''
+      duration:
+        units: inst
+        concentration: false
+        override: false
+      effects: []
+      range:
+        units: self
+        override: false
+      target:
+        template:
+          contiguous: false
+          units: ft
+        affects:
+          choice: false
+        override: false
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      profiles:
+        - cr: '@target.cr'
+          name: ''
+          _id: LHLfS5BSpourwoiO
+          sizes: []
+          types:
+            - beast
+          movement: []
+          level:
+            min: null
+            max: null
+      settings: null
+      transform:
+        customize: false
+        preset: polymorph
+      name: ''
+      _id: X06AwuyyIsMYwCIh
   identifier: polymorph
 sort: 0
-flags: {}
+flags:
+  dnd5e:
+    riders:
+      activity: []
+      effect: []
 img: icons/magic/control/energy-stream-link-large-teal.webp
 effects:
   - name: Polymorph
@@ -157,11 +212,11 @@ effects:
 folder: 5auWSClKMDUIV5Ni
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.346'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 5.1.0
   createdTime: 1725037345165
-  modifiedTime: 1725992716313
+  modifiedTime: 1753221628672
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!04nMsTWkIFvkbXlY'

--- a/packs/_source/spells/9th-level/true-polymorph.yml
+++ b/packs/_source/spells/9th-level/true-polymorph.yml
@@ -132,19 +132,74 @@ system:
         spent: 0
         recovery: []
       sort: 0
+    7K2q8LlTG7EVWGfl:
+      type: transform
+      sort: 0
+      activation:
+        type: ''
+        override: true
+        condition: ''
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: false
+        targets: []
+      description:
+        chatFlavor: ''
+      duration:
+        units: inst
+        concentration: false
+        override: false
+      effects: []
+      range:
+        units: self
+        override: false
+      target:
+        template:
+          contiguous: false
+          units: ft
+        affects:
+          choice: false
+        override: false
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      profiles:
+        - cr: '@target.cr'
+          name: ''
+          _id: LHLfS5BSpourwoiO
+          sizes: []
+          types: []
+          movement: []
+          level:
+            min: null
+            max: null
+      settings: null
+      transform:
+        customize: false
+        preset: polymorph
+      name: ''
+      _id: 7K2q8LlTG7EVWGfl
+      img: ''
   identifier: true-polymorph
 sort: 0
-flags: {}
+flags:
+  dnd5e:
+    riders:
+      activity: []
+      effect: []
 img: icons/magic/control/debuff-energy-snare-purple-pink.webp
 effects: []
 folder: KL6ZY4VRMjojGrL4
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.346'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 5.1.0
   createdTime: 1725037355728
-  modifiedTime: 1725992719711
+  modifiedTime: 1753221658554
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!QbQZKoXOgHWN06aa'

--- a/packs/_source/spells/9th-level/true-polymorph.yml
+++ b/packs/_source/spells/9th-level/true-polymorph.yml
@@ -167,7 +167,7 @@ system:
         recovery: []
         max: ''
       profiles:
-        - cr: '@target.cr'
+        - cr: '@target.details.cr'
           name: ''
           _id: LHLfS5BSpourwoiO
           sizes: []

--- a/packs/_source/spells24/4th-level/polymorph.yml
+++ b/packs/_source/spells24/4th-level/polymorph.yml
@@ -140,7 +140,7 @@ system:
         recovery: []
         max: ''
       profiles:
-        - cr: '@target.cr'
+        - cr: '@target.details.cr'
           name: ''
           _id: LHLfS5BSpourwoiO
           sizes: []

--- a/packs/_source/spells24/4th-level/polymorph.yml
+++ b/packs/_source/spells24/4th-level/polymorph.yml
@@ -104,6 +104,58 @@ system:
         spent: 0
         recovery: []
       sort: 0
+    wgyusQWRKY9gCTiu:
+      type: transform
+      _id: wgyusQWRKY9gCTiu
+      sort: 0
+      activation:
+        type: ''
+        override: true
+        condition: ''
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: false
+        targets: []
+      description:
+        chatFlavor: ''
+      duration:
+        units: inst
+        concentration: false
+        override: false
+      effects: []
+      range:
+        units: self
+        override: false
+      target:
+        template:
+          contiguous: false
+          units: ft
+        affects:
+          choice: false
+        override: false
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      profiles:
+        - cr: '@target.cr'
+          name: ''
+          _id: LHLfS5BSpourwoiO
+          sizes: []
+          types:
+            - beast
+          movement: []
+          level:
+            min: null
+            max: null
+      settings: null
+      transform:
+        customize: false
+        preset: polymorph
+      name: ''
+      img: ''
   identifier: polymorph
 _id: phbsplPolymorph0
 type: spell
@@ -120,11 +172,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.346'
   systemId: dnd5e
-  systemVersion: 4.4.2
+  systemVersion: 5.1.0
   createdTime: 1724425966419
-  modifiedTime: 1746119719866
+  modifiedTime: 1753221584794
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplPolymorph0'

--- a/packs/_source/spells24/9th-level/true-polymorph.yml
+++ b/packs/_source/spells24/9th-level/true-polymorph.yml
@@ -164,7 +164,7 @@ system:
         recovery: []
         max: ''
       profiles:
-        - cr: '@target.cr'
+        - cr: '@target.details.cr'
           name: ''
           _id: LHLfS5BSpourwoiO
           sizes: []

--- a/packs/_source/spells24/9th-level/true-polymorph.yml
+++ b/packs/_source/spells24/9th-level/true-polymorph.yml
@@ -129,6 +129,57 @@ system:
       name: ''
       img: ''
       appliedEffects: []
+    NnjZWZzSmEsey562:
+      type: transform
+      sort: 0
+      activation:
+        type: ''
+        override: true
+        condition: ''
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: false
+        targets: []
+      description:
+        chatFlavor: ''
+      duration:
+        units: inst
+        concentration: false
+        override: false
+      effects: []
+      range:
+        units: self
+        override: false
+      target:
+        template:
+          contiguous: false
+          units: ft
+        affects:
+          choice: false
+        override: false
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      profiles:
+        - cr: '@target.cr'
+          name: ''
+          _id: LHLfS5BSpourwoiO
+          sizes: []
+          types: []
+          movement: []
+          level:
+            min: null
+            max: null
+      settings: null
+      transform:
+        customize: false
+        preset: polymorph
+      name: ''
+      _id: NnjZWZzSmEsey562
+      img: ''
   identifier: true-polymorph
 _id: phbsplTruePolymo
 type: spell
@@ -145,11 +196,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.346'
   systemId: dnd5e
-  systemVersion: 4.4.2
+  systemVersion: 5.1.0
   createdTime: 1724425976104
-  modifiedTime: 1746119773121
+  modifiedTime: 1753221605222
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplTruePolymo'


### PR DESCRIPTION
Adds `@target.details.cr` to the roll data for the Transform activity allowing it to be used when selecting the CR restriction in the compendium browser. If multiple targets are selected, then this number is the lowest of all of them.

Closes #5422