### PR TITLE
[#6200] Add missing save proficiencies to 2014 NPC stat block

### DIFF
--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -658,7 +658,9 @@ export default class NPCData extends CreatureTemplate {
         saves: formatter.format(
           Object.entries(CONFIG.DND5E.abilities)
             .filter(([k]) => this.abilities[k].saveProf.multiplier !== 0)
-            .map(([k, { abbreviation }]) => `${abbreviation.capitalize()} ${formatNumber(this.abilities[k].save.value, { signDisplay: "always" })}`)
+            .map(([k, { abbreviation }]) =>
+              `${abbreviation.capitalize()} ${formatNumber(this.abilities[k].save.value, { signDisplay: "always" })}`
+            )
         ),
 
         // Senses (e.g. `Blindsight 60 ft., Darkvision 120 ft.; Passive Perception 27`)


### PR DESCRIPTION
Adds the missing `saves` property to the NPC stat block embed context.
Note that ability abbreviations here are only capitalized (instead of fully uppercase), since that's what I could find in official published content. 

Closes #6200.