### PR TITLE
Cast values to strings in lookup enricher

### DIFF
--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -960,6 +960,7 @@ function enrichLookup(config, fallback, options) {
   const data = activity ? activity.getRollData().activity : options.rollData
     ?? options.relativeTo?.getRollData?.() ?? {};
   let value = foundry.utils.getProperty(data, keyPath.substring(1)) ?? fallback;
+  if ( value !== undefined ) value = String(value);
   if ( value && style ) {
     if ( style === "capitalize" ) value = value.capitalize();
     else if ( style === "lowercase" ) value = value.toLowerCase();


### PR DESCRIPTION
Specifically checking only for `undefined` since values can otherwise be falsy (such as of course `false`).

Closes #6024.