### PR TITLE
SortingHelper deprecation

### DIFF
--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -1305,7 +1305,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
       else if ( f.id === srcId ) source = f;
       return f.id !== srcId;
     });
-    const updates = foundry.utils.SortingHelpers.performIntegerSort(source, { target, siblings });
+    const updates = foundry.utils.performIntegerSort(source, { target, siblings });
     const favorites = this.actor.system.favorites.reduce((map, f) => map.set(f.id, { ...f }), new Map());
     for ( const { target, update } of updates ) {
       const favorite = favorites.get(target.id);

--- a/module/applications/item/config/starting-equipment-config.mjs
+++ b/module/applications/item/config/starting-equipment-config.mjs
@@ -270,7 +270,7 @@ export default class StartingEquipmentConfig extends DocumentSheet5e {
     if ( target && (target !== dragEntry) ) {
       updateData ??= {};
       const siblings = this.document.system.startingEquipment.filter(s => s._id !== dragEntry._id);
-      const sortUpdates = foundry.utils.SortingHelpers.performIntegerSort(dragEntry, { target, siblings, sortBefore });
+      const sortUpdates = foundry.utils.performIntegerSort(dragEntry, { target, siblings, sortBefore });
       for ( const update of sortUpdates ) {
         updateData[`startingEquipment.${update.target._id}.sort`] = update.update.sort;
       }

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -310,7 +310,7 @@ export default class ContainerSheet extends ItemSheet5e {
     }
 
     // Perform the sort
-    const sortUpdates = foundry.utils.SortingHelpers.performIntegerSort(item, {target, siblings});
+    const sortUpdates = foundry.utils.performIntegerSort(item, {target, siblings});
     const updateData = sortUpdates.map(u => {
       const update = u.update;
       update._id = u.target.id;

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -933,7 +933,7 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
       const target = this.item.system.activities.get(targetId);
       if ( !target || (target === source) ) return;
       const siblings = this.item.system.activities.filter(a => a._id !== id);
-      const sortUpdates = foundry.utils.SortingHelpers.performIntegerSort(source, { target, siblings });
+      const sortUpdates = foundry.utils.performIntegerSort(source, { target, siblings });
       const updateData = Object.fromEntries(sortUpdates.map(({ target, update }) => {
         return [target._id, { sort: update.sort }];
       }));

--- a/module/applications/settings/module-art-settings.mjs
+++ b/module/applications/settings/module-art-settings.mjs
@@ -69,7 +69,7 @@ export default class ModuleArtSettingsConfig extends FormApplication {
     const config = configs[idx];
     const target = configs[sortBefore ? idx - 1 : idx + 1];
     configs.splice(idx, 1);
-    const updates = foundry.utils.SortingHelpers.performIntegerSort(config, {
+    const updates = foundry.utils.performIntegerSort(config, {
       target, sortBefore,
       siblings: configs,
       sortKey: "priority"


### PR DESCRIPTION
`SortingHelper` entirely deprecated. `performIntegerSort` is directly on `foundry.utils`.

(Fixes those in #5857 and one more)