### PR TITLE
[#5914] Update item-sheet maxLevel check from `!configMode` to `this.item.parent`

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -423,7 +423,7 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
     const advancement = {};
     const configMode = !this.item.parent || (this._mode === ItemSheet5e.MODES.EDIT);
     const legacyDisplay = this.options.legacyDisplay;
-    const maxLevel = !configMode ? (this.item.system.levels ?? this.item.class?.system.levels
+    const maxLevel = this.item.parent ? (this.item.system.levels ?? this.item.class?.system.levels
       ?? this.item.parent.system.details?.level ?? -1) : -1;
 
     // Improperly configured advancements


### PR DESCRIPTION
Just a small change to restore the option to modify advancement choices. It looks like this was a side effect of [this change](https://github.com/foundryvtt/dnd5e/commit/054e58d02ea0e6ceb65dd44a396678b9a4e2f9f7#diff-97656250854f673ff52d31bfa12d06fe197a71e0e26772f6c33736490b2002dbR417).

I confirmed editing/creating items outside of actors still works as expected. 

Closes #5914.