### PR TITLE
[#6455] Allow hint to be displayed in compendium browser

### DIFF
--- a/less/v2/compendium-browser.less
+++ b/less/v2/compendium-browser.less
@@ -217,6 +217,8 @@
     overflow-y: auto;
     scrollbar-gutter: stable;
 
+    > .note { margin-inline: 4px; }
+
     .results-loading {
       text-align: center;
       padding: 20px;

--- a/module/applications/_types.mjs
+++ b/module/applications/_types.mjs
@@ -17,6 +17,7 @@
  * @property {{locked: CompendiumBrowserFilters, initial: CompendiumBrowserFilters}} filters  Filters to set to start.
  *                                              Locked filters won't be able to be changed by the user. Initial filters
  *                                              will be set to start but can be changed.
+ * @property {string|null} hint                 Hint displayed in the interface.
  * @property {CompendiumBrowserSelectionConfiguration} selection  Configuration used to define document selections.
  */
 

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -60,6 +60,7 @@ export default class CompendiumBrowser extends Application5e {
       handler: CompendiumBrowser.#onHandleSubmit,
       closeOnSubmit: true
     },
+    hint: null,
     position: {
       width: 850,
       height: 700
@@ -583,6 +584,7 @@ export default class CompendiumBrowser extends Application5e {
       indexFields: new Set(["system.source"])
     });
     context.displaySelection = this.displaySelection;
+    context.hint = this.options.hint;
     return context;
   }
 

--- a/templates/compendium/browser-results.hbs
+++ b/templates/compendium/browser-results.hbs
@@ -1,4 +1,6 @@
-<div class="inventory-element">
+<section class="inventory-element">
+
+    {{#if hint}}<p class="note info">{{ hint }}</p>{{/if}}
 
     <section class="items-list browser-results">
 
@@ -20,4 +22,4 @@
 
     </section>
 
-</div>
+</section>


### PR DESCRIPTION
Adds an optional `hint` to the compendium browser that will be displayed at the top of the results list for situations where additional context is needed for selecting an item.

<img width="861" height="714" alt="Compendium Browser Hint" src="https://github.com/user-attachments/assets/b677153e-a5ab-424b-b57f-8bd701b9bb71" />

Closes #6455