### PR TITLE
[#6536] Add new range & targeting labels for descriptions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -815,6 +815,17 @@
 "DND5E.AttunementOverride": "Override attunement",
 "DND5E.Attuned": "Attuned",
 "DND5E.AreaOfEffect": {
+  "Description": {
+    "Full": "{sizes} {type}",
+    "FullCounted": "{count} {sizes} {type}",
+    "Height": "high",
+    "Length": "long",
+    "Radius": "radius",
+    "SizeSimple": "{number}-{unit}",
+    "SizeType": "{number}-{unit}-{type}",
+    "Thickness": "thick",
+    "Width": "wide"
+  },
   "Label": "Area of Effect",
   "Size": {
     "Label": "Size",
@@ -4426,6 +4437,7 @@
       "Label": "Ally",
       "Counted": {
         "any": "any allies",
+        "each": "each ally",
         "every": "every ally",
         "one": "{number} ally",
         "other": "{number} allies"
@@ -4438,20 +4450,25 @@
       "Label": "Circle",
       "Counted": {
         "one": "{number} circle",
-        "other": "{number} circles"
+        "other": "{number} circles",
+        "oneSized": "{sizes} Circle",
+        "otherSized": "{number} {sizes} Circles"
       }
     },
     "Cone": {
       "Label": "Cone",
       "Counted": {
         "one": "{number} cone",
-        "other": "{number} cones"
+        "other": "{number} cones",
+        "oneSized": "{sizes} Cone",
+        "otherSized": "{number} {sizes} Cones"
       }
     },
     "Creature": {
       "Label": "Creature",
       "Counted": {
         "any": "any creatures",
+        "each": "each creature",
         "every": "every creature",
         "one": "{number} creature",
         "other": "{number} creatures"
@@ -4461,6 +4478,7 @@
       "Label": "Creature or Object",
       "Counted": {
         "any": "any creatures or objects",
+        "each": "each creature or object",
         "every": "every creature or object",
         "one": "{number} creature or object",
         "other": "{number} creatures or objects"
@@ -4470,27 +4488,34 @@
       "Label": "Cube",
       "Counted": {
         "one": "{number} cube",
-        "other": "{number} cubes"
+        "other": "{number} cubes",
+        "oneSized": "{sizes} Cube",
+        "otherSized": "{number} {sizes} Cubes"
       }
     },
     "Cylinder": {
       "Label": "Cylinder",
       "Counted": {
         "one": "{number} cylinder",
-        "other": "{number} cylinders"
+        "other": "{number} cylinders",
+        "oneSized": "{sizes} Cylinder",
+        "otherSized": "{number} {sizes} Cylinders"
       }
     },
     "Emanation": {
       "Label": "Emanation",
       "Counted": {
         "one": "{number} emanation",
-        "other": "{number} emanations"
+        "other": "{number} emanations",
+        "oneSized": "{sizes} Emanation",
+        "otherSized": "{number} {sizes} Emanations"
       }
     },
     "Enemy": {
       "Label": "Enemy",
       "Counted": {
         "any": "any enemies",
+        "each": "each enemy",
         "every": "every enemy",
         "one": "{number} enemy",
         "other": "{number} enemies"
@@ -4500,13 +4525,16 @@
       "Label": "Line",
       "Counted": {
         "one": "{number} line",
-        "other": "{number} lines"
+        "other": "{number} lines",
+        "oneSized": "{sizes} Line",
+        "otherSized": "{number} {sizes} Lines"
       }
     },
     "Object": {
       "Label": "Object",
       "Counted": {
         "any": "any objects",
+        "each": "each object",
         "every": "every object",
         "one": "{number} object",
         "other": "{number} objects"
@@ -4516,39 +4544,57 @@
       "Label": "Radius",
       "Counted": {
         "one": "{number} radius",
-        "other": "{number} radii"
+        "other": "{number} radii",
+        "oneSized": "{sizes} Radius",
+        "otherSized": "{number} {sizes} Radii"
       }
     },
     "Self": {
       "Label": "Self"
     },
-    "Sphere": {
-      "Label": "Sphere",
-      "Counted": {
-        "one": "{number} sphere",
-        "other": "{number} spheres"
-      }
-    },
     "Space": {
       "Label": "Space",
       "Counted": {
         "any": "any spaces",
+        "each": "each space",
         "every": "every space",
-        "one": "{number} space",
-        "other": "{number} spaces"
+        "one": "{number} Space",
+        "other": "{number} Spaces"
+      }
+    },
+    "Sphere": {
+      "Label": "Sphere",
+      "Counted": {
+        "one": "{number} sphere",
+        "other": "{number} spheres",
+        "oneSized": "{sizes} Sphere",
+        "otherSized": "{number} {sizes} Spheres"
+      }
+    },
+    "Special": {
+      "Label": "{special}",
+      "Counted": {
+        "any": "any {special}",
+        "each": "each {special}",
+        "every": "every {special}",
+        "one": "{number} {special}",
+        "other": "{number} {special}"
       }
     },
     "Square": {
       "Label": "Square",
       "Counted": {
         "one": "{number} square",
-        "other": "{number} squares"
+        "other": "{number} squares",
+        "oneSized": "{sizes} Square",
+        "otherSized": "{number} {sizes} Squares"
       }
     },
     "Target": {
       "Label": "Target",
       "Counted": {
         "any": "any targets",
+        "each": "each target",
         "every": "every target",
         "one": "{number} target",
         "other": "{number} targets"
@@ -4558,13 +4604,16 @@
       "Label": "Wall",
       "Counted": {
         "one": "{number} wall",
-        "other": "{number} walls"
+        "other": "{number} walls",
+        "oneSized": "{sizes} Wall",
+        "otherSized": "{number} {sizes} Walls"
       }
     },
     "WillingCreature": {
       "Label": "Willing Creature",
       "Counted": {
         "any": "any willing creatures",
+        "each": "each willing creature",
         "every": "every willing creature",
         "one": "{number} willing creature",
         "other": "{number} willing creatures"
@@ -4976,21 +5025,25 @@
 "DND5E.UNITS": {
   "DISTANCE": {
     "Foot": {
+      "Abbreviation": "ft",
       "Label": "Feet",
-      "Abbreviation": "ft"
+      "Template": "foot"
     },
     "Kilometer": {
+      "Abbreviation": "km",
       "Label": "Kilometers",
-      "Abbreviation": "km"
+      "Template": "kilometer"
     },
     "Label": "Distance Unit",
     "Meter": {
+      "Abbreviation": "m",
       "Label": "Meters",
-      "Abbreviation": "m"
+      "Template": "meter"
     },
     "Mile": {
+      "Abbreviation": "mi",
       "Label": "Miles",
-      "Abbreviation": "mi"
+      "Template": "mile"
     }
   },
   "TIME": {

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -646,6 +646,7 @@
 
 /**
  * @typedef {UnitConfiguration} MovementUnitConfiguration
+ * @property {string} template                   Localized label for a template size (e.g. 50-foot).
  * @property {"day"|"round"} [travelResolution]  Whether the distance is per-round or per-day when used in the context
  *                                               of overland travel.
  */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2486,6 +2486,7 @@ DND5E.movementUnits = {
   ft: {
     label: "DND5E.UNITS.DISTANCE.Foot.Label",
     abbreviation: "DND5E.UNITS.DISTANCE.Foot.Abbreviation",
+    template: "DND5E.UNITS.DISTANCE.Foot.Template",
     conversion: 1,
     formattingUnit: "foot",
     type: "imperial",
@@ -2494,6 +2495,7 @@ DND5E.movementUnits = {
   mi: {
     label: "DND5E.UNITS.DISTANCE.Mile.Label",
     abbreviation: "DND5E.UNITS.DISTANCE.Mile.Abbreviation",
+    template: "DND5E.UNITS.DISTANCE.Mile.Template",
     conversion: 5_280,
     formattingUnit: "mile",
     type: "imperial",
@@ -2502,6 +2504,7 @@ DND5E.movementUnits = {
   m: {
     label: "DND5E.UNITS.DISTANCE.Meter.Label",
     abbreviation: "DND5E.UNITS.DISTANCE.Meter.Abbreviation",
+    template: "DND5E.UNITS.DISTANCE.Meter.Template",
     conversion: 10 / 3, // D&D uses a simplified 5ft -> 1.5m conversion.
     formattingUnit: "meter",
     type: "metric",
@@ -2510,13 +2513,14 @@ DND5E.movementUnits = {
   km: {
     label: "DND5E.UNITS.DISTANCE.Kilometer.Label",
     abbreviation: "DND5E.UNITS.DISTANCE.Kilometer.Abbreviation",
+    template: "DND5E.UNITS.DISTANCE.Kilometer.Template",
     conversion: 10_000 / 3, // Matching simplified conversion
     formattingUnit: "kilometer",
     type: "metric",
     travelResolution: "day"
   }
 };
-preLocalize("movementUnits", { keys: ["label", "abbreviation"] });
+preLocalize("movementUnits", { keys: ["label", "abbreviation", "template"] });
 
 /* -------------------------------------------- */
 

--- a/module/data/shared/range-field.mjs
+++ b/module/data/shared/range-field.mjs
@@ -33,13 +33,22 @@ export default class RangeField extends SchemaField {
       prepareFormulaValue(this, "range.value", "DND5E.RANGE.FIELDS.range.value.label", rollData);
     } else this.range.value = null;
 
-    if ( labels && this.range.units ) {
+    this.range.labels ??= {};
+    if ( this.range.units ) {
       if ( this.range.scalar && this.range.value ) {
-        labels.range = formatLength(this.range.value, this.range.units);
-        labels.rangeParts = formatLength(this.range.value, this.range.units, { parts: true });
+        this.range.labels.range = formatLength(this.range.value, this.range.units);
+        this.range.labels.rangeParts = formatLength(this.range.value, this.range.units, { parts: true });
+        this.range.labels.description = formatLength(this.range.value, this.range.units, { unitDisplay: "long" });
       } else if ( !this.range.scalar ) {
-        labels.range = CONFIG.DND5E.distanceUnits[this.range.units];
+        this.range.labels.range = CONFIG.DND5E.distanceUnits[this.range.units];
       }
-    } else if ( labels ) labels.range = game.i18n.localize("DND5E.DistSelf");
+    } else this.range.labels.range = game.i18n.localize("DND5E.DistSelf");
+
+    if ( labels ) {
+      labels.description ??= {};
+      labels.description.range ||= this.range.labels.description;
+      labels.range ||= this.range.labels.range;
+      labels.rangeParts ||= this.range.labels.rangeParts;
+    }
   }
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -842,6 +842,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       data.item.flags = { ...this.flags };
       data.item.name = this.name;
     }
+    data.labels = this.labels;
     data.scaling = new Scaling(this.scalingIncrease);
     return data;
   }

--- a/packs/_source/monsterfeatures24/actions/acid-spray.yml
+++ b/packs/_source/monsterfeatures24/actions/acid-spray.yml
@@ -86,12 +86,8 @@ system:
   description:
     value: >-
       <p><em>Dexterity Saving Throw: </em>DC [[lookup @save.dc.value
-      activity=20GU2JBM5zJfNPD1]], each [[lookup @target.affects.type
-      activity=20GU2JBM5zJfNPD1]] in a [[lookup @target.template.size
-      activity=20GU2JBM5zJfNPD1]]-[[lookup @target.template.units
-      activity=20GU2JBM5zJfNPD1]]-long, [[lookup @target.template.width
-      activity=20GU2JBM5zJfNPD1]]-[[lookup @target.template.units
-      activity=20GU2JBM5zJfNPD1]]-wide [[lookup @target.template.type capitalize
+      activity=20GU2JBM5zJfNPD1]], [[lookup @labels.description.affects
+      activity=20GU2JBM5zJfNPD1]] in a [[lookup @labels.description.template
       activity=20GU2JBM5zJfNPD1]]. <em>Failure: </em>[[/damage average]] damage.
       <em>Success:</em> Half damage.</p>
     chat: ''
@@ -114,11 +110,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 4.2.2
+  systemVersion: 5.2.2
   createdTime: 1733432292956
-  modifiedTime: 1738096017760
+  modifiedTime: 1765235930883
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 1800000

--- a/packs/_source/spells24/3rd-level/fireball.yml
+++ b/packs/_source/spells24/3rd-level/fireball.yml
@@ -3,13 +3,14 @@ system:
   description:
     value: >-
       <p>A bright streak flashes from you to a point you choose within range and
-      then blossoms with a low roar into a fiery explosion. Each creature in a
-      20-foot-radius Sphere centered on that point makes a Dexterity saving
-      throw, taking 8d6 Fire damage on a failed save or half as much damage on a
-      successful one.</p><p>Flammable objects in the area that aren't being worn
-      or carried start burning.</p><p><strong>Using a Higher-Level Spell
-      Slot.</strong> The damage increases by 1d6 for each spell slot level above
-      3.</p>
+      then blossoms with a low roar into a fiery explosion. [[lookup
+      @labels.description.affects capitalize]] in a [[lookup
+      @labels.description.template]] centered on that point makes a Dexterity
+      saving throw, taking 8d6 Fire damage on a failed save or half as much
+      damage on a successful one.</p><p>Flammable objects in the area that
+      aren't being worn or carried start burning.</p><p><strong>Using a
+      Higher-Level Spell Slot.</strong> The damage increases by 1d6 for each
+      spell slot level above 3.</p>
     chat: ''
   source:
     custom: ''
@@ -126,11 +127,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 5.2.2
   createdTime: 1724425954119
-  modifiedTime: 1745256793145
+  modifiedTime: 1765235810166
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplFireball00'


### PR DESCRIPTION
Adds several new labels for use in item descriptions to allow for easier customization of generic features and localization of all units used in items. Adds these new labels:

- `@labels.description.affects`: "each creature"
- `@labels.description.range`: "120 feet"
- `@labels.description.template`: "20-foot Sphere"
- `@labels.description.templateSize`: "20-foot"
- `@labels.description.templateType`: "Sphere"

Updated "Fireball" in spells and "Acid Spray" in monster features to demonstrate how this can be used to improve descriptions.

Closes #6536