### PR TITLE
[#2857] Convert exhaustion `toggle` to increment/decrement

### DIFF
--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1996,12 +1996,12 @@ dialog.dnd5e2.application {
         .title { font-size: var(--font-size-13); }
       }
 
-      .exhaustion-level {
-        max-width: 16px;
-        height: 15px;
-        padding: 0 2.5px;
-        font-size: var(--font-size-16);
+      .condition-level {
+        block-size: 16px;
+        font-size: var(--font-size-15);
         font-weight: 900;
+        inline-size: 15px;
+        text-align: center;
       }
     }
   }

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1995,6 +1995,14 @@ dialog.dnd5e2.application {
         flex: 1;
         .title { font-size: var(--font-size-13); }
       }
+
+      .exhaustion-level {
+        max-width: 16px;
+        height: 15px;
+        padding: 0 2.5px;
+        font-size: var(--font-size-16);
+        font-weight: 900;
+      }
     }
   }
 }

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -253,12 +253,18 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       conditionIds.add(id);
       const existing = this.actor.effects.get(id);
       const { disabled } = existing ?? {};
-      arr.push({
+      const condition = {
         name, reference,
         id: k,
         img: existing?.img ?? img,
         disabled: existing ? disabled : true
-      });
+      };
+      // Add exhaustion level for exhaustion condition
+      if ( k === "exhaustion" ) {
+        condition.isExhaustion = true;
+        condition.exhaustionLevel = this.actor.system.attributes?.exhaustion ?? 0;
+      }
+      arr.push(condition);
       return arr;
     }, []);
 

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1,4 +1,5 @@
 import * as Trait from "../../../documents/actor/trait.mjs";
+import ConditionData from "../../../data/active-effect/condition.mjs";
 import Item5e from "../../../documents/item.mjs";
 import {
   formatLength,
@@ -259,11 +260,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
         img: existing?.img ?? img,
         disabled: existing ? disabled : true
       };
-      // Add exhaustion level for exhaustion condition
-      if ( k === "exhaustion" ) {
-        condition.isExhaustion = true;
-        condition.exhaustionLevel = this.actor.system.attributes?.exhaustion ?? 0;
-      }
+      if ( ConditionData.hasLevels(k) ) condition.level = this.actor.system.conditions?.[k] ?? 0;
       arr.push(condition);
       return arr;
     }, []);

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -1,4 +1,5 @@
 import Actor5e from "../../documents/actor/actor.mjs";
+import ConditionData from "../../data/active-effect/condition.mjs";
 import {staticID} from "../../utils.mjs";
 import ContextMenu5e from "../context-menu.mjs";
 
@@ -100,11 +101,14 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
 
     for ( const control of this.querySelectorAll("[data-action]") ) {
       control.addEventListener("click", event => {
-        this._onAction(event.currentTarget, event.currentTarget.dataset.action);
+        this._onAction(event.currentTarget, event.currentTarget.dataset.action, { event });
       });
-      control.addEventListener("contextmenu", event => {
-        this._onAction(event.currentTarget, event.currentTarget.dataset.action, event);
-      });
+      if ( control.dataset.action === "toggleCondition" ) {
+        control.addEventListener("contextmenu", event => {
+          event.preventDefault();
+          this._onAction(event.currentTarget, event.currentTarget.dataset.action, { event });
+        });
+      }
     }
 
     for ( const source of this.querySelectorAll(".effect-source a") ) {
@@ -223,26 +227,26 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
         label: "DND5E.ContextMenuActionEdit",
         icon: "<i class='fas fa-edit fa-fw'></i>",
         visible: () => effect.isOwner,
-        onClick: (_, target) => this._onAction(target, "edit")
+        onClick: (event, target) => this._onAction(target, "edit", { event })
       },
       {
         label: "DND5E.ContextMenuActionDuplicate",
         icon: "<i class='fas fa-copy fa-fw'></i>",
         visible: () => effect.isOwner,
-        onClick: (_, target) => this._onAction(target, "duplicate")
+        onClick: (event, target) => this._onAction(target, "duplicate", { event })
       },
       {
         label: "DND5E.ContextMenuActionDelete",
         icon: "<i class='fas fa-trash fa-fw'></i>",
         visible: () => effect.isOwner && !isConcentrationEffect,
-        onClick: (_, target) => this._onAction(target, "delete")
+        onClick: (event, target) => this._onAction(target, "delete", { event })
       },
       {
         label: effect.disabled ? "DND5E.ContextMenuActionEnable" : "DND5E.ContextMenuActionDisable",
         icon: effect.disabled ? "<i class='fas fa-check fa-fw'></i>" : "<i class='fas fa-times fa-fw'></i>",
         group: "state",
         visible: () => effect.isOwner && !isConcentrationEffect,
-        onClick: (_, target) => this._onAction(target, "toggle")
+        onClick: (event, target) => this._onAction(target, "toggle", { event })
       },
       {
         label: "DND5E.CONCENTRATION.Action.Break",
@@ -256,7 +260,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
         icon: `<i class="fa-solid fa-${expanded ? "compress" : "expand"}"></i>`,
         group: "collapsible",
         visible: () => "canExpand" in this.app ? this.app.canExpand(effect) : true,
-        onClick: (_, target) => this._onAction(target, "toggleExpand")
+        onClick: (event, target) => this._onAction(target, "toggleExpand", { event })
       }
     ];
 
