### PR TITLE
Add 'wondrous item' as consumable subtype

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1466,6 +1466,9 @@
     },
     "Wand": {
       "Label": "Wand"
+    },
+    "Wondrous": {
+      "Label": "Wondrous Item"
     }
   }
 },

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1841,6 +1841,9 @@ DND5E.consumableTypes = {
   },
   trinket: {
     label: "DND5E.CONSUMABLE.Type.Trinket.Label"
+  },
+  wondrous: {
+    label: "DND5E.CONSUMABLE.Type.Wondrous.Label"
   }
 };
 preLocalize("consumableTypes", { key: "label", sort: true });


### PR DESCRIPTION
There's a good number of shared subtypes between Equipment and Consumable so they could potentially grab from a shared object and combine with their unique subtypes but it doesn't seem worth the potentially breaking change.

Closes #5858.