### PR TITLE
[#4610] Allow certain enrichers to be invoked from chat

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -616,10 +616,7 @@ Hooks.on("renderChatLog", (app, html, data) => {
 });
 Hooks.on("renderChatPopout", (app, html, data) => documents.Item5e.chatListeners(html));
 
-Hooks.on("chatMessage", (app, message, data) => {
-  if ( applications.Award.chatMessage(message) === false ) return false;
-  return enrichers.chatMessage(message);
-});
+Hooks.on("chatMessage", (app, message, data) => enrichers.chatMessage(message));
 Hooks.on("createChatMessage", dataModels.chatMessage.RequestMessageData.onCreateMessage);
 Hooks.on("updateChatMessage", dataModels.chatMessage.RequestMessageData.onUpdateResultMessage);
 

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -616,7 +616,10 @@ Hooks.on("renderChatLog", (app, html, data) => {
 });
 Hooks.on("renderChatPopout", (app, html, data) => documents.Item5e.chatListeners(html));
 
-Hooks.on("chatMessage", (app, message, data) => applications.Award.chatMessage(message));
+Hooks.on("chatMessage", (app, message, data) => {
+  if ( applications.Award.chatMessage(message) === false ) return false;
+  return enrichers.chatMessage(message);
+});
 Hooks.on("createChatMessage", dataModels.chatMessage.RequestMessageData.onCreateMessage);
 Hooks.on("updateChatMessage", dataModels.chatMessage.RequestMessageData.onUpdateResultMessage);
 

--- a/module/applications/award.mjs
+++ b/module/applications/award.mjs
@@ -343,8 +343,8 @@ export default class Award extends Application5e {
 
   /**
    * Use the `chatMessage` hook to determine if an award command was typed.
-   * @param {string} message   Text of the message being posted.
-   * @returns {boolean|void}   Returns `false` to prevent the message from continuing to parse.
+   * @param {string} message  Text of the message being posted.
+   * @returns {false|void}    Returns `false` to prevent the message from continuing to parse.
    */
   static chatMessage(message) {
     if ( !this.COMMAND_PATTERN.test(message) ) return;

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4850,13 +4850,15 @@ Object.defineProperty(DND5E, "enrichmentLookup", {
         spellSchools: foundry.utils.deepClone(DND5E.spellSchools),
         tools: foundry.utils.deepClone(DND5E.tools)
       };
-      const addFullKeys = key => Object.entries(DND5E[key]).forEach(([k, v]) =>
-        _enrichmentLookup[key][slugify(v.fullKey)] = { ...v, key: k }
-      );
+      const addFullKeys = key => Object.entries(DND5E[key]).forEach(([k, v]) => {
+        _enrichmentLookup[key][k].key = k;
+        if ( v.fullKey ) _enrichmentLookup[key][slugify(v.fullKey)] = { ...v, key: k };
+      });
       addFullKeys("abilities");
       addFullKeys("skills");
       addFullKeys("spellSchools");
-      Object.entries(DND5E.vehicleTypes).forEach(([k, label]) => _enrichmentLookup.tools[k] = { label });
+      addFullKeys("tools");
+      Object.entries(DND5E.vehicleTypes).forEach(([k, label]) => _enrichmentLookup.tools[k] = { label, key: k });
     }
     return _enrichmentLookup;
   },

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -9,8 +9,10 @@ const slugify = value => value?.slugify().replaceAll("-", "").replaceAll("(", ""
 const logWarning = (msg, options) =>
   log(options.relativeTo ? `${msg} [${options.relativeTo.uuid}]` : msg, { level: "warn" });
 
-const VALID_CHAT_COMMANDS = ["attack", "check", "concentration", "damage", "heal", "healing", "save", "skill", "tool"];
-const VALID_COMMANDS = [...VALID_CHAT_COMMANDS, "award", "item"];
+const VALID_CHAT_COMMANDS = [
+  "attack", "award", "check", "concentration", "damage", "heal", "healing", "save", "skill", "tool"
+];
+const VALID_COMMANDS = [...VALID_CHAT_COMMANDS, "item"];
 const makeCommandPattern = commands => `/(?<type>${commands.join("|")})(?<config> .*?)?`;
 const CHAT_REGEX = new RegExp(`^${makeCommandPattern(VALID_CHAT_COMMANDS)}$`, "i");
 
@@ -51,6 +53,7 @@ export function chatMessage(message) {
   config = parseConfig(config, { multiple: ["damage", "heal", "healing"].includes(type) });
   switch (type) {
     case "attack": handleAttackCommand(config); break;
+    case "award": Award.handleAward(message); break;
     case "heal":
     case "healing": config._isHealing = true;
     case "damage": handleDamageCommand(config); break;

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -60,6 +60,7 @@ export function chatMessage(message) {
     case "check":
     case "skill":
     case "tool": handleCheckCommand(config); break;
+    case "concentration": config._isConcentration = true;
     case "save": handleSaveCommand(config); break;
   }
   return false;
@@ -310,7 +311,7 @@ async function rollAttack(config, event) {
     attackMode, event,
     hookNames: ["attack", "d20Test"],
     rolls: [{
-      parts: [formula.replace(/^\s*\+\s*/, "")],
+      parts: formula ? [formula.replace(/^\s*\+\s*/, "")] : [],
       options: {
         target: targets.length === 1 ? targets[0].ac : undefined
       }
@@ -667,7 +668,13 @@ function handleCheckCommand(config) {
 function createCheckRequestButtons(dataset) {
   const skills = foundry.utils.getType(dataset.skill) === "string" ? dataset.skill.split("|") : dataset.skill ?? [];
   const tools = foundry.utils.getType(dataset.tool) === "string" ? dataset.tool.split("|") : dataset.tool ?? [];
-  if ( (skills.length + tools.length) <= 1 ) return [createRequestButton(dataset)];
+  if ( (skills.length + tools.length) <= 1 ) {
+    if ( !dataset.ability ) {
+      if ( skills.length === 1 ) dataset.ability = CONFIG.DND5E.skills[skills[0]]?.ability;
+      else if ( tools.length === 1 ) dataset.ability = CONFIG.DND5E.tools[tools[0]]?.ability;
+    }
+    return [createRequestButton(dataset)];
+  }
   const baseDataset = { ...dataset };
   delete baseDataset.skill;
   delete baseDataset.tool;
@@ -825,7 +832,7 @@ export async function enrichSave(config, label, options) {
  */
 async function handleSaveCommand(config) {
   config = parseSaveConfig(config);
-  config.type = "save";
+  config.type = config._isConcentration ? "concentration" : "save";
   if ( config.request ) return handlePostRequest(config);
   config.ability = config.ability[0];
   rollCheckSave(config);

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -9,16 +9,18 @@ const slugify = value => value?.slugify().replaceAll("-", "").replaceAll("(", ""
 const logWarning = (msg, options) =>
   log(options.relativeTo ? `${msg} [${options.relativeTo.uuid}]` : msg, { level: "warn" });
 
+const VALID_CHAT_COMMANDS = ["attack", "check", "concentration", "damage", "heal", "healing", "save", "skill", "tool"];
+const VALID_COMMANDS = [...VALID_CHAT_COMMANDS, "award", "item"];
+const makeCommandPattern = commands => `/(?<type>${commands.join("|")})(?<config> .*?)?`;
+const CHAT_REGEX = new RegExp(`^${makeCommandPattern(VALID_CHAT_COMMANDS)}$`, "i");
+
 /**
  * Set up custom text enrichers.
  */
 export function registerCustomEnrichers() {
-  const stringNames = [
-    "attack", "award", "check", "concentration", "damage", "heal", "healing", "item", "save", "skill", "tool"
-  ];
   CONFIG.TextEditor.enrichers.push({
     id: "dnd5e-enricher",
-    pattern: new RegExp(`\\[\\[/(?<type>${stringNames.join("|")})(?<config> .*?)?]](?!])(?:{(?<label>[^}]+)})?`, "gi"),
+    pattern: new RegExp(`\\[\\[${makeCommandPattern(VALID_COMMANDS)}]](?!])(?:{(?<label>[^}]+)})?`, "gi"),
     enricher: enrichString,
     onRender: onRenderEnricher
   },
@@ -33,6 +35,31 @@ export function registerCustomEnrichers() {
     enricher: enrichString,
     onRender: onRenderEnricher
   });
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Use the `chatMessage` hook to determine if an enricher command was typed.
+ * @param {string} message  Text of the message being posted.
+ * @returns {false|void}    Returns `false` to prevent the message from continuing to parse.
+ */
+export function chatMessage(message) {
+  const match = message.match(CHAT_REGEX);
+  if ( !match ) return;
+  let { type, config } = match.groups;
+  config = parseConfig(config, { multiple: ["damage", "heal", "healing"].includes(type) });
+  switch (type) {
+    case "attack": handleAttackCommand(config); break;
+    case "heal":
+    case "healing": config._isHealing = true;
+    case "damage": handleDamageCommand(config); break;
+    case "check":
+    case "skill":
+    case "tool": handleCheckCommand(config); break;
+    case "save": handleSaveCommand(config); break;
+  }
+  return false;
 }
 
 /* -------------------------------------------- */
@@ -166,17 +193,7 @@ export async function enrichAttack(config, label, options) {
     return null;
   }
 
-  const formulaParts = [];
-  if ( config.formula ) formulaParts.push(config.formula);
-  for ( const value of config.values ) {
-    if ( value in CONFIG.DND5E.attackModes ) config.attackMode = value;
-    else if ( value === "extended" ) config.format = "extended";
-    else formulaParts.push(value);
-  }
-  config.formula = Roll.defaultImplementation.replaceFormulaData(
-    formulaParts.join(" "),
-    options.rollData ?? options.relativeTo?.getRollData?.() ?? {}
-  );
+  config = parseAttackConfig(config, options);
 
   const activity = config.activity ? options.relativeTo?.system?.activities?.get(config.activity)
     : !config.formula ? options.relativeTo?.system?.activities?.getByType("attack")[0] : null;
@@ -233,6 +250,40 @@ export async function enrichAttack(config, label, options) {
   }
 
   return span;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Handle a attack command in chat.
+ * @param {object} config  Configuration data.
+ */
+function handleAttackCommand(config) {
+  rollAttack(parseAttackConfig(config));
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Parse the raw configuration data for a attack enricher.
+ * @param {object} config                   Configuration data.
+ * @param {EnrichmentOptions} [options={}]  Options provided to customize text enrichment.
+ * @returns {object}
+ */
+function parseAttackConfig(config, options={}) {
+  const formulaParts = [];
+  if ( config.formula ) formulaParts.push(config.formula);
+  for ( const value of config.values ) {
+    if ( value in CONFIG.DND5E.attackModes ) config.attackMode = value;
+    else if ( value === "extended" ) config.format = "extended";
+    else formulaParts.push(value);
+  }
+  config.formula = Roll.defaultImplementation.replaceFormulaData(
+    formulaParts.join(" "),
+    options.rollData ?? options.relativeTo?.getRollData?.() ?? {}
+  );
+
+  return config;
 }
 
 /* -------------------------------------------- */
@@ -449,17 +500,7 @@ export async function enrichAward(config, label, options) {
  * ```
  */
 export async function enrichCheck(config, label, options) {
-  config.skill = config.skill?.replaceAll("/", "|").split("|") ?? [];
-  config.tool = config.tool?.replaceAll("/", "|").split("|") ?? [];
-  for ( let value of config.values ) {
-    const slug = foundry.utils.getType(value) === "string" ? slugify(value) : value;
-    if ( slug in CONFIG.DND5E.enrichmentLookup.abilities ) config.ability = slug;
-    else if ( slug in CONFIG.DND5E.enrichmentLookup.skills ) config.skill.push(slug);
-    else if ( slug in CONFIG.DND5E.enrichmentLookup.tools ) config.tool.push(slug);
-    else if ( Number.isNumeric(value) ) config.dc = Number(value);
-    else config[value] = true;
-  }
-  delete config.values;
+  config = parseCheckConfig(config, options);
 
   const groups = new Map();
   let invalid = false;
@@ -600,13 +641,29 @@ export async function enrichCheck(config, label, options) {
 /* -------------------------------------------- */
 
 /**
+ * Handle a check command in chat.
+ * @param {object} config  Configuration data.
+ */
+function handleCheckCommand(config) {
+  config = parseCheckConfig(config);
+  config.type = "check";
+  if ( config.request ) return handlePostRequest(config);
+  config.skill = config.skill[0];
+  config.tool = config.tool[0];
+  config.type = config.skill ? "skill" : config.tool ? "tool" : "check";
+  rollCheckSave(config);
+}
+
+/* -------------------------------------------- */
+
+/**
  * Create the buttons for a check requested in chat.
  * @param {object} dataset
  * @returns {object[]}
  */
 function createCheckRequestButtons(dataset) {
-  const skills = dataset.skill?.split("|") ?? [];
-  const tools = dataset.tool?.split("|") ?? [];
+  const skills = foundry.utils.getType(dataset.skill) === "string" ? dataset.skill.split("|") : dataset.skill ?? [];
+  const tools = foundry.utils.getType(dataset.tool) === "string" ? dataset.tool.split("|") : dataset.tool ?? [];
   if ( (skills.length + tools.length) <= 1 ) return [createRequestButton(dataset)];
   const baseDataset = { ...dataset };
   delete baseDataset.skill;
@@ -619,6 +676,30 @@ function createCheckRequestButtons(dataset) {
       ability: CONFIG.DND5E.tools[tool]?.ability, ...baseDataset, format: "short", tool, type: "tool"
     }))
   ];
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Parse the raw configuration data for a check enricher.
+ * @param {object} config                   Configuration data.
+ * @param {EnrichmentOptions} [options={}]  Options provided to customize text enrichment.
+ * @returns {object}
+ */
+function parseCheckConfig(config, options={}) {
+  config.skill = config.skill?.replaceAll("/", "|").split("|") ?? [];
+  config.tool = config.tool?.replaceAll("/", "|").split("|") ?? [];
+  for ( let value of config.values ) {
+    const slug = foundry.utils.getType(value) === "string" ? slugify(value) : value;
+    if ( slug in CONFIG.DND5E.enrichmentLookup.abilities ) config.ability = slug;
+    else if ( slug in CONFIG.DND5E.enrichmentLookup.skills ) config.skill.push(slug);
+    else if ( slug in CONFIG.DND5E.enrichmentLookup.tools ) config.tool.push(slug);
+    else if ( Number.isNumeric(value) ) config.dc = Number(value);
+    else config[value] = true;
+  }
+  delete config.values;
+
+  return config;
 }
 
 /* -------------------------------------------- */
@@ -684,16 +765,7 @@ function createCheckRequestButtons(dataset) {
  * ```
  */
 export async function enrichSave(config, label, options) {
-  config.ability = config.ability?.replace("/", "|").split("|") ?? [];
-  for ( let value of config.values ) {
-    const slug = foundry.utils.getType(value) === "string" ? slugify(value) : value;
-    if ( slug in CONFIG.DND5E.enrichmentLookup.abilities ) config.ability.push(slug);
-    else if ( Number.isNumeric(value) ) config.dc = Number(value);
-    else config[value] = true;
-  }
-  config.ability = config.ability
-    .filter(a => a in CONFIG.DND5E.enrichmentLookup.abilities)
-    .map(a => CONFIG.DND5E.enrichmentLookup.abilities[a].key ?? a);
+  config = parseSaveConfig(config, options);
 
   const activity = config.activity ? options.relativeTo?.system?.activities?.get(config.activity)
     : !config.ability.length ? options.relativeTo?.system?.activities?.getByType("save")[0] : null;
@@ -745,13 +817,51 @@ export async function enrichSave(config, label, options) {
 /* -------------------------------------------- */
 
 /**
+ * Handle a save command in chat.
+ * @param {object} config  Configuration data.
+ */
+async function handleSaveCommand(config) {
+  config = parseSaveConfig(config);
+  config.type = "save";
+  if ( config.request ) return handlePostRequest(config);
+  config.ability = config.ability[0];
+  rollCheckSave(config);
+}
+
+/* -------------------------------------------- */
+
+/**
  * Create the buttons for a save requested in chat.
  * @param {object} dataset
  * @returns {object[]}
  */
 function createSaveRequestButtons(dataset) {
-  return (dataset.ability?.split("|") ?? [])
-    .map(ability => createRequestButton({ ...dataset, format: "long", ability }));
+  const abilities = foundry.utils.getType(dataset.ability) === "string" ? dataset.ability.split("|")
+    : dataset.ability ?? [];
+  return abilities.map(ability => createRequestButton({ ...dataset, format: "long", ability }));
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Parse the raw configuration data for a check enricher.
+ * @param {object} config                   Configuration data.
+ * @param {EnrichmentOptions} [options={}]  Options provided to customize text enrichment.
+ * @returns {object}
+ */
+function parseSaveConfig(config, options={}) {
+  config.ability = config.ability?.replace("/", "|").split("|") ?? [];
+  for ( let value of config.values ) {
+    const slug = foundry.utils.getType(value) === "string" ? slugify(value) : value;
+    if ( slug in CONFIG.DND5E.enrichmentLookup.abilities ) config.ability.push(slug);
+    else if ( Number.isNumeric(value) ) config.dc = Number(value);
+    else config[value] = true;
+  }
+  config.ability = config.ability
+    .filter(a => a in CONFIG.DND5E.enrichmentLookup.abilities)
+    .map(a => CONFIG.DND5E.enrichmentLookup.abilities[a].key ?? a);
+
+  return config;
 }
 
 /* -------------------------------------------- */
@@ -887,37 +997,7 @@ async function rollCheckSave(config, event) {
  * ````
  */
 export async function enrichDamage(configs, label, options) {
-  const config = { type: "damage", formulas: [], damageTypes: [], rollType: configs._isHealing ? "healing" : "damage" };
-  const types = CONFIG.DND5E.enrichmentLookup.damageTypes;
-  for ( const c of configs ) {
-    const formulaParts = [];
-    if ( c.activity ) config.activity = c.activity;
-    if ( c.attackMode ) config.attackMode = c.attackMode;
-    if ( c.average ) config.average = c.average;
-    if ( c.format ) config.format = c.format;
-    if ( c.formula ) formulaParts.push(c.formula);
-    c.type = c.type?.replaceAll("/", "|").split("|") ?? [];
-    for ( const value of c.values ) {
-      const slug = foundry.utils.getType(value) === "string" ? slugify(value) : value;
-      if ( slug in types ) c.type.push(types[slug]);
-      else if ( value in CONFIG.DND5E.attackModes ) config.attackMode = value;
-      else if ( value === "average" ) config.average = true;
-      else if ( value === "extended" ) config.format = "extended";
-      else if ( value === "temp" ) c.type.push("temphp");
-      else formulaParts.push(value);
-    }
-    c.formula = Roll.defaultImplementation.replaceFormulaData(
-      formulaParts.join(" "),
-      options.rollData ?? options.relativeTo?.getRollData?.() ?? {}
-    );
-    if ( configs._isHealing && !c.type.length ) c.type.push("healing");
-    if ( c.formula ) {
-      config.formulas.push(c.formula);
-      config.damageTypes.push(c.type.join("|"));
-    }
-  }
-  config.damageTypes = config.damageTypes.map(t => t?.replace("/", "|"));
-  if ( config.format === "extended" ) config.average ??= true;
+  const config = parseDamageConfig(configs, options);
 
   if ( config.activity && config.formulas.length ) {
     logWarning(`Activity ID and formulas found while enriching ${config._input}, only one is supported.`, options);
@@ -1012,6 +1092,59 @@ export async function enrichDamage(configs, label, options) {
 }
 
 /* -------------------------------------------- */
+/**
+ * Handle a damage command in chat.
+ * @param {object[]} configs  Configuration data.
+ */
+function handleDamageCommand(configs) {
+  rollDamage(parseDamageConfig(configs));
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Parse the raw configuration data for a damage enricher.
+ * @param {object[]} configs                Configuration data.
+ * @param {EnrichmentOptions} [options={}]  Options provided to customize text enrichment.
+ * @returns {object}
+ */
+function parseDamageConfig(configs, options={}) {
+  const config = { type: "damage", formulas: [], damageTypes: [], rollType: configs._isHealing ? "healing" : "damage" };
+  const lookup = CONFIG.DND5E.enrichmentLookup;
+  for ( const c of configs ) {
+    const formulaParts = [];
+    if ( c.activity ) config.activity = c.activity;
+    if ( c.attackMode ) config.attackMode = c.attackMode;
+    if ( c.average ) config.average = c.average;
+    if ( c.format ) config.format = c.format;
+    if ( c.formula ) formulaParts.push(c.formula);
+    c.type = c.type?.replaceAll("/", "|").split("|") ?? [];
+    for ( const value of c.values ) {
+      const slug = foundry.utils.getType(value) === "string" ? slugify(value) : value;
+      if ( value in lookup.damageTypes ) c.type.push(slug);
+      else if ( slug in CONFIG.DND5E.attackModes ) config.attackMode = slug;
+      else if ( slug === "average" ) config.average = true;
+      else if ( slug === "extended" ) config.format = "extended";
+      else if ( slug === "temp" ) c.type.push("temphp");
+      else formulaParts.push(value);
+    }
+    c.formula = Roll.defaultImplementation.replaceFormulaData(
+      formulaParts.join(" "),
+      options.rollData ?? options.relativeTo?.getRollData?.() ?? {}
+    );
+    if ( configs._isHealing && !c.type.length ) c.type.push("healing");
+    if ( c.formula ) {
+      config.formulas.push(c.formula);
+      config.damageTypes.push(c.type.join("|"));
+    }
+  }
+  config.damageTypes = config.damageTypes.map(t => t?.replace("/", "|"));
+  if ( config.format === "extended" ) config.average ??= true;
+
+  return config;
+}
+
+/* -------------------------------------------- */
 
 /**
  * Perform a damage roll.
@@ -1027,8 +1160,10 @@ async function rollDamage(config, event) {
     if ( activity ) return activity.rollDamage({ attackMode, event });
   }
 
-  formulas = formulas?.split("&") ?? [];
-  damageTypes = damageTypes?.split("&") ?? [];
+  if ( event ) {
+    formulas = formulas?.split("&") ?? [];
+    damageTypes = damageTypes?.split("&") ?? [];
+  }
 
   const rollConfig = {
     attackMode, event,
@@ -1652,12 +1787,14 @@ async function handleEndConcentration(event, target) {
 
 /**
  * Handle creating a roll request chat message.
- * @param {Event} event         Triggering click event.
- * @param {HTMLElement} target  Button that was clicked.
+ * @param {object|Event} dataset  Configuration dataset or triggering click event.
+ * @param {HTMLElement} [target]  Button that was clicked.
  */
-async function handlePostRequest(event, target) {
-  window.getSelection().empty();
-  const dataset = getRollActionDataset(target);
+async function handlePostRequest(dataset, target) {
+  if ( dataset instanceof Event ) {
+    window.getSelection().empty();
+    dataset = getRollActionDataset(target);
+  }
 
   let buttons;
   if ( dataset.type === "check" ) buttons = createCheckRequestButtons(dataset);

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -647,11 +647,15 @@ export async function enrichCheck(config, label, options) {
 /**
  * Handle a check command in chat.
  * @param {object} config  Configuration data.
+ * @returns {void}
  */
 function handleCheckCommand(config) {
   config = parseCheckConfig(config);
   config.type = "check";
   if ( config.request ) return handlePostRequest(config);
+  if ( (config.tool.length === 1) && (config.skill.length > 0) && (dnd5e.settings.rulesVersion === "modern") ) {
+    config.usingTool = config.tool.pop();
+  }
   config.skill = config.skill[0];
   config.tool = config.tool[0];
   config.type = config.skill ? "skill" : config.tool ? "tool" : "check";
@@ -678,6 +682,7 @@ function createCheckRequestButtons(dataset) {
   const baseDataset = { ...dataset };
   delete baseDataset.skill;
   delete baseDataset.tool;
+  if ( (tools.length === 1) && (dnd5e.settings.rulesVersion === "modern") ) baseDataset.usingTool = tools.pop();
   return [
     ...skills.map(skill => createRequestButton({
       ability: CONFIG.DND5E.skills[skill].ability, ...baseDataset, format: "short", skill, type: "skill"

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -532,14 +532,14 @@ export async function enrichCheck(config, label, options) {
   }
 
   // TODO: Support "spellcasting" ability
-  let abilityConfig = CONFIG.DND5E.enrichmentLookup.abilities[slugify(config.ability)];
+  let abilityConfig = CONFIG.DND5E.abilities[config.ability];
   if ( config.ability && !abilityConfig ) {
     logWarning(`Ability "${config.ability}" not found while enriching ${config._input}.`, options);
     invalid = true;
   } else if ( abilityConfig?.key ) config.ability = abilityConfig.key;
 
   for ( let [index, skill] of config.skill.entries() ) {
-    const skillConfig = CONFIG.DND5E.enrichmentLookup.skills[slugify(skill)];
+    const skillConfig = CONFIG.DND5E.skills[skill];
     if ( skillConfig ) {
       if ( skillConfig.key ) skill = config.skill[index] = skillConfig.key;
       const ability = config.ability || skillConfig.ability;
@@ -553,10 +553,9 @@ export async function enrichCheck(config, label, options) {
 
   let usingTool;
   for ( const tool of config.tool ) {
-    const toolConfig = CONFIG.DND5E.tools[slugify(tool)];
-    const toolUUID = CONFIG.DND5E.enrichmentLookup.tools[slugify(tool)];
-    const toolIndex = toolUUID?.id ? Trait.getBaseItem(toolUUID.id, { indexOnly: true }) : null;
-    const toolLabel = toolIndex?.name ?? toolUUID?.label;
+    const toolConfig = CONFIG.DND5E.enrichmentLookup.tools[slugify(tool)];
+    const toolIndex = Trait.getBaseItem(toolConfig?.id ?? "", { indexOnly: true });
+    const toolLabel = toolIndex?.name ?? toolConfig?.label;
     if ( toolLabel ) {
       const ability = config.ability || toolConfig?.ability;
       if ( config.skill.length && (config.tool.length === 1) && (config._rules === "2024") ) {
@@ -604,7 +603,7 @@ export async function enrichCheck(config, label, options) {
       // Multiple associated proficiencies, link each individually
       if ( associated.length > 1 ) parts.push(
         _loc("EDITOR.DND5E.Inline.SpecificCheck", {
-          ability: CONFIG.DND5E.enrichmentLookup.abilities[ability].label,
+          ability: CONFIG.DND5E.abilities[ability].label,
           type: formatter.format(associated.map(a => createRollLink(a.label, makeConfig(a)).outerHTML ))
         })
       );
@@ -652,10 +651,10 @@ export async function enrichCheck(config, label, options) {
 function handleCheckCommand(config) {
   config = parseCheckConfig(config);
   config.type = "check";
-  if ( config.request ) return handlePostRequest(config);
   if ( (config.tool.length === 1) && (config.skill.length > 0) && (dnd5e.settings.rulesVersion === "modern") ) {
     config.usingTool = config.tool.pop();
   }
+  if ( config.request ) return handlePostRequest(config);
   config.skill = config.skill[0];
   config.tool = config.tool[0];
   config.type = config.skill ? "skill" : config.tool ? "tool" : "check";
@@ -672,7 +671,7 @@ function handleCheckCommand(config) {
 function createCheckRequestButtons(dataset) {
   const skills = foundry.utils.getType(dataset.skill) === "string" ? dataset.skill.split("|") : dataset.skill ?? [];
   const tools = foundry.utils.getType(dataset.tool) === "string" ? dataset.tool.split("|") : dataset.tool ?? [];
-  if ( (skills.length + tools.length) <= 1 ) {
+  if ( ((skills.length + tools.length) <= 1) && !dataset.usingTool ) {
     if ( !dataset.ability ) {
       if ( skills.length === 1 ) dataset.ability = CONFIG.DND5E.skills[skills[0]]?.ability;
       else if ( tools.length === 1 ) dataset.ability = CONFIG.DND5E.tools[tools[0]]?.ability;
@@ -682,7 +681,6 @@ function createCheckRequestButtons(dataset) {
   const baseDataset = { ...dataset };
   delete baseDataset.skill;
   delete baseDataset.tool;
-  if ( (tools.length === 1) && (dnd5e.settings.rulesVersion === "modern") ) baseDataset.usingTool = tools.pop();
   return [
     ...skills.map(skill => createRequestButton({
       ability: CONFIG.DND5E.skills[skill].ability, ...baseDataset, format: "short", skill, type: "skill"
@@ -702,13 +700,14 @@ function createCheckRequestButtons(dataset) {
  * @returns {object}
  */
 export function parseCheckConfig(config, options={}) {
+  const lookup = CONFIG.DND5E.enrichmentLookup;
   config.skill = config.skill?.replaceAll("/", "|").split("|") ?? [];
   config.tool = config.tool?.replaceAll("/", "|").split("|") ?? [];
   for ( let value of config.values ) {
     const slug = foundry.utils.getType(value) === "string" ? slugify(value) : value;
-    if ( slug in CONFIG.DND5E.enrichmentLookup.abilities ) config.ability = slug;
-    else if ( slug in CONFIG.DND5E.enrichmentLookup.skills ) config.skill.push(slug);
-    else if ( slug in CONFIG.DND5E.enrichmentLookup.tools ) config.tool.push(slug);
+    if ( slug in lookup.abilities ) config.ability = lookup.abilities[slug].key;
+    else if ( slug in lookup.skills ) config.skill.push(lookup.skills[slug].key);
+    else if ( slug in lookup.tools ) config.tool.push(lookup.tools[slug].key);
     else if ( Number.isNumeric(value) ) config.dc = Number(value);
     else config[value] = true;
   }
@@ -865,16 +864,15 @@ function createSaveRequestButtons(dataset) {
  * @returns {object}
  */
 export function parseSaveConfig(config, options={}) {
+  const lookup = CONFIG.DND5E.enrichmentLookup;
   config.ability = config.ability?.replace("/", "|").split("|") ?? [];
   for ( let value of config.values ) {
     const slug = foundry.utils.getType(value) === "string" ? slugify(value) : value;
-    if ( slug in CONFIG.DND5E.enrichmentLookup.abilities ) config.ability.push(slug);
+    if ( slug in lookup.abilities ) config.ability.push(lookup.abilities[slug].key);
     else if ( Number.isNumeric(value) ) config.dc = Number(value);
     else config[value] = true;
   }
-  config.ability = config.ability
-    .filter(a => a in CONFIG.DND5E.enrichmentLookup.abilities)
-    .map(a => CONFIG.DND5E.enrichmentLookup.abilities[a].key ?? a);
+  config.ability = config.ability.filter(a => a in CONFIG.DND5E.enrichmentLookup.abilities);
 
   return config;
 }
@@ -1136,7 +1134,7 @@ export function parseDamageConfig(configs, options={}) {
     c.type = c.type?.replaceAll("/", "|").split("|") ?? [];
     for ( const value of c.values ) {
       const slug = foundry.utils.getType(value) === "string" ? slugify(value) : value;
-      if ( value in lookup.damageTypes ) c.type.push(slug);
+      if ( slug in lookup.damageTypes ) c.type.push(lookup.damageTypes[slug]);
       else if ( slug in CONFIG.DND5E.attackModes ) config.attackMode = slug;
       else if ( slug === "average" ) config.average = true;
       else if ( slug === "extended" ) config.format = "extended";

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -270,7 +270,7 @@ function handleAttackCommand(config) {
  * @param {EnrichmentOptions} [options={}]  Options provided to customize text enrichment.
  * @returns {object}
  */
-function parseAttackConfig(config, options={}) {
+export function parseAttackConfig(config, options={}) {
   const formulaParts = [];
   if ( config.formula ) formulaParts.push(config.formula);
   for ( const value of config.values ) {
@@ -686,7 +686,7 @@ function createCheckRequestButtons(dataset) {
  * @param {EnrichmentOptions} [options={}]  Options provided to customize text enrichment.
  * @returns {object}
  */
-function parseCheckConfig(config, options={}) {
+export function parseCheckConfig(config, options={}) {
   config.skill = config.skill?.replaceAll("/", "|").split("|") ?? [];
   config.tool = config.tool?.replaceAll("/", "|").split("|") ?? [];
   for ( let value of config.values ) {
@@ -849,7 +849,7 @@ function createSaveRequestButtons(dataset) {
  * @param {EnrichmentOptions} [options={}]  Options provided to customize text enrichment.
  * @returns {object}
  */
-function parseSaveConfig(config, options={}) {
+export function parseSaveConfig(config, options={}) {
   config.ability = config.ability?.replace("/", "|").split("|") ?? [];
   for ( let value of config.values ) {
     const slug = foundry.utils.getType(value) === "string" ? slugify(value) : value;
@@ -1108,7 +1108,7 @@ function handleDamageCommand(configs) {
  * @param {EnrichmentOptions} [options={}]  Options provided to customize text enrichment.
  * @returns {object}
  */
-function parseDamageConfig(configs, options={}) {
+export function parseDamageConfig(configs, options={}) {
   const config = { type: "damage", formulas: [], damageTypes: [], rollType: configs._isHealing ? "healing" : "damage" };
   const lookup = CONFIG.DND5E.enrichmentLookup;
   for ( const c of configs ) {

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -47,7 +47,7 @@ export function registerCustomEnrichers() {
  * @returns {false|void}    Returns `false` to prevent the message from continuing to parse.
  */
 export function chatMessage(message) {
-  const match = message.match(CHAT_REGEX);
+  const match = message.replace(/^<p>|<\/p>$/gi, "").match(CHAT_REGEX);
   if ( !match ) return;
   let { type, config } = match.groups;
   config = parseConfig(config, { multiple: ["damage", "heal", "healing"].includes(type) });


### PR DESCRIPTION
Allows for `/check`, `/save`, `/attack` and `/damage` commands to be used from chat using the same options as if they were used in the enricher format.

For the `/check` and `/save` commands, a new `request` option can be included to create a roll request card directly.

Closes #4610