### PR TITLE
[#6063] Check for `neverBlockMovement` when constraining movement & finding movement path

### DIFF
--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -20,9 +20,11 @@ export default class Token5e extends foundry.canvas.placeables.Token {
 
   /** @inheritDoc */
   findMovementPath(waypoints, options) {
+    const neverBlockStatuses = CONFIG.statusEffects.filter(s => s.neverBlockMovement).map(s => s.id);
 
-    // Normal behavior if movement automation is disabled or this.actor is not a creature
-    if ( game.settings.get("dnd5e", "disableMovementAutomation") || !this.document.actor?.system.isCreature ) {
+    // Normal behavior if movement automation is disabled, this.actor is not a creature, or this.actor cannot block
+    if ( game.settings.get("dnd5e", "disableMovementAutomation") || !this.document.actor?.system.isCreature
+      || neverBlockStatuses.some(status => this.document.actor.statuses.has(status)) ) {
       return super.findMovementPath(waypoints, options);
     }
 
@@ -79,8 +81,11 @@ export default class Token5e extends foundry.canvas.placeables.Token {
   constrainMovementPath(waypoints, options) {
     let { preview=false, ignoreTokens=false } = options; // Custom constrain option to ignore tokens
 
+    const neverBlockStatuses = CONFIG.statusEffects.filter(s => s.neverBlockMovement).map(s => s.id);
+
     ignoreTokens ||= game.settings.get("dnd5e", "disableMovementAutomation");
     ignoreTokens ||= !this.actor?.system.isCreature;
+    ignoreTokens ||= neverBlockStatuses.some(status => this.actor?.statuses.has(status));
 
     if ( ignoreTokens ) return super.constrainMovementPath(waypoints, options);
 


### PR DESCRIPTION
Closes #6063 
Makes me think we could consider a `Actor5e#canBlockMovement` getter which would be something like
```js
get canBlockMovement() {
  const neverBlockStatuses = CONFIG.statusEffects.filter(s => s.neverBlockMovement).map(s => s.id);
  return this.isCreature && !neverBlockStatuses.some(status => this.statuses.has(status));
}
```