### PR TITLE
Assign document and pseudo-document default types

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -545,6 +545,10 @@ Hooks.once("ready", function() {
     }
   });
 
+  // Assign default document types.
+  CONFIG.Actor.defaultType = game.user.isGM ? "npc" : "character";
+  CONFIG.Item.defaultType = "feat";
+
   // Adjust sourced items on actors now that compendium UUID redirects have been initialized
   game.actors.forEach(a => a.sourcedItems._redirectKeys());
 

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -545,10 +545,6 @@ Hooks.once("ready", function() {
     }
   });
 
-  // Assign default document types.
-  CONFIG.Actor.defaultType = game.user.isGM ? "npc" : "character";
-  CONFIG.Item.defaultType = "feat";
-
   // Adjust sourced items on actors now that compendium UUID redirects have been initialized
   game.actors.forEach(a => a.sourcedItems._redirectKeys());
 

--- a/module/applications/create-document-dialog.mjs
+++ b/module/applications/create-document-dialog.mjs
@@ -116,7 +116,7 @@ export default class CreateDocumentDialog extends Dialog5e {
       context.hasTypes = true;
 
       // Some dialogs may restrict types, resulting in nothing pre-selected.
-      if (!context.types.some(t => t.selected)) {
+      if ( !context.types.some(t => t.selected) ) {
         context.types[0].selected = true;
         defaultType = context.types[0].type;
       }

--- a/module/applications/create-document-dialog.mjs
+++ b/module/applications/create-document-dialog.mjs
@@ -145,7 +145,7 @@ export default class CreateDocumentDialog extends Dialog5e {
   _onChangeForm(formConfig, event) {
     super._onChangeForm(formConfig, event);
 
-    if (event.target.name === "type") {
+    if ( event.target.name === "type" ) {
       const name = this.element.querySelector('[name="name"]');
       const { pack, parent } = this.options.createOptions;
       name.placeholder = this.documentType.defaultName({ type: event.target.value, pack, parent });

--- a/module/applications/create-document-dialog.mjs
+++ b/module/applications/create-document-dialog.mjs
@@ -169,7 +169,7 @@ export default class CreateDocumentDialog extends Dialog5e {
     }));
     foundry.utils.mergeObject(this.options.createData, formData.object);
     this.#submitted = true;
-    if (CONFIG[this.documentName]) CONFIG[this.documentName].defaultType = this.options.createData.type;
+    if ( CONFIG[this.documentName] ) CONFIG[this.documentName].defaultType = this.options.createData.type;
     else this.documentType.defaultType = this.options.createData.type;
     await this.close();
   }

--- a/module/applications/create-document-dialog.mjs
+++ b/module/applications/create-document-dialog.mjs
@@ -87,8 +87,7 @@ export default class CreateDocumentDialog extends Dialog5e {
     context.types = [];
     context.hasTypes = false;
     let defaultType = this.options.createData.type
-      ?? this.documentType.defaultType
-      ?? CONFIG[this.documentName]?.defaultType;
+      ?? game.settings.get("dnd5e", "defaultDocumentSubtypes")[this.documentName];
     const TYPES = this.documentType._createDialogTypes?.(parent) ?? this.documentType.TYPES;
     if ( TYPES?.length > 1 ) {
       if ( this.options.types?.length === 0 ) throw new Error("The array of sub-types to restrict to must not be empty");
@@ -169,8 +168,9 @@ export default class CreateDocumentDialog extends Dialog5e {
     }));
     foundry.utils.mergeObject(this.options.createData, formData.object);
     this.#submitted = true;
-    if ( CONFIG[this.documentName] ) CONFIG[this.documentName].defaultType = this.options.createData.type;
-    else this.documentType.defaultType = this.options.createData.type;
+    const subtypes = game.settings.get("dnd5e", "defaultDocumentSubtypes");
+    subtypes[this.documentName] = this.options.createData.type;
+    game.settings.set("dnd5e", "defaultDocumentSubtypes", subtypes);
     await this.close();
   }
 

--- a/module/applications/create-document-dialog.mjs
+++ b/module/applications/create-document-dialog.mjs
@@ -86,7 +86,9 @@ export default class CreateDocumentDialog extends Dialog5e {
 
     context.types = [];
     context.hasTypes = false;
-    const defaultType = this.options.createData.type ?? CONFIG[this.documentName]?.defaultType;
+    let defaultType = this.options.createData.type
+      ?? this.documentType.defaultType
+      ?? CONFIG[this.documentName]?.defaultType;
     const TYPES = this.documentType._createDialogTypes?.(parent) ?? this.documentType.TYPES;
     if ( TYPES?.length > 1 ) {
       if ( this.options.types?.length === 0 ) throw new Error("The array of sub-types to restrict to must not be empty");
@@ -112,6 +114,15 @@ export default class CreateDocumentDialog extends Dialog5e {
 
       context.types.sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang));
       context.hasTypes = true;
+
+      // Some dialogs may restrict types, resulting in nothing pre-selected.
+      if (!context.types.some(t => t.selected)) {
+        context.types[0].selected = true;
+        defaultType = context.types[0].type;
+      }
+
+      // Apply default name of documents.
+      context.defaultName = this.documentType.defaultName({ type: defaultType, pack, parent });
     }
 
     return context;
@@ -129,6 +140,19 @@ export default class CreateDocumentDialog extends Dialog5e {
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  _onChangeForm(formConfig, event) {
+    super._onChangeForm(formConfig, event);
+
+    if (event.target.name === "type") {
+      const name = this.element.querySelector('[name="name"]');
+      const { pack, parent } = this.options.createOptions;
+      name.placeholder = this.documentType.defaultName({ type: event.target.value, pack, parent });
+    }
+  }
+
+  /* -------------------------------------------- */
   /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 
@@ -141,10 +165,12 @@ export default class CreateDocumentDialog extends Dialog5e {
    */
   static async #handleFormSubmission(event, form, formData) {
     if ( !form.checkValidity() ) throw new Error(_loc("DOCUMENT.DND5E.Warning.SelectType", {
-      name: _loc(documentType.metadata.label ?? `DOCUMENT.DND5E.${documentType.documentName}`)
+      name: _loc(this.documentType.metadata.label ?? `DOCUMENT.DND5E.${this.documentType.documentName}`)
     }));
     foundry.utils.mergeObject(this.options.createData, formData.object);
     this.#submitted = true;
+    if (CONFIG[this.documentName]) CONFIG[this.documentName].defaultType = this.options.createData.type;
+    else this.documentType.defaultType = this.options.createData.type;
     await this.close();
   }
 

--- a/module/documents/mixins/pseudo-document.mjs
+++ b/module/documents/mixins/pseudo-document.mjs
@@ -32,6 +32,14 @@ export default function PseudoDocumentMixin(Base) {
     static _sheets = new Map();
 
     /* -------------------------------------------- */
+
+    /**
+     * The default type for the purpose of a creation dialog.
+     * @type {string|void}
+     */
+    static defaultType;
+
+    /* -------------------------------------------- */
     /*  Model Configuration                         */
     /* -------------------------------------------- */
 
@@ -271,6 +279,19 @@ export default function PseudoDocumentMixin(Base) {
     static async createDialog(data={}, createOptions={}, dialogOptions={}) {
       CreateDocumentDialog.migrateOptions(createOptions, dialogOptions);
       return CreateDocumentDialog.prompt(this, data, createOptions, dialogOptions);
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * The default display name of a pseudo-document of this type.
+     * @param {object} options
+     * @param {string} options.type
+     * @returns {string}
+     */
+    static defaultName({ type }) {
+      const title = this.documentConfig[type].documentClass.metadata.title;
+      return game.i18n.localize(title);
     }
 
     /* -------------------------------------------- */

--- a/module/documents/mixins/pseudo-document.mjs
+++ b/module/documents/mixins/pseudo-document.mjs
@@ -32,14 +32,6 @@ export default function PseudoDocumentMixin(Base) {
     static _sheets = new Map();
 
     /* -------------------------------------------- */
-
-    /**
-     * The default type for the purpose of a creation dialog.
-     * @type {string|void}
-     */
-    static defaultType;
-
-    /* -------------------------------------------- */
     /*  Model Configuration                         */
     /* -------------------------------------------- */
 

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -622,6 +622,14 @@ function cacheSettings() {
  * Register additional settings after modules have had a chance to initialize to give them a chance to modify choices.
  */
 export function registerDeferredSettings() {
+  game.settings.register("dnd5e", "defaultDocumentSubtypes", {
+    name: "Default Document Subtypes",
+    scope: "client",
+    config: false,
+    type: Object,
+    default: { Actor: game.user.isGM ? "npc" : "character", Item: "feat" }
+  });
+
   game.settings.register("dnd5e", "theme", {
     name: "SETTINGS.DND5E.THEME.Name",
     hint: "SETTINGS.DND5E.THEME.Hint",

--- a/templates/apps/document-create.hbs
+++ b/templates/apps/document-create.hbs
@@ -1,7 +1,7 @@
 <div>
     <header>
         <input type="text" class="document-name uninput" name="name" value="{{ name }}" autofocus
-               placeholder="{{ localize 'DOCUMENT.FIELDS.name.label' }}">
+               placeholder="{{ ifThen defaultName defaultName (localize 'DOCUMENT.FIELDS.name.label') }}">
         {{#if hasFolders}}
         <select class="unselect" name="folder">
             {{ selectOptions folders selected=folder labelAttr="name" valueAttr="id" }}
@@ -15,7 +15,7 @@
             <label>
                 {{ dnd5e-icon icon alt=label }}
                 <span>{{ label }}</span>
-                <input type="radio" name="type" value="{{ type }}" required {{checked (eq type ../type)}}
+                <input type="radio" name="type" value="{{ type }}" required {{checked selected}}
                        {{ disabled disabled }}>
             </label>
         </li>


### PR DESCRIPTION
- Assign default types to document types.
- Reassign default types of document types and pseudo-document types when one is created.
- Update createDialog to adjust placeholder in name field.

Closes #6464.
Closes #6405.