### PR TITLE
[#6390] Display legendary resistance uses in stat block embeds

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3061,6 +3061,7 @@
   },
   "Label": "Legendary Resistance",
   "LabelPl": "Legendary Resistances",
+  "LairUses": "{normal}/Day, or {lair}/Day in Lair",
   "Max": "Maximum Legendary Resistances",
   "Ordinal": {
     "one": "{n}st Legendary Resistance",

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -431,6 +431,15 @@ export default class NPCData extends CreatureTemplate {
     legact.value = Math.clamp(legact.max - legact.spent, 0, legact.max);
     legres.value = Math.clamp(legres.max - legres.spent, 0, legres.max);
     this.resources.legact.label = this.getLegendaryActionsDescription();
+    const legendaryResistanceItem = this.parent.identifiedItems.get("legendary-resistance", { type: "feat" })?.first();
+    if ( legres.max && legendaryResistanceItem ) {
+      const max = this._source.resources.legres.max;
+      const modernRules = (this.source?.rules
+        || (game.settings.get("dnd5e", "rulesVersion") === "modern" ? "2024" : "2014")) === "2024";
+      legendaryResistanceItem.system.uses.label = this.resources.lair.value && modernRules ? game.i18n.format(
+        "DND5E.LegendaryResistance.LairUses",  { normal: formatNumber(max), lair: formatNumber(max + 1) }
+      ) : `${formatNumber(max)}/${CONFIG.DND5E.limitedUsePeriods.day?.label ?? ""}`;
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -58,7 +58,7 @@ export default class UsesField extends SchemaField {
     }
     if ( labels ) labels.recovery = game.i18n.getListFormatter({ style: "narrow" }).format(periods);
 
-    this.uses.label = UsesField.getStatblockLabel.call(this);
+    this.uses.label ??= UsesField.getStatblockLabel.call(this);
 
     Object.defineProperty(this.uses, "rollRecharge", {
       value: UsesField.rollRecharge.bind(this.parent?.system ? this.parent : this),


### PR DESCRIPTION
NPCs will add a custom label to an item with the identifier of `legendary-resistance` that takes the resistance values from the actor data, rather than the item uses like normal. This also takes the lair increase into account.

Closes #6390