### PR TITLE
Remove `heavy` property from Frost Giant Great Bow

### DIFF
--- a/packs/_source/actors24/giant/frost-giant.yml
+++ b/packs/_source/actors24/giant/frost-giant.yml
@@ -946,7 +946,6 @@ items:
       magicalBonus: null
       properties:
         - amm
-        - hvy
         - two
       proficient: null
       range:

--- a/packs/_source/monsterfeatures24/attacks/great-bow.yml
+++ b/packs/_source/monsterfeatures24/attacks/great-bow.yml
@@ -132,7 +132,6 @@ system:
   magicalBonus: null
   properties:
     - amm
-    - hvy
     - two
   proficient: null
   range:


### PR DESCRIPTION
Simply removes the heavy property from the Frost Giant HeavyBow and the standalone monster feature as well. Closes #6347 

Will need this fixed in the Monster Manual Premium module as well.