### PR TITLE
[#6304] Add movement bonus that applies only to existing speeds

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3742,6 +3742,9 @@
     "Configure": "Configure Movement Speed"
   },
   "FIELDS": {
+    "bonus": {
+      "label": "Movement Bonus"
+    },
     "ignoredDifficultTerrain": {
       "label": "Ignored Difficult Terrain"
     },

--- a/module/applications/shared/movement-senses-config.mjs
+++ b/module/applications/shared/movement-senses-config.mjs
@@ -117,6 +117,11 @@ export default class MovementSensesConfig extends BaseConfigSheet {
       value: context.data.hover,
       localize: true
     };
+    if ( context.fields.bonus ) extras.push({
+      field: context.fields.bonus,
+      value: context.data.bonus,
+      localize: true
+    });
     if ( context.fields.ignoredDifficultTerrain ) extras.push({
       field: context.fields.ignoredDifficultTerrain,
       value: context.data.ignoredDifficultTerrain,

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -213,7 +213,7 @@ export default class CharacterData extends CreatureTemplate {
     AttributesFields.prepareConcentration.call(this, rollData);
     AttributesFields.prepareEncumbrance.call(this, rollData);
     AttributesFields.prepareInitiative.call(this, rollData);
-    AttributesFields.prepareMovement.call(this);
+    AttributesFields.prepareMovement.call(this, rollData);
     AttributesFields.prepareSpellcastingAbility.call(this);
     TraitsFields.prepareLanguages.call(this);
     TraitsFields.prepareResistImmune.call(this);

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -408,7 +408,7 @@ export default class NPCData extends CreatureTemplate {
     AttributesFields.prepareEncumbrance.call(this, rollData);
     AttributesFields.prepareExhaustionLevel.call(this);
     AttributesFields.prepareInitiative.call(this, rollData);
-    AttributesFields.prepareMovement.call(this);
+    AttributesFields.prepareMovement.call(this, rollData);
     AttributesFields.prepareSpellcastingAbility.call(this);
     SourceField.prepareData.call(this.source, this.parent._stats?.compendiumSource ?? this.parent.uuid);
     TraitsFields.prepareLanguages.call(this);

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -409,8 +409,9 @@ export default class AttributesFields {
   /**
    * Modify movement speeds taking exhaustion and any other conditions into account.
    * @this {CharacterData|NPCData}
+   * @param {object} rollData  The Actor's roll data.
    */
-  static prepareMovement() {
+  static prepareMovement(rollData=this.parent.getRollData()) {
     const statuses = this.parent.statuses;
     const noMovement = this.parent.hasConditionEffect("noMovement");
     const halfMovement = this.parent.hasConditionEffect("halfMovement");
@@ -422,6 +423,7 @@ export default class AttributesFields {
     let reduction = game.settings.get("dnd5e", "rulesVersion") === "modern"
       ? (this.attributes.exhaustion ?? 0) * (CONFIG.DND5E.conditionTypes.exhaustion?.reduction?.speed ?? 0) : 0;
     reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, units);
+    const bonus = simplifyBonus(this.attributes.movement.bonus, rollData);
     const field = this.schema.getField("attributes.movement");
     this.attributes.movement.max = 0;
     let slowed = false;
@@ -440,6 +442,7 @@ export default class AttributesFields {
           speed = Math.min(speed, CONFIG.DND5E.encumbrance.speedReduction.exceedingCarryingCapacity[units] ?? 0);
         }
       }
+      if ( speed ) speed = Math.max(0, speed + bonus);
       this.attributes.movement[type] = speed;
       this.attributes.movement.max = Math.max(speed, this.attributes.movement.max);
       const base = this._source.attributes.movement[type] ?? this.attributes.movement.fromSpecies?.[type];

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -266,7 +266,7 @@ export default class VehicleData extends CommonTemplate {
     AttributesFields.prepareEncumbrance.call(this, rollData, { validateItem: item => !item.isMountable });
     AttributesFields.prepareHitPoints.call(this, this.attributes.hp);
     AttributesFields.prepareInitiative.call(this, rollData);
-    AttributesFields.prepareMovement.call(this);
+    AttributesFields.prepareMovement.call(this, rollData);
     SourceField.prepareData.call(this.source, this.parent._stats?.compendiumSource ?? this.parent.uuid);
     TraitsFields.prepareResistImmune.call(this);
     TravelField.prepareData.call(this, rollData);

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -31,7 +31,7 @@ export default class RaceData extends ItemDataModel.mixin(AdvancementTemplate, I
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      movement: new MovementField({ special: false }, { initialUnits: defaultUnits("length") }),
+      movement: new MovementField({ bonus: false, special: false }, { initialUnits: defaultUnits("length") }),
       senses: new SensesField({}, { initialUnits: defaultUnits("length") }),
       type: new CreatureTypeField({ swarm: false }, { initial: { value: "humanoid" } })
     });

--- a/module/data/shared/_types.mjs
+++ b/module/data/shared/_types.mjs
@@ -52,6 +52,7 @@
  * @property {number} fly                           Actor flying speed.
  * @property {number} swim                          Actor swimming speed.
  * @property {number} walk                          Actor walking speed.
+ * @property {string} bonus                         Bonus applied to all movement types that already have a speed.
  * @property {string} special                       Semi-colon separated list of special movement information.
  * @property {string} units                         Movement used to measure the various speeds.
  * @property {boolean} hover                        This flying creature able to hover in place.

--- a/module/data/shared/movement-field.mjs
+++ b/module/data/shared/movement-field.mjs
@@ -1,3 +1,5 @@
+import FormulaField from "../fields/formula-field.mjs";
+
 const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields;
 
 /**
@@ -16,6 +18,7 @@ export default class MovementField extends foundry.data.fields.SchemaField {
       fly: new NumberField({ ...numberConfig, label: "DND5E.MOVEMENT.Type.Fly", speed: true }),
       swim: new NumberField({ ...numberConfig, label: "DND5E.MOVEMENT.Type.Swim", speed: true }),
       walk: new NumberField({ ...numberConfig, label: "DND5E.MOVEMENT.Type.Walk", speed: true }),
+      bonus: new FormulaField({ deterministic: true, label: "DND5E.MOVEMENT.FIELDS.bonus.label" }),
       special: new StringField({ label: "DND5E.MOVEMENT.FIELDS.special.label" }),
       units: new StringField({
         required: true, nullable: true, blank: false, initial: initialUnits, label: "DND5E.MOVEMENT.FIELDS.units.label"


### PR DESCRIPTION
Introduces the `attributes.movement.bonus` formula field that allows users to enter a bonus that is applied to all movement speeds so long as a given movement type already has a speed.

Closes #6304