### PR TITLE
[#5944] Cached spell `uses` reference actual consumption target when necessary

### DIFF
--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -851,9 +851,12 @@ export default class BaseActorSheet extends PrimarySheetMixin(
 
     // Linked Uses
     const cachedFor = fromUuidSync(item.flags.dnd5e?.cachedFor, { relative: this.actor, strict: false });
-    if ( cachedFor ) ctx.linkedUses = cachedFor.consumption?.targets.find(t => t.type === "activityUses")
-      ? cachedFor.uses : cachedFor.consumption?.targets.find(t => t.type === "itemUses")
-        ? cachedFor.item.system.uses : null;
+    if ( cachedFor ) {
+      const targetItemUses = cachedFor.consumption?.targets.find(t => t.type === "itemUses");
+      ctx.linkedUses = cachedFor.consumption?.targets.find(t => t.type === "activityUses")
+        ? cachedFor.uses : targetItemUses
+          ? (this.actor.items.get(targetItemUses.target) ?? cachedFor.item).system.uses : null;
+    }
     ctx.uses = { ...(item.system.uses ?? {}) };
     ctx.uses.hasRecharge = item.hasRecharge;
     ctx.uses.hasUses = item.hasLimitedUses;


### PR DESCRIPTION
Closes #5944 
Previously, if any `itemUses`-type consumption target, assumed the parent item of the cast activity. Now, will try to grab the specified item by ID (falling back to parent item, as it should for the self-targeting empty string).