### PR TITLE
[#6078] Use source name in edit mode on character sheets

### DIFF
--- a/templates/actors/character-header.hbs
+++ b/templates/actors/character-header.hbs
@@ -5,7 +5,7 @@
 
         {{!-- Name --}}
         {{#if editable}}
-        <input type="text" name="name" class="document-name uninput" value="{{ actor.name }}">
+        <input type="text" name="name" class="document-name uninput" value="{{ actor._source.name }}">
         {{else}}
         <div class="document-name">{{ actor.name }}</div>
         {{/if}}


### PR DESCRIPTION
An effect on an actor targeting `name` repeatedly applies.