### PR TITLE
[#6238, #6329, #6349] Actor transformation fixes

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2835,7 +2835,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     // Token appearance updates
     const tokenPropsFromSource = ["width", "height", "alpha", "lockRotation", "ring"];
     const tokenTexturePropsFromSource = ["offsetX", "offsetY", "scaleX", "scaleY", "src", "tint"];
-    const tokenPropsFromSelf = ["bar1", "bar2", "displayBars", "displayName", "disposition", "rotation", "elevation"];
+    const tokenPropsFromSelf = [
+      "bar1", "bar2", "displayBars", "displayName", "disposition", "rotation", "elevation", "hidden"
+    ];
 
     for ( const k of tokenPropsFromSource ) {
       d.prototypeToken[k] = sourceData.prototypeToken[k];
@@ -3039,7 +3041,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( this.isToken ) {
       const tokenData = d.prototypeToken;
       delete d.prototypeToken;
-      tokenData.hidden = this.token.hidden;
       for ( const k of tokenPropsFromSelf ) {
         tokenData[k] = this.token[k];
       }
@@ -3101,7 +3102,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       newTokenData._id = t.id;
       newTokenData.actorId = newActor.id;
       newTokenData.actorLink = true;
-      newTokenData.hidden = t.document.hidden;
       for ( const k of tokenPropsFromSelf ) {
         newTokenData[k] = t.document[k];
       }


### PR DESCRIPTION
This includes:

a) Fix for reverting multi-stage transformation of unlinked tokens (closes #6349, thanks @roth-michael).
b) Reviewed logic to clean up flags on revert. To describe it shortly:
  - the `isOriginalActor` bool was always false;
  - most flags (but not all) were deleted anyway when their document was;
  - flags on polymorphed world actors were not deleted when restored by a player.

c) Added a new `previousTokenData` flag to store the original `texture.src` to be restored on revert instead of using the prototype one (closes #6329).
d) Use own token's data for `bar1`, `bar2`, `displayBars`, `displayName`, `disposition`, `rotation`, `elevation` instead of the prototype's. Also store the original token name in the same `previousTokenData` flag to be restored on revert. Closes #6238, _but_ it's worth noting that the issue actually exists for linked tokens too, and an approach like this one could not work in that case (if you have multiple linked tokens for the same actor with different token names/displayBars/etc, which properties do you use?). I do think that it's a much rarer situation though.

I'm aware that the transform functions are delicate. I'll continue testing on my end, but let me know if you notice any issue.
