### PR TITLE
[#4957] Automatically scale down titles that don't fit

### DIFF
--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1133,7 +1133,7 @@
 
     &:has(h2:not(:empty)) { margin-block-end: calc(var(--font-size-24) + 12px); }
 
-    h1, h2 {
+    h1, h2, .title-measure {
       position: absolute;
       inset-inline: 0;
       color: var(--color-text-primary);
@@ -1144,13 +1144,19 @@
     }
     h1 {
       inset-block-start: calc(var(--header-height) - 20px);
-      font-size: var(--font-size-24);
+      font-size: calc(var(--font-size-24) * var(--font-size-scale, 1));
     }
     h2 {
       inset-block-start: calc(var(--header-height) + var(--font-size-16));
       margin: 0;
       font-size: var(--font-size-16);
       text-shadow: none;
+    }
+    .title-measure {
+      font-size: var(--font-size-24);
+      inset: unset;
+      overflow: visible;
+      text-wrap: nowrap;
     }
 
     .header-control:not(.unbutton) { background: var(--dnd5e-background-25); }
@@ -1170,6 +1176,7 @@
       border-radius: 4px;
     }
   }
+  .title-measure { visibility: hidden; }
 
   &.minimized .window-header {
     h1 { all: revert-layer; }

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1133,7 +1133,7 @@
 
     &:has(h2:not(:empty)) { margin-block-end: calc(var(--font-size-24) + 12px); }
 
-    h1, h2, .title-measure {
+    h1, h2 {
       position: absolute;
       inset-inline: 0;
       color: var(--color-text-primary);
@@ -1151,12 +1151,6 @@
       margin: 0;
       font-size: var(--font-size-16);
       text-shadow: none;
-    }
-    .title-measure {
-      font-size: var(--font-size-24);
-      inset: unset;
-      overflow: visible;
-      text-wrap: nowrap;
     }
 
     .header-control:not(.unbutton) { background: var(--dnd5e-background-25); }
@@ -1176,7 +1170,6 @@
       border-radius: 4px;
     }
   }
-  .title-measure { visibility: hidden; }
 
   &.minimized .window-header {
     h1 { all: revert-layer; }

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -727,7 +727,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     );
     Object.assign(warnings.dataset, { action: "openWarnings", tooltip: "Warnings", tooltipDirection: "DOWN" });
     warnings.setAttribute("aria-label", _loc("Warnings"));
-    html.querySelector(".window-header .window-subtitle").after(warnings);
+    this.window.subtitle.after(warnings);
 
     return html;
   }

--- a/module/applications/api/application-v2-mixin.mjs
+++ b/module/applications/api/application-v2-mixin.mjs
@@ -62,6 +62,18 @@ export default function ApplicationV2Mixin(Base, { handlebars=true }={}) {
     }
 
     /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    get window() {
+      return { ...super.window, ...this.#window };
+    }
+
+    #window = {
+      subtitle: null,
+      titleMeasure: null
+    };
+
+    /* -------------------------------------------- */
     /*  Rendering                                   */
     /* -------------------------------------------- */
 
