### PR TITLE
[#5934] Add setting for players to use effect application tray

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2645,7 +2645,7 @@
     },
     "Header": "Effects",
     "Warning": {
-      "Concentration": "Applying an effect that is being concentrated on by another character requires GM permissions.",
+      "Concentration": "Applying an effect that is being concentrated requires an active GM to be present.",
       "Ownership": "Effects cannot be applied to tokens you are not the owner of."
     }
   },
@@ -6898,6 +6898,10 @@
     "Name": "Piety Score"
   },
   "PERMISSIONS": {
+    "AllowEffects": {
+      "Hint": "Allow players to use the effect application tray when an actor they own is the target of an effect.",
+      "Name": "Allow Player Effect Application"
+    },
     "AllowRests": {
       "Hint": "Allow players to rest directly from their characters' sheets. When disabled, players will only be able to rest when the GM makes a request from the party.",
       "Name": "Allow Individual Rests"

--- a/lang/en.json
+++ b/lang/en.json
@@ -2717,6 +2717,10 @@
     "Label": "Change",
     "Title": "{effect} Change #{number}"
   },
+  "DisabledTooltip": {
+    "Disabled": "This effect is currently selected in one or more of its Item's Activities, and therefore cannot be suspended.",
+    "Transfer": "This effect is currently selected in one or more of its Item's Activities, and therefore cannot passively apply to the Item's Actor."
+  },
   "DropHint": "Drop an Active Effect here",
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
   "Expiry": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -2662,7 +2662,6 @@
     },
     "Header": "Effects",
     "Warning": {
-      "Concentration": "Applying an effect that is being concentrated requires an active GM to be present.",
       "Ownership": "Effects cannot be applied to tokens you are not the owner of."
     }
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -2662,7 +2662,7 @@
     },
     "Header": "Effects",
     "Warning": {
-      "Concentration": "Applying an effect that is being concentrated on by another character requires GM permissions.",
+      "Concentration": "Applying an effect that is being concentrated requires an active GM to be present.",
       "Ownership": "Effects cannot be applied to tokens you are not the owner of."
     }
   },
@@ -6924,6 +6924,10 @@
     "Name": "Piety Score"
   },
   "PERMISSIONS": {
+    "AllowEffects": {
+      "Hint": "Allow players to use the effect application tray when an actor they own is the target of an effect.",
+      "Name": "Allow Player Effect Application"
+    },
     "AllowRests": {
       "Hint": "Allow players to rest directly from their characters' sheets. When disabled, players will only be able to rest when the GM makes a request from the party.",
       "Name": "Allow Individual Rests"

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -343,10 +343,6 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       }, effectFlags) };
     }
 
-    if ( !game.user.isGM && concentration && !concentration.isOwner ) {
-      throw new Error(_loc("DND5E.EFFECT.Application.Warning.Concentration"));
-    }
-
     // Otherwise, create a new effect on the target
     return { action: "create", data: foundry.utils.mergeObject({
       ...effect.toObject(),

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -351,10 +351,6 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       }, effectFlags) };
     }
 
