### PR TITLE
[#6247] Add speed reduction from armor's strength requirement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2887,6 +2887,10 @@
   "EnhancedDualWielding": {
     "Name": "Enhanced Dual Wielding",
     "Hint": "Allow bonus action extra attacks using any melee weapon without the Two-Handed property."
+  },
+  "IgnoreArmorSpeedReduction": {
+    "Name": "Ignore Armor Speed Reduction",
+    "Hint": "Ignore the reduction to speed when wearing armor without meeting the strength requirement."
   }
 },
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4256,6 +4256,12 @@ DND5E.characterFlags = {
     section: "DND5E.RacialTraits",
     type: Boolean
   },
+  ignoreArmorSpeedReduction: {
+    name: "DND5E.FLAGS.IgnoreArmorSpeedReduction.Name",
+    hint: "DND5E.FLAGS.IgnoreArmorSpeedReduction.Hint",
+    section: "DND5E.RacialTraits",
+    type: Boolean
+  },
   initiativeAlert: {
     name: "DND5E.FlagsAlert",
     hint: "DND5E.FlagsAlertHint",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1557,6 +1557,15 @@ DND5E.armorProficienciesMap = {
 /* -------------------------------------------- */
 
 /**
+ * Amount of speed reduction caused by wearing armor but not meeting the strength requirement in feet.
+ * Value will be converted to the appropriate value to match the actor's speed unit.
+ * @type {number}
+ */
+DND5E.armorSpeedReduction = 10;
+
+/* -------------------------------------------- */
+
+/**
  * The basic armor types in 5e. This enables specific armor proficiencies,
  * automated AC calculation in NPCs, and starting equipment.
  * @enum {string}

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -165,7 +165,7 @@ export default class AttributesFields {
     }, { armors: [], shields: [] });
 
     // Set stealth disadvantage
-    if ( armors[0]?.system.properties.has("stealthDisadvantage") ) {
+    if ( armors[0]?.system.properties.has("stealthDisadvantage") && this.skills ) {
       AdvantageModeField.setMode(this, "skills.ste.roll.mode", -1);
     }
 
@@ -410,7 +410,7 @@ export default class AttributesFields {
 
   /**
    * Modify movement speeds taking exhaustion and any other conditions into account.
-   * @this {CharacterData|NPCData}
+   * @this {CharacterData|NPCData|VehicleData}
    * @param {ActorRollData} rollData  The Actor's roll data.
    */
   static prepareMovement(rollData=this.parent.getRollData()) {

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -430,6 +430,9 @@ export default class AttributesFields {
     const units = this.attributes.movement.units ??= defaultUnits("length");
     let reduction = dnd5e.settings.rulesVersion === "modern" && !this.traits?.ci?.value?.has("exhaustion")
       ? (this.attributes.exhaustion ?? 0) * (CONFIG.DND5E.conditionTypes.exhaustion?.reduction?.speed ?? 0) : 0;
+    if ( (this.attributes.ac?.equippedArmor?.system.strength ?? 0) > (this.abilities?.str?.value ?? Infinity) ) {
+      reduction += CONFIG.DND5E.armorSpeedReduction;
+    }
     reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, units);
     const bonus = simplifyBonus(this.attributes.movement.bonus, rollData);
     this.attributes.movement.max = 0;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -430,7 +430,8 @@ export default class AttributesFields {
     const units = this.attributes.movement.units ??= defaultUnits("length");
     let reduction = dnd5e.settings.rulesVersion === "modern" && !this.traits?.ci?.value?.has("exhaustion")
       ? (this.attributes.exhaustion ?? 0) * (CONFIG.DND5E.conditionTypes.exhaustion?.reduction?.speed ?? 0) : 0;
-    if ( (this.attributes.ac?.equippedArmor?.system.strength ?? 0) > (this.abilities?.str?.value ?? Infinity) ) {
+    if ( ((this.attributes.ac?.equippedArmor?.system.strength ?? 0) > (this.abilities?.str?.value ?? Infinity))
+      && !this.parent.flags.dnd5e?.ignoreArmorSpeedReduction ) {
       reduction += CONFIG.DND5E.armorSpeedReduction;
     }
     reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, units);

--- a/module/data/fields/advantage-mode-field.mjs
+++ b/module/data/fields/advantage-mode-field.mjs
@@ -169,6 +169,10 @@ export default class AdvantageModeField extends foundry.data.fields.NumberField 
   static setMode(model, keyPath, value, { override=false }={}) {
     const field = keyPath.startsWith("system.") ? model.system.schema.getField(keyPath.slice(7))
       : model.schema.getField(keyPath);
+    if ( !field ) {
+      console.error(`No field found at "${keyPath}" to apply advantage to.`);
+      return 0;
+    }
     const type = override ? "override" : "add";
     const change = { key: keyPath, value, type };
     const final = field.applyChange(foundry.utils.getProperty(model, keyPath), model, change);

--- a/packs/_source/races/dwarf/hill-dwarf.yml
+++ b/packs/_source/races/dwarf/hill-dwarf.yml
@@ -44,8 +44,10 @@ system:
       id="secret-bkbaaEWqAGbU8ZgK"><p><strong>Foundry
       Note</strong></p><p>Dwarven Toughness should be configured by adding 1 to
       the "Per Level" bonus in HP configuration on your character sheet
-      (accessible using the cog next to your character's hit
-      points).</p></section>
+      (accessible using the cog next to your character's hit points).</p><p>The
+      "Ignore Armor Speed Reduction" flag in the Special Traits tab can be used
+      to prevent armor from reducing your speed if you don't have sufficient
+      strength.</p></section>
     chat: ''
   source:
     custom: ''
@@ -182,11 +184,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 5.2.0
   createdTime: 1725037392950
-  modifiedTime: 1725992703517
+  modifiedTime: 1769455937269
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0


### PR DESCRIPTION
Add speed reduction when wearing armor and not meeting its strength requirement. The reduction is defined in the config at `DND5E.armorSpeedReduction` in feet and converted to meters if necessary.

Closes #6247