### PR TITLE
[#4398] Allow specification of `additional` initial filters when initializing Compendium Browser

### DIFF
--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -69,7 +69,7 @@ export default class CompendiumBrowser extends Application5e {
       const isAdvanced = this._mode === this.constructor.MODES.ADVANCED;
       const tab = this.constructor.TABS.find(t => t.tab === this.options.tab);
       if ( !tab || (!!tab.advanced !== isAdvanced) ) this.options.tab = isAdvanced ? "actors" : "classes";
-      this._applyTabFilters(this.options.tab, true);
+      this._applyTabFilters(this.options.tab, { keepFilters: true });
     }
   }
 
@@ -828,11 +828,12 @@ export default class CompendiumBrowser extends Application5e {
 
   /**
    * Apply filters based on the selected tab.
-   * @param {string} id                   The tab ID.
-   * @param {boolean} [keepFilters=false] Whether to keep the existing additional filters
+   * @param {string} id                           The tab ID.
+   * @param {object} [options]                    Additional options
+   * @param {boolean} [options.keepFilters=false] Whether to keep the existing additional filters
    * @protected
    */
-  _applyTabFilters(id, keepFilters=false) {
+  _applyTabFilters(id, { keepFilters=false }={}) {
     const tab = this.constructor.TABS.find(t => t.tab === id);
     if ( !tab ) return;
     const { documentClass, types } = tab;


### PR DESCRIPTION
Closes #4398
Current behavior deletes `this.#filters.additional` on tab filter application (which _always_ gets called at end of constructor unless there are locked filters), to keep filters from one tab from erroneously applying to another. 

Added an argument to `_applyTabFilters`, `keepFilters` (defaults to false) which, if true, _won't_ delete those `additional` filters. This makes it possible to do, for instance:
```js
new dnd5e.applications.CompendiumBrowser({
    tab: "spells",
    filters: {
        initial: {
            additional: {
                spelllist: {
                    "class:cleric": 1
                },
                level: {
                    max: 5
                }
            }
        }
    }
}).render(true)
```
and get an appropriately initially-filtered (but not locked) CB:
<img width="221" height="466" alt="image" src="https://github.com/user-attachments/assets/2e36c679-0ba0-4624-bf2e-e89397be35d7" />

Additional logic provided for the special handling of the "feats" tab, so as to avoid clobbering `additional` filters there, too.