@@ -107,6 +119,14 @@ export default function ApplicationV2Mixin(Base, { handlebars=true }={}) {
     _onFirstRender(context, options) {
       super._onFirstRender(context, options);
       this._renderContainers(context, options);
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    _onPosition(position) {
+      super._onPosition(position);
+      if ( "width" in position ) this.#scaleTitle();
     }
 
     /* -------------------------------------------- */
@@ -160,10 +180,18 @@ export default function ApplicationV2Mixin(Base, { handlebars=true }={}) {
       const frame = await super._renderFrame(options);
       if ( !this.hasFrame ) return frame;
 
+      // Title
+      const titleMeasure = document.createElement("span");
+      titleMeasure.ariaHidden = true;
+      titleMeasure.classList.add("title-measure");
+      frame?.querySelector(".window-title")?.insertAdjacentElement("afterend", titleMeasure);
+      this.#window.titleMeasure = titleMeasure;
+
       // Subtitles
       const subtitle = document.createElement("h2");
       subtitle.classList.add("window-subtitle");
       frame?.querySelector(".window-title")?.insertAdjacentElement("afterend", subtitle);
+      this.#window.subtitle = subtitle;
 
       // Icon
       if ( (options.window?.icon ?? "").includes(".") ) {
@@ -237,9 +265,13 @@ export default function ApplicationV2Mixin(Base, { handlebars=true }={}) {
     /** @inheritDoc */
     _updateFrame(options) {
       super._updateFrame(options);
-      if ( options.window && ("subtitle" in options.window) ) {
-        this.element.querySelector(".window-header > .window-subtitle").innerText = options.window.subtitle;
+      const window = options.window;
+      if ( !window ) return;
+      if ( ("title" in window) && this.#window.titleMeasure ) {
+        this.window.titleMeasure.innerText = window.title;
+        this.#scaleTitle();
       }
+      if ( ("subtitle" in window) && this.#window.subtitle ) this.#window.subtitle.innerText = window.subtitle;
     }
 
     /* -------------------------------------------- */
@@ -288,6 +320,21 @@ export default function ApplicationV2Mixin(Base, { handlebars=true }={}) {
         if ( element.tagName === "TEXTAREA" ) element.readOnly = true;
         else element.disabled = true;
       }
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Scale the font size of the app's title to ensure it fits.
+     */
+    #scaleTitle() {
+      requestAnimationFrame(() => {
+        const maxWidth = this.element.offsetWidth - 60;
+        const fullWidth = this.window.titleMeasure.offsetWidth;
+        if ( fullWidth > maxWidth ) {
+          this.window.title.style.setProperty("--font-size-scale", Math.clamp(maxWidth / fullWidth, 0.5, 1));
+        }
+      });
     }
 
     /* -------------------------------------------- */

--- a/module/applications/api/application-v2-mixin.mjs
+++ b/module/applications/api/application-v2-mixin.mjs
@@ -69,8 +69,7 @@ export default function ApplicationV2Mixin(Base, { handlebars=true }={}) {
     }
 
     #window = {
-      subtitle: null,
-      titleMeasure: null
+      subtitle: null
     };
 
     /* -------------------------------------------- */
@@ -180,13 +179,6 @@ export default function ApplicationV2Mixin(Base, { handlebars=true }={}) {
       const frame = await super._renderFrame(options);
       if ( !this.hasFrame ) return frame;
 
-      // Title
-      const titleMeasure = document.createElement("span");
-      titleMeasure.ariaHidden = true;
-      titleMeasure.classList.add("title-measure");
-      frame?.querySelector(".window-title")?.insertAdjacentElement("afterend", titleMeasure);
-      this.#window.titleMeasure = titleMeasure;
-
       // Subtitles
       const subtitle = document.createElement("h2");
       subtitle.classList.add("window-subtitle");
@@ -265,13 +257,10 @@ export default function ApplicationV2Mixin(Base, { handlebars=true }={}) {
     /** @inheritDoc */
     _updateFrame(options) {
       super._updateFrame(options);
-      const window = options.window;
-      if ( !window ) return;
-      if ( ("title" in window) && this.#window.titleMeasure ) {
-        this.window.titleMeasure.innerText = window.title;
-        this.#scaleTitle();
-      }
-      if ( ("subtitle" in window) && this.#window.subtitle ) this.#window.subtitle.innerText = window.subtitle;
+      const win = options.window;
+      if ( !win ) return;
+      if ( ("title" in win) && this.#window.title ) this.#scaleTitle();
+      if ( ("subtitle" in win) && this.#window.subtitle ) this.#window.subtitle.innerText = win.subtitle;
     }
 
     /* -------------------------------------------- */
@@ -329,11 +318,15 @@ export default function ApplicationV2Mixin(Base, { handlebars=true }={}) {
      */
     #scaleTitle() {
       requestAnimationFrame(() => {
+        const { title } = this.window;
+        if ( !this.element || !title ) return;
+        // Divide by existing font scale to recover original size.
+        const scale = parseFloat(title.style.getPropertyValue("--font-size-scale")) || 1;
+        const range = document.createRange();
+        range.selectNodeContents(title);
+        const fullWidth = range.getBoundingClientRect().width / scale;
         const maxWidth = this.element.offsetWidth - 60;
-        const fullWidth = this.window.titleMeasure.offsetWidth;
-        if ( fullWidth > maxWidth ) {
-          this.window.title.style.setProperty("--font-size-scale", Math.clamp(maxWidth / fullWidth, 0.5, 1));
-        }
+        if ( fullWidth ) title.style.setProperty("--font-size-scale", Math.clamp(maxWidth / fullWidth, 0.5, 1));
       });
     }
 

--- a/module/applications/api/primary-sheet-mixin.mjs
+++ b/module/applications/api/primary-sheet-mixin.mjs
@@ -137,7 +137,7 @@ export default function PrimarySheetMixin(Base) {
           <span></span>
         </div>
       `;
-      html.querySelector(".window-subtitle")?.after(elements);
+      this.window.subtitle?.after(elements);
     }
 
     /* -------------------------------------------- */


### PR DESCRIPTION
Adds some resizing of the title in all system applications to try and prevent the title from being cut off. The title can be scaled down up to 50%.

<img width="384" height="294" alt="Title Resizing" src="https://github.com/user-attachments/assets/9ae7b4d9-cdfe-498a-b5a2-021aa8caf99a" />

This is achieved by creating a second copy of the title that isn't visible and isn't constrained by the window's width. On render or resize the width of this invisible copy is compared against the width of the window, and if it is wider then a scaling factor is applied via CSS to the window's title.

Closes #4957