### PR TITLE
Fix 2024 Monk (Disciplined Survivor)

### DIFF
--- a/packs/_source/classes24/monk/class-features/disciplined-survivor.yml
+++ b/packs/_source/classes24/monk/class-features/disciplined-survivor.yml
@@ -94,9 +94,9 @@ effects:
     type: base
     system: {}
     changes:
-      - key: system.attributes.death.roll.mode
-        mode: 2
-        value: '1'
+      - key: flags.dnd5e.diamondSoul
+        mode: 5
+        value: 'true'
         priority: null
     disabled: false
     duration:

--- a/packs/_source/classes24/monk/monk.yml
+++ b/packs/_source/classes24/monk/monk.yml
@@ -399,24 +399,6 @@ system:
       value: {}
       title: Unarmored Movement
       hint: ''
-    - _id: wOFoztcLEFPTTmK7
-      type: Trait
-      configuration:
-        mode: default
-        allowReplacements: false
-        grants:
-          - saves:str
-          - saves:dex
-          - saves:con
-          - saves:int
-          - saves:wis
-          - saves:cha
-        choices: []
-      value:
-        chosen: []
-      level: 14
-      title: Disciplined Survivor
-      hint: ''
     - _id: OGo9kMbx7cFuGx00
       type: Subclass
       configuration: {}


### PR DESCRIPTION
Added `str` and `dex` save proficiencies to guard against multiclass that don't grant these proficiencies. Added passive effect to additionally grant `adv` on death saves. Closes #6137