### PR TITLE
[#3077] Swap chat icon based on preferred sheet artwork

### DIFF
--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -46,16 +46,22 @@
         place-content: center;
       }
 
-      img {
+      img, video {
         width: 38px;
         height: 38px;
-        border-radius: 4px;
-        box-shadow: 0 0 6px rgb(0 0 0 / 85%);
-        object-fit: cover;
-        object-position: top;
         border: none;
         flex: none;
+      }
+      .avatar:not(.token) img {
+        border-radius: 4px;
+        box-shadow: 0 0 6px rgb(0 0 0 / 85%);
         background: var(--dnd5e-background-alt-1);
+        object-fit: cover;
+        object-position: top;
+      }
+      .avatar.token :is(img, video) {
+        object-fix: contain;
+        object-position: center;
       }
     }
 

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -473,23 +473,13 @@ export default class BaseActorSheet extends PrimarySheetMixin(
    * @protected
    */
   async _preparePortrait(context) {
-    const showTokenPortrait = this.actor.getFlag("dnd5e", "showTokenPortrait") === true;
-    const token = this.actor.isToken ? this.actor.token : this.actor.prototypeToken;
-    const defaultArtwork = Actor.implementation.getDefaultArtwork(this.actor._source)?.img;
-    let action = "editImage";
-    let texture = token?.texture.src;
-    if ( showTokenPortrait && token?.randomImg ) {
-      const images = await this.actor.getTokenImages();
-      texture = images[Math.floor(Math.random() * images.length)];
-      action = "configurePrototypeToken";
-    }
-    const src = (showTokenPortrait ? texture : this.actor.img) ?? defaultArtwork;
+    const portraitData = await this.actor.getPreferredArtwork();
     return {
-      src, action,
-      token: showTokenPortrait,
-      path: showTokenPortrait ? this.actor.isToken ? "token.texture.src" : "prototypeToken.texture.src" : "img",
-      type: showTokenPortrait ? "imagevideo" : "image",
-      isVideo: foundry.helpers.media.VideoHelper.hasVideoExtension(src)
+      ...portraitData,
+      action: portraitData.isRandom ? "configurePrototypeToken" : "editImage",
+      path: portraitData.isToken ? this.actor.isToken ? "token.texture.src" : "prototypeToken.texture.src" : "img",
+      token: portraitData.isToken,
+      type: portraitData.token ? "imagevideo" : "image"
     };
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -36,6 +36,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
+   * Cached copy of the preferred artwork.
+   * @type {{ src: string, isToken: boolean, isRandom: boolean, isVideo: boolean }|null}
+   */
+  _preferredArtwork = this._preferredArtwork;
+
+  /* -------------------------------------------- */
+
+  /**
    * Mapping of item identifiers to the items.
    * @type {IdentifiedItemsMap<string, Set<Item5e>>}
    */
@@ -253,6 +261,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   _clearCachedValues() {
     this._lazy = {};
+    this._preferredArtwork = null;
   }
 
   /* --------------------------------------------- */
@@ -338,6 +347,33 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
         "_stats.duplicateSource": actor.uuid
       }, { save: true });
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Select appropriate artwork to display on sheet & chat cards based on `showTokenPortrait` flag.
+   * @returns {Promise<{ src: string, token: boolean, isRandom: boolean, isVideo: boolean }>}
+   */
+  async getPreferredArtwork() {
+    if ( !this._preferredArtwork ) {
+      const showTokenPortrait = this.getFlag("dnd5e", "showTokenPortrait") === true;
+      const token = this.isToken ? this.token : this.prototypeToken;
+      const defaultArtwork = Actor.implementation.getDefaultArtwork(this._source)?.img;
+      let texture = token?.texture.src;
+      if ( showTokenPortrait && token?.randomImg ) {
+        const images = await this.getTokenImages();
+        texture = images[Math.floor(Math.random() * images.length)];
+      }
+      const src = (showTokenPortrait ? texture : this.img) ?? defaultArtwork;
+      this._preferredArtwork = {
+        src,
+        isRandom: showTokenPortrait && token?.randomImg,
+        isToken: showTokenPortrait,
+        isVideo: foundry.helpers.media.VideoHelper.hasVideoExtension(src)
+      };
+    }
+    return this._preferredArtwork;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -129,7 +129,7 @@ export default class ChatMessage5e extends ChatMessage {
       html.querySelectorAll(".description.collapsible").forEach(el => el.classList.add("collapsed"));
     }
 
-    this._enrichChatCard(html);
+    await this._enrichChatCard(html);
     this._collapseTrays(html);
     this._activateActivityListeners(html);
     dnd5e.bastion._activateChatListeners(this, html);
@@ -266,28 +266,38 @@ export default class ChatMessage5e extends ChatMessage {
    * @param {HTMLElement} html  The chat card markup.
    * @protected
    */
-  _enrichChatCard(html) {
+  async _enrichChatCard(html) {
     html.querySelectorAll(".dnd5e2").forEach(el => el.classList.remove("dnd5e2")); // Legacy
     html.classList.add("dnd5e2");
 
     // Header matter
     const actor = this.getAssociatedActor();
+    const avatar = document.createElement("a");
+    avatar.classList.add("avatar");
+    let avatarImg = document.createElement("img");
 
     let img;
     let nameText;
     if ( this.isContentVisible ) {
-      img = actor?.img ?? this.author?.avatar;
+      const artworkData = await actor?.getPreferredArtwork();
+      img = artworkData?.src ?? this.author?.avatar;
       nameText = this.alias;
+      if ( artworkData?.isToken ) avatar.classList.add("token");
+      if ( artworkData?.isVideo ) {
+        avatarImg = document.createElement("video");
+        avatarImg.toggleAttribute("autoplay", true);
+        avatarImg.toggleAttribute("muted", true);
+        avatarImg.toggleAttribute("disablepictureinpicture", true);
+        avatarImg.toggleAttribute("loop", true);
+        avatarImg.toggleAttribute("playsinline", true);
+      }
     } else {
       img = this.author?.avatar;
       nameText = this.author?.name ?? "";
     }
     img ??= CONST.DEFAULT_TOKEN;
 
-    const avatar = document.createElement("a");
-    avatar.classList.add("avatar");
     if ( actor ) avatar.dataset.uuid = actor.uuid;
-    const avatarImg = document.createElement("img");
     Object.assign(avatarImg, { src: img, alt: nameText });
     avatar.append(avatarImg);
 


### PR DESCRIPTION
If a character or NPC has their token displayed on the sheet rather than their portrait, display that in the chat card also. Moves the logic for selecting the artwork into its own method so it can be shared between the sheet and the chat card, and cache the result so each chat card doesn't end up with a different random token.

Closes #3077