### PR TITLE
[#3168] Support Spell Properties Without Abbreviation or Tag

### DIFF
--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -375,9 +375,17 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
       const config = this.validProperties.has(c) ? CONFIG.DND5E.itemProperties[c] : null;
       if ( !config ) return obj;
       const { abbreviation: abbr, label, icon } = config;
-      obj.all.push({ abbr, icon, tag: config.isTag });
-      if ( config.isTag ) obj.tags.push(label);
-      else obj.vsm.push(abbr);
+      // Only add properties to display arrays if they have displayable content
+      if ( config.isTag ) {
+        // Tag properties: add to tags if has label
+        if ( label ) obj.tags.push(label);
+        if ( abbr || icon ) obj.all.push({ abbr, icon, tag: true });
+      } else if ( abbr ) {
+        // VSM properties: only add if has abbreviation
+        obj.vsm.push(abbr);
+        obj.all.push({ abbr, icon, tag: false });
+      }
+      // Properties with neither abbreviation nor isTag are silently ignored for display
       return obj;
     }, { all: [], vsm: [], tags: [] });
     labels.components.vsm = game.i18n.getListFormatter({ style: "narrow" }).format(labels.components.vsm);


### PR DESCRIPTION
This PR fixes an error that occurs when adding custom spell properties without an `abbreviation` field or `isTag` flag, and enables "silent" properties for programmatic use.

## Issue

When module/world developers attempt to add custom spell properties via:

```javascript
CONFIG.DND5E.itemProperties.test = {
  label: "Test"
};
CONFIG.DND5E.validProperties.spell.add("test");
```

The system throws errors during spell data preparation:

```
TypeError: Iterable yielded undefined which is not a string
    at ListFormat.format (<anonymous>)
    at SpellData.prepareDerivedData (spell.mjs:257:77)
```

If a spell with this property is saved and the world reloaded, the Actor sheet becomes inaccessible.

## Solution

Modified the property processing logic to only add properties to display arrays if they have displayable content:


Closes #6378, #3168