### PR TITLE
[#6126] Display icon for rider activities and effects on item

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1924,7 +1924,11 @@
     "Dissociate": "Dissociate Effect"
   },
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
-  "Label": "Available Effects"
+  "Label": "Available Effects",
+  "RIDER": {
+    "Activity": "Enchantment Rider Activity",
+    "Effect": "Enchantment Rider Effect"
+  }
 },
 "DND5E.EffectsApplyTokens": "Apply to selected tokens",
 "DND5E.EffectApplyWarningConcentration": "Applying an effect that is being concentrated on by another character requires GM permissions.",

--- a/less/v2/items.less
+++ b/less/v2/items.less
@@ -524,6 +524,7 @@
       --icon-fill: var(--activity-icon-color);
       flex: 0 0 50px;
       height: 24px;
+      gap: 8px;
 
       .gold-icon {
         border-width: 1px;

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -250,6 +250,7 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
         return {
           id, name, sort,
           img: { src: img, svg: img?.endsWith(".svg") },
+          isRider: activity.isRider,
           uuid: activity.uuid
         };
       });
@@ -374,7 +375,8 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
           id, name, img, disabled, duration, source,
           parent,
           durationParts: duration.remaining ? duration.label.split(", ") : [],
-          hasTooltip: true
+          hasTooltip: true,
+          isRider: this.item.getFlag("dnd5e", "riders.effect")?.includes(id)
         });
         return arr;
       }, []);

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -179,6 +179,16 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Is this activity a rider for a non-applied enchantment?
+   * @type {boolean}
+   */
+  get isRider() {
+    return this.item.getFlag("dnd5e", "riders.activity")?.includes(this.id);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Is this activity on a spell scroll that is scaled.
    * @type {boolean}
    */

--- a/templates/items/activities.hbs
+++ b/templates/items/activities.hbs
@@ -3,12 +3,15 @@
     <div class="activity card" data-activity-id="{{ id }}" data-uuid="{{ uuid }}">
 
         {{!-- Icon --}}
-        <div class="icon {{#if img.svg}}svg{{/if}}">
+        <div class="icon flexrow {{#if img.svg}}svg{{/if}}">
             {{#if img.svg}}
             <dnd5e-icon src="{{ img.src }}"></dnd5e-icon>
             {{else}}
             <img src="{{ img.src }}" class="gold-icon" alt="{{ name }}">
             {{/if}}
+            {{#if isRider~}}
+            <i class="fa-solid fa-paperclip" data-tooltip aria-label="{{ localize 'DND5E.EFFECT.RIDER.Activity' }}"></i>
+            {{~/if}}
         </div>
 
         {{!-- Name --}}

--- a/templates/shared/active-effects2.hbs
+++ b/templates/shared/active-effects2.hbs
@@ -36,7 +36,13 @@
                     <div class="item-name item-tooltip effect-name">
                         <img class="item-image gold-icon" src="{{ img }}" alt="{{ name }}">
                         <div class="name name-stacked">
-                            <span class="title">{{ name }}</span>
+                            <span class="title">
+                                {{ name }}
+                                {{#if isRider~}}
+                                <i class="fa-solid fa-paperclip" data-tooltip
+                                   aria-label="{{ localize 'DND5E.EFFECT.RIDER.Effect' }}"></i>
+                                {{~/if}}
+                            </span>
                         </div>
                         {{#if duration.remaining}}
                         <div class="duration">


### PR DESCRIPTION
Adds a small paperclip icon next to rider activities and effects to make it clear that they are riders.

<img width="519" height="363" alt="Rider Activities Icon" src="https://github.com/user-attachments/assets/92182188-0775-46e9-b9cb-d51ee360fbe2" />
<img width="510" height="482" alt="Rider Effects Icon" src="https://github.com/user-attachments/assets/5f516435-2599-42d8-9fdd-43d09bfc7388" />


Closes #6126