### PR TITLE
[#5294] Add temp HP option for summoned creatures

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4303,6 +4303,10 @@
         "label": "Summon Prompt",
         "hint": "Should the player be prompted to place the summons? Players will still be able to summon from the chat card if prompt is disabled."
       }
+    },
+    "tempHP": {
+      "label": "Temp HP",
+      "hint": "Grant the summoned creature temp HP, replacing any existing temp HP."
     }
   },
   "Action": {

--- a/module/data/activity/_types.mjs
+++ b/module/data/activity/_types.mjs
@@ -171,6 +171,7 @@
  * @property {object} summon
  * @property {""|"cr"} summon.mode          Method of determining what type of creature is summoned.
  * @property {boolean} summon.prompt        Should the player be prompted to place the summons?
+ * @property {string} tempHP                Temporary HP granted to the summoned creature.
  */
 
 /**

--- a/module/data/activity/summon-data.mjs
+++ b/module/data/activity/summon-data.mjs
@@ -51,7 +51,8 @@ export default class BaseSummonActivityData extends BaseActivityData {
       summon: new SchemaField({
         mode: new StringField(),
         prompt: new BooleanField({ initial: true })
-      })
+      }),
+      tempHP: new FormulaField()
     };
   }
 

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -374,6 +374,13 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
       }
     }
 
+    // Add temp HP
+    if ( this.tempHP ) {
+      const tempHP = new Roll(this.tempHP, rollData);
+      await tempHP.evaluate();
+      actorUpdates["system.attributes.hp.temp"] = tempHP.total;
+    }
+
     // Change creature size
     if ( this.creatureSizes.size ) {
       const size = this.creatureSizes.has(options.creatureSize) ? options.creatureSize : this.creatureSizes.first();

--- a/templates/activity/parts/summon-changes.hbs
+++ b/templates/activity/parts/summon-changes.hbs
@@ -11,6 +11,7 @@
         {{ formField fields.bonuses.fields.ac value=source.bonuses.ac rootId=partId }}
         {{ formField fields.bonuses.fields.hd value=source.bonuses.hd rootId=partId }}
         {{ formField fields.bonuses.fields.hp value=source.bonuses.hp rootId=partId }}
+        {{ formField fields.tempHP value=source.tempHP rootId=partId }}
         {{ formField fields.creatureSizes value=source.creatureSizes options=creatureSizeOptions rootId=partId }}
         {{ formField fields.creatureTypes value=source.creatureTypes options=creatureTypeOptions rootId=partId }}
     </fieldset>


### PR DESCRIPTION
The temp HP option will replace any temp HP on the existing actor with the result of the formula.

Closes #5294