### PR TITLE
[#5927] Add setting for auto-applying dead/unconscious in combat

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -6500,7 +6500,7 @@
     },
     "AutoApplyDowned": {
       "Name": "Auto-Apply Downed Conditions",
-      "Hint": "Automatically apply \"Dead\" (for unimportant NPCs) or \"Unconscious\" (for others) when an actor is reduced to 0 HP in combat or fails their third death saving throw.",
+      "Hint": "Automatically apply the \"Dead\" or \"Unconscious\" status when a creature is reduced to 0 HP in combat. Unimportant NPCs are marked Dead. Important NPCs and PCs are marked Unconscious first, and Dead if they fail three death saving throws.",
       "None": "Never",
       "DeadOnly": "For NPCs (dead only)",
       "NPCs": "For NPCs (dead and unconscious)",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6499,7 +6499,7 @@
       "Hint": "Append the raw Dexterity ability score to break ties in Initiative."
     },
     "AutoApplyDowned": {
-      "Name": "Auto-Apply Downed Conditions",
+      "Name": "Auto-Apply Downed",
       "Hint": "Automatically apply the \"Dead\" or \"Unconscious\" status when a creature is reduced to 0 HP in combat. Unimportant NPCs are marked Dead. Important NPCs and PCs are marked Unconscious first, and Dead if they fail three death saving throws.",
       "None": "Never",
       "DeadOnly": "For NPCs (dead only)",
@@ -6522,6 +6522,9 @@
       "Hint": "Use the same initiative roll for identical creatures."
     }
   },
