### PR TITLE
Add ability to enchant directly from compendium

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2305,6 +2305,7 @@
     "ConcentrationEnded": "Cannot apply this enchantment because concentration has ended.",
     "MissingProperty": "Item must have one of these properties to be enchanted: {validProperties}.",
     "NoMagicalItems": "Items that are already magical cannot be enchanted.",
+    "NoTargetActor": "Enchanting from a compendium requires an assigned character or selected token.",
     "NoSubtype": "Only {allowedType} items can be enchanted by this enchantment, but this item doesn't have a sub-type.",
     "WrongType": "{incorrectType} items cannot be enchanted by this enchantment, only {allowedType} items are allowed."
   }

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -50,7 +50,7 @@ class DependentsRegistry {
    * @returns {string}
    */
   static #resolveDependentID(idOrUuid, dependent) {
-    if ( idOrUuid.length > 16 ) return idOrUuid;
+    if ( idOrUuid.length > 16 ) return foundry.utils.parseUuid(idOrUuid, { relative: dependent })?.uuid;
     let relative = dependent.parent;
     if ( relative && !(relative instanceof Item) ) relative = relative.parent;
     return relative.effects.get(idOrUuid)?.uuid;


### PR DESCRIPTION
When an item from a compendium is dragged on the enchant tray it will now be duplicated and a copy created on the actor that used the enchant activity (if the player is the owner) or the player's selected token or assigned character.

The item that is created in this manner is automatically made dependent on its own effect, ensuring that if the enchantment is disabled the created item will also be removed.