### PR TITLE
[#6295] Allow travel hour per day to be customized

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4595,7 +4595,16 @@
   }
 },
 
-"DND5E.Travel": {
+"DND5E.TRAVEL": {
+  "FIELDS": {
+    "pace": {
+      "label": "Pace"
+    },
+    "time": {
+      "hint": "Number of hours traveled per day used to convert travel speed to pace.",
+      "label": "Hours per Day"
+    }
+  },
   "Label": "Travel Pace",
   "Pace": {
     "Fast": "Fast",

--- a/module/applications/shared/movement-senses-config.mjs
+++ b/module/applications/shared/movement-senses-config.mjs
@@ -171,6 +171,11 @@ export default class MovementSensesConfig extends BaseConfigSheet {
       options: Object.entries(CONFIG.DND5E.travelPace).map(([value, { label }]) => ({ value, label })),
       value: data.pace
     });
+    if ( context.travel.fields.time ) context.travel.extras.push({
+      field: context.travel.fields.time,
+      localize: true,
+      value: data.time
+    });
     if ( context.fields ) context.legend = game.i18n.localize("DND5E.MOVEMENT.Speed");
   }
 }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2624,18 +2624,29 @@ patchConfig("movementTypes", "label", { since: "DnD5e 5.1", until: "DnD5e 5.3" }
 /* -------------------------------------------- */
 
 /**
+ * Default number of hours per day traveled by specific actor types.
+ * @enum {number}
+ */
+DND5E.travelTimes = {
+  group: 8,
+  vehicle: 24
+};
+
+/* -------------------------------------------- */
+
+/**
  * Types of movement supported by creature actors in the system.
  * @enum {MovementTypeConfig}
  */
 DND5E.travelTypes = {
   land: {
-    label: "DND5E.Travel.Type.Land"
+    label: "DND5E.TRAVEL.Type.Land"
   },
   water: {
-    label: "DND5E.Travel.Type.Water"
+    label: "DND5E.TRAVEL.Type.Water"
   },
   air: {
-    label: "DND5E.Travel.Type.Air"
+    label: "DND5E.TRAVEL.Type.Air"
   }
 };
 preLocalize("travelTypes", { key: "label" });
@@ -2655,17 +2666,17 @@ preLocalize("travelTypes", { key: "label" });
  */
 DND5E.travelPace = Object.freeze({
   slow: {
-    label: "DND5E.Travel.Pace.Slow",
+    label: "DND5E.TRAVEL.Pace.Slow",
     standard: 18,
     multiplier: 2 / 3
   },
   normal: {
-    label: "DND5E.Travel.Pace.Normal",
+    label: "DND5E.TRAVEL.Pace.Normal",
     standard: 24,
     multiplier: 1
   },
   fast: {
-    label: "DND5E.Travel.Pace.Fast",
+    label: "DND5E.TRAVEL.Pace.Fast",
     standard: 30,
     multiplier: 4 / 3
   }

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -41,7 +41,9 @@ export default class GroupData extends GroupTemplate {
         actor: new ForeignDocumentField(foundry.documents.BaseActor)
       }), { label: "DND5E.GroupMembers" }),
       attributes: new SchemaField({
-        travel: new TravelField({}, { initialUnits: defaultUnits("travel") })
+        travel: new TravelField({}, {
+          initialTime: () => CONFIG.DND5E.travelTimes.group, initialUnits: () => defaultUnits("travel")
+        })
       }, { label: "DND5E.Attributes" }),
       details: new SchemaField({
         xp: new SchemaField({

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -146,7 +146,9 @@ export default class VehicleData extends CommonTemplate {
         quality: new SchemaField({
           value: new NumberField({ required: true, nullable: false, integer: true, min: -10, max: 10, initial: 4 })
         }),
-        travel: new TravelField({ pace: false, }, { initialUnits: defaultUnits("travel") })
+        travel: new TravelField({ pace: false, }, {
+          initialTime: () => CONFIG.DND5E.travelTimes.vehicle, initialUnits: () => defaultUnits("travel")
+        })
       }, { label: "DND5E.Attributes" }),
       crew: new SchemaField({
         max: new NumberField({ min: 0, integer: true }),

--- a/templates/actors/group/header.hbs
+++ b/templates/actors/group/header.hbs
@@ -42,7 +42,7 @@
             {{!-- Movement --}}
             <div class="movement card">
                 <div class="header travel-pace">
-                    <h3>{{ localize "DND5E.Travel.Label" }}</h3>
+                    <h3>{{ localize "DND5E.TRAVEL.Label" }}</h3>
                     {{#if editable}}
                     <button type="button" class="config-button unbutton" data-action="showConfiguration"
                             data-config="movement" data-tooltip aria-label="{{ localize "DND5E.MOVEMENT.Action.Configure" }}">
@@ -62,19 +62,19 @@
                 </div>
                 <div class="info">
                     <div>
-                        <span class="label">{{ localize "DND5E.Travel.Type.Land" }}</span>
+                        <span class="label">{{ localize "DND5E.TRAVEL.Type.Land" }}</span>
                         <span class="value">
                             {{ dnd5e-numberFormat system.attributes.travel.paces.land blank="—" }}
                         </span>
                     </div>
                     <div>
-                        <span class="label">{{ localize "DND5E.Travel.Type.Water" }}</span>
+                        <span class="label">{{ localize "DND5E.TRAVEL.Type.Water" }}</span>
                         <span class="value">
                             {{ dnd5e-numberFormat system.attributes.travel.paces.water blank="—" }}
                         </span>
                     </div>
                     <div>
-                        <span class="label">{{ localize "DND5E.Travel.Type.Air" }}</span>
+                        <span class="label">{{ localize "DND5E.TRAVEL.Type.Air" }}</span>
                         <span class="value">
                             {{ dnd5e-numberFormat system.attributes.travel.paces.air blank="—" }}
                         </span>

--- a/templates/actors/vehicle/sidebar.hbs
+++ b/templates/actors/vehicle/sidebar.hbs
@@ -165,13 +165,13 @@
     {{/if}}
     {{#if showTravelSpeed}}
     {{> "systems/dnd5e/templates/actors/parts/actor-trait-line.hbs" icon="fa-solid fa-sailboat"
-        label="DND5E.Travel.Speed" configAction="movement" configLabel="DND5E.MOVEMENT.Action.Configure"
+        label="DND5E.TRAVEL.Speed" configAction="movement" configLabel="DND5E.MOVEMENT.Action.Configure"
         unitsConfig=CONFIG.travelUnits formatted=(dnd5e-formatTravelSpeed system.attributes.travel.speeds.max
         unit=system.attributes.travel.units period="hour" parts=true) }}
     {{/if}}
     {{#if showTravelPace}}
     {{> "systems/dnd5e/templates/actors/parts/actor-trait-line.hbs" icon="fa-solid fa-sun"
-        label="DND5E.Travel.Label" configAction="movement" configLabel="DND5E.MOVEMENT.Action.Configure"
+        label="DND5E.TRAVEL.Label" configAction="movement" configLabel="DND5E.MOVEMENT.Action.Configure"
         unitsConfig=CONFIG.travelUnits formatted=(dnd5e-formatTravelSpeed system.attributes.travel.paces.max
         unit=system.attributes.travel.units period="day" parts=true) }}
     {{/if}}

--- a/templates/shared/config/movement-senses-config.hbs
+++ b/templates/shared/config/movement-senses-config.hbs
@@ -28,13 +28,13 @@
 
     {{#with travel}}
     <fieldset class="card">
-        <legend>{{ localize "DND5E.Travel.Speed" }}</legend>
+        <legend>{{ localize "DND5E.TRAVEL.Speed" }}</legend>
         <div class="header">
             <div class="form-group split-group">
                 <span></span>
                 <div class="form-fields">
-                    <span>{{ localize "DND5E.Travel.Per.Hour" }}</span>
-                    <span>{{ localize "DND5E.Travel.Per.Day" }}</span>
+                    <span>{{ localize "DND5E.TRAVEL.Per.Hour" }}</span>
+                    <span>{{ localize "DND5E.TRAVEL.Per.Day" }}</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Adds `attributes.travel.time` to allow customizing number of hours traveled per day. The default for this value can be customized using `CONFIG.DND5E.travelTimes` and defaults to 8 hours for groups and 24 hours for vehicles.