### PR TITLE
[#6514] Fix healing when damage threshold is set

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -903,7 +903,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     damages.amount = damages.amount > 0 ? Math.floor(damages.amount) : Math.ceil(damages.amount);
 
     // Apply damage threshold
-    if ( (damages.amount > 0 && damages.amount < (this.system.attributes?.hp?.dt ?? -Infinity))
+    if ( ((damages.amount > 0) && (damages.amount < (this.system.attributes?.hp?.dt ?? -Infinity)))
       && !((options.ignore === true) || options.ignore?.threshold) ) {
       damages.amount = 0;
       damages.forEach(d => {


### PR DESCRIPTION
Addendum to PR #6513 to fully fix #6514, apologies for having missed it the first time (and thanks @roth-michael for bringing it up). As mentioned in the issue's discussion, this assumes that damage thresholds do not apply in any way to healing damage.