### PR TITLE
Add `spellcastingAbility` that takes highest ability

### DIFF
--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -242,7 +242,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   get spellcastingAbility() {
     let ability;
     if ( this.isSpell ) ability = this.item.system.availableAbilities?.first();
-    return ability ?? this.actor?.system.attributes?.spellcasting ?? null;
+    return ability ?? this.actor?.spellcastingAbility ?? null;
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/summon-data.mjs
+++ b/module/data/activity/summon-data.mjs
@@ -66,7 +66,7 @@ export default class BaseSummonActivityData extends BaseActivityData {
 
   /** @inheritDoc */
   get ability() {
-    return this.match.ability || super.ability || this.item.abilityMod || this.actor?.system.attributes?.spellcasting;
+    return this.match.ability || super.ability || this.item.abilityMod || this.actor?.system.spellcastingAbility;
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/summon-data.mjs
+++ b/module/data/activity/summon-data.mjs
@@ -66,7 +66,7 @@ export default class BaseSummonActivityData extends BaseActivityData {
 
   /** @inheritDoc */
   get ability() {
-    return this.match.ability || super.ability || this.item.abilityMod || this.actor?.system.spellcastingAbility;
+    return this.match.ability || super.ability || this.item.abilityMod || this.actor?.spellcastingAbility;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -131,7 +131,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
   /** @inheritDoc */
   get _typeAbilityMod() {
     if ( this.type.value !== "scroll" ) return null;
-    return this.parent?.actor?.system.attributes.spellcasting || "int";
+    return this.parent?.actor?.spellcastingAbility ?? "int";
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -47,7 +47,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
   /**
    * Lazily computed store of classes, subclasses, background, and species.
-   * @type {Record<string, Record<string, Item5e|Item5e[]>>}
+   * @type {Record<string, Record<string, Item5e|Item5e[]|string>>}
    */
   _lazy = {};
 
@@ -117,6 +117,21 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( this.statuses.has("coverThreeQuarters") ) return coverThreeQuarters?.coverBonus;
     else if ( this.statuses.has("coverHalf") ) return coverHalf?.coverBonus;
     return 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Highest ability associated with a spellcasting class.
+   * @type {string}
+   */
+  get spellcastingAbility() {
+    if ( this._lazy.spellcastingAbility !== undefined ) return this._lazy.spellcastingAbility;
+    return this._lazy.spellcastingAbility = Object.values(this.spellcastingClasses).reduce((o, c) => {
+      const ability = c.system.spellcasting.ability;
+      if ( this.system.abilities[ability]?.mod > o.mod ) return { ability, mod: this.system.abilities[ability].mod };
+      return o;
+    }, { ability: null, mod: -Infinity })?.ability ?? this.system.attributes?.spellcasting ?? "int";
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Adds `spellcastingAbility` property to actors that returns the highest ability from among their spellcasting classes or their spellcasting attribute if no spellcasting classes are found.

Unblocks #4934
Unblocks #5092