### PR TITLE
[#6002] Account for `token` being undefined in `getAnimationOptions`

### DIFF
--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -121,7 +121,7 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
       const actionConfig = CONFIG.Token.movement.actions[type];
       if ( !actionConfig ) continue;
       actionConfig.getAnimationOptions = token => {
-        const actorMovement = token.actor?.system.attributes?.movement ?? {};
+        const actorMovement = token?.actor?.system.attributes?.movement ?? {};
         if ( !(type in actorMovement) || actorMovement[type] ) return {};
         return { movementSpeed: CONFIG.Token.movement.defaultSpeed / 2 };
       };


### PR DESCRIPTION
Closes #6002 
By Foundry's own typedef, it shouldn't ever be undefined. However, in `Token._configureAnimationMovementSpeed` it's called without any parameters, so for the time being at least we must account for that possibility.