### PR TITLE
Modify `base` AE type with system-specific data

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -7,19 +7,25 @@
   }
 },
 
-"TYPES.Actor.character": "Player Character",
-"TYPES.Actor.characterPl": "Player Characters",
-"TYPES.Actor.encounter": "Encounter",
-"TYPES.Actor.encounterPl": "Encounters",
-"TYPES.Actor.group": "Group",
-"TYPES.Actor.groupPl": "Groups",
-"TYPES.Actor.npc": "Non-Player Character",
-"TYPES.Actor.npcPl": "Non-Player Characters",
-"TYPES.Actor.vehicle": "Vehicle",
-"TYPES.Actor.vehiclePl": "Vehicles",
+"TYPES.Actor": {
+  "character": "Player Character",
+  "characterPl": "Player Characters",
+  "encounter": "Encounter",
+  "encounterPl": "Encounters",
+  "group": "Group",
+  "groupPl": "Groups",
+  "npc": "Non-Player Character",
+  "npcPl": "Non-Player Characters",
+  "vehicle": "Vehicle",
+  "vehiclePl": "Vehicles"
+},
 
-"TYPES.ActiveEffect.enchantment": "Enchantment",
-"TYPES.ActiveEffect.enchantmentPl": "Enchantments",
+"TYPES.ActiveEffect": {
+  "enchantment": "Enchantment",
+  "enchantmentPl": "Enchantments",
+  "standard": "Effect",
+  "standardPl": "Effects"
+},
 
 "TYPES.ChatMessage": {
   "request": "Request Message",
@@ -28,34 +34,36 @@
   "usage": "Usage Message"
 },
 
-"TYPES.Item.background": "Background",
-"TYPES.Item.backgroundPl": "Backgrounds",
-"TYPES.Item.container": "Container",
-"TYPES.Item.containerPl": "Containers",
-"TYPES.Item.class": "Class",
-"TYPES.Item.classPl": "Classes",
-"TYPES.Item.consumable": "Consumable",
-"TYPES.Item.consumablePl": "Consumables",
-"TYPES.Item.equipment": "Equipment",
-"TYPES.Item.equipmentPl": "Equipment",
-"TYPES.Item.facility": "Facility",
-"TYPES.Item.facilityPl": "Facilities",
-"TYPES.Item.feat": "Feature",
-"TYPES.Item.featurePl": "Features",
-"TYPES.Item.loot": "Loot",
-"TYPES.Item.lootPl": "Loot",
-"TYPES.Item.race": "Species",
-"TYPES.Item.racePl": "Species",
-"TYPES.Item.raceLegacy": "Race",
-"TYPES.Item.raceLegacyPl": "Races",
-"TYPES.Item.spell": "Spell",
-"TYPES.Item.spellPl": "Spells",
-"TYPES.Item.subclass": "Subclass",
-"TYPES.Item.subclassPl": "Subclasses",
-"TYPES.Item.tool": "Tool",
-"TYPES.Item.toolPl": "Tools",
-"TYPES.Item.weapon": "Weapon",
-"TYPES.Item.weaponPl": "Weapons",
+"TYPES.Item": {
+  "background": "Background",
+  "backgroundPl": "Backgrounds",
+  "container": "Container",
+  "containerPl": "Containers",
+  "class": "Class",
+  "classPl": "Classes",
+  "consumable": "Consumable",
+  "consumablePl": "Consumables",
+  "equipment": "Equipment",
+  "equipmentPl": "Equipment",
+  "facility": "Facility",
+  "facilityPl": "Facilities",
+  "feat": "Feature",
+  "featurePl": "Features",
+  "loot": "Loot",
+  "lootPl": "Loot",
+  "race": "Species",
+  "racePl": "Species",
+  "raceLegacy": "Race",
+  "raceLegacyPl": "Races",
+  "spell": "Spell",
+  "spellPl": "Spells",
+  "subclass": "Subclass",
+  "subclassPl": "Subclasses",
+  "tool": "Tool",
+  "toolPl": "Tools",
+  "weapon": "Weapon",
+  "weaponPl": "Weapons"
+},
 
 "TYPES.RegionBehavior": {
   "dnd5e.difficultTerrain": "Difficult Terrain",
@@ -1661,12 +1669,6 @@
 "DND5E.ConCharmed": "Charmed",
 "DND5E.ConDeafened": "Deafened",
 "DND5E.ConDiseased": "Diseased",
-"DND5E.CONDITIONS": {
-  "RiderConditions": {
-    "label": "Separate Status Conditions",
-    "hint": "When this Active Effect is applied, these additional status conditions will be applied separately."
-  }
-},
 "DND5E.ConExhaustion": "Exhaustion",
 "DND5E.ConFrightened": "Frightened",
 "DND5E.ConGrappled": "Grappled",
@@ -2242,25 +2244,51 @@
 "DND5E.DurationUnits": "Duration Units",
 "DND5E.DurationValue": "Duration Value",
 "DND5E.Dusk": "Dusk",
+
 "DND5E.Effect": "Effect",
-"DND5E.Effects": "Effects",
+
 "DND5E.EFFECT": {
   "Action": {
     "Create": "Create Effect",
     "Delete": "Delete Effect",
-    "Dissociate": "Dissociate Effect"
+    "Dissociate": "Dissociate Effect",
+    "Search": "Search effects"
+  },
+  "Application": {
+    "Action": {
+      "ApplyTokens": "Apply to selected tokens"
+    },
+    "Header": "Effects",
+    "Warning": {
+      "Concentration": "Applying an effect that is being concentrated on by another character requires GM permissions.",
+      "Ownership": "Effects cannot be applied to tokens you are not the owner of."
+    }
   },
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
   "Label": "Available Effects",
   "RIDER": {
     "Activity": "Enchantment Rider Activity",
-    "Effect": "Enchantment Rider Effect"
-  }
+    "Effect": "Enchantment Rider Effect",
+    "FIELDS": {
+      "rider": {
+        "statuses": {
+          "hint": "When this Active Effect is applied, these additional status conditions will be applied separately.",
+          "label": "Separate Status Conditions"
+        }
+      }
+    }
+  },
+  "STANDARD": {
+    "FIELDS": {
+      "magical": {
+        "hint": "This effect is from a magical source and should be disabled when magic isn't available.",
+        "label": "Magical"
+      }
+    }
+  },
+  "Tab": "Effects"
 },
-"DND5E.EffectsApplyTokens": "Apply to selected tokens",
-"DND5E.EffectApplyWarningConcentration": "Applying an effect that is being concentrated on by another character requires GM permissions.",
-"DND5E.EffectApplyWarningOwnership": "Effects cannot be applied to tokens you are not the owner of.",
-"DND5E.EffectsSearch": "Search effects",
+
 
 "DND5E.ENCHANT": {
   "FIELDS": {
@@ -2365,18 +2393,9 @@
     "Inactive": "Inactive Enchantments"
   },
   "FIELDS": {
-    "enchantment": {
-      "label": "Enchantment Configuration",
-      "items": {
-        "max": {
-          "label": "Item Limit",
-          "hint": "Formula for the maximum number of enchantments of this type that can be active at a time."
-        },
-        "period": {
-          "label": "Replacement Period",
-          "hint": "How frequently the enchantments of this type can be re-bound to different items."
-        }
-      }
+    "magical": {
+      "hint": "This enchantment is magical and should be disabled when magic isn't available.",
+      "label": "Magical"
     }
   },
   "Items": {
@@ -2736,6 +2755,19 @@
     "cover": {
       "label": "Cover",
       "hint": "Cover provided to crew by this vehicle feature."
+    },
+    "enchant": {
+      "label": "Enchantment Configuration",
+      "items": {
+        "max": {
+          "label": "Item Limit",
+          "hint": "Formula for the maximum number of enchantments of this type that can be active at a time."
+        },
+        "period": {
+          "label": "Replacement Period",
+          "hint": "How frequently the enchantments of this type can be re-bound to different items."
+        }
+      }
     },
     "properties": {
       "label": "Feature Properties"

--- a/lang/en.json
+++ b/lang/en.json
@@ -22,9 +22,7 @@
 
 "TYPES.ActiveEffect": {
   "enchantment": "Enchantment",
-  "enchantmentPl": "Enchantments",
-  "standard": "Effect",
-  "standardPl": "Effects"
+  "enchantmentPl": "Enchantments"
 },
 
 "TYPES.ChatMessage": {
@@ -2264,6 +2262,14 @@
       "Ownership": "Effects cannot be applied to tokens you are not the owner of."
     }
   },
+  "BASE": {
+    "FIELDS": {
+      "magical": {
+        "hint": "This effect is from a magical source and should be disabled when magic isn't available.",
+        "label": "Magical"
+      }
+    }
+  },
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
   "Label": "Available Effects",
   "RIDER": {
@@ -2275,14 +2281,6 @@
           "hint": "When this Active Effect is applied, these additional status conditions will be applied separately.",
           "label": "Separate Status Conditions"
         }
-      }
-    }
-  },
-  "STANDARD": {
-    "FIELDS": {
-      "magical": {
-        "hint": "This effect is from a magical source and should be disabled when magic isn't available.",
-        "label": "Magical"
       }
     }
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -7,19 +7,25 @@
   }
 },
 
-"TYPES.Actor.character": "Player Character",
-"TYPES.Actor.characterPl": "Player Characters",
-"TYPES.Actor.encounter": "Encounter",
-"TYPES.Actor.encounterPl": "Encounters",
-"TYPES.Actor.group": "Group",
-"TYPES.Actor.groupPl": "Groups",
-"TYPES.Actor.npc": "Non-Player Character",
-"TYPES.Actor.npcPl": "Non-Player Characters",
-"TYPES.Actor.vehicle": "Vehicle",
-"TYPES.Actor.vehiclePl": "Vehicles",
+"TYPES.Actor": {
+  "character": "Player Character",
+  "characterPl": "Player Characters",
+  "encounter": "Encounter",
+  "encounterPl": "Encounters",
+  "group": "Group",
+  "groupPl": "Groups",
+  "npc": "Non-Player Character",
+  "npcPl": "Non-Player Characters",
+  "vehicle": "Vehicle",
+  "vehiclePl": "Vehicles"
+},
 
-"TYPES.ActiveEffect.enchantment": "Enchantment",
-"TYPES.ActiveEffect.enchantmentPl": "Enchantments",
+"TYPES.ActiveEffect": {
+  "enchantment": "Enchantment",
+  "enchantmentPl": "Enchantments",
+  "standard": "Effect",
+  "standardPl": "Effects"
+},
 
 "TYPES.ChatMessage": {
   "request": "Request Message",
@@ -28,34 +34,36 @@
   "usage": "Usage Message"
 },
 
