### PR TITLE
[#6259] Add level limits to activity's applied effects

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -278,6 +278,18 @@
       }
     },
     "effects": {
+      "element": {
+        "level": {
+          "label": "Level Limit",
+          "hint": "Range of levels required to apply this effect.",
+          "max": {
+            "label": "Maximum Level"
+          },
+          "min": {
+            "label": "Minimum Level"
+          }
+        }
+      },
       "label": "Applied Effects"
     },
     "img": {

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -54,7 +54,9 @@ export default class ActivitySheet extends PseudoDocumentSheet {
     effect: {
       template: "systems/dnd5e/templates/activity/effect.hbs",
       templates: [
-        "systems/dnd5e/templates/activity/parts/activity-effects.hbs"
+        "systems/dnd5e/templates/activity/parts/activity-effects.hbs",
+        "systems/dnd5e/templates/activity/parts/activity-effect-level-limit.hbs",
+        "systems/dnd5e/templates/activity/parts/activity-effect-settings.hbs"
       ]
     }
   };
@@ -279,7 +281,7 @@ export default class ActivitySheet extends PseudoDocumentSheet {
           prefix: `effects.${data._index}.`,
           source: context.source.effects[data._index] ?? data,
           contentLink: data.effect.toAnchor().outerHTML,
-          additionalSettings: null
+          additionalSettings: "systems/dnd5e/templates/activity/parts/activity-effect-settings.hbs"
         };
         arr.push(this._prepareAppliedEffectContext(context, effect));
         return arr;

--- a/module/data/activity/_types.mjs
+++ b/module/data/activity/_types.mjs
@@ -107,9 +107,6 @@
 
 /**
  * @typedef {EffectApplicationData} EnchantEffectApplicationData
- * @property {object} level
- * @property {number} level.min             Minimum level at which this profile can be used.
- * @property {number} level.max             Maximum level at which this profile can be used.
  * @property {object} riders
  * @property {Set<string>} riders.activity  IDs of other activities on this item that will be added when enchanting.
  * @property {Set<string>} riders.effect    IDs of other effects on this item that will be added when enchanting.

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -131,7 +131,10 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * @type {ActiveEffect5e[]|null}
    */
   get applicableEffects() {
-    return this.effects?.map(e => e.effect).filter(e => e) ?? null;
+    const level = this.relevantLevel;
+    return this.effects?.filter(e =>
+      e.effect && ((e.level?.min ?? -Infinity) <= level) && (level <= (e.level?.max ?? Infinity))
+    ).map(e => e.effect) ?? null;
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/enchant-data.mjs
+++ b/module/data/activity/enchant-data.mjs
@@ -21,10 +21,6 @@ export default class BaseEnchantActivityData extends BaseActivityData {
     return {
       ...super.defineSchema(),
       effects: new ArrayField(new AppliedEffectField({
-        level: new SchemaField({
-          min: new NumberField({ min: 0, integer: true }),
-          max: new NumberField({ min: 0, integer: true })
-        }),
         riders: new SchemaField({
           activity: new SetField(new DocumentIdField()),
           effect: new SetField(new DocumentIdField()),
@@ -77,9 +73,7 @@ export default class BaseEnchantActivityData extends BaseActivityData {
    * @type {EnchantEffectApplicationData[]}
    */
   get availableEnchantments() {
-    const keyPath = (this.item.type === "spell") && (this.item.system.level > 0) ? "item.level"
-      : this.enchant.identifier ? `classes.${this.enchant.identifier}.levels` : "details.level";
-    const level = foundry.utils.getProperty(this.getRollData(), keyPath) ?? 0;
+    const level = this.relevantLevel;
     return this.effects
       .filter(e => e.effect && ((e.level.min ?? -Infinity) <= level) && (level <= (e.level.max ?? Infinity)));
   }

--- a/module/data/activity/fields/_types.mjs
+++ b/module/data/activity/fields/_types.mjs
@@ -1,6 +1,9 @@
 /**
  * @typedef EffectApplicationData
  * @property {string} _id  ID of the effect to apply.
+ * @property {object} level
+ * @property {number} level.min  Minimum level at which this effect can be applied.
+ * @property {number} level.max  Maximum level at which this effect can be applied.
  */
 
 /**

--- a/module/data/activity/fields/applied-effect-field.mjs
+++ b/module/data/activity/fields/applied-effect-field.mjs
@@ -1,14 +1,20 @@
-const { DocumentIdField, SchemaField } = foundry.data.fields;
+const { DocumentIdField, NumberField, SchemaField } = foundry.data.fields;
 
 /**
  * Field for storing an active effects applied by an activity.
  */
 export default class AppliedEffectField extends SchemaField {
   constructor(fields={}, options={}) {
-    super({
+    fields = {
       _id: new DocumentIdField(),
+      level: new SchemaField({
+        min: new NumberField({ min: 0, integer: true }),
+        max: new NumberField({ min: 0, integer: true })
+      }),
       ...fields
-    }, options);
+    };
+    Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);
+    super(fields, options);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -270,10 +270,7 @@ export default function ActivityMixin(Base) {
           flags: {
             dnd5e: {
               ...this.messageFlags,
-              messageType: "usage",
-              use: {
-                effects: this.applicableEffects?.map(e => e.id)
-              }
+              messageType: "usage"
             }
           }
         },
@@ -827,6 +824,8 @@ export default function ActivityMixin(Base) {
      */
     _finalizeMessageConfig(usageConfig, messageConfig, results) {
       messageConfig.data.rolls = (messageConfig.data.rolls ?? []).concat(results.updates.rolls);
+      const effects = this.applicableEffects?.map(e => e.id);
+      if ( effects ) foundry.utils.setProperty(messageConfig.data, "flags.dnd5e.use.effects", effects);
     }
 
     /* -------------------------------------------- */

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -474,7 +474,7 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
     }
 
     // Add applied effects
-    actorUpdates.effects.push(...this.effects.map(e => e.effect?.toObject()).filter(e => e));
+    actorUpdates.effects.push(...this.applicableEffects.map(e => e.toObject()));
 
     return { actorUpdates, tokenUpdates };
   }

--- a/templates/activity/parts/activity-effect-level-limit.hbs
+++ b/templates/activity/parts/activity-effect-level-limit.hbs
@@ -1,0 +1,12 @@
+<div class="form-group">
+    <label>{{ localize "DND5E.ACTIVITY.FIELDS.effects.element.level.label" }}</label>
+    <div class="form-fields range-fields">
+        {{ formInput fields.level.fields.min name=(concat prefix "level.min") value=data.level.min
+                     placeholder="0" ariaLabel=(localize "DND5E.LevelLimit.Min")
+                     input=@root.inputs.createNumberInput }}
+        <dnd5e-icon src="systems/dnd5e/icons/svg/range-connector.svg" class="sep"></dnd5e-icon>
+        {{ formInput fields.level.fields.max name=(concat prefix "level.max") value=data.level.max
+                     placeholder="∞" ariaLabel=(localize "DND5E.LevelLimit.Max") }}
+    </div>
+    <p class="hint">{{ localize "DND5E.ACTIVITY.FIELDS.effects.element.level.hint" }}</p>
+</div>

--- a/templates/activity/parts/activity-effect-settings.hbs
+++ b/templates/activity/parts/activity-effect-settings.hbs
@@ -1,0 +1,3 @@
+<div>
+    {{> "systems/dnd5e/templates/activity/parts/activity-effect-level-limit.hbs" }}
+</div>

--- a/templates/activity/parts/save-effect-settings.hbs
+++ b/templates/activity/parts/save-effect-settings.hbs
@@ -2,4 +2,5 @@
     {{ formField fields.onSave name=(concat prefix "onSave") value=data.onSave localize=true
                  label="DND5E.SAVE.FIELDS.effects.onSave.label" hint="DND5E.SAVE.FIELDS.effects.onSave.hint"
                  input=@root.inputs.createCheckboxInput rootId=@root.partId }}
+    {{> "systems/dnd5e/templates/activity/parts/activity-effect-level-limit.hbs" }}
 </div>


### PR DESCRIPTION
Adds the ability for any effect applied by an activity to have a level limit set similar to the way the Enchant Activity currently functions.

Custom activities should get his behavior by default unless they are providing their own `additionalSettings` template for effects (similar to the system's `SaveActivity`). In that case, those activities will need to add the level limits partial to their own effects settings template.

Closes #6259