### PR TITLE
[#5176] Add extended roll configuration to actor data models

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -94,6 +94,28 @@
     "SaveLabel": "{ability} Save",
     "Title": "Configure {ability}"
   },
+  "FIELDS": {
+    "abilities": {
+      "element": {
+        "check": {
+          "roll": {
+            "bonus": { "label": "Check Bonus" },
+            "max": { "label": "Maximum Check Roll" },
+            "min": { "label": "Minimum Check Roll" },
+            "mode": { "label": "Check Advantage Mode" }
+          }
+        },
+        "save": {
+          "roll": {
+            "bonus": { "label": "Save Bonus" },
+            "max": { "label": "Maximum Save Roll" },
+            "min": { "label": "Minimum Save Roll" },
+            "mode": { "label": "Save Advantage Mode" }
+          }
+        }
+      }
+    }
+  },
   "Formatter": {
     "Check": {
       "AdvantageMode": "{name} Check Advantage Mode",
@@ -164,7 +186,6 @@
 "DND5E.AbilityCheckConfigure": "{ability} Ability Checks",
 "DND5E.AbilityCheckConfigurationHint": "Configure check bonuses.",
 "DND5E.AbilityConfigurationHint": "Configure ability saving throw proficiency, saving throw bonuses, and check bonuses.",
-"DND5E.AbilityCheckBonus": "Check Bonus",
 "DND5E.AbilityCheckGlobalBonusHint": "This bonus applies to all ability checks made by this actor.",
 "DND5E.Action": "Action",
 "DND5E.ActionAbbr": "A",
@@ -1766,8 +1787,6 @@
   "Title": "Check"
 },
 
-"DND5E.CheckBonus": "Check Bonus",
-
 "DND5E.CLASS": {
   "Multiclass": {
     "Title": "Multiclassing"
@@ -1940,21 +1959,14 @@
   "FIELDS": {
     "attributes": {
       "concentration": {
-        "bonuses": {
-          "label": "Concentration Bonuses",
-          "save": {
-            "label": "Concentration Bonus"
-          }
-        },
         "label": "Concentration",
-        "limit": {
-          "label": "Concentration Limit"
-        },
+        "limit": { "label": "Concentration Limit" },
         "roll": {
-          "ability": "Concentration Save Ability",
-          "max": "Maximum Concentration Save Roll",
-          "min": "Minimum Concentration Save Roll",
-          "mode": "Concentration Save Advantage Mode"
+          "ability": { "label": "Concentration Ability" },
+          "bonus": { "label": "Concentration Bonus" },
+          "max": { "label": "Maximum Concentration Roll" },
+          "min": { "label": "Minimum Concentration Roll" },
+          "mode": { "label": "Concentration Advantage Mode" }
         }
       }
     }
@@ -2475,7 +2487,6 @@
 "DND5E.Dawn": "Dawn",
 "DND5E.Day": "Day",
 "DND5E.DeathSave": "Death Saves",
-"DND5E.DeathSaveBonus": "Death Save Bonus",
 "DND5E.DeathSaveConfigure": "Configure Death Saves",
 "DND5E.DeathSaveCriticalSuccess": "{name} critically succeeded on a death saving throw and has regained 1 Hit Point!",
 "DND5E.DeathSaveHide": "Hide Death Saves",
@@ -2495,6 +2506,22 @@
 "DND5E.DeathSaveRoll": "Roll a Death Saving Throw",
 "DND5E.DeathSavingThrow": "Death Saving Throw",
 "DND5E.DeathSaveUnnecessary": "You do not need to roll death saves because you have a positive number of hit points or have already reached 3 successes or failures.",
+
+"DND5E.DEATH": {
+  "FIELDS": {
+    "attributes": {
+      "death": {
+        "roll": {
+          "bonus": { "label": "Death Save Bonus" },
+          "max": { "label": "Maximum Death Save Roll" },
+          "min": { "label": "Minimum Death Save Roll" },
+          "mode": { "label": "Death Save Advantage Mode" }
+        }
+      }
+    }
+  }
+},
+
 "DND5E.Default": "Default",
 "DND5E.DefaultSpecific": "Default ({default})",
 "DND5E.DefaultAbilityCheck": "Default Ability Check",
@@ -3601,10 +3628,25 @@
 "DND5E.Immunities": "Immunities",
 "DND5E.Initiative": "Initiative",
 "DND5E.InitiativeAbbr": "Init",
-"DND5E.InitiativeBonus": "Initiative Bonus",
 "DND5E.InitiativeRoll": "Initiative Roll",
 "DND5E.InitiativeConfig": "Configure Initiative",
 "DND5E.InitiativeConfigHint": "Configure initiative modifiers and bonuses which apply to this Actor.",
+
+"DND5E.INITIATIVE": {
+  "FIELDS": {
+    "attributes": {
+      "init": {
+        "roll": {
+          "bonus": { "label": "Initiative Bonus" },
+          "max": { "label": "Maximum Initiative Roll" },
+          "min": { "label": "Minimum Initiative Roll" },
+          "mode": { "label": "Initiative Advantage Mode" }
+        }
+      }
+    }
+  }
+},
+
 "DND5E.Inspiration": "Inspiration",
 "DND5E.Inventory": "Inventory",
 "DND5E.InventorySearch": "Search inventory",
@@ -4523,7 +4565,6 @@
   }
 },
 
-"DND5E.SaveBonus": "Saving Throw Bonus",
 "DND5E.SaveGlobalBonusHint": "This bonus applies to all saving throws made by this actor.",
 "DND5E.Scroll": {
   "CreateFrom": "Create Scroll from {spell}",
@@ -4607,6 +4648,18 @@
 "DND5E.SizeTinyAbbr": "Tn",
 
 "DND5E.SKILL": {
+  "FIELDS": {
+    "skills": {
+      "element": {
+        "roll": {
+          "bonus": { "label": "Skill Check Bonus" },
+          "max": { "label": "Maximum Skill Check Roll" },
+          "min": { "label": "Minimum Skill Check Roll" },
+          "mode": { "label": "Skill Check Advantage Mode" }
+        }
+      }
+    }
+  },
   "Formatter": {
     "CheckBonus": "{name} Check Bonus",
     "PassiveBonus": "Passive {name} Bonus",
@@ -4652,7 +4705,6 @@
 "DND5E.SkillConfigure": "Configure Skill",
 "DND5E.SkillsConfig": "Configure Skills",
 "DND5E.SkillBonuses": "Skill Bonuses",
-"DND5E.SkillBonusCheck": "Check Bonus",
 "DND5E.SkillBonusPassive": "Passive Bonus",
 "DND5E.SkillConfigurationHint": "Configure skill proficiency and bonuses.",
 "DND5E.SkillGlobalBonusCheckHint": "This bonus applies to all skill checks made by this actor.",
@@ -5480,6 +5532,18 @@
 "DND5E.ToggleDescription": "Toggle Description",
 
 "DND5E.TOOL": {
+  "FIELDS": {
+    "tools": {
+      "element": {
+        "roll": {
+          "bonus": { "label": "Tool Check Bonus" },
+          "max": { "label": "Maximum Tool Check Roll" },
+          "min": { "label": "Minimum Tool Check Roll" },
+          "mode": { "label": "Tool Check Advantage Mode" }
+        }
+      }
+    }
+  },
   "Formatter": {
     "CheckBonus": "{name} Check Bonus",
     "Proficiency": "{name} Proficiency"

--- a/lang/en.json
+++ b/lang/en.json
@@ -4295,81 +4295,83 @@
     "type": "Roll Type"
   },
   "FIELDS": {
-    "ability": {
-      "check": {
-        "bonus": { "label": "Global Ability Check Bonus" },
-        "max": { "label": "Maximum Global Ability Check Roll" },
-        "min": { "label": "Minimum Global Ability Check Roll" },
-        "mode": { "label": "Global Ability Check Advantage Mode" },
-        "proficiency": { "label": "Global Ability Check Proficiency" }
+    "rolls": {
+      "ability": {
+        "check": {
+          "bonus": { "label": "Global Ability Check Bonus" },
+          "max": { "label": "Maximum Global Ability Check Roll" },
+          "min": { "label": "Minimum Global Ability Check Roll" },
+          "mode": { "label": "Global Ability Check Advantage Mode" },
+          "proficiency": { "label": "Global Ability Check Proficiency" }
+        },
+        "label": "Ability Roll Modification",
+        "save": {
+          "bonus": { "label": "Global Ability Save Bonus" },
+          "max": { "label": "Maximum Global Ability Save Roll" },
+          "min": { "label": "Minimum Global Ability Save Roll" },
+          "mode": { "label": "Global Ability Save Advantage Mode" },
+          "proficiency": { "label": "Global Ability Save Proficiency" }
+        },
+        "skill": {
+          "bonus": { "label": "Global Skill Check Bonus" },
+          "max": { "label": "Maximum Global Skill Check Roll" },
+          "min": { "label": "Minimum Global Skill Check Roll" },
+          "mode": { "label": "Global Skill Check Advantage Mode" },
+          "proficiency": { "label": "Global Skill Check Proficiency" }
+        },
+        "tool": {
+          "bonus": { "label": "Global Tool Check Bonus" },
+          "max": { "label": "Maximum Global Tool Check Roll" },
+          "min": { "label": "Minimum Global Tool Check Roll" },
+          "mode": { "label": "Global Tool Check Advantage Mode" },
+          "proficiency": { "label": "Global Tool Check Proficiency" }
+        }
       },
-      "label": "Ability Roll Modification",
-      "save": {
-        "bonus": { "label": "Global Ability Save Bonus" },
-        "max": { "label": "Maximum Global Ability Save Roll" },
-        "min": { "label": "Minimum Global Ability Save Roll" },
-        "mode": { "label": "Global Ability Save Advantage Mode" },
-        "proficiency": { "label": "Global Ability Save Proficiency" }
+      "attack": {
+        "bonus": { "label": "Global Attack Bonus" },
+        "label": "Attack Roll Modification",
+        "max": { "label": "Maximum Global Attack Roll" },
+        "min": { "label": "Minimum Global Attack Roll" },
+        "mode": { "label": "Global Attack Advantage Mode" },
+        "msak": {
+          "bonus": { "label": "Melee Spell Attack Bonus" },
+          "max": { "label": "Maximum Melee Spell Attack Roll" },
+          "min": { "label": "Minimum Melee Spell Attack Roll" },
+          "mode": { "label": "Melee Spell Attack Advantage Mode" }
+        },
+        "mwak": {
+          "bonus": { "label": "Melee Weapon Attack Bonus" },
+          "max": { "label": "Maximum Melee Weapon Attack Roll" },
+          "min": { "label": "Minimum Melee Weapon Attack Roll" },
+          "mode": { "label": "Melee Weapon Attack Advantage Mode" }
+        },
+        "rsak": {
+          "bonus": { "label": "Ranged Spell Attack Bonus" },
+          "max": { "label": "Maximum Ranged Spell Attack Roll" },
+          "min": { "label": "Minimum Ranged Spell Attack Roll" },
+          "mode": { "label": "Ranged Spell Attack Advantage Mode" }
+        },
+        "rwak": {
+          "bonus": { "label": "Ranged Weapon Attack Bonus" },
+          "max": { "label": "Maximum Ranged Weapon Attack Roll" },
+          "min": { "label": "Minimum Ranged Weapon Attack Roll" },
+          "mode": { "label": "Ranged Weapon Attack Advantage Mode" }
+        }
       },
-      "skill": {
-        "bonus": { "label": "Global Skill Check Bonus" },
-        "max": { "label": "Maximum Global Skill Check Roll" },
-        "min": { "label": "Minimum Global Skill Check Roll" },
-        "mode": { "label": "Global Skill Check Advantage Mode" },
-        "proficiency": { "label": "Global Skill Check Proficiency" }
-      },
-      "tool": {
-        "bonus": { "label": "Global Tool Check Bonus" },
-        "max": { "label": "Maximum Global Tool Check Roll" },
-        "min": { "label": "Minimum Global Tool Check Roll" },
-        "mode": { "label": "Global Tool Check Advantage Mode" },
-        "proficiency": { "label": "Global Tool Check Proficiency" }
-      }
-    },
-    "attack": {
-      "bonus": { "label": "Global Attack Bonus" },
-      "label": "Attack Roll Modification",
-      "max": { "label": "Maximum Global Attack Roll" },
-      "min": { "label": "Minimum Global Attack Roll" },
-      "mode": { "label": "Global Attack Advantage Mode" },
-      "msak": {
-        "bonus": { "label": "Melee Spell Attack Bonus" },
-        "max": { "label": "Maximum Melee Spell Attack Roll" },
-        "min": { "label": "Minimum Melee Spell Attack Roll" },
-        "mode": { "label": "Melee Spell Attack Advantage Mode" }
-      },
-      "mwak": {
-        "bonus": { "label": "Melee Weapon Attack Bonus" },
-        "max": { "label": "Maximum Melee Weapon Attack Roll" },
-        "min": { "label": "Minimum Melee Weapon Attack Roll" },
-        "mode": { "label": "Melee Weapon Attack Advantage Mode" }
-      },
-      "rsak": {
-        "bonus": { "label": "Ranged Spell Attack Bonus" },
-        "max": { "label": "Maximum Ranged Spell Attack Roll" },
-        "min": { "label": "Minimum Ranged Spell Attack Roll" },
-        "mode": { "label": "Ranged Spell Attack Advantage Mode" }
-      },
-      "rwak": {
-        "bonus": { "label": "Ranged Weapon Attack Bonus" },
-        "max": { "label": "Maximum Ranged Weapon Attack Roll" },
-        "min": { "label": "Minimum Ranged Weapon Attack Roll" },
-        "mode": { "label": "Ranged Weapon Attack Advantage Mode" }
-      }
-    },
-    "damage": {
-      "label": "Damage Roll Modification",
-      "msak": {
-        "bonus": { "label": "Melee Spell Attack Damage Bonus" }
-      },
-      "mwak": {
-        "bonus": { "label": "Melee Weapon Attack Damage Bonus" }
-      },
-      "rsak": {
-        "bonus": { "label": "Ranged Spell Attack Damage Bonus" }
-      },
-      "rwak": {
-        "bonus": { "label": "Ranged Weapon Attack Damage Bonus" }
+      "damage": {
+        "label": "Damage Roll Modification",
+        "msak": {
+          "bonus": { "label": "Melee Spell Attack Damage Bonus" }
+        },
+        "mwak": {
+          "bonus": { "label": "Melee Weapon Attack Damage Bonus" }
+        },
+        "rsak": {
+          "bonus": { "label": "Ranged Spell Attack Damage Bonus" }
+        },
+        "rwak": {
+          "bonus": { "label": "Ranged Weapon Attack Damage Bonus" }
+        }
       }
     }
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -4329,6 +4329,7 @@
 "DND5E.RitualAbbr": "R",
 
 "DND5E.ROLL": {
+  "Bonus": "Roll Bonus",
   "Description": {
     "ability": "Roll Ability",
     "attack": {
@@ -4343,6 +4344,7 @@
   },
   "Formatter": {
     "AdvantageMode": "{name} Advantage Mode",
+    "Bonus": "{name} Roll Bonus",
     "Maximum": "Maximum {name} Roll",
     "Minimum": "Minimum {name} Roll",
     "ModifierAbility": "{name} Modifier Ability"

--- a/lang/en.json
+++ b/lang/en.json
@@ -1325,54 +1325,6 @@
     "bonuses": {
       "label": "Global Bonuses",
       "hint": "Global bonuses as formulas which are added to certain rolls.",
-      "abilities": {
-        "label": "Global Ability Bonuses",
-        "check": {
-          "label": "Global Ability Check Bonus"
-        },
-        "save": {
-          "label": "Global Saving Throw Bonus"
-        },
-        "skill": {
-          "label": "Global Skill Check Bonus"
-        }
-      },
-      "msak": {
-        "label": "Melee Spell Bonuses",
-        "attack": {
-          "label": "Melee Spell Attack Bonus"
-        },
-        "damage": {
-          "label": "Melee Spell Damage Bonus"
-        }
-      },
-      "mwak": {
-        "label": "Melee Weapon Bonuses",
-        "attack": {
-          "label": "Melee Weapon Attack Bonus"
-        },
-        "damage": {
-          "label": "Melee Weapon Damage Bonus"
-        }
-      },
-      "rsak": {
-        "label": "Ranged Spell Bonuses",
-        "attack": {
-          "label": "Ranged Spell Attack Bonus"
-        },
-        "damage": {
-          "label": "Ranged Spell Damage Bonus"
-        }
-      },
-      "rwak": {
-        "label": "Ranged Weapon Bonuses",
-        "attack": {
-          "label": "Ranged Weapon Attack Bonus"
-        },
-        "damage": {
-          "label": "Ranged Weapon Damage Bonus"
-        }
-      },
       "spell": {
         "label": "Global Spell Bonuses",
         "dc": {
@@ -4342,12 +4294,102 @@
     "tool": "Rolled Tool",
     "type": "Roll Type"
   },
+  "FIELDS": {
+    "ability": {
+      "check": {
+        "bonus": { "label": "Global Ability Check Bonus" },
+        "max": { "label": "Maximum Global Ability Check Roll" },
+        "min": { "label": "Minimum Global Ability Check Roll" },
+        "mode": { "label": "Global Ability Check Advantage Mode" },
+        "proficiency": { "label": "Global Ability Check Proficiency" }
+      },
+      "label": "Ability Roll Modification",
+      "save": {
+        "bonus": { "label": "Global Ability Save Bonus" },
+        "max": { "label": "Maximum Global Ability Save Roll" },
+        "min": { "label": "Minimum Global Ability Save Roll" },
+        "mode": { "label": "Global Ability Save Advantage Mode" },
+        "proficiency": { "label": "Global Ability Save Proficiency" }
+      },
+      "skill": {
+        "bonus": { "label": "Global Skill Check Bonus" },
+        "max": { "label": "Maximum Global Skill Check Roll" },
+        "min": { "label": "Minimum Global Skill Check Roll" },
+        "mode": { "label": "Global Skill Check Advantage Mode" },
+        "proficiency": { "label": "Global Skill Check Proficiency" }
+      },
+      "tool": {
+        "bonus": { "label": "Global Tool Check Bonus" },
+        "max": { "label": "Maximum Global Tool Check Roll" },
+        "min": { "label": "Minimum Global Tool Check Roll" },
+        "mode": { "label": "Global Tool Check Advantage Mode" },
+        "proficiency": { "label": "Global Tool Check Proficiency" }
+      }
+    },
+    "attack": {
+      "bonus": { "label": "Global Attack Bonus" },
+      "label": "Attack Roll Modification",
+      "max": { "label": "Maximum Global Attack Roll" },
+      "min": { "label": "Minimum Global Attack Roll" },
+      "mode": { "label": "Global Attack Advantage Mode" },
+      "msak": {
+        "bonus": { "label": "Melee Spell Attack Bonus" },
+        "max": { "label": "Maximum Melee Spell Attack Roll" },
+        "min": { "label": "Minimum Melee Spell Attack Roll" },
+        "mode": { "label": "Melee Spell Attack Advantage Mode" }
+      },
+      "mwak": {
+        "bonus": { "label": "Melee Weapon Attack Bonus" },
+        "max": { "label": "Maximum Melee Weapon Attack Roll" },
+        "min": { "label": "Minimum Melee Weapon Attack Roll" },
+        "mode": { "label": "Melee Weapon Attack Advantage Mode" }
+      },
+      "rsak": {
+        "bonus": { "label": "Ranged Spell Attack Bonus" },
+        "max": { "label": "Maximum Ranged Spell Attack Roll" },
+        "min": { "label": "Minimum Ranged Spell Attack Roll" },
+        "mode": { "label": "Ranged Spell Attack Advantage Mode" }
+      },
+      "rwak": {
+        "bonus": { "label": "Ranged Weapon Attack Bonus" },
+        "max": { "label": "Maximum Ranged Weapon Attack Roll" },
+        "min": { "label": "Minimum Ranged Weapon Attack Roll" },
+        "mode": { "label": "Ranged Weapon Attack Advantage Mode" }
+      }
+    },
+    "damage": {
+      "label": "Damage Roll Modification",
+      "msak": {
+        "bonus": { "label": "Melee Spell Attack Damage Bonus" }
+      },
+      "mwak": {
+        "bonus": { "label": "Melee Weapon Attack Damage Bonus" }
+      },
+      "rsak": {
+        "bonus": { "label": "Ranged Spell Attack Damage Bonus" }
+      },
+      "rwak": {
+        "bonus": { "label": "Ranged Weapon Attack Damage Bonus" }
+      }
+    }
+  },
   "Formatter": {
     "AdvantageMode": "{name} Advantage Mode",
     "Bonus": "{name} Roll Bonus",
     "Maximum": "Maximum {name} Roll",
     "Minimum": "Minimum {name} Roll",
     "ModifierAbility": "{name} Modifier Ability"
+  },
+  "Generic": {
+    "D20": {
+      "bonus": { "label": "Roll Bonus" },
+      "max": { "label": "Maximum Roll" },
+      "min": { "label": "Minimum Roll" },
+      "mode": { "label": "Advantage Mode" }
+    },
+    "Damage": {
+      "bonus": { "label": "Damage Bonus" }
+    }
   },
   "Range": {
     "Label": "Roll Range",

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -387,7 +387,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       });
     };
     addBonus(this.document.system.schema.fields.bonuses);
-    addBonus(this.document.system.schema.fields.roll, true);
+    addBonus(this.document.system.schema.fields.rolls, true);
     if ( globals.length ) sections[_loc("DND5E.BONUSES.FIELDS.bonuses.label")] = globals;
 
     flags.sections = Object.entries(sections).map(([label, fields]) => ({ label, fields }));

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -379,11 +379,15 @@ export default class BaseActorSheet extends PrimarySheetMixin(
 
     // Global Bonuses
     const globals = [];
-    const addBonus = field => {
-      if ( field instanceof SchemaField ) Object.values(field.fields).forEach(f => addBonus(f));
-      else globals.push({ field, name: field.fieldPath, value: foundry.utils.getProperty(source, field.fieldPath) });
+    const addBonus = (field, checkName=false) => {
+      if ( field instanceof SchemaField ) Object.values(field.fields).forEach(f => addBonus(f, checkName));
+      else if ( !checkName || (field.name === "bonus") ) globals.push({
+        field, disabled: context.flags.disabled, localize: true, name: field.fieldPath,
+        value: foundry.utils.getProperty(source, field.fieldPath)
+      });
     };
     addBonus(this.document.system.schema.fields.bonuses);
+    addBonus(this.document.system.schema.fields.roll, true);
     if ( globals.length ) sections[_loc("DND5E.BONUSES.FIELDS.bonuses.label")] = globals;
 
     flags.sections = Object.entries(sections).map(([label, fields]) => ({ label, fields }));

--- a/module/applications/actor/config/base-proficiency-config.mjs
+++ b/module/applications/actor/config/base-proficiency-config.mjs
@@ -68,8 +68,8 @@ export default class BaseProficiencyConfig extends BaseConfigSheet {
     context.label = this.propertyLabel;
     context.prefix = `system.${keyPath}.${this.options.key}.`;
 
-    const globalAbilityField = this.document.system.schema.getField("roll.ability");
-    if ( globalAbilityField ) context.global = { data: source.roll?.ability ?? {}, fields: globalAbilityField.fields };
+    const globalAbilityField = this.document.system.schema.getField("rolls.ability");
+    if ( globalAbilityField ) context.global = { data: source.rolls?.ability ?? {}, fields: globalAbilityField.fields };
 
     return context;
   }

--- a/module/applications/actor/config/base-proficiency-config.mjs
+++ b/module/applications/actor/config/base-proficiency-config.mjs
@@ -68,10 +68,8 @@ export default class BaseProficiencyConfig extends BaseConfigSheet {
     context.label = this.propertyLabel;
     context.prefix = `system.${keyPath}.${this.options.key}.`;
 
-    if ( this.document.system.bonuses?.abilities ) context.global = {
-      data: source.bonuses?.abilities ?? {},
-      fields: this.document.system.schema.fields.bonuses.fields.abilities.fields
-    };
+    const globalAbilityField = this.document.system.schema.getField("roll.ability");
+    if ( globalAbilityField ) context.global = { data: source.roll?.ability ?? {}, fields: globalAbilityField.fields };
 
     return context;
   }

--- a/module/applications/actor/config/concentration-config.mjs
+++ b/module/applications/actor/config/concentration-config.mjs
@@ -48,8 +48,8 @@ export default class ConcentrationConfig extends BaseConfigSheet {
       ...Object.entries(CONFIG.DND5E.abilities).map(([value, { label }]) => ({ value, label }))
     ];
 
-    const globalAbilityField = this.document.system.schema.getField("roll.ability");
-    if ( globalAbilityField ) context.global = { data: source.roll?.ability ?? {}, fields: globalAbilityField.fields };
+    const globalAbilityField = this.document.system.schema.getField("rolls.ability");
+    if ( globalAbilityField ) context.global = { data: source.rolls?.ability ?? {}, fields: globalAbilityField.fields };
 
     return context;
   }

--- a/module/applications/actor/config/concentration-config.mjs
+++ b/module/applications/actor/config/concentration-config.mjs
@@ -48,10 +48,8 @@ export default class ConcentrationConfig extends BaseConfigSheet {
       ...Object.entries(CONFIG.DND5E.abilities).map(([value, { label }]) => ({ value, label }))
     ];
 
-    if ( this.document.system.bonuses?.abilities ) context.global = {
-      data: source.bonuses?.abilities ?? {},
-      fields: this.document.system.schema.fields.bonuses.fields.abilities.fields
-    };
+    const globalAbilityField = this.document.system.schema.getField("roll.ability");
+    if ( globalAbilityField ) context.global = { data: source.roll?.ability ?? {}, fields: globalAbilityField.fields };
 
     return context;
   }

--- a/module/applications/actor/config/death-config.mjs
+++ b/module/applications/actor/config/death-config.mjs
@@ -42,10 +42,8 @@ export default class DeathConfig extends BaseConfigSheet {
     context.data = source.attributes?.death ?? {};
     context.fields = this.document.system.schema.getField("attributes.death").fields;
 
-    if ( this.document.system.bonuses?.abilities ) context.global = {
-      data: source.bonuses?.abilities ?? {},
-      fields: this.document.system.schema.getField("bonuses.abilities").fields
-    };
+    const globalAbilityField = this.document.system.schema.getField("roll.ability");
+    if ( globalAbilityField ) context.global = { data: source.roll?.ability ?? {}, fields: globalAbilityField.fields };
 
     return context;
   }

--- a/module/applications/actor/config/death-config.mjs
+++ b/module/applications/actor/config/death-config.mjs
@@ -42,8 +42,8 @@ export default class DeathConfig extends BaseConfigSheet {
     context.data = source.attributes?.death ?? {};
     context.fields = this.document.system.schema.getField("attributes.death").fields;
 
-    const globalAbilityField = this.document.system.schema.getField("roll.ability");
-    if ( globalAbilityField ) context.global = { data: source.roll?.ability ?? {}, fields: globalAbilityField.fields };
+    const globalAbilityField = this.document.system.schema.getField("rolls.ability");
+    if ( globalAbilityField ) context.global = { data: source.rolls?.ability ?? {}, fields: globalAbilityField.fields };
 
     return context;
   }

--- a/module/applications/actor/config/initiative-config.mjs
+++ b/module/applications/actor/config/initiative-config.mjs
@@ -60,9 +60,9 @@ export default class InitiativeConfig extends BaseConfigSheet {
         value: source.system.rolls?.ability?.check?.bonus
       },
       local: {
-        field: this.document.system.schema.fields.abilities.model.fields.bonuses.fields.check,
-        name: `system.abilities.${ability}.bonuses.check`,
-        value: source.system.abilities[ability]?.bonuses.check
+        field: this.document.system.schema.fields.abilities.model.fields.check.fields.roll.fields.bonus,
+        name: `system.abilities.${ability}.check.roll.bonus`,
+        value: source.system.abilities[ability]?.check.roll.bonus
       }
     };
 

--- a/module/applications/actor/config/initiative-config.mjs
+++ b/module/applications/actor/config/initiative-config.mjs
@@ -55,9 +55,9 @@ export default class InitiativeConfig extends BaseConfigSheet {
     context.ability = {
       label: _loc("DND5E.AbilityCheckConfigure", { ability: abilityConfig.label }),
       global: {
-        field: this.document.system.schema.fields.roll?.fields.ability.fields.check.fields.bonus,
-        name: "system.roll.ability.check.bonus",
-        value: source.system.roll?.ability?.check?.bonus
+        field: this.document.system.schema.fields.rolls?.fields.ability.fields.check.fields.bonus,
+        name: "system.rolls.ability.check.bonus",
+        value: source.system.rolls?.ability?.check?.bonus
       },
       local: {
         field: this.document.system.schema.fields.abilities.model.fields.bonuses.fields.check,

--- a/module/applications/actor/config/initiative-config.mjs
+++ b/module/applications/actor/config/initiative-config.mjs
@@ -55,9 +55,9 @@ export default class InitiativeConfig extends BaseConfigSheet {
     context.ability = {
       label: _loc("DND5E.AbilityCheckConfigure", { ability: abilityConfig.label }),
       global: {
-        field: this.document.system.schema.fields.bonuses?.fields.abilities.fields.check,
-        name: "system.bonuses.abilities.check",
-        value: source.system.bonuses?.abilities.check
+        field: this.document.system.schema.fields.roll?.fields.ability.fields.check.fields.bonus,
+        name: "system.roll.ability.check.bonus",
+        value: source.system.roll?.ability?.check?.bonus
       },
       local: {
         field: this.document.system.schema.fields.abilities.model.fields.bonuses.fields.check,

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -366,7 +366,7 @@ export default class NPCActorSheet extends BaseActorSheet {
     // Skills & Tools
     const skillSetting = game.settings.get("dnd5e", "defaultSkills");
     context.skills = this._prepareSkillsTools(context, "skills")
-      .filter(v => v.prof.multiplier || skillSetting.has(v.key) || v.bonuses.check || v.bonuses.passive);
+      .filter(v => v.prof.multiplier || skillSetting.has(v.key) || v.roll.bonus || v.bonuses.passive);
     context.tools = this._prepareSkillsTools(context, "tools");
 
     // Speed

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -446,10 +446,10 @@ export default class NPCActorSheet extends BaseActorSheet {
     context = await super._prepareSpellsContext(context, options);
     context.classSpellcasting = Object.values(this.actor.classes).some(c => c.spellcasting?.levels);
 
-    const { abilities, attributes, roll } = this.actor.system;
+    const { abilities, attributes, rolls } = this.actor.system;
     context.spellcasting = [];
-    const msak = simplifyBonus(roll.attack?.msak?.bonus, context.rollData);
-    const rsak = simplifyBonus(roll.attack?.rsak?.bonus, context.rollData);
+    const msak = simplifyBonus(rolls.attack?.msak?.bonus, context.rollData);
+    const rsak = simplifyBonus(rolls.attack?.rsak?.bonus, context.rollData);
     const spellcaster = Object.values(this.actor.spellcastingClasses)[0];
     const ability = spellcaster?.spellcasting.ability ?? attributes.spellcasting;
     const spellAbility = abilities[ability];

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -417,14 +417,18 @@ export default class NPCActorSheet extends BaseActorSheet {
         name: "system.traits.important",
         value: context.source.traits.important
       }, {
-        label: "DND5E.NPC.FIELDS.attributes.price.label",
-        hint: "DND5E.NPC.FIELDS.attributes.price.hint",
+        group: {
+          label: "DND5E.NPC.FIELDS.attributes.price.label",
+          hint: "DND5E.NPC.FIELDS.attributes.price.hint"
+        },
         fields: [{
+          classes: "label-top",
           field: fields.attributes.fields.price.fields.value,
           name: "system.attributes.price.value",
           value: context.source.attributes.price.value
         }, {
           choices: CONFIG.DND5E.currencies,
+          classes: "label-top",
           field: fields.attributes.fields.price.fields.denomination,
           name: "system.attributes.price.denomination",
           value: context.source.attributes.price.denomination
@@ -442,10 +446,10 @@ export default class NPCActorSheet extends BaseActorSheet {
     context = await super._prepareSpellsContext(context, options);
     context.classSpellcasting = Object.values(this.actor.classes).some(c => c.spellcasting?.levels);
 
-    const { abilities, attributes, bonuses } = this.actor.system;
+    const { abilities, attributes, roll } = this.actor.system;
     context.spellcasting = [];
-    const msak = simplifyBonus(bonuses.msak.attack, context.rollData);
-    const rsak = simplifyBonus(bonuses.rsak.attack, context.rollData);
+    const msak = simplifyBonus(roll.attack?.msak?.bonus, context.rollData);
+    const rsak = simplifyBonus(roll.attack?.rsak?.bonus, context.rollData);
     const spellcaster = Object.values(this.actor.spellcastingClasses)[0];
     const ability = spellcaster?.spellcasting.ability ?? attributes.spellcasting;
     const spellAbility = abilities[ability];

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -269,8 +269,8 @@ export default class BaseAttackActivityData extends BaseActivityData {
       bonus: this.attack.bonus,
       weaponMagic: weapon.magicAvailable ? weapon.magicalBonus : null,
       ammoMagic: ammo?.magicAvailable ? ammo.magicalBonus : null,
-      actorGenericBonus: this.actor?.system.roll?.attack?.bonus,
-      actorSpecificBonus: this.actor?.system.roll?.attack?.[this.getActionType(attackMode)]?.bonus,
+      actorGenericBonus: this.actor?.system.rolls?.attack?.bonus,
+      actorSpecificBonus: this.actor?.system.rolls?.attack?.[this.getActionType(attackMode)]?.bonus,
       ruleBonus: AppliedRules.collect("attack:bonus", this.actor, this.item).filterWith(rollData).toFormula(),
       situational
     }, rollData);

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -269,7 +269,8 @@ export default class BaseAttackActivityData extends BaseActivityData {
       bonus: this.attack.bonus,
       weaponMagic: weapon.magicAvailable ? weapon.magicalBonus : null,
       ammoMagic: ammo?.magicAvailable ? ammo.magicalBonus : null,
-      actorBonus: this.actor?.system.bonuses?.[this.getActionType(attackMode)]?.attack,
+      actorGenericBonus: this.actor?.system.roll?.attack?.bonus,
+      actorSpecificBonus: this.actor?.system.roll?.attack?.[this.getActionType(attackMode)]?.bonus,
       ruleBonus: AppliedRules.collect("attack:bonus", this.actor, this.item).filterWith(rollData).toFormula(),
       situational
     }, rollData);

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -2,6 +2,7 @@ import simplifyRollFormula from "../../dice/simplify-roll-formula.mjs";
 import AppliedRules from "../../documents/applied-rules.mjs";
 import { convertLength, formatLength, formatNumber, simplifyBonus } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
+import D20RollModificationField from "../shared/d20-roll-modification-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
@@ -263,15 +264,16 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
     const weapon = this.item.system;
     const ammo = this.actor?.items.get(ammunition)?.system;
+    const { bonus } = this.actor ? D20RollModificationField.combineFields(this.actor.system, [
+      "rolls.attack", `rolls.attack.${this.getActionType(attackMode)}`
+    ], { rules: { category: "attack", actor: this.actor, item: this.item, rollData } }) : {};
     const { parts, data } = CONFIG.Dice.BasicRoll.constructParts({
       mod: this.attack.ability !== "none" ? rollData.mod : null,
       prof: weapon.prof?.term,
       bonus: this.attack.bonus,
       weaponMagic: weapon.magicAvailable ? weapon.magicalBonus : null,
       ammoMagic: ammo?.magicAvailable ? ammo.magicalBonus : null,
-      actorGenericBonus: this.actor?.system.rolls?.attack?.bonus,
-      actorSpecificBonus: this.actor?.system.rolls?.attack?.[this.getActionType(attackMode)]?.bonus,
-      ruleBonus: AppliedRules.collect("attack:bonus", this.actor, this.item).filterWith(rollData).toFormula(),
+      ruleBonus: bonus,
       situational
     }, rollData);
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -845,7 +845,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
     if ( index === 0 ) {
       const actionType = this.getActionType(rollConfig.attackMode);
-      const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.bonuses.${actionType}.damage`);
+      const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.roll.damage.${actionType}.bonus`);
       if ( bonus && !/^0+$/.test(bonus) ) parts.push(bonus);
       if ( this.item.system.damage?.bonus ) parts.push(String(this.item.system.damage.bonus));
     }

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -845,7 +845,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
     if ( index === 0 ) {
       const actionType = this.getActionType(rollConfig.attackMode);
-      const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.roll.damage.${actionType}.bonus`);
+      const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.rolls.damage.${actionType}.bonus`);
       if ( bonus && !/^0+$/.test(bonus) ) parts.push(bonus);
       if ( this.item.system.damage?.bonus ) parts.push(String(this.item.system.damage.bonus));
     }

--- a/module/data/actor/_types.mjs
+++ b/module/data/actor/_types.mjs
@@ -20,8 +20,6 @@
  * @property {Omit<RollConfigData, "ability">} attributes.death
  * @property {number} attributes.death.success            Number of successful death saves.
  * @property {number} attributes.death.failure            Number of failed death saves.
- * @property {object} attributes.death.bonuses
- * @property {string} attributes.death.bonuses.save       Numeric or dice bonus to death saving throws.
  * @property {number} attributes.inspiration              Does this character have inspiration?
  * @property {object} attributes.piety
  * @property {number} attributes.piety.value              The creature's piety score.
@@ -140,8 +138,6 @@
  * @property {Omit<RollConfigData, "ability">} attributes.death
  * @property {number} attributes.death.success        Number of successful death saves.
  * @property {number} attributes.death.failure        Number of failed death saves.
- * @property {object} attributes.death.bonuses
- * @property {string} attributes.death.bonuses.save   Numeric or dice bonus to death saving throws.
  * @property {object} attributes.price
  * @property {number|null} attributes.price.value     The creature's value in the specified denomination.
  * @property {string} attributes.price.denomination   The currency denomination.

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -78,10 +78,8 @@ export default class CharacterData extends CreatureTemplate {
           failure: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveFailures"
           }),
-          bonuses: new SchemaField({
-            save: new FormulaField({ required: true, label: "DND5E.DeathSaveBonus" })
-          })
-        }, { label: "DND5E.DeathSave" }),
+          bonuses: new SchemaField({}, { persisted: false })
+        }, { label: "DND5E.DeathSave", labelPrefix: "DND5E.DEATH.FIELDS.attributes.death.roll." }),
         inspiration: new BooleanField({ required: true, label: "DND5E.Inspiration" }),
         piety: new SchemaField({
           value: new NumberField({

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -33,7 +33,7 @@ export default class CharacterData extends CreatureTemplate {
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.BONUSES", "DND5E.CHARACTER"];
+  static LOCALIZATION_PREFIXES = ["DND5E.BONUSES", "DND5E.ROLL", "DND5E.CHARACTER"];
 
   /* -------------------------------------------- */
 
@@ -201,6 +201,7 @@ export default class CharacterData extends CreatureTemplate {
     AttributesFields.prepareBaseEncumbrance.call(this);
     MovementField._shim(this.attributes.movement);
     SensesField._shim(this.attributes.senses);
+    this.shimBonusData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -33,7 +33,7 @@ export default class NPCData extends CreatureTemplate {
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.NPC", "DND5E.BONUSES", "DND5E.SOURCE"];
+  static LOCALIZATION_PREFIXES = ["DND5E.NPC", "DND5E.BONUSES", "DND5E.ROLL", "DND5E.SOURCE"];
 
   /* -------------------------------------------- */
 
@@ -400,6 +400,7 @@ export default class NPCData extends CreatureTemplate {
     AttributesFields.prepareBaseEncumbrance.call(this);
     MovementField._shim(this.attributes.movement);
     SensesField._shim(this.attributes.senses);
+    this.shimBonusData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -74,10 +74,8 @@ export default class NPCData extends CreatureTemplate {
           failure: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveFailures"
           }),
-          bonuses: new SchemaField({
-            save: new FormulaField({ required: true, label: "DND5E.DeathSaveBonus" })
-          })
-        }, { label: "DND5E.DeathSave" }),
+          bonuses: new SchemaField({}, { persisted: false })
+        }, { label: "DND5E.DeathSave", labelPrefix: "DND5E.DEATH.FIELDS.attributes.death.roll." }),
         price: new SchemaField({
           value: new NumberField({ initial: null, min: 0 }),
           denomination: new StringField({ required: true, blank: false, initial: () => CONFIG.DND5E.defaultCurrency })

--- a/module/data/actor/templates/_types.mjs
+++ b/module/data/actor/templates/_types.mjs
@@ -9,8 +9,6 @@
  * @typedef AttributesCommonData
  * @property {ArmorClassData} ac       Armor class configuration.
  * @property {RollConfigData} init
- * @property {string} init.ability     The ability used for initiative rolls.
- * @property {string} init.bonus       The bonus provided to initiative rolls.
  * @property {MovementData} movement
  */
 
@@ -22,9 +20,6 @@
  * @property {string} spellcasting                Primary spellcasting ability.
  * @property {number} exhaustion                  Creature's exhaustion level.
  * @property {RollConfigData} concentration
- * @property {string} concentration.ability       The ability used for concentration saving throws.
- * @property {object} concentration.bonuses
- * @property {string} concentration.bonuses.save  The bonus provided to concentration saving throws.
  * @property {number} concentration.limit         The amount of items this actor can concentrate on.
  * @property {object} loyalty
  * @property {number} loyalty.value               The creature's loyalty score.
@@ -66,11 +61,8 @@
  * @property {number} value          Ability score.
  * @property {number} proficient     Proficiency value for saves.
  * @property {number} max            Maximum possible score for the ability.
- * @property {object} bonuses        Bonuses that modify ability checks and saves.
- * @property {string} bonuses.check  Numeric or dice bonus to ability checks.
- * @property {string} bonuses.save   Numeric or dice bonus to ability saving throws.
- * @property {RollConfigData} check    Properties related to ability checks.
- * @property {RollConfigData} save     Properties related to saving throws.
+ * @property {Omit<RollConfigData, "ability">} check  Properties related to ability checks.
+ * @property {Omit<RollConfigData, "ability">} save   Properties related to saving throws.
  */
 
 /**
@@ -108,15 +100,12 @@
  * @typedef {RollConfigData} SkillData
  * @property {number} value            Proficiency level creature has in this skill.
  * @property {object} bonuses          Bonuses for this skill.
- * @property {string} bonuses.check    Numeric or dice bonus to skill's check.
  * @property {string} bonuses.passive  Numeric bonus to skill's passive check.
  */
 
 /**
  * @typedef {RollConfigData} ToolData
  * @property {number} value            Proficiency level creature has in this tool.
- * @property {object} bonuses          Bonuses for this tool.
- * @property {string} bonuses.check    Numeric or dice bonus to tool's check.
  */
 
 /**

--- a/module/data/actor/templates/_types.mjs
+++ b/module/data/actor/templates/_types.mjs
@@ -76,36 +76,32 @@
 /**
  * @typedef {CommonTemplateData} CreatureTemplateData
  * @property {object} bonuses
- * @property {AttackBonusesData} bonuses.mwak        Bonuses to melee weapon attacks.
- * @property {AttackBonusesData} bonuses.rwak        Bonuses to ranged weapon attacks.
- * @property {AttackBonusesData} bonuses.msak        Bonuses to melee spell attacks.
- * @property {AttackBonusesData} bonuses.rsak        Bonuses to ranged spell attacks.
- * @property {object} bonuses.abilities              Bonuses to ability scores.
- * @property {string} bonuses.abilities.check        Numeric or dice bonus to ability checks.
- * @property {string} bonuses.abilities.save         Numeric or dice bonus to ability saves.
- * @property {string} bonuses.abilities.skill        Numeric or dice bonus to skill checks.
  * @property {object} bonuses.spell                  Bonuses to spells.
  * @property {string} bonuses.spell.dc               Numeric bonus to spellcasting DC.
- * @property {object} rolls
- * @property {object} rolls.ability
- * @property {D20RollModificationData} rolls.ability.check  Modifications to ability checks.
- * @property {D20RollModificationData} rolls.ability.save   Modifications to ability saves.
- * @property {D20RollModificationData} rolls.ability.skill  Modifications to skill checks.
- * @property {AttackModificationData} rolls.attack          Modifications to attack rolls.
- * @property {AttackModificationData} rolls.attack.spell    Modifications to spell attacks.
- * @property {AttackModificationData} rolls.attack.weapon   Modifications to weapon attacks.
- * @property {AttackDamageData} rolls.damage                Damage bonuses to attacks.
- * @property {AttackDamageData} rolls.damage.spell          Damage bonuses to spell attacks.
- * @property {AttackDamageData} rolls.damage.weapon         Damage bonuses to weapon attacks.
+ * @property {object} roll
+ * @property {object} roll.ability
+ * @property {ProficientRollModificationData} roll.ability.check  Modifications to ability checks.
+ * @property {ProficientRollModificationData} roll.ability.save   Modifications to ability saves.
+ * @property {ProficientRollModificationData} roll.ability.skill  Modifications to skill checks.
+ * @property {ProficientRollModificationData} roll.ability.tool   Modifications to tool checks.
+ * @property {D20ModificationData} roll.attack       Modifications to attack rolls.
+ * @property {D20ModificationData} roll.attack.msak  Modifications to melee spell attack rolls.
+ * @property {D20ModificationData} roll.attack.mwak  Modifications to melee weapon attack rolls.
+ * @property {D20ModificationData} roll.attack.rsak  Modifications to ranged spell attack rolls.
+ * @property {D20ModificationData} roll.attack.rwak  Modifications to ranged weapon attack rolls.
+ * @property {object} roll.damage
+ * @property {DamageRollModificationData} roll.damage.msak  Damage bonuses to melee spell attacks.
+ * @property {DamageRollModificationData} roll.damage.mwak  Damage bonuses to melee weapon attacks.
+ * @property {DamageRollModificationData} roll.damage.rsak  Damage bonuses to ranged spell attacks.
+ * @property {DamageRollModificationData} roll.damage.rwak  Damage bonuses to ranged weapon attacks.
  * @property {Record<string, ToolData>} tools        Actor's tools.
  * @property {Record<string, SkillData>} skills      Actor's skills.
  * @property {Record<string, SpellSlotData>} spells  Actor's spell slots.
  */
 
 /**
- * @typedef {DamageRollModificationData} AttackModificationData
- * @property {DamageRollModificationData} melee   Damage bonus for melee attacks in this category.
- * @property {DamageRollModificationData} ranged  Damage bonus for ranged attacks in this category.
+ * @typedef {D20RollModificationData} ProficientRollModificationData
+ * @property {number} melee   Damage bonus for melee attacks in this category.
  */
 
 /**

--- a/module/data/actor/templates/_types.mjs
+++ b/module/data/actor/templates/_types.mjs
@@ -1,5 +1,7 @@
 /**
- * @import { MovementData, RollConfigData, SensesData } from "../../shared/_types.mjs";
+ * @import {
+ *   D20RollModificationData, DamageRollModificationData, MovementData, RollConfigData, SensesData
+ * } from "../../shared/_types.mjs";
  * @import { ACFormulaData, DamageTraitData, SimpleTraitData } from "../fields/_types.mjs";
  */
 
@@ -84,15 +86,26 @@
  * @property {string} bonuses.abilities.skill        Numeric or dice bonus to skill checks.
  * @property {object} bonuses.spell                  Bonuses to spells.
  * @property {string} bonuses.spell.dc               Numeric bonus to spellcasting DC.
+ * @property {object} rolls
+ * @property {object} rolls.ability
+ * @property {D20RollModificationData} rolls.ability.check  Modifications to ability checks.
+ * @property {D20RollModificationData} rolls.ability.save   Modifications to ability saves.
+ * @property {D20RollModificationData} rolls.ability.skill  Modifications to skill checks.
+ * @property {AttackModificationData} rolls.attack          Modifications to attack rolls.
+ * @property {AttackModificationData} rolls.attack.spell    Modifications to spell attacks.
+ * @property {AttackModificationData} rolls.attack.weapon   Modifications to weapon attacks.
+ * @property {AttackDamageData} rolls.damage                Damage bonuses to attacks.
+ * @property {AttackDamageData} rolls.damage.spell          Damage bonuses to spell attacks.
+ * @property {AttackDamageData} rolls.damage.weapon         Damage bonuses to weapon attacks.
  * @property {Record<string, ToolData>} tools        Actor's tools.
  * @property {Record<string, SkillData>} skills      Actor's skills.
  * @property {Record<string, SpellSlotData>} spells  Actor's spell slots.
  */
 
 /**
- * @typedef AttackBonusesData
- * @property {string} attack  Numeric or dice bonus to attack rolls.
- * @property {string} damage  Numeric or dice bonus to damage rolls.
+ * @typedef {DamageRollModificationData} AttackModificationData
+ * @property {DamageRollModificationData} melee   Damage bonus for melee attacks in this category.
+ * @property {DamageRollModificationData} ranged  Damage bonus for ranged attacks in this category.
  */
 
 /**

--- a/module/data/actor/templates/_types.mjs
+++ b/module/data/actor/templates/_types.mjs
@@ -78,22 +78,22 @@
  * @property {object} bonuses
  * @property {object} bonuses.spell                  Bonuses to spells.
  * @property {string} bonuses.spell.dc               Numeric bonus to spellcasting DC.
- * @property {object} roll
- * @property {object} roll.ability
- * @property {ProficientRollModificationData} roll.ability.check  Modifications to ability checks.
- * @property {ProficientRollModificationData} roll.ability.save   Modifications to ability saves.
- * @property {ProficientRollModificationData} roll.ability.skill  Modifications to skill checks.
- * @property {ProficientRollModificationData} roll.ability.tool   Modifications to tool checks.
- * @property {D20ModificationData} roll.attack       Modifications to attack rolls.
- * @property {D20ModificationData} roll.attack.msak  Modifications to melee spell attack rolls.
- * @property {D20ModificationData} roll.attack.mwak  Modifications to melee weapon attack rolls.
- * @property {D20ModificationData} roll.attack.rsak  Modifications to ranged spell attack rolls.
- * @property {D20ModificationData} roll.attack.rwak  Modifications to ranged weapon attack rolls.
- * @property {object} roll.damage
- * @property {DamageRollModificationData} roll.damage.msak  Damage bonuses to melee spell attacks.
- * @property {DamageRollModificationData} roll.damage.mwak  Damage bonuses to melee weapon attacks.
- * @property {DamageRollModificationData} roll.damage.rsak  Damage bonuses to ranged spell attacks.
- * @property {DamageRollModificationData} roll.damage.rwak  Damage bonuses to ranged weapon attacks.
+ * @property {object} rolls
+ * @property {object} rolls.ability
+ * @property {ProficientRollModificationData} rolls.ability.check  Modifications to ability checks.
+ * @property {ProficientRollModificationData} rolls.ability.save   Modifications to ability saves.
+ * @property {ProficientRollModificationData} rolls.ability.skill  Modifications to skill checks.
+ * @property {ProficientRollModificationData} rolls.ability.tool   Modifications to tool checks.
+ * @property {D20ModificationData} rolls.attack       Modifications to attack rolls.
+ * @property {D20ModificationData} rolls.attack.msak  Modifications to melee spell attack rolls.
+ * @property {D20ModificationData} rolls.attack.mwak  Modifications to melee weapon attack rolls.
+ * @property {D20ModificationData} rolls.attack.rsak  Modifications to ranged spell attack rolls.
+ * @property {D20ModificationData} rolls.attack.rwak  Modifications to ranged weapon attack rolls.
+ * @property {object} rolls.damage
+ * @property {DamageRollModificationData} rolls.damage.msak  Damage bonuses to melee spell attacks.
+ * @property {DamageRollModificationData} rolls.damage.mwak  Damage bonuses to melee weapon attacks.
+ * @property {DamageRollModificationData} rolls.damage.rsak  Damage bonuses to ranged spell attacks.
+ * @property {DamageRollModificationData} rolls.damage.rwak  Damage bonuses to ranged weapon attacks.
  * @property {Record<string, ToolData>} tools        Actor's tools.
  * @property {Record<string, SkillData>} skills      Actor's skills.
  * @property {Record<string, SpellSlotData>} spells  Actor's spell slots.

--- a/module/data/actor/templates/_types.mjs
+++ b/module/data/actor/templates/_types.mjs
@@ -84,11 +84,11 @@
  * @property {ProficientRollModificationData} rolls.ability.save   Modifications to ability saves.
  * @property {ProficientRollModificationData} rolls.ability.skill  Modifications to skill checks.
  * @property {ProficientRollModificationData} rolls.ability.tool   Modifications to tool checks.
- * @property {D20ModificationData} rolls.attack       Modifications to attack rolls.
- * @property {D20ModificationData} rolls.attack.msak  Modifications to melee spell attack rolls.
- * @property {D20ModificationData} rolls.attack.mwak  Modifications to melee weapon attack rolls.
- * @property {D20ModificationData} rolls.attack.rsak  Modifications to ranged spell attack rolls.
- * @property {D20ModificationData} rolls.attack.rwak  Modifications to ranged weapon attack rolls.
+ * @property {D20RollModificationData} rolls.attack       Modifications to attack rolls.
+ * @property {D20RollModificationData} rolls.attack.msak  Modifications to melee spell attack rolls.
+ * @property {D20RollModificationData} rolls.attack.mwak  Modifications to melee weapon attack rolls.
+ * @property {D20RollModificationData} rolls.attack.rsak  Modifications to ranged spell attack rolls.
+ * @property {D20RollModificationData} rolls.attack.rwak  Modifications to ranged weapon attack rolls.
  * @property {object} rolls.damage
  * @property {DamageRollModificationData} rolls.damage.msak  Damage bonuses to melee spell attacks.
  * @property {DamageRollModificationData} rolls.damage.mwak  Damage bonuses to melee weapon attacks.
@@ -101,7 +101,7 @@
 
 /**
  * @typedef {D20RollModificationData} ProficientRollModificationData
- * @property {number} melee   Damage bonus for melee attacks in this category.
+ * @property {number} proficiency  Minimum proficiency level for this roll.
  */
 
 /**

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -486,7 +486,7 @@ export default class AttributesFields {
   static prepareInitiative(rollData) {
     const init = this.attributes.init ??= {};
     const flags = this.parent.flags.dnd5e ?? {};
-    const globalCheckBonus = simplifyBonus(this.roll?.ability?.check?.bonus, rollData);
+    const globalCheckBonus = simplifyBonus(this.rolls?.ability?.check?.bonus, rollData);
 
     // Compute initiative modifier
     const abilityId = init.ability || CONFIG.DND5E.defaultAbilities.initiative;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -486,7 +486,7 @@ export default class AttributesFields {
   static prepareInitiative(rollData) {
     const init = this.attributes.init ??= {};
     const flags = this.parent.flags.dnd5e ?? {};
-    const globalCheckBonus = simplifyBonus(this.bonuses?.abilities?.check, rollData);
+    const globalCheckBonus = simplifyBonus(this.roll?.ability?.check?.bonus, rollData);
 
     // Compute initiative modifier
     const abilityId = init.ability || CONFIG.DND5E.defaultAbilities.initiative;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -128,9 +128,8 @@ export default class AttributesFields {
         })
       }, { persisted: false }),
       init: new RollConfigField({
-        ability: "",
-        bonus: new FormulaField({ required: true, label: "DND5E.InitiativeBonus" })
-      }, { label: "DND5E.Initiative" }),
+        bonuses: new SchemaField({}, { persisted: false })
+      }, { label: "DND5E.Initiative", labelPrefix: "DND5E.INITIATIVE.FIELDS.attributes.init.roll." }),
       movement: new MovementField()
     };
   }
@@ -160,16 +159,11 @@ export default class AttributesFields {
         required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.Exhaustion"
       }),
       concentration: new RollConfigField({
-        ability: "",
-        bonuses: new SchemaField({
-          save: new FormulaField({
-            required: true, label: "DND5E.CONCENTRATION.FIELDS.attributes.concentration.bonuses.save.label"
-          })
-        }),
+        bonuses: new SchemaField({}, { persisted: false }),
         limit: new NumberField({
           integer: true, min: 0, initial: 1, label: "DND5E.CONCENTRATION.FIELDS.attributes.concentration.limit.label"
         })
-      }, { label: "DND5E.Concentration" }),
+      }, { label: "DND5E.Concentration", labelPrefix: "DND5E.CONCENTRATION.FIELDS.attributes.concentration.roll." }),
       loyalty: new SchemaField({
         value: new NumberField({ integer: true, min: 0, max: 20, label: "DND5E.Loyalty" })
       })
@@ -224,8 +218,9 @@ export default class AttributesFields {
   static _migrateInitiative(source) {
     const init = source?.init;
     if ( !init?.value || (typeof init?.bonus === "string") ) return;
-    if ( init.bonus ) init.bonus += init.value < 0 ? ` - ${init.value * -1}` : ` + ${init.value}`;
-    else init.bonus = `${init.value}`;
+    init.roll ??= {};
+    if ( init.roll.bonus ) init.roll.bonus += init.value < 0 ? ` - ${init.value * -1}` : ` + ${init.value}`;
+    else init.roll.bonus = `${init.value}`;
   }
 
   /* -------------------------------------------- */
@@ -360,7 +355,7 @@ export default class AttributesFields {
     const { concentration } = this.attributes;
     const abilityId = concentration.ability || CONFIG.DND5E.defaultAbilities.concentration;
     const ability = this.abilities?.[abilityId] || {};
-    const bonus = simplifyBonus(concentration.bonuses.save, rollData);
+    const bonus = simplifyBonus(concentration.roll.bonus, rollData);
     concentration.save = (ability.save?.value ?? 0) + bonus;
   }
 
@@ -514,8 +509,8 @@ export default class AttributesFields {
     rollData.roll = { ability: abilityId, proficient: init.prof.multiplier >= 1, type: "initiative" };
 
     // Total initiative includes all numeric terms
-    const initBonus = simplifyBonus(init.bonus, rollData);
-    const abilityBonus = simplifyBonus(ability.bonuses?.check, rollData);
+    const initBonus = simplifyBonus(init.roll.bonus, rollData);
+    const abilityBonus = simplifyBonus(ability.check?.roll?.bonus, rollData);
     const ruleBonus = simplifyBonus(
       AppliedRules.collect("check:bonus", this.parent).filterWith(rollData).toFormula(), rollData
     );

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -147,12 +147,12 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
     const flags = this.parent.flags.dnd5e ?? {};
     const { prof = 0, ac } = this.attributes ?? {};
     Object.values(this.abilities).forEach(a => a.mod = Math.floor((a.value - 10) / 2));
-    const checkBonus = simplifyBonus(this.roll?.ability?.check?.bonus, rollData);
-    const saveBonus = simplifyBonus(this.roll?.ability?.save?.bonus, rollData);
+    const checkBonus = simplifyBonus(this.rolls?.ability?.check?.bonus, rollData);
+    const saveBonus = simplifyBonus(this.rolls?.ability?.save?.bonus, rollData);
     const dcBonus = simplifyBonus(this.bonuses?.spell?.dc, rollData);
     for ( const [id, abl] of Object.entries(this.abilities) ) {
       if ( flags.diamondSoul ) abl.proficient = 1;  // Diamond Soul is proficient in all saves
-      abl.proficient = Math.max(abl.proficient, this.roll?.ability?.save?.proficiency ?? -Infinity);
+      abl.proficient = Math.max(abl.proficient, this.rolls?.ability?.save?.proficiency ?? -Infinity);
       const originalAbility = originalSaves?.[id];
       if ( originalAbility?.proficient ) {
         abl.merged = true;
@@ -221,8 +221,8 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
    */
   calculateAbilityCheckProficiency(multiplier, ability, options={}) {
     let roundDown = true;
-    multiplier = Math.max(multiplier, this.roll?.ability?.check?.proficiency ?? -Infinity);
-    if ( options.skill ) multiplier = Math.max(multiplier, this.roll?.ability?.skill?.proficiency ?? -Infinity);
+    multiplier = Math.max(multiplier, this.rolls?.ability?.check?.proficiency ?? -Infinity);
+    if ( options.skill ) multiplier = Math.max(multiplier, this.rolls?.ability?.skill?.proficiency ?? -Infinity);
     if ( (multiplier < 1) && ((dnd5e.settings.rulesVersion === "legacy") || options.skill) ) {
       if ( this.parent._isRemarkableAthlete(ability) ) {
         multiplier = .5;
@@ -245,7 +245,7 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
    * @returns {Proficiency}
    */
   calculateToolProficiency(multiplier, ability, options={}) {
-    multiplier = Math.max(multiplier, this.roll?.ability?.tool?.proficiency ?? -Infinity);
+    multiplier = Math.max(multiplier, this.rolls?.ability?.tool?.proficiency ?? -Infinity);
     if ( (multiplier === 1) && this.parent.flags.dnd5e?.toolExpertise ) {
       return new Proficiency(this.attributes.prof, 2, true);
     }

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -44,16 +44,15 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
           required: true, integer: true, nullable: true, min: 0, initial: null, label: "DND5E.AbilityScoreMax",
           labelFormatter: "DND5E.ABILITY.Formatter.Maximum"
         }),
-        bonuses: new SchemaField({
-          check: new FormulaField({
-            required: true, label: "DND5E.AbilityCheckBonus", labelFormatter: "DND5E.ABILITY.Formatter.Check.Bonus"
-          }),
-          save: new FormulaField({
-            required: true, label: "DND5E.SaveBonus", labelFormatter: "DND5E.ABILITY.Formatter.Save.Bonus"
-          })
-        }, { label: "DND5E.AbilityBonuses" }),
-        check: new RollConfigField({ ability: false }, { labelFormatterPrefix: "DND5E.ABILITY.Formatter.Check." }),
-        save: new RollConfigField({ ability: false }, { labelFormatterPrefix: "DND5E.ABILITY.Formatter.Save." })
+        bonuses: new SchemaField({}, { label: "DND5E.AbilityBonuses", persisted: false }),
+        check: new RollConfigField({ ability: false }, {
+          labelPrefix: "DND5E.ABILITY.FIELDS.abilities.element.check.roll.",
+          labelFormatterPrefix: "DND5E.ABILITY.Formatter.Check."
+        }),
+        save: new RollConfigField({ ability: false }, {
+          labelPrefix: "DND5E.ABILITY.FIELDS.abilities.element.save.roll.",
+          labelFormatterPrefix: "DND5E.ABILITY.Formatter.Save."
+        })
       }), {
         initialKeys: CONFIG.DND5E.abilities, initialValue: this._initialAbilityValue.bind(this),
         initialKeysOnly: true, label: "DND5E.Abilities", entryLabel: key => CONFIG.DND5E.abilities[key]?.label
@@ -61,6 +60,51 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
       conditions: new MappingField(new NumberField({ integer: true, min: 1 }), { persisted: false })
     });
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Migrated paths for various bonuses.
+   * @type {Array}
+   */
+  static #BONUS_FIELD_PATHS = [
+    ["attributes.concentration.bonuses.save", "attributes.concentration.roll.bonus"],
+    ["attributes.death.bonuses.save", "attributes.death.roll.bonus"],
+    ["attributes.init.bonus", "attributes.init.roll.bonus"],
+    ["bonuses.mwak.attack", "roll.attack.mwak.bonus"],
+    ["bonuses.mwak.damage", "roll.damage.mwak.bonus"],
+    ["bonuses.rwak.attack", "roll.attack.rwak.bonus"],
+    ["bonuses.rwak.damage", "roll.damage.rwak.bonus"],
+    ["bonuses.msak.attack", "roll.attack.msak.bonus"],
+    ["bonuses.msak.damage", "roll.damage.msak.bonus"],
+    ["bonuses.rsak.attack", "roll.attack.rsak.bonus"],
+    ["bonuses.rsak.damage", "roll.damage.rsak.bonus"],
+    ["bonuses.abilities.check", "roll.ability.check.bonus"],
+    ["bonuses.abilities.save", "roll.ability.save.bonus"],
+    ["bonuses.abilities.skill", "roll.ability.skill.bonus"]
+  ];
+
+  /* -------------------------------------------- */
+
+  /**
+   * Migrated paths for abilities.
+   * @type {Array}
+   */
+  static #ABILITY_BONUS_FIELD_PATHS = [
+    ["bonuses.check", "check.roll.bonus"],
+    ["bonuses.save", "save.roll.bonus"]
+  ];
+
+  /* -------------------------------------------- */
+
+  /**
+   * Migrated paths for skills & tools.
+   * @type {Array}
+   */
+  static #SKILL_TOOL_BONUS_FIELD_PATHS = [
+    ["bonuses.check", "check.roll.bonus"],
+    ["bonuses.save", "save.roll.bonus"]
+  ];
 
   /* -------------------------------------------- */
 
@@ -90,6 +134,7 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
   static _migrateData(source) {
     super._migrateData(source);
     CommonTemplate.#migrateACData(source);
+    CommonTemplate.#migrateBonusData(source);
     CommonTemplate.#migrateMovementData(source);
     return source;
   }
@@ -120,6 +165,32 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
   /* -------------------------------------------- */
 
   /**
+   * Migrate roll bonus data from `bonuses` to `roll` as well as various other bonuses into roll fields.
+   * @param {object} source       The candidate source data from which the model will be constructed.
+   * @param {string[][]} [paths]  Field re-mappings.
+   */
+  static #migrateBonusData(source, paths) {
+    for ( const [original, updated] of paths ?? CommonTemplate.#BONUS_FIELD_PATHS ) {
+      if ( foundry.utils.hasProperty(source, updated) ) continue;
+      const value = foundry.utils.getProperty(source, original);
+      if ( !value ) continue;
+      foundry.utils.setProperty(source, updated, value);
+    }
+    if ( paths ) return;
+    for ( const value of Object.values(source.abilities ?? {}) ) {
+      CommonTemplate.#migrateBonusData(value, CommonTemplate.#ABILITY_BONUS_FIELD_PATHS)
+    }
+    for ( const value of Object.values(source.skills ?? {}) ) {
+      CommonTemplate.#migrateBonusData(value, CommonTemplate.#SKILL_TOOL_BONUS_FIELD_PATHS)
+    }
+    for ( const value of Object.values(source.tools ?? {}) ) {
+      CommonTemplate.#migrateBonusData(value, CommonTemplate.#SKILL_TOOL_BONUS_FIELD_PATHS)
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Migrate the actor speed string to movement object.
    * @param {object} source  The candidate source data from which the model will be constructed.
    */
@@ -131,6 +202,44 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
     source.attributes.movement.speeds ??= {};
     const s = original.split(" ");
     if ( s.length > 0 ) source.attributes.movement.speeds.walk = Number.isNumeric(s[0]) ? parseInt(s[0]) : 0;
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Shims                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Apply shims for the old bonus locations.
+   * @param {object} [data]       Base data model to shim.
+   * @param {string[][]} [paths]  Field re-mappings.
+   * @param {string} [prefix]     Path prefix for the deprecation warnings.
+   */
+  shimBonusData(data=this, paths=null, prefix="") {
+    for ( const [original, updated] of paths ?? CommonTemplate.#BONUS_FIELD_PATHS ) {
+      const parts = original.split(".");
+      const key = parts.pop();
+      const objectPath = parts.join(".");
+      const container = foundry.utils.getProperty(data, objectPath);
+      if ( !container ) continue;
+      Object.defineProperty(container, key, {
+        get: () => {
+          foundry.utils.logCompatibilityWarning(`${prefix}${original} has moved to "${prefix}${updated}".`, {
+            since: "DnD5e 6.0", until: "DnD5e 7.0", once: true
+          });
+          return foundry.utils.getProperty(data, updated) ?? "";
+        }
+      });
+    }
+    if ( paths ) return;
+    for ( const [key, value] of Object.entries(this.abilities ?? {}) ) {
+      this.shimBonusData(value, CommonTemplate.#ABILITY_BONUS_FIELD_PATHS, `abilities.${key}.`);
+    }
+    for ( const [key, value] of Object.entries(this.skills ?? {}) ) {
+      this.shimBonusData(value, CommonTemplate.#SKILL_TOOL_BONUS_FIELD_PATHS, `skills.${key}.`);
+    }
+    for ( const [key, value] of Object.entries(this.tools ?? {}) ) {
+      this.shimBonusData(value, CommonTemplate.#SKILL_TOOL_BONUS_FIELD_PATHS, `tools.${key}.`);
+    }
   }
 
   /* -------------------------------------------- */
@@ -167,13 +276,13 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
       rollData = { ...rollData };
       rollData.roll = { ability: id, proficient: abl.checkProf.multiplier >= 1, type: "ability" };
 
-      const checkBonusAbl = simplifyBonus(abl.bonuses?.check, rollData);
+      const checkBonusAbl = simplifyBonus(abl.check?.roll?.bonus, rollData);
       const checkBonusRules = simplifyBonus(
         AppliedRules.collect("check:bonus", this.parent).filterWith(rollData).toFormula(), rollData
       );
       abl.checkBonus = checkBonusAbl + checkBonusRules + checkBonus;
 
-      const saveBonusAbl = simplifyBonus(abl.bonuses?.save, rollData);
+      const saveBonusAbl = simplifyBonus(abl.save?.roll?.bonus, rollData);
       const cover = id === "dex" ? Math.max(ac?.cover ?? 0, this.parent.coverBonus) : 0;
       rollData.roll.proficient = abl.saveProf.multiplier >= 1;
       const saveBonusRules = simplifyBonus(

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -52,8 +52,8 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
             required: true, label: "DND5E.SaveBonus", labelFormatter: "DND5E.ABILITY.Formatter.Save.Bonus"
           })
         }, { label: "DND5E.AbilityBonuses" }),
-        check: new RollConfigField({ ability: false, labelFormatterPrefix: "DND5E.ABILITY.Formatter.Check." }),
-        save: new RollConfigField({ ability: false, labelFormatterPrefix: "DND5E.ABILITY.Formatter.Save." })
+        check: new RollConfigField({ ability: false }, { labelFormatterPrefix: "DND5E.ABILITY.Formatter.Check." }),
+        save: new RollConfigField({ ability: false }, { labelFormatterPrefix: "DND5E.ABILITY.Formatter.Save." })
       }), {
         initialKeys: CONFIG.DND5E.abilities, initialValue: this._initialAbilityValue.bind(this),
         initialKeysOnly: true, label: "DND5E.Abilities", entryLabel: key => CONFIG.DND5E.abilities[key]?.label
@@ -147,11 +147,12 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
     const flags = this.parent.flags.dnd5e ?? {};
     const { prof = 0, ac } = this.attributes ?? {};
     Object.values(this.abilities).forEach(a => a.mod = Math.floor((a.value - 10) / 2));
-    const checkBonus = simplifyBonus(this.bonuses?.abilities?.check, rollData);
-    const saveBonus = simplifyBonus(this.bonuses?.abilities?.save, rollData);
+    const checkBonus = simplifyBonus(this.roll?.ability?.check?.bonus, rollData);
+    const saveBonus = simplifyBonus(this.roll?.ability?.save?.bonus, rollData);
     const dcBonus = simplifyBonus(this.bonuses?.spell?.dc, rollData);
     for ( const [id, abl] of Object.entries(this.abilities) ) {
       if ( flags.diamondSoul ) abl.proficient = 1;  // Diamond Soul is proficient in all saves
+      abl.proficient = Math.max(abl.proficient, this.roll?.ability?.save?.proficiency ?? -Infinity);
       const originalAbility = originalSaves?.[id];
       if ( originalAbility?.proficient ) {
         abl.merged = true;
@@ -220,6 +221,8 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
    */
   calculateAbilityCheckProficiency(multiplier, ability, options={}) {
     let roundDown = true;
+    multiplier = Math.max(multiplier, this.roll?.ability?.check?.proficiency ?? -Infinity);
+    if ( options.skill ) multiplier = Math.max(multiplier, this.roll?.ability?.skill?.proficiency ?? -Infinity);
     if ( (multiplier < 1) && ((dnd5e.settings.rulesVersion === "legacy") || options.skill) ) {
       if ( this.parent._isRemarkableAthlete(ability) ) {
         multiplier = .5;
@@ -242,6 +245,7 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
    * @returns {Proficiency}
    */
   calculateToolProficiency(multiplier, ability, options={}) {
+    multiplier = Math.max(multiplier, this.roll?.ability?.tool?.proficiency ?? -Infinity);
     if ( (multiplier === 1) && this.parent.flags.dnd5e?.toolExpertise ) {
       return new Proficiency(this.attributes.prof, 2, true);
     }

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -71,17 +71,17 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
     ["attributes.concentration.bonuses.save", "attributes.concentration.roll.bonus"],
     ["attributes.death.bonuses.save", "attributes.death.roll.bonus"],
     ["attributes.init.bonus", "attributes.init.roll.bonus"],
-    ["bonuses.mwak.attack", "roll.attack.mwak.bonus"],
-    ["bonuses.mwak.damage", "roll.damage.mwak.bonus"],
-    ["bonuses.rwak.attack", "roll.attack.rwak.bonus"],
-    ["bonuses.rwak.damage", "roll.damage.rwak.bonus"],
-    ["bonuses.msak.attack", "roll.attack.msak.bonus"],
-    ["bonuses.msak.damage", "roll.damage.msak.bonus"],
-    ["bonuses.rsak.attack", "roll.attack.rsak.bonus"],
-    ["bonuses.rsak.damage", "roll.damage.rsak.bonus"],
-    ["bonuses.abilities.check", "roll.ability.check.bonus"],
-    ["bonuses.abilities.save", "roll.ability.save.bonus"],
-    ["bonuses.abilities.skill", "roll.ability.skill.bonus"]
+    ["bonuses.mwak.attack", "rolls.attack.mwak.bonus"],
+    ["bonuses.mwak.damage", "rolls.damage.mwak.bonus"],
+    ["bonuses.rwak.attack", "rolls.attack.rwak.bonus"],
+    ["bonuses.rwak.damage", "rolls.damage.rwak.bonus"],
+    ["bonuses.msak.attack", "rolls.attack.msak.bonus"],
+    ["bonuses.msak.damage", "rolls.damage.msak.bonus"],
+    ["bonuses.rsak.attack", "rolls.attack.rsak.bonus"],
+    ["bonuses.rsak.damage", "rolls.damage.rsak.bonus"],
+    ["bonuses.abilities.check", "rolls.ability.check.bonus"],
+    ["bonuses.abilities.save", "rolls.ability.save.bonus"],
+    ["bonuses.abilities.skill", "rolls.ability.skill.bonus"]
   ];
 
   /* -------------------------------------------- */
@@ -102,8 +102,7 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
    * @type {Array}
    */
   static #SKILL_TOOL_BONUS_FIELD_PATHS = [
-    ["bonuses.check", "check.roll.bonus"],
-    ["bonuses.save", "save.roll.bonus"]
+    ["bonuses.check", "check.roll.bonus"]
   ];
 
   /* -------------------------------------------- */

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -4,6 +4,8 @@ import { simplifyBonus } from "../../../utils.mjs";
 import AdvantageModeField from "../../fields/advantage-mode-field.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 import MappingField from "../../fields/mapping-field.mjs";
+import D20RollModificationField from "../../shared/d20-roll-modification-field.mjs";
+import DamageRollModificationField from "../../shared/damage-roll-modification-field.mjs";
 import RollConfigField from "../../shared/roll-config-field.mjs";
 import SensesField from "../../shared/senses-field.mjs";
 import CommonTemplate from "./common.mjs";
@@ -41,6 +43,39 @@ export default class CreatureTemplate extends CommonTemplate {
         }),
         spell: new SchemaField({
           dc: new FormulaField({ required: true, deterministic: true })
+        })
+      }),
+      rolls: new SchemaField({
+        ability: new SchemaField({
+          check: new D20RollModificationField(),
+          save: new D20RollModificationField(),
+          skill: new D20RollModificationField()
+        }),
+        attack: new D20RollModificationField({
+          melee: new D20RollModificationField(),
+          ranged: new D20RollModificationField(),
+          spell: new D20RollModificationField({
+            melee: new D20RollModificationField(),
+            ranged: new D20RollModificationField()
+          }),
+          weapon: new D20RollModificationField({
+            melee: new D20RollModificationField(),
+            ranged: new D20RollModificationField()
+          })
+        }),
+        damage: new DamageRollModificationField({
+          attack: new DamageRollModificationField({
+            melee: new DamageRollModificationField(),
+            ranged: new DamageRollModificationField(),
+            spell: new DamageRollModificationField({
+              melee: new DamageRollModificationField(),
+              ranged: new DamageRollModificationField()
+            }),
+            weapon: new DamageRollModificationField({
+              melee: new DamageRollModificationField(),
+              ranged: new DamageRollModificationField()
+            })
+          })
         })
       }),
       skills: new MappingField(new RollConfigField({

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -197,7 +197,8 @@ export default class CreatureTemplate extends CommonTemplate {
   static #migrateBonusData(source) {
     if ( !source.bonuses ) return;
     for ( const [original, updated] of CreatureTemplate.#BONUS_FIELD_PATHS ) {
-      const value = foundry.utils.getProperty(source.bonuses, original)
+      if ( foundry.utils.hasProperty(source.rolls, updated) ) continue;
+      const value = foundry.utils.getProperty(source.bonuses, original);
       if ( !value ) continue;
       source.rolls ??= {};
       foundry.utils.setProperty(source.rolls, updated, value);
@@ -275,7 +276,7 @@ export default class CreatureTemplate extends CommonTemplate {
       const [category, key] = original.split(".");
       this.bonuses[category] ??= {};
       Object.defineProperty(this.bonuses[category], key, {
-        get() {
+        get: () => {
           foundry.utils.logCompatibilityWarning(`bonuses.${original} has moved to "rolls.${updated}".`, {
             since: "DnD5e 6.0", until: "DnD5e 7.0", once: true
           });

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -14,7 +14,7 @@ const { NumberField, SchemaField } = foundry.data.fields;
 
 /**
  * @import { ActorRollData } from "../../../documents/_types.mjs";
- * @import { AttackBonusesData, CreatureTemplateData, SkillData } from "./_types.mjs";
+ * @import { CreatureTemplateData, SkillData } from "./_types.mjs";
  */
 
 /**
@@ -32,51 +32,49 @@ export default class CreatureTemplate extends CommonTemplate {
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
       bonuses: new SchemaField({
-        mwak: makeAttackBonuses(),
-        rwak: makeAttackBonuses(),
-        msak: makeAttackBonuses(),
-        rsak: makeAttackBonuses(),
-        abilities: new SchemaField({
-          check: new FormulaField({ required: true }),
-          save: new FormulaField({ required: true }),
-          skill: new FormulaField({ required: true })
-        }),
         spell: new SchemaField({
           dc: new FormulaField({ required: true, deterministic: true })
         })
       }),
-      rolls: new SchemaField({
+      roll: new SchemaField({
         ability: new SchemaField({
-          check: new D20RollModificationField(),
-          save: new D20RollModificationField(),
-          skill: new D20RollModificationField()
-        }),
-        attack: new D20RollModificationField({
-          melee: new D20RollModificationField(),
-          ranged: new D20RollModificationField(),
-          spell: new D20RollModificationField({
-            melee: new D20RollModificationField(),
-            ranged: new D20RollModificationField()
-          }),
-          weapon: new D20RollModificationField({
-            melee: new D20RollModificationField(),
-            ranged: new D20RollModificationField()
-          })
-        }),
-        damage: new DamageRollModificationField({
-          attack: new DamageRollModificationField({
-            melee: new DamageRollModificationField(),
-            ranged: new DamageRollModificationField(),
-            spell: new DamageRollModificationField({
-              melee: new DamageRollModificationField(),
-              ranged: new DamageRollModificationField()
-            }),
-            weapon: new DamageRollModificationField({
-              melee: new DamageRollModificationField(),
-              ranged: new DamageRollModificationField()
+          check: new D20RollModificationField({
+            proficiency: new NumberField({
+              choices: [0, 0.5, 1, 2], initial: 0, persisted: false,
+              label: "DND5E.ROLL.FIELDS.ability.check.proficiency.label"
             })
-          })
-        })
+          }, { labelPrefix: "DND5E.ROLL.FIELDS.ability.check." }),
+          save: new D20RollModificationField({
+            proficiency: new NumberField({
+              choices: [0, 1], initial: 0, persisted: false,
+              label: "DND5E.ROLL.FIELDS.ability.save.proficiency.label"
+            })
+          }, { labelPrefix: "DND5E.ROLL.FIELDS.ability.save." }),
+          skill: new D20RollModificationField({
+            proficiency: new NumberField({
+              choices: [0, 0.5, 1, 2], initial: 0, persisted: false,
+              label: "DND5E.ROLL.FIELDS.ability.skill.proficiency.label"
+            })
+          }, { labelPrefix: "DND5E.ROLL.FIELDS.ability.skill." }),
+          tool: new D20RollModificationField({
+            proficiency: new NumberField({
+              choices: [0, 0.5, 1, 2], initial: 0, persisted: false,
+              label: "DND5E.ROLL.FIELDS.ability.tool.proficiency.label"
+            })
+          }, { labelPrefix: "DND5E.ROLL.FIELDS.ability.tool." })
+        }, { required: false }),
+        attack: new D20RollModificationField({
+          msak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.attack.msak." }),
+          mwak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.attack.mwak." }),
+          rsak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.attack.rsak." }),
+          rwak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.attack.rwak." })
+        }, { labelPrefix: "DND5E.ROLL.FIELDS.attack." }),
+        damage: new SchemaField({
+          msak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.damage.msak." }),
+          mwak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.damage.mwak." }),
+          rsak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.damage.rsak." }),
+          rwak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.damage.rwak." })
+        }, { required: false })
       }),
       skills: new MappingField(new RollConfigField({
         value: new NumberField({
@@ -118,6 +116,26 @@ export default class CreatureTemplate extends CommonTemplate {
       }), { initialKeys: this._spellLevels, label: "DND5E.SpellLevels" })
     });
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Migrated paths from `bonuses` to `roll`.
+   * @type {Array}
+   */
+  static #BONUS_FIELD_PATHS = [
+    ["mwak.attack", "attack.mwak.bonus"],
+    ["mwak.damage", "damage.mwak.bonus"],
+    ["rwak.attack", "attack.rwak.bonus"],
+    ["rwak.damage", "damage.rwak.bonus"],
+    ["msak.attack", "attack.msak.bonus"],
+    ["msak.damage", "damage.msak.bonus"],
+    ["rsak.attack", "attack.rsak.bonus"],
+    ["rsak.damage", "damage.rsak.bonus"],
+    ["abilities.check", "ability.check.bonus"],
+    ["abilities.save", "ability.save.bonus"],
+    ["abilities.skill", "ability.skill.bonus"]
+  ];
 
   /* -------------------------------------------- */
 
@@ -164,9 +182,26 @@ export default class CreatureTemplate extends CommonTemplate {
   /** @inheritDoc */
   static _migrateData(source) {
     super._migrateData(source);
+    CreatureTemplate.#migrateBonusData(source);
     CreatureTemplate.#migrateSensesData(source);
     CreatureTemplate.#migrateToolData(source);
     return source;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Migrate roll bonus data from `bonuses` to `roll`.
+   * @param {object} source  The candidate source data from which the model will be constructed.
+   */
+  static #migrateBonusData(source) {
+    if ( !source.bonuses ) return;
+    for ( const [original, updated] of CreatureTemplate.#BONUS_FIELD_PATHS ) {
+      const value = foundry.utils.getProperty(source.bonuses, original)
+      if ( !value ) continue;
+      source.roll ??= {};
+      foundry.utils.setProperty(source.roll, updated, value);
+    }
   }
 
   /* -------------------------------------------- */
@@ -228,6 +263,29 @@ export default class CreatureTemplate extends CommonTemplate {
   }
 
   /* -------------------------------------------- */
+  /*  Data Shims                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Apply shims for the old bonus locations.
+   */
+  shimBonusData() {
+    this.bonuses ??= {};
+    for ( const [original, updated] of CreatureTemplate.#BONUS_FIELD_PATHS ) {
+      const [category, key] = original.split(".");
+      this.bonuses[category] ??= {};
+      Object.defineProperty(this.bonuses[category], key, {
+        get() {
+          foundry.utils.logCompatibilityWarning(`bonuses.${original} has moved to "roll.${updated}".`, {
+            since: "DnD5e 6.0", until: "DnD5e 7.0", once: true
+          });
+          return foundry.utils.getProperty(this.roll, updated) ?? "";
+        }
+      });
+    }
+  }
+
+  /* -------------------------------------------- */
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 
@@ -238,9 +296,9 @@ export default class CreatureTemplate extends CommonTemplate {
    * @param {object} [options.originalSkills]      Original skills data for transformed actors.
    */
   prepareSkills({ rollData={}, originalSkills }={}) {
-    const globalBonuses = this.bonuses.abilities;
-    const globalCheckBonus = simplifyBonus(globalBonuses.check, rollData);
-    const globalSkillBonus = simplifyBonus(globalBonuses.skill, rollData);
+    const globalBonuses = this.roll.ability;
+    const globalCheckBonus = simplifyBonus(globalBonuses?.check?.bonus, rollData);
+    const globalSkillBonus = simplifyBonus(globalBonuses?.skill?.bonus, rollData);
     for ( const [id, skillData] of Object.entries(this.skills) ) {
       this.prepareSkill(id, { skillData, rollData, originalSkills, globalBonuses, globalCheckBonus, globalSkillBonus });
     }
@@ -278,9 +336,9 @@ export default class CreatureTemplate extends CommonTemplate {
     skillData ??= foundry.utils.deepClone(this.skills[skillId]);
     rollData ??= this.parent.getRollData();
     originalSkills ??= flags.originalActor ? game.actors?.get(flags.originalActor)?.system?.skills : null;
-    globalBonuses ??= this.bonuses.abilities ?? {};
-    globalCheckBonus ??= simplifyBonus(globalBonuses.check, rollData);
-    globalSkillBonus ??= simplifyBonus(globalBonuses.skill, rollData);
+    globalBonuses ??= this.roll.ability ?? {};
+    globalCheckBonus ??= simplifyBonus(globalBonuses.check?.bonus, rollData);
+    globalSkillBonus ??= simplifyBonus(globalBonuses.skill?.bonus, rollData);
     ability ??= skillData.ability;
     const abilityData = this.abilities[ability];
     skillData.ability = ability;
@@ -332,7 +390,8 @@ export default class CreatureTemplate extends CommonTemplate {
     const passive = flags.observantFeat && CONFIG.DND5E.characterFlags.observantFeat.skills.includes(skillId) ? 5 : 0;
     const passiveBonus = simplifyBonus(skillData.bonuses?.passive, rollData);
     const advantageMode = AdvantageModeField.combineFields(this, [
-      `abilities.${ability}.check.roll.mode`, `skills.${skillId}.roll.mode`
+      `abilities.${ability}.check.roll.mode`, `skills.${skillId}.roll.mode`,
+      "roll.ability.check.mode", "roll.ability.skill.mode"
     ], AppliedRules.collect("check:advantage", this.parent).filterWith(rollData).toAdvantageCounts())?.mode ?? 0;
     skillData.passive = CONFIG.DND5E.skillPassive.base + skillData.mod + skillData.bonus + skillData.prof.flat
       + passive + passiveBonus + (advantageMode * CONFIG.DND5E.skillPassive.modifier);
@@ -348,7 +407,8 @@ export default class CreatureTemplate extends CommonTemplate {
    * @param {ActorRollData} [options.rollData={}]  Roll data used to calculate bonuses.
    */
   prepareTools({ rollData={} }={}) {
-    const globalCheckBonus = simplifyBonus(this.bonuses.abilities.check, rollData);
+    const globalCheckBonus = simplifyBonus(this.roll.ability?.check?.bonus, rollData);
+    const globalToolBonus = simplifyBonus(this.roll.ability?.tool?.bonus, rollData);
     for ( const [id, tool] of Object.entries(this.tools) ) {
       const ability = this.abilities[tool.ability];
       tool.prof = this.calculateToolProficiency(tool.value, tool.ability);
@@ -363,8 +423,8 @@ export default class CreatureTemplate extends CommonTemplate {
         AppliedRules.collect("check:bonus", this.parent).filterWith(rollData).toFormula(), rollData
       );
       tool.effectValue = tool.value;
+      tool.bonus = baseBonus + globalCheckBonus + globalToolBonus + checkBonusAbl + ruleBonus;
       tool.mod = ability?.mod ?? 0;
-      tool.bonus = baseBonus + globalCheckBonus + checkBonusAbl + ruleBonus;
       tool.total = tool.mod + tool.bonus;
       if ( Number.isNumeric(tool.prof.term) ) tool.total += tool.prof.flat;
       tool.value = tool.prof.multiplier;
@@ -390,18 +450,4 @@ export default class CreatureTemplate extends CommonTemplate {
     }
     return data;
   }
-}
-
-/* -------------------------------------------- */
-
-/**
- * Produce the schema field for a simple trait.
- * @param {object} schemaOptions  Options passed to the outer schema.
- * @returns {AttackBonusesData}
- */
-function makeAttackBonuses(schemaOptions={}) {
-  return new SchemaField({
-    attack: new FormulaField({required: true}),
-    damage: new FormulaField({required: true})
-  }, schemaOptions);
 }

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -253,7 +253,7 @@ export default class CreatureTemplate extends CommonTemplate {
    *                                             If undefined, the skills of the actor identified by
    *                                             `this.flags.dnd5e.originalActor` are used.
    * @param {object} [options.globalBonuses]     Global ability bonuses for this actor.
-   *                                             If undefined, `this.system.bonuses.abilities` is used.
+   *                                             If undefined, `this.system.rolls.ability` is used.
    * @param {number} [options.globalCheckBonus]  Global check bonus for this actor.
    *                                             If undefined, `globalBonuses.check` will be evaluated using `rollData`.
    * @param {number} [options.globalSkillBonus]  Global skill bonus for this actor.

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -77,35 +77,30 @@ export default class CreatureTemplate extends CommonTemplate {
         }, { required: false })
       }),
       skills: new MappingField(new RollConfigField({
-        value: new NumberField({
-          required: true, nullable: false, min: 0, max: 2, step: 0.5, initial: 0, label: "DND5E.ProficiencyLevel",
-          labelFormatter: "DND5E.SKILL.Formatter.Proficiency"
-        }),
         ability: "dex",
         bonuses: new SchemaField({
-          check: new FormulaField({
-            required: true, label: "DND5E.SkillBonusCheck", labelFormatter: "DND5E.SKILL.Formatter.CheckBonus"
-          }),
           passive: new FormulaField({
             required: true, label: "DND5E.SkillBonusPassive", labelFormatter: "DND5E.SKILL.Formatter.PassiveBonus"
           })
-        }, { label: "DND5E.SkillBonuses" })
-      }), {
+        }, { label: "DND5E.SkillBonuses" }),
+        value: new NumberField({
+          required: true, nullable: false, min: 0, max: 2, step: 0.5, initial: 0, label: "DND5E.ProficiencyLevel",
+          labelFormatter: "DND5E.SKILL.Formatter.Proficiency"
+        })
+      }, { labelPrefix: "DND5E.SKILL.FIELDS.skills.element.roll." }), {
         initialKeys: CONFIG.DND5E.skills, initialValue: this._initialSkillValue,
         initialKeysOnly: true, label: "DND5E.Skills", entryLabel: key => CONFIG.DND5E.skills[key]?.label
       }),
       tools: new MappingField(new RollConfigField({
+        ability: "int",
+        bonuses: new SchemaField({}, { persisted: false }),
         value: new NumberField({
           required: true, nullable: false, min: 0, max: 2, step: 0.5, initial: 0, label: "DND5E.ProficiencyLevel",
           labelFormatter: "DND5E.TOOL.Formatter.Proficiency"
-        }),
-        ability: "int",
-        bonuses: new SchemaField({
-          check: new FormulaField({
-            required: true, label: "DND5E.CheckBonus", labelFormatter: "DND5E.TOOL.Formatter.CheckBonus"
-          })
-        }, { label: "DND5E.ToolBonuses" })
-      }), { entryLabel: key => Trait.keyLabel(key, { trait: "tool" }) }),
+        })
+      }, { labelPrefix: "DND5E.TOOL.FIELDS.tools.element.roll." }), {
+        entryLabel: key => Trait.keyLabel(key, { trait: "tool" })
+      }),
       spells: new MappingField(new SchemaField({
         value: new NumberField({
           nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.SpellProgAvailable"
@@ -116,26 +111,6 @@ export default class CreatureTemplate extends CommonTemplate {
       }), { initialKeys: this._spellLevels, label: "DND5E.SpellLevels" })
     });
   }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Migrated paths from `bonuses` to `roll`.
-   * @type {Array}
-   */
-  static #BONUS_FIELD_PATHS = [
-    ["mwak.attack", "attack.mwak.bonus"],
-    ["mwak.damage", "damage.mwak.bonus"],
-    ["rwak.attack", "attack.rwak.bonus"],
-    ["rwak.damage", "damage.rwak.bonus"],
-    ["msak.attack", "attack.msak.bonus"],
-    ["msak.damage", "damage.msak.bonus"],
-    ["rsak.attack", "attack.rsak.bonus"],
-    ["rsak.damage", "damage.rsak.bonus"],
-    ["abilities.check", "ability.check.bonus"],
-    ["abilities.save", "ability.save.bonus"],
-    ["abilities.skill", "ability.skill.bonus"]
-  ];
 
   /* -------------------------------------------- */
 
@@ -182,27 +157,9 @@ export default class CreatureTemplate extends CommonTemplate {
   /** @inheritDoc */
   static _migrateData(source) {
     super._migrateData(source);
-    CreatureTemplate.#migrateBonusData(source);
     CreatureTemplate.#migrateSensesData(source);
     CreatureTemplate.#migrateToolData(source);
     return source;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Migrate roll bonus data from `bonuses` to `roll`.
-   * @param {object} source  The candidate source data from which the model will be constructed.
-   */
-  static #migrateBonusData(source) {
-    if ( !source.bonuses ) return;
-    for ( const [original, updated] of CreatureTemplate.#BONUS_FIELD_PATHS ) {
-      if ( foundry.utils.hasProperty(source.rolls, updated) ) continue;
-      const value = foundry.utils.getProperty(source.bonuses, original);
-      if ( !value ) continue;
-      source.rolls ??= {};
-      foundry.utils.setProperty(source.rolls, updated, value);
-    }
   }
 
   /* -------------------------------------------- */
@@ -260,29 +217,6 @@ export default class CreatureTemplate extends CommonTemplate {
         ability: "int",
         bonuses: {check: ""}
       };
-    }
-  }
-
-  /* -------------------------------------------- */
-  /*  Data Shims                                  */
-  /* -------------------------------------------- */
-
-  /**
-   * Apply shims for the old bonus locations.
-   */
-  shimBonusData() {
-    this.bonuses ??= {};
-    for ( const [original, updated] of CreatureTemplate.#BONUS_FIELD_PATHS ) {
-      const [category, key] = original.split(".");
-      this.bonuses[category] ??= {};
-      Object.defineProperty(this.bonuses[category], key, {
-        get: () => {
-          foundry.utils.logCompatibilityWarning(`bonuses.${original} has moved to "rolls.${updated}".`, {
-            since: "DnD5e 6.0", until: "DnD5e 7.0", once: true
-          });
-          return foundry.utils.getProperty(this.rolls, updated) ?? "";
-        }
-      });
     }
   }
 
@@ -361,9 +295,9 @@ export default class CreatureTemplate extends CommonTemplate {
     rollData.roll = { ability, proficient: skillData.prof.multiplier >= 1, skill: skillId, type: "skill" };
 
     // Compute modifier
-    const checkBonusAbl = simplifyBonus(abilityData?.bonuses?.check, rollData);
+    const checkBonusAbl = simplifyBonus(abilityData?.check?.roll?.bonus, rollData);
     skillData.effectValue = skillData.value;
-    const baseBonus = simplifyBonus(skillData.bonuses?.check, rollData);
+    const baseBonus = simplifyBonus(skillData.roll?.bonus, rollData);
     const ruleBonus = simplifyBonus(
       AppliedRules.collect("check:bonus", this.parent).filterWith(rollData).toFormula(), rollData
     );
@@ -376,7 +310,7 @@ export default class CreatureTemplate extends CommonTemplate {
     // If we merged skills when transforming, take the highest bonus
     const difference = (originalSkill?.total ?? 0) - skillData.total;
     if ( originalSkill && (difference > 0) ) {
-      skillData.bonuses.check = `${skillData.bonuses.check ?? ""} + ${difference}`;
+      skillData.roll.bonus = `${skillData.roll.bonus ?? ""} + ${difference}`;
       skillData.bonus += difference;
       skillData.total += difference;
     }
@@ -418,8 +352,8 @@ export default class CreatureTemplate extends CommonTemplate {
       rollData = { ...rollData };
       rollData.roll = { ability: tool.ability, proficient: tool.prof.multiplier >= 1, tool: id, type: "tool" };
 
-      const baseBonus = simplifyBonus(tool.bonuses.check, rollData);
-      const checkBonusAbl = simplifyBonus(ability?.bonuses?.check, rollData);
+      const baseBonus = simplifyBonus(tool.roll.bonus, rollData);
+      const checkBonusAbl = simplifyBonus(ability?.check?.roll?.bonus, rollData);
       const ruleBonus = simplifyBonus(
         AppliedRules.collect("check:bonus", this.parent).filterWith(rollData).toFormula(), rollData
       );

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -36,44 +36,44 @@ export default class CreatureTemplate extends CommonTemplate {
           dc: new FormulaField({ required: true, deterministic: true })
         })
       }),
-      roll: new SchemaField({
+      rolls: new SchemaField({
         ability: new SchemaField({
           check: new D20RollModificationField({
             proficiency: new NumberField({
               choices: [0, 0.5, 1, 2], initial: 0, persisted: false,
-              label: "DND5E.ROLL.FIELDS.ability.check.proficiency.label"
+              label: "DND5E.ROLL.FIELDS.rolls.ability.check.proficiency.label"
             })
-          }, { labelPrefix: "DND5E.ROLL.FIELDS.ability.check." }),
+          }, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.ability.check." }),
           save: new D20RollModificationField({
             proficiency: new NumberField({
               choices: [0, 1], initial: 0, persisted: false,
-              label: "DND5E.ROLL.FIELDS.ability.save.proficiency.label"
+              label: "DND5E.ROLL.FIELDS.rolls.ability.save.proficiency.label"
             })
-          }, { labelPrefix: "DND5E.ROLL.FIELDS.ability.save." }),
+          }, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.ability.save." }),
           skill: new D20RollModificationField({
             proficiency: new NumberField({
               choices: [0, 0.5, 1, 2], initial: 0, persisted: false,
-              label: "DND5E.ROLL.FIELDS.ability.skill.proficiency.label"
+              label: "DND5E.ROLL.FIELDS.rolls.ability.skill.proficiency.label"
             })
-          }, { labelPrefix: "DND5E.ROLL.FIELDS.ability.skill." }),
+          }, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.ability.skill." }),
           tool: new D20RollModificationField({
             proficiency: new NumberField({
               choices: [0, 0.5, 1, 2], initial: 0, persisted: false,
-              label: "DND5E.ROLL.FIELDS.ability.tool.proficiency.label"
+              label: "DND5E.ROLL.FIELDS.rolls.ability.tool.proficiency.label"
             })
-          }, { labelPrefix: "DND5E.ROLL.FIELDS.ability.tool." })
+          }, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.ability.tool." })
         }, { required: false }),
         attack: new D20RollModificationField({
-          msak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.attack.msak." }),
-          mwak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.attack.mwak." }),
-          rsak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.attack.rsak." }),
-          rwak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.attack.rwak." })
-        }, { labelPrefix: "DND5E.ROLL.FIELDS.attack." }),
+          msak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.attack.msak." }),
+          mwak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.attack.mwak." }),
+          rsak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.attack.rsak." }),
+          rwak: new D20RollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.attack.rwak." })
+        }, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.attack." }),
         damage: new SchemaField({
-          msak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.damage.msak." }),
-          mwak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.damage.mwak." }),
-          rsak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.damage.rsak." }),
-          rwak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.damage.rwak." })
+          msak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.damage.msak." }),
+          mwak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.damage.mwak." }),
+          rsak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.damage.rsak." }),
+          rwak: new DamageRollModificationField({}, { labelPrefix: "DND5E.ROLL.FIELDS.rolls.damage.rwak." })
         }, { required: false })
       }),
       skills: new MappingField(new RollConfigField({
@@ -199,8 +199,8 @@ export default class CreatureTemplate extends CommonTemplate {
     for ( const [original, updated] of CreatureTemplate.#BONUS_FIELD_PATHS ) {
       const value = foundry.utils.getProperty(source.bonuses, original)
       if ( !value ) continue;
-      source.roll ??= {};
-      foundry.utils.setProperty(source.roll, updated, value);
+      source.rolls ??= {};
+      foundry.utils.setProperty(source.rolls, updated, value);
     }
   }
 
@@ -276,10 +276,10 @@ export default class CreatureTemplate extends CommonTemplate {
       this.bonuses[category] ??= {};
       Object.defineProperty(this.bonuses[category], key, {
         get() {
-          foundry.utils.logCompatibilityWarning(`bonuses.${original} has moved to "roll.${updated}".`, {
+          foundry.utils.logCompatibilityWarning(`bonuses.${original} has moved to "rolls.${updated}".`, {
             since: "DnD5e 6.0", until: "DnD5e 7.0", once: true
           });
-          return foundry.utils.getProperty(this.roll, updated) ?? "";
+          return foundry.utils.getProperty(this.rolls, updated) ?? "";
         }
       });
     }
@@ -296,7 +296,7 @@ export default class CreatureTemplate extends CommonTemplate {
    * @param {object} [options.originalSkills]      Original skills data for transformed actors.
    */
   prepareSkills({ rollData={}, originalSkills }={}) {
-    const globalBonuses = this.roll.ability;
+    const globalBonuses = this.rolls.ability;
     const globalCheckBonus = simplifyBonus(globalBonuses?.check?.bonus, rollData);
     const globalSkillBonus = simplifyBonus(globalBonuses?.skill?.bonus, rollData);
     for ( const [id, skillData] of Object.entries(this.skills) ) {
@@ -336,7 +336,7 @@ export default class CreatureTemplate extends CommonTemplate {
     skillData ??= foundry.utils.deepClone(this.skills[skillId]);
     rollData ??= this.parent.getRollData();
     originalSkills ??= flags.originalActor ? game.actors?.get(flags.originalActor)?.system?.skills : null;
-    globalBonuses ??= this.roll.ability ?? {};
+    globalBonuses ??= this.rolls.ability ?? {};
     globalCheckBonus ??= simplifyBonus(globalBonuses.check?.bonus, rollData);
     globalSkillBonus ??= simplifyBonus(globalBonuses.skill?.bonus, rollData);
     ability ??= skillData.ability;
@@ -391,7 +391,7 @@ export default class CreatureTemplate extends CommonTemplate {
     const passiveBonus = simplifyBonus(skillData.bonuses?.passive, rollData);
     const advantageMode = AdvantageModeField.combineFields(this, [
       `abilities.${ability}.check.roll.mode`, `skills.${skillId}.roll.mode`,
-      "roll.ability.check.mode", "roll.ability.skill.mode"
+      "rolls.ability.check.mode", "rolls.ability.skill.mode"
     ], AppliedRules.collect("check:advantage", this.parent).filterWith(rollData).toAdvantageCounts())?.mode ?? 0;
     skillData.passive = CONFIG.DND5E.skillPassive.base + skillData.mod + skillData.bonus + skillData.prof.flat
       + passive + passiveBonus + (advantageMode * CONFIG.DND5E.skillPassive.modifier);
@@ -407,8 +407,8 @@ export default class CreatureTemplate extends CommonTemplate {
    * @param {ActorRollData} [options.rollData={}]  Roll data used to calculate bonuses.
    */
   prepareTools({ rollData={} }={}) {
-    const globalCheckBonus = simplifyBonus(this.roll.ability?.check?.bonus, rollData);
-    const globalToolBonus = simplifyBonus(this.roll.ability?.tool?.bonus, rollData);
+    const globalCheckBonus = simplifyBonus(this.rolls.ability?.check?.bonus, rollData);
+    const globalToolBonus = simplifyBonus(this.rolls.ability?.tool?.bonus, rollData);
     for ( const [id, tool] of Object.entries(this.tools) ) {
       const ability = this.abilities[tool.ability];
       tool.prof = this.calculateToolProficiency(tool.value, tool.ability);

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -268,6 +268,7 @@ export default class VehicleData extends CommonTemplate {
     AttributesFields.prepareBaseArmorClass.call(this);
     AttributesFields.prepareBaseEncumbrance.call(this);
     MovementField._shim(this.attributes.movement);
+    this.shimBonusData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/fields/spellcasting-field.mjs
+++ b/module/data/item/fields/spellcasting-field.mjs
@@ -53,9 +53,10 @@ export default class SpellcastingField extends SchemaField {
     const ability = actor.system.abilities?.[this.spellcasting.ability];
     const mod = ability?.mod ?? 0;
     const modProf = mod + (actor.system.attributes?.prof ?? 0);
-    const msak = simplifyBonus(actor.system.bonuses?.msak?.attack, rollData);
-    const rsak = simplifyBonus(actor.system.bonuses?.rsak?.attack, rollData);
-    this.spellcasting.attack = modProf + (msak === rsak ? msak : 0);
+    const attackBonus = simplifyBonus(actor.system.roll?.attack?.bonus, rollData);
+    const msakBonus = simplifyBonus(actor.system.roll?.attack?.msak?.bonus, rollData);
+    const rsakBonus = simplifyBonus(actor.system.roll?.attack?.rsak?.bonus, rollData);
+    this.spellcasting.attack = modProf + attackBonus + (msakBonus === rsakBonus ? msakBonus : 0);
     this.spellcasting.save = ability?.dc ?? (8 + modProf);
   }
 }

--- a/module/data/item/fields/spellcasting-field.mjs
+++ b/module/data/item/fields/spellcasting-field.mjs
@@ -53,9 +53,9 @@ export default class SpellcastingField extends SchemaField {
     const ability = actor.system.abilities?.[this.spellcasting.ability];
     const mod = ability?.mod ?? 0;
     const modProf = mod + (actor.system.attributes?.prof ?? 0);
-    const attackBonus = simplifyBonus(actor.system.roll?.attack?.bonus, rollData);
-    const msakBonus = simplifyBonus(actor.system.roll?.attack?.msak?.bonus, rollData);
-    const rsakBonus = simplifyBonus(actor.system.roll?.attack?.rsak?.bonus, rollData);
+    const attackBonus = simplifyBonus(actor.system.rolls?.attack?.bonus, rollData);
+    const msakBonus = simplifyBonus(actor.system.rolls?.attack?.msak?.bonus, rollData);
+    const rsakBonus = simplifyBonus(actor.system.rolls?.attack?.rsak?.bonus, rollData);
     this.spellcasting.attack = modProf + attackBonus + (msakBonus === rsakBonus ? msakBonus : 0);
     this.spellcasting.save = ability?.dc ?? (8 + modProf);
   }

--- a/module/data/shared/_module.mjs
+++ b/module/data/shared/_module.mjs
@@ -1,7 +1,9 @@
 export {default as ActivationField} from "./activation-field.mjs";
 export {default as CreatureTypeField} from "./creature-type-field.mjs";
 export {default as CurrencyTemplate} from "./currency.mjs";
+export {default as D20RollModificationField} from "./d20-roll-modification-field.mjs";
 export {default as DamageField, DamageData} from "./damage-field.mjs";
+export {default as DamageRollModificationField} from "./damage-roll-modification-field.mjs";
 export {default as DurationField} from "./duration-field.mjs";
 export {default as MovementField} from "./movement-field.mjs";
 export {default as RangeField} from "./range-field.mjs";

--- a/module/data/shared/_types.mjs
+++ b/module/data/shared/_types.mjs
@@ -93,6 +93,14 @@
  */
 
 /**
+ * @typedef RulesDetails
+ * @property {string} category    Category of rules to retrieve (e.g. "attack" or "check").
+ * @property {Actor5e} actor      Actor from which to fetch rules.
+ * @property {Item5e} [item]      Item from which to fetch rules.
+ * @property {RollData} rollData  Roll data with which to filter the rules.
+ */
+
+/**
  * @typedef SensesData
  * @property {Record<string, number} ranges  Ranges of various senses.
  * @property {string} units                  Distance units used to measure senses.

--- a/module/data/shared/_types.mjs
+++ b/module/data/shared/_types.mjs
@@ -23,6 +23,14 @@
  */
 
 /**
+ * @typedef D20RollModificationData
+ * @property {string} bonus  Bonus added to the roll.
+ * @property {number} min    Minimum number on the die rolled.
+ * @property {number} max    Maximum number on the die rolled.
+ * @property {number} mode   Should the roll be with disadvantage or advantage by default?
+ */
+
+/**
  * @typedef DamageData
  * @property {number} number           Number of dice to roll.
  * @property {number} denomination     Die denomination to roll.
@@ -43,6 +51,11 @@
  * @typedef DamageFormulaOptions
  * @property {Set<string>|false} modifiers  Additional modifiers to apply to the formula, if possible.
  *                                          A `false` value will remove modifiers provided by damage data.
+ */
+
+/**
+ * @typedef DamageRollModificationData
+ * @property {string} bonus  Bonus added to the roll.
  */
 
 /**

--- a/module/data/shared/_types.mjs
+++ b/module/data/shared/_types.mjs
@@ -85,11 +85,8 @@
 
 /**
  * @typedef RollConfigData
- * @property {string} [ability]  Default ability associated with this roll.
- * @property {object} roll
- * @property {number} roll.min   Minimum number on the die rolled.
- * @property {number} roll.max   Maximum number on the die rolled.
- * @property {number} roll.mode  Should the roll be with disadvantage or advantage by default?
+ * @property {string} ability    Default ability associated with this roll.
+ * @property {D20RollModificationData} roll
  */
 
 /**

--- a/module/data/shared/d20-roll-modification-field.mjs
+++ b/module/data/shared/d20-roll-modification-field.mjs
@@ -1,0 +1,26 @@
+import AdvantageModeField from "../fields/advantage-mode-field.mjs";
+import FormulaField from "../fields/formula-field.mjs";
+
+const { NumberField, SchemaField } = foundry.data.fields;
+
+/**
+ * Field for storing modifications on a roll.
+ */
+export default class D20RollModificationField extends SchemaField {
+  constructor(fields={}, options={}) {
+    const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
+    fields = {
+      bonus: new FormulaField({ label: "DND5E.ROLL.Bonus", labelFomatter: `${labelFormatterPrefix}Bonus` }),
+      min: new NumberField({
+        ...opts, label: "DND5E.ROLL.Range.Minimum", labelFormatter: `${labelFormatterPrefix}Minimum`
+      }),
+      max: new NumberField({
+        ...opts, label: "DND5E.ROLL.Range.Maximum", labelFormatter: `${labelFormatterPrefix}Maximum`
+      }),
+      mode: new AdvantageModeField({ labelFormatter: `${labelFormatterPrefix}AdvantageMode` }),
+      ...fields
+    };
+    Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);
+    super(fields, { required: false, ...options });
+  }
+}

--- a/module/data/shared/d20-roll-modification-field.mjs
+++ b/module/data/shared/d20-roll-modification-field.mjs
@@ -18,7 +18,7 @@ export default class D20RollModificationField extends SchemaField {
     const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
     fields = {
       bonus: new FormulaField({
-        label: `${labelPrefix}bonus.label`, labelFomatter: `${labelFormatterPrefix}Bonus`
+        label: `${labelPrefix}bonus.label`, labelFormatter: `${labelFormatterPrefix}Bonus`
       }),
       min: new NumberField({
         ...opts, label: `${labelPrefix}min.label`, labelFormatter: `${labelFormatterPrefix}Minimum`

--- a/module/data/shared/d20-roll-modification-field.mjs
+++ b/module/data/shared/d20-roll-modification-field.mjs
@@ -1,5 +1,10 @@
+import AppliedRules from "../../documents/applied-rules.mjs";
 import AdvantageModeField from "../fields/advantage-mode-field.mjs";
 import FormulaField from "../fields/formula-field.mjs";
+
+/**
+ * @import { RulesDetails } from "./_types.mjs";
+ */
 
 const { NumberField, SchemaField } = foundry.data.fields;
 
@@ -36,14 +41,13 @@ export default class D20RollModificationField extends SchemaField {
 
   /**
    * Combine data from multiple roll modification fields to produce final advantage and range values.
-   * @param {DataModel} model                 The model containing the fields.
-   * @param {string[]} keyPaths               Paths to the individual fields to combine within the model.
-   * @param {object} [options={}]
-   * @param {number} [options.advantages]     External sources of advantage.
-   * @param {number} [options.disadvantages]  External sources of disadvantage.
+   * @param {DataModel} model                          The model containing the fields.
+   * @param {string[]} keyPaths                        Paths to the individual fields to combine within the model.
+   * @param {Partial<AdvantageModeData>} [options={}]  External sources of advantage or disadvantage.
+   * @param {RulesDetails} [options.rules]             Data used to fetch rules.
    * @returns {{ advantage: boolean, disadvantage: boolean, maximum: number, minimum: number }}
    */
-  static combineFields(model, keyPaths, options={}) {
+  static combineFields(model, keyPaths, { rules={}, ...options }={}) {
     let maximum = Infinity;
     let minimum = -Infinity;
     for ( const kp of keyPaths ) {
@@ -52,8 +56,28 @@ export default class D20RollModificationField extends SchemaField {
       minimum = Math.max(minimum, data.min ?? -Infinity);
     }
     const { advantage, disadvantage } = AdvantageModeField.combineFields(
-      model, keyPaths.map(kp => `${kp}.mode`), options
+      model, keyPaths.map(kp => `${kp}.mode`), rules.actor
+        ? D20RollModificationField.#makeRulesIterator("advantage", rules).toAdvantageCounts(options) : options
     );
-    return { advantage, disadvantage, maximum, minimum };
+    return {
+      advantage, disadvantage,
+      maximum: rules.actor
+        ? D20RollModificationField.#makeRulesIterator("maximum", rules).resolve(rules.rollData).toSmallest(maximum)
+        : maximum,
+      minimum: rules.actor
+        ? D20RollModificationField.#makeRulesIterator("minimum", rules).resolve(rules.rollData).toLargest(minimum)
+        : minimum
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Helper to create a rules iterator from a category and the provided rules configuration.
+   * @param {string} type         Rules type to fetch (e.g. "advantage" or "bonus").
+   * @param {RulesDetails} rules  Data used to configure the rules object.
+   */
+  static #makeRulesIterator(type, rules) {
+    return AppliedRules.collect(`${rules.category}:${type}`, rules.actor, rules.item).filterWith(rules.rollData);
   }
 }

--- a/module/data/shared/d20-roll-modification-field.mjs
+++ b/module/data/shared/d20-roll-modification-field.mjs
@@ -7,20 +7,53 @@ const { NumberField, SchemaField } = foundry.data.fields;
  * Field for storing modifications on a roll.
  */
 export default class D20RollModificationField extends SchemaField {
-  constructor(fields={}, options={}) {
+  constructor(fields={}, {
+    labelPrefix="DND5E.ROLL.Generic.D20.", labelFormatterPrefix="DND5E.ROLL.Formatter.", ...options
+  }={}) {
     const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
     fields = {
-      bonus: new FormulaField({ label: "DND5E.ROLL.Bonus", labelFomatter: `${labelFormatterPrefix}Bonus` }),
+      bonus: new FormulaField({
+        label: `${labelPrefix}bonus.label`, labelFomatter: `${labelFormatterPrefix}Bonus`
+      }),
       min: new NumberField({
-        ...opts, label: "DND5E.ROLL.Range.Minimum", labelFormatter: `${labelFormatterPrefix}Minimum`
+        ...opts, label: `${labelPrefix}min.label`, labelFormatter: `${labelFormatterPrefix}Minimum`
       }),
       max: new NumberField({
-        ...opts, label: "DND5E.ROLL.Range.Maximum", labelFormatter: `${labelFormatterPrefix}Maximum`
+        ...opts, label: `${labelPrefix}max.label`, labelFormatter: `${labelFormatterPrefix}Maximum`
       }),
-      mode: new AdvantageModeField({ labelFormatter: `${labelFormatterPrefix}AdvantageMode` }),
+      mode: new AdvantageModeField({
+        label: `${labelPrefix}mode.label`, labelFormatter: `${labelFormatterPrefix}AdvantageMode`
+      }),
       ...fields
     };
     Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);
     super(fields, { required: false, ...options });
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Combine data from multiple roll modification fields to produce final advantage and range values.
+   * @param {DataModel} model                 The model containing the fields.
+   * @param {string[]} keyPaths               Paths to the individual fields to combine within the model.
+   * @param {object} [options={}]
+   * @param {number} [options.advantages]     External sources of advantage.
+   * @param {number} [options.disadvantages]  External sources of disadvantage.
+   * @returns {{ advantage: boolean, disadvantage: boolean, maximum: number, minimum: number }}
+   */
+  static combineFields(model, keyPaths, options={}) {
+    let maximum = Infinity;
+    let minimum = -Infinity;
+    for ( const kp of keyPaths ) {
+      const data = foundry.utils.getProperty(model, kp) ?? {};
+      maximum = Math.min(maximum, data.max ?? Infinity);
+      minimum = Math.max(minimum, data.min ?? -Infinity);
+    }
+    const { advantage, disadvantage } = AdvantageModeField.combineFields(
+      model, keyPaths.map(kp => `${kp}.mode`), options
+    );
+    return { advantage, disadvantage, maximum, minimum };
   }
 }

--- a/module/data/shared/d20-roll-modification-field.mjs
+++ b/module/data/shared/d20-roll-modification-field.mjs
@@ -40,20 +40,22 @@ export default class D20RollModificationField extends SchemaField {
   /* -------------------------------------------- */
 
   /**
-   * Combine data from multiple roll modification fields to produce final advantage and range values.
+   * Combine data from multiple roll modification fields to produce final advantage, bonus, and range values.
    * @param {DataModel} model                          The model containing the fields.
    * @param {string[]} keyPaths                        Paths to the individual fields to combine within the model.
    * @param {Partial<AdvantageModeData>} [options={}]  External sources of advantage or disadvantage.
    * @param {RulesDetails} [options.rules]             Data used to fetch rules.
-   * @returns {{ advantage: boolean, disadvantage: boolean, maximum: number, minimum: number }}
+   * @returns {{ advantage: boolean, disadvantage: boolean, bonus: string, maximum: number, minimum: number }}
    */
   static combineFields(model, keyPaths, { rules={}, ...options }={}) {
     let maximum = Infinity;
     let minimum = -Infinity;
+    const parts = [];
     for ( const kp of keyPaths ) {
       const data = foundry.utils.getProperty(model, kp) ?? {};
       maximum = Math.min(maximum, data.max ?? Infinity);
       minimum = Math.max(minimum, data.min ?? -Infinity);
+      if ( data.bonus ) parts.push(data.bonus);
     }
     const { advantage, disadvantage } = AdvantageModeField.combineFields(
       model, keyPaths.map(kp => `${kp}.mode`), rules.actor
@@ -61,6 +63,9 @@ export default class D20RollModificationField extends SchemaField {
     );
     return {
       advantage, disadvantage,
+      bonus: rules.actor
+        ? D20RollModificationField.#makeRulesIterator("bonus", rules).toFormula(parts)
+        : parts.join(" + "),
       maximum: rules.actor
         ? D20RollModificationField.#makeRulesIterator("maximum", rules).resolve(rules.rollData).toSmallest(maximum)
         : maximum,

--- a/module/data/shared/damage-roll-modification-field.mjs
+++ b/module/data/shared/damage-roll-modification-field.mjs
@@ -1,0 +1,17 @@
+import FormulaField from "../fields/formula-field.mjs";
+
+const { NumberField, SchemaField } = foundry.data.fields;
+
+/**
+ * Field for storing modifications on a damage roll.
+ */
+export default class DamageRollModificationField extends SchemaField {
+  constructor(fields={}, options={}) {
+    fields = {
+      bonus: new FormulaField(),
+      ...fields
+    };
+    Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);
+    super(fields, { required: false, ...options });
+  }
+}

--- a/module/data/shared/damage-roll-modification-field.mjs
+++ b/module/data/shared/damage-roll-modification-field.mjs
@@ -6,9 +6,9 @@ const { NumberField, SchemaField } = foundry.data.fields;
  * Field for storing modifications on a damage roll.
  */
 export default class DamageRollModificationField extends SchemaField {
-  constructor(fields={}, options={}) {
+  constructor(fields={}, { labelPrefix="DND5E.ROLL.Generic.Damage.", ...options }={}) {
     fields = {
-      bonus: new FormulaField(),
+      bonus: new FormulaField({ label: `${labelPrefix}bonus.label` }),
       ...fields
     };
     Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -1,13 +1,12 @@
-import AdvantageModeField from "../fields/advantage-mode-field.mjs";
+import D2RollModificationField from "./d20-roll-modification-field.mjs";
 
-const { StringField, NumberField, SchemaField } = foundry.data.fields;
+const { SchemaField, StringField } = foundry.data.fields;
 
 /**
  * Field for storing data for a specific type of roll.
  */
-export default class RollConfigField extends foundry.data.fields.SchemaField {
+export default class RollConfigField extends SchemaField {
   constructor({ roll={}, ability="", labelFormatterPrefix="DND5E.ROLL.Formatter.", ...fields }={}, options={}) {
-    const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
     fields = {
       ability: (ability === false) ? null : new StringField({
         required: true,
@@ -15,16 +14,7 @@ export default class RollConfigField extends foundry.data.fields.SchemaField {
         label: "DND5E.AbilityModifier",
         labelFormatter: `${labelFormatterPrefix}ModifierAbility`
       }),
-      roll: new SchemaField({
-        min: new NumberField({
-          ...opts, label: "DND5E.ROLL.Range.Minimum", labelFormatter: `${labelFormatterPrefix}Minimum`
-        }),
-        max: new NumberField({
-          ...opts, label: "DND5E.ROLL.Range.Maximum", labelFormatter: `${labelFormatterPrefix}Maximum`
-        }),
-        mode: new AdvantageModeField({ labelFormatter: `${labelFormatterPrefix}AdvantageMode` }),
-        ...roll
-      }),
+      roll: new D2RollModificationField({ bonus: false, labelFormatterPrefix, ...roll }, { required: true }),
       ...fields
     };
     Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -6,7 +6,9 @@ const { SchemaField, StringField } = foundry.data.fields;
  * Field for storing data for a specific type of roll.
  */
 export default class RollConfigField extends SchemaField {
-  constructor({ roll={}, ability="", labelFormatterPrefix="DND5E.ROLL.Formatter.", ...fields }={}, options={}) {
+  constructor({ roll={}, ability="", ...fields }={}, {
+    labelPrefix, labelFormatterPrefix="DND5E.ROLL.Formatter.", ...options
+  }={}) {
     fields = {
       ability: (ability === false) ? null : new StringField({
         required: true,
@@ -14,7 +16,10 @@ export default class RollConfigField extends SchemaField {
         label: "DND5E.AbilityModifier",
         labelFormatter: `${labelFormatterPrefix}ModifierAbility`
       }),
-      roll: new D2RollModificationField({ bonus: false, labelFormatterPrefix, ...roll }, { required: true }),
+      roll: new D2RollModificationField(
+        { bonus: false, ...roll },
+        { labelPrefix, labelFormatterPrefix, required: true }
+      ),
       ...fields
     };
     Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -1,4 +1,4 @@
-import D2RollModificationField from "./d20-roll-modification-field.mjs";
+import D20RollModificationField from "./d20-roll-modification-field.mjs";
 
 const { SchemaField, StringField } = foundry.data.fields;
 
@@ -16,7 +16,7 @@ export default class RollConfigField extends SchemaField {
         label: "DND5E.AbilityModifier",
         labelFormatter: `${labelFormatterPrefix}ModifierAbility`
       }),
-      roll: new D2RollModificationField(roll, { labelPrefix, labelFormatterPrefix, required: true }),
+      roll: new D20RollModificationField(roll, { labelPrefix, labelFormatterPrefix, required: true }),
       ...fields
     };
     Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -6,7 +6,7 @@ const { SchemaField, StringField } = foundry.data.fields;
  * Field for storing data for a specific type of roll.
  */
 export default class RollConfigField extends SchemaField {
-  constructor({ roll={}, ability="", ...fields }={}, {
+  constructor({ ability="", roll={}, ...fields }={}, {
     labelPrefix, labelFormatterPrefix="DND5E.ROLL.Formatter.", ...options
   }={}) {
     fields = {
@@ -16,10 +16,7 @@ export default class RollConfigField extends SchemaField {
         label: "DND5E.AbilityModifier",
         labelFormatter: `${labelFormatterPrefix}ModifierAbility`
       }),
-      roll: new D2RollModificationField(
-        { bonus: false, ...roll },
-        { labelPrefix, labelFormatterPrefix, required: true }
-      ),
+      roll: new D2RollModificationField(roll, { labelPrefix, labelFormatterPrefix, required: true }),
       ...fields
     };
     Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -79,7 +79,18 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     "system.attributes.senses.darkvision": { key: "system.attributes.senses.ranges.darkvision" },
     "system.attributes.senses.blindsight": { key: "system.attributes.senses.ranges.blindsight" },
     "system.attributes.senses.tremorsense": { key: "system.attributes.senses.ranges.tremorsense" },
-    "system.attributes.senses.truesight": { key: "system.attributes.senses.ranges.truesight" }
+    "system.attributes.senses.truesight": { key: "system.attributes.senses.ranges.truesight" },
+    "system.bonuses.mwak.attack": { key: "system.roll.attack.mwak.bonus" },
+    "system.bonuses.msak.attack": { key: "system.roll.attack.msak.bonus" },
+    "system.bonuses.rwak.attack": { key: "system.roll.attack.rwak.bonus" },
+    "system.bonuses.rsak.attack": { key: "system.roll.attack.rsak.bonus" },
+    "system.bonuses.mwak.damage": { key: "system.roll.damage.mwak.bonus" },
+    "system.bonuses.msak.damage": { key: "system.roll.damage.msak.bonus" },
+    "system.bonuses.rwak.damage": { key: "system.roll.damage.rwak.bonus" },
+    "system.bonuses.rsak.damage": { key: "system.roll.damage.rsak.bonus" },
+    "system.bonuses.abilities.check": { key: "system.roll.ability.check.bonus" },
+    "system.bonuses.abilities.save": { key: "system.roll.ability.save.bonus" },
+    "system.bonuses.abilities.skill": { key: "system.roll.ability.skill.bonus" }
   };
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -80,17 +80,17 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     "system.attributes.senses.blindsight": { key: "system.attributes.senses.ranges.blindsight" },
     "system.attributes.senses.tremorsense": { key: "system.attributes.senses.ranges.tremorsense" },
     "system.attributes.senses.truesight": { key: "system.attributes.senses.ranges.truesight" },
-    "system.bonuses.mwak.attack": { key: "system.roll.attack.mwak.bonus" },
-    "system.bonuses.msak.attack": { key: "system.roll.attack.msak.bonus" },
-    "system.bonuses.rwak.attack": { key: "system.roll.attack.rwak.bonus" },
-    "system.bonuses.rsak.attack": { key: "system.roll.attack.rsak.bonus" },
-    "system.bonuses.mwak.damage": { key: "system.roll.damage.mwak.bonus" },
-    "system.bonuses.msak.damage": { key: "system.roll.damage.msak.bonus" },
-    "system.bonuses.rwak.damage": { key: "system.roll.damage.rwak.bonus" },
-    "system.bonuses.rsak.damage": { key: "system.roll.damage.rsak.bonus" },
-    "system.bonuses.abilities.check": { key: "system.roll.ability.check.bonus" },
-    "system.bonuses.abilities.save": { key: "system.roll.ability.save.bonus" },
-    "system.bonuses.abilities.skill": { key: "system.roll.ability.skill.bonus" }
+    "system.bonuses.mwak.attack": { key: "system.rolls.attack.mwak.bonus" },
+    "system.bonuses.msak.attack": { key: "system.rolls.attack.msak.bonus" },
+    "system.bonuses.rwak.attack": { key: "system.rolls.attack.rwak.bonus" },
+    "system.bonuses.rsak.attack": { key: "system.rolls.attack.rsak.bonus" },
+    "system.bonuses.mwak.damage": { key: "system.rolls.damage.mwak.bonus" },
+    "system.bonuses.msak.damage": { key: "system.rolls.damage.msak.bonus" },
+    "system.bonuses.rwak.damage": { key: "system.rolls.damage.rwak.bonus" },
+    "system.bonuses.rsak.damage": { key: "system.rolls.damage.rsak.bonus" },
+    "system.bonuses.abilities.check": { key: "system.rolls.ability.check.bonus" },
+    "system.bonuses.abilities.save": { key: "system.rolls.ability.save.bonus" },
+    "system.bonuses.abilities.skill": { key: "system.rolls.ability.skill.bonus" }
   };
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -14,6 +14,8 @@ const { NumberField, ObjectField, SchemaField, SetField, StringField } = foundry
  * @import { FavoriteData5e } from "../data/abstract/_types.mjs";
  */
 
+const BONUS_SHIM_REGEX = new RegExp(/system\.(abilities|skills|tools)\.(\w+)\.bonuses\.(check|save)/);
+
 /**
  * Extend the base ActiveEffect class to implement system-specific logic.
  */
@@ -69,6 +71,9 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @type {Record<string, { key: string, [type]: string, [value]: Function, [warning]: object }>}
    */
   static SHIM_FIELDS = {
+    "system.attributes.concentration.bonuses.save": { key: "system.attributes.concentration.roll.bonus" },
+    "system.attributes.death.bonuses.save": { key: "system.attributes.death.roll.bonus" },
+    "system.attributes.init.bonus": { key: "system.attributes.init.roll.bonus" },
     "system.attributes.movement.speed": { key: "system.attributes.movement.walk" },
     "system.attributes.movement.burrow": { key: "system.attributes.movement.speeds.burrow" },
     "system.attributes.movement.climb": { key: "system.attributes.movement.speeds.climb" },
@@ -463,8 +468,12 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @protected
    */
   _applyChangeShim(change) {
-    const shim = ActiveEffect5e.SHIM_FIELDS[change.key];
-    if ( !shim ) return change;
+    let shim = ActiveEffect5e.SHIM_FIELDS[change.key];
+    if ( !shim ) {
+      const [, category, key, type] = change.key.match(BONUS_SHIM_REGEX) ?? [];
+      if ( !category ) return change;
+      shim = { key: `system.${category}.${key}.${category === "abilities" ? `${type}.` : ""}roll.bonus` };
+    }
     if ( shim.warning ) foundry.utils.logCompatibilityWarning(
       `The active effect key "${change.key}" has been deprecated and should be changed to "${shim.key}".`,
       shim.warning

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -122,7 +122,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const rollData = this.getRollData({ roll: { attackMode: rollConfig.attackMode } });
     const { advantage, disadvantage } = this.actor ? D20RollModificationField.combineFields(this.actor.system, [
       "roll.attack", `roll.attack.${this.getActionType(rollConfig.attackMode)}`
-    ], AppliedRules.collect("attack:advantage", this.actor, this.item).filterWith(rollData).toAdvantageCounts()) : {};
+    ], { rules: { category: "attack", actor: this.actor, item: this.item, rollData } }) : {};
 
     rollConfig.hookNames = [...(config.hookNames ?? []), "attack", "d20Test"];
     rollConfig.rolls = [CONFIG.Dice.D20Roll.mergeConfigs({
@@ -259,14 +259,10 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const mastery = formData?.get("mastery") ?? process.mastery;
 
     let { parts, data } = this.getAttackData({ ammunition, attackMode });
-    const options = CONFIG.Dice.D20Roll.mergeOptions({
-      maximum: this.actor
-        ? AppliedRules.collect("attack:maximum", this.actor, this.item).filterWith(data).resolve(data).toSmallest()
-        : undefined,
-      minimum: this.actor
-        ? AppliedRules.collect("attack:minimum", this.actor, this.item).filterWith(data).resolve(data).toLargest()
-        : undefined,
-    }, config.options);
+    const { maximum, minimum } = this.actor ? D20RollModificationField.combineFields(this.actor.system, [
+      "roll.attack", `roll.attack.${this.getActionType(attackMode)}`
+    ], { rules: { category: "attack", actor: this.actor, item: this.item, rollData: data } }) : {};
+    const options = CONFIG.Dice.D20Roll.mergeOptions({ maximum, minimum }, config.options);
     if ( ammunition !== undefined ) options.ammunition = ammunition;
     if ( attackMode !== undefined ) options.attackMode = attackMode;
     if ( mastery !== undefined ) options.mastery = mastery;

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -2,6 +2,7 @@ import AttackSheet from "../../applications/activity/attack-sheet.mjs";
 import AttackRollConfigurationDialog from "../../applications/dice/attack-configuration-dialog.mjs";
 import BaseAttackActivityData from "../../data/activity/attack-data.mjs";
 import AdvantageModeField from "../../data/fields/advantage-mode-field.mjs";
+import D20RollModificationField from "../../data/shared/d20-roll-modification-field.mjs";
 import { getTargetDescriptors } from "../../utils.mjs";
 import AppliedRules from "../applied-rules.mjs";
 import ActivityMixin from "./mixin.mjs";
@@ -119,10 +120,9 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     }
 
     const rollData = this.getRollData({ roll: { attackMode: rollConfig.attackMode } });
-    const { advantage, disadvantage } = this.actor ? AdvantageModeField.combineFields(
-      this.actor.system, [],
-      AppliedRules.collect("attack:advantage", this.actor, this.item).filterWith(rollData).toAdvantageCounts()
-    ) : {};
+    const { advantage, disadvantage } = this.actor ? D20RollModificationField.combineFields(this.actor.system, [
+      "roll.attack", `roll.attack.${this.getActionType(rollConfig.attackMode)}`
+    ], AppliedRules.collect("attack:advantage", this.actor, this.item).filterWith(rollData).toAdvantageCounts()) : {};
 
     rollConfig.hookNames = [...(config.hookNames ?? []), "attack", "d20Test"];
     rollConfig.rolls = [CONFIG.Dice.D20Roll.mergeConfigs({
@@ -259,14 +259,14 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const mastery = formData?.get("mastery") ?? process.mastery;
 
     let { parts, data } = this.getAttackData({ ammunition, attackMode });
-    const options = foundry.utils.mergeObject({
+    const options = CONFIG.Dice.D20Roll.mergeOptions({
       maximum: this.actor
         ? AppliedRules.collect("attack:maximum", this.actor, this.item).filterWith(data).resolve(data).toSmallest()
         : undefined,
       minimum: this.actor
         ? AppliedRules.collect("attack:minimum", this.actor, this.item).filterWith(data).resolve(data).toLargest()
         : undefined,
-    }, config.options ?? {});
+    }, config.options);
     if ( ammunition !== undefined ) options.ammunition = ammunition;
     if ( attackMode !== undefined ) options.attackMode = attackMode;
     if ( mastery !== undefined ) options.mastery = mastery;

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -121,7 +121,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
 
     const rollData = this.getRollData({ roll: { attackMode: rollConfig.attackMode } });
     const { advantage, disadvantage } = this.actor ? D20RollModificationField.combineFields(this.actor.system, [
-      "roll.attack", `roll.attack.${this.getActionType(rollConfig.attackMode)}`
+      "rolls.attack", `rolls.attack.${this.getActionType(rollConfig.attackMode)}`
     ], { rules: { category: "attack", actor: this.actor, item: this.item, rollData } }) : {};
 
     rollConfig.hookNames = [...(config.hookNames ?? []), "attack", "d20Test"];
@@ -260,7 +260,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
 
     let { parts, data } = this.getAttackData({ ammunition, attackMode });
     const { maximum, minimum } = this.actor ? D20RollModificationField.combineFields(this.actor.system, [
-      "roll.attack", `roll.attack.${this.getActionType(attackMode)}`
+      "rolls.attack", `rolls.attack.${this.getActionType(attackMode)}`
     ], { rules: { category: "attack", actor: this.actor, item: this.item, rollData: data } }) : {};
     const options = CONFIG.Dice.D20Roll.mergeOptions({ maximum, minimum }, config.options);
     if ( ammunition !== undefined ) options.ammunition = ammunition;

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -416,7 +416,7 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
             rollData.abilities?.[this.ability]?.mod,
             prof,
             CONFIG.Dice.BasicRoll.replaceFormulaData(
-              rollData.roll?.attack?.[typeMapping[actionType] ?? actionType]?.bonus ?? "", rollData
+              rollData.rolls?.attack?.[typeMapping[actionType] ?? actionType]?.bonus ?? "", rollData
             )
           ].filter(p => p);
           attack = parts.join(" + ");

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -416,7 +416,7 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
             rollData.abilities?.[this.ability]?.mod,
             prof,
             CONFIG.Dice.BasicRoll.replaceFormulaData(
-              rollData.bonuses?.[typeMapping[actionType] ?? actionType]?.attack ?? "", rollData
+              rollData.roll?.attack?.[typeMapping[actionType] ?? actionType]?.bonus ?? "", rollData
             )
           ].filter(p => p);
           attack = parts.join(" + ");

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1653,20 +1653,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       return null;
     }
 
-    const parts = [];
-    let data = {};
-    const options = D20RollModificationField.combineFields(this.system, [
-      "attributes.death.roll", "rolls.ability.save"
+    const { bonus, ...options } = D20RollModificationField.combineFields(this.system, [
+      "attributes.death.roll"
     ]);
-
-    // Diamond Soul adds proficiency
-    if ( this.getFlag("dnd5e", "diamondSoul") ) {
-      parts.push("@prof");
-      data.prof = new Proficiency(this.system.attributes.prof, 1).term;
-    }
-
-    // Death save bonus
-    if ( death.bonuses.save ) parts.push(death.bonuses.save);
+    const { parts, data } = CONFIG.Dice.D20Roll.constructParts({
+      prof: this.getFlag("dnd5e", "diamondSoul") ? new Proficiency(this.system.attributes.prof, 1).term : null,
+      deathBonus: death.bonuses.save
+    }, {});
 
     const rollConfig = foundry.utils.mergeObject({ saveType: "death", target: 10 }, config);
     rollConfig.hookNames = [...(config.hookNames ?? []), "deathSave"];

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -6,6 +6,7 @@ import TravelField from "../../data/actor/fields/travel-field.mjs";
 import ActivationsField from "../../data/chat-message/fields/activations-field.mjs";
 import { ActorDeltasField } from "../../data/chat-message/fields/deltas-field.mjs";
 import AdvantageModeField from "../../data/fields/advantage-mode-field.mjs";
+import D20RollModificationField from "../../data/shared/d20-roll-modification-field.mjs";
 import TransformationSetting from "../../data/settings/transformation-setting.mjs";
 import { createRollLabel } from "../../enrichers.mjs";
 import {
@@ -1343,9 +1344,11 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       [type]: config[type],
       type
     };
-    const { advantage, disadvantage } = AdvantageModeField.combineFields(this.system, [
-      `abilities.${abilityId}.check.roll.mode`,
-      `${type}s.${type === "skill" ? config.skill : config.tool}.roll.mode`
+    const { advantage, disadvantage } = D20RollModificationField.combineFields(this.system, [
+      `abilities.${abilityId}.check.roll`,
+      "roll.ability.check",
+      `roll.ability.${type}`,
+      `${type}s.${type === "skill" ? config.skill : config.tool}.roll`
     ], AppliedRules.collect("check:advantage", this).filterWith(rollData).toAdvantageCounts({
       advantages: { count: Number(doubleProf) + Number(pace.advantage) },
       disadvantages: { count: Number(pace.disadvantage) }
@@ -1447,21 +1450,24 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       [`${config[type]}Bonus`]: relevant?.bonuses?.check,
       extraBonus: process.bonus,
       [`${abilityId}CheckBonus`]: ability?.bonuses?.check,
-      [`${type}Bonus`]: this.system.bonuses?.abilities?.[type],
-      abilityCheckBonus: this.system.bonuses?.abilities?.check,
+      [`${type}Bonus`]: this.system.roll?.ability?.[type]?.bonus,
+      abilityCheckBonus: this.system.roll?.ability?.check?.bonus,
       ruleBonus: AppliedRules.collect("check:bonus", this).filterWith(rollData).toFormula()
     }, { ...rollData });
 
     // Add condition reductions.
     this.addConditionRollReduction(parts, data);
 
-    config.options = foundry.utils.mergeObject({
-      maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).resolve(rollData).toSmallest(
-        Math.min(relevant?.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity)
-      ),
-      minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).resolve(rollData).toLargest(
-        Math.max(relevant?.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
-      )
+    const { maximum, minimum } = D20RollModificationField.combineFields(this.system, [
+      `abilities.${abilityId}.check.roll`,
+      "roll.ability.check",
+      `roll.ability.${type}`,
+      `${type}s.${type === "skill" ? process.skill : process.tool}.roll`
+    ]);
+
+    config.options = CONFIG.Dice.D20Roll.mergeOptions({
+      maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).resolve(rollData).toSmallest(maximum),
+      minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).resolve(rollData).toLargest(minimum)
     }, config.options ?? {});
     config.parts = [...(config.parts ?? []), ...parts];
     config.data = { ...data, ...(config.data ?? {}) };
@@ -1570,16 +1576,15 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       mod: ability?.mod,
       prof: ability?.[`${type}Prof`].hasProficiency ? ability[`${type}Prof`].term : null,
       [`${config.ability}${type.capitalize()}Bonus`]: ability?.bonuses[type],
-      [`${type}Bonus`]: this.system.bonuses?.abilities?.[type],
+      [`${type}Bonus`]: this.system.roll?.ability?.[type]?.bonus,
       ruleBonus: AppliedRules.collect(`${type}:bonus`, this).filterWith(rollData).toFormula(),
       cover: (config.ability === "dex") && (type === "save") ? this.system.attributes?.ac?.cover : null
     }, rollData);
 
-    const { advantage, disadvantage } = AdvantageModeField.combineFields(this.system, [
-      `abilities.${config.ability}.${type}.roll.mode`
-    ], AppliedRules.collect(`${type}:advantage`, this).filterWith(rollData).toAdvantageCounts());
     const options = {
-      advantage, disadvantage,
+      ...D20RollModificationField.combineFields(this.system, [
+        `abilities.${config.ability}.${type}.roll`, `roll.ability.${type}`
+      ], AppliedRules.collect(`${type}:advantage`, this).filterWith(rollData).toAdvantageCounts()),
       maximum: AppliedRules.collect(`${type}:maximum`, this).filterWith(rollData).resolve(rollData).toSmallest(
         ability?.[type]?.roll.max
       ),
@@ -1664,12 +1669,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     const parts = [];
     let data = {};
-    const options = {
-      advantage: death.roll.mode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE,
-      disadvantage: death.roll.mode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE,
-      maximum: death.roll.max,
-      minimum: death.roll.min
-    };
+    const options = D20RollModificationField.combineFields(this.system, [
+      "attributes.death.roll", "roll.ability.save"
+    ]);
 
     // Diamond Soul adds proficiency
     if ( this.getFlag("dnd5e", "diamondSoul") ) {
@@ -1901,15 +1903,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       prof: init.prof.hasProficiency ? init.prof.term : null,
       initiativeBonus: init.bonus,
       [`${abilityId}AbilityCheckBonus`]: ability?.bonuses?.check,
-      abilityCheckBonus: this.system.bonuses?.abilities?.check,
+      abilityCheckBonus: this.system.roll?.ability?.check?.bonus,
       ruleBonus: AppliedRules.collect("check:bonus", this).filterWith(rollData).toFormula(),
       alert: flags.initiativeAlert && (dnd5e.settings.rulesVersion === "legacy") ? 5 : null
     }, rollData);
-
-    const { advantage, disadvantage } = AdvantageModeField.combineFields(this.system, [
-      `abilities.${abilityId}.check.roll.mode`,
-      "attributes.init.roll.mode"
-    ], AppliedRules.collect("check:advantage", this).filterWith(rollData).toAdvantageCounts());
 
     // Add condition reductions
     this.addConditionRollReduction(parts, data);
@@ -1923,15 +1920,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const useScore = (scoreMode === "all") || ((scoreMode === "npcs") && game.user.isGM && this.system.isNPC);
 
     options = foundry.utils.mergeObject({
-      advantage, disadvantage,
+      ...D20RollModificationField.combineFields(this.system, [
+        `abilities.${abilityId}.check.roll`, "attributes.init.roll", "roll.ability.check"
+      ], AppliedRules.collect("check:advantage", this).filterWith(rollData).toAdvantageCounts()),
       fixed: useScore ? init.score : undefined,
       flavor: options.flavor ?? _loc("DND5E.Initiative"),
       halflingLucky: flags.halflingLucky ?? false,
       maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).resolve(rollData).toSmallest(
-        Math.min(init.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity)
+        Math.min(init.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity) // TODO: Add roll.ability.check
       ),
       minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).resolve(rollData).toLargest(
-        Math.max(init.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
+        Math.max(init.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity) // TODO: Add roll.ability.check
       )
     }, options);
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1445,26 +1445,24 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       type: type
     });
 
+    const { bonus, maximum, minimum } = D20RollModificationField.combineFields(this.system, [
+      `abilities.${abilityId}.check.roll`,
+      "rolls.ability.check",
+      `rolls.ability.${type}`,
+      `${type}s.${type === "skill" ? process.skill : process.tool}.roll`
+    ], { rules: { category: "check", actor: this, rollData } });
+
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: ability?.mod,
       prof: prof?.hasProficiency ? prof.term : null,
       [`${config[type]}Bonus`]: relevant?.bonuses?.check,
       extraBonus: process.bonus,
       [`${abilityId}CheckBonus`]: ability?.bonuses?.check,
-      [`${type}Bonus`]: this.system.rolls?.ability?.[type]?.bonus,
-      abilityCheckBonus: this.system.rolls?.ability?.check?.bonus,
-      ruleBonus: AppliedRules.collect("check:bonus", this).filterWith(rollData).toFormula()
+      ruleBonus: bonus
     }, { ...rollData });
 
     // Add condition reductions.
     this.addConditionRollReduction(parts, data);
-
-    const { maximum, minimum } = D20RollModificationField.combineFields(this.system, [
-      `abilities.${abilityId}.check.roll`,
-      "rolls.ability.check",
-      `rolls.ability.${type}`,
-      `${type}s.${type === "skill" ? process.skill : process.tool}.roll`
-    ], { rules: { category: "check", actor: this, rollData } });
 
     config.options = CONFIG.Dice.D20Roll.mergeOptions({ maximum, minimum }, config.options ?? {});
     config.parts = [...(config.parts ?? []), ...parts];
@@ -1570,18 +1568,16 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       proficient: ability?.[`${type}Prof`]?.multiplier >= 1,
       type: config[`${type}Type`] ?? "ability"
     });
+    const { bonus, ...options } = D20RollModificationField.combineFields(this.system, [
+      `abilities.${config.ability}.${type}.roll`, `rolls.ability.${type}`
+    ], { rules: { category: type, actor: this, rollData } });
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: ability?.mod,
       prof: ability?.[`${type}Prof`].hasProficiency ? ability[`${type}Prof`].term : null,
       [`${config.ability}${type.capitalize()}Bonus`]: ability?.bonuses[type],
-      [`${type}Bonus`]: this.system.rolls?.ability?.[type]?.bonus,
-      ruleBonus: AppliedRules.collect(`${type}:bonus`, this).filterWith(rollData).toFormula(),
+      ruleBonus: bonus,
       cover: (config.ability === "dex") && (type === "save") ? this.system.attributes?.ac?.cover : null
     }, rollData);
-
-    const options = D20RollModificationField.combineFields(this.system, [
-      `abilities.${config.ability}.${type}.roll`, `rolls.ability.${type}`
-    ], { rules: { category: type, actor: this, rollData } });
 
     const rollConfig = foundry.utils.mergeObject({
       halflingLucky: this.getFlag("dnd5e", "halflingLucky")
@@ -1888,13 +1884,15 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       proficient: init.prof.multiplier >= 1,
       type: "initiative"
     });
+    const { advantage, disadvantage, bonus, maximum, minimum } = D20RollModificationField.combineFields(this.system, [
+      `abilities.${abilityId}.check.roll`, "attributes.init.roll", "rolls.ability.check"
+    ], { rules: { category: "check", actor: this, rollData } });
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: init?.mod,
       prof: init.prof.hasProficiency ? init.prof.term : null,
       initiativeBonus: init.bonus,
       [`${abilityId}AbilityCheckBonus`]: ability?.bonuses?.check,
-      abilityCheckBonus: this.system.rolls?.ability?.check?.bonus,
-      ruleBonus: AppliedRules.collect("check:bonus", this).filterWith(rollData).toFormula(),
+      ruleBonus: bonus,
       alert: flags.initiativeAlert && (dnd5e.settings.rulesVersion === "legacy") ? 5 : null
     }, rollData);
 
@@ -1910,9 +1908,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const useScore = (scoreMode === "all") || ((scoreMode === "npcs") && game.user.isGM && this.system.isNPC);
 
     options = foundry.utils.mergeObject({
-      ...D20RollModificationField.combineFields(this.system, [
-        `abilities.${abilityId}.check.roll`, "attributes.init.roll", "rolls.ability.check"
-      ], { rules: { category: "check", actor: this, rollData } }),
+      advantage, disadvantage, maximum, minimum,
       fixed: useScore ? init.score : undefined,
       flavor: options.flavor ?? _loc("DND5E.Initiative"),
       halflingLucky: flags.halflingLucky ?? false,

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1346,8 +1346,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     };
     const { advantage, disadvantage } = D20RollModificationField.combineFields(this.system, [
       `abilities.${abilityId}.check.roll`,
-      "roll.ability.check",
-      `roll.ability.${type}`,
+      "rolls.ability.check",
+      `rolls.ability.${type}`,
       `${type}s.${type === "skill" ? config.skill : config.tool}.roll`
     ], {
       advantages: { count: Number(doubleProf) + Number(pace.advantage) },
@@ -1451,8 +1451,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       [`${config[type]}Bonus`]: relevant?.bonuses?.check,
       extraBonus: process.bonus,
       [`${abilityId}CheckBonus`]: ability?.bonuses?.check,
-      [`${type}Bonus`]: this.system.roll?.ability?.[type]?.bonus,
-      abilityCheckBonus: this.system.roll?.ability?.check?.bonus,
+      [`${type}Bonus`]: this.system.rolls?.ability?.[type]?.bonus,
+      abilityCheckBonus: this.system.rolls?.ability?.check?.bonus,
       ruleBonus: AppliedRules.collect("check:bonus", this).filterWith(rollData).toFormula()
     }, { ...rollData });
 
@@ -1461,8 +1461,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     const { maximum, minimum } = D20RollModificationField.combineFields(this.system, [
       `abilities.${abilityId}.check.roll`,
-      "roll.ability.check",
-      `roll.ability.${type}`,
+      "rolls.ability.check",
+      `rolls.ability.${type}`,
       `${type}s.${type === "skill" ? process.skill : process.tool}.roll`
     ], { rules: { category: "check", actor: this, rollData } });
 
@@ -1574,13 +1574,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       mod: ability?.mod,
       prof: ability?.[`${type}Prof`].hasProficiency ? ability[`${type}Prof`].term : null,
       [`${config.ability}${type.capitalize()}Bonus`]: ability?.bonuses[type],
-      [`${type}Bonus`]: this.system.roll?.ability?.[type]?.bonus,
+      [`${type}Bonus`]: this.system.rolls?.ability?.[type]?.bonus,
       ruleBonus: AppliedRules.collect(`${type}:bonus`, this).filterWith(rollData).toFormula(),
       cover: (config.ability === "dex") && (type === "save") ? this.system.attributes?.ac?.cover : null
     }, rollData);
 
     const options = D20RollModificationField.combineFields(this.system, [
-      `abilities.${config.ability}.${type}.roll`, `roll.ability.${type}`
+      `abilities.${config.ability}.${type}.roll`, `rolls.ability.${type}`
     ], { rules: { category: type, actor: this, rollData } });
 
     const rollConfig = foundry.utils.mergeObject({
@@ -1660,7 +1660,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const parts = [];
     let data = {};
     const options = D20RollModificationField.combineFields(this.system, [
-      "attributes.death.roll", "roll.ability.save"
+      "attributes.death.roll", "rolls.ability.save"
     ]);
 
     // Diamond Soul adds proficiency
@@ -1893,7 +1893,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       prof: init.prof.hasProficiency ? init.prof.term : null,
       initiativeBonus: init.bonus,
       [`${abilityId}AbilityCheckBonus`]: ability?.bonuses?.check,
-      abilityCheckBonus: this.system.roll?.ability?.check?.bonus,
+      abilityCheckBonus: this.system.rolls?.ability?.check?.bonus,
       ruleBonus: AppliedRules.collect("check:bonus", this).filterWith(rollData).toFormula(),
       alert: flags.initiativeAlert && (dnd5e.settings.rulesVersion === "legacy") ? 5 : null
     }, rollData);
@@ -1911,7 +1911,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     options = foundry.utils.mergeObject({
       ...D20RollModificationField.combineFields(this.system, [
-        `abilities.${abilityId}.check.roll`, "attributes.init.roll", "roll.ability.check"
+        `abilities.${abilityId}.check.roll`, "attributes.init.roll", "rolls.ability.check"
       ], { rules: { category: "check", actor: this, rollData } }),
       fixed: useScore ? init.score : undefined,
       flavor: options.flavor ?? _loc("DND5E.Initiative"),

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1455,9 +1455,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: ability?.mod,
       prof: prof?.hasProficiency ? prof.term : null,
-      [`${config[type]}Bonus`]: relevant?.bonuses?.check,
       extraBonus: process.bonus,
-      [`${abilityId}CheckBonus`]: ability?.bonuses?.check,
       ruleBonus: bonus
     }, { ...rollData });
 
@@ -1574,7 +1572,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: ability?.mod,
       prof: ability?.[`${type}Prof`].hasProficiency ? ability[`${type}Prof`].term : null,
-      [`${config.ability}${type.capitalize()}Bonus`]: ability?.bonuses[type],
       ruleBonus: bonus,
       cover: (config.ability === "dex") && (type === "save") ? this.system.attributes?.ac?.cover : null
     }, rollData);
@@ -1658,7 +1655,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     ]);
     const { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       prof: this.getFlag("dnd5e", "diamondSoul") ? new Proficiency(this.system.attributes.prof, 1).term : null,
-      deathBonus: death.bonuses.save
+      deathBonus: bonus
     }, {});
 
     const rollConfig = foundry.utils.mergeObject({ saveType: "death", target: 10 }, config);
@@ -1784,18 +1781,11 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const conc = this.system.attributes?.concentration;
     if ( !conc ) throw new Error("You may not make a Concentration Saving Throw with this Actor.");
 
-    let data = {};
-    const parts = [];
-    const options = {
-      advantage: conc.roll.mode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE,
-      disadvantage: conc.roll.mode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE,
-      isConcentration: true,
-      maximum: conc.roll.max,
-      minimum: conc.roll.min
-    };
-
-    // Concentration bonus
-    if ( conc.bonuses.save ) parts.push(conc.bonuses.save);
+    const { bonus, ...options } = D20RollModificationField.combineFields(this.system, [
+      "attributes.concentration.roll"
+    ]);
+    options.isConcentration = true;
+    const { parts, data } = CONFIG.Dice.D20Roll.constructParts({ concentrationBonus: bonus }, {});
 
     const rollConfig = foundry.utils.mergeObject({
       ability: (conc.ability in CONFIG.DND5E.abilities) ? conc.ability : CONFIG.DND5E.defaultAbilities.concentration,
@@ -1883,8 +1873,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: init?.mod,
       prof: init.prof.hasProficiency ? init.prof.term : null,
-      initiativeBonus: init.bonus,
-      [`${abilityId}AbilityCheckBonus`]: ability?.bonuses?.check,
       ruleBonus: bonus,
       alert: flags.initiativeAlert && (dnd5e.settings.rulesVersion === "legacy") ? 5 : null
     }, rollData);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1349,10 +1349,11 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       "roll.ability.check",
       `roll.ability.${type}`,
       `${type}s.${type === "skill" ? config.skill : config.tool}.roll`
-    ], AppliedRules.collect("check:advantage", this).filterWith(rollData).toAdvantageCounts({
+    ], {
       advantages: { count: Number(doubleProf) + Number(pace.advantage) },
-      disadvantages: { count: Number(pace.disadvantage) }
-    }));
+      disadvantages: { count: Number(pace.disadvantage) },
+      rules: { category: "check", actor: this, rollData }
+    });
 
     const rollConfig = foundry.utils.mergeObject({
       advantage, disadvantage,
@@ -1463,12 +1464,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       "roll.ability.check",
       `roll.ability.${type}`,
       `${type}s.${type === "skill" ? process.skill : process.tool}.roll`
-    ]);
+    ], { rules: { category: "check", actor: this, rollData } });
 
-    config.options = CONFIG.Dice.D20Roll.mergeOptions({
-      maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).resolve(rollData).toSmallest(maximum),
-      minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).resolve(rollData).toLargest(minimum)
-    }, config.options ?? {});
+    config.options = CONFIG.Dice.D20Roll.mergeOptions({ maximum, minimum }, config.options ?? {});
     config.parts = [...(config.parts ?? []), ...parts];
     config.data = { ...data, ...(config.data ?? {}) };
     config.data.abilityId = abilityId;
@@ -1581,17 +1579,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       cover: (config.ability === "dex") && (type === "save") ? this.system.attributes?.ac?.cover : null
     }, rollData);
 
-    const options = {
-      ...D20RollModificationField.combineFields(this.system, [
-        `abilities.${config.ability}.${type}.roll`, `roll.ability.${type}`
-      ], AppliedRules.collect(`${type}:advantage`, this).filterWith(rollData).toAdvantageCounts()),
-      maximum: AppliedRules.collect(`${type}:maximum`, this).filterWith(rollData).resolve(rollData).toSmallest(
-        ability?.[type]?.roll.max
-      ),
-      minimum: AppliedRules.collect(`${type}:minimum`, this).filterWith(rollData).resolve(rollData).toLargest(
-        ability?.[type]?.roll.min
-      )
-    };
+    const options = D20RollModificationField.combineFields(this.system, [
+      `abilities.${config.ability}.${type}.roll`, `roll.ability.${type}`
+    ], { rules: { category: type, actor: this, rollData } });
 
     const rollConfig = foundry.utils.mergeObject({
       halflingLucky: this.getFlag("dnd5e", "halflingLucky")
@@ -1922,16 +1912,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     options = foundry.utils.mergeObject({
       ...D20RollModificationField.combineFields(this.system, [
         `abilities.${abilityId}.check.roll`, "attributes.init.roll", "roll.ability.check"
-      ], AppliedRules.collect("check:advantage", this).filterWith(rollData).toAdvantageCounts()),
+      ], { rules: { category: "check", actor: this, rollData } }),
       fixed: useScore ? init.score : undefined,
       flavor: options.flavor ?? _loc("DND5E.Initiative"),
       halflingLucky: flags.halflingLucky ?? false,
-      maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).resolve(rollData).toSmallest(
-        Math.min(init.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity) // TODO: Add roll.ability.check
-      ),
-      minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).resolve(rollData).toLargest(
-        Math.max(init.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity) // TODO: Add roll.ability.check
-      )
     }, options);
 
     const rollConfig = { parts, data, options, subject: this };

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -167,10 +167,11 @@ class RulesIterator extends Iterator {
 
   /**
    * Convert each value of the iterator to a single formula.
+   * @param {string[]} [parts]  Additional parts to combine.
    * @returns {string}
    */
-  toFormula() {
-    return this.values(String).toArray().join(" + ");
+  toFormula(parts) {
+    return this.values(String).toArray().concat(parts ?? []).join(" + ");
   }
 
   /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1434,7 +1434,7 @@ export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemNa
   }
 
   // Derived fields
-  else if ( attr === "attributes.init.total" ) label = "DND5E.InitiativeBonus";
+  else if ( attr === "attributes.init.total" ) label = "DND5E.INITIATIVE.FIELDS.attributes.init.roll.bonus.label";
   else if ( (attr === "attributes.ac.value") || (attr === "attributes.ac.flat") ) label = "DND5E.ArmorClass";
   else if ( attr === "attributes.spell.attack" ) label = "DND5E.SpellAttackBonus";
   else if ( attr === "attributes.spell.dc" ) label = "DND5E.SpellDC";

--- a/templates/actors/config/ability-config.hbs
+++ b/templates/actors/config/ability-config.hbs
@@ -21,10 +21,10 @@
         <div class="form-group">
             <p class="hint">{{ localize "DND5E.ABILITY.SECTIONS.Bonuses.Hint" ability=label }}</p>
         </div>
-        {{ formField fields.bonuses.fields.save name=(concat prefix "bonuses.save") value=data.bonuses.save
-                     localize=true rootId=partId }}
-        {{ formField fields.bonuses.fields.check name=(concat prefix "bonuses.check") value=data.bonuses.check
-                     localize=true rootId=partId }}
+        {{ formField fields.save.fields.roll.fields.bonus name=(concat prefix "save.roll.bonus")
+                     value=data.save.roll.bonus localize=true rootId=partId }}
+        {{ formField fields.check.fields.roll.fields.bonus name=(concat prefix "check.roll.bonus")
+                     value=data.check.roll.bonus localize=true rootId=partId }}
     </fieldset>
 
     {{!-- Check Rolls --}}

--- a/templates/actors/config/ability-config.hbs
+++ b/templates/actors/config/ability-config.hbs
@@ -70,8 +70,8 @@
         <div class="form-group">
             <p class="hint">{{ localize "DND5E.ABILITY.SECTIONS.Global.Hint" }}</p>
         </div>
-        {{ formField global.fields.save value=global.data.save localize=true rootId=partId }}
-        {{ formField global.fields.check value=global.data.check localize=true rootId=partId }}
+        {{ formField global.fields.save.fields.bonus value=global.data.save.bonus localize=true rootId=partId }}
+        {{ formField global.fields.check.fields.bonus value=global.data.check.bonus localize=true rootId=partId }}
     </fieldset>
     {{/if}}
 </section>

--- a/templates/actors/config/concentration-config.hbs
+++ b/templates/actors/config/concentration-config.hbs
@@ -3,7 +3,7 @@
     <fieldset class="card">
         <legend>{{ localize "DND5E.Concentration" }}</legend>
         {{ formField fields.ability value=data.ability options=abilityOptions localize=true rootId=partId }}
-        {{ formField fields.bonuses.fields.save value=data.bonuses.save localize=true rootId=partId }}
+        {{ formField fields.roll.fields.bonus value=data.roll.bonus localize=true rootId=partId }}
         {{ formField fields.limit value=data.limit placeholder="1" localize=true rootId=partId }}
     </fieldset>
 

--- a/templates/actors/config/concentration-config.hbs
+++ b/templates/actors/config/concentration-config.hbs
@@ -30,7 +30,7 @@
         <div class="form-group">
             <p class="hint">{{ localize "DND5E.ABILITY.SECTIONS.Global.Hint" }}</p>
         </div>
-        {{ formField global.fields.save value=global.data.save localize=true rootId=partId }}
+        {{ formField global.fields.save.fields.bonus value=global.data.save.bonus localize=true rootId=partId }}
     </fieldset>
     {{/if}}
 </section>

--- a/templates/actors/config/death-config.hbs
+++ b/templates/actors/config/death-config.hbs
@@ -2,7 +2,7 @@
     {{!-- Death --}}
     <fieldset class="card">
         <legend>{{ localize "DND5E.DeathSave" }}</legend>
-        {{ formField fields.bonuses.fields.save value=data.bonuses.save localize=true rootId=partId }}
+        {{ formField fields.roll.fields.bonus value=data.roll.bonus localize=true rootId=partId }}
     </fieldset>
 
     {{!-- Rolls --}}

--- a/templates/actors/config/death-config.hbs
+++ b/templates/actors/config/death-config.hbs
@@ -28,7 +28,7 @@
         <div class="form-group">
             <p class="hint">{{ localize "DND5E.ABILITY.SECTIONS.Global.Hint" }}</p>
         </div>
-        {{ formField global.fields.save value=global.data.save localize=true rootId=partId }}
+        {{ formField global.fields.save.fields.bonus value=global.data.save.bonus localize=true rootId=partId }}
     </fieldset>
     {{/if}}
 </section>

--- a/templates/actors/config/initiative-config.hbs
+++ b/templates/actors/config/initiative-config.hbs
@@ -3,7 +3,7 @@
     <fieldset class="card">
         <legend>{{ localize "DND5E.Initiative" }}</legend>
         {{ formField fields.ability value=data.ability options=abilityOptions localize=true rootId=partId }}
-        {{ formField fields.bonus value=data.bonus localize=true rootId=partId }}
+        {{ formField fields.roll.fields.bonus value=data.roll.bonus localize=true rootId=partId }}
         <hr>
         {{#each flags}}
         {{ formField field name=name value=value input=../inputs.createCheckboxInput rootId=../partId }}

--- a/templates/actors/config/skill-tool-config.hbs
+++ b/templates/actors/config/skill-tool-config.hbs
@@ -18,7 +18,7 @@
         {{ formField fields.bonuses.fields.passive name=(concat prefix "bonuses.passive") value=data.bonuses.passive
                      localize=true rootId=partId }}
         {{/if}}
-        {{ formField fields.bonuses.fields.check name=(concat prefix "bonuses.check") value=data.bonuses.check
+        {{ formField fields.roll.fields.bonus name=(concat prefix "roll.bonus") value=data.roll.bonus
                      localize=true rootId=partId }}
     </fieldset>
 

--- a/templates/actors/config/skill-tool-config.hbs
+++ b/templates/actors/config/skill-tool-config.hbs
@@ -47,9 +47,11 @@
         <div class="form-group">
             <p class="hint">{{ localize (concat section "Global.Hint") }}</p>
         </div>
-        {{ formField global.fields.check value=global.data.check localize=true rootId=partId }}
+        {{ formField global.fields.check.fields.bonus value=global.data.check.bonus localize=true rootId=partId }}
         {{#if global.skill}}
-        {{ formField global.fields.skill value=global.data.skill localize=true rootId=partId }}
+        {{ formField global.fields.skill.fields.bonus value=global.data.skill.bonus localize=true rootId=partId }}
+        {{else}}
+        {{ formField global.fields.tool.fields.bonus value=global.data.tool.bonus localize=true rootId=partId }}
         {{/if}}
     </fieldset>
     {{/if}}

--- a/templates/actors/tabs/creature-special-traits.hbs
+++ b/templates/actors/tabs/creature-special-traits.hbs
@@ -13,23 +13,7 @@
     {{#each flags.sections}}
     <fieldset class="card">
         <legend>{{ label }}</legend>
-        {{#each fields}}
-        {{#if fields}}
-        <div class="form-group split-group">
-            <label>{{ localize label }}</label>
-            <div class="form-fields">
-                {{#each fields}}
-                {{ formInput field name=name value=value choices=choices placeholder=placeholder input=input
-                             disabled=@root.flags.disabled }}
-                {{/each}}
-            </div>
-            {{#if hint}}<p class="hint">{{ localize hint }}</p>{{/if}}
-        </div>
-        {{else}}
-        {{ formField field name=name value=value choices=choices placeholder=placeholder input=input
-                     disabled=@root.flags.disabled rootId=@root.partId }}
-        {{/if}}
-        {{/each}}
+        {{> "dnd5e.fieldlist" fields }}
     </fieldset>
     {{/each}}
 </section>

--- a/templates/shared/fields/fieldlist.hbs
+++ b/templates/shared/fields/fieldlist.hbs
@@ -4,13 +4,24 @@
 {{!-- Normal Field --}}
 {{#unless (eq visible false)}}
 {{#if name}}{{!-- TODO: Work around core issue with providing undefined name --}}
-{{ formField field name=name value=value input=input options=options disabled=disabled localize=localize
-             placeholder=placeholder label=label hint=hint classes=classes rootId=@root.partId }}
+{{ formField field name=name value=value input=input choices=choices options=options disabled=disabled localize=localize
+             placeholder=placeholder label=label hint=hint classes=classes disabled=disabled rootId=@root.partId }}
 {{else}}
-{{ formField field value=value input=input options=options disabled=disabled localize=localize
-             placeholder=placeholder label=label hint=hint classes=classes rootId=@root.partId }}
+{{ formField field value=value input=input choices=choices options=options disabled=disabled localize=localize
+             placeholder=placeholder label=label hint=hint classes=classes disabled=disabled rootId=@root.partId }}
 {{/if}}
 {{/unless}}
+
+{{else if fields}}
+
+{{!-- Split Field --}}
+<div class="form-group split-group {{ group.classes }}" {{ dnd5e-dataset group.dataset }}>
+    {{#if group.label}}<label>{{ localize group.label }}</label>{{/if}}
+    <div class="form-fields">
+        {{> "dnd5e.fieldlist" fields }}
+    </div>
+    {{#if group.hint}}<p class="hint">{{ localize group.hint }}</p>{{/if}}
+</div>
 
 {{else if template}}
 

--- a/templates/shared/fields/fieldlist.hbs
+++ b/templates/shared/fields/fieldlist.hbs
@@ -5,10 +5,10 @@
 {{#unless (eq visible false)}}
 {{#if name}}{{!-- TODO: Work around core issue with providing undefined name --}}
 {{ formField field name=name value=value input=input choices=choices options=options disabled=disabled localize=localize
-             placeholder=placeholder label=label hint=hint classes=classes disabled=disabled rootId=@root.partId }}
+             placeholder=placeholder label=label hint=hint classes=classes rootId=@root.partId }}
 {{else}}
 {{ formField field value=value input=input choices=choices options=options disabled=disabled localize=localize
-             placeholder=placeholder label=label hint=hint classes=classes disabled=disabled rootId=@root.partId }}
+             placeholder=placeholder label=label hint=hint classes=classes rootId=@root.partId }}
 {{/if}}
 {{/unless}}
 


### PR DESCRIPTION
Adds a new data structure to actor data models for storing more information on rolls. This structure replaces the existing bonuses data and adds roll mode support for setting roll modes, minimums, and maximums. It also allows for more options to apply changes in both more specific and more general ways:

```
// Bonus added to all ability checks
system.rolls.ability.check.bonus | ADD | 1d4
// Disadvantage on all attack rolls
system.rolls.attack.mode | ADD | -1
// Minimum for ranged spell attacks
system.rolls.attack.rsak.min | OVERRIDE | 10
// Bonus to melee weapon attacks
system.rolls.damage.mwak.bonus | ADD | 1d6[radiant]
```

Closes #5176