-"TYPES.Item.background": "Background",
-"TYPES.Item.backgroundPl": "Backgrounds",
-"TYPES.Item.container": "Container",
-"TYPES.Item.containerPl": "Containers",
-"TYPES.Item.class": "Class",
-"TYPES.Item.classPl": "Classes",
-"TYPES.Item.consumable": "Consumable",
-"TYPES.Item.consumablePl": "Consumables",
-"TYPES.Item.equipment": "Equipment",
-"TYPES.Item.equipmentPl": "Equipment",
-"TYPES.Item.facility": "Facility",
-"TYPES.Item.facilityPl": "Facilities",
-"TYPES.Item.feat": "Feature",
-"TYPES.Item.featurePl": "Features",
-"TYPES.Item.loot": "Loot",
-"TYPES.Item.lootPl": "Loot",
-"TYPES.Item.race": "Species",
-"TYPES.Item.racePl": "Species",
-"TYPES.Item.raceLegacy": "Race",
-"TYPES.Item.raceLegacyPl": "Races",
-"TYPES.Item.spell": "Spell",
-"TYPES.Item.spellPl": "Spells",
-"TYPES.Item.subclass": "Subclass",
-"TYPES.Item.subclassPl": "Subclasses",
-"TYPES.Item.tool": "Tool",
-"TYPES.Item.toolPl": "Tools",
-"TYPES.Item.weapon": "Weapon",
-"TYPES.Item.weaponPl": "Weapons",
+"TYPES.Item": {
+  "background": "Background",
+  "backgroundPl": "Backgrounds",
+  "container": "Container",
+  "containerPl": "Containers",
+  "class": "Class",
+  "classPl": "Classes",
+  "consumable": "Consumable",
+  "consumablePl": "Consumables",
+  "equipment": "Equipment",
+  "equipmentPl": "Equipment",
+  "facility": "Facility",
+  "facilityPl": "Facilities",
+  "feat": "Feature",
+  "featurePl": "Features",
+  "loot": "Loot",
+  "lootPl": "Loot",
+  "race": "Species",
+  "racePl": "Species",
+  "raceLegacy": "Race",
+  "raceLegacyPl": "Races",
+  "spell": "Spell",
+  "spellPl": "Spells",
+  "subclass": "Subclass",
+  "subclassPl": "Subclasses",
+  "tool": "Tool",
+  "toolPl": "Tools",
+  "weapon": "Weapon",
+  "weaponPl": "Weapons"
+},
 
 "TYPES.RegionBehavior": {
   "dnd5e.applyActiveEffect": "Apply Active Effect (5e)",
@@ -1766,12 +1774,6 @@
 "DND5E.ConCharmed": "Charmed",
 "DND5E.ConDeafened": "Deafened",
 "DND5E.ConDiseased": "Diseased",
-"DND5E.CONDITIONS": {
-  "RiderConditions": {
-    "label": "Separate Status Conditions",
-    "hint": "When this Active Effect is applied, these additional status conditions will be applied separately."
-  }
-},
 "DND5E.ConExhaustion": "Exhaustion",
 "DND5E.ConFrightened": "Frightened",
 "DND5E.ConGrappled": "Grappled",
@@ -2352,25 +2354,51 @@
 "DND5E.DurationUnits": "Duration Units",
 "DND5E.DurationValue": "Duration Value",
 "DND5E.Dusk": "Dusk",
+
 "DND5E.Effect": "Effect",
-"DND5E.Effects": "Effects",
+
 "DND5E.EFFECT": {
   "Action": {
     "Create": "Create Effect",
     "Delete": "Delete Effect",
-    "Dissociate": "Dissociate Effect"
+    "Dissociate": "Dissociate Effect",
+    "Search": "Search effects"
+  },
+  "Application": {
+    "Action": {
+      "ApplyTokens": "Apply to selected tokens"
+    },
+    "Header": "Effects",
+    "Warning": {
+      "Concentration": "Applying an effect that is being concentrated on by another character requires GM permissions.",
+      "Ownership": "Effects cannot be applied to tokens you are not the owner of."
+    }
   },
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
   "Label": "Available Effects",
   "RIDER": {
     "Activity": "Enchantment Rider Activity",
-    "Effect": "Enchantment Rider Effect"
-  }
+    "Effect": "Enchantment Rider Effect",
+    "FIELDS": {
+      "rider": {
+        "statuses": {
+          "hint": "When this Active Effect is applied, these additional status conditions will be applied separately.",
+          "label": "Separate Status Conditions"
+        }
+      }
+    }
+  },
+  "STANDARD": {
+    "FIELDS": {
+      "magical": {
+        "hint": "This effect is from a magical source and should be disabled when magic isn't available.",
+        "label": "Magical"
+      }
+    }
+  },
+  "Tab": "Effects"
 },
-"DND5E.EffectsApplyTokens": "Apply to selected tokens",
-"DND5E.EffectApplyWarningConcentration": "Applying an effect that is being concentrated on by another character requires GM permissions.",
-"DND5E.EffectApplyWarningOwnership": "Effects cannot be applied to tokens you are not the owner of.",
-"DND5E.EffectsSearch": "Search effects",
+
 
 "DND5E.ENCHANT": {
   "FIELDS": {
@@ -2475,18 +2503,9 @@
     "Inactive": "Inactive Enchantments"
   },
   "FIELDS": {
-    "enchantment": {
-      "label": "Enchantment Configuration",
-      "items": {
-        "max": {
-          "label": "Item Limit",
-          "hint": "Formula for the maximum number of enchantments of this type that can be active at a time."
-        },
-        "period": {
-          "label": "Replacement Period",
-          "hint": "How frequently the enchantments of this type can be re-bound to different items."
-        }
-      }
+    "magical": {
+      "hint": "This enchantment is magical and should be disabled when magic isn't available.",
+      "label": "Magical"
     }
   },
   "Items": {
@@ -2846,6 +2865,19 @@
     "cover": {
       "label": "Cover",
       "hint": "Cover provided to crew by this vehicle feature."
+    },
+    "enchant": {
+      "label": "Enchantment Configuration",
+      "items": {
+        "max": {
+          "label": "Item Limit",
+          "hint": "Formula for the maximum number of enchantments of this type that can be active at a time."
+        },
+        "period": {
+          "label": "Replacement Period",
+          "hint": "How frequently the enchantments of this type can be re-bound to different items."
+        }
+      }
     },
     "properties": {
       "label": "Feature Properties"

--- a/lang/en.json
+++ b/lang/en.json
@@ -22,9 +22,7 @@
 
 "TYPES.ActiveEffect": {
   "enchantment": "Enchantment",
-  "enchantmentPl": "Enchantments",
-  "standard": "Effect",
-  "standardPl": "Effects"
+  "enchantmentPl": "Enchantments"
 },
 
 "TYPES.ChatMessage": {
@@ -2374,6 +2372,14 @@
       "Ownership": "Effects cannot be applied to tokens you are not the owner of."
     }
   },
+  "BASE": {
+    "FIELDS": {
+      "magical": {
+        "hint": "This effect is from a magical source and should be disabled when magic isn't available.",
+        "label": "Magical"
+      }
+    }
+  },
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
   "Label": "Available Effects",
   "RIDER": {
@@ -2385,14 +2391,6 @@
           "hint": "When this Active Effect is applied, these additional status conditions will be applied separately.",
           "label": "Separate Status Conditions"
         }
-      }
-    }
-  },
-  "STANDARD": {
-    "FIELDS": {
-      "magical": {
-        "hint": "This effect is from a magical source and should be disabled when magic isn't available.",
-        "label": "Magical"
       }
     }
   },

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -130,7 +130,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
     { tab: "inventory", label: "DND5E.Inventory", svg: "systems/dnd5e/icons/svg/backpack.svg" },
     { tab: "features", label: "DND5E.Features", icon: "fas fa-list" },
     { tab: "spells", label: "TYPES.Item.spellPl", icon: "fas fa-book" },
-    { tab: "effects", label: "DND5E.Effects", icon: "fas fa-bolt" },
+    { tab: "effects", label: "DND5E.EFFECT.Tab", icon: "fas fa-bolt" },
     { tab: "biography", label: "DND5E.Biography", icon: "fas fa-feather" },
     { tab: "bastion", label: "DND5E.Bastion.Label", icon: "fas fa-chess-rook" },
     { tab: "specialTraits", label: "DND5E.SpecialTraits", icon: "fas fa-star" }

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -130,7 +130,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
     { tab: "inventory", label: "DND5E.Inventory", svg: "systems/dnd5e/icons/svg/backpack.svg" },
     { tab: "features", label: "DND5E.Features", icon: "fas fa-list" },
     { tab: "spells", label: "TYPES.Item.spellPl", icon: "fas fa-book" },
-    { tab: "effects", label: "DND5E.Effects", icon: "fas fa-bolt" },
+    { tab: "effects", label: "DND5E.EFFECT.Tab", icon: "fas fa-bolt" },
     { tab: "biography", label: "DND5E.Biography", icon: "fas fa-feather" },
     { tab: "bastion", label: "DND5E.Bastion.Label", icon: "fas fa-chess-rook", condition: this.hasBastion },
     { tab: "specialTraits", label: "DND5E.SpecialTraits", icon: "fas fa-star" }

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -90,7 +90,7 @@ export default class NPCActorSheet extends BaseActorSheet {
     { tab: "features", label: "DND5E.Features", icon: "fas fa-list" },
     { tab: "inventory", label: "DND5E.Inventory", svg: "systems/dnd5e/icons/svg/backpack.svg" },
     { tab: "spells", label: "TYPES.Item.spellPl", icon: "fas fa-book" },
-    { tab: "effects", label: "DND5E.Effects", icon: "fas fa-bolt" },
+    { tab: "effects", label: "DND5E.EFFECT.Tab", icon: "fas fa-bolt" },
     { tab: "biography", label: "DND5E.Biography", icon: "fas fa-feather" },
     { tab: "specialTraits", label: "DND5E.SpecialTraits", icon: "fas fa-star" }
   ];

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -89,7 +89,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       div.innerHTML = `
         <label class="roboto-upper">
           <i class="fa-solid fa-bolt"></i>
-          <span>${game.i18n.localize("DND5E.Effects")}</span>
+          <span>${game.i18n.localize("DND5E.EFFECT.Application.Header")}</span>
           <i class="fa-solid fa-caret-down"></i>
         </label>
         <div class="collapsible-content">
@@ -128,7 +128,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
           <span class="subtitle">${effect.duration.label}</span>
         </div>
         <button class="apply-effect" type="button" data-action="applyEffect"
-                data-tooltip aria-label="${game.i18n.localize("DND5E.EffectsApplyTokens")}">
+                data-tooltip aria-label="${game.i18n.localize("DND5E.EFFECT.Application.Action.ApplyTokens")}">
           <i class="fas fa-reply-all fa-flip-horizontal" inert></i>
         </button>
       `;
