### PR TITLE
[#6383] Allow synthetic actors to set a flag to false

### DIFF
--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1642,6 +1642,10 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     // Remove any flags that are false-ish
     for ( const [key, value] of Object.entries(submitData.flags?.dnd5e ?? {}) ) {
       if ( value ) continue;
+
+      // Keep the flag for synthetic actor overrides
+      if ( this.actor.isToken && this.actor.parent.baseActor.getFlag("dnd5e", key) ) continue;
+
       delete submitData.flags.dnd5e[key];
       if ( foundry.utils.hasProperty(this.document._source, `flags.dnd5e.${key}`) ) {
         submitData.flags.dnd5e[`-=${key}`] = null;


### PR DESCRIPTION
Small change to the base sheet's `_processFormData` to keep false-ish flags when a synthetic actor is trying to override a base actor's `true` value.

As an aside, I was a little surprised by how issue #6383 manifests itself through core's update logic. I'm out of my depth there, but it seems to me that, when the system submits the flag deletion on the synthetic actor (which does nothing) the actor delta's `updateSource` is failing to update the synthetic actor again. If anyone has the expertise and knowledge to review that, it might be a potential issue in core too.

Closes #6383 