### PR TITLE
[#2291, #5770] Tie item uses recovery into calendar system

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -537,13 +537,14 @@ Hooks.once("i18nInit", () => {
  * Once the entire VTT framework is initialized, check to see if we should perform a data migration
  */
 Hooks.once("ready", function() {
-  // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
+  // Wait to register certain hooks so that modules can register earlier if they want to
   Hooks.on("hotbarDrop", (bar, data, slot) => {
     if ( ["ActiveEffect", "Activity", "Item"].includes(data.type) ) {
       documents.macro.create5eMacro(data, slot);
       return false;
     }
   });
+  Hooks.on("updateWorldTime", dataModels.calendar.CalendarData5e.onTimePassage);
 
   // Adjust sourced items on actors now that compendium UUID redirects have been initialized
   game.actors.forEach(a => a.sourcedItems._redirectKeys());

--- a/lang/en.json
+++ b/lang/en.json
@@ -28,6 +28,7 @@
 "TYPES.ChatMessage": {
   "request": "Request Message",
   "rest": "Rest Message",
+  "timePassed": "Time Passed Message",
   "turn": "Combat Turn Message",
   "usage": "Usage Message"
 },
@@ -1279,6 +1280,13 @@
       "hint": "Allow the calendar UI to be viewed & customized by all users.",
       "label": "Enabled"
     },
+    "dailyRecovery": {
+      "calendar": "Calendar Recovery (via time passing)",
+      "default": "Default (tied to calendar enabled setting)",
+      "hint": "Control whether limited uses with day, dawn, and dusk recovery are recovered based on the world calendar or through the rest dialog.",
+      "label": "Daily Recovery Mode",
+      "manual": "Manual Recovery (via rest dialog)"
+    },
     "formatters": {
       "date": {
         "label": "Date Format"
@@ -1468,6 +1476,17 @@
       "Autumn": "Autumn",
       "Winter": "Winter"
     }
+  },
+  "TimePassage": {
+    "Midnight": "A new day has begun.",
+    "Sunrise": "The sun has risen.",
+    "Sunset": "The sun has set.",
+    "SunsetSunrise": "The sun has set and a new dawn of a new day has come.",
+    "TimePassed": {
+      "one": "{number} has passed.",
+      "other": "{number} have passed."
+    },
+    "Title": "Passage of Time"
   }
 },
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -1481,7 +1481,7 @@
     "Midnight": "A new day has begun.",
     "Sunrise": "The sun has risen.",
     "Sunset": "The sun has set.",
-    "SunsetSunrise": "The sun has set and a new dawn of a new day has come.",
+    "SunsetSunrise": "The sun has set and the dawn of a new day has come.",
     "TimePassed": {
       "one": "{number} has passed.",
       "other": "{number} have passed."

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -102,7 +102,7 @@ export default class BaseRestDialog extends Dialog5e {
    */
   get promptNewDay() {
     // Only prompt if rest is longer than 10 minutes and less than 24 hours
-    return (this.duration > 10) && (this.duration < 1440);
+    return dnd5e.settings.calendarConfig.manualRecovery && (this.duration > 10) && (this.duration < 1440);
   }
 
   /* -------------------------------------------- */

--- a/module/applications/settings/calendar-settings.mjs
+++ b/module/applications/settings/calendar-settings.mjs
@@ -69,6 +69,7 @@ export default class CalendarSettingsConfig extends BaseSettingsConfig {
       .map(([name, field]) => ({
         field,
         input: field instanceof BooleanField ? createCheckboxInput : undefined,
+        localize: !!field.choices,
         name: `calendarConfig.${name}`,
         value: data[name]
       }));

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4568,6 +4568,20 @@ preLocalize("calendar.calendars", { keys: ["label", "group"] });
 preLocalize("calendar.formatters", { keys: ["label", "group"] });
 
 /* -------------------------------------------- */
+
+/**
+ * Mapping of time deltas created by time passing in the calendar system to limited use recovery periods.
+ * Note: Ordering is important in this entry because it determines the order in which these recovery periods
+ * will be selected if multiple applicable periods are found during the recovery process.
+ * @type {Map<string, string>}
+ */
+DND5E.calendarDeltasRecoveryMapping = new Map([
+  ["midnights", "day"],
+  ["sunrises", "dawn"],
+  ["sunsets", "dusk"]
+]);
+
+/* -------------------------------------------- */
 /*  Requests                                    */
 /* -------------------------------------------- */
 

--- a/module/data/calendar/_types.mjs
+++ b/module/data/calendar/_types.mjs
@@ -23,6 +23,12 @@
  * @property {number} sunsets    Number of sunsets that occurred during a time change.
  */
 
+/**
+ * @typedef {CalendarTimeDeltas} TimePassageData
+ * @property {number} worldTime  Timecode for world after time as passed.
+ * @property {number} deltaTime  Change to the timecode that occurred.
+ */
+
 /* -------------------------------------------- */
 
 /**

--- a/module/data/calendar/calendar-data.mjs
+++ b/module/data/calendar/calendar-data.mjs
@@ -339,7 +339,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
    */
   static onTimePassage(worldTime, deltaTime, options, userId) {
     if ( !game.user.isActiveGM || (deltaTime <= 0) ) return;
-    const timePassageData = { worldTime, deltaTime, ...options.dnd5e.deltas };
+    const timePassageData = { worldTime, deltaTime, ...(options.dnd5e?.deltas ?? {}) };
     CalendarData5e.handleTimePassage(timePassageData);
   }
 
@@ -355,40 +355,39 @@ export default class CalendarData5e extends foundry.data.CalendarData {
       if ( timePassageData[d] ) periods.set(p, timePassageData[d]);
     }
 
-    const deltas = [];
+    const changes = [];
     const rolls = [];
 
-    if ( !game.settings.get("dnd5e", "calendarConfig").manualRecovery ) {
-      const performItemUpdates = async (items, updates) => {
-        for ( const item of items ) {
-          const result = await item.system.recoverUses?.(periods, item.getRollData()) ?? {};
-          if ( !foundry.utils.isEmpty(result?.updates) ) {
-            deltas.push({ uuid: item.uuid, deltas: IndividualDeltaField.getDeltas(item, result.updates) });
+    if ( !game.settings.get("dnd5e", "calendarConfig").manualRecovery && periods.size ) {
+      const operations = [];
+      for ( const actor of game.actors ) {
+        const deltas = { deleted: [], item: {} };
+        const deleted = [];
+        const updates = [];
+        for ( const item of actor.items ) {
+          const result = await item.system.recoverUses?.(periods) ?? {};
+          if ( result?.rolls ) rolls.push(...result.rolls);
+          if ( result?.destroy ) {
+            deltas.deleted.push(item.toObject());
+            deleted.push(item.id);
+          } else if ( !foundry.utils.isEmpty(result?.updates) ) {
+            deltas.item[item.id] = IndividualDeltaField.getDeltas(item, result.updates);
             updates.push({ _id: item.id, ...result.updates });
-            rolls.push(...result.rolls);
           }
         }
-      };
-
-      const itemUpdates = [];
-      await performItemUpdates(game.items, itemUpdates);
-      if ( itemUpdates.length ) await Item.updateDocuments(itemUpdates);
-
-      for ( const actor of game.actors ) {
-        const actorUpdates = [];
-        await performItemUpdates(actor.items, actorUpdates);
-        if ( actorUpdates.length ) await actor.updateEmbeddedDocuments("Item", actorUpdates);
+        if ( deleted.length ) operations.push({ action: "delete", documentName: "Item", ids: deleted, parent: actor });
+        if ( updates.length ) operations.push({ action: "update", documentName: "Item", updates, parent: actor });
+        if ( deltas.deleted.length || !foundry.utils.isEmpty(deltas.item) ) changes.push({ deltas, uuid: actor.uuid });
       }
+      await foundry.documents.modifyBatch(operations);
     }
 
     const messageConfig = {
-      create: deltas.length > 0,
+      create: changes.length > 0,
       data: {
         content: this.generateTimePassageMessage(timePassageData),
         rolls,
-        system: {
-          changes: deltas
-        },
+        system: { changes },
         title: game.i18n.localize("DND5E.CALENDAR.TimePassage.Title"),
         type: "timePassed"
       }
@@ -404,7 +403,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
      */
     Hooks.callAll("dnd5e.preCreateTimePassedMessage", messageConfig);
 
-    if ( messageConfig.create ) return ChatMessage.implementation.create(messageConfig.data);
+    if ( messageConfig.create ) ChatMessage.implementation.create(messageConfig.data);
   }
 
   /* -------------------------------------------- */

--- a/module/data/calendar/calendar-data.mjs
+++ b/module/data/calendar/calendar-data.mjs
@@ -346,7 +346,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
   /* -------------------------------------------- */
 
   /**
-   * Trigger recovery for any world items based on the passage of time.
+   * Trigger recovery for any world actors based on the passage of time.
    * @param {TimePassageData} timePassageData
    */
   static async handleTimePassage(timePassageData) {

--- a/module/data/calendar/calendar-data.mjs
+++ b/module/data/calendar/calendar-data.mjs
@@ -358,7 +358,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
     const changes = [];
     const rolls = [];
 
-    if ( !game.settings.get("dnd5e", "calendarConfig").manualRecovery && periods.size ) {
+    if ( !dnd5e.settings.calendarConfig.manualRecovery && periods.size ) {
       const operations = [];
       for ( const actor of game.actors ) {
         const deltas = { deleted: [], item: {} };

--- a/module/data/chat-message/_module.mjs
+++ b/module/data/chat-message/_module.mjs
@@ -2,6 +2,7 @@ import BastionAttackMessageData from "./bastion-attack-message-data.mjs";
 import BastionTurnMessageData from "./bastion-turn-message-data.mjs";
 import RequestMessageData from "./request-message-data.mjs";
 import RestMessageData from "./rest-message-data.mjs";
+import TimePassedMessageData from "./time-passed-message-data.mjs";
 import TurnMessageData from "./turn-message-data.mjs";
 import UsageMessageData from "./usage-message-data.mjs";
 
@@ -10,6 +11,7 @@ export {
   BastionTurnMessageData,
   RequestMessageData,
   RestMessageData,
+  TimePassedMessageData,
   TurnMessageData,
   UsageMessageData
 };
@@ -20,6 +22,7 @@ export const config = {
   bastionTurn: BastionTurnMessageData,
   request: RequestMessageData,
   rest: RestMessageData,
+  timePassed: TimePassedMessageData,
   turn: TurnMessageData,
   usage: UsageMessageData
 };

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -1,6 +1,6 @@
 /**
  * @import { BastionTurnItem } from "../../documents/_types.mjs";
- * @import { ActivationsData, ActorDeltasData } from "./fields/_types.mjs";
+ * @import { ActivationsData, ActorDeltasData, IndividualDeltaData } from "./fields/_types.mjs";
  */
 
 /**
@@ -56,6 +56,19 @@
  * @property {ActorDeltasData} deltas       Actor/item recovery from this turn change.
  * @property {ChatMessage5e} [request]      Rest request chat message for which this rest was performed.
  * @property {string} type                  Type of rest performed.
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * @typedef TimePassedMessageSystemData
+ * @property {DocumentDeltasData[]} changes  Item recovery from this time change.
+ */
+
+/**
+ * @typedef DocumentDeltasData
+ * @param {IndividualDeltaData} deltas  Data deltas for an document update.
+ * @param {string} uuid                 UUID of the document to which the deltas apply.
  */
 
 /* -------------------------------------------- */

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -1,6 +1,6 @@
 /**
  * @import { BastionTurnItem } from "../../documents/_types.mjs";
- * @import { ActivationsData, ActorDeltasData, IndividualDeltaData } from "./fields/_types.mjs";
+ * @import { ActivationsData, ActorDeltasData } from "./fields/_types.mjs";
  */
 
 /**
@@ -67,8 +67,8 @@
 
 /**
  * @typedef DocumentDeltasData
- * @param {IndividualDeltaData} deltas  Data deltas for an document update.
- * @param {string} uuid                 UUID of the document to which the deltas apply.
+ * @property {ActorDeltasData} deltas  Data deltas for a actor update.
+ * @property {string} uuid             UUID of the actor to which the deltas apply.
  */
 
 /* -------------------------------------------- */

--- a/module/data/chat-message/fields/deltas-field.mjs
+++ b/module/data/chat-message/fields/deltas-field.mjs
@@ -111,7 +111,8 @@ export class IndividualDeltaField extends SchemaField {
    * Prepare a delta for display in a chat message.
    * @this {IndividualDeltaData}
    * @param {Actor5e|Item5e} doc  Actor or item to which this delta applies.
-   * @param {Roll[]} [rolls]      Rolls that may be associated with a delta.
+   * @param {Roll[]} [rolls]      Rolls that may be associated with a delta. Should be pre-filtered to only the rolls
+   *                              that apply to this delta.
    * @returns {DeltaDisplayContext}
    */
   static processDelta(doc, rolls=[]) {

--- a/module/data/chat-message/time-passed-message-data.mjs
+++ b/module/data/chat-message/time-passed-message-data.mjs
@@ -1,0 +1,70 @@
+import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+import ActivationsField from "./fields/activations-field.mjs";
+import { IndividualDeltaField } from "./fields/deltas-field.mjs";
+
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+const { ArrayField, DocumentUUIDField, SchemaField } = foundry.data.fields;
+
+/**
+ * @import { IndividualDeltaData } from "./fields/deltas-field.mjs";
+ */
+
+/**
+ * @typedef DocumentDeltasData
+ * @param {IndividualDeltaData} deltas  Data deltas for an document update.
+ * @param {string} uuid                 UUID of the document to which the deltas apply.
+ */
+
+/**
+ * Data stored in a time passed chat message.
+ *
+ * @property {DocumentDeltasData[]} changes  Item recovery from this time change.
+ */
+export default class TimePassedMessageData extends ChatMessageDataModel {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {
+      changes: new ArrayField(new SchemaField({
+        deltas: new ArrayField(new IndividualDeltaField()),
+        uuid: new DocumentUUIDField()
+      }))
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    template: "systems/dnd5e/templates/chat/time-passed-card.hbs"
+  }, { inplace: false }));
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext() {
+    const context = {
+      content: await TextEditor.enrichHTML(this.parent.content, { rollData: this.parent.getRollData() }),
+      deltas: []
+    };
+
+    for ( const { deltas, uuid } of this.changes ) {
+      const doc = fromUuidSync(uuid, { strict: false });
+      if ( !doc?.testUserPermission(game.user, "OBSERVER") ) continue;
+      for ( const delta of deltas ) {
+        context.deltas.push(IndividualDeltaField.processDelta.call(
+          delta, doc, this.parent.rolls
+            .filter(r => (r.options.delta?.itemUuid === doc.uuid) && (r.options.delta?.keyPath === delta.keyPath))
+        ));
+      }
+    }
+
+    return context;
+  }
+}

--- a/module/data/chat-message/time-passed-message-data.mjs
+++ b/module/data/chat-message/time-passed-message-data.mjs
@@ -6,19 +6,13 @@ const TextEditor = foundry.applications.ux.TextEditor.implementation;
 const { ArrayField, DocumentUUIDField, SchemaField } = foundry.data.fields;
 
 /**
- * @import { IndividualDeltaData } from "./fields/deltas-field.mjs";
- */
-
-/**
- * @typedef DocumentDeltasData
- * @param {IndividualDeltaData} deltas  Data deltas for an document update.
- * @param {string} uuid                 UUID of the document to which the deltas apply.
+ * @import { TimePassedMessageSystemData } from "./_types.mjs";
  */
 
 /**
  * Data stored in a time passed chat message.
- *
- * @property {DocumentDeltasData[]} changes  Item recovery from this time change.
+ * @extends {ChatMessageDataModel<TimePassedMessageSystemData>}
+ * @mixes TimePassedMessageSystemData
  */
 export default class TimePassedMessageData extends ChatMessageDataModel {
 

--- a/module/data/chat-message/time-passed-message-data.mjs
+++ b/module/data/chat-message/time-passed-message-data.mjs
@@ -1,6 +1,5 @@
 import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
-import ActivationsField from "./fields/activations-field.mjs";
-import { IndividualDeltaField } from "./fields/deltas-field.mjs";
+import { ActorDeltasField } from "./fields/deltas-field.mjs";
 
 const TextEditor = foundry.applications.ux.TextEditor.implementation;
 const { ArrayField, DocumentUUIDField, SchemaField } = foundry.data.fields;
@@ -24,7 +23,7 @@ export default class TimePassedMessageData extends ChatMessageDataModel {
   static defineSchema() {
     return {
       changes: new ArrayField(new SchemaField({
-        deltas: new ArrayField(new IndividualDeltaField()),
+        deltas: new ActorDeltasField(),
         uuid: new DocumentUUIDField()
       }))
     };
@@ -49,14 +48,9 @@ export default class TimePassedMessageData extends ChatMessageDataModel {
     };
 
     for ( const { deltas, uuid } of this.changes ) {
-      const doc = fromUuidSync(uuid, { strict: false });
-      if ( !doc?.testUserPermission(game.user, "OBSERVER") ) continue;
-      for ( const delta of deltas ) {
-        context.deltas.push(IndividualDeltaField.processDelta.call(
-          delta, doc, this.parent.rolls
-            .filter(r => (r.options.delta?.itemUuid === doc.uuid) && (r.options.delta?.keyPath === delta.keyPath))
-        ));
-      }
+      const actor = fromUuidSync(uuid, { strict: false });
+      if ( !actor?.testUserPermission(game.user, "OBSERVER") ) continue;
+      context.deltas.push(...ActorDeltasField.processDeltas.call(deltas, actor, this.parent.rolls));
     }
 
     return context;

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -358,8 +358,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
       }
     };
 
-    if ( !rollData && (this.activities.some(a => a.uses?.recovery.some(u => u.type === "formula"))
-      || this.uses.recovery.some(u => u.type === "formula")) ) rollData = this.parent.getRollData();
+    if ( !rollData && this.uses.recovery.some(u => u.type === "formula") ) rollData = this.parent.getRollData();
 
     const result = await UsesField.recoverUses.call(this, periods, rollData);
     if ( result ) {
@@ -373,6 +372,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
 
     for ( const activity of this.activities ) {
       if ( activity.dependentOrigin?.active === false ) continue;
+      if ( !rollData && activity.uses?.recovery.some(u => u.type === "formula") ) rollData = this.parent.getRollData();
       const result = await UsesField.recoverUses.call(activity, periods, rollData);
       if ( result ) {
         foundry.utils.mergeObject(updates, { [`system.activities.${activity.id}.uses`]: result.updates });

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -329,18 +329,27 @@ export default class ActivitiesTemplate extends SystemDataModel {
 
   /**
    * Perform any item & activity uses recovery.
-   * @param {string[]} periods       Recovery periods to check.
-   * @param {ItemRollData} rollData  Roll data to use when evaluating recovery formulas.
+   * @param {Map<string, number>} periods  Recovery periods to check, mapped to the number of times occurred.
+   * @param {ItemRollData} rollData        Roll data to use when evaluating recovery formulas.
    * @returns {Promise<{ updates: object, rolls: BasicRoll[], destroy: boolean }>}
    */
   async recoverUses(periods, rollData) {
+    if ( foundry.utils.getType(periods) === "Array" ) {
+      foundry.utils.logCompatibilityWarning(
+        "The periods parameter of `recoverUses` is now a mapping of periods to times triggered.",
+        { since: "DnD5e 6.0", until: "DnD5e 6.2" }
+      );
+      periods = new Map(periods.map(p => [p, 1]));
+    }
+
     const updates = {};
     const rolls = [];
     const autoRecharge = game.settings.get("dnd5e", "autoRecharge");
-    const shouldRecharge = periods.includes("turnStart") && this.parent.actor.system.isNPC && (autoRecharge !== "no");
+    const shouldRecharge = periods.has("turnStart") && this.parent.actor.system.isNPC && (autoRecharge !== "no");
     const recharge = async doc => {
       const config = { apply: false };
       const message = { create: autoRecharge !== "silent" };
+      // TODO: Roll multiple times if multiple `turnStarts` are present
       const result = await UsesField.rollRecharge.call(doc, config, {}, message);
       if ( result ) {
         if ( doc instanceof Item ) foundry.utils.mergeObject(updates, result.updates);

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -330,7 +330,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
   /**
    * Perform any item & activity uses recovery.
    * @param {Map<string, number>} periods  Recovery periods to check, mapped to the number of times occurred.
-   * @param {ItemRollData} rollData        Roll data to use when evaluating recovery formulas.
+   * @param {ItemRollData} [rollData]      Roll data to use when evaluating recovery formulas.
    * @returns {Promise<{ updates: object, rolls: BasicRoll[], destroy: boolean }>}
    */
   async recoverUses(periods, rollData) {
@@ -357,6 +357,9 @@ export default class ActivitiesTemplate extends SystemDataModel {
         rolls.push(...result.rolls);
       }
     };
+
+    if ( !rollData && (this.activities.some(a => a.uses?.recovery.some(u => u.type === "formula"))
+      || this.uses.recovery.some(u => u.type === "formula")) ) rollData = this.parent.getRollData();
 
     const result = await UsesField.recoverUses.call(this, periods, rollData);
     if ( result ) {

--- a/module/data/settings/_types.mjs
+++ b/module/data/settings/_types.mjs
@@ -9,7 +9,9 @@
 
 /**
  * @typedef CalendarConfigSettingData
- * @property {boolean} enabled         Enable the calendar system for all users.
+ * @property {boolean} enabled                       Enable the calendar system for all users.
+ * @property {""|"calendar"|"manual"} dailyRecovery  How daily recovery uses are handled. A blank value is automatic
+ *                                                   based on the calendar being enabled.
  */
 
 /**

--- a/module/data/settings/calendar-setting.mjs
+++ b/module/data/settings/calendar-setting.mjs
@@ -19,8 +19,25 @@ export class CalendarConfigSetting extends foundry.abstract.DataModel {
   /** @override */
   static defineSchema() {
     return {
-      enabled: new BooleanField()
+      enabled: new BooleanField({ required: true }),
+      dailyRecovery: new StringField({ choices: {
+        "": "DND5E.CALENDAR.FIELDS.dailyRecovery.default",
+        calendar: "DND5E.CALENDAR.FIELDS.dailyRecovery.calendar",
+        manual: "DND5E.CALENDAR.FIELDS.dailyRecovery.manual"
+      } })
     };
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Should item usage recovery be handled manually through the rest dialog?
+   * @type {boolean}
+   */
+  get manualRecovery() {
+    return this.dailyRecovery === "manual" || (!this.dailyRecovery && !this.enabled);
   }
 }
 

--- a/module/data/settings/calendar-setting.mjs
+++ b/module/data/settings/calendar-setting.mjs
@@ -37,7 +37,7 @@ export class CalendarConfigSetting extends foundry.abstract.DataModel {
    * @type {boolean}
    */
   get manualRecovery() {
-    return this.dailyRecovery === "manual" || (!this.dailyRecovery && !this.enabled);
+    return (this.dailyRecovery === "manual") || (!this.dailyRecovery && !this.enabled);
   }
 }
 

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -180,11 +180,11 @@ export default class UsesField extends SchemaField {
   /**
    * Determine uses recovery.
    * @this {ItemDataModel|BaseActivityData}
-   * @param {Map<string, number>} periods          Recovery periods to check, mapped to the number of times occurred.
-   * @param {ActorRollData|ItemRollData} rollData  Roll data to use when evaluating recover formulas.
+   * @param {Map<string, number>} periods            Recovery periods to check, mapped to the number of times occurred.
+   * @param {ActorRollData|ItemRollData} [rollData]  Roll data to use when evaluating recovery formulas.
    * @returns {Promise<{ updates: object, rolls: BasicRoll[] }|false>}
    */
-  static async recoverUses(periods, rollData) {
+  static async recoverUses(periods, rollData={}) {
     if ( foundry.utils.getType(periods) === "Array" ) {
       foundry.utils.logCompatibilityWarning(
         "The periods parameter of `recoverUses` is now a mapping of periods to times triggered.",

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -180,20 +180,31 @@ export default class UsesField extends SchemaField {
   /**
    * Determine uses recovery.
    * @this {ItemDataModel|BaseActivityData}
-   * @param {string[]} periods                     Recovery periods to check.
-   * @param {ActorRollData|ItemRollData} rollData  Roll data to use when evaluating recovery formulas.
+   * @param {Map<string, number>} periods          Recovery periods to check, mapped to the number of times occurred.
+   * @param {ActorRollData|ItemRollData} rollData  Roll data to use when evaluating recover formulas.
    * @returns {Promise<{ updates: object, rolls: BasicRoll[] }|false>}
    */
   static async recoverUses(periods, rollData) {
+    if ( foundry.utils.getType(periods) === "Array" ) {
+      foundry.utils.logCompatibilityWarning(
+        "The periods parameter of `recoverUses` is now a mapping of periods to times triggered.",
+        { since: "DnD5e 6.0", until: "DnD5e 6.2" }
+      );
+      periods = new Map(periods.map(p => [p, 1]));
+    }
+
     if ( !this.uses?.recovery.length ) return false;
 
     // Search the recovery profiles in order to find the first matching period,
     // and then find the first profile that uses that recovery period
+    let count;
     let profile;
     findPeriod: {
-      for ( const period of periods ) {
+      for ( const [period, periodCount] of periods.entries() ) {
+        if ( periodCount < 1 ) continue;
         for ( const recovery of this.uses.recovery ) {
           if ( recovery.period === period ) {
+            count = periodCount;
             profile = recovery;
             break findPeriod;
           }
@@ -206,19 +217,19 @@ export default class UsesField extends SchemaField {
     const rolls = [];
     const item = this.item ?? this.parent;
 
-    if ( profile.type === "recoverAll" ) updates.spent = 0;
-    else if ( profile.type === "loseAll" ) updates.spent = this.uses.max;
-    else if ( profile.formula ) {
+    if ( profile.type === "recoverAll" ) {
+      if ( this.uses.spent !== 0 ) updates.spent = 0;
+    } else if ( profile.type === "loseAll" ) {
+      if ( this.uses.spent !== this.uses.max ) updates.spent = this.uses.max;
+    } else if ( profile.formula ) {
       let roll;
       let total;
       try {
-        const delta = this.parent instanceof Item ? { item: this.parent.id, keyPath: "system.uses.spent" }
-          : { item: this.item.id, keyPath: `system.activities.${this.id}.uses.spent` };
+        const delta = this.parent instanceof Item
+          ? { item: this.parent.id, itemUuid: this.parent.uuid, keyPath: "system.uses.spent" }
+          : { item: this.item.id, itemUuid: this.item.uuid, keyPath: `system.activities.${this.id}.uses.spent` };
         roll = new CONFIG.Dice.BasicRoll(profile.formula, rollData, { delta });
-        if ( ["day", "dawn", "dusk"].includes(profile.period)
-          && (game.settings.get("dnd5e", "restVariant") === "gritty") ) {
-          roll.alter(7, 0, { multiplyNumeric: true });
-        }
+        if ( count > 1 ) roll.alter(count, 0, { multiplyNumeric: true });
         total = (await roll.evaluate()).total;
       } catch(err) {
         Hooks.onError("UsesField#recoverUses", err, {
@@ -238,7 +249,7 @@ export default class UsesField extends SchemaField {
       }
     }
 
-    return { updates, rolls };
+    return foundry.utils.isEmpty(updates) ? false : { updates, rolls };
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2571,10 +2571,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     recoverShortRestUses, recoverLongRestUses, recoverDailyUses, ...config
   }={}, result={}) {
     const restConfig = CONFIG.DND5E.restTypes[config.type];
-    const recovery = Array.from(restConfig.recoverPeriods ?? []);
-    if ( recoverShortRestUses ) recovery.unshift("sr");
-    if ( recoverLongRestUses ) recovery.unshift("lr");
-    if ( recoverDailyUses || config.newDay ) recovery.unshift("day", "dawn", "dusk");
+    let recovery = Array.from(restConfig.recoverPeriods ?? []).map(p => [p, 1]);
+    if ( recoverShortRestUses ) recovery.unshift(["sr", 1]);
+    if ( recoverLongRestUses ) recovery.unshift(["lr", 1]);
+    if ( (recoverDailyUses || config.newDay) && game.settings.get("dnd5e", "calendarConfig").manualRecovery ) {
+      const days = (game.settings.get("dnd5e", "restVariant") === "gritty") && (config.type === "long") ? 7 : 1;
+      recovery.unshift(["day", days], ["dawn", days], ["dusk", days]);
+    }
+    recovery = new Map(recovery);
 
     result.updateItems ??= [];
     result.rolls ??= [];

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2584,8 +2584,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     result.rolls ??= [];
     for ( const item of this.items ) {
       if ( item.isHidden || (foundry.utils.getType(item.system.recoverUses) !== "function") ) continue;
-      const rollData = item.getRollData();
-      const { updates, rolls, destroy } = await item.system.recoverUses(recovery, rollData);
+      const { updates, rolls, destroy } = await item.system.recoverUses(recovery);
       if ( destroy ) {
         result.deleteItems.push(item.id);
       } else if ( !foundry.utils.isEmpty(updates) ) {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2574,8 +2574,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     let recovery = Array.from(restConfig.recoverPeriods ?? []).map(p => [p, 1]);
     if ( recoverShortRestUses ) recovery.unshift(["sr", 1]);
     if ( recoverLongRestUses ) recovery.unshift(["lr", 1]);
-    if ( (recoverDailyUses || config.newDay) && game.settings.get("dnd5e", "calendarConfig").manualRecovery ) {
-      const days = (game.settings.get("dnd5e", "restVariant") === "gritty") && (config.type === "long") ? 7 : 1;
+    if ( (recoverDailyUses || config.newDay) && dnd5e.settings.calendarConfig.manualRecovery ) {
+      const days = (dnd5e.settings.restVariant === "gritty") && (config.type === "long") ? 7 : 1;
       recovery.unshift(["day", days], ["dawn", days], ["dusk", days]);
     }
     recovery = new Map(recovery);

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -123,8 +123,7 @@ export default class Combatant5e extends Combatant {
     const recoveryPeriods = new Map(periods.map(p => [p, 1]));
     for ( const item of this.actor?.items ?? [] ) {
       if ( item.isHidden || (foundry.utils.getType(item.system.recoverUses) !== "function") ) continue;
-      const rollData = item.getRollData();
-      const { updates, rolls, destroy } = await item.system.recoverUses(recoveryPeriods, rollData);
+      const { updates, rolls, destroy } = await item.system.recoverUses(recoveryPeriods);
       if ( destroy ) {
         results.delete.push(item.id);
       } else if ( !foundry.utils.isEmpty(updates) ) {

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -120,10 +120,11 @@ export default class Combatant5e extends Combatant {
     const results = { actor: {}, delete: [], item: [], rolls: [] };
     await this.actor?.system.recoverCombatUses?.(periods, results);
 
+    const recoveryPeriods = new Map(periods.map(p => [p, 1]));
     for ( const item of this.actor?.items ?? [] ) {
       if ( item.isHidden || (foundry.utils.getType(item.system.recoverUses) !== "function") ) continue;
       const rollData = item.getRollData();
-      const { updates, rolls, destroy } = await item.system.recoverUses(Array.from(periods), rollData);
+      const { updates, rolls, destroy } = await item.system.recoverUses(recoveryPeriods, rollData);
       if ( destroy ) {
         results.delete.push(item.id);
       } else if ( !foundry.utils.isEmpty(updates) ) {

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -116,13 +116,18 @@ export function formatModifier(mod) {
  * @returns {string}
  */
 export function formatNumber(value, { blank, numerals, ordinal, words, ...options }={}) {
-  if ( words && game.i18n.has(`DND5E.NUMBER.${value}`, false) ) return _loc(`DND5E.NUMBER.${value}`);
   if ( !value && (typeof blank === "string") ) return blank;
+  if ( (numerals || words) && options.unit ) {
+    return _formatNumberParts(value, { numerals, words, ...options }).map(({ value }) => value).join("");
+  }
   if ( numerals ) return _formatNumberAsNumerals(value);
   if ( ordinal ) return _formatNumberAsOrdinal(value, options);
+  if ( words ) return _formatNumberAsWords(value, options);
   const formatter = new Intl.NumberFormat(game.i18n.lang, options);
   return formatter.format(value);
 }
+
+/* -------------------------------------------- */
 
 /**
  * Roman numerals.
@@ -152,11 +157,12 @@ function _formatNumberAsNumerals(n) {
 
 /**
  * Format a number using an ordinal format.
- * @param {number} n        The number to format.
- * @param {object} options  Options forwarded to `formatNumber`.
+ * @param {number} n             The number to format.
+ * @param {object} [options={}]  Options forwarded to `formatNumber`.
  * @returns {string}
  */
 function _formatNumberAsOrdinal(n, options={}) {
+  if ( options.style === "unit" ) throw new Error("Cannot format number as ordinal with unit formatting.");
   const pr = getPluralRules({ type: "ordinal" }).select(n);
   const number = formatNumber(n, options);
   return game.i18n.has(`DND5E.ORDINAL.${pr}`) ? _loc(`DND5E.ORDINAL.${pr}`, { number }) : number;
@@ -165,15 +171,64 @@ function _formatNumberAsOrdinal(n, options={}) {
 /* -------------------------------------------- */
 
 /**
+ * Format a number using an word format.
+ * @param {number} n          The number to format.
+ * @param {object} [options]  Options forwarded to `formatNumber`.
+ * @returns {string|false}
+ */
+function _formatNumberAsWords(n, options) {
+  return game.i18n.has(`DND5E.NUMBER.${n}`, false) ? _loc(`DND5E.NUMBER.${n}`) : formatNumber(n, options);
+}
+
+/* -------------------------------------------- */
+
+/**
  * Produce a number with the parts wrapped in their own spans.
- * @param {number} value      A number for format.
+ * @param {number} value      The number to format.
  * @param {object} [options]  Formatting options.
  * @returns {string}
  */
 export function formatNumberParts(value, options) {
-  if ( options.numerals ) throw new Error("Cannot segment numbers when formatted as numerals.");
-  return new Intl.NumberFormat(game.i18n.lang, options).formatToParts(value)
+  return _formatNumberParts(value, options)
     .reduce((str, { type, value }) => `${str}<span class="${type}">${value}</span>`, "");
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Format a number to parts while handling the "words" and "numerals" options.
+ * @param {number} value                The number to format.
+ * @param {object} [options={}]         Formatting options.
+ * @param {boolean} [options.numerals]  Format the number as roman numerals.
+ * @param {boolean} [options.ordinal]   Use ordinal formatting.
+ * @param {string} [options.unit]       Unit to use for formatting.
+ * @param {boolean} [options.words]     Write out number as full word, if possible.
+ * @returns {{ type: string, value: string }[]}
+ */
+function _formatNumberParts(value, { numerals, ordinal, words, unit, ...options }={}) {
+  const parts = new Intl.NumberFormat(game.i18n.lang, { unit, ...options }).formatToParts(value);
+  if ( ordinal ) throw new Error("Cannot segment numbers when formatted as ordinal.");
+  if ( !numerals && !words ) return parts;
+
+  // Find portions for number and replace with proper value
+  let startIndex;
+  let length = 0;
+  for ( const [index, part] of parts.entries() ) {
+    if ( ["integer", "group", "decimal", "fraction"].includes(part.type) ) {
+      startIndex ??= index;
+      length += 1;
+    } else if ( length > 0 ) break;
+  }
+  if ( startIndex === undefined ) return parts;
+
+  let replacement;
+  if ( numerals ) replacement = [{ type: "numeral", value: _formatNumberAsNumerals(value, options) }];
+  else if ( words && game.i18n.has(`DND5E.NUMBER.${value}`, false) ) {
+    replacement = [{ type: "word", value: _formatNumberAsWords(value, options) }];
+  }
+  if ( replacement ) parts.splice(startIndex, length, ...replacement);
+
+  return parts;
 }
 
 /* -------------------------------------------- */

--- a/system.json
+++ b/system.json
@@ -49,6 +49,7 @@
       "bastionTurn": {},
       "request": {},
       "rest": {},
+      "timePassed": {},
       "turn": {},
       "usage": {}
     },

--- a/templates/chat/time-passed-card.hbs
+++ b/templates/chat/time-passed-card.hbs
@@ -1,0 +1,6 @@
+<div class="chat-card time-passed-card">
+    {{{ content }}}
+
+    {{!-- Deltas --}}
+    {{#if deltas.length}}{{> "dnd5e.card-deltas" }}{{/if}}
+</div>


### PR DESCRIPTION
Allows recovery for for periods of "day", "dawn", or "dusk" to be triggered by the passage of world time rather that through the rest dialog. This is gated by a setting that by default is tied to whether the calendar is enabled, but can be set to manual if needed (for example, if using a module-provided calendar).

Some changes were made to the `recoverUses` API to support the passage of multiple relevant recovery periods if the time was advanced more than one day. This also fixes the bug with short rests when using the gritty realism rest setting.

When a time passes the system checks to see if any relevant recovery periods should trigger and if so, triggers recovery for all world and actor items. If any changes were made, it then creates a chat message to indicate the time passage and display any deltas. These deltas are gated by observer permissions.

<img width="312" height="312" alt="Time Passage Messages" src="https://github.com/user-attachments/assets/b526f9cc-0ac7-4603-bc27-e01d6f6f2e06" />

The created chat message also has a description of the time that passed (e.g. "The sun has risen." or "Two days have passed."). In order to support better localization of these times, some updates have been made to the number formatting system to support the `words` (and `numerals`) settings when formatting with units.

One potential point of improvement is how we handle selection of recovery periods. At the moment, we only select the first recovery profile that matches a provided period. This may cause issues for cases where a "dawn" and "dusk" may have passed in one update. If you had an item that was only usable during the daytime, you might say it recovers all uses at dawn and loses them at dusk. This works fine so long as you do not advance past both periods at the same time. In the future the recovery uses method might be update with the option of selecting multiple profiles so long as they are not marked as mutually exclusive.

Closes #2291
Closes #5770