### PR TITLE
Critical damage fixes

### DIFF
--- a/module/applications/dice/d20-configuration-dialog.mjs
+++ b/module/applications/dice/d20-configuration-dialog.mjs
@@ -63,14 +63,13 @@ export default class D20RollConfigurationDialog extends RollConfigurationDialog 
   /* -------------------------------------------- */
 
   /** @override */
-  _finalizeRolls(action) {
+  _finalizeConfig(config, action) {
     let advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.NORMAL;
     if ( action === "advantage" ) advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
     else if ( action === "disadvantage" ) advantageMode = CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
-    return this.rolls.map(roll => {
+    for ( const roll of config.rolls ?? [] ) {
+      roll.options ??= {};
       roll.options.advantageMode = advantageMode;
-      roll.configureModifiers();
-      return roll;
-    });
+    }
   }
 }

--- a/module/applications/dice/damage-configuration-dialog.mjs
+++ b/module/applications/dice/damage-configuration-dialog.mjs
@@ -87,12 +87,11 @@ export default class DamageRollConfigurationDialog extends RollConfigurationDial
   /* -------------------------------------------- */
 
   /** @override */
-  _finalizeRolls(action) {
-    this.config.isCritical = action === "critical";
-    return this.rolls.map(roll => {
-      roll.options.isCritical = this.config.isCritical;
-      roll.configureDamage({ critical: this.config.critical });
-      return roll;
-    });
+  _finalizeConfig(config, action) {
+    config.isCritical = action === "critical";
+    for ( const roll of config.rolls ?? [] ) {
+      roll.options ??= {};
+      roll.options.isCritical = config.isCritical;
+    }
   }
 }