@@ -183,7 +183,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     const concentration = this.chatMessage.getAssociatedActor()?.effects.get(this.chatMessage.system.concentration);
     const origin = concentration ?? effect;
     if ( !game.user.isGM && !actor.isOwner ) {
-      throw new Error(game.i18n.localize("DND5E.EffectApplyWarningOwnership"));
+      throw new Error(game.i18n.localize("DND5E.EFFECT.Application.Warning.Ownership"));
     }
 
     const effectFlags = {
@@ -206,7 +206,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     }
 
     if ( !game.user.isGM && concentration && !concentration.isOwner ) {
-      throw new Error(game.i18n.localize("DND5E.EffectApplyWarningConcentration"));
+      throw new Error(game.i18n.localize("DND5E.EFFECT.Application.Warning.Concentration"));
     }
 
     // Otherwise, create a new effect on the target

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -89,7 +89,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       div.innerHTML = `
         <label class="roboto-upper">
           <i class="fa-solid fa-bolt"></i>
-          <span>${_loc("DND5E.Effects")}</span>
+          <span>${_loc("DND5E.EFFECT.Application.Header")}</span>
           <i class="fa-solid fa-caret-down"></i>
         </label>
         <div class="collapsible-content">
@@ -135,7 +135,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
           <span class="subtitle">${effect.duration.label}</span>
         </div>
         <button class="apply-effect" type="button" data-action="applyEffect"
-                data-tooltip aria-label="${_loc("DND5E.EffectsApplyTokens")}">
+                data-tooltip aria-label="${_loc("DND5E.EFFECT.Application.Action.ApplyTokens")}">
           <i class="fas fa-reply-all fa-flip-horizontal" inert></i>
         </button>
       `;
@@ -190,7 +190,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     const concentration = this.chatMessage.getAssociatedActor()?.effects.get(this.chatMessage.system.concentration);
     const origin = concentration ?? effect;
     if ( !game.user.isGM && !actor.isOwner ) {
-      throw new Error(_loc("DND5E.EffectApplyWarningOwnership"));
+      throw new Error(_loc("DND5E.EFFECT.Application.Warning.Ownership"));
     }
 
     const effectFlags = {
@@ -221,7 +221,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     }
 
     if ( !game.user.isGM && concentration && !concentration.isOwner ) {
-      throw new Error(_loc("DND5E.EffectApplyWarningConcentration"));
+      throw new Error(_loc("DND5E.EFFECT.Application.Warning.Concentration"));
     }
 
     // Otherwise, create a new effect on the target

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -282,7 +282,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
     const isActor = this.document instanceof Actor;
     const isEnchantment = li.dataset.effectType.startsWith("enchantment");
     return this.document.createEmbeddedDocuments("ActiveEffect", [{
-      type: isEnchantment ? "enchantment" : "standard",
+      type: isEnchantment ? "enchantment" : "base",
       name: isActor ? game.i18n.localize("DND5E.EffectNew") : this.document.name,
       icon: isActor ? "icons/svg/aura.svg" : this.document.img,
       origin: isEnchantment ? undefined : this.document.uuid,

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -125,9 +125,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
 
     // Iterate over active effects, classifying them into categories
     for ( const e of effects ) {
-      if ( (e.dependentOrigin?.active === false) || ((e.parent.system?.identified === false) && !game.user.isGM) ) {
-        continue;
-      }
+      if ( e.isConcealed ) continue;
       if ( e.isAppliedEnchantment ) {
         if ( e.disabled ) categories.enchantmentInactive.effects.push(e);
         else categories.enchantmentActive.effects.push(e);

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -284,12 +284,15 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
     const isActor = this.document instanceof Actor;
     const isEnchantment = li.dataset.effectType.startsWith("enchantment");
     return this.document.createEmbeddedDocuments("ActiveEffect", [{
-      type: isEnchantment ? "enchantment" : "base",
+      type: isEnchantment ? "enchantment" : "standard",
       name: isActor ? game.i18n.localize("DND5E.EffectNew") : this.document.name,
       icon: isActor ? "icons/svg/aura.svg" : this.document.img,
       origin: isEnchantment ? undefined : this.document.uuid,
       "duration.rounds": li.dataset.effectType === "temporary" ? 1 : undefined,
-      disabled: ["inactive", "enchantmentInactive"].includes(li.dataset.effectType)
+      disabled: ["inactive", "enchantmentInactive"].includes(li.dataset.effectType),
+      system: {
+        magical: !isActor && this.document.system.properties?.has("mgc")
+      }
     }]);
   }
 

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -286,12 +286,15 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
     const isActor = this.document instanceof Actor;
     const isEnchantment = li.dataset.effectType.startsWith("enchantment");
     return this.document.createEmbeddedDocuments("ActiveEffect", [{
-      type: isEnchantment ? "enchantment" : "base",
+      type: isEnchantment ? "enchantment" : "standard",
       name: isActor ? _loc("DND5E.EffectNew") : this.document.name,
       icon: isActor ? "icons/svg/aura.svg" : this.document.img,
       origin: isEnchantment ? undefined : this.document.uuid,
       "duration.rounds": li.dataset.effectType === "temporary" ? 1 : undefined,
-      disabled: ["inactive", "enchantmentInactive"].includes(li.dataset.effectType)
+      disabled: ["inactive", "enchantmentInactive"].includes(li.dataset.effectType),
+      system: {
+        magical: !isActor && this.document.system.properties?.has("mgc")
+      }
     }]);
   }
 

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -284,7 +284,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
     const isActor = this.document instanceof Actor;
     const isEnchantment = li.dataset.effectType.startsWith("enchantment");
     return this.document.createEmbeddedDocuments("ActiveEffect", [{
-      type: isEnchantment ? "enchantment" : "standard",
+      type: isEnchantment ? "enchantment" : "base",
       name: isActor ? _loc("DND5E.EffectNew") : this.document.name,
       icon: isActor ? "icons/svg/aura.svg" : this.document.img,
       origin: isEnchantment ? undefined : this.document.uuid,

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -689,8 +689,7 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
         origin: this.document.uuid,
         system: {
           magical: this.document.system.properties?.has("mgc")
-        },
-        type: "standard"
+        }
       }, { parent: this.document, renderSheet: true }, { sheet: this });
     }
   }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -686,7 +686,11 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
       return ActiveEffect.implementation.createDialog({
         name: this.document.name,
         img: this.document.img,
-        origin: this.document.uuid
+        origin: this.document.uuid,
+        system: {
+          magical: this.document.system.properties?.has("mgc")
+        },
+        type: "standard"
       }, { parent: this.document, renderSheet: true }, { sheet: this });
     }
   }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -674,7 +674,11 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
       return ActiveEffect.implementation.createDialog({
         name: this.document.name,
         img: this.document.img,
-        origin: this.document.uuid
+        origin: this.document.uuid,
+        system: {
+          magical: this.document.system.properties?.has("mgc")
+        },
+        type: "standard"
       }, { parent: this.document, renderSheet: true });
     }
   }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -677,8 +677,7 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
         origin: this.document.uuid,
         system: {
           magical: this.document.system.properties?.has("mgc")
-        },
-        type: "standard"
+        }
       }, { parent: this.document, renderSheet: true });
     }
   }

