### PR TITLE
Tool, weapon, equipment `baseItem` compatibility

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -516,10 +516,13 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
       options.push({ value, label: baseItem.name });
     }
 
-    return options.length ? [
-      { value: "", label: "" },
-      ...options.sort((lhs, rhs) => lhs.label.localeCompare(rhs.label, game.i18n.lang))
-    ] : null;
+    if ( !options.length ) return null;
+
+    options.sort((lhs, rhs) => lhs.label.localeCompare(rhs.label, game.i18n.lang));
+    const baseId = this.item.system._source.type.baseItem ?? this.item.system.type.baseItem;
+    if ( baseId && !(baseId in baseIds) ) options.unshift({ value: baseId, label: baseId });
+    options.unshift({ value: "", label: "" });
+    return options;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
If a weapon adds a new tool type, armor type, shield type, or weapon type, and is then later disabled, viewing one of the items' sheets shows an empty `system.type.baseItem` dropdown, and any unrelated change to the item makes the item lose this property.

This is especially not good for the "Net" weapon type, which is not a thing in the Modern ruleset, meaning that not only will items get wonky by disabling a module, they can also get wonky by changing the rule setting back and forth.

This PR adds the current value in as a temporary option if truthy and not in the record of base item ids.