### PR TITLE
[#6063] Fix ethereal tokens not being able to move through others

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -390,6 +390,7 @@ function _configureStatusEffects() {
     }
     effects.push(data);
     if ( special ) CONFIG.specialStatusEffects[special] = data.id;
+    if ( data.neverBlockMovement ) DND5E.neverBlockStatuses.add(data.id);
   };
   CONFIG.statusEffects = Object.entries(CONFIG.DND5E.statusEffects).reduce((arr, [id, data]) => {
     const original = CONFIG.statusEffects.find(s => s.id === id);

--- a/module/canvas/layers/tokens.mjs
+++ b/module/canvas/layers/tokens.mjs
@@ -12,7 +12,6 @@ export default class TokenLayer5e extends foundry.canvas.layers.TokenLayer {
     const tokenSize = CONFIG.DND5E.actorSizes[token.actor?.system.traits?.size]?.numerical ?? 2;
     const modernRules = game.settings.get("dnd5e", "rulesVersion") === "modern";
     const halflingNimbleness = token.actor?.getFlag("dnd5e", "halflingNimbleness");
-    const neverBlockStatuses = CONFIG.statusEffects.filter(s => s.neverBlockMovement).map(s => s.id);
     return found.some(t => {
       // Only creatures block movement.
       if ( !t.actor?.system.isCreature ) return false;
@@ -21,7 +20,7 @@ export default class TokenLayer5e extends foundry.canvas.layers.TokenLayer {
       if ( token.document.disposition === t.document.disposition ) return false;
 
       // If creature has any statuses that should never block movement, don't block movement
-      if ( neverBlockStatuses.some(status => t.actor.statuses.has(status)) ) return false;
+      if ( t.actor.statuses.intersects(CONFIG.DND5E.neverBlockStatuses) ) return false;
 
       const occupiedSize = CONFIG.DND5E.actorSizes[t.actor.system.traits.size]?.numerical ?? 2;
       // In modern rules, Tiny creatures can be moved through

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -21,8 +21,9 @@ export default class Token5e extends foundry.canvas.placeables.Token {
   /** @inheritDoc */
   findMovementPath(waypoints, options) {
 
-    // Normal behavior if movement automation is disabled or this.actor is not a creature
-    if ( game.settings.get("dnd5e", "disableMovementAutomation") || !this.document.actor?.system.isCreature ) {
+    // Normal behavior if movement automation is disabled or this actor is not a creature or cannot block
+    if ( game.settings.get("dnd5e", "disableMovementAutomation") || !this.document.actor?.system.isCreature
+      || this.document.actor.statuses.intersects(CONFIG.DND5E.neverBlockStatuses) ) {
       return super.findMovementPath(waypoints, options);
     }
 
@@ -81,6 +82,7 @@ export default class Token5e extends foundry.canvas.placeables.Token {
 
     ignoreTokens ||= game.settings.get("dnd5e", "disableMovementAutomation");
     ignoreTokens ||= !this.actor?.system.isCreature;
+    ignoreTokens ||= this.actor?.statuses?.intersects(CONFIG.DND5E.neverBlockStatuses);
 
     if ( ignoreTokens ) return super.constrainMovementPath(waypoints, options);
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4273,6 +4273,14 @@ DND5E.statusEffects = {
 /* -------------------------------------------- */
 
 /**
+ * Status effects that never block token movement. Populated during the setup process.
+ * @type {Set<string>}
+ */
+DND5E.neverBlockStatuses = new Set();
+
+/* -------------------------------------------- */
+
+/**
  * Configuration for the special bloodied status effect.
  * @type {{ name: string, img: string, threshold: number }}
  */


### PR DESCRIPTION
Adds a check to see if the current token has a status effect that doesn't block movement in `Token5e#constrainMovementPath`. To avoid having to re-prepare the list of statuses that don't block movement constantly, adds a `CONFIG.DND5E.neverBlocksStatuses` set that is prepared and sealed when during the setup process.

Closes #6063