### PR TITLE
Don't consider token-blocking for resize "movements"

### DIFF
--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -82,6 +82,9 @@ export default class Token5e extends foundry.canvas.placeables.Token {
     ignoreTokens ||= game.settings.get("dnd5e", "disableMovementAutomation");
     ignoreTokens ||= !this.actor?.system.isCreature;
 
+    // Ignore tokens if path contains resize
+    ignoreTokens ||= waypoints.some(w => (w.width !== waypoints[0].width) || (w.height !== waypoints[0].height));
+
     if ( ignoreTokens ) return super.constrainMovementPath(waypoints, options);
 
     // Ignore preview if token vision is disabled or the current user is a GM


### PR DESCRIPTION
If any part of a movement contains a token resize, don't consider whether tokens would block the path during said movement.