### PR TITLE
[#5581] Add direct link mode for selection in Transform activity

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4344,6 +4344,7 @@
       "Delete": "Delete Profile"
     },
     "ChallengeRatingLabel": "Challenge Rating of {cr} or lower",
+    "DropHint": "Drop creature here",
     "Empty": "Click the <i class=\"fas fa-plus\"></i> button above to create a profile.",
     "Label": "Transform Profile"
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -4297,6 +4297,9 @@
         "types": {
           "hint": "List of creature types from which the source creature can be selected.",
           "label": "Creature Types"
+        },
+        "uuid": {
+          "label": "Linked Actor"
         }
       },
       "label": "Transform Profiles"
@@ -4314,9 +4317,8 @@
       "mode": {
         "label": "Mode",
         "hint": "Sets how the transformation source creatures are selected.",
-        "Appearance": "Appearance Only",
-        "Default": "Compendium Browser",
-        "Direct": "Direct Link"
+        "CR": "By Challenge Rating",
+        "Direct": "By Direct Link"
       },
       "preset": {
         "label": "Preset"

--- a/less/v2/activities.less
+++ b/less/v2/activities.less
@@ -99,10 +99,10 @@
 }
 
 /* ----------------------------------------- */
-/*  Summon Activity                          */
+/*  Summon & Transform Activity              */
 /* ----------------------------------------- */
 
