### PR TITLE
[#6019] Add "Webs" to difficult terrain types, add to actors

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3219,7 +3219,8 @@
       "Rocks": "Rubble or Rocks",
       "Liquid": "Shallow Liquid",
       "Slope": "Steep Slope",
-      "Snow": "Deep Snow"
+      "Snow": "Deep Snow",
+      "Webs": "Webs"
     }
   },
   "ROTATEAREA": {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2547,6 +2547,9 @@ DND5E.difficultTerrainTypes = {
   },
   snow: {
     label: "DND5E.REGIONBEHAVIORS.DIFFICULTTERRAIN.Type.Snow"
+  },
+  web: {
+    label: "DND5E.REGIONBEHAVIORS.DIFFICULTTERRAIN.Type.Webs"
   }
 };
 preLocalize("difficultTerrainTypes", { key: "label", sort: true });

--- a/packs/_source/actors24/beast/giant-spider.yml
+++ b/packs/_source/actors24/beast/giant-spider.yml
@@ -356,8 +356,11 @@ system:
       fly: null
       swim: null
       walk: 30
-      units: null
+      units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -982,11 +985,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1740679134446
-  modifiedTime: 1745712719448
+  modifiedTime: 1755806531569
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!mmGiantSpider000'

--- a/packs/_source/actors24/beast/spider.yml
+++ b/packs/_source/actors24/beast/spider.yml
@@ -356,8 +356,11 @@ system:
       fly: null
       swim: null
       walk: 20
-      units: null
+      units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -814,11 +817,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1740679136185
-  modifiedTime: 1745712727499
+  modifiedTime: 1755806516014
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!mmSpider00000000'

--- a/packs/_source/actors24/monstrosity/drider.yml
+++ b/packs/_source/actors24/monstrosity/drider.yml
@@ -358,8 +358,11 @@ system:
       fly: null
       swim: null
       walk: 30
-      units: null
+      units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -1931,11 +1934,11 @@ flags:
     showTokenPortrait: false
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1745416008124
-  modifiedTime: 1745712716851
+  modifiedTime: 1755806547366
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/actors24/monstrosity/ettercap.yml
+++ b/packs/_source/actors24/monstrosity/ettercap.yml
@@ -358,8 +358,11 @@ system:
       fly: null
       swim: null
       walk: 30
-      units: null
+      units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -1371,11 +1374,11 @@ flags:
     showTokenPortrait: false
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1745416008124
-  modifiedTime: 1745712717502
+  modifiedTime: 1755806639853
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/actors24/monstrosity/phase-spider.yml
+++ b/packs/_source/actors24/monstrosity/phase-spider.yml
@@ -358,8 +358,11 @@ system:
       fly: null
       swim: null
       walk: 30
-      units: null
+      units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -1123,11 +1126,11 @@ flags:
     showTokenPortrait: false
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1745416008124
-  modifiedTime: 1745712724699
+  modifiedTime: 1755806672135
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/monsters/beast/giant-spider.yml
+++ b/packs/_source/monsters/beast/giant-spider.yml
@@ -72,6 +72,9 @@ system:
       walk: 30
       units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -1056,11 +1059,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1726171264897
-  modifiedTime: 1741121766147
+  modifiedTime: 1755806606108
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!v99wOosUJjUgcUNF'

--- a/packs/_source/monsters/beast/spider.yml
+++ b/packs/_source/monsters/beast/spider.yml
@@ -72,6 +72,9 @@ system:
       walk: 20
       units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -872,11 +875,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1726171199655
-  modifiedTime: 1741122955830
+  modifiedTime: 1755806601112
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!28gU50HtG8Kp7uIz'

--- a/packs/_source/monsters/beast/swarm-of-spiders.yml
+++ b/packs/_source/monsters/beast/swarm-of-spiders.yml
@@ -72,6 +72,9 @@ system:
       walk: 20
       units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -867,11 +870,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1726171202327
-  modifiedTime: 1741123679009
+  modifiedTime: 1755806592867
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!4udpeEneFSZK9NTB'

