### PR TITLE
[#6062, #6113] Update card intersection for multiple user trays

### DIFF
--- a/module/applications/chat-log.mjs
+++ b/module/applications/chat-log.mjs
@@ -41,9 +41,9 @@ export default class ChatLog5e extends foundry.applications.sidebar.tabs.ChatLog
    * @param {IntersectionObserverEntry[]} entries  The observed elements that have entered or left the viewport.
    */
   #onCardIntersects(entries) {
+    const selector = ChatMessage5e.TRAY_TYPES.join(", ");
     for ( const { isIntersecting, target } of entries ) {
-      const tray = target.querySelector("damage-application, effect-application");
-      if ( tray ) tray.visible = isIntersecting;
+      target.querySelectorAll(selector).forEach(t => t.visible = isIntersecting);
     }
   }
 


### PR DESCRIPTION
Modify `onCardIntersects` in the chat log to pull from `TRAY_TYPES` in `ChatMessage5e` to allow additional tray types to be defined. It Also now uses `querySelectorAll` to support multiple trays rather than just one per card.

Closes #6062
Closes #6113