@@ -269,7 +273,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
         icon: "<i class='fas fa-bookmark fa-fw'></i>",
         group: "state",
         visible: () => effect.isOwner,
-        onClick: (_, target) => this._onAction(target, isFavorited ? "unfavorite" : "favorite")
+        onClick: (event, target) => this._onAction(target, isFavorited ? "unfavorite" : "favorite", { event })
       });
     }
 
@@ -280,13 +284,14 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
 
   /**
    * Handle effects actions.
-   * @param {Element} target         Button or context menu entry that triggered this action.
-   * @param {string} action          Action being triggered.
-   * @param {PointerEvent} [event]   Original pointer event if available.
+   * @param {Element} target                Button or context menu entry that triggered this action.
+   * @param {string} action                 Action being triggered.
+   * @param {object} [options]
+   * @param {PointerEvent} [options.event]  The triggering event.
    * @returns {Promise}
    * @protected
    */
-  async _onAction(target, action, event) {
+  async _onAction(target, action, { event }={}) {
     const customEvent = new CustomEvent("effect", {
       bubbles: true,
       cancelable: true,
@@ -295,7 +300,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
     if ( target.dispatchEvent(customEvent) === false ) return;
 
     if ( action === "toggleCondition" ) {
-      return this._onToggleCondition(target.closest("[data-condition-id]")?.dataset.conditionId, event);
+      return this._onToggleCondition(target.closest("[data-condition-id]")?.dataset.conditionId, { event });
     }
 
     const dataset = target.closest("[data-effect-id]")?.dataset;
@@ -329,21 +334,19 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
 
   /**
    * Handle toggling a condition.
-   * @param {string} conditionId       The condition identifier.
-   * @param {PointerEvent} [event]     Original pointer event if available.
+   * @param {string} conditionId            The condition identifier.
+   * @param {object} [options]
+   * @param {PointerEvent} [options.event]  The triggering event.
    * @returns {Promise}
    * @protected
    */
-  async _onToggleCondition(conditionId, event) {
-    // Handle exhaustion specially - increment/decrement level
-    if ( conditionId === "exhaustion" ) {
-      // Initialize exhaustion to 0 if not set
-      let level = foundry.utils.getProperty(this.document, "system.attributes.exhaustion");
-      if ( !Number.isFinite(level) ) await this.document.update({ "system.attributes.exhaustion": 0 });
-      return ActiveEffect.implementation._manageExhaustion(event, this.document);
+  async _onToggleCondition(conditionId, { event }={}) {
+    // Leveled conditions increment/decrement.
+    if ( ConditionData.hasLevels(conditionId) ) {
+      return this.document.toggleStatusEffect(conditionId, { levels: event?.type === "contextmenu" ? -1 : 1 });
     }
 
-    // Handle other conditions normally
+    // Other conditions toggle on and off.
     const existing = this.document.effects.get(staticID(`dnd5e${conditionId}`));
     if ( existing ) return existing.delete();
     const effect = await ActiveEffect.implementation.fromStatusEffect(conditionId);

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -102,6 +102,9 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
       control.addEventListener("click", event => {
         this._onAction(event.currentTarget, event.currentTarget.dataset.action);
       });
+      control.addEventListener("contextmenu", event => {
+        this._onAction(event.currentTarget, event.currentTarget.dataset.action, event);
+      });
     }
 
     for ( const source of this.querySelectorAll(".effect-source a") ) {
@@ -277,21 +280,22 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
 
   /**
    * Handle effects actions.
-   * @param {Element} target  Button or context menu entry that triggered this action.
-   * @param {string} action   Action being triggered.
+   * @param {Element} target         Button or context menu entry that triggered this action.
+   * @param {string} action          Action being triggered.
+   * @param {PointerEvent} [event]   Original pointer event if available.
    * @returns {Promise}
    * @protected
    */
-  async _onAction(target, action) {
-    const event = new CustomEvent("effect", {
+  async _onAction(target, action, event) {
+    const customEvent = new CustomEvent("effect", {
       bubbles: true,
       cancelable: true,
       detail: action
     });
-    if ( target.dispatchEvent(event) === false ) return;
+    if ( target.dispatchEvent(customEvent) === false ) return;
 
     if ( action === "toggleCondition" ) {
-      return this._onToggleCondition(target.closest("[data-condition-id]")?.dataset.conditionId);
+      return this._onToggleCondition(target.closest("[data-condition-id]")?.dataset.conditionId, event);
     }
 
     const dataset = target.closest("[data-effect-id]")?.dataset;
@@ -325,11 +329,28 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
 
   /**
    * Handle toggling a condition.
-   * @param {string} conditionId  The condition identifier.
+   * @param {string} conditionId       The condition identifier.
+   * @param {PointerEvent} [event]     Original pointer event if available.
    * @returns {Promise}
    * @protected
    */
-  async _onToggleCondition(conditionId) {
+  async _onToggleCondition(conditionId, event) {
+    // Handle exhaustion specially - increment/decrement level
+    if ( conditionId === "exhaustion" ) {
+      let level = foundry.utils.getProperty(this.document, "system.attributes.exhaustion");
+      if ( !Number.isFinite(level) ) level = 0;
+      if ( event ) {
+        event.preventDefault();
+        event.stopPropagation();
+        // Left click increments, right click decrements
+        if ( event.button === 0 ) level++;
+        else if ( event.button === 2 ) level--;
+      }
+      const max = CONFIG.DND5E.conditionTypes.exhaustion.levels;
+      return this.document.update({ "system.attributes.exhaustion": Math.clamp(level, 0, max) });
+    }
+
+    // Handle other conditions normally
     const existing = this.document.effects.get(staticID(`dnd5e${conditionId}`));
     if ( existing ) return existing.delete();
     const effect = await ActiveEffect.implementation.fromStatusEffect(conditionId);

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -337,17 +337,10 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
   async _onToggleCondition(conditionId, event) {
     // Handle exhaustion specially - increment/decrement level
     if ( conditionId === "exhaustion" ) {
+      // Initialize exhaustion to 0 if not set
       let level = foundry.utils.getProperty(this.document, "system.attributes.exhaustion");
-      if ( !Number.isFinite(level) ) level = 0;
-      if ( event ) {
-        event.preventDefault();
-        event.stopPropagation();
-        // Left click increments, right click decrements
-        if ( event.button === 0 ) level++;
-        else if ( event.button === 2 ) level--;
-      }
-      const max = CONFIG.DND5E.conditionTypes.exhaustion.levels;
-      return this.document.update({ "system.attributes.exhaustion": Math.clamp(level, 0, max) });
+      if ( !Number.isFinite(level) ) await this.document.update({ "system.attributes.exhaustion": 0 });
+      return ActiveEffect.implementation._manageExhaustion(event, this.document);
     }
 
     // Handle other conditions normally

--- a/templates/shared/active-effects.hbs
+++ b/templates/shared/active-effects.hbs
@@ -86,7 +86,11 @@
                     <div class="name-stacked">
                         <span class="title">{{ name }}</span>
                     </div>
+                    {{#if isExhaustion}}
+                    <span class="exhaustion-level">{{ exhaustionLevel }}</span>
+                    {{else}}
                     <i class="fa-solid fa-toggle-{{ ifThen disabled "off" "on" }}"></i>
+                    {{/if}}
                 </li>
                 {{/each}}
             </ul>

--- a/templates/shared/active-effects.hbs
+++ b/templates/shared/active-effects.hbs
@@ -86,8 +86,8 @@
                     <div class="name-stacked">
                         <span class="title">{{ name }}</span>
                     </div>
-                    {{#if isExhaustion}}
-                    <span class="exhaustion-level">{{ exhaustionLevel }}</span>
+                    {{#if level includeZero=true}}
+                    <span class="condition-level">{{ level }}</span>
                     {{else}}
                     <i class="fa-solid fa-toggle-{{ ifThen disabled "off" "on" }}"></i>
                     {{/if}}


### PR DESCRIPTION
Closes #2857.

Adds special handling for exhaustion in the conditions table of the effects tab. This mimics the similar behavior where left clicking increases the exhaustion number, and right clicking decreases the exhaustion number.

I had to pass `event` through `_onAction` into `_onToggleCondition`, if there is a cleaner approach you would like me to take let me know.

![FVTT_Desktop_Client_vRjaCfD06z](https://github.com/user-attachments/assets/202bf54c-fc55-4724-9002-f0df550405d2)