--- a/packs/_source/monsters/monstrosity/drider.yml
+++ b/packs/_source/monsters/monstrosity/drider.yml
@@ -72,6 +72,9 @@ system:
       walk: 30
       units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -1736,11 +1739,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1726171198662
-  modifiedTime: 1745107675163
+  modifiedTime: 1755806570472
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!1OQbxoZI5BtlB2ME'

--- a/packs/_source/monsters/monstrosity/ettercap.yml
+++ b/packs/_source/monsters/monstrosity/ettercap.yml
@@ -72,6 +72,9 @@ system:
       walk: 30
       units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -1261,11 +1264,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1726171240568
-  modifiedTime: 1745175110156
+  modifiedTime: 1755806615578
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!aKt7vFAS1J0x3FQm'

--- a/packs/_source/monsters/monstrosity/phase-spider.yml
+++ b/packs/_source/monsters/monstrosity/phase-spider.yml
@@ -72,6 +72,9 @@ system:
       walk: 30
       units: ft
       hover: false
+      ignoredDifficultTerrain:
+        - web
+      special: ''
     attunement:
       max: 3
     senses:
@@ -931,11 +934,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.1.3
   createdTime: 1726171253960
-  modifiedTime: 1741122580134
+  modifiedTime: 1755806587786
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!llSG0Hi4eGlRlQ4o'

--- a/packs/_source/spells/4th-level/freedom-of-movement.yml
+++ b/packs/_source/spells/4th-level/freedom-of-movement.yml
@@ -32,11 +32,14 @@ system:
       type: creature
       count: '1'
       choice: false
+      special: ''
     template:
       units: ''
       contiguous: false
+      type: ''
   range:
     units: touch
+    special: ''
   uses:
     max: ''
     recovery: []
@@ -122,23 +125,30 @@ effects:
         mode: 2
         value: restrained
         priority: null
+      - key: system.attributes.movement.ignoredDifficultTerrain
+        mode: 2
+        value: all
+        priority: null
     description: >-
       <p>The target's Movement is unaffected by difficult terrain, and Spells
       and other magical Effects can neither reduce the target's speed nor cause
       the target to be Paralyzed or Restrained.</p>
     transfer: false
     statuses: []
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          statuses: []
     tint: '#ffffff'
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '13.347'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 5.1.3
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1755806855234
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     img: icons/skills/melee/strike-blade-knife-white-red.webp
     type: base
@@ -148,11 +158,11 @@ effects:
 folder: 5auWSClKMDUIV5Ni
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.347'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 5.1.3
   createdTime: 1725037361182
-  modifiedTime: 1725992721490
+  modifiedTime: 1755806857216
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!da0a1t2FqaTjRZGT'

--- a/packs/_source/spells24/4th-level/freedom-of-movement.yml
+++ b/packs/_source/spells24/4th-level/freedom-of-movement.yml
@@ -121,7 +121,10 @@ effects:
       startRound: null
       startTurn: null
     disabled: false
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          statuses: []
     img: icons/skills/movement/feet-bladed-boots-fire.webp
     _id: bcTPZ6dJ4kHwaBRD
     type: base
@@ -139,6 +142,10 @@ effects:
         mode: 4
         value: '1'
         priority: null
+      - key: system.attributes.movement.ignoredDifficultTerrain
+        mode: 2
+        value: all
+        priority: null
     description: ''
     tint: '#ffffff'
     transfer: false
@@ -147,12 +154,12 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '13.347'
       systemId: dnd5e
-      systemVersion: 4.0.0
+      systemVersion: 5.1.3
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1755806834292
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!items.effects!phbsplFreedomofM.bcTPZ6dJ4kHwaBRD'
 folder: qi3IbnEwap7mRw4b


### PR DESCRIPTION
Adds "Webs" to the types of difficult terrain and adds immunity to it to all monsters with the "Web Walker" feature.

Also adjusts "Freedom of Movement" to ignore all difficult terrain types.

Closes #6019