-    if ( !game.user.isGM && concentration && !concentration.isOwner ) {
-      throw new Error(_loc("DND5E.EFFECT.Application.Warning.Concentration"));
-    }
-
     // Otherwise, create a new effect on the target
     const effectData = foundry.utils.mergeObject({
       ...effect.toObject(),

--- a/module/data/active-effect/base.mjs
+++ b/module/data/active-effect/base.mjs
@@ -35,6 +35,16 @@ export default class BaseEffectData extends ActiveEffectDataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareBaseData() {
+    super.prepareBaseData();
+    if ( this.isOnActivity ) this.parent.transfer = this.parent.disabled = false;
+  }
+
+  /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
 
@@ -46,11 +56,37 @@ export default class BaseEffectData extends ActiveEffectDataModel {
   /* -------------------------------------------- */
 
   /**
+   * Is this effect selected by any activity on its parent item?
+   * @type {boolean}
+   */
+  get isOnActivity() {
+    return this.item
+      && (this.item.system.activities?.contents ?? []).some(a => a.effects.some(e => e._id === this.parent._id));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Is this effect a rider for a non-applied enchantment?
    * @type {boolean}
    */
   get isRider() {
     return this.item?.getFlag("dnd5e", "riders.effect")?.includes?.(this.parent.id) ?? false;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners & Handlers                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  onRenderActiveEffectConfig(app, html, context) {
+    if ( !this.isOnActivity ) return;
+    const checkboxes = html.querySelectorAll('dnd5e-checkbox[name="transfer"], dnd5e-checkbox[name="disabled"]');
+    for ( const checkbox of checkboxes ) {
+      if ( app.isEditable ) checkbox.dataset.tooltip = `DND5E.EFFECT.DisabledTooltip.${checkbox.name.capitalize()}`;
+      checkbox.disabled = true;
+      checkbox.checked = false;
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -114,8 +114,11 @@ export default class UsageMessageData extends ItemMessageData {
     }
 
     const item = this.parent.getAssociatedItem();
+    const activity = await fromUuid(this.activity.uuid);
+    const allowPlayerApplication = this.targets?.some(t => fromUuidSync(t.token).isOwner)
+      || ((this.parent.author?.id === game.user.id) && (activity.target.affects.type === "self"));
     context.effects = (await Promise.all(this.effects.map(uuid => fromUuid(uuid, { relative: item }))))
-      .filter(e => e && (game.user.isGM || (e.transfer & (this.parent.author?.id === game.user.id))));
+      .filter(e => e && ( game.user.isGM || dnd5e.settings.allowPlayerEffectsTray && allowPlayerApplication));
     return context;
   }
 

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -117,9 +117,9 @@ export default class UsageMessageData extends ItemMessageData {
     const item = this.parent.getAssociatedItem();
     const activity = this.parent.getAssociatedActivity();
     const allowPlayerApplication = this.targets?.some(t => TargetsField.resolve(t).token?.isOwner)
-      || ((this.parent.author?.id === game.user.id) && (activity.target.affects.type === "self"));
+      || ((this.parent.author?.id === game.user.id) && (activity?.target.affects.type === "self"));
     context.effects = (await Promise.all(this.effects.map(uuid => fromUuid(uuid, { relative: item }))))
-      .filter(e => e && (game.user.isGM || dnd5e.settings.allowPlayerEffectsTray && allowPlayerApplication));
+      .filter(e => e && (game.user.isGM || (dnd5e.settings.allowPlayerEffectsTray && allowPlayerApplication)));
     return context;
   }
 

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -118,7 +118,7 @@ export default class UsageMessageData extends ItemMessageData {
     const allowPlayerApplication = this.targets?.some(t => fromUuidSync(t.token).isOwner)
       || ((this.parent.author?.id === game.user.id) && (activity.target.affects.type === "self"));
     context.effects = (await Promise.all(this.effects.map(uuid => fromUuid(uuid, { relative: item }))))
-      .filter(e => e && ( game.user.isGM || dnd5e.settings.allowPlayerEffectsTray && allowPlayerApplication));
+      .filter(e => e && (game.user.isGM || dnd5e.settings.allowPlayerEffectsTray && allowPlayerApplication));
     return context;
   }
 

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -1,6 +1,7 @@
 import ItemMessageData from "./item-message-data.mjs";
 import { ActorDeltasField } from "./fields/deltas-field.mjs";
 import SourceReferenceField from "./fields/source-reference-field.mjs";
+import TargetsField from "./fields/targets-field.mjs";
 
 const {
   ArrayField, BooleanField, DocumentIdField, HTMLField, NumberField, ObjectField, SchemaField, StringField
@@ -114,8 +115,8 @@ export default class UsageMessageData extends ItemMessageData {
     }
 
     const item = this.parent.getAssociatedItem();
-    const activity = await fromUuid(this.activity.uuid);
-    const allowPlayerApplication = this.targets?.some(t => fromUuidSync(t.token).isOwner)
+    const activity = this.parent.getAssociatedActivity();
+    const allowPlayerApplication = this.targets?.some(t => TargetsField.resolve(t).token?.isOwner)
       || ((this.parent.author?.id === game.user.id) && (activity.target.affects.type === "self"));
     context.effects = (await Promise.all(this.effects.map(uuid => fromUuid(uuid, { relative: item }))))
       .filter(e => e && (game.user.isGM || dnd5e.settings.allowPlayerEffectsTray && allowPlayerApplication));

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -766,6 +766,13 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( await super._preCreate(data, options, user) === false ) return false;
     if ( options.keepOrigin === false ) this.updateSource({ origin: this.parent.uuid });
 
+    // Cannot apply a concentration-dependent effect without an active GM
+    const dependentUuid = this.getFlag("dnd5e", "dependentOn");
+    if ( dependentUuid && !game.users.activeGM ) {
+      ui.notifications.warn("DND5E.EFFECT.Application.Warning.Concentration", { localize: true });
+      return false;
+    }
+
     // Special expiries are evaluated live in isExpiryEvent so we set duration to `null` to so it's always triggered
     const { units, expiry } = this.duration;
     if ( expiry && !this.expirySupportsDuration(expiry) ) this.updateSource({ "duration.value": null });

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -798,6 +798,13 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( await super._preCreate(data, options, user) === false ) return false;
     if ( options.keepOrigin === false ) this.updateSource({ origin: this.parent.uuid });
 
+    // Cannot apply a concentration-dependent effect without an active GM
+    const dependentUuid = this.getFlag("dnd5e", "dependentOn");
+    if ( dependentUuid && !game.users.activeGM ) {
+      ui.notifications.warn("DND5E.EFFECT.Application.Warning.Concentration", { localize: true });
+      return false;
+    }
+
     // Special expiries are evaluated live in isExpiryEvent so we set duration to `null` to so it's always triggered
     const { units, expiry } = this.duration;
     if ( expiry && !this.expirySupportsDuration(expiry) ) this.updateSource({ "duration.value": null });

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -798,13 +798,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( await super._preCreate(data, options, user) === false ) return false;
     if ( options.keepOrigin === false ) this.updateSource({ origin: this.parent.uuid });
 
-    // Cannot apply a concentration-dependent effect without an active GM
-    const dependentUuid = this.getFlag("dnd5e", "dependentOn");
-    if ( dependentUuid && !game.users.activeGM ) {
-      ui.notifications.warn("DND5E.EFFECT.Application.Warning.Concentration", { localize: true });
-      return false;
-    }
-
     // Special expiries are evaluated live in isExpiryEvent so we set duration to `null` to so it's always triggered
     const { units, expiry } = this.duration;
     if ( expiry && !this.expirySupportsDuration(expiry) ) this.updateSource({ "duration.value": null });

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -162,16 +162,6 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
       }
     }
 
-    // If concentration is required, ensure it is still being maintained & GM is present
-    if ( !game.user.isGM && concentration && !concentration.isOwner ) {
-      if ( strict ) {
-        ui.notifications.error("DND5E.EFFECT.Application.Warning.Concentration", { console: false });
-        return null;
-      } else {
-        concentration = null;
-      }
-    }
-
     const flags = { enchantmentProfile: profileId };
     if ( concentration ) flags.dependentOn = concentration.uuid;
     const enchantmentData = effect.clone({ origin: this.uuid, "flags.dnd5e": flags }).toObject();

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -163,16 +163,6 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
       }
     }
 
-    // If concentration is required, ensure it is still being maintained & GM is present
-    if ( !game.user.isGM && concentration && !concentration.isOwner ) {
-      if ( strict ) {
-        ui.notifications.error("DND5E.EFFECT.Application.Warning.Concentration", { console: false });
-        return null;
-      } else {
-        concentration = null;
-      }
-    }
-
     const flags = { enchantmentProfile: profileId };
     if ( concentration ) flags.dependentOn = concentration.uuid;
     const enchantmentData = effect.clone({ origin: this.uuid, "flags.dnd5e": flags }).toObject();

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -251,6 +251,16 @@ export function registerSystemSettings() {
     })
   });
 
