### PR TITLE
Add convenience getter for primary party

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -61,6 +61,7 @@ Hooks.once("init", function() {
   CONFIG.DND5E = DND5E;
   CONFIG.ActiveEffect.documentClass = documents.ActiveEffect5e;
   CONFIG.ActiveEffect.legacyTransferral = false;
+  CONFIG.Actor.collection = dataModels.collection.Actors5e;
   CONFIG.Actor.documentClass = documents.Actor5e;
   CONFIG.Canvas.layers.tokens.layerClass = CONFIG.Token.layerClass = canvas.layers.TokenLayer5e;
   CONFIG.ChatMessage.documentClass = documents.ChatMessage5e;

--- a/module/applications/award.mjs
+++ b/module/applications/award.mjs
@@ -77,7 +77,7 @@ export default class Award extends Application5e {
   get transferDestinations() {
     if ( this.isPartyAward ) return this.origin.system.transferDestinations ?? [];
     if ( !game.user.isGM ) return [];
-    const primaryParty = game.settings.get("dnd5e", "primaryParty")?.actor;
+    const primaryParty = game.actors.party;
     return primaryParty
       ? [primaryParty, ...primaryParty.system.transferDestinations]
       : game.users.map(u => u.character).filter(c => c);
@@ -111,7 +111,7 @@ export default class Award extends Application5e {
     context.destinations = Award.prepareDestinations(this.transferDestinations, this.award.savedDestinations);
     context.each = this.award.each ?? false;
     context.hideXP = game.settings.get("dnd5e", "levelingMode") === "noxp";
-    context.noPrimaryParty = !game.settings.get("dnd5e", "primaryParty")?.actor && !this.isPartyAward;
+    context.noPrimaryParty = !game.actors.party && !this.isPartyAward;
     context.xp = this.award.xp ?? this.origin?.system.details.xp.value ?? this.origin?.system.details.xp.derived;
 
     return context;
@@ -379,7 +379,7 @@ export default class Award extends Application5e {
       }
 
       // If the party command is set, a primary party is set, and the award isn't empty, skip the UI
-      const primaryParty = game.settings.get("dnd5e", "primaryParty")?.actor;
+      const primaryParty = game.actors.party;
       if ( party && primaryParty && (xp || filteredKeys(currency).length) ) {
         const destinations = each ? primaryParty.system.playerCharacters : [primaryParty];
         const results = new Map();

--- a/module/applications/currency-manager.mjs
+++ b/module/applications/currency-manager.mjs
@@ -75,7 +75,7 @@ export default class CurrencyManager extends Application5e {
     destinations.push(...(actor?.system.transferDestinations ?? []));
     destinations.push(...(actor?.itemTypes.container.filter(b => b !== this.document) ?? []));
     if ( game.user.isGM ) {
-      const primaryParty = game.settings.get("dnd5e", "primaryParty")?.actor;
+      const primaryParty = game.actors.party;
       if ( primaryParty && (this.document !== primaryParty) && !destinations.includes(primaryParty) ) {
         destinations.push(primaryParty);
       }

--- a/module/data/abstract/actor-data-model.mjs
+++ b/module/data/abstract/actor-data-model.mjs
@@ -32,7 +32,7 @@ export default class ActorDataModel extends SystemDataModel {
    * @type {Actor5e[]}
    */
   get transferDestinations() {
-    const primaryParty = game.settings.get("dnd5e", "primaryParty")?.actor;
+    const primaryParty = game.actors.party;
     if ( !primaryParty?.system.members.ids.has(this.parent.id) ) return [];
     const destinations = primaryParty.system.members.map(m => m.actor).filter(a => a.isOwner && a !== this.parent);
     if ( primaryParty.isOwner ) destinations.unshift(primaryParty);

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -352,7 +352,7 @@ export default class GroupActor extends ActorDataModel.mixin(CurrencyTemplate) {
    */
   _onUpdate(changed, options, userId) {
     if ( !foundry.utils.hasProperty(changed, "system.type.value") || (game.user !== game.users.activeGM)
-      || (game.settings.get("dnd5e", "primaryParty")?.actor !== this.parent)
+      || (game.actors.party !== this.parent)
       || (foundry.utils.getProperty(changed, "system.type.value") === "party") ) return;
     game.settings.set("dnd5e", "primaryParty", { actor: null });
   }

--- a/module/data/collection/_module.mjs
+++ b/module/data/collection/_module.mjs
@@ -1,1 +1,2 @@
+export {default as Actors5e} from "./actors-collection.mjs";
 export {default as Items5e} from "./items-collection.mjs";

--- a/module/data/collection/actors-collection.mjs
+++ b/module/data/collection/actors-collection.mjs
@@ -1,0 +1,12 @@
+/**
+ * Custom actors collection.
+ */
+export default class Actors5e extends foundry.documents.collections.Actors {
+  /**
+   * The primary party.
+   * @type {Actor5e|null}
+   */
+  get party() {
+    return game.settings.get("dnd5e", "primaryParty")?.actor ?? null;
+  }
+}

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3123,7 +3123,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       },
       condition: li => {
         const actor = game.actors.get(li.dataset.documentId ?? li.dataset.entryId);
-        const primary = game.settings.get("dnd5e", "primaryParty")?.actor;
+        const primary = game.actors.party;
         return game.user.isGM && (actor?.type === "group")
           && (actor.system.type.value === "party") && (actor !== primary);
       },
@@ -3136,8 +3136,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       },
       condition: li => {
         const actor = game.actors.get(li.dataset.documentId ?? li.dataset.entryId);
-        const primary = game.settings.get("dnd5e", "primaryParty")?.actor;
-        return game.user.isGM && (actor === primary);
+        return game.user.isGM && (actor === game.actors.party);
       },
       group: "system"
     });
@@ -3150,7 +3149,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @param {HTMLElement} html
    */
   static onRenderActorDirectory(html) {
-    const primaryParty = game.settings.get("dnd5e", "primaryParty")?.actor;
+    const primaryParty = game.actors.party;
     if ( primaryParty ) {
       const element = html?.querySelector(`[data-entry-id="${primaryParty.id}"]`);
       element?.classList.add("primary-party");

--- a/module/tooltips.mjs
+++ b/module/tooltips.mjs
@@ -139,7 +139,7 @@ export default class Tooltips5e {
       label = game.i18n.format("DND5E.SkillPassiveHint", { skill: abilityConfig.label });
     }
 
-    const party = game.settings.get("dnd5e", "primaryParty")?.actor;
+    const party = game.actors.party;
     if ( !party ) {
       this.tooltip.innerHTML = label;
       return;


### PR DESCRIPTION
Adds `game.actors.party` which returns the primary party. Useful to not have to look up the setting manually and use optional chaining.