### PR TITLE
[#5237, #5293] Improve currency in starting equipment labels

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3811,12 +3811,15 @@
     "Tool": "Choose Tool",
     "Weapon": "Choose Weapon"
   },
+  "ChooseList": "<em>Choose {prefixes}:</em> {choices}",
+  "Currency": "Currency",
   "DropHint": "Drop item here to link",
   "IfProficient": "If Proficient",
   "Operator": {
     "AND": "All of…",
     "OR": "One of…"
   },
+  "Prefixes":  "abcdefghijklmnopqrstuvwxyz",
   "RequireProficiency": "Require Proficiency",
   "SpecificItem": "Specific Item",
   "Warning": {

--- a/module/applications/journal/class-page-sheet.mjs
+++ b/module/applications/journal/class-page-sheet.mjs
@@ -180,7 +180,7 @@ export default class JournalClassPageSheet extends JournalEntryPageHandlebarsShe
       };
     }
 
-    advancement.equipment = item.system.startingEquipmentDescription;
+    advancement.equipment = item.system.getStartingEquipmentDescription({ modernStyle });
 
     return advancement;
   }

--- a/module/data/item/templates/starting-equipment.mjs
+++ b/module/data/item/templates/starting-equipment.mjs
@@ -30,14 +30,48 @@ export default class StartingEquipmentTemplate extends SystemDataModel {
    * @type {string}
    */
   get startingEquipmentDescription() {
+    return this.getStartingEquipmentDescription();
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Create a HTML formatted description of the starting equipment on this item.
+   * @param {object} [options={}]
+   * @param {boolean} [options.modernStyle]       Should this be formatted according to modern rules or legacy.
+   * @returns {string}
+   */
+  getStartingEquipmentDescription({ modernStyle }={}) {
     const topLevel = this.startingEquipment.filter(e => !e.group);
     if ( !topLevel.length ) return "";
 
-    // If more than one entry, display as an unordered list (like for classes)
-    if ( topLevel.length > 1 ) return `<ul>${topLevel.map(e => `<li>${e.label}</li>`).join("")}</ul>`;
+    // If more than one entry, display as an unordered list (like for legacy classes)
+    if ( topLevel.length > 1 ) {
+      return `<ul>${topLevel.map(e => `<li>${e.generateLabel({ modernStyle })}</li>`).join("")}</ul>`;
+    }
+
+    // For modern classes, display as "Choose A or B"
+    modernStyle ??= (this.source.rules === "2024")
+      || (!this.source.rules && (game.settings.get("dnd5e", "rulesVersion") === "modern"));
+    if ( modernStyle ) {
+      const entries = topLevel[0].type === "OR" ? topLevel[0].children : topLevel;
+      if ( this.wealth ) entries.push(new EquipmentEntryData({ type: "currency", key: "gp", count: this.wealth }));
+      if ( entries.length > 1 ) {
+        const usedPrefixes = [];
+        const choices = EquipmentEntryData.prefixOrEntries(
+          entries.map(e => e.generateLabel({ modernStyle, depth: 2 })), { modernStyle, usedPrefixes }
+        );
+        const formatter = game.i18n.getListFormatter({ type: "disjunction" });
+        return `<p>${game.i18n.format("DND5E.StartingEquipment.ChooseList", {
+          prefixes: formatter.format(usedPrefixes), choices: formatter.format(choices)
+        })}</p>`;
+      }
+    }
 
     // Otherwise display as its own paragraph (like for backgrounds)
-    return `<p>${game.i18n.getListFormatter().format(topLevel.map(e => e.label))}</p>`;
+    return `<p>${game.i18n.getListFormatter().format(topLevel.map(e => e.generateLabel({ modernStyle })))}</p>`;
   }
 }
 
@@ -76,6 +110,9 @@ export class EquipmentEntryData extends foundry.abstract.DataModel {
     weapon: "DND5E.StartingEquipment.Choice.Weapon",
     focus: "DND5E.StartingEquipment.Choice.Focus",
 
+    // Currency
+    currency: "DND5E.StartingEquipment.Currency",
+
     // Generic item type
     linked: "DND5E.StartingEquipment.SpecificItem"
   };
@@ -99,6 +136,9 @@ export class EquipmentEntryData extends foundry.abstract.DataModel {
       label: "DND5E.Armor",
       config: "armorTypes"
     },
+    currency: {
+      config: "currencies"
+    },
     focus: {
       label: "DND5E.Focus.Label",
       config: "focusTypes"
@@ -118,13 +158,13 @@ export class EquipmentEntryData extends foundry.abstract.DataModel {
   /** @inheritDoc */
   static defineSchema() {
     return {
-      _id: new DocumentIdField({initial: () => foundry.utils.randomID()}),
-      group: new StringField({nullable: true, initial: null}),
+      _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
+      group: new StringField({ nullable: true, initial: null }),
       sort: new IntegerSortField(),
-      type: new StringField({required: true, initial: "OR", choices: this.TYPES}),
-      count: new NumberField({initial: undefined}),
-      key: new StringField({initial: undefined}),
-      requiresProficiency: new BooleanField({label: "DND5E.StartingEquipment.Proficient.Label"})
+      type: new StringField({ required: true, initial: "OR", choices: this.TYPES }),
+      count: new NumberField({ initial: undefined }),
+      key: new StringField({ initial: undefined }),
+      requiresProficiency: new BooleanField({ label: "DND5E.StartingEquipment.Proficient.Label" })
     };
   }
 
@@ -148,33 +188,7 @@ export class EquipmentEntryData extends foundry.abstract.DataModel {
    * @type {string}
    */
   get label() {
-    let label;
-
-    switch ( this.type ) {
-      // For AND/OR, use a simple conjunction/disjunction list (e.g. "first, second, and third")
-      case "AND":
-      case "OR":
-        return game.i18n.getListFormatter({type: this.type === "AND" ? "conjunction" : "disjunction", style: "long"})
-          .format(this.children.map(c => c.label).filter(l => l));
-
-      // For linked type, fetch the name using the index
-      case "linked":
-        label = linkForUuid(this.key);
-        break;
-
-      // For category types, grab category information from config
-      default:
-        label = this.categoryLabel;
-        break;
-    }
-
-    if ( !label ) return "";
-    if ( this.count > 1 ) label = `${formatNumber(this.count)}&times; ${label}`;
-    else if ( this.type !== "linked" ) label = game.i18n.format("DND5E.TraitConfigChooseAnyUncounted", { type: label });
-    if ( (this.type === "linked") && this.requiresProficiency ) {
-      label += ` (${game.i18n.localize("DND5E.StartingEquipment.IfProficient").toLowerCase()})`;
-    }
-    return label;
+    return this.generateLabel();
   }
 
   /* -------------------------------------------- */
@@ -215,5 +229,79 @@ export class EquipmentEntryData extends foundry.abstract.DataModel {
       obj[k] = foundry.utils.getType(v) === "Object" ? v.label : v;
       return obj;
     }, {});
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Transform this entry into a human readable label.
+   * @param {object} [options={}]
+   * @param {number} [options.depth=1]       Current depth of label being generated.
+   * @param {boolean} [options.modernStyle]  Use modern style for OR entries.
+   * @type {string}
+   */
+  generateLabel({ depth=1, modernStyle }={}) {
+    let label;
+    modernStyle ??= (this.parent.source?.rules === "2024")
+      || (!this.parent.source?.rules && (game.settings.get("dnd5e", "rulesVersion") === "modern"));
+
+    switch ( this.type ) {
+      // For AND/OR, use a simple conjunction/disjunction list (e.g. "first, second, and third")
+      case "AND":
+      case "OR":
+        let entries = this.children.map(c => c.generateLabel({ depth: depth + 1, modernStyle })).filter(_ => _);
+        if ( (this.type === "OR") && (entries.length > 1) ) {
+          entries = EquipmentEntryData.prefixOrEntries(entries, { depth, modernStyle });
+        }
+        return game.i18n.getListFormatter({ type: this.type === "AND" ? "conjunction" : "disjunction", style: "long" })
+          .format(entries);
+
+      case "currency":
+        const currencyConfig = CONFIG.DND5E.currencies[this.key];
+        if ( this.count && currencyConfig ) label = `${this.count} ${currencyConfig.abbreviation.toUpperCase()}`;
+        break;
+
+      // For linked type, fetch the name using the index
+      case "linked":
+        label = linkForUuid(this.key);
+        break;
+
+      // For category types, grab category information from config
+      default:
+        label = this.categoryLabel;
+        break;
+    }
+
+    if ( !label ) return "";
+    if ( this.type === "currency" ) return label;
+    if ( this.count > 1 ) label = `${formatNumber(this.count)}&times; ${label}`;
+    else if ( this.type !== "linked" ) label = game.i18n.format("DND5E.TraitConfigChooseAnyUncounted", { type: label });
+    if ( (this.type === "linked") && this.requiresProficiency ) {
+      label += ` (${game.i18n.localize("DND5E.StartingEquipment.IfProficient").toLowerCase()})`;
+    }
+    return label;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prefix each OR entry at a certain level with a letter.
+   * @param {string[]} entries                    Entries to prefix.
+   * @param {object} [options={}]
+   * @param {number} [options.depth=1]            Current depth of the OR entry (1 or 2).
+   * @param {boolean} [options.modernStyle=true]  Capitalized first level markers rather than lowercased.
+   * @param {string[]} [options.usedPrefixes]     Prefixes that were used.
+   * @returns {string[]}
+   */
+  static prefixOrEntries(entries, { depth=1, modernStyle=true, usedPrefixes }={}) {
+    let letters = game.i18n.localize("DND5E.StartingEquipment.Prefixes");
+    if (!letters) return entries;
+    if ( (modernStyle && (depth == 1)) || (!modernStyle && (depth === 2)) ) letters = letters.toUpperCase();
+    return entries.map((e, idx) => {
+      if ( usedPrefixes ) usedPrefixes.push(letters[idx]);
+      return `(${letters[idx]}) ${e}`;
+    });
   }
 }

--- a/packs/_source/classes24/barbarian/barbarian.yml
+++ b/packs/_source/classes24/barbarian/barbarian.yml
@@ -13,16 +13,18 @@ system:
     license: CC-BY-4.0
     book: SRD 5.2
   startingEquipment:
-    - type: OR
-      requiresProficiency: false
-      _id: iEStK5sr3bu18iLG
-      group: ''
-      sort: 100000
     - type: AND
       requiresProficiency: false
       _id: 0Yx0DOCxeeNYZw7n
-      group: iEStK5sr3bu18iLG
-      sort: 800000
+      group: ''
+      sort: 0
+    - type: linked
+      count: 1
+      key: Compendium.dnd5e.equipment24.Item.phbwepGreataxe00
+      requiresProficiency: false
+      _id: ubIakV0ZwY5Av8bB
+      group: 0Yx0DOCxeeNYZw7n
+      sort: 150000
     - type: linked
       count: null
       key: Compendium.dnd5e.equipment24.Item.phbagExplorersPa
@@ -36,14 +38,14 @@ system:
       requiresProficiency: false
       _id: CF9oDnOKVLy0OehZ
       group: 0Yx0DOCxeeNYZw7n
-      sort: 400000
-    - type: linked
-      count: 1
-      key: Compendium.dnd5e.equipment24.Item.phbwepGreataxe00
+      sort: 225000
+    - type: currency
+      count: 15
+      key: gp
       requiresProficiency: false
-      _id: ubIakV0ZwY5Av8bB
+      _id: Xc0Dsr2G1lJ6yLsY
       group: 0Yx0DOCxeeNYZw7n
-      sort: 600000
+      sort: 700000
   identifier: barbarian
   levels: 1
   advancement:
@@ -559,11 +561,11 @@ folder: ZzMJGIp9Rxhr2hDV
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735865940469
-  modifiedTime: 1752706172822
+  modifiedTime: 1757541406172
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/bard/bard.yml
+++ b/packs/_source/classes24/bard/bard.yml
@@ -79,6 +79,13 @@ system:
       _id: X63sE2GlxSzKzUho
       group: tWEfE6HLPbiS0OtF
       sort: 475000
+    - type: currency
+      count: 19
+      key: gp
+      requiresProficiency: false
+      _id: WMhogYYNWoJmO3k6
+      group: tWEfE6HLPbiS0OtF
+      sort: 800000
   identifier: bard
   levels: 1
   advancement:
@@ -529,11 +536,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735866377962
-  modifiedTime: 1752705712593
+  modifiedTime: 1757541456276
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/cleric/cleric.yml
+++ b/packs/_source/classes24/cleric/cleric.yml
@@ -82,6 +82,13 @@ system:
       _id: svexQM2NoMbtszQz
       group: hRVywVtYMIyj47LI
       sort: 600000
+    - type: currency
+      count: 7
+      key: gp
+      requiresProficiency: false
+      _id: SM5Tru74IHIrgmjJ
+      group: hRVywVtYMIyj47LI
+      sort: 700000
   identifier: cleric
   levels: 1
   advancement:
@@ -499,11 +506,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735866373481
-  modifiedTime: 1752705736618
+  modifiedTime: 1757541484584
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/druid/druid.yml
+++ b/packs/_source/classes24/druid/druid.yml
@@ -100,6 +100,13 @@ system:
       _id: f6RriL1CTIForH9O
       group: SE7gQkJVBVBLku2Z
       sort: 700000
+    - type: currency
+      count: 9
+      key: gp
+      requiresProficiency: false
+      _id: lSik2V9Hely7gsff
+      group: SE7gQkJVBVBLku2Z
+      sort: 900000
   identifier: druid
   levels: 1
   advancement:
@@ -607,11 +614,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735866366918
-  modifiedTime: 1752705792156
+  modifiedTime: 1757541518030
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/fighter/fighter.yml
+++ b/packs/_source/classes24/fighter/fighter.yml
@@ -59,6 +59,13 @@ system:
       _id: HXnWybFbmiQJ7jxw
       group: NgcVsnjvVJsL3xLw
       sort: 800000
+    - type: currency
+      count: 4
+      key: gp
+      requiresProficiency: false
+      _id: a1YXCzXv1aGDIw86
+      group: NgcVsnjvVJsL3xLw
+      sort: 1600000
     - type: AND
       requiresProficiency: false
       _id: mXHlWriN3u7VGUmQ
@@ -113,6 +120,13 @@ system:
       _id: gf3zQAZHgglaMuN1
       group: mXHlWriN3u7VGUmQ
       sort: 1500000
+    - type: currency
+      count: 11
+      key: gp
+      requiresProficiency: false
+      _id: N6FXv4CBSpxAodCH
+      group: mXHlWriN3u7VGUmQ
+      sort: 1700000
   identifier: fighter
   levels: 1
   advancement:
@@ -677,11 +691,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.347'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.3
+  systemVersion: 5.2.0
   createdTime: 1735866361253
-  modifiedTime: 1755622114129
+  modifiedTime: 1757541560929
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/monk/monk.yml
+++ b/packs/_source/classes24/monk/monk.yml
@@ -87,6 +87,13 @@ system:
       _id: YZ87ItdbDaRpBDQ2
       group: z3xcULs5Q70zNQ2D
       sort: 700000
+    - type: currency
+      count: 11
+      key: gp
+      requiresProficiency: false
+      _id: LFeGHcHHhv8YPetO
+      group: z3xcULs5Q70zNQ2D
+      sort: 800000
   identifier: monk
   levels: 1
   advancement:
@@ -583,11 +590,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735866307724
-  modifiedTime: 1752705841415
+  modifiedTime: 1757541602069
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/paladin/paladin.yml
+++ b/packs/_source/classes24/paladin/paladin.yml
@@ -102,6 +102,13 @@ system:
       _id: QtswKbw3wDtJyho7
       group: 55QxZJqMqe2yhcIx
       sort: 650000
+    - type: currency
+      count: 9
+      key: gp
+      requiresProficiency: false
+      _id: YWOqClo8j5g8L4Ml
+      group: 55QxZJqMqe2yhcIx
+      sort: 750000
   identifier: paladin
   levels: 1
   advancement:
@@ -571,11 +578,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735866297701
-  modifiedTime: 1752705867279
+  modifiedTime: 1757541629246
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/ranger/ranger.yml
+++ b/packs/_source/classes24/ranger/ranger.yml
@@ -114,6 +114,13 @@ system:
       _id: 3BV41WTrCIy6HLHS
       group: WFIcVPxUX9AVm6Bi
       sort: 900000
+    - type: currency
+      count: 7
+      key: gp
+      requiresProficiency: false
+      _id: Rpvzjvy76WfbCkxs
+      group: WFIcVPxUX9AVm6Bi
+      sort: 1000000
   identifier: ranger
   levels: 1
   advancement:
@@ -652,11 +659,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735932734523
-  modifiedTime: 1752705893809
+  modifiedTime: 1757541658137
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/rogue/rogue.yml
+++ b/packs/_source/classes24/rogue/rogue.yml
@@ -111,6 +111,13 @@ system:
       _id: 4tEh3PUpH9nhT646
       group: H3jVZpWr5rfZX6BH
       sort: 900000
+    - type: currency
+      count: 8
+      key: gp
+      requiresProficiency: false
+      _id: 6DenAQ9zLnDOTxZD
+      group: H3jVZpWr5rfZX6BH
+      sort: 1000000
   identifier: rogue
   levels: 1
   advancement:
@@ -618,11 +625,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735866292069
-  modifiedTime: 1752705919417
+  modifiedTime: 1757541688719
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/sorcerer/sorcerer.yml
+++ b/packs/_source/classes24/sorcerer/sorcerer.yml
@@ -85,6 +85,13 @@ system:
       _id: LgbG4QYKBQTlDhOd
       group: pR0mEuxe1qPdiMXB
       sort: 500000
+    - type: currency
+      count: 28
+      key: gp
+      requiresProficiency: false
+      _id: mXGHdwbuSIEboiMy
+      group: pR0mEuxe1qPdiMXB
+      sort: 700000
   identifier: sorcerer
   levels: 1
   advancement:
@@ -469,11 +476,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735866286897
-  modifiedTime: 1752705940073
+  modifiedTime: 1757541715654
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/warlock/warlock.yml
+++ b/packs/_source/classes24/warlock/warlock.yml
@@ -94,6 +94,13 @@ system:
       _id: QtlLMEGt8LF296xx
       group: HNL3GVldnPCsg4BR
       sort: 800000
+    - type: currency
+      count: 15
+      key: gp
+      requiresProficiency: false
+      _id: KqxMWGbayv1QRIDV
+      group: HNL3GVldnPCsg4BR
+      sort: 900000
   identifier: warlock
   levels: 1
   advancement:
@@ -573,11 +580,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735866281378
-  modifiedTime: 1752705960661
+  modifiedTime: 1757541745637
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/wizard/wizard.yml
+++ b/packs/_source/classes24/wizard/wizard.yml
@@ -103,6 +103,13 @@ system:
       _id: ipKkaDAn6KnKgpVH
       group: zcKhKDfR6l9mjjo0
       sort: 500000
+    - type: currency
+      count: 5
+      key: gp
+      requiresProficiency: false
+      _id: xxd2IhkKWk9bmLjp
+      group: zcKhKDfR6l9mjjo0
+      sort: 700000
   identifier: wizard
   levels: 1
   advancement:
@@ -428,11 +435,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.348'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.2.0
   createdTime: 1735866273692
-  modifiedTime: 1752705980871
+  modifiedTime: 1757541790477
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0


### PR DESCRIPTION
Add a new entry type to starting equipment that allows entering currency directly. SRD 5.2 classes have been updated to include the missing gold from their starting equipment.

<img width="436" height="88" alt="Starting Equipment Gold Config" src="https://github.com/user-attachments/assets/14a7298c-9514-410a-bd86-3d6d5d99c320" />

Make use of this new currency entry to display the starting equipment list with the starting wealth included as an option when using the modern rules formatting.

<img width="632" height="100" alt="Starting Equipment Gold Modern" src="https://github.com/user-attachments/assets/13974d55-ed49-42bd-99af-44395e7fffae" />

Also adds letter prefixes to OR-lists to more accurately reflect how classes are displayed in both the mordern and legacy styles.

<img width="572" height="152" alt="Starting Equipment Gold Legacy" src="https://github.com/user-attachments/assets/5ffda25f-86da-4ef1-b079-09254f6f9b23" />

Closes #5237
Closes #5293