### PR TITLE
Flag: Proficiency in all Skills

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2540,6 +2540,8 @@
 "DND5E.FlagsTitle": "Configure Special Traits",
 "DND5E.FlagsDiamondSoul": "Diamond Soul",
 "DND5E.FlagsDiamondSoulHint": "Gain proficiency to all saving throws.",
+"DND5E.FlagsAllAroundAdept": "All-Around Adept",
+"DND5E.FlagsAllAroundAdeptHint": "You gain proficiency in all skills.",
 "DND5E.FlagsPowerfulBuild": "Powerful Build",
 "DND5E.FlagsPowerfulBuildHint": "Provides increased carrying capacity.",
 "DND5E.FlagsElvenAccuracy": "Elven Accuracy",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2541,7 +2541,7 @@
 "DND5E.FlagsDiamondSoul": "Diamond Soul",
 "DND5E.FlagsDiamondSoulHint": "Gain proficiency to all saving throws.",
 "DND5E.FlagsAllAroundAdept": "All-Around Adept",
-"DND5E.FlagsAllAroundAdeptHint": "You gain proficiency in all skills.",
+"DND5E.FlagsAllAroundAdeptHint": "Gain proficiency in all skills.",
 "DND5E.FlagsPowerfulBuild": "Powerful Build",
 "DND5E.FlagsPowerfulBuildHint": "Provides increased carrying capacity.",
 "DND5E.FlagsElvenAccuracy": "Elven Accuracy",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4713,6 +4713,12 @@ DND5E.characterFlags = {
     section: "DND5E.Feats",
     type: Boolean
   },
+  allAroundAdept: {
+    name: "DND5E.FlagsAllAroundAdept",
+    hint: "DND5E.FlagsAllAroundAdeptHint",
+    section: "DND5E.Feats",
+    type: Boolean
+  },
   enhancedDualWielding: {
     name: "DND5E.FLAGS.EnhancedDualWielding.Name",
     hint: "DND5E.FLAGS.EnhancedDualWielding.Hint",

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -192,12 +192,17 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
   calculateAbilityCheckProficiency(multiplier, ability) {
     let roundDown = true;
     if ( multiplier < 1 ) {
-      if ( this.parent._isRemarkableAthlete(ability) ) {
-        multiplier = .5;
-        roundDown = false;
+	  if ( this.parent.flags.dnd5e?.allAroundAdept ) {
+		  multiplier = 1;
+	  }
+	  else {
+        if ( this.parent._isRemarkableAthlete(ability) ) {
+          multiplier = .5;
+          roundDown = false;
+        }
+        else if ( this.parent.flags.dnd5e?.jackOfAllTrades ) multiplier = .5;
       }
-      else if ( this.parent.flags.dnd5e?.jackOfAllTrades ) multiplier = .5;
-    }
+	}
     return new Proficiency(this.attributes.prof, multiplier, roundDown);
   }
 


### PR DESCRIPTION
Adds a new Flag `allAroundAdept` and extends `calculateAbilityCheckProficiency` to grant a multiplier of `1` to all skills if this flag is set.
Closes https://github.com/foundryvtt/dnd5e/issues/6135