### PR TITLE
[#6366] Add `PoolTerm` damage roll simplification for damage tooltip

### DIFF
--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -612,9 +612,7 @@ export default class ChatMessage5e extends ChatMessage {
           const result = term.results[i];
           // Apply main result classes to individual dice
           simplified.dice.forEach(die => {
-            const resultClasses = termResultClasses
-              .filter(c => result[c])
-              .join(" ");
+            const resultClasses = termResultClasses.filter(c => result[c]).join(" ");
             if ( resultClasses.length ) die.classes += ` ${resultClasses}`;
           });
           aggregate.dice.push(...simplified.dice);


### PR DESCRIPTION
Allow `_simplifyDamageRoll` to process `PoolTerm`s. Individual dice will be added to the tooltip with the appropriate CSS classes.

Closes #6366 