--- a/module/data/abstract/_module.mjs
+++ b/module/data/abstract/_module.mjs
@@ -1,3 +1,4 @@
+export {default as ActiveEffectDataModel} from "./active-effect-data-model.mjs";
 export {default as ActorDataModel} from "./actor-data-model.mjs";
 export {default as ChatMessageDataModel} from "./chat-message-data-model.mjs";
 export {default as ItemDataModel} from "./item-data-model.mjs";

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -31,6 +31,17 @@ export default class ActiveEffectDataModel extends (ActiveEffectTypeDataModel ??
   /* -------------------------------------------- */
 
   /**
+   * Should this status effect be hidden from the current user? Concealed effects are still applied, but won't be
+   * visible on the actor's token or in the effects list on sheets.
+   * @type {boolean}
+   */
+  get isConcealed() {
+    return false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Item within which this effect is contained, if any.
    * @type {Item5e|void}
    */

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -1,0 +1,52 @@
+const { ActiveEffectTypeDataModel } = foundry.data;
+const { TypeDataModel } = foundry.abstract;
+
+/**
+ * Abstract base class to add some shared functionality to all of the system's custom active effect types.
+ * @abstract
+ */
+export default class ActiveEffectDataModel extends (ActiveEffectTypeDataModel ?? TypeDataModel) {
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Actor within which this effect is embedded.
+   * @type {Actor5e|void}
+   */
+  get actor() {
+    return this.item ? this.item.actor : this.parent.parent instanceof Actor ? this.parent.parent : undefined;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Document type to which this active effect should apply its changes.
+   * @type {string}
+   */
+  get applicableType() {
+    return "Actor";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Item within which this effect is contained, if any.
+   * @type {Item5e|void}
+   */
+  get item() {
+    return this.parent.parent instanceof Item ? this.parent.parent : undefined;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Add modifications to the core ActiveEffect config.
+   * @param {ActiveEffectConfig} app            The ActiveEffect config.
+   * @param {HTMLElement} html                  The ActiveEffect config element.
+   * @param {ApplicationRenderContext} context  The app's rendering context.
+   */
+  onRenderActiveEffectConfig(app, html, context) {}
+}

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -1,11 +1,8 @@
-const { ActiveEffectTypeDataModel } = foundry.data;
-const { TypeDataModel } = foundry.abstract;
-
 /**
  * Abstract base class to add some shared functionality to all of the system's custom active effect types.
  * @abstract
  */
-export default class ActiveEffectDataModel extends (ActiveEffectTypeDataModel ?? TypeDataModel) {
+export default class ActiveEffectDataModel extends foundry.data.ActiveEffectTypeDataModel {
   /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */

--- a/module/data/active-effect/_module.mjs
+++ b/module/data/active-effect/_module.mjs
@@ -1,7 +1,12 @@
 import EnchantmentData from "./enchantment.mjs";
+import StandardEffectData from "./standard.mjs";
 
-export { EnchantmentData };
+export {
+  EnchantmentData,
+  StandardEffectData
+};
 
 export const config = {
-  enchantment: EnchantmentData
+  enchantment: EnchantmentData,
+  standard: StandardEffectData
 };

--- a/module/data/active-effect/_module.mjs
+++ b/module/data/active-effect/_module.mjs
@@ -1,12 +1,12 @@
+import BaseEffectData from "./base.mjs";
 import EnchantmentData from "./enchantment.mjs";
-import StandardEffectData from "./standard.mjs";
 
 export {
-  EnchantmentData,
-  StandardEffectData
+  BaseEffectData,
+  EnchantmentData
 };
 
 export const config = {
-  enchantment: EnchantmentData,
-  standard: StandardEffectData
+  base: BaseEffectData,
+  enchantment: EnchantmentData
 };

--- a/module/data/active-effect/_types.mjs
+++ b/module/data/active-effect/_types.mjs
@@ -1,0 +1,11 @@
+/**
+ * @typedef EnchantmentActiveEffectSystemData
+ * @property {boolean} magic               Does this effect originate from a magical source?
+ */
+
+/**
+ * @typedef StandardActiveEffectSystemData
+ * @property {boolean} magic               Does this effect originate from a magical source?
+ * @property {object} rider
+ * @property {Set<string>} rider.statuses  Additional status effects that are separately applied when effect is applied.
+ */

--- a/module/data/active-effect/_types.mjs
+++ b/module/data/active-effect/_types.mjs
@@ -1,11 +1,13 @@
 /**
- * @typedef EnchantmentActiveEffectSystemData
- * @property {boolean} magic               Does this effect originate from a magical source?
- */
-
-/**
- * @typedef StandardActiveEffectSystemData
+ * @typedef baseActiveEffectSystemData
+ * @property {EffectChangeData[]} changes  Changes to apply to the actor.
  * @property {boolean} magic               Does this effect originate from a magical source?
  * @property {object} rider
  * @property {Set<string>} rider.statuses  Additional status effects that are separately applied when effect is applied.
+ */
+
+/**
+ * @typedef EnchantmentActiveEffectSystemData
+ * @property {EffectChangeData[]} changes  Changes to apply to the item.
+ * @property {boolean} magic               Does this effect originate from a magical source?
  */

--- a/module/data/active-effect/_types.mjs
+++ b/module/data/active-effect/_types.mjs
@@ -1,5 +1,5 @@
 /**
- * @typedef baseActiveEffectSystemData
+ * @typedef BaseActiveEffectSystemData
  * @property {EffectChangeData[]} changes  Changes to apply to the actor.
  * @property {boolean} magic               Does this effect originate from a magical source?
  * @property {object} rider

--- a/module/data/active-effect/_types.mjs
+++ b/module/data/active-effect/_types.mjs
@@ -1,7 +1,7 @@
 /**
  * @typedef BaseActiveEffectSystemData
  * @property {EffectChangeData[]} changes  Changes to apply to the actor.
- * @property {boolean} magic               Does this effect originate from a magical source?
+ * @property {boolean} magical             Does this effect originate from a magical source?
  * @property {object} rider
  * @property {Set<string>} rider.statuses  Additional status effects that are separately applied when effect is applied.
  */
@@ -9,5 +9,5 @@
 /**
  * @typedef EnchantmentActiveEffectSystemData
  * @property {EffectChangeData[]} changes  Changes to apply to the item.
- * @property {boolean} magic               Does this effect originate from a magical source?
+ * @property {boolean} magical             Does this effect originate from a magical source?
  */

--- a/module/data/active-effect/base.mjs
+++ b/module/data/active-effect/base.mjs
@@ -3,28 +3,28 @@ import ActiveEffectDataModel from "../abstract/active-effect-data-model.mjs";
 const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
- * @import { StandardActiveEffectSystemData } from "./types.mjs";
+ * @import { baseActiveEffectSystemData } from "./types.mjs";
  */
 
 /**
- * System data model for standard active effects.
- * @extends {ActiveEffectDataModel<StandardActiveEffectSystemData>}
- * @mixes StandardActiveEffectSystemData
+ * System data model for base active effects.
+ * @extends {ActiveEffectDataModel<baseActiveEffectSystemData>}
+ * @mixes baseActiveEffectSystemData
  */
-export default class StandardEffectData extends ActiveEffectDataModel {
+export default class baseEffectData extends ActiveEffectDataModel {
   /* -------------------------------------------- */
   /*  Model Configuration                         */
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.EFFECT.STANDARD", "DND5E.EFFECT.RIDER"];
+  static LOCALIZATION_PREFIXES = ["DND5E.EFFECT.BASE", "DND5E.EFFECT.RIDER"];
 
   /* -------------------------------------------- */
 
   /** @override */
   static defineSchema() {
     return {
-      ...(foundry.data.ActiveEffectTypeDataModel ? super.defineSchema() : {}),
+      ...super.defineSchema(),
       magical: new BooleanField(),
       rider: new SchemaField({
         statuses: new SetField(new StringField())

--- a/module/data/active-effect/base.mjs
+++ b/module/data/active-effect/base.mjs
@@ -3,15 +3,15 @@ import ActiveEffectDataModel from "../abstract/active-effect-data-model.mjs";
 const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
- * @import { baseActiveEffectSystemData } from "./types.mjs";
+ * @import { BaseActiveEffectSystemData } from "./types.mjs";
  */
 
 /**
  * System data model for base active effects.
- * @extends {ActiveEffectDataModel<baseActiveEffectSystemData>}
- * @mixes baseActiveEffectSystemData
+ * @extends {ActiveEffectDataModel<BaseActiveEffectSystemData>}
+ * @mixes BaseActiveEffectSystemData
  */
-export default class baseEffectData extends ActiveEffectDataModel {
+export default class BaseEffectData extends ActiveEffectDataModel {
   /* -------------------------------------------- */
   /*  Model Configuration                         */
   /* -------------------------------------------- */

--- a/module/data/active-effect/base.mjs
+++ b/module/data/active-effect/base.mjs
@@ -3,7 +3,7 @@ import ActiveEffectDataModel from "../abstract/active-effect-data-model.mjs";
 const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
- * @import { BaseActiveEffectSystemData } from "./types.mjs";
+ * @import { BaseActiveEffectSystemData } from "./_types.mjs";
  */
 
 /**

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -4,7 +4,13 @@ import { DamageData } from "../shared/damage-field.mjs";
 const { BooleanField } = foundry.data.fields;
 
 /**
+ * @import { EnchantmentActiveEffectSystemData } from "./types.mjs";
+ */
+
+/**
  * System data model for enchantment active effects.
+ * @extends {ActiveEffectDataModel<EnchantmentActiveEffectSystemData>}
+ * @mixes EnchantmentActiveEffectSystemData
  */
 export default class EnchantmentData extends ActiveEffectDataModel {
   /* -------------------------------------------- */

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -25,7 +25,7 @@ export default class EnchantmentData extends ActiveEffectDataModel {
   /** @override */
   static defineSchema() {
     return {
-      ...(foundry.data.ActiveEffectTypeDataModel ? super.defineSchema() : {}),
+      ...super.defineSchema(),
       magical: new BooleanField({ initial: true })
     };
   }

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -1,7 +1,7 @@
 import { DamageData } from "../shared/damage-field.mjs";
 
 const { ActiveEffectTypeDataModel } = foundry.data;
-const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { BooleanField } = foundry.data.fields;
 const { TypeDataModel } = foundry.abstract;
 
 /**
@@ -13,7 +13,7 @@ export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeD
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.ENCHANTMENT", "DND5E.EFFECT.RIDER"];
+  static LOCALIZATION_PREFIXES = ["DND5E.ENCHANTMENT"];
 
   /* -------------------------------------------- */
 
@@ -21,13 +21,12 @@ export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeD
   static defineSchema() {
     return {
       ...(ActiveEffectTypeDataModel ? super.defineSchema() : {}),
-      magical: new BooleanField({ initial: true }),
-      rider: new SchemaField({
-        statuses: new SetField(new StringField())
-      })
+      magical: new BooleanField({ initial: true })
     };
   }
 
+  /* -------------------------------------------- */
+  /*  Effect Application                          */
   /* -------------------------------------------- */
 
   /**

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -1,15 +1,31 @@
 import { DamageData } from "../shared/damage-field.mjs";
 
 const { ActiveEffectTypeDataModel } = foundry.data;
+const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 const { TypeDataModel } = foundry.abstract;
 
 /**
  * System data model for enchantment active effects.
  */
 export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeDataModel) {
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.ENCHANTMENT", "DND5E.EFFECT.RIDER"];
+
+  /* -------------------------------------------- */
+
   /** @override */
   static defineSchema() {
-    return ActiveEffectTypeDataModel ? super.defineSchema() : {};
+    return {
+      ...(ActiveEffectTypeDataModel ? super.defineSchema() : {}),
+      magical: new BooleanField({ initial: true }),
+      rider: new SchemaField({
+        statuses: new SetField(new StringField())
+      })
+    };
   }
 
   /* -------------------------------------------- */
@@ -114,6 +130,21 @@ export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeD
         change.key = "system.prepared";
         break;
     }
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners & Handlers                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Add modifications to the core ActiveEffect config.
+   * @param {ActiveEffectConfig} app           The ActiveEffect config.
+   * @param {HTMLElement} html                 The ActiveEffect config element.
+   * @param {ApplicationRenderContext} object  The app's rendering context.
+   */
+  onRenderActiveEffectConfig(app, html, context) {
+    const toRemove = html.querySelectorAll('.form-group:has([name="transfer"], [name="statuses"])');
+    toRemove.forEach(f => f.remove());
   }
 
   /* -------------------------------------------- */

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -1,13 +1,12 @@
+import ActiveEffectDataModel from "../abstract/active-effect-data-model.mjs";
 import { DamageData } from "../shared/damage-field.mjs";
 
-const { ActiveEffectTypeDataModel } = foundry.data;
 const { BooleanField } = foundry.data.fields;
-const { TypeDataModel } = foundry.abstract;
 
 /**
  * System data model for enchantment active effects.
  */
-export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeDataModel) {
+export default class EnchantmentData extends ActiveEffectDataModel {
   /* -------------------------------------------- */
   /*  Model Configuration                         */
   /* -------------------------------------------- */
@@ -20,9 +19,38 @@ export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeD
   /** @override */
   static defineSchema() {
     return {
-      ...(ActiveEffectTypeDataModel ? super.defineSchema() : {}),
+      ...(foundry.data.ActiveEffectTypeDataModel ? super.defineSchema() : {}),
       magical: new BooleanField({ initial: true })
     };
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get applicableType() {
+    return this.isApplied ? "Item" : "";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Has this enchantment been applied by another item, or was it directly created.
+   * @type {boolean}
+   */
+  get isApplied() {
+    return !!this.parent.origin && (this.parent.origin !== this.item?.uuid);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Item containing this enchantment.
+   * @type {Item5e|void}
+   */
+  get item() {
+    return this.parent.parent;
   }
 
   /* -------------------------------------------- */
@@ -135,15 +163,45 @@ export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeD
   /*  Event Listeners & Handlers                  */
   /* -------------------------------------------- */
 
-  /**
-   * Add modifications to the core ActiveEffect config.
-   * @param {ActiveEffectConfig} app           The ActiveEffect config.
-   * @param {HTMLElement} html                 The ActiveEffect config element.
-   * @param {ApplicationRenderContext} object  The app's rendering context.
-   */
+  /** @override */
   onRenderActiveEffectConfig(app, html, context) {
     const toRemove = html.querySelectorAll('.form-group:has([name="transfer"], [name="statuses"])');
     toRemove.forEach(f => f.remove());
+  }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preCreate(data, options, user) {
+    if ((await super._preCreate(data, options, user)) === false) return false;
+
+    // Enchantments cannot be added directly to actors
+    if ( this.parent.parent instanceof Actor ) {
+      ui.notifications.error("DND5E.ENCHANTMENT.Warning.NotOnActor", { localize: true });
+      return false;
+    }
+
+    if ( this.isApplied ) {
+      const origin = await fromUuid(this.parent.origin);
+      const errors = origin?.canEnchant?.(this.item);
+      if ( errors?.length ) {
+        errors.forEach(err => console.error(err));
+        return false;
+      }
+      this.parent.updateSource({ disabled: false });
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    if ( this.isApplied ) dnd5e.registry.enchantments.untrack(this.origin, this.uuid);
+    document.body.querySelectorAll(`enchantment-application:has([data-enchantment-uuid="${this.uuid}"]`)
+      .forEach(element => element.buildItemList());
   }
 
   /* -------------------------------------------- */

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -54,6 +54,16 @@ export default class EnchantmentData extends ActiveEffectDataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    if ( this.isApplied && this.parent.uuid ) dnd5e.registry.enchantments.track(this.parent.origin, this.parent.uuid);
+  }
+
+  /* -------------------------------------------- */
   /*  Effect Application                          */
   /* -------------------------------------------- */
 
@@ -197,10 +207,21 @@ export default class EnchantmentData extends ActiveEffectDataModel {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  async _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
+    if ( options.chatMessageOrigin ) {
+      document.body.querySelectorAll(`[data-message-id="${options.chatMessageOrigin}"] enchantment-application`)
+        .forEach(element => element.buildItemList());
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   _onDelete(options, userId) {
     super._onDelete(options, userId);
     if ( this.isApplied ) dnd5e.registry.enchantments.untrack(this.origin, this.uuid);
-    document.body.querySelectorAll(`enchantment-application:has([data-enchantment-uuid="${this.uuid}"]`)
+    document.body.querySelectorAll(`enchantment-application:has([data-enchantment-uuid="${this.parent.uuid}"]`)
       .forEach(element => element.buildItemList());
   }
 

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -170,7 +170,7 @@ export default class EnchantmentData extends ActiveEffectDataModel {
 
   /** @inheritDoc */
   async _preCreate(data, options, user) {
-    if ((await super._preCreate(data, options, user)) === false) return false;
+    if ( (await super._preCreate(data, options, user)) === false ) return false;
 
     // Enchantments cannot be added directly to actors
     if ( this.parent.parent instanceof Actor ) {
@@ -205,7 +205,7 @@ export default class EnchantmentData extends ActiveEffectDataModel {
   /** @inheritDoc */
   _onDelete(options, userId) {
     super._onDelete(options, userId);
-    if ( this.isApplied ) dnd5e.registry.enchantments.untrack(this.origin, this.uuid);
+    if ( this.isApplied ) dnd5e.registry.enchantments.untrack(this.parent.origin, this.parent.uuid);
     document.body.querySelectorAll(`enchantment-application:has([data-enchantment-uuid="${this.parent.uuid}"]`)
       .forEach(element => element.buildItemList());
   }

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -1,15 +1,31 @@
 import { DamageData } from "../shared/damage-field.mjs";
 
 const { ActiveEffectTypeDataModel } = foundry.data;
+const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 const { TypeDataModel } = foundry.abstract;
 
 /**
  * System data model for enchantment active effects.
  */
 export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeDataModel) {
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.ENCHANTMENT", "DND5E.EFFECT.RIDER"];
+
+  /* -------------------------------------------- */
+
   /** @override */
   static defineSchema() {
-    return ActiveEffectTypeDataModel ? super.defineSchema() : {};
+    return {
+      ...(ActiveEffectTypeDataModel ? super.defineSchema() : {}),
+      magical: new BooleanField({ initial: true }),
+      rider: new SchemaField({
+        statuses: new SetField(new StringField())
+      })
+    };
   }
 
   /* -------------------------------------------- */
@@ -93,6 +109,21 @@ export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeD
         }
         return false;
     }
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners & Handlers                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Add modifications to the core ActiveEffect config.
+   * @param {ActiveEffectConfig} app           The ActiveEffect config.
+   * @param {HTMLElement} html                 The ActiveEffect config element.
+   * @param {ApplicationRenderContext} object  The app's rendering context.
+   */
+  onRenderActiveEffectConfig(app, html, context) {
+    const toRemove = html.querySelectorAll('.form-group:has([name="transfer"], [name="statuses"])');
+    toRemove.forEach(f => f.remove());
   }
 
   /* -------------------------------------------- */

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -1,13 +1,12 @@
+import ActiveEffectDataModel from "../abstract/active-effect-data-model.mjs";
 import { DamageData } from "../shared/damage-field.mjs";
 
-const { ActiveEffectTypeDataModel } = foundry.data;
 const { BooleanField } = foundry.data.fields;
-const { TypeDataModel } = foundry.abstract;
 
 /**
  * System data model for enchantment active effects.
  */
-export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeDataModel) {
+export default class EnchantmentData extends ActiveEffectDataModel {
   /* -------------------------------------------- */
   /*  Model Configuration                         */
   /* -------------------------------------------- */
@@ -20,9 +19,38 @@ export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeD
   /** @override */
   static defineSchema() {
     return {
-      ...(ActiveEffectTypeDataModel ? super.defineSchema() : {}),
+      ...(foundry.data.ActiveEffectTypeDataModel ? super.defineSchema() : {}),
       magical: new BooleanField({ initial: true })
     };
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get applicableType() {
+    return this.isApplied ? "Item" : "";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Has this enchantment been applied by another item, or was it directly created.
+   * @type {boolean}
+   */
+  get isApplied() {
+    return !!this.parent.origin && (this.parent.origin !== this.item?.uuid);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Item containing this enchantment.
+   * @type {Item5e|void}
+   */
+  get item() {
+    return this.parent.parent;
   }
 
   /* -------------------------------------------- */
@@ -114,15 +142,45 @@ export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeD
   /*  Event Listeners & Handlers                  */
   /* -------------------------------------------- */
 
-  /**
-   * Add modifications to the core ActiveEffect config.
-   * @param {ActiveEffectConfig} app           The ActiveEffect config.
-   * @param {HTMLElement} html                 The ActiveEffect config element.
-   * @param {ApplicationRenderContext} object  The app's rendering context.
-   */
+  /** @override */
   onRenderActiveEffectConfig(app, html, context) {
     const toRemove = html.querySelectorAll('.form-group:has([name="transfer"], [name="statuses"])');
     toRemove.forEach(f => f.remove());
+  }
+
+  /* -------------------------------------------- */
+  /*  Socket Event Handlers                       */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preCreate(data, options, user) {
+    if ((await super._preCreate(data, options, user)) === false) return false;
+
+    // Enchantments cannot be added directly to actors
+    if ( this.parent.parent instanceof Actor ) {
+      ui.notifications.error("DND5E.ENCHANTMENT.Warning.NotOnActor");
+      return false;
+    }
+
+    if ( this.isApplied ) {
+      const origin = await fromUuid(this.parent.origin);
+      const errors = origin?.canEnchant?.(this.item);
+      if ( errors?.length ) {
+        errors.forEach(err => console.error(err));
+        return false;
+      }
+      this.parent.updateSource({ disabled: false });
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    if ( this.isApplied ) dnd5e.registry.enchantments.untrack(this.origin, this.uuid);
+    document.body.querySelectorAll(`enchantment-application:has([data-enchantment-uuid="${this.uuid}"]`)
+      .forEach(element => element.buildItemList());
   }
 
   /* -------------------------------------------- */

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -54,6 +54,16 @@ export default class EnchantmentData extends ActiveEffectDataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    if ( this.isApplied && this.parent.uuid ) dnd5e.registry.enchantments.track(this.parent.origin, this.parent.uuid);
+  }
+
+  /* -------------------------------------------- */
   /*  Effect Application                          */
   /* -------------------------------------------- */
 
@@ -176,10 +186,21 @@ export default class EnchantmentData extends ActiveEffectDataModel {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  async _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
+    if ( options.chatMessageOrigin ) {
+      document.body.querySelectorAll(`[data-message-id="${options.chatMessageOrigin}"] enchantment-application`)
+        .forEach(element => element.buildItemList());
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   _onDelete(options, userId) {
     super._onDelete(options, userId);
     if ( this.isApplied ) dnd5e.registry.enchantments.untrack(this.origin, this.uuid);
-    document.body.querySelectorAll(`enchantment-application:has([data-enchantment-uuid="${this.uuid}"]`)
+    document.body.querySelectorAll(`enchantment-application:has([data-enchantment-uuid="${this.parent.uuid}"]`)
       .forEach(element => element.buildItemList());
   }
 

--- a/module/data/active-effect/standard.mjs
+++ b/module/data/active-effect/standard.mjs
@@ -19,7 +19,7 @@ export default class StandardEffectData extends (ActiveEffectTypeDataModel ?? Ty
   static defineSchema() {
     return {
       ...(ActiveEffectTypeDataModel ? super.defineSchema() : {}),
-      magical: new BooleanField({ initial: true }),
+      magical: new BooleanField(),
       rider: new SchemaField({
         statuses: new SetField(new StringField())
       })

--- a/module/data/active-effect/standard.mjs
+++ b/module/data/active-effect/standard.mjs
@@ -1,0 +1,28 @@
+const { ActiveEffectTypeDataModel } = foundry.data;
+const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { TypeDataModel } = foundry.abstract;
+
+/**
+ * System data model for standard active effects.
+ */
+export default class StandardEffectData extends (ActiveEffectTypeDataModel ?? TypeDataModel) {
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.EFFECT.STANDARD", "DND5E.EFFECT.RIDER"];
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {
+      ...(ActiveEffectTypeDataModel ? super.defineSchema() : {}),
+      magical: new BooleanField({ initial: true }),
+      rider: new SchemaField({
+        statuses: new SetField(new StringField())
+      })
+    };
+  }
+}

--- a/module/data/active-effect/standard.mjs
+++ b/module/data/active-effect/standard.mjs
@@ -3,7 +3,13 @@ import ActiveEffectDataModel from "../abstract/active-effect-data-model.mjs";
 const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
+ * @import { StandardActiveEffectSystemData } from "./types.mjs";
+ */
+
+/**
  * System data model for standard active effects.
+ * @extends {ActiveEffectDataModel<StandardActiveEffectSystemData>}
+ * @mixes StandardActiveEffectSystemData
  */
 export default class StandardEffectData extends ActiveEffectDataModel {
   /* -------------------------------------------- */

--- a/module/data/active-effect/standard.mjs
+++ b/module/data/active-effect/standard.mjs
@@ -1,11 +1,11 @@
-const { ActiveEffectTypeDataModel } = foundry.data;
+import ActiveEffectDataModel from "../abstract/active-effect-data-model.mjs";
+
 const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
-const { TypeDataModel } = foundry.abstract;
 
 /**
  * System data model for standard active effects.
  */
-export default class StandardEffectData extends (ActiveEffectTypeDataModel ?? TypeDataModel) {
+export default class StandardEffectData extends ActiveEffectDataModel {
   /* -------------------------------------------- */
   /*  Model Configuration                         */
   /* -------------------------------------------- */
@@ -18,11 +18,30 @@ export default class StandardEffectData extends (ActiveEffectTypeDataModel ?? Ty
   /** @override */
   static defineSchema() {
     return {
-      ...(ActiveEffectTypeDataModel ? super.defineSchema() : {}),
+      ...(foundry.data.ActiveEffectTypeDataModel ? super.defineSchema() : {}),
       magical: new BooleanField(),
       rider: new SchemaField({
         statuses: new SetField(new StringField())
       })
     };
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get applicableType() {
+    return this.isRider ? "" : "Actor";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this effect a rider for a non-applied enchantment?
+   * @type {boolean}
+   */
+  get isRider() {
+    return this.item?.getFlag("dnd5e", "riders.effect")?.includes(this.parent.id) ?? false;
   }
 }

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -36,7 +36,7 @@ export default class FeatData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.FEATURE", "DND5E.ENCHANTMENT", "DND5E.Prerequisites", "DND5E.SOURCE"];
+  static LOCALIZATION_PREFIXES = ["DND5E.FEATURE", "DND5E.Prerequisites", "DND5E.SOURCE"];
 
   /* -------------------------------------------- */
 

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -37,7 +37,7 @@ export default class FeatData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.FEATURE", "DND5E.ENCHANTMENT", "DND5E.Prerequisites", "DND5E.SOURCE"];
+  static LOCALIZATION_PREFIXES = ["DND5E.FEATURE", "DND5E.Prerequisites", "DND5E.SOURCE"];
 
   /* -------------------------------------------- */
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -120,6 +120,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   get isSuppressed() {
     if ( super.isSuppressed ) return true;
+    if ( this.system.magical && this.parent.actor?.statuses.has("antimagic") ) return true;
     if ( this.type === "enchantment" ) return false;
     if ( this.parent instanceof dnd5e.documents.Item5e ) {
       if ( this.parent.areEffectsSuppressed ) return true;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -425,7 +425,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   prepareDerivedData() {
     super.prepareDerivedData();
     if ( this.id === this.constructor.ID.EXHAUSTION ) this._prepareExhaustionLevel();
-    if ( this.isAppliedEnchantment && this.uuid ) dnd5e.registry.enchantments.track(this.origin, this.uuid);
   }
 
   /* -------------------------------------------- */
@@ -599,10 +598,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( userId === game.userId ) {
       if ( this.active && (this.parent instanceof Actor) ) await this.createRiderConditions();
       if ( this.isAppliedEnchantment ) await this.createRiderEnchantments(options);
-    }
-    if ( options.chatMessageOrigin ) {
-      document.body.querySelectorAll(`[data-message-id="${options.chatMessageOrigin}"] enchantment-application`)
-        .forEach(element => element.buildItemList());
     }
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -170,6 +170,11 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
     }
 
+    else if ( data.type === "base" ) {
+      data.type = "standard";
+      foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
+    }
+
     return super._initializeSource(data, options);
   }
 
@@ -178,6 +183,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   static migrateData(data) {
     data = super.migrateData(data);
+
     for ( const change of data.changes ?? [] ) {
       if ( change.key === "flags.dnd5e.initiativeAdv" ) {
         change.key = "system.attributes.init.roll.mode";
@@ -185,6 +191,12 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
         change.value = 1;
       }
     }
+
+    if ( data.flags?.dnd5e?.riders?.statuses && !data.system?.rider?.statuses ) {
+      foundry.utils.setProperty(data, "system.rider.statuses", data.flags.dnd5e.riders.statuses);
+      delete data.flags.dnd5e.riders.statuses;
+    }
+
     return data;
   }
 
@@ -446,11 +458,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @returns {Promise<ActiveEffect5e[]>}      Created rider effects.
    */
   async createRiderConditions() {
-    const riders = new Set();
-
-    for ( const status of this.getFlag("dnd5e", "riders.statuses") ?? [] ) {
-      riders.add(status);
-    }
+    const riders = new Set(this.system.riders?.statuses ?? []);
 
     for ( const status of this.statuses ) {
       const r = CONFIG.statusEffects.find(e => e.id === status)?.riders ?? [];
@@ -730,16 +738,25 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @param {ApplicationRenderContext} context The app's rendering context.
    */
   static onRenderActiveEffectConfig(app, html, context) {
-    const element = new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {}).toFormGroup({
-      label: game.i18n.localize("DND5E.CONDITIONS.RiderConditions.label"),
-      hint: game.i18n.localize("DND5E.CONDITIONS.RiderConditions.hint")
-    }, {
-      name: "flags.dnd5e.riders.statuses",
-      value: app.document.getFlag("dnd5e", "riders.statuses") ?? [],
+    if ( app.document.system.onRenderActiveEffectConfig?.(app, html, context) === false ) return;
+    const fields = app.document.system.schema.fields;
+    const magicalField = fields.magical?.toFormGroup({}, {
+      value: app.document.system._source.magical,
+      disabled: !context.editable
+    });
+    const statusesField = fields.rider?.fields?.statuses?.toFormGroup({}, {
+      value: app.document.system._source.rider?.statuses ?? [],
       options: CONFIG.statusEffects.map(se => ({ value: se.id, label: se.name })),
       disabled: !context.editable
     });
-    html.querySelector("[data-tab=details] > .form-group:has([name=statuses])")?.after(element);
+    const detailsTab = html.querySelector("[data-application-part=details]");
+    const statuses = detailsTab.querySelector("& > .form-group:has([name=statuses])");
+    if ( statuses ) {
+      if ( magicalField ) statuses?.before(magicalField);
+      if ( statusesField ) statuses?.after(statusesField);
+    } else {
+      detailsTab.append(magicalField, statusesField);
+    }
 
     // Add tooltip with link to wiki for effects/enchantments
     const helpIconElement = document.createElement("i");

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -115,6 +115,9 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @type {boolean}
    */
   get isConcealed() {
+    if ( this.system.isConcealed ) return true;
+    if ( this.dependentOrigin?.active === false ) return true;
+    if ( (this.parent.system?.identified === false) && !game.user.isGM ) return true;
     if ( this.target?.testUserPermission(game.user, "OBSERVER") ) return false;
 
     // Hide bloodied status effect from players unless the token is friendly
@@ -179,6 +182,11 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       data.type = "enchantment";
       delete data.flags.dnd5e.type;
       foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
+    }
+
+    else if ( (data.type === "base") && data.statuses.includes(CONFIG.specialStatusEffects.CONCENTRATING) ) {
+      // TODO: Hold concentration-based effects back to be migrated to activation-type effects
+      // See: https://github.com/foundryvtt/dnd5e/issues/4425
     }
 
     else if ( data.type === "base" ) {

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -80,6 +80,16 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /* -------------------------------------------- */
 
   /**
+   * Document type to which this active effect should apply its changes.
+   * @type {string}
+   */
+  get applicableType() {
+    return this.system.applicableType ?? "Actor";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Another effect that granted this effect as a rider.
    * @type {ActiveEffect5e|null}
    */
@@ -95,7 +105,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @type {boolean}
    */
   get isAppliedEnchantment() {
-    return (this.type === "enchantment") && !!this.origin && (this.origin !== this.parent.uuid);
+    return (this.type === "enchantment") && this.system.isApplied;
   }
 
   /* -------------------------------------------- */
@@ -521,10 +531,9 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       foundry.utils.setProperty(activityData, "flags.dnd5e.dependentOn", this.id);
       riderActivities[activityData._id] = activityData;
     }
-    let createdActivities = [];
     if ( !foundry.utils.isEmpty(riderActivities) ) {
       await this.parent.update({ "system.activities": riderActivities });
-      createdActivities = Object.keys(riderActivities).map(id => this.parent.system.activities?.get(id));
+      const createdActivities = Object.keys(riderActivities).map(id => this.parent.system.activities?.get(id));
       createdActivities.forEach(a => a.effects?.forEach(e => {
         if ( !this.parent.effects.has(e._id) ) riderEffects.push(item.effects.get(e._id)?.toObject());
       }));
@@ -580,22 +589,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   async _preCreate(data, options, user) {
     if ( await super._preCreate(data, options, user) === false ) return false;
     if ( options.keepOrigin === false ) this.updateSource({ origin: this.parent.uuid });
-
-    // Enchantments cannot be added directly to actors
-    if ( (this.type === "enchantment") && (this.parent instanceof Actor) ) {
-      ui.notifications.error("DND5E.ENCHANTMENT.Warning.NotOnActor", { localize: true });
-      return false;
-    }
-
-    if ( this.isAppliedEnchantment ) {
-      const origin = await fromUuid(this.origin);
-      const errors = origin?.canEnchant?.(this.parent);
-      if ( errors?.length ) {
-        errors.forEach(err => console.error(err));
-        return false;
-      }
-      this.updateSource({ disabled: false });
-    }
   }
 
   /* -------------------------------------------- */
@@ -663,9 +656,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   _onDelete(options, userId) {
     super._onDelete(options, userId);
     if ( game.user === game.users.activeGM ) this.getDependents().forEach(e => e.delete());
-    if ( this.isAppliedEnchantment ) dnd5e.registry.enchantments.untrack(this.origin, this.uuid);
-    document.body.querySelectorAll(`enchantment-application:has([data-enchantment-uuid="${this.uuid}"]`)
-      .forEach(element => element.buildItemList());
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -755,7 +755,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       if ( magicalField ) statuses?.before(magicalField);
       if ( statusesField ) statuses?.after(statusesField);
     } else {
-      detailsTab.append(magicalField, statusesField);
+      detailsTab.append(...[magicalField, statusesField].filter(_ => _));
     }
 
     // Add tooltip with link to wiki for effects/enchantments

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -184,16 +184,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
     }
 
-    else if ( (data.type === "base") && data.statuses.includes(CONFIG.specialStatusEffects.CONCENTRATING) ) {
-      // TODO: Hold concentration-based effects back to be migrated to activation-type effects
-      // See: https://github.com/foundryvtt/dnd5e/issues/4425
-    }
-
-    else if ( data.type === "base" ) {
-      data.type = "standard";
-      foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
-    }
-
     return super._initializeSource(data, options);
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -976,6 +976,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     else if ( this.isTemporary ) properties.push("DND5E.EffectType.Temporary");
     else properties.push("DND5E.EffectType.Passive");
     if ( this.type === "enchantment" ) properties.push("DND5E.ENCHANTMENT.Label");
+    if ( this.system.magical ) properties.push("DND5E.ITEM.Property.Magical");
 
     return {
       content: await foundry.applications.handlebars.renderTemplate(

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -180,16 +180,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
     }
 
-    else if ( (data.type === "base") && data.statuses.includes(CONFIG.specialStatusEffects.CONCENTRATING) ) {
-      // TODO: Hold concentration-based effects back to be migrated to activation-type effects
-      // See: https://github.com/foundryvtt/dnd5e/issues/4425
-    }
-
-    else if ( data.type === "base" ) {
-      data.type = "standard";
-      foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
-    }
-
     return super._initializeSource(data, options);
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -111,6 +111,9 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @type {boolean}
    */
   get isConcealed() {
+    if ( this.system.isConcealed ) return true;
+    if ( this.dependentOrigin?.active === false ) return true;
+    if ( (this.parent.system?.identified === false) && !game.user.isGM ) return true;
     if ( this.target?.testUserPermission(game.user, "OBSERVER") ) return false;
 
     // Hide bloodied status effect from players unless the token is friendly
@@ -175,6 +178,11 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       data.type = "enchantment";
       delete data.flags.dnd5e.type;
       foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
+    }
+
+    else if ( (data.type === "base") && data.statuses.includes(CONFIG.specialStatusEffects.CONCENTRATING) ) {
+      // TODO: Hold concentration-based effects back to be migrated to activation-type effects
+      // See: https://github.com/foundryvtt/dnd5e/issues/4425
     }
 
     else if ( data.type === "base" ) {

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -76,6 +76,16 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /* -------------------------------------------- */
 
   /**
+   * Document type to which this active effect should apply its changes.
+   * @type {string}
+   */
+  get applicableType() {
+    return this.system.applicableType ?? "Actor";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Another effect that granted this effect as a rider.
    * @type {ActiveEffect5e|null}
    */
@@ -91,7 +101,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @type {boolean}
    */
   get isAppliedEnchantment() {
-    return (this.type === "enchantment") && !!this.origin && (this.origin !== this.parent.uuid);
+    return (this.type === "enchantment") && this.system.isApplied;
   }
 
   /* -------------------------------------------- */
@@ -519,10 +529,9 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       foundry.utils.setProperty(activityData, "flags.dnd5e.dependentOn", this.id);
       riderActivities[activityData._id] = activityData;
     }
-    let createdActivities = [];
     if ( !foundry.utils.isEmpty(riderActivities) ) {
       await this.parent.update({ "system.activities": riderActivities });
-      createdActivities = Object.keys(riderActivities).map(id => this.parent.system.activities?.get(id));
+      const createdActivities = Object.keys(riderActivities).map(id => this.parent.system.activities?.get(id));
       createdActivities.forEach(a => a.effects?.forEach(e => {
         if ( !this.parent.effects.has(e._id) ) riderEffects.push(item.effects.get(e._id)?.toObject());
       }));
@@ -578,22 +587,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   async _preCreate(data, options, user) {
     if ( await super._preCreate(data, options, user) === false ) return false;
     if ( options.keepOrigin === false ) this.updateSource({ origin: this.parent.uuid });
-
-    // Enchantments cannot be added directly to actors
-    if ( (this.type === "enchantment") && (this.parent instanceof Actor) ) {
-      ui.notifications.error("DND5E.ENCHANTMENT.Warning.NotOnActor");
-      return false;
-    }
-
-    if ( this.isAppliedEnchantment ) {
-      const origin = await fromUuid(this.origin);
-      const errors = origin?.canEnchant?.(this.parent);
-      if ( errors?.length ) {
-        errors.forEach(err => console.error(err));
-        return false;
-      }
-      this.updateSource({ disabled: false });
-    }
   }
 
   /* -------------------------------------------- */
@@ -679,9 +672,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   _onDelete(options, userId) {
     super._onDelete(options, userId);
     if ( game.user === game.users.activeGM ) this.getDependents().forEach(e => e.delete());
-    if ( this.isAppliedEnchantment ) dnd5e.registry.enchantments.untrack(this.origin, this.uuid);
-    document.body.querySelectorAll(`enchantment-application:has([data-enchantment-uuid="${this.uuid}"]`)
-      .forEach(element => element.buildItemList());
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -166,6 +166,11 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
     }
 
+    else if ( data.type === "base" ) {
+      data.type = "standard";
+      foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
+    }
+
     return super._initializeSource(data, options);
   }
 
@@ -174,6 +179,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   static migrateData(source) {
     source = super.migrateData(source);
+
     for ( const change of source.changes ?? [] ) {
       if ( change.key === "flags.dnd5e.initiativeAdv" ) {
         change.key = "system.attributes.init.roll.mode";
@@ -181,6 +187,12 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
         change.value = 1;
       }
     }
+
+    if ( source.flags?.dnd5e?.riders?.statuses && !source.system?.rider?.statuses ) {
+      foundry.utils.setProperty(source, "system.rider.statuses", source.flags.dnd5e.riders.statuses);
+      delete source.flags.dnd5e.riders.statuses;
+    }
+
     return source;
   }
 
@@ -444,11 +456,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @returns {Promise<ActiveEffect5e[]>}      Created rider effects.
    */
   async createRiderConditions() {
-    const riders = new Set();
-
-    for ( const status of this.getFlag("dnd5e", "riders.statuses") ?? [] ) {
-      riders.add(status);
-    }
+    const riders = new Set(this.system.riders?.statuses ?? []);
 
     for ( const status of this.statuses ) {
       const r = CONFIG.statusEffects.find(e => e.id === status)?.riders ?? [];
@@ -760,16 +768,25 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @param {ApplicationRenderContext} context The app's rendering context.
    */
   static onRenderActiveEffectConfig(app, html, context) {
-    const element = new foundry.data.fields.SetField(new foundry.data.fields.StringField(), {}).toFormGroup({
-      label: _loc("DND5E.CONDITIONS.RiderConditions.label"),
-      hint: _loc("DND5E.CONDITIONS.RiderConditions.hint")
-    }, {
-      name: "flags.dnd5e.riders.statuses",
-      value: app.document.getFlag("dnd5e", "riders.statuses") ?? [],
+    if ( app.document.system.onRenderActiveEffectConfig?.(app, html, context) === false ) return;
+    const fields = app.document.system.schema.fields;
+    const magicalField = fields.magical?.toFormGroup({}, {
+      value: app.document.system._source.magical,
+      disabled: !context.editable
+    });
+    const statusesField = fields.rider?.fields?.statuses?.toFormGroup({}, {
+      value: app.document.system._source.rider?.statuses ?? [],
       options: CONFIG.statusEffects.map(se => ({ value: se.id, label: se.name })),
       disabled: !context.editable
     });
-    html.querySelector("[data-tab=details] > .form-group:has([name=statuses])")?.after(element);
+    const detailsTab = html.querySelector("[data-application-part=details]");
+    const statuses = detailsTab.querySelector("& > .form-group:has([name=statuses])");
+    if ( statuses ) {
+      if ( magicalField ) statuses?.before(magicalField);
+      if ( statusesField ) statuses?.after(statusesField);
+    } else {
+      detailsTab.append(magicalField, statusesField);
+    }
 
     // Add tooltip with link to wiki for effects/enchantments
     const helpIconElement = document.createElement("i");

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -785,7 +785,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       if ( magicalField ) statuses?.before(magicalField);
       if ( statusesField ) statuses?.after(statusesField);
     } else {
-      detailsTab.append(magicalField, statusesField);
+      detailsTab.append(...[magicalField, statusesField].filter(_ => _));
     }
 
     // Add tooltip with link to wiki for effects/enchantments

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -423,7 +423,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   prepareDerivedData() {
     super.prepareDerivedData();
     if ( this.id === this.constructor.ID.EXHAUSTION ) this._prepareExhaustionLevel();
-    if ( this.isAppliedEnchantment && this.uuid ) dnd5e.registry.enchantments.track(this.origin, this.uuid);
   }
 
   /* -------------------------------------------- */
@@ -597,10 +596,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( userId === game.userId ) {
       if ( this.active && (this.parent instanceof Actor) ) await this.createRiderConditions();
       if ( this.isAppliedEnchantment ) await this.createRiderEnchantments(options);
-    }
-    if ( options.chatMessageOrigin ) {
-      document.body.querySelectorAll(`[data-message-id="${options.chatMessageOrigin}"] enchantment-application`)
-        .forEach(element => element.buildItemList());
     }
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -116,6 +116,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   get isSuppressed() {
     if ( super.isSuppressed ) return true;
+    if ( this.system.magical && this.parent.actor?.statuses.has("antimagic") ) return true;
     if ( this.type === "enchantment" ) return false;
     if ( this.parent instanceof dnd5e.documents.Item5e ) {
       if ( this.parent.areEffectsSuppressed ) return true;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -990,6 +990,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     else if ( this.isTemporary ) properties.push("DND5E.EffectType.Temporary");
     else properties.push("DND5E.EffectType.Passive");
     if ( this.type === "enchantment" ) properties.push("DND5E.ENCHANTMENT.Label");
+    if ( this.system.magical ) properties.push("DND5E.ITEM.Property.Magical");
     properties = properties.map(p => _loc(p));
     properties.unshift(...this.statuses.map(id => CONFIG.statusEffects[id]?.name).filter(_ => _));
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -464,7 +464,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @returns {Promise<ActiveEffect5e[]>}      Created rider effects.
    */
   async createRiderConditions() {
-    const riders = new Set(this.system.riders?.statuses ?? []);
+    const riders = new Set(this.system.rider?.statuses ?? []);
 
     for ( const status of this.statuses ) {
       const r = CONFIG.statusEffects.find(e => e.id === status)?.riders ?? [];

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -163,7 +163,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
     // If concentration is required, ensure it is still being maintained & GM is present
     if ( !game.user.isGM && concentration && !concentration.isOwner ) {
       if ( strict ) {
-        ui.notifications.error("DND5E.EffectApplyWarningConcentration", { console: false, localize: true });
+        ui.notifications.error("DND5E.EFFECT.Application.Warning.Concentration", { console: false, localize: true });
         return null;
       } else {
         concentration = null;

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -163,7 +163,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
     // If concentration is required, ensure it is still being maintained & GM is present
     if ( !game.user.isGM && concentration && !concentration.isOwner ) {
       if ( strict ) {
-        ui.notifications.error("DND5E.EffectApplyWarningConcentration", { console: false });
+        ui.notifications.error("DND5E.EFFECT.Application.Warning.Concentration", { console: false });
         return null;
       } else {
         concentration = null;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -313,9 +313,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /** @inheritDoc */
   *allApplicableEffects() {
     for ( const effect of super.allApplicableEffects() ) {
-      if ( effect.type === "enchantment" ) continue;
-      if ( effect.parent?.getFlag("dnd5e", "riders.effect")?.includes(effect.id) ) continue;
-      yield effect;
+      if ( effect.applicableType === "Actor" ) yield effect;
     }
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -372,9 +372,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /** @inheritDoc */
   *allApplicableEffects() {
     for ( const effect of super.allApplicableEffects() ) {
-      if ( effect.type === "enchantment" ) continue;
-      if ( effect.parent?.getFlag("dnd5e", "riders.effect")?.includes(effect.id) ) continue;
-      yield effect;
+      if ( effect.applicableType === "Actor" ) yield effect;
     }
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -433,7 +433,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   *allApplicableEffects() {
     for ( const effect of this.effects ) {
-      if ( effect.isAppliedEnchantment ) yield effect;
+      if ( effect.applicableType === "Item" ) yield effect;
     }
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -459,7 +459,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   *allApplicableEffects() {
     for ( const effect of this.effects ) {
-      if ( effect.isAppliedEnchantment ) yield effect;
+      if ( effect.applicableType === "Item" ) yield effect;
     }
   }
 

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -680,8 +680,11 @@ export function migrateEffectData(effect, migrationData, { parent }={}) {
   const updateData = {};
   _migrateDocumentIcon(effect, updateData, {...migrationData, field: "img"});
   _migrateEffectArmorClass(effect, updateData);
+  if ( foundry.utils.isNewerVersion("5.2.0", effect._stats?.systemVersion ?? parent?._stats?.systemVersion) ) {
+    _migrateEffectMagical(effect, parent, updateData);
+  }
   if ( foundry.utils.isNewerVersion("3.1.0", effect._stats?.systemVersion ?? parent?._stats?.systemVersion) ) {
-    _migrateTransferEffect(effect, parent, updateData);
+    _migrateEffectTransfer(effect, parent, updateData);
   }
   return updateData;
 }
@@ -982,6 +985,42 @@ function _migrateEffectArmorClass(effect, updateData) {
 /* -------------------------------------------- */
 
 /**
+ * Marks effects on spells & items marked with "Magical" property as magical.
+ * @param {object} effect      Effect data to migrate.
+ * @param {object} parent      The parent of this effect.
+ * @param {object} updateData  Existing update to expand upon.
+ * @returns {object}           The updateData to apply.
+ */
+function _migrateEffectMagical(effect, parent, updateData) {
+  if ( isSpellOrScroll(parent) || parent.system?.properties?.includes("mgc") ) updateData["system.magical"] = true;
+  return updateData;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Disable transfer on effects on spell items
+ * @param {object} effect      Effect data to migrate.
+ * @param {object} parent      The parent of this effect.
+ * @param {object} updateData  Existing update to expand upon.
+ * @returns {object}           The updateData to apply.
+ */
+function _migrateEffectTransfer(effect, parent, updateData) {
+  if ( !effect.transfer ) return updateData;
+  if ( !isSpellOrScroll(parent) ) return updateData;
+
+  updateData.transfer = false;
+  updateData.disabled = true;
+  updateData["duration.startTime"] = null;
+  updateData["duration.startRound"] = null;
+  updateData["duration.startTurn"] = null;
+
+  return updateData;
+}
+
+/* -------------------------------------------- */
+
+/**
  * Move `uses.value` to `uses.spent` for items.
  * @param {Item5e} item        Full item instance.
  * @param {object} itemData    Item data to migrate.
@@ -996,28 +1035,6 @@ function _migrateItemUses(item, itemData, updateData, flags) {
     flags.persistSourceMigration = true;
   }
   if ( value !== undefined ) updateData["flags.dnd5e.-=migratedUses"] = null;
-}
-
-/* -------------------------------------------- */
-
-/**
- * Disable transfer on effects on spell items
- * @param {object} effect      Effect data to migrate.
- * @param {object} parent      The parent of this effect.
- * @param {object} updateData  Existing update to expand upon.
- * @returns {object}           The updateData to apply.
- */
-function _migrateTransferEffect(effect, parent, updateData) {
-  if ( !effect.transfer ) return updateData;
-  if ( !isSpellOrScroll(parent) ) return updateData;
-
-  updateData.transfer = false;
-  updateData.disabled = true;
-  updateData["duration.startTime"] = null;
-  updateData["duration.startRound"] = null;
-  updateData["duration.startTurn"] = null;
-
-  return updateData;
 }
 
 /* -------------------------------------------- */

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -739,8 +739,11 @@ export function migrateEffectData(effect, migrationData, { parent }={}) {
   const updateData = {};
   _migrateDocumentIcon(effect, updateData, {...migrationData, field: "img"});
   _migrateEffectArmorClass(effect, updateData);
+  if ( foundry.utils.isNewerVersion("5.2.0", effect._stats?.systemVersion ?? parent?._stats?.systemVersion) ) {
+    _migrateEffectMagical(effect, parent, updateData);
+  }
   if ( foundry.utils.isNewerVersion("3.1.0", effect._stats?.systemVersion ?? parent?._stats?.systemVersion) ) {
-    _migrateTransferEffect(effect, parent, updateData);
+    _migrateEffectTransfer(effect, parent, updateData);
   }
   return updateData;
 }
@@ -1041,6 +1044,42 @@ function _migrateEffectArmorClass(effect, updateData) {
 /* -------------------------------------------- */
 
 /**
+ * Marks effects on spells & items marked with "Magical" property as magical.
+ * @param {object} effect      Effect data to migrate.
+ * @param {object} parent      The parent of this effect.
+ * @param {object} updateData  Existing update to expand upon.
+ * @returns {object}           The updateData to apply.
+ */
+function _migrateEffectMagical(effect, parent, updateData) {
+  if ( isSpellOrScroll(parent) || parent.system?.properties?.includes("mgc") ) updateData["system.magical"] = true;
+  return updateData;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Disable transfer on effects on spell items
+ * @param {object} effect      Effect data to migrate.
+ * @param {object} parent      The parent of this effect.
+ * @param {object} updateData  Existing update to expand upon.
+ * @returns {object}           The updateData to apply.
+ */
+function _migrateEffectTransfer(effect, parent, updateData) {
+  if ( !effect.transfer ) return updateData;
+  if ( !isSpellOrScroll(parent) ) return updateData;
+
+  updateData.transfer = false;
+  updateData.disabled = true;
+  updateData["duration.startTime"] = null;
+  updateData["duration.startRound"] = null;
+  updateData["duration.startTurn"] = null;
+
+  return updateData;
+}
+
+/* -------------------------------------------- */
+
+/**
  * Move `uses.value` to `uses.spent` for items.
  * @param {Item5e} item        Full item instance.
  * @param {object} itemData    Item data to migrate.
@@ -1055,28 +1094,6 @@ function _migrateItemUses(item, itemData, updateData, flags) {
     flags.persistSourceMigration = true;
   }
   if ( value !== undefined ) updateData["flags.dnd5e.migratedUses"] = _del;
-}
-
-/* -------------------------------------------- */
-
-/**
- * Disable transfer on effects on spell items
- * @param {object} effect      Effect data to migrate.
- * @param {object} parent      The parent of this effect.
- * @param {object} updateData  Existing update to expand upon.
- * @returns {object}           The updateData to apply.
- */
-function _migrateTransferEffect(effect, parent, updateData) {
-  if ( !effect.transfer ) return updateData;
-  if ( !isSpellOrScroll(parent) ) return updateData;
-
-  updateData.transfer = false;
-  updateData.disabled = true;
-  updateData["duration.startTime"] = null;
-  updateData["duration.startRound"] = null;
-  updateData["duration.startTurn"] = null;
-
-  return updateData;
 }
 
 /* -------------------------------------------- */

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -739,7 +739,7 @@ export function migrateEffectData(effect, migrationData, { parent }={}) {
   const updateData = {};
   _migrateDocumentIcon(effect, updateData, {...migrationData, field: "img"});
   _migrateEffectArmorClass(effect, updateData);
-  if ( foundry.utils.isNewerVersion("5.2.0", effect._stats?.systemVersion ?? parent?._stats?.systemVersion) ) {
+  if ( foundry.utils.isNewerVersion("6.0.0", effect._stats?.systemVersion ?? parent?._stats?.systemVersion) ) {
     _migrateEffectMagical(effect, parent, updateData);
   }
   if ( foundry.utils.isNewerVersion("3.1.0", effect._stats?.systemVersion ?? parent?._stats?.systemVersion) ) {

--- a/system.json
+++ b/system.json
@@ -25,7 +25,8 @@
   ],
   "documentTypes": {
     "ActiveEffect": {
-      "enchantment": {}
+      "enchantment": {},
+      "standard": {}
     },
     "Actor": {
       "character": {

--- a/system.json
+++ b/system.json
@@ -2,14 +2,14 @@
   "id": "dnd5e",
   "title": "Dungeons & Dragons Fifth Edition",
   "description": "A system for playing the fifth edition of the world's most popular role-playing game in the Foundry Virtual Tabletop environment.",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "compatibility": {
-    "minimum": "13.347",
-    "verified": "13"
+    "minimum": "14.353",
+    "verified": "14"
   },
   "url": "https://github.com/foundryvtt/dnd5e/",
   "manifest": "https://raw.githubusercontent.com/foundryvtt/dnd5e/master/system.json",
-  "download": "https://github.com/foundryvtt/dnd5e/releases/download/release-5.3.0/dnd5e-release-5.3.0.zip",
+  "download": "https://github.com/foundryvtt/dnd5e/releases/download/release-6.0.0/dnd5e-release-6.0.0.zip",
   "authors": [
     {
       "name": "Atropos",
@@ -25,8 +25,7 @@
   ],
   "documentTypes": {
     "ActiveEffect": {
-      "enchantment": {},
-      "standard": {}
+      "enchantment": {}
     },
     "Actor": {
       "character": {

--- a/system.json
+++ b/system.json
@@ -25,8 +25,7 @@
   ],
   "documentTypes": {
     "ActiveEffect": {
-      "enchantment": {},
-      "standard": {}
+      "enchantment": {}
     },
     "Actor": {
       "character": {

--- a/templates/items/details/details-feat.hbs
+++ b/templates/items/details/details-feat.hbs
@@ -32,13 +32,13 @@
 
     {{!-- Max Enchantments --}}
     {{ formField fields.enchant.fields.max value=source.enchant.max localize=true
-                 label="DND5E.ENCHANTMENT.FIELDS.enchantment.items.max.label"
-                 hint="DND5E.ENCHANTMENT.FIELDS.enchantment.items.max.hint" rootId=partId }}
+                 label="DND5E.FEATURE.FIELDS.enchant.items.max.label"
+                 hint="DND5E.FEATURE.FIELDS.enchant.items.max.hint" rootId=partId }}
 
     {{!-- Enchantment Replacement --}}
     {{ formField fields.enchant.fields.period value=source.enchant.period localize=true
                  choices=CONFIG.enchantmentPeriods labelAttr="label" blank="DND5E.ENCHANTMENT.Period.Never"
-                 label="DND5E.ENCHANTMENT.FIELDS.enchantment.items.period.label"
-                 hint="DND5E.ENCHANTMENT.FIELDS.enchantment.items.period.hint" rootId=partId }}
+                 label="DND5E.FEATURE.FIELDS.enchant.items.period.label"
+                 hint="DND5E.FEATURE.FIELDS.enchant.items.period.hint" rootId=partId }}
 </fieldset>
 {{/if}}

--- a/templates/shared/active-effects.hbs
+++ b/templates/shared/active-effects.hbs
@@ -1,7 +1,7 @@
 <{{ elements.effects }} class="effects-element">
 
     {{!-- Searching --}}
-    <item-list-controls for="effects" label="{{ localize "DND5E.EffectsSearch" }}" sort="a"
+    <item-list-controls for="effects" label="{{ localize "DND5E.EFFECT.Action.Search" }}" sort="a"
                         collection="effects"></item-list-controls>
 
     {{!-- Effects List --}}


### PR DESCRIPTION
This new effect type replaces the base type provided by core that adds a `magical` toggle and moves rider statuses from flags into the system data. An in-memory migration handles changing the type and moving the status riders from flags, while system migration handles setting a logical default for the new `magical` property.

Creates `ActiveEffectDataModel` that new can extend to gain some default functionality. This new model includes getters for the actor and item containing the effect, as well as `applicableType` which returns the document type to which the effect should apply. This allows some of the previous explicit checks for enchantments and rider effects to be handled by the specific types and supports  module-provided AE types that can apply to actors, items, or neither.
    
Also moves some of the enchantment-specific creation & deletion logic into the system data model instead.