--- a/module/applications/dice/roll-configuration-dialog.mjs
+++ b/module/applications/dice/roll-configuration-dialog.mjs
@@ -348,12 +348,27 @@ export default class RollConfigurationDialog extends Dialog5e {
   /* -------------------------------------------- */
 
   /**
-   * Make any final modifications to rolls based on the button clicked.
+   * Apply any action-specific changes to the roll configuration before the final rolls are built.
+   * @param {BasicRollProcessConfiguration} config  Roll configuration data to mutate in place.
+   * @param {string} action                         Action on the button clicked.
+   * @protected
+   */
+  _finalizeConfig(config, action) {}
+
+  /* -------------------------------------------- */
+
+  /**
+   * Make any final modifications to rolls based on the button clicked, by re-building them from a fresh copy of the
+   * configuration. Subclasses adjust the configuration for the chosen action in _finalizeConfig, rather than mutating
+   * the already-built rolls, so that each roll is constructed exactly once.
    * @param {string} action  Action on the button clicked.
    * @returns {BasicRoll[]}
    * @protected
    */
   _finalizeRolls(action) {
+    const config = foundry.utils.deepClone(this.#config);
+    this._finalizeConfig(config, action);
+    this.#buildRolls(config, new foundry.applications.ux.FormDataExtended(this.form));
     return this.rolls;
   }
 

--- a/module/dice/_types.mjs
+++ b/module/dice/_types.mjs
@@ -220,3 +220,15 @@
  * @property {string} [rollMode]         The roll mode to apply to this message from `CONFIG.ChatMessage.modes`.
  * @property {object} [data={}]          Additional data used when creating the message.
  */
+
+/* -------------------------------------------- */
+
+/**
+ * Dice modifier data for terms that are going to be pre-calculated.
+ *
+ * @typedef BasicRollTermApplicableModifier
+ * @property {string} command  The parsed base modifier command.
+ * @property {string} value    The parsed numerical part of the modifier.
+ * @property {boolean} keep    Whether this is a "keep" modifier.
+ * @property {boolean} drop    Whether this is a "drop" modifier.
+ */

--- a/module/dice/_types.mjs
+++ b/module/dice/_types.mjs
@@ -220,15 +220,3 @@
  * @property {string} [rollMode]         The roll mode to apply to this message from `CONFIG.ChatMessage.modes`.
  * @property {object} [data={}]          Additional data used when creating the message.
  */
-
-/* -------------------------------------------- */
-
-/**
- * Dice modifier data for terms that are going to be pre-calculated.
- *
- * @typedef BasicRollTermApplicableModifier
- * @property {string} command  The parsed base modifier command.
- * @property {string} value    The parsed numerical part of the modifier.
- * @property {boolean} keep    Whether this is a "keep" modifier.
- * @property {boolean} drop    Whether this is a "drop" modifier.
- */

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -1,7 +1,7 @@
 import RollConfigurationDialog from "../applications/dice/roll-configuration-dialog.mjs";
 import BasicDie from "./basic-die.mjs";
 
-const { DiceTerm, NumericTerm } = foundry.dice.terms;
+const { DiceTerm, NumericTerm, PoolTerm } = foundry.dice.terms;
 
 /**
  * @import {
@@ -365,20 +365,53 @@ export default class BasicRoll extends Roll {
   /* -------------------------------------------- */
 
   /**
-   * Replaces all dice terms that have modifiers with their maximum/minimum value.
+   * Replaces all dice or pool terms that have modifiers with their maximum/minimum value.
    *
    * @param {object} [options={}]            Extra optional arguments which describe or modify the BasicRoll.
    */
   preCalculateDiceTerms(options={}) {
     if ( this._evaluated || (!options.maximize && !options.minimize) ) return;
     this.terms = this.terms.map(term => {
-      if ( (term instanceof DiceTerm) && term.modifiers.length ) {
+      if ( (term instanceof DiceTerm || term instanceof PoolTerm) && term.modifiers.length ) {
         const minimize = !options.maximize;
-        const number = this.constructor.preCalculateTerm(term, { minimize });
+        const fn = term instanceof DiceTerm ? "preCalculateTerm" : "preCalculatePoolTerm";
+        const number = this.constructor[fn](term, { minimize });
         if ( Number.isFinite(number) ) return new NumericTerm({ number, options: term.options });
       }
       return term;
     });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Summarizes information about valid applicable modifiers for the term to be minimized or maximized.
+   *
+   * @param {DiceTerm|PoolTerm} term  PoolTerm to get the maximum/minimum value.
+   * @returns {BasicRollTermApplicableModifier[]}
+   * @internal
+   */
+  static _matchValidModifiers(term) {
+    const currentModifiers = foundry.utils.deepClone(term.modifiers);
+    const keep = new Set(["k", "kh", "kl"]);
+    const drop = new Set(["d", "dh", "dl"]);
+    const validModifiers = new Set([...keep, ...drop]);
+    let rgx = /([kd][hl]?)(\d+)?/i;
+    if ( term instanceof DiceTerm ) {
+      validModifiers.add("max").add("min");
+      rgx = /(m[ai][xn]|[kd][hl]?)(\d+)?/i;
+    }
+    let modifierCommands = [];
+    for ( const modifier of currentModifiers ) {
+      const match = modifier.match(rgx);
+      if ( !match ) continue;
+      if ( match[0].length < match.input.length ) currentModifiers.push(match.input.slice(match[0].length));
+      let [, command, value] = match;
+      command = command.toLowerCase();
+      if ( !validModifiers.has(command) ) continue;
+      modifierCommands.push({ command, value: value ?? "", keep: keep.has(command), drop: drop.has(command) });
+    }
+    return modifierCommands;
   }
 
   /* -------------------------------------------- */
@@ -395,32 +428,43 @@ export default class BasicRoll extends Roll {
   static preCalculateTerm(die, { minimize=false }={}) {
     let face = minimize ? 1 : die.faces;
     let number = die.number;
-    const currentModifiers = foundry.utils.deepClone(die.modifiers);
-    const keep = new Set(["k", "kh", "kl"]);
-    const drop = new Set(["d", "dh", "dl"]);
-    const validModifiers = new Set([...keep, ...drop, "max", "min"]);
-    let matchedModifier = false;
-
-    for ( const modifier of currentModifiers ) {
-      const rgx = /(m[ai][xn]|[kd][hl]?)(\d+)?/i;
-      const match = modifier.match(rgx);
-      if ( !match ) continue;
-      if ( match[0].length < match.input.length ) currentModifiers.push(match.input.slice(match[0].length));
-      let [, command, value] = match;
-      command = command.toLowerCase();
-      if ( !validModifiers.has(command) ) continue;
-
-      matchedModifier = true;
-      const amount = parseInt(value) || (command === "max" || command === "min" ? -1 : 1);
+    const modifiers = BasicRoll._matchValidModifiers(die);
+    if ( !modifiers.length ) return null;
+    for ( const modifier of modifiers ) {
+      const amount = parseInt(modifier.value) || (modifier.command === "max" || modifier.command === "min" ? -1 : 1);
       if ( amount > 0 ) {
-        if ( (command === "max" && minimize) || (command === "min" && !minimize) ) continue;
-        else if ( (command === "max" || command === "min") ) face = Math.min(die.faces, amount);
-        else if ( keep.has(command) ) number = Math.min(number, amount);
-        else if ( drop.has(command) ) number = Math.max(1, number - amount);
+        if ( (modifier.command === "max" && minimize) || (modifier.command === "min" && !minimize) ) continue;
+        else if ( (modifier.command === "max" || modifier.command === "min") ) face = Math.min(die.faces, amount);
+        else if ( modifier.keep ) number = Math.min(number, amount);
+        else if ( modifier.drop ) number = Math.max(1, number - amount);
       }
     }
 
-    return matchedModifier ? face * number : null;
+    return face * number;
+
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Gets information from passed die and calculates the maximum or minimum value that could be rolled.
+   *
+   * @param {PoolTerm} pool                           PoolTerm to get the maximum/minimum value.
+   * @param {object} [preCalculateOptions={}]         Additional options to modify preCalculate functionality.
+   * @param {boolean} [preCalculateOptions.minimize=false]  Calculate the minimum value instead of the maximum.
+   * @returns {number|null}                                 Maximum/Minimum value that could be rolled as an integer, or
+   *                                                        null if the modifiers could not be precalculated.
+   */
+  static preCalculatePoolTerm(pool, { minimize=false }={}) {
+    pool.evaluate({ maximize: !minimize, minimize });
+    const modifiers = BasicRoll._matchValidModifiers(pool);
+    if ( !modifiers.length ) return null;
+    for ( const modifier of modifiers ) {
+      if ( modifier.keep ) pool.keep(modifier.command + modifier.value);
+      else if ( modifier.drop ) pool.drop(modifier.command + modifier.value);
+    }
+
+    return pool.total;
   }
 
   /* -------------------------------------------- */

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -366,7 +366,6 @@ export default class BasicRoll extends Roll {
 
   /**
    * Replaces all dice or pool terms that have modifiers with their maximum/minimum value.
-   *
    * @param {object} [options={}]            Extra optional arguments which describe or modify the BasicRoll.
    */
   preCalculateDiceTerms(options={}) {
@@ -385,85 +384,61 @@ export default class BasicRoll extends Roll {
   /* -------------------------------------------- */
 
   /**
-   * Summarizes information about valid applicable modifiers for the term to be minimized or maximized.
-   *
-   * @param {DiceTerm|PoolTerm} term  PoolTerm to get the maximum/minimum value.
-   * @returns {BasicRollTermApplicableModifier[]}
+   * Synchronously apply a term's result-selection modifiers to its already-populated results by dispatching to the
+   * term's own modifier handlers. Asynchronous handlers are skipped, as they cannot be awaited on this synchronous
+   * path. Reroll and advantage/disadvantage could not change a forced extreme in any case, but explosion could (its
+   * maximum is unbounded).
+   * @param {DiceTerm|PoolTerm} term  Term whose results have been populated with their maximum or minimum faces.
    * @internal
    */
-  static _matchValidModifiers(term) {
-    const currentModifiers = foundry.utils.deepClone(term.modifiers);
-    const keep = new Set(["k", "kh", "kl"]);
-    const drop = new Set(["d", "dh", "dl"]);
-    const validModifiers = new Set([...keep, ...drop]);
-    let rgx = /([kd][hl]?)(\d+)?/i;
-    if ( term instanceof DiceTerm ) {
-      validModifiers.add("max").add("min");
-      rgx = /(m[ai][xn]|[kd][hl]?)(\d+)?/i;
-    }
-    let modifierCommands = [];
-    for ( const modifier of currentModifiers ) {
-      const match = modifier.match(rgx);
-      if ( !match ) continue;
-      if ( match[0].length < match.input.length ) currentModifiers.push(match.input.slice(match[0].length));
-      let [, command, value] = match;
-      command = command.toLowerCase();
-      if ( !validModifiers.has(command) ) continue;
-      modifierCommands.push({ command, value: value ?? "", keep: keep.has(command), drop: drop.has(command) });
-    }
-    return modifierCommands;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Gets information from passed die and calculates the maximum or minimum value that could be rolled.
-   *
-   * @param {DiceTerm} die                            DiceTerm to get the maximum/minimum value.
-   * @param {object} [preCalculateOptions={}]         Additional options to modify preCalculate functionality.
-   * @param {boolean} [preCalculateOptions.minimize=false]  Calculate the minimum value instead of the maximum.
-   * @returns {number|null}                                 Maximum/Minimum value that could be rolled as an integer, or
-   *                                                        null if the modifiers could not be precalculated.
-   */
-  static preCalculateTerm(die, { minimize=false }={}) {
-    let face = minimize ? 1 : die.faces;
-    let number = die.number;
-    const modifiers = BasicRoll._matchValidModifiers(die);
-    if ( !modifiers.length ) return null;
-    for ( const modifier of modifiers ) {
-      const amount = parseInt(modifier.value) || (modifier.command === "max" || modifier.command === "min" ? -1 : 1);
-      if ( amount > 0 ) {
-        if ( (modifier.command === "max" && minimize) || (modifier.command === "min" && !minimize) ) continue;
-        else if ( (modifier.command === "max" || modifier.command === "min") ) face = Math.min(die.faces, amount);
-        else if ( modifier.keep ) number = Math.min(number, amount);
-        else if ( modifier.drop ) number = Math.max(1, number - amount);
+  static _applyMaxMinModifiers(term) {
+    const cls = term.constructor;
+    const union = Object.keys(cls.MODIFIERS).sort((a, b) => b.length - a.length).join("|");
+    const pattern = new RegExp(`(${union})[^A-z\\s()+\\-*/]*`, "gi");
+    for ( const sequence of term.modifiers.map(m => m.toLowerCase()) ) {
+      for ( const [matched, command] of sequence.matchAll(pattern) ) {
+        let fn = cls.MODIFIERS[command];
+        if ( typeof fn === "string" ) fn = term[fn];
+        if ( (typeof fn === "function") && !(fn instanceof foundry.utils.AsyncFunction) ) fn.call(term, matched);
       }
     }
-
-    return face * number;
-
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Gets information from passed die and calculates the maximum or minimum value that could be rolled.
-   *
-   * @param {PoolTerm} pool                           PoolTerm to get the maximum/minimum value.
-   * @param {object} [preCalculateOptions={}]         Additional options to modify preCalculate functionality.
+   * Calculate the maximum or minimum value that could be rolled by a dice term, honoring all of its modifiers by
+   * populating its results with the extreme face value and then delegating to the term's real modifier handlers.
+   * @param {DiceTerm} die                                  DiceTerm to get the maximum/minimum value.
+   * @param {object} [preCalculateOptions={}]               Additional options to modify preCalculate functionality.
    * @param {boolean} [preCalculateOptions.minimize=false]  Calculate the minimum value instead of the maximum.
    * @returns {number|null}                                 Maximum/Minimum value that could be rolled as an integer, or
-   *                                                        null if the modifiers could not be precalculated.
+   *                                                        null if the term could not be precalculated.
+   */
+  static preCalculateTerm(die, { minimize=false }={}) {
+    if ( !die.modifiers.length || !Number.isFinite(die.number) || !Number.isFinite(die.faces) ) return null;
+    for ( let n = die.results.length; n < Math.abs(die.number); n++ ) {
+      die.results.push({ active: true, result: minimize ? Math.min(1, die.faces) : die.faces });
+    }
+    die._evaluated = true;
+    this._applyMaxMinModifiers(die);
+    return die.total;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Calculate the maximum or minimum value that could be rolled by a pool term, honoring all of its modifiers by
+   * evaluating the pool at its extreme and then delegating to the term's real modifier handlers.
+   * @param {PoolTerm} pool                                 PoolTerm to get the maximum/minimum value.
+   * @param {object} [preCalculateOptions={}]               Additional options to modify preCalculate functionality.
+   * @param {boolean} [preCalculateOptions.minimize=false]  Calculate the minimum value instead of the maximum.
+   * @returns {number|null}                                 Maximum/Minimum value that could be rolled as an integer, or
+   *                                                        null if the term could not be precalculated.
    */
   static preCalculatePoolTerm(pool, { minimize=false }={}) {
     pool.evaluate({ maximize: !minimize, minimize });
-    const modifiers = BasicRoll._matchValidModifiers(pool);
-    if ( !modifiers.length ) return null;
-    for ( const modifier of modifiers ) {
-      if ( modifier.keep ) pool.keep(modifier.command + modifier.value);
-      else if ( modifier.drop ) pool.drop(modifier.command + modifier.value);
-    }
-
+    this._applyMaxMinModifiers(pool);
     return pool.total;
   }
 

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -2,9 +2,7 @@ import DamageRollConfigurationDialog from "../applications/dice/damage-configura
 import { areKeysPressed } from "../utils.mjs";
 import BasicRoll from "./basic-roll.mjs";
 
-const {
-  DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, RollTerm, StringTerm
-} = foundry.dice.terms;
+const { DiceTerm, NumericTerm, OperatorTerm, ParentheticalTerm, RollTerm } = foundry.dice.terms;
 
 /**
  * @import { CriticalDamageConfiguration, DamageRollOptions } from "./_types.mjs";
@@ -104,57 +102,14 @@ export default class DamageRoll extends BasicRoll {
   /* -------------------------------------------- */
 
   /**
-   * Perform any term-merging required to ensure that criticals can be calculated successfully.
+   * Perform any preprocessing of the roll's terms required before critical damage is configured..
    * @protected
    */
   preprocessFormula() {
-    for ( let [i, term] of this.terms.entries() ) {
-      const nextTerm = this.terms[i + 1];
-      const prevTerm = this.terms[i - 1];
-
-      // Convert shorthand dX terms to 1dX preemptively to allow them to be appropriately doubled for criticals
-      if ( (term instanceof StringTerm) && /^d\d+/.test(term.term) && !(prevTerm instanceof ParentheticalTerm) ) {
-        const formula = `1${term.term}`;
-        const newTerm = new Roll(formula).terms[0];
-        this.terms.splice(i, 1, newTerm);
-        term = newTerm;
-      }
-
-      // Merge parenthetical terms that follow string terms to build a dice term (to allow criticals)
-      else if ( (term instanceof ParentheticalTerm) && (prevTerm instanceof StringTerm)
-        && prevTerm.term.match(/^[0-9]*d$/)) {
-        if ( term.isDeterministic ) {
-          let newFormula = `${prevTerm.term}${term.evaluate().total}`;
-          let deleteCount = 2;
-
-          // Merge in any roll modifiers
-          if ( nextTerm instanceof StringTerm ) {
-            newFormula += nextTerm.term;
-            deleteCount += 1;
-          }
-
-          const newTerm = (new Roll(newFormula)).terms[0];
-          this.terms.splice(i - 1, deleteCount, newTerm);
-          term = newTerm;
-        }
-      }
-
-      // Merge any parenthetical terms followed by string terms
-      else if ( (term instanceof ParentheticalTerm || term instanceof FunctionTerm) && (nextTerm instanceof StringTerm)
-        && nextTerm.term.match(/^d[0-9]*$/)) {
-        if ( term.isDeterministic ) {
-          const newFormula = `${term.evaluate().total}${nextTerm.term}`;
-          const newTerm = (new Roll(newFormula)).terms[0];
-          this.terms.splice(i, 2, newTerm);
-          term = newTerm;
-        }
-      }
-    }
-
     // Re-compile the underlying formula
     this.resetFormula();
 
-    // Mark configuration as complete
+    // Mark preprocessing as complete
     this.options.preprocessed = true;
   }
 

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -164,45 +164,50 @@ export default class DamageRoll extends BasicRoll {
     this.terms = this.terms.filter(t => !t.options.criticalBonusDamage && !t.options.criticalFlatBonus);
 
     const flatBonus = new Map();
+    let extraTerms = [];
     for ( let [i, term] of this.terms.entries() ) {
-      // Multiply dice terms
-      if ( term instanceof DiceTerm ) {
-        if ( term._number instanceof Roll ) {
+      if ( !(term instanceof OperatorTerm )) {
+        if ( term instanceof DiceTerm && term._number instanceof Roll ) {
           // Complex number term.
           if ( !term._number.isDeterministic ) continue;
           if ( !term._number._evaluated ) term._number.evaluateSync();
         }
-        term.options.baseNumber = term.options.baseNumber ?? term.number; // Reset back
-        term.number = term.options.baseNumber;
-        if ( this.isCritical ) {
-          let cm = critical.multiplier ?? 2;
-          let cb = (critical.bonusDice && (i === 0)) ? critical.bonusDice : 0;
-
-          // Powerful critical - add maximized damage dice and reset term alterations
-          if ( critical.powerfulCritical ) {
-            const bonus = Roll.create(term.formula).evaluateSync({ maximize: true }).total * (Math.max(1, cm-1) + cb);
-            if ( bonus > 0 ) {
-              const flavor = term.flavor?.toLowerCase().trim() ?? _loc("DND5E.PowerfulCritical");
-              flatBonus.set(flavor, (flatBonus.get(flavor) ?? 0) + bonus);
-            }
-            cm = 1;
-            cb = 0;
-          }
-
-          // Alter the damage term
-          term.alter(cm, cb);
-          term.options.critical = true;
-        }
-      }
-
-      else if ( term instanceof NumericTerm ) {
-        // Multiply numeric terms
-        if ( critical.multiplyNumeric ) {
+        if ( term instanceof DiceTerm || ( term instanceof NumericTerm && critical.multiplyNumeric ) ) {
           term.options.baseNumber = term.options.baseNumber ?? term.number; // Reset back
           term.number = term.options.baseNumber;
-          if ( this.isCritical ) {
-            term.number *= (critical.multiplier ?? 2);
-            term.options.critical = true;
+        }
+        if ( this.isCritical ) {
+          term.options.critical = true;
+          if ( term instanceof NumericTerm ) {
+            if ( critical.multiplyNumeric ) {
+              // Multiply numeric terms
+              term.number *= (critical.multiplier ?? 2);
+            }
+          } else {
+            let cm = critical.multiplier ?? 2;
+            let cb = (critical.bonusDice && (i === 0)) ? critical.bonusDice : 0;
+
+            // Powerful critical - add maximized damage dice and reset term alterations
+            if ( critical.powerfulCritical ) {
+              const bonus = Roll.create(term.formula).evaluateSync({ maximize: true }).total * (Math.max(1, cm-1) + cb);
+              if ( bonus > 0 ) {
+                const flavor = term.flavor?.toLowerCase().trim() ?? _loc("DND5E.PowerfulCritical");
+                flatBonus.set(flavor, (flatBonus.get(flavor) ?? 0) + bonus);
+              }
+              cm = 1;
+              cb = 0;
+            }
+
+            if ( term instanceof DiceTerm && !term.modifiers.length ) {
+              // Alter the damage dice term
+              term.alter(cm, cb);
+            } else if ( !term.isDeterministic ) {
+              // Complex terms are added
+              for ( let i = 0; i < cm - 1 + cb; i++ ) {
+                extraTerms.push(new OperatorTerm({ operator: "+" }));
+                extraTerms.push(...Roll.create(term.formula).terms);
+              }
+            }
           }
         }
       }
@@ -218,7 +223,10 @@ export default class DamageRoll extends BasicRoll {
 
     // Add extra critical damage term
     if ( this.isCritical && critical.bonusDamage ) {
-      let extraTerms = new Roll(critical.bonusDamage, this.data).terms;
+      extraTerms = extraTerms.concat(new Roll(critical.bonusDamage, this.data).terms);
+    }
+
+    if (extraTerms.length) {
       if ( !(extraTerms[0] instanceof OperatorTerm) ) extraTerms.unshift(new OperatorTerm({ operator: "+" }));
       extraTerms.forEach(t => t.options.criticalBonusDamage = true);
       this.terms.push(...extraTerms);

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -2,7 +2,9 @@ import DamageRollConfigurationDialog from "../applications/dice/damage-configura
 import { areKeysPressed } from "../utils.mjs";
 import BasicRoll from "./basic-roll.mjs";
 
-const { DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, StringTerm } = foundry.dice.terms;
+const {
+  DiceTerm, FunctionTerm, NumericTerm, OperatorTerm, ParentheticalTerm, RollTerm, StringTerm
+} = foundry.dice.terms;
 
 /**
  * @import { CriticalDamageConfiguration, DamageRollOptions } from "./_types.mjs";
@@ -28,6 +30,14 @@ export default class DamageRoll extends BasicRoll {
 
   /** @inheritDoc */
   static DefaultConfigurationDialog = DamageRollConfigurationDialog;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Operators that bind more strongly than additive operators.
+   * @type {Set<string>}
+   */
+  static #BINDING_OPERATORS = new Set(["*", "/", "%"]);
 
   /* -------------------------------------------- */
   /*  Static Construction                         */
@@ -160,76 +170,27 @@ export default class DamageRoll extends BasicRoll {
   configureDamage({ critical={} }={}) {
     critical = foundry.utils.mergeObject(critical, this.options.critical ?? {}, { inplace: false });
 
-    // Remove previous critical bonus damage
-    this.terms = this.terms.filter(t => !t.options.criticalBonusDamage && !t.options.criticalFlatBonus);
+    // Rebuild the term list from the pristine, post-preprocess formula captured on the first call, so that re-running
+    // this method (e.g. toggling critical in the damage dialog) always starts from the same base rather than
+    // compounding transforms on top of an already-modified list.
+    this.options.baseFormula ??= this._formula;
+    this.terms = this.constructor.parse(this.options.baseFormula, this.data);
 
-    const flatBonus = new Map();
-    let extraTerms = [];
-    for ( let [i, term] of this.terms.entries() ) {
-      if ( !(term instanceof OperatorTerm )) {
-        if ( term instanceof DiceTerm && term._number instanceof Roll ) {
-          // Complex number term.
-          if ( !term._number.isDeterministic ) continue;
-          if ( !term._number._evaluated ) term._number.evaluateSync();
-        }
-        if ( term instanceof DiceTerm || ( term instanceof NumericTerm && critical.multiplyNumeric ) ) {
-          term.options.baseNumber = term.options.baseNumber ?? term.number; // Reset back
-          term.number = term.options.baseNumber;
-        }
-        if ( this.isCritical ) {
-          term.options.critical = true;
-          if ( term instanceof NumericTerm ) {
-            if ( critical.multiplyNumeric ) {
-              // Multiply numeric terms
-              term.number *= (critical.multiplier ?? 2);
-            }
-          } else {
-            let cm = critical.multiplier ?? 2;
-            let cb = (critical.bonusDice && (i === 0)) ? critical.bonusDice : 0;
-
-            // Powerful critical - add maximized damage dice and reset term alterations
-            if ( critical.powerfulCritical ) {
-              const bonus = Roll.create(term.formula).evaluateSync({ maximize: true }).total * (Math.max(1, cm-1) + cb);
-              if ( bonus > 0 ) {
-                const flavor = term.flavor?.toLowerCase().trim() ?? _loc("DND5E.PowerfulCritical");
-                flatBonus.set(flavor, (flatBonus.get(flavor) ?? 0) + bonus);
-              }
-              cm = 1;
-              cb = 0;
-            }
-
-            if ( term instanceof DiceTerm && !term.modifiers.length ) {
-              // Alter the damage dice term
-              term.alter(cm, cb);
-            } else if ( !term.isDeterministic ) {
-              // Complex terms are added
-              for ( let i = 0; i < cm - 1 + cb; i++ ) {
-                extraTerms.push(new OperatorTerm({ operator: "+" }));
-                extraTerms.push(...Roll.create(term.formula).terms);
-              }
-            }
-          }
-        }
+    if ( this.isCritical ) {
+      const newTerms = [];
+      for ( const [i, term] of this.terms.entries() ) {
+        if ( term instanceof OperatorTerm ) newTerms.push(term);
+        else newTerms.push(...this.#applyCriticalTerm(term, critical, i));
       }
-    }
 
-    // Add powerful critical bonus
-    if ( critical.powerfulCritical && flatBonus.size ) {
-      for ( const [type, number] of flatBonus.entries() ) {
-        this.terms.push(new OperatorTerm({ operator: "+", options: { criticalFlatBonus: true } }));
-        this.terms.push(new NumericTerm({ number, options: { flavor: type, criticalFlatBonus: true } }));
+      // Add extra, unmodified critical damage.
+      if ( critical.bonusDamage ) {
+        const bonusTerms = new Roll(critical.bonusDamage, this.data).terms;
+        if ( !(bonusTerms[0] instanceof OperatorTerm) ) newTerms.push(new OperatorTerm({ operator: "+" }));
+        newTerms.push(...bonusTerms);
       }
-    }
 
-    // Add extra critical damage term
-    if ( this.isCritical && critical.bonusDamage ) {
-      extraTerms = extraTerms.concat(new Roll(critical.bonusDamage, this.data).terms);
-    }
-
-    if (extraTerms.length) {
-      if ( !(extraTerms[0] instanceof OperatorTerm) ) extraTerms.unshift(new OperatorTerm({ operator: "+" }));
-      extraTerms.forEach(t => t.options.criticalBonusDamage = true);
-      this.terms.push(...extraTerms);
+      this.terms = newTerms;
     }
 
     // Re-compile the underlying formula
@@ -237,5 +198,95 @@ export default class DamageRoll extends BasicRoll {
 
     // Mark configuration as complete
     this.options.configured = true;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Apply critical scaling to a single non-operator term, mutating it in place where possible and returning the
+   * term(s) that should occupy its slot.
+   * @param {RollTerm} term                          The term to scale.
+   * @param {CriticalDamageConfiguration} critical   The resolved critical configuration.
+   * @param {number} index                           Index of the term within this.terms.
+   * @returns {RollTerm[]}                           The term, plus any copies or bonuses added alongside it.
+   */
+  #applyCriticalTerm(term, critical, index) {
+    // If a dice term's count is itself a roll, flatten a deterministic one to a plain integer so it scales and clones
+    // cleanly. A random count is left as a roll: a plain die falls through to alter(), which multiplies the count roll
+    // in place (rolled once, then doubled), and a modified die is left untouched, since duplicating it would need the
+    // rolled count shared across the copies, which cannot be done synchronously.
+    if ( (term instanceof DiceTerm) && (term._number instanceof Roll) ) {
+      if ( term._number.isDeterministic ) term.number = term._number.evaluateSync().total;
+      else if ( term.modifiers.length ) return [term];
+    }
+
+    term.options.critical = true;
+
+    // Numeric terms are only multiplied when configured to do so.
+    if ( term instanceof NumericTerm ) {
+      if ( critical.multiplyNumeric ) term.number *= (critical.multiplier ?? 2);
+      return [term];
+    }
+
+    let cm = critical.multiplier ?? 2;
+    let cb = (critical.bonusDice && !index) ? critical.bonusDice : 0;
+
+    // Powerful critical replaces the extra dice with their maximized value, added as a flat bonus.
+    if ( critical.powerfulCritical ) {
+      const bonus = Roll.create(term.formula).evaluateSync({ maximize: true }).total * (Math.max(1, cm - 1) + cb);
+      if ( bonus <= 0 ) return [term];
+      const flavor = term.flavor?.toLowerCase().trim() ?? _loc("DND5E.PowerfulCritical");
+      return this.#placeCritical(term, [new NumericTerm({ number: bonus, options: { flavor } })], index);
+    }
+
+    // For RAW criticals without modifiers we can double the dice with alter.
+    if ( (term instanceof DiceTerm) && !term.modifiers.length ) {
+      term.alter(cm, cb);
+      return [term];
+    }
+
+    // Modified or complex terms are duplicated and placed via #placeCritical.
+    const copies = (cm - 1) + cb;
+    if ( !term.isDeterministic && (copies > 0) ) {
+      const clones = Array.from({ length: copies }, () => RollTerm.fromData(foundry.utils.deepClone(term.toJSON())));
+      return this.#placeCritical(term, clones, index);
+    }
+
+    return [term];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Position a critical term together with its extra copies or bonuses. Additive terms are spliced inline carrying the
+   * term's sign, and a term bound by a higher-precedence operator (*, /, %) is wrapped in a parenthetical so that
+   * operator applies to the whole group. The shared damage type is carried onto any wrapper because chunkTerms does
+   * not introspect parentheticals.
+   * @param {RollTerm} term      The original critical term.
+   * @param {RollTerm[]} extras  Additional copies or bonus terms to place alongside it.
+   * @param {number} index       Index of the term within this.terms.
+   * @returns {RollTerm[]}       The terms that should occupy the original term's slot.
+   */
+  #placeCritical(term, extras, index) {
+    const bound = t => (t instanceof OperatorTerm) && DamageRoll.#BINDING_OPERATORS.has(t.operator);
+    const prev = this.terms[index - 1];
+    const next = this.terms[index + 1];
+
+    // Case 1 - Bound by a higher-precedence operator. Wrap so it applies to the whole group. The wrapper is the
+    // canonical carrier of the group's damage type (chunkTerms reads it there, as it does not recurse into
+    // parentheticals), so move the term's options onto the wrapper and clear the inner flavors to avoid ugly display.
+    if ( bound(prev) || bound(next) ) {
+      const options = foundry.utils.deepClone(term.options);
+      const group = [term];
+      for ( const extra of extras ) group.push(new OperatorTerm({ operator: "+" }), extra);
+      for ( const t of group ) t.options.flavor = "";
+      return [ParentheticalTerm.fromTerms(group, options)];
+    }
+
+    // Case 2 - Additive. Splice inline, carrying the term's sign.
+    const sign = (prev instanceof OperatorTerm) ? prev.operator : "+";
+    const placed = [term];
+    for ( const extra of extras ) placed.push(new OperatorTerm({ operator: sign }), extra);
+    return placed;
   }
 }

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -176,19 +176,20 @@ export default class DamageRoll extends BasicRoll {
         term.number = term.options.baseNumber;
         if ( this.isCritical ) {
           let cm = critical.multiplier ?? 2;
+          let cb = (critical.bonusDice && (i === 0)) ? critical.bonusDice : 0;
 
-          // Powerful critical - maximize damage and reduce the multiplier by 1
+          // Powerful critical - add maximized damage dice and reset term alterations
           if ( critical.powerfulCritical ) {
-            const bonus = Roll.create(term.formula).evaluateSync({ maximize: true }).total;
+            const bonus = Roll.create(term.formula).evaluateSync({ maximize: true }).total * (Math.max(1, cm-1) + cb);
             if ( bonus > 0 ) {
               const flavor = term.flavor?.toLowerCase().trim() ?? _loc("DND5E.PowerfulCritical");
               flatBonus.set(flavor, (flatBonus.get(flavor) ?? 0) + bonus);
             }
-            cm = Math.max(1, cm-1);
+            cm = 1;
+            cb = 0;
           }
 
           // Alter the damage term
-          let cb = (critical.bonusDice && (i === 0)) ? critical.bonusDice : 0;
           term.alter(cm, cb);
           term.options.critical = true;
         }

--- a/module/dice/damage-roll.mjs
+++ b/module/dice/damage-roll.mjs
@@ -168,13 +168,11 @@ export default class DamageRoll extends BasicRoll {
    * @protected
    */
   configureDamage({ critical={} }={}) {
+    // Critical scaling is destructive and applied exactly once. The damage dialog re-builds rolls from configuration
+    // rather than re-running this method, so a second call (e.g. from external code) is a no-op rather than a
+    // double-application.
+    if ( this.options.configured ) return;
     critical = foundry.utils.mergeObject(critical, this.options.critical ?? {}, { inplace: false });
-
-    // Rebuild the term list from the pristine, post-preprocess formula captured on the first call, so that re-running
-    // this method (e.g. toggling critical in the damage dialog) always starts from the same base rather than
-    // compounding transforms on top of an already-modified list.
-    this.options.baseFormula ??= this._formula;
-    this.terms = this.constructor.parse(this.options.baseFormula, this.data);
 
     if ( this.isCritical ) {
       const newTerms = [];


### PR DESCRIPTION
This PR tries to provide a reasonable implementation of critical damage configuration for complex damage rolls.
The first, simpler commit is a fix for #4910, to allow maximization of all bonus critical dice.
The second takes a larger opinionated general approach, targeting issues #4752, #5060, #5726:

- `NumericTerm`s and `DiceTerm`s with no modifiers keep the original logic;
- `NumericTerm`s with modifiers and any other non-deterministic term are duplicated (or more precisely, added to the formula multiple times according to the critical multiplier and bonus dice available).

Some work on `BasicRoll` was necessary to correctly sync-evaluate maximized pool terms with modifiers.
A few examples of critical transformations:

- `2d6 + 3` -> `4d6 + 3`
- `2d6kh + 3` -> `2d6kh + 3 + 2d6kh`
- `floor(3d6/2) + 1` -> `floor(3d6/2) + 1 + floor(3d6/2)`
- `2d6kh + 3`, with 2 bonus dice and powerful criticals -> `2d6kh + 3 + 18`
- `{1d10,3d4}kl + 2` , with multiply numeric and powerful critical -> `{1d10,3d4}kl + 4 + 10`