### PR TITLE
[#6425, #6426, #6427] Fix issues with Mythic actions in stat blocks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -227,6 +227,10 @@
       "Label": "Minute"
     },
     "Mythic": {
+      "Counted": {
+        "one": "{number} mythic action",
+        "other": "{number} mythic actions"
+      },
       "Header": "Mythic Actions",
       "Label": "Mythic Action"
     },
@@ -3189,7 +3193,9 @@
 "DND5E.Notes": "Notes",
 
 "DND5E.NPC": {
-  "Label": "NPC",
+  "ActionCostCounted": {
+    "other": "Costs {number} Actions"
+  },
   "FIELDS": {
     "attributes": {
       "price": {
@@ -3210,10 +3216,12 @@
       }
     }
   },
+  "Label": "NPC",
   "SECTIONS": {
     "Actions": "Actions",
     "BonusActions": "Bonus Actions",
     "LegendaryActions": "Legendary Actions",
+    "MythicActions": "Mythic Actions",
     "Reactions": "Reactions",
     "Traits": "Traits"
   }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1040,6 +1040,10 @@ DND5E.activityActivationTypes = {
     scalar: true
   },
   mythic: {
+    counted: "DND5E.ACTIVATION.Type.Mythic.Counted",
+    consume: {
+      property: "resources.legact"
+    },
     label: "DND5E.ACTIVATION.Type.Mythic.Label",
     header: "DND5E.ACTIVATION.Type.Mythic.Header",
     group: "DND5E.ACTIVATION.Category.Monster",

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -633,6 +633,11 @@ export default class NPCData extends CreatureTemplate {
           label: game.i18n.localize("DND5E.NPC.SECTIONS.LegendaryActions"),
           description: "",
           actions: []
+        },
+        mythic: {
+          label: game.i18n.localize("DND5E.NPC.SECTIONS.MythicActions"),
+          description: "",
+          actions: []
         }
       },
       CONFIG: CONFIG.DND5E,
@@ -801,6 +806,8 @@ export default class NPCData extends CreatureTemplate {
         }));
         if ( item.identifier === "legendary-actions" ) {
           context.actionSections.legendary.description = description;
+        } else if ( item.identifier === "mythic-actions" ) {
+          context.actionSections.mythic.description = description;
         } else {
           const openingTag = description.match(/^\s*(<p(?:\s[^>]+)?>)/gi)?.[0];
           if ( openingTag ) description = description.replace(openingTag, "");

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -251,6 +251,7 @@ export default class FeatData extends ItemDataModel.mixin(
     let label;
     const activation = this.activities.contents[0]?.activation.type;
     if ( activation === "legendary" ) label = game.i18n.localize("DND5E.LegendaryAction.Label");
+    if ( activation === "mythic" ) label = game.i18n.localize("DND5E.MythicActionLabel");
     else if ( activation === "lair" ) label = game.i18n.localize("DND5E.LAIR.Action.Label");
     else if ( activation === "action" && this.hasAttack ) label = game.i18n.localize("DND5E.Attack");
     else if ( activation ) label = game.i18n.localize("DND5E.Action");

--- a/module/data/shared/uses-field.mjs
+++ b/module/data/shared/uses-field.mjs
@@ -1,4 +1,4 @@
-import { formatNumber, formatRange, prepareFormulaValue } from "../../utils.mjs";
+import { formatNumber, formatRange, getPluralRules, prepareFormulaValue } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
 const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
@@ -90,6 +90,15 @@ export default class UsesField extends SchemaField {
    * @returns {string}
    */
   static getStatblockLabel() {
+    // Legendary/Mythic Actions
+    if ( (this.activation?.type === "legendary") || (this.activation?.type === "mythic") ) {
+      if ( this.activation.value < 2 ) return "";
+      const pr = getPluralRules();
+      return game.i18n.format(`DND5E.NPC.ActionCostCounted.${pr.select(this.activation.value)}`, {
+        number: formatNumber(this.activation.value)
+      });
+    }
+
     if ( !this.uses.max || (this.uses.recovery.length !== 1) ) return "";
     const recovery = this.uses.recovery[0];
 


### PR DESCRIPTION
Adds a Mythic Actions section to NPC stat block embeds that will display any mythic actions and takes its description from an item with the `mythic-actions` identifier. Also displays the action cost for mythic and legendary actions on NPC stat blocks.

Also sets mythic actions to automatically consume legendary actions from the NPC and improves some labels on mythic actions.

Closes #6425
Closes #6426
Closes #6427