### PR TITLE
[#6368] Allow for non-physical ammo properties

### DIFF
--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -331,13 +331,12 @@
  * Configuration data for item properties.
  *
  * @typedef ItemPropertyConfiguration
- * @property {string} label                 Localized label.
- * @property {string} [abbreviation]        Localized abbreviation.
- * @property {string} [icon]                Icon that can be used in certain places to represent this property.
- * @property {string} [reference]           Reference to a rule page describing this property.
- * @property {boolean} [isPhysical]         Is this property one that can cause damage resistance bypasses?
- * @property {boolean} [isTag]              Is this spell property a tag, rather than a component?
- * @property {boolean} [validForAmmunition] Can this property be applied to ammunition without being physical?
+ * @property {string} label           Localized label.
+ * @property {string} [abbreviation]  Localized abbreviation.
+ * @property {string} [icon]          Icon that can be used in certain places to represent this property.
+ * @property {string} [reference]     Reference to a rule page describing this property.
+ * @property {boolean} [isPhysical]   Is this property one that can cause damage resistance bypasses?
+ * @property {boolean} [isTag]        Is this spell property a tag, rather than a component?
  */
 
 /* -------------------------------------------- */

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -331,12 +331,13 @@
  * Configuration data for item properties.
  *
  * @typedef ItemPropertyConfiguration
- * @property {string} label           Localized label.
- * @property {string} [abbreviation]  Localized abbreviation.
- * @property {string} [icon]          Icon that can be used in certain places to represent this property.
- * @property {string} [reference]     Reference to a rule page describing this property.
- * @property {boolean} [isPhysical]   Is this property one that can cause damage resistance bypasses?
- * @property {boolean} [isTag]        Is this spell property a tag, rather than a component?
+ * @property {string} label                 Localized label.
+ * @property {string} [abbreviation]        Localized abbreviation.
+ * @property {string} [icon]                Icon that can be used in certain places to represent this property.
+ * @property {string} [reference]           Reference to a rule page describing this property.
+ * @property {boolean} [isPhysical]         Is this property one that can cause damage resistance bypasses?
+ * @property {boolean} [isTag]              Is this spell property a tag, rather than a component?
+ * @property {boolean} [validForAmmunition] Can this property be applied to ammunition without being physical?
  */
 
 /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1931,7 +1931,8 @@ DND5E.itemProperties = {
     label: "DND5E.ITEM.Property.Reload"
   },
   ret: {
-    label: "DND5E.ITEM.Property.Returning"
+    label: "DND5E.ITEM.Property.Returning",
+    validForAmmunition: true
   },
   ritual: {
     label: "DND5E.ITEM.Property.Ritual",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1931,8 +1931,7 @@ DND5E.itemProperties = {
     label: "DND5E.ITEM.Property.Reload"
   },
   ret: {
-    label: "DND5E.ITEM.Property.Returning",
-    validForAmmunition: true
+    label: "DND5E.ITEM.Property.Returning"
   },
   ritual: {
     label: "DND5E.ITEM.Property.Ritual",
@@ -2043,6 +2042,8 @@ DND5E.validProperties = {
     "mgc"
   ])
 };
+
+DND5E.validProperties.consumable.ammo = new Set(["ret"]);
 
 /* -------------------------------------------- */
 

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -168,7 +168,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
   get validProperties() {
     const valid = super.validProperties;
     if ( this.type.value === "ammo" ) Object.entries(CONFIG.DND5E.itemProperties).forEach(([k, v]) => {
-      if ( v.isPhysical || v.validForAmmunition ) valid.add(k);
+      if ( v.isPhysical ) valid.add(k);
     });
     else if ( this.type.value === "scroll" ) CONFIG.DND5E.validProperties.spell
       .filter(p => p !== "material").forEach(p => valid.add(p));

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -168,8 +168,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
   get validProperties() {
     const valid = super.validProperties;
     if ( this.type.value === "ammo" ) Object.entries(CONFIG.DND5E.itemProperties).forEach(([k, v]) => {
-      if ( v.isPhysical ) valid.add(k);
-      valid.add("ret");
+      if ( v.isPhysical || v.validForAmmunition ) valid.add(k);
     });
     else if ( this.type.value === "scroll" ) CONFIG.DND5E.validProperties.spell
       .filter(p => p !== "material").forEach(p => valid.add(p));

--- a/module/data/item/templates/item-description.mjs
+++ b/module/data/item/templates/item-description.mjs
@@ -36,7 +36,8 @@ export default class ItemDescriptionTemplate extends SystemDataModel {
    * @returns {Set<string>}
    */
   get validProperties() {
-    const valid = new Set(CONFIG.DND5E.validProperties[this.parent.type] ?? []);
+    const config = CONFIG.DND5E.validProperties[this.parent.type] ?? [];
+    const valid = new Set([...config, ...(config[this.type?.value] ?? [])]);
     if ( this.parent.actor?.system.isNPC && this.schema.has("quantity") ) valid.add("gear");
     return valid;
   }


### PR DESCRIPTION
Added a `validForAmmunition` property to allow for non-physical weapon properties like 'Armor Piercing' from 3rd party premium module "Grim Hollow Player's Guide". Closes #6368 