### PR TITLE
[#5025] Switch legendaries to use `spent` rather than `value`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2920,7 +2920,8 @@
     "few": "{n}rd Legendary Action",
     "other": "{n}th Legendary Action"
   },
-  "Remaining": "Remaining Legendary Actions"
+  "Remaining": "Remaining Legendary Actions",
+  "Spent": "Spent Legendary Actions"
 },
 
 "DND5E.LegendaryResistance": {
@@ -2936,7 +2937,8 @@
     "other": "{n}th Legendary Resistance"
   },
   "Remaining": "Remaining Legendary Resistances",
-  "Resisted": "Used Legendary Resistance"
+  "Resisted": "Used Legendary Resistance",
+  "Spent": "Spent Legendary Resistances"
 },
 
 "DND5E.Level": "Level",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2912,6 +2912,7 @@
   "Description": "Legendary Action Uses: {uses}. Immediately after another creature’s turn, the {name} can expend a use to take one of the following actions. The {name} regains all expended uses at the start of each of its turns.",
   "DescriptionLegacy": "The {name} can take {usesNamed}, choosing from the options below. Only one legendary action option can be used at a time and only at the end of another creature’s turn. The {name} regains spent legendary actions at the start of its turn.",
   "Label": "Legendary Action",
+  "LabelPl": "Legendary Actions",
   "LairUses": "{normal} ({lair} in Lair)",
   "Max": "Maximum Legendary Actions",
   "Ordinal": {
@@ -2929,6 +2930,7 @@
     "Resist": "Legendary Resistance"
   },
   "Label": "Legendary Resistance",
+  "LabelPl": "Legendary Resistances",
   "Max": "Maximum Legendary Resistances",
   "Ordinal": {
     "one": "{n}st Legendary Resistance",

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1571,9 +1571,10 @@ export default class BaseActorSheet extends PrimarySheetMixin(
   static #togglePip(event, target) {
     const n = Number(target.closest("[data-n]")?.dataset.n);
     const prop = target.dataset.prop ?? target.closest("[data-prop]")?.dataset.prop;
-    if ( !n || Number.isNaN(n) || !prop ) return;
+    if ( !Number.isNumeric(n) || !prop ) return;
     let value = foundry.utils.getProperty(this.actor, prop);
-    if ( value === n ) value--;
+    if ( (value === n) && prop.endsWith(".value") ) value--;
+    else if ( (value === n) && prop.endsWith(".spent") ) value++;
     else value = n;
     this.submit({ updateData: { [prop]: value } });
   }

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -280,7 +280,7 @@ export default class NPCActorSheet extends BaseActorSheet {
         const classes = ["pip"];
         if ( filled ) classes.push("filled");
         return {
-          n, filled,
+          n: max - n, filled,
           tooltip: `DND5E.${i18n}.Label`,
           label: game.i18n.format(`DND5E.${i18n}.Ordinal.${plurals.select(n)}`, { n }),
           classes: classes.join(" ")

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -160,7 +160,7 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
         activity: this.activity.name, attribute: this.target, item: this.item.name
       })
     );
-    const current = foundry.utils.getProperty(this.actor, keyPath);
+    let current = foundry.utils.getProperty(this.actor, keyPath);
 
     let warningMessage;
     if ( (cost > 0) && !current ) warningMessage = "DND5E.CONSUMPTION.Warning.None";
@@ -170,7 +170,13 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
       type: game.i18n.format("DND5E.CONSUMPTION.Type.Attribute.Warning", { attribute: this.target })
     }));
 
