### PR TITLE
Fixed missing month conversion in duration field

### DIFF
--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -66,6 +66,7 @@ export default class DurationField extends SchemaField {
       case "minute": return { seconds: this.value * 60 };
       case "hour": return { seconds: this.value * 60 * 60 };
       case "day": return { seconds: this.value * 60 * 60 * 24 };
+      case "month": return { seconds: this.value * 60 * 60 * 24 * 30 };
       case "year": return { seconds: this.value * 60 * 60 * 24 * 365 };
       default: return {};
     }


### PR DESCRIPTION
When I cast a spell with a duration, the concentration value gets applied to the active effect when using hour/day/year etc., but not when using months. This appears to be because the conversion function is missing months.

Since D&D uses a 30 day month (assuming we can ignore the in-between days), this is an easy tweak. See screenshot below for issue:

<img width="2098" height="638" alt="image" src="https://github.com/user-attachments/assets/fb95010f-12e9-40f8-8248-dbecc8677adc" />
<img width="2104" height="580" alt="image" src="https://github.com/user-attachments/assets/e8d53030-8152-4890-a017-54e557c1257c" />