+  // Allow Player use of Effect Application Tray
+  game.settings.register("dnd5e", "allowPlayerEffectsTray", {
+    name: "SETTINGS.DND5E.PERMISSIONS.AllowEffects.Name",
+    hint: "SETTINGS.DND5E.PERMISSIONS.AllowEffects.Hint",
+    scope: "world",
+    config: true,
+    default: true,
+    type: Boolean
+  });
+
   // Allow Rests from Sheet
   game.settings.register("dnd5e", "allowRests", {
     name: "SETTINGS.DND5E.PERMISSIONS.AllowRests.Name",

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -257,7 +257,7 @@ export function registerSystemSettings() {
     hint: "SETTINGS.DND5E.PERMISSIONS.AllowEffects.Hint",
     scope: "world",
     config: true,
-    default: true,
+    default: false,
     type: Boolean
   });
 


### PR DESCRIPTION
Closes #5934 
Closes #4529 by happenstance.

Setting enabled by default.
Players will see the effect application tray if:
- It's a transfer effect & they own the chat card (existing behavior)
- The setting is enabled, the chat card is owned by the user, and the associated activity targets self
- The setting is enabled and the chat card's targets include at least one owned actor of the user

Other changes to existing behavior:
Concentration-dependent effects (including enchantments) no longer update the concentration effect when applied via chat tray (or chat enchant drag-drop). Instead, the effects are given a `flags.dnd5e.dependsOn` flag with the UUID of the concentration effect. Then, in `_preCreate`, if that flag is populated but there is no active GM, the creation is blocked with a warning (similar to how breaking concentration is treated when there are dependent effects on unowned actors). In `_onCreate`, if the flag is populated and the user is the active GM, _then_ the concentration effect is updated to reflect its dependent(s). This update is done via Semaphore to avoid race conditions when multiple concentration-dependent effects are created in quick succession. 