### PR TITLE
[#6015, #6042] Always show movement ruler highlight, change movement automation setting from a boolean to a dropdown

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5513,7 +5513,11 @@
   "AUTOMATION": {
     "Movement": {
       "Name": "Disable Movement Automation",
-      "Hint": "Do not apply difficult terrain movement penalties, or prevent creatures from moving through each other according to the rules version."
+      "Hint": "Do not apply difficult terrain movement penalties, including tokens counting as difficult terrain according to the rules version."
+    },
+    "TokenBlocking": {
+      "Name": "Disable Token Blocking",
+      "Hint": "Do not prevent creatures from moving through each other according to the rules version."
     }
   },
   "BLOODIED": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -5513,10 +5513,10 @@
   "AUTOMATION": {
     "Movement": {
       "Name": "Movement Automation",
-      "Hint": "Configure the amount of movement automation used by the system.",
-      "Full": "Full: Tokens may block or hinder movement of other tokens",
-      "NoBlocking": "Partial: Tokens may act as difficult terrain but cannot block each other",
-      "None": "None: Tokens can move freely through each other, difficult terrain does nothing"
+      "Hint": "Configure the amount of movement automation used by the system: Full automation including token blocking, partial automation of difficult terrain only, or off entirely.",
+      "Full": "Full",
+      "NoBlocking": "Partial",
+      "None": "None"
     }
   },
   "BLOODIED": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -5512,12 +5512,11 @@
 "SETTINGS.DND5E": {
   "AUTOMATION": {
     "Movement": {
-      "Name": "Disable Movement Automation",
-      "Hint": "Do not apply difficult terrain movement penalties, including tokens counting as difficult terrain according to the rules version."
-    },
-    "TokenBlocking": {
-      "Name": "Disable Token Blocking",
-      "Hint": "Do not prevent creatures from moving through each other according to the rules version."
+      "Name": "Movement Automation",
+      "Hint": "Configure the amount of movement automation used by the system.",
+      "Full": "Full: Tokens may block or hinder movement of other tokens",
+      "NoBlocking": "Partial: Tokens may act as difficult terrain but cannot block each other",
+      "None": "None: Tokens can move freely through each other, difficult terrain does nothing"
     }
   },
   "BLOODIED": {

--- a/module/canvas/ruler.mjs
+++ b/module/canvas/ruler.mjs
@@ -85,10 +85,9 @@ export default class TokenRuler5e extends foundry.canvas.placeables.tokens.Token
    * @returns {object} The adjusted style, or existing style if no adjustment is necessary
    */
   #getSpeedBasedStyle(waypoint, style) {
-    // If movement automation disabled, or if showing a different client's measurement, use default style
-    const noAutomation = game.settings.get("dnd5e", "disableMovementAutomation");
-    const isSameClient = game.user.id in this.token._plannedMovement;
-    if ( noAutomation || !isSameClient || CONFIG.Token.movement.actions[waypoint.action]?.teleport ) return style;
+    // If showing a different client's measurement, use default style
+    if ( !(game.user.id in this.token._plannedMovement)
+      || CONFIG.Token.movement.actions[waypoint.action]?.teleport ) return style;
 
     // Get actor's movement speed for currently selected token movement action
     const movement = this.token.actor?.system.attributes?.movement;
@@ -104,9 +103,9 @@ export default class TokenRuler5e extends foundry.canvas.placeables.tokens.Token
     // Color `normal` if <= max speed, else `double` if <= double max speed, else `triple`
     const { normal, double, triple } = CONFIG.DND5E.tokenRulerColors;
     const increment = (waypoint.measurement.cost - .1) / currActionSpeed;
-    if ( increment <= 1 ) style.color = normal;
-    else if ( increment <= 2 ) style.color = double;
-    else style.color = triple;
+    if ( increment <= 1 ) style.color = normal ?? style.color;
+    else if ( increment <= 2 ) style.color = double ?? style.color;
+    else style.color = triple ?? style.color;
     return style;
   }
 }

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -21,8 +21,8 @@ export default class Token5e extends foundry.canvas.placeables.Token {
   /** @inheritDoc */
   findMovementPath(waypoints, options) {
 
-    // Normal behavior if movement automation is disabled or this actor is not a creature or cannot block
-    if ( game.settings.get("dnd5e", "disableMovementAutomation") || !this.document.actor?.system.isCreature
+    // Normal behavior if token blocking is disabled or this actor is not a creature or cannot block
+    if ( game.settings.get("dnd5e", "disableTokenBlocking") || !this.document.actor?.system.isCreature
       || this.document.actor.statuses.intersects(CONFIG.DND5E.neverBlockStatuses) ) {
       return super.findMovementPath(waypoints, options);
     }
@@ -80,7 +80,7 @@ export default class Token5e extends foundry.canvas.placeables.Token {
   constrainMovementPath(waypoints, options) {
     let { preview=false, ignoreTokens=false } = options; // Custom constrain option to ignore tokens
 
-    ignoreTokens ||= game.settings.get("dnd5e", "disableMovementAutomation");
+    ignoreTokens ||= game.settings.get("dnd5e", "disableTokenBlocking");
     ignoreTokens ||= !this.actor?.system.isCreature;
     ignoreTokens ||= this.actor?.statuses?.intersects(CONFIG.DND5E.neverBlockStatuses);
 

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -22,7 +22,7 @@ export default class Token5e extends foundry.canvas.placeables.Token {
   findMovementPath(waypoints, options) {
 
     // Normal behavior if token blocking is disabled or this actor is not a creature or cannot block
-    if ( game.settings.get("dnd5e", "disableTokenBlocking") || !this.document.actor?.system.isCreature
+    if ( (game.settings.get("dnd5e", "movementAutomation") !== "full") || !this.document.actor?.system.isCreature
       || this.document.actor.statuses.intersects(CONFIG.DND5E.neverBlockStatuses) ) {
       return super.findMovementPath(waypoints, options);
     }
@@ -52,7 +52,7 @@ export default class Token5e extends foundry.canvas.placeables.Token {
   /** @inheritDoc */
   _getMovementCostFunction(options) {
     const costFunction = super._getMovementCostFunction(options);
-    if ( game.settings.get("dnd5e", "disableMovementAutomation") ) return costFunction;
+    if ( game.settings.get("dnd5e", "movementAutomation") === "none" ) return costFunction;
 
     const ignoredDifficultTerrain = this.actor?.system.attributes?.movement?.ignoredDifficultTerrain ?? new Set();
     const ignoreDifficult = ["all", "nonmagical"].some(i => ignoredDifficultTerrain.has(i));
@@ -80,7 +80,7 @@ export default class Token5e extends foundry.canvas.placeables.Token {
   constrainMovementPath(waypoints, options) {
     let { preview=false, ignoreTokens=false } = options; // Custom constrain option to ignore tokens
 
-    ignoreTokens ||= game.settings.get("dnd5e", "disableTokenBlocking");
+    ignoreTokens ||= game.settings.get("dnd5e", "movementAutomation") !== "full";
     ignoreTokens ||= !this.actor?.system.isCreature;
     ignoreTokens ||= this.actor?.statuses?.intersects(CONFIG.DND5E.neverBlockStatuses);
 

--- a/module/data/terrain-data.mjs
+++ b/module/data/terrain-data.mjs
@@ -32,7 +32,7 @@ export default class TerrainData5e extends foundry.data.TerrainData {
 
   /** @override */
   static resolveTerrainEffects(effects) {
-    const noAutomation = game.settings.get("dnd5e", "disableMovementAutomation");
+    const noAutomation = game.settings.get("dnd5e", "movementAutomation") === "none";
     let data = super.resolveTerrainEffects(effects);
     if ( noAutomation || !effects.some(e => e.name === "difficultTerrain") ) return data;
     if ( !data ) return new this({ difficulty: 2, difficultTerrain: true });

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -128,7 +128,7 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
       actionConfig.getCostFunction = (...args) => this.getMovementActionCostFunction(type, ...args);
     }
     CONFIG.Token.movement.actions.crawl.getCostFunction = token => {
-      const noAutomation = game.settings.get("dnd5e", "disableMovementAutomation");
+      const noAutomation = game.settings.get("dnd5e", "movementAutomation") === "none";
       const { actor } = token;
       const actorMovement = actor?.system.attributes?.movement;
       const hasMovement = actorMovement !== undefined;
@@ -148,7 +148,7 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
    * @returns {TokenMovementActionCostFunction}
    */
   static getMovementActionCostFunction(type, token, options) {
-    const noAutomation = game.settings.get("dnd5e", "disableMovementAutomation");
+    const noAutomation = game.settings.get("dnd5e", "movementAutomation") === "none";
     const { actor } = token;
     const actorMovement = actor?.system.attributes?.movement;
     const walkFallback = CONFIG.DND5E.movementTypes[type]?.walkFallback;

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -431,6 +431,14 @@ export async function migrateSettings() {
   if ( (disableExperienceTracking !== undefined) && (levelingMode === undefined) ) {
     await game.settings.set("dnd5e", "levelingMode", "noxp");
   }
+  // Migrate Disable Movement Automation to Movement Automation
+  const disableMovementAutomation = game.settings.storage.get("world")
+    ?.find(s => s.key === "dnd5e.disableMovementAutomation")?.value;
+  const movementAutomation = game.settings.storage.get("world")
+    ?.find(s => s.key === "dnd5e.movementAutomation")?.value;
+  if ( (disableMovementAutomation !== undefined) && (movementAutomation === undefined) ) {
+    await game.settings.set("dnd5e", "movementAutomation", disableMovementAutomation ? "none" : "full");
+  }
 }
 
 /* -------------------------------------------- */

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -89,6 +89,15 @@ export function registerSystemSettings() {
     type: Boolean
   });
 
+  game.settings.register("dnd5e", "disableTokenBlocking", {
+    name: "SETTINGS.DND5E.AUTOMATION.TokenBlocking.Name",
+    hint: "SETTINGS.DND5E.AUTOMATION.TokenBlocking.Hint",
+    scope: "world",
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
   // Allow rotating square templates
   game.settings.register("dnd5e", "gridAlignedSquareTemplates", {
     name: "SETTINGS.5eGridAlignedSquareTemplatesN",

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -80,22 +80,18 @@ export function registerSystemSettings() {
   });
 
   // Movement automation
-  game.settings.register("dnd5e", "disableMovementAutomation", {
+  game.settings.register("dnd5e", "movementAutomation", {
     name: "SETTINGS.DND5E.AUTOMATION.Movement.Name",
     hint: "SETTINGS.DND5E.AUTOMATION.Movement.Hint",
     scope: "world",
     config: true,
-    default: false,
-    type: Boolean
-  });
-
-  game.settings.register("dnd5e", "disableTokenBlocking", {
-    name: "SETTINGS.DND5E.AUTOMATION.TokenBlocking.Name",
-    hint: "SETTINGS.DND5E.AUTOMATION.TokenBlocking.Hint",
-    scope: "world",
-    config: true,
-    default: false,
-    type: Boolean
+    default: "full",
+    type: String,
+    choices: {
+      full: "SETTINGS.DND5E.AUTOMATION.Movement.Full",
+      noBlocking: "SETTINGS.DND5E.AUTOMATION.Movement.NoBlocking",
+      none: "SETTINGS.DND5E.AUTOMATION.Movement.None"
+    }
   });
 
   // Allow rotating square templates

--- a/system.json
+++ b/system.json
@@ -575,7 +575,7 @@
         "SRD 5.2": "SOURCE.BOOK.SRD52"
       }
     },
-    "needsMigrationVersion": "5.1.0",
+    "needsMigrationVersion": "5.2.0",
     "compatibleMigrationVersion": "0.8",
     "hotReload": {
       "extensions": ["css", "hbs", "json"],


### PR DESCRIPTION
Closes #6015 
Closes #6042 
Existing "Disable Movement Automation" setting covers only difficult terrain & token-caused difficult terrain. Replacement  "Movement Automation" setting has, in addition to a `none` (equivalent of current `true`) and a `full` (equivalent of current `false`), a `noBlocking`, which is the full automation _except for_ enforced blocking of movement due to enemy tokens. The old setting will be migrated to the new one according to the above-listed equivalents. Movement distance highlighting now always shown (but can be disabled by setting `CONFIG.DND5E.tokenRulerColors`'s values to `null`.