### PR TITLE
[#3514] Allow AC formulae to reference spell mod

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -235,12 +235,12 @@ export default class CharacterData extends CreatureTemplate {
     this.prepareCurrency();
     this.prepareSkills({ rollData, originalSkills });
     this.prepareTools({ rollData });
+    AttributesFields.prepareSpellcastingAbility.call(this);
     AttributesFields.prepareArmorClass.call(this, rollData);
     AttributesFields.prepareConcentration.call(this, rollData);
     AttributesFields.prepareEncumbrance.call(this, rollData);
     AttributesFields.prepareInitiative.call(this, rollData);
     AttributesFields.prepareMovement.call(this, rollData);
-    AttributesFields.prepareSpellcastingAbility.call(this);
     TraitsFields.prepareLanguages.call(this);
     TraitsFields.prepareResistImmune.call(this);
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -421,13 +421,13 @@ export default class NPCData extends CreatureTemplate {
     this.prepareCurrency();
     this.prepareSkills({ rollData, originalSkills });
     this.prepareTools({ rollData });
+    AttributesFields.prepareSpellcastingAbility.call(this);
     AttributesFields.prepareArmorClass.call(this, rollData);
     AttributesFields.prepareConcentration.call(this, rollData);
     AttributesFields.prepareEncumbrance.call(this, rollData);
     AttributesFields.prepareExhaustionLevel.call(this);
     AttributesFields.prepareInitiative.call(this, rollData);
     AttributesFields.prepareMovement.call(this, rollData);
-    AttributesFields.prepareSpellcastingAbility.call(this);
     SourceField.prepareData.call(this.source, this.parent._stats?.compendiumSource ?? this.parent.uuid);
     TraitsFields.prepareLanguages.call(this);
     TraitsFields.prepareResistImmune.call(this);


### PR DESCRIPTION
Rather than simplifying `ac.min`, `ac.bonus`, and then deriving `ac.value` immediately during data prep, the first two are never simplified (don't think there's much reason to), and `ac.value` is moved to a getter that is derived only once when needed.

This allows for using any roll data properties as an AC bonus, despite data prep order.

Tested with an effect:
```
system.attributes.ac.bonus | ADD      | @attributes.spell.mod
system.attributes.ac.min   | OVERRIDE | 5 * @attributes.spell.mod
```

Closes #3514.