### PR TITLE
[#6123] Fix token ruler always displaying red for certain actions

### DIFF
--- a/module/canvas/ruler.mjs
+++ b/module/canvas/ruler.mjs
@@ -88,7 +88,7 @@ export default class TokenRuler5e extends foundry.canvas.placeables.tokens.Token
     // If movement automation disabled, or if showing a different client's measurement, use default style
     const noAutomation = game.settings.get("dnd5e", "disableMovementAutomation");
     const isSameClient = game.user.id in this.token._plannedMovement;
-    if ( noAutomation || !isSameClient ) return style;
+    if ( noAutomation || !isSameClient || CONFIG.Token.movement.actions[waypoint.action]?.teleport ) return style;
 
     // Get actor's movement speed for currently selected token movement action
     const movement = this.token.actor?.system.attributes?.movement;
@@ -96,7 +96,8 @@ export default class TokenRuler5e extends foundry.canvas.placeables.tokens.Token
     let currActionSpeed = movement[waypoint.action] ?? 0;
 
     // If current action can fall back to walk, treat "max" speed as maximum between current & walk
-    if ( CONFIG.DND5E.movementTypes[waypoint.action]?.walkFallback ) {
+    if ( CONFIG.DND5E.movementTypes[waypoint.action]?.walkFallback
+      || !CONFIG.DND5E.movementTypes[waypoint.action] ) {
       currActionSpeed = Math.max(currActionSpeed, movement.walk);
     }
 


### PR DESCRIPTION
Any teleport action (blink or displace) will skip the ruler coloring and use the default logic instead.

Other movement types not found in `CONFIG.DND5E.movementTypes` will now use the walk fallback.

Closes #6123