### PR TITLE
[#6210] Limit group travel pace if any members are below half speed

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4603,7 +4603,8 @@
     "Fast": "Fast",
     "Normal": "Normal",
     "Slow": "Slow"
-  }
+  },
+  "Slowed": "Slowed"
 },
 
 "DND5E.Treasure": {

--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -313,7 +313,7 @@ export default class GroupActorSheet extends MultiActorSheet {
     if ( type !== "skill" ) return;
     const { uuid } = target.closest("[data-uuid]")?.dataset ?? {};
     const actor = await fromUuid(uuid);
-    actor?.rollSkill({ event, skill: key, pace: this.actor.system.attributes.movement.pace });
+    actor?.rollSkill({ event, skill: key, pace: this.actor.system.attributes.movement.effectivePace });
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -184,7 +184,22 @@ export default class GroupData extends GroupTemplate {
 
   /** @inheritDoc */
   prepareDerivedData() {
-    this.parent.labels.pace = CONFIG.DND5E.travelPace[this.attributes.movement.pace]?.label;
+    const members = this.members;
+    Object.defineProperty(this.attributes.movement, "slowed", {
+      get() {
+        return members.some(m => m.actor?.system.attributes?.movement?.slowed);
+      }
+    });
+    Object.defineProperty(this.attributes.movement, "effectivePace", {
+      get() {
+        return this.slowed ? "slow" : this.pace;
+      }
+    });
+    Object.defineProperty(this.attributes.movement, "paceLabel", {
+      get() {
+        return CONFIG.DND5E.travelPace[this.effectivePace]?.label;
+      }
+    });
     MovementField.prepareData.call(this.attributes.movement, this.schema.getField("attributes.movement"));
   }
 

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -446,6 +446,9 @@ export default class AttributesFields {
           speed = Math.min(speed, CONFIG.DND5E.encumbrance.speedReduction.exceedingCarryingCapacity[units] ?? 0);
         }
       }
+      if ( (type === "walk") && this.attributes.movement.walk ) {
+        this.attributes.movement.slowed = speed <= Math.floor(this.attributes.movement.walk / 2);
+      }
       this.attributes.movement[type] = speed;
     }
   }

--- a/templates/actors/group/header.hbs
+++ b/templates/actors/group/header.hbs
@@ -50,12 +50,14 @@
                     </button>
                     {{else}}
                     <button type="button" class="unbutton config-button" data-action="changePace" data-increment="-1"
-                            data-tooltip aria-label="{{ localize "DND5E.Group.Action.ChangePace" }}">
+                            data-tooltip aria-label="{{ localize "DND5E.Group.Action.ChangePace" }}"
+                            {{ disabled system.attributes.movement.slowed }}>
                         <i class="fa-solid fa-chevron-left" inert></i>
                     </button>
-                    <span class="pace subtitle">{{ labels.pace }}</span>
+                    <span class="pace subtitle">{{ system.attributes.movement.paceLabel }}</span>
                     <button type="button" class="unbutton config-button" data-action="changePace" data-increment="1"
-                            data-tooltip aria-label="{{ localize "DND5E.Group.Action.ChangePace" }}">
+                            data-tooltip aria-label="{{ localize "DND5E.Group.Action.ChangePace" }}"
+                            {{ disabled system.attributes.movement.slowed }}>
                         <i class="fa-solid fa-chevron-right" inert></i>
                     </button>
                     {{/if}}

--- a/templates/actors/group/member.hbs
+++ b/templates/actors/group/member.hbs
@@ -76,7 +76,13 @@
             </div>
             <div>
                 <i class="fa-solid fa-shoe-prints" data-tooltip aria-label="{{ localize "DND5E.Speed" }}"></i>
-                <span class="value">{{ system.attributes.movement.walk }}</span>
+                <span class="value">
+                    {{ system.attributes.movement.walk }}
+                    {{#if system.attributes.movement.slowed}}
+                    <i class="fa-solid fa-triangle-exclamation" data-tooltip
+                       aria-label="{{ localize 'DND5E.Travel.Slowed' }}"></i>
+                    {{/if}}
+                </span>
             </div>
         </div>
         <div class="info">


### PR DESCRIPTION
Limits the group's pace to "Slow" if any members are below half their normal walking speed. This is done by adding a new `slowed` boolean to actor's movement data. Currently this only takes into account speed reductions from status effects, not from any active effects that might be reducing their speed.

Created a new `effectivePace` getter and moved the pace label into a getter also to ensure that changes to actor's speeds can be reflected on the group actor after a render, rather than requiring a complete re-preparation of the group actor data.

Closes #6210