### PR TITLE
[6340] Fix item icons not being draggable in compendium browser

### DIFF
--- a/templates/compendium/browser-entry.hbs
+++ b/templates/compendium/browser-entry.hbs
@@ -5,7 +5,8 @@
         <div class="item-name rollable" role="button" data-action="openLink">
 
             {{#if entry.img}}
-            <img class="item-image gold-icon" loading="lazy" src="{{ entry.img }}" alt="{{ entry.name }}">
+            <img class="item-image gold-icon" loading="lazy" src="{{ entry.img }}" alt="{{ entry.name }}"
+                 draggable="false">
             {{/if}}
 
             <div class="name name-stacked">


### PR DESCRIPTION
Adds the missing `draggable="false"` attribute to item icons in the compendium browser.

Closes #6340.