### PR TITLE
[#6528] Add flag for controlling NPC gear/features categorization

### DIFF
--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -474,7 +474,8 @@ export default class NPCActorSheet extends BaseActorSheet {
   _assignItemCategories(item) {
     if ( ["class", "subclass"].includes(item.type) ) return new Set(["classes"]);
     const categories = super._assignItemCategories(item);
-    if ( item.type === "weapon" ) categories.add("features");
+    if ( (item.type === "weapon")
+      && (item.flags.dnd5e?.statBlockOverride?.section !== "gearOnly") ) categories.add("features");
     return categories;
   }
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -500,7 +500,8 @@ export default class NPCData extends CreatureTemplate {
    */
   getGear() {
     return this.parent.items
-      .filter(i => i.system.quantity && (i.system.type?.value !== "natural"))
+      .filter(i => i.system.quantity && (i.system.type?.value !== "natural")
+        && (i.flags.dnd5e?.statBlockOverride?.section !== "featureOnly"))
       .sort((lhs, rhs) => lhs.name.localeCompare(rhs.name, game.i18n.lang));
   }
 
@@ -797,7 +798,8 @@ export default class NPCData extends CreatureTemplate {
     }
 
     for ( const item of this.parent.items ) {
-      if ( !["feat", "weapon"].includes(item.type) ) continue;
+      if ( !["feat", "weapon"].includes(item.type)
+        || (item.flags.dnd5e?.statBlockOverride?.section === "gearOnly") ) continue;
       const category = item.system.properties.has("trait") ? "trait"
         : (item.system.activities?.contents[0]?.activation?.type ?? "trait");
       if ( category in context.actionSections ) {


### PR DESCRIPTION
Adds a new flag `dnd5e.statBlockOverride.section` for individual items that takes the options `gearOnly` and `featuresOnly`. If `gearOnly` is set, then the item will appear in the gear list on the NPC embeds, but not in the Actions section of the stat block of on the Features tab of the NPC sheet. If `featuresOnly` is set then the item will appear in the Actions section of the stat block and the Features tab of the NPC sheet but not in the gear list.

Both of these settings will only cause the change to occur if the item is already valid in that area, so setting this flag on a feature item won't cause it to appear in the Gear list because it isn't a physical item.

Closes #6528