-    updates.actor[keyPath] = current - cost;
+    const adjustedKeyPath = keyPath.replace(/\.value$/, ".spent");
+    const isSpent = (keyPath !== adjustedKeyPath) && !foundry.utils.hasProperty(this.actor._source, keyPath)
+      && foundry.utils.hasProperty(this.actor._source, adjustedKeyPath);
+    if ( isSpent ) {
+      current = foundry.utils.getProperty(this.actor, adjustedKeyPath);
+      updates.actor[adjustedKeyPath] = current + cost;
+    } else updates.actor[keyPath] = current - cost;
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -483,6 +483,20 @@ export default class NPCData extends CreatureTemplate {
   }
 
   /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preUpdate(changes, options, user) {
+    if ( (await super._preUpdate(changes, options, user)) === false ) return false;
+    for ( const k of ["legact", "legres"] ) {
+      if ( !foundry.utils.hasProperty(changes, `system.resources.${k}.value`) ) continue;
+      const spent = this.resources[k].max - changes.system.resources[k].value;
+      foundry.utils.setProperty(changes, `system.resources.${k}.spent`, spent);
+    }
+  }
+
+  /* -------------------------------------------- */
   /*  Helpers                                     */
   /* -------------------------------------------- */
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -622,7 +622,7 @@ export default function ActivityMixin(Base) {
             }));
             errors.push(err);
           } else {
-            updates.actor["system.resources.legact.value"] = legendary.value - count;
+            updates.actor["system.resources.legact.spent"] = legendary.spent + count;
           }
         }
       }

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -52,6 +52,8 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
       const hp = this.actor.system.attributes.hp || {};
       data.value += (hp.temp || 0);
       data.max = Math.max(0, hp.effectiveMax);
+    } else if ( ["resources.legact", "resources.legres"].includes(data?.attribute) ) {
+      data.editable = true;
     }
     return data;
   }

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1178,7 +1178,9 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   }
 
   // Resources
+  else if ( attr === "resources.legact.spent" ) label = "DND5E.LegendaryAction.LabelPl";
   else if ( attr === "resources.legact.value" ) label = "DND5E.LegendaryAction.Remaining";
+  else if ( attr === "resources.legres.spent" ) label = "DND5E.LegendaryResistance.LabelPl";
   else if ( attr === "resources.legres.value" ) label = "DND5E.LegendaryResistance.Remaining";
 
   // Skills.

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1177,6 +1177,10 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
     label = game.i18n.format("DND5E.AbilityScoreL", { ability: CONFIG.DND5E.abilities[key].label });
   }
 
+  // Resources
+  else if ( attr === "resources.legact.value" ) label = "DND5E.LegendaryAction.Remaining";
+  else if ( attr === "resources.legres.value" ) label = "DND5E.LegendaryResistance.Remaining";
+
   // Skills.
   else if ( attr.startsWith("skills.") ) {
     const [, key] = attr.split(".");

--- a/templates/actors/npc-header.hbs
+++ b/templates/actors/npc-header.hbs
@@ -363,7 +363,7 @@
                 {{#if system.resources.legact.max}}
                 <div class="legact">
                     <span class="label roboto-upper">{{ localize "DND5E.LegendaryAction.Label" }}</span>
-                    <div class="pips" data-prop="system.resources.legact.value">
+                    <div class="pips" data-prop="system.resources.legact.spent">
                         {{#each legact}}
                             {{> ".pip" }}
                         {{/each}}
@@ -373,7 +373,7 @@
                 {{#if system.resources.legres.max}}
                 <div class="legres">
                     <span class="label roboto-upper">{{ localize "DND5E.LegendaryResistance.Label" }}</span>
-                    <div class="pips" data-prop="system.resources.legres.value">
+                    <div class="pips" data-prop="system.resources.legres.spent">
                         {{#each legres}}
                             {{> ".pip" }}
                         {{/each}}


### PR DESCRIPTION
Change legendary actions and resistances from storing a `value` to storing the number of `spent`. This leads to the correct number of available legendaries when an NPC enters or leaves their lair.

Some adjustments were made to `consumeAttribute` to allow for adjusting `spent` when the consumption target is `value`. This helps ensure the consumption limits are correct and that no migration is needed for consumption targets.

Closes #5025