-.summon-activity.sheet .separated-list:not(.effects-list) {
+:is(.summon-activity, .transform-activity).sheet .separated-list:not(.effects-list) {
   .content-link, .drop-area, .name {
     display: flex;
     align-items: center;

--- a/module/applications/activity/transform-sheet.mjs
+++ b/module/applications/activity/transform-sheet.mjs
@@ -73,6 +73,10 @@ export default class TransformSheet extends ActivitySheet {
     context.movementTypeOptions = Object.entries(CONFIG.DND5E.movementTypes)
       .map(([value, { label }]) => ({ value, label }));
 
+    context.profileModes = [
+      { value: "", label: game.i18n.localize("DND5E.TRANSFORM.FIELDS.transform.mode.Direct") },
+      { value: "cr", label: game.i18n.localize("DND5E.TRANSFORM.FIELDS.transform.mode.CR") }
+    ];
     context.profiles = context.source.profiles.map((data, index) => ({
       data, index,
       collapsed: this.expandedSections.get(`profiles.${data._id}`) ? "" : "collapsed",

--- a/module/data/activity/summon-data.mjs
+++ b/module/data/activity/summon-data.mjs
@@ -3,7 +3,7 @@ import IdentifierField from "../fields/identifier-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
 const {
-  ArrayField, BooleanField, DocumentIdField, NumberField, SchemaField, SetField, StringField
+  ArrayField, BooleanField, DocumentIdField, DocumentUUIDField, NumberField, SchemaField, SetField, StringField
 } = foundry.data.fields;
 
 /**
@@ -75,7 +75,7 @@ export default class SummonActivityData extends BaseActivityData {
         }),
         name: new StringField(),
         types: new SetField(new StringField()),
-        uuid: new StringField()
+        uuid: new DocumentUUIDField()
       })),
       summon: new SchemaField({
         identifier: new IdentifierField(),

--- a/module/data/activity/transform-data.mjs
+++ b/module/data/activity/transform-data.mjs
@@ -4,7 +4,8 @@ import TransformationSetting from "../settings/transformation-setting.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
 const {
-  ArrayField, BooleanField, DocumentIdField, EmbeddedDataField, NumberField, SchemaField, SetField, StringField
+  ArrayField, BooleanField, DocumentIdField, DocumentUUIDField, EmbeddedDataField,
+  NumberField, SchemaField, SetField, StringField
 } = foundry.data.fields;
 
 /**
@@ -14,6 +15,7 @@ const {
 /**
  * @typedef TransformProfile
  * @property {string} _id            Unique ID for this profile.
+ * @property {string} cr             Formula for the CR of creature to transform into if in CR mode.
  * @property {object} level
  * @property {number} level.min      Minimum level at which this profile can be used.
  * @property {number} level.max      Maximum level at which this profile can be used.
@@ -21,6 +23,7 @@ const {
  * @property {string} name           Display name for this profile.
  * @property {Set<string>} sizes     Allowed creature sizes, or blank to allow all sizes.
  * @property {Set<string>} types     Allowed creature types, or blank to allow all types.
+ * @property {string} uuid           UUID of the actor to transform into if in direct mode.
  */
 
 /**
@@ -32,6 +35,7 @@ const {
  * @property {boolean} transform.customize     Should any customized settings be respected or should the default
  *                                             settings for the selected profile be used instead.
  * @property {string} transform.identifier     Class identifier that will be used to determine applicable level.
+ * @property {string} transform.mode           Method of determining what type of creature to transform into.
  * @property {string} transform.preset         Transformation preset to use.
  */
 export default class TransformActivityData extends BaseActivityData {
@@ -49,12 +53,14 @@ export default class TransformActivityData extends BaseActivityData {
         movement: new SetField(new StringField()),
         name: new StringField(),
         sizes: new SetField(new StringField()),
-        types: new SetField(new StringField())
+        types: new SetField(new StringField()),
+        uuid: new DocumentUUIDField({ type: "Actor" })
       })),
       settings: new EmbeddedDataField(TransformationSetting, { nullable: true, initial: null }),
       transform: new SchemaField({
         customize: new BooleanField(),
         identifier: new IdentifierField(),
+        mode: new StringField({ initial: "cr" }),
         preset: new StringField()
       })
     };

--- a/module/data/activity/transform-data.mjs
+++ b/module/data/activity/transform-data.mjs
@@ -35,7 +35,7 @@ const {
  * @property {boolean} transform.customize     Should any customized settings be respected or should the default
  *                                             settings for the selected profile be used instead.
  * @property {string} transform.identifier     Class identifier that will be used to determine applicable level.
- * @property {string} transform.mode           Method of determining what type of creature to transform into.
+ * @property {""|"cr"} transform.mode          Method of determining what type of creature to transform into.
  * @property {string} transform.preset         Transformation preset to use.
  */
 export default class TransformActivityData extends BaseActivityData {

--- a/module/documents/activity/transform.mjs
+++ b/module/documents/activity/transform.mjs
@@ -116,7 +116,7 @@ export default class TransformActivity extends ActivityMixin(TransformActivityDa
   async _finalizeUsage(config, results) {
     const profile = this.profiles.find(p => p._id === config.transform?.profile);
     if ( profile ) {
-      const uuid = await this.queryActor(profile);
+      const uuid = !this.transform.mode ? profile.uuid : await this.queryActor(profile);
       if ( uuid ) {
         if ( results.message instanceof ChatMessage ) results.message.setFlag("dnd5e", "transform.uuid", uuid);
         else foundry.utils.setProperty(results.message, "flags.dnd5e.transform.uuid", uuid);

--- a/templates/activity/parts/transform-profiles.hbs
+++ b/templates/activity/parts/transform-profiles.hbs
@@ -8,6 +8,7 @@
             </button>
         </legend>
         {{#with fields.transform.fields as |fields|}}
+        {{ formField fields.mode value=../source.transform.mode options=../profileModes }}
         {{#unless @root.activity.isSpell}}
         {{ formField fields.identifier value=../source.transform.identifier }}
         {{/unless}}
@@ -31,8 +32,15 @@
         <div class="form-fields">
 
             {{!-- CR --}}
+            {{#if (eq @root.source.transform.mode "cr")}}
             {{ formField fields.cr name=(concat prefix "cr") value=data.cr localize=true hint=false classes="label-top"
                          label="DND5E.TRANSFORM.FIELDS.profiles.element.cr.abbr" }}
+
+            {{ else }}
+
+            {{ formInput fields.uuid name=(concat prefix "uuid") value=data.uuid }}
+
+            {{/if}}
 
             {{!-- Name --}}
             {{ formField fields.name name=(concat prefix "name") value=data.name hint=false classes="label-top"
@@ -54,12 +62,14 @@
         </label>
         <div class="collapsible-content">
             <div class="wrapper">
+                {{#if (eq @root.source.transform.mode "cr")}}
                 {{ formField fields.sizes name=(concat prefix "sizes") value=data.sizes
                              options=@root.creatureSizeOptions }}
                 {{ formField fields.types name=(concat prefix "types") value=data.types
                              options=@root.creatureTypeOptions }}
                 {{ formField fields.movement name=(concat prefix "movement") value=data.movement
                              options=@root.movementTypeOptions }}
+                {{/if}}
                 <div class="form-group">
                     <label>{{ localize "DND5E.TRANSFORM.FIELDS.profiles.element.level.label" }}</label>
                     <div class="form-fields range-fields">

--- a/templates/activity/parts/transform-profiles.hbs
+++ b/templates/activity/parts/transform-profiles.hbs
@@ -36,9 +36,15 @@
             {{ formField fields.cr name=(concat prefix "cr") value=data.cr localize=true hint=false classes="label-top"
                          label="DND5E.TRANSFORM.FIELDS.profiles.element.cr.abbr" }}
 
-            {{ else }}
+            {{else if document}}
 
-            {{ formInput fields.uuid name=(concat prefix "uuid") value=data.uuid }}
+            {{!-- UUID --}}
+            {{{ dnd5e-linkForUuid data.uuid }}}
+
+            {{else~}}
+
+            {{!-- Drop Area --}}
+            <div class="drop-area">{{ localize "DND5E.TRANSFORM.Profile.DropHint" }}</div>
 
             {{/if}}
 


### PR DESCRIPTION
Adds mode to the Transform activity to select between the default CR mode and a new Direct Link mode (similar to how the Summon activity is set up). When the direct link mode is selected a UUID field replaces the CR field allowing adding a specific actor which will be used when transforming.

<img width="523" height="393" alt="Transform - Direct Link" src="https://github.com/user-attachments/assets/cb10e723-86cc-43e9-bc07-d40ae69e7246" />



Closes #5581