+  "CONDITIONS": {
+    "Name": "Conditions"
+  },
   "CRITICAL": {
     "Name": "Critical Damage",
     "MaxDice": {
@@ -6536,9 +6539,6 @@
   "DEFAULTSKILLS": {
     "Name": "Default Skills",
     "Hint": "The default skills that appear on NPC sheets regardless of level of proficiency."
-  },
-  "EFFECTS": {
-    "Name": "Effects"
   },
   "ENCOUNTERS": {
     "Name": "Encounters",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6500,10 +6500,11 @@
     },
     "AutoApplyDowned": {
       "Name": "Auto-Apply Downed Conditions",
-      "Hint": "Automatically apply \"Dead\" (for unimportant NPCs) or \"Unconscious\" (for others) when an actor is reduced to 0 HP in combat.",
-      "None": "Never auto-apply",
-      "DeadOnly": "Auto-apply \"Dead\"",
-      "All": "Auto-apply \"Dead\" and \"Unconscious\""
+      "Hint": "Automatically apply \"Dead\" (for unimportant NPCs) or \"Unconscious\" (for others) when an actor is reduced to 0 HP in combat or fails their third death saving throw.",
+      "None": "Never",
+      "DeadOnly": "For NPCs (dead only)",
+      "NPCs": "For NPCs (dead and unconscious)",
+      "All": "Always"
     },
     "InitiativeScore": {
       "Name": "Initiative Score",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6500,7 +6500,7 @@
     },
     "AutoApplyDowned": {
       "Name": "Auto-Apply Downed",
-      "Hint": "Automatically apply the \"Dead\" or \"Unconscious\" status when a creature is reduced to 0 HP in combat. Unimportant NPCs are marked Dead. Important NPCs and PCs are marked Unconscious first, and Dead if they fail three death saving throws.",
+      "Hint": "Automatically mark a creature as Dead or Unconscious when it is reduced to 0 HP in combat. Unimportant NPCs are marked Dead. Important NPCs and PCs are marked Unconscious first, and Dead if they fail three death saving throws.",
       "None": "Never",
       "DeadOnly": "For NPCs (dead only)",
       "NPCs": "For NPCs (dead and unconscious)",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6498,6 +6498,13 @@
       "Name": "Dexterity Tiebreaker",
       "Hint": "Append the raw Dexterity ability score to break ties in Initiative."
     },
+    "AutoApplyDowned": {
+      "Name": "Auto-Apply Downed Conditions",
+      "Hint": "Automatically apply \"Dead\" (for unimportant NPCs) or \"Unconscious\" (for others) when an actor is reduced to 0 HP in combat.",
+      "None": "Never auto-apply",
+      "DeadOnly": "Auto-apply \"Dead\"",
+      "All": "Auto-apply \"Dead\" and \"Unconscious\""
+    },
     "InitiativeScore": {
       "Name": "Initiative Score",
       "Hint": "Use a creature's initiative score (10 + bonus) rather than rolling for initiative.",
@@ -6528,6 +6535,9 @@
   "DEFAULTSKILLS": {
     "Name": "Default Skills",
     "Hint": "The default skills that appear on NPC sheets regardless of level of proficiency."
+  },
+  "EFFECTS": {
+    "Name": "Effects"
   },
   "ENCOUNTERS": {
     "Name": "Encounters",

--- a/module/applications/settings/combat-settings.mjs
+++ b/module/applications/settings/combat-settings.mjs
@@ -24,7 +24,7 @@ export default class CombatSettingsConfig extends BaseSettingsConfig {
     npcs: {
       template: "systems/dnd5e/templates/settings/base-config.hbs"
     },
-    effects: {
+    conditions: {
       template: "systems/dnd5e/templates/settings/base-config.hbs"
     },
     encounterPlacement: {
@@ -72,11 +72,11 @@ export default class CombatSettingsConfig extends BaseSettingsConfig {
         ];
         context.legend = _loc("SETTINGS.DND5E.ENCOUNTERS.Name");
         break;
-      case "effects":
+      case "conditions":
         context.fields = [
           this.createSettingField("autoApplyDowned")
         ];
-        context.legend = _loc("SETTINGS.DND5E.EFFECTS.Name");
+        context.legend = _loc("SETTINGS.DND5E.CONDITIONS.Name");
         break;
     }
     return context;

--- a/module/applications/settings/combat-settings.mjs
+++ b/module/applications/settings/combat-settings.mjs
@@ -24,6 +24,9 @@ export default class CombatSettingsConfig extends BaseSettingsConfig {
     npcs: {
       template: "systems/dnd5e/templates/settings/base-config.hbs"
     },
+    effects: {
+      template: "systems/dnd5e/templates/settings/base-config.hbs"
+    },
     encounterPlacement: {
       template: "systems/dnd5e/templates/settings/base-config.hbs"
     },
@@ -68,6 +71,12 @@ export default class CombatSettingsConfig extends BaseSettingsConfig {
           this.createSettingField("encounterPlacementBehavior")
         ];
         context.legend = _loc("SETTINGS.DND5E.ENCOUNTERS.Name");
+        break;
+      case "effects":
+        context.fields = [
+          this.createSettingField("autoApplyDowned")
+        ];
+        context.legend = _loc("SETTINGS.DND5E.EFFECTS.Name");
         break;
     }
     return context;

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -286,6 +286,7 @@ export default class CharacterData extends CreatureTemplate {
   _onUpdate(changed, options, userId) {
     super._onUpdate(changed, options, userId);
     AttributesFields.onUpdateHP.call(this, changed, options, userId);
+    AttributesFields.onUpdateDeathSaves.call(this, changed, options, userId);
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -487,6 +487,7 @@ export default class NPCData extends CreatureTemplate {
   _onUpdate(changed, options, userId) {
     super._onUpdate(changed, options, userId);
     AttributesFields.onUpdateHP.call(this, changed, options, userId);
+    AttributesFields.onUpdateDeathSaves.call(this, changed, options, userId);
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -691,4 +691,18 @@ export default class AttributesFields {
      */
     Hooks.callAll(`dnd5e.${changes.total > 0 ? "heal" : "damage"}Actor`, this.parent, changes, changed, userId);
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Trigger auto-downed logic if failed third death save
+   * @this {CharacterData|NPCData}
+   * @param {object} changed  The differential data that was changed relative to the document's prior values.
+   * @param {object} options  Additional options which modify the update request.
+   * @param {string} userId   The id of the User requesting the document update.
+   */
+  static async onUpdateDeathSaves(changed, options, userId) {
+    if ( changed.system?.attributes?.death?.failure !== 3 ) return;
+    if (userId === game.userId ) await this.parent.updateDowned(options);
+  }
 }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -703,6 +703,9 @@ export default class AttributesFields {
    */
   static async onUpdateDeathSaves(changed, options, userId) {
     if ( changed.system?.attributes?.death?.failure !== 3 ) return;
+
+    // If hp update is included, updateDowned will be called in onUpdateHP, so exit early
+    if ( !!changed.system.attributes.hp ) return;
     if ( userId === game.userId ) await this.parent.updateDowned(options);
   }
 }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -695,7 +695,7 @@ export default class AttributesFields {
   /* -------------------------------------------- */
 
   /**
-   * Trigger auto-downed logic if failed third death save
+   * Trigger auto-downed logic if failed three death saves.
    * @this {CharacterData|NPCData}
    * @param {object} changed  The differential data that was changed relative to the document's prior values.
    * @param {object} options  Additional options which modify the update request.
@@ -703,6 +703,6 @@ export default class AttributesFields {
    */
   static async onUpdateDeathSaves(changed, options, userId) {
     if ( changed.system?.attributes?.death?.failure !== 3 ) return;
-    if (userId === game.userId ) await this.parent.updateDowned(options);
+    if ( userId === game.userId ) await this.parent.updateDowned(options);
   }
 }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -656,7 +656,10 @@ export default class AttributesFields {
    */
   static async onUpdateHP(changed, options, userId) {
     if ( !changed.system?.attributes?.hp ) return;
-    if ( userId === game.userId ) await this.parent.updateBloodied(options);
+    if ( userId === game.userId ) {
+      await this.parent.updateBloodied(options);
+      await this.parent.updateDowned(options);
+    }
 
     const hp = options.dnd5e?.hp;
     if ( !hp || options.isRest || options.isAdvancement ) return;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3622,9 +3622,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       const autoEffects = this.effects.filter(e => e.getFlag("dnd5e", "autoDowned"));
       return this.deleteEmbeddedDocuments("ActiveEffect", autoEffects.map(e => e.id));
     }
+    const conditionEffects = this.effects.documentsByType.condition;
+    const isDead = conditionEffects.some(e => e.system.type === "dead");
+    const isUnconscious = conditionEffects.some(e => e.system.type === "unconscious");
 
     // Do not auto-apply statuses outside of combat or if already dead
-    if ( !this.inCombat || this.statuses.has("dead") ) return;
+    if ( !this.inCombat || isDead ) return;
     const failedDeathSaves = this.system.attributes.death.failure >= 3;
     let toApply = null;
     if ( this.type === "npc" ) {
@@ -3642,7 +3645,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       statuses: ["dead"],
       showIcon: CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS
     }, { parent: this, keepId: true });
-    else if ( !this.statuses.has("unconscious") ) return ActiveEffect.implementation.create({
+    else if ( !isUnconscious ) return ActiveEffect.implementation.create({
       _id: CONFIG.statusEffects.unconscious._id,
       img: CONFIG.statusEffects.unconscious.img,
       flags: { dnd5e: { autoDowned: true } },

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3616,14 +3616,40 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( autoApplyDowned === "none" ) return;
     const hp = this.system.attributes?.hp;
     if ( !hp ) return;
-    if ( hp.value ) return this.statuses.has("dead") ? this.toggleStatusEffect("dead", { active: false }) : undefined;
-    if ( !this.inCombat ) return;
-    const hasDeathSaves = this.type === "character" || (this.type === "npc" && this.system.traits.important);
-    if ( hasDeathSaves ) {
-      if ( autoApplyDowned === "all" ) return this.toggleStatusEffect("unconscious", { active: true, overlay: true });
-    } else if ( this.type === "npc" ) {
-      return this.toggleStatusEffect("dead", { active: true, overlay: true });
+
+    // If non-zero, remove any auto-downed effects
+    if ( hp.value ) {
+      const autoEffects = this.effects.filter(e => e.getFlag("dnd5e", "autoDowned"));
+      return this.deleteEmbeddedDocuments("ActiveEffect", autoEffects.map(e => e.id));
     }
+
+    // Do not auto-apply statuses outside of combat or if already dead
+    if ( !this.inCombat || this.statuses.has("dead") ) return;
+    const failedDeathSaves = this.system.attributes.death.failure >= 3
+    let toApply = null;
+    if ( this.type === "npc" ) {
+      if ( !this.system.traits.important ) toApply = "dead";
+      else if ( autoApplyDowned !== "deadOnly" ) toApply = failedDeathSaves ? "dead" : "unconscious";
+    } else if ( (this.type === "character") && (autoApplyDowned === "all") ) {
+      toApply = failedDeathSaves ? "dead" : "unconscious";
+    }
+    if ( !toApply ) return;
+    if ( toApply === "dead" ) return ActiveEffect.implementation.create({
+      _id: CONFIG.statusEffects.dead._id,
+      img: CONFIG.statusEffects.dead.img,
+      flags: { dnd5e: { autoDowned: true }, core: { overlay: true } },
+      name: CONFIG.statusEffects.dead.name,
+      statuses: ["dead"],
+      showIcon: CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS
+    }, { parent: this, keepId: true });
+    else if ( !this.statuses.has("unconscious") ) return ActiveEffect.implementation.create({
+      _id: CONFIG.statusEffects.unconscious._id,
+      img: CONFIG.statusEffects.unconscious.img,
+      flags: { dnd5e: { autoDowned: true } },
+      name: _loc(CONFIG.statusEffects.unconscious.name),
+      statuses: ["unconscious"],
+      showIcon: CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS
+    }, { parent: this, keepId: true });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3607,6 +3607,28 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
+   * Handle applying/removing the dead/unconscious status.
+   * @param {DocumentModificationContext} options  Additional options supplied with the update.
+   * @returns {Promise<ActiveEffect|boolean|undefined>|void}
+   */
+  updateDowned(options) {
+    const autoApplyDowned = game.settings.get("dnd5e", "autoApplyDowned");
+    if ( autoApplyDowned === "none" ) return;
+    const hp = this.system.attributes?.hp;
+    if ( !hp ) return;
+    if ( hp.value ) return this.statuses.has("dead") ? this.toggleStatusEffect("dead", { active: false }) : undefined;
+    if ( !this.inCombat ) return;
+    const hasDeathSaves = this.type === "character" || (this.type === "npc" && this.system.traits.important);
+    if ( hasDeathSaves ) {
+      if ( autoApplyDowned === "all" ) return this.toggleStatusEffect("unconscious", { active: true, overlay: true });
+    } else if ( this.type === "npc" ) {
+      return this.toggleStatusEffect("dead", { active: true, overlay: true });
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Handle applying/removing encumbrance statuses.
    * @param {DocumentModificationContext} options  Additional options supplied with the update.
    * @returns {Promise<ActiveEffect>|void}

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3609,10 +3609,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Handle applying/removing the dead/unconscious status.
    * @param {DocumentModificationContext} options  Additional options supplied with the update.
-   * @returns {Promise<ActiveEffect|boolean|undefined>|void}
+   * @returns {Promise<ActiveEffect|boolean|void>|void}
    */
   updateDowned(options) {
-    const autoApplyDowned = game.settings.get("dnd5e", "autoApplyDowned");
+    const { autoApplyDowned } = dnd5e.settings;
     if ( autoApplyDowned === "none" ) return;
     const hp = this.system.attributes?.hp;
     if ( !hp ) return;
@@ -3625,7 +3625,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     // Do not auto-apply statuses outside of combat or if already dead
     if ( !this.inCombat || this.statuses.has("dead") ) return;
-    const failedDeathSaves = this.system.attributes.death.failure >= 3
+    const failedDeathSaves = this.system.attributes.death.failure >= 3;
     let toApply = null;
     if ( this.type === "npc" ) {
       if ( !this.system.traits.important ) toApply = "dead";
@@ -3646,7 +3646,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       _id: CONFIG.statusEffects.unconscious._id,
       img: CONFIG.statusEffects.unconscious.img,
       flags: { dnd5e: { autoDowned: true } },
-      name: _loc(CONFIG.statusEffects.unconscious.name),
+      name: CONFIG.statusEffects.unconscious.name,
       statuses: ["unconscious"],
       showIcon: CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS
     }, { parent: this, keepId: true });

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3643,7 +3643,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       flags: { dnd5e: { autoDowned: true }, core: { overlay: true } },
       name: CONFIG.statusEffects.dead.name,
       statuses: ["dead"],
-      showIcon: CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS
+      showIcon: CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS,
+      type: "condition",
+      system: { type: "dead" }
     }, { parent: this, keepId: true });
     else if ( !isUnconscious ) return ActiveEffect.implementation.create({
       _id: CONFIG.statusEffects.unconscious._id,
@@ -3651,7 +3653,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       flags: { dnd5e: { autoDowned: true } },
       name: CONFIG.statusEffects.unconscious.name,
       statuses: ["unconscious"],
-      showIcon: CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS
+      showIcon: CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS,
+      type: "condition",
+      system: { type: "unconscious" }
     }, { parent: this, keepId: true });
   }
 

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -512,6 +512,7 @@ export function registerSystemSettings() {
     choices: {
       none: "SETTINGS.DND5E.COMBAT.AutoApplyDowned.None",
       deadOnly: "SETTINGS.DND5E.COMBAT.AutoApplyDowned.DeadOnly",
+      npcs: "SETTINGS.DND5E.COMBAT.AutoApplyDowned.NPCs",
       all: "SETTINGS.DND5E.COMBAT.AutoApplyDowned.All"
     }
   });

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -502,6 +502,20 @@ export function registerSystemSettings() {
     }
   });
 
+  game.settings.register("dnd5e", "autoApplyDowned", {
+    name: "SETTINGS.DND5E.COMBAT.AutoApplyDowned.Name",
+    hint: "SETTINGS.DND5E.COMBAT.AutoApplyDowned.Hint",
+    scope: "world",
+    config: false,
+    default: "none",
+    type: String,
+    choices: {
+      none: "SETTINGS.DND5E.COMBAT.AutoApplyDowned.None",
+      deadOnly: "SETTINGS.DND5E.COMBAT.AutoApplyDowned.DeadOnly",
+      all: "SETTINGS.DND5E.COMBAT.AutoApplyDowned.All"
+    }
+  });
+
   // Variant Rules
   game.settings.registerMenu("dnd5e", "variantRulesConfiguration", {
     name: "SETTINGS.DND5E.VARIANT.Name",


### PR DESCRIPTION
Closes #5927 
Currently, a single setting with a dropdown, located in a new section of the Combat Settings menu.
`none`: Existing behavior
`deadOnly`: NPCs not marked important, if reduced to 0hp _in combat_, will have the `dead` status toggled on. Unimportant NPCs _out of combat_ will have `dead` status toggled off if they have an HP update which leaves them at a non-zero hp.
`all`: Same as `deadOnly`, but additionally PCs and Important NPCs, if reduced to 0hp _in combat_, will have the `unconscious` status toggled on.

Happy to play with wording, and also don't feel strongly on the out-of-combat treatment of the `dead` status. A "lite" version of this could focus only on `dead` for unimportant NPCs, making the setting a checkbox, and putting it squarely in the "NPCs" section of the combat settings menu.