### PR TITLE
Derive Jump movement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3833,6 +3833,7 @@
     "Burrow": "Burrow",
     "Climb": "Climb",
     "Fly": "Fly",
+    "Jump": "Jump",
     "Speed": "Speed",
     "Swim": "Swim",
     "Walk": "Walk"

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -371,19 +371,12 @@
 
 /**
  * @typedef MovementTypeConfiguration
- * @property {DeriveSpeedFunction} [deriveSpeed]  Function used to derive the max action speed.
  * @property {boolean} [hidden=false]             Whether this movement speed is displayed in the actor's sheet.
  * @property {string} label                       Localized label for the movement type.
  * @property {string} [travel]                    Travel type in `CONFIG.DND5E.travelTypes` to map this movement
  *                                                speed to. If not provided, then `land` is assumed.
  * @property {boolean} [walkFallback]             When this special movement type runs out, can the actor fall back
  *                                                to using their walk speed at 2x cost?
- */
-
-/**
- * @callback DeriveSpeedFunction
- * @param {Token5e} token  The token attempting the movement.
- * @returns {number}
  */
 
 /* -------------------------------------------- */

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -371,11 +371,19 @@
 
 /**
  * @typedef MovementTypeConfiguration
- * @property {string} label            Localized label for the movement type.
- * @property {string} [travel]         Travel type in `CONFIG.DND5E.travelTypes` to map this movement speed to. If not
- *                                     provided, then `land` is assumed.
- * @property {boolean} [walkFallback]  When this special movement type runs out, can the actor fall back to using their
- *                                     walk speed at 2x cost?
+ * @property {DeriveSpeedFunction} [deriveSpeed]  Function used to derive the max action speed.
+ * @property {boolean} [hidden=false]             Whether this movement speed is displayed in the actor's sheet.
+ * @property {string} label                       Localized label for the movement type.
+ * @property {string} [travel]                    Travel type in `CONFIG.DND5E.travelTypes` to map this movement
+ *                                                speed to. If not provided, then `land` is assumed.
+ * @property {boolean} [walkFallback]             When this special movement type runs out, can the actor fall back
+ *                                                to using their walk speed at 2x cost?
+ */
+
+/**
+ * @callback DeriveSpeedFunction
+ * @param {Token5e} token  The token attempting the movement.
+ * @returns {number}
  */
 
 /* -------------------------------------------- */

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -571,7 +571,8 @@ export default class CharacterActorSheet extends BaseActorSheet {
     context.favorites = await this._prepareFavorites();
 
     // Speed
-    context.speed = Object.entries(CONFIG.DND5E.movementTypes).reduce((obj, [k, { label }]) => {
+    context.speed = Object.entries(CONFIG.DND5E.movementTypes).reduce((obj, [k, { hidden, label }]) => {
+      if ( hidden ) return obj;
       const value = attributes.movement[k];
       if ( value > obj.value ) Object.assign(obj, { value, label });
       return obj;

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -371,7 +371,7 @@ export default class NPCActorSheet extends BaseActorSheet {
 
     // Speed
     context.speed = [
-      ...Object.entries(CONFIG.DND5E.movementTypes).map(([k, { label }]) => {
+      ...Object.entries(CONFIG.DND5E.movementTypes).filter(([k, m]) => !m.hidden).map(([k, { label }]) => {
         const value = attributes.movement[k];
         if ( !value ) return null;
         const data = { label, value };

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -371,7 +371,7 @@ export default class NPCActorSheet extends BaseActorSheet {
 
     // Speed
     context.speed = [
-      ...Object.entries(CONFIG.DND5E.movementTypes).filter(([k, m]) => !m.hidden).map(([k, { label }]) => {
+      ...Object.entries(CONFIG.DND5E.movementTypes).filter(([, m]) => !m.hidden).map(([k, { label }]) => {
         const value = attributes.movement[k];
         if ( !value ) return null;
         const data = { label, value };

--- a/module/applications/shared/movement-senses-config.mjs
+++ b/module/applications/shared/movement-senses-config.mjs
@@ -95,7 +95,7 @@ export default class MovementSensesConfig extends BaseConfigSheet {
         name: this.subPath ? `system.${this.keyPath}.${this.subPath}.${key}` : `system.${this.keyPath}.${key}`,
         value: this.subPath ? context.data[this.subPath][key] : context.data[key],
         placeholder: placeholderData?.[key] ?? ""
-      }));
+      })).filter(type => type.field);
 
       context.unitsOptions = Object.entries(CONFIG.DND5E.movementUnits).map(([value, { label }]) => ({ value, label }));
       context.unitsOptions.blank = false;

--- a/module/canvas/ruler.mjs
+++ b/module/canvas/ruler.mjs
@@ -100,6 +100,11 @@ export default class TokenRuler5e extends foundry.canvas.placeables.tokens.Token
       currActionSpeed = Math.max(currActionSpeed, movement.walk);
     }
 
+    // If current action has a derived speed, use that instead
+    if ( CONFIG.DND5E.movementTypes[waypoint.action]?.deriveSpeed ) {
+      currActionSpeed = CONFIG.DND5E.movementTypes[waypoint.action].deriveSpeed(this.token);
+    }
+
     // Color `normal` if <= max speed, else `double` if <= double max speed, else `triple`
     const { normal, double, triple } = CONFIG.DND5E.tokenRulerColors;
     const increment = (waypoint.measurement.cost - .1) / currActionSpeed;

--- a/module/canvas/ruler.mjs
+++ b/module/canvas/ruler.mjs
@@ -100,11 +100,6 @@ export default class TokenRuler5e extends foundry.canvas.placeables.tokens.Token
       currActionSpeed = Math.max(currActionSpeed, movement.walk);
     }
 
-    // If current action has a derived speed, use that instead
-    if ( CONFIG.DND5E.movementTypes[waypoint.action]?.deriveSpeed ) {
-      currActionSpeed = CONFIG.DND5E.movementTypes[waypoint.action].deriveSpeed(this.token);
-    }
-
     // Color `normal` if <= max speed, else `double` if <= double max speed, else `triple`
     const { normal, double, triple } = CONFIG.DND5E.tokenRulerColors;
     const increment = (waypoint.measurement.cost - .1) / currActionSpeed;

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2419,6 +2419,11 @@ DND5E.movementTypes = {
     label: "DND5E.MOVEMENT.Type.Fly",
     travel: "air"
   },
+  jump: {
+    label: "DND5E.MOVEMENT.Type.Jump",
+    deriveSpeed: token => token.actor?.system.attributes?.movement.jump ?? 0,
+    hidden: true
+  },
   swim: {
     label: "DND5E.MOVEMENT.Type.Swim",
     travel: "water",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2421,7 +2421,6 @@ DND5E.movementTypes = {
   },
   jump: {
     label: "DND5E.MOVEMENT.Type.Jump",
-    deriveSpeed: token => token.actor?.system.attributes?.movement.jump ?? 0,
     hidden: true
   },
   swim: {

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -453,6 +453,7 @@ export default class AttributesFields {
     }
     const baseSpeed = this._source.attributes.movement.walk || this.attributes.movement.fromSpecies?.walk;
     this.attributes.movement.slowed = this.attributes.movement.walk <= (simplifyBonus(baseSpeed, rollData) / 2);
+    this.attributes.movement.jump = (this.abilities?.str.value ?? 0) / 2;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2597,7 +2597,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       unit ? formatLength(value ?? 0, unit, { parts: true })
         : `${value ?? 0} <span class="units">${units}</span>`
     }</span>`;
-    return Object.entries(CONFIG.DND5E.movementTypes).reduce((html, [k, { label }]) => {
+    return Object.entries(CONFIG.DND5E.movementTypes).reduce((html, [k, { hidden, label }]) => {
+      if ( hidden ) return html;
       const value = movement[k];
       if ( value || (k === "walk") ) html += `
         <div class="row">

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -136,6 +136,8 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
         ? cost => cost
         : (cost, _from, _to, distance) => cost + distance;
     };
+    CONFIG.Token.movement.actions.jump.deriveTerrainDifficulty = () => 1;
+    CONFIG.Token.movement.actions.jump.getCostFunction = () => cost => cost;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
This might be more opinionated than I'm comfortable with, let me know what you think. The safer part of this PR is a correction of the movement cost for Jump to bring it in line with the rules (as described in #6410).

Then, to evaluate the ruler's styling, instead of hardcoding a specific behavior for `jump` I'm proposing a callback configuration property called `deriveSpeed`, which would allow defining a movement type with its own custom calculation for the base speed used by the ruler. This works well enough for Jump, where green (corresponding to half the strength score) would be ok, and yellow (full strength score) would suggest that the movement might have other requirements (the 10ft run-up). But it's definitely possible that this is too specific to be actually useful.
