### PR TITLE
Add application for configuring overall Table of Contents flags

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4442,6 +4442,37 @@
 "DND5E.Supply": "Supply",
 "DND5E.Suppressed": "Suppressed",
 
+"DND5E.TABLEOFCONTENTS": {
+  "Action": {
+    "Configure": "Configure Table of Contents"
+  },
+  "FIELDS": {
+    "position": {
+      "label": "Position"
+    },
+    "type": {
+      "label": "Type"
+    }
+  },
+  "JournalEntry": "Journal Entry",
+  "NoFolder": "No Folder",
+  "Special": {
+    "After": "After {chapter}",
+    "End": "End of Table of Contents"
+  },
+  "Title": "Table of Contents",
+  "Type": {
+    "Appendix": "Appendix",
+    "Chapter": "Chapter",
+    "Header": "Header",
+    "Special": "Special"
+  },
+  "Warning": {
+    "DuplicateHeader": "Only one entry can be set with the Header type.",
+    "DuplicatePosition": "Each Chapter and Appendix should have a unique position value."
+  }
+},
+
 "DND5E.TARGET": {
   "Action": {
     "PlaceTemplate": "Place Measured Template"

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -193,6 +193,10 @@
 
         option { color: var(--color-text-primary); }
       }
+
+      .form-group .form-fields > span {
+        padding-inline-start: 6px;
+      }
     }
 
     .info {

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -392,6 +392,8 @@
         margin: 0 6px;
       }
 
+      > :is(.fas, .fa-solid) { flex: 0; }
+
       multi-select .tags.input-element-tags .tag { background: var(--dnd5e-background-parchment); }
     }
 

--- a/module/applications/journal/_module.mjs
+++ b/module/applications/journal/_module.mjs
@@ -7,4 +7,5 @@ export {default as JournalEntrySheet5e} from "./journal-entry-sheet.mjs";
 export {default as JournalSpellListPageSheet} from "./spells-page-sheet.mjs";
 export {default as TableOfContentsCompendium} from "./table-of-contents.mjs";
 
+export {default as CompendiumTOCConfig} from "./config/compendium-toc-config.mjs";
 export {default as JournalNavigationConfig} from "./config/journal-navigation-config.mjs";

--- a/module/applications/journal/config/compendium-toc-config.mjs
+++ b/module/applications/journal/config/compendium-toc-config.mjs
@@ -166,7 +166,7 @@ export default class CompendiumTOCConfig extends Application5e {
     for ( const [id, flags] of Object.entries(submitData) ) {
       const update = { _id: id };
       for ( const key of ["type", "position", "append"] ) {
-        if ( flags[key] ) update[`flags.dnd5e.${key}`] = flags[key];
+        if ( flags[key] || (flags[key] === 0) ) update[`flags.dnd5e.${key}`] = flags[key];
         else update[`flags.dnd5e.-=${key}`] = null;
       }
       updates.push(update);

--- a/module/applications/journal/config/compendium-toc-config.mjs
+++ b/module/applications/journal/config/compendium-toc-config.mjs
@@ -1,0 +1,178 @@
+import Application5e from "../../api/application.mjs";
+
+const { NumberField, StringField } = foundry.data.fields;
+
+/**
+ * Application for configuring which documents appear in the Table of Contents.
+ */
+export default class CompendiumTOCConfig extends Application5e {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["config-sheet", "standard-form"],
+    compendium: null,
+    form: {
+      handler: CompendiumTOCConfig.#onSubmitForm,
+      submitOnChange: true
+    },
+    position: {
+      width: 600
+    },
+    tag: "form",
+    window: {
+      title: "DND5E.TABLEOFCONTENTS.Title"
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    form: {
+      template: "systems/dnd5e/templates/journal/config/compendium-toc-config.hbs"
+    }
+  };
+
+  /* --------------------------------------------- */
+  /*  Properties                                   */
+  /* --------------------------------------------- */
+
+  /**
+   * The compendium being configured.
+   * @type {CompendiumCollection}
+   */
+  get compendium() {
+    return this.options.compendium;
+  }
+
+  /* --------------------------------------------- */
+
+  /** @override */
+  get title() {
+    return game.i18n.localize(this.options.window.title);
+  }
+
+  /* --------------------------------------------- */
+
+  /** @override */
+  get subtitle() {
+    return this.compendium.metadata.label;
+  }
+
+  /* --------------------------------------------- */
+  /*  Rendering                                    */
+  /* --------------------------------------------- */
+
+  /** @inheritDoc */
+  _initializeApplicationOptions(options) {
+    options = super._initializeApplicationOptions(options);
+    options.id = `compendium-toc-config-${options.compendium.collection.replaceAll(".", "_")}`;
+    return options;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+
+    // TODO: Ideally this would be `getIndex({ fields: ["flags.dnd5e.type", "flags.dnd5e.position"] })`
+    // but that doesn't seem to properly update the flags when they are updated
+    const docs = await this.compendium.getDocuments();
+    const counts = {};
+    const chapterOptions = docs
+      .reduce((arr, doc) => {
+        const flags = doc.flags.dnd5e ?? {};
+        if ( flags.type ) {
+          counts[`${flags.type}-${flags.position ?? 0}`] ??= 0;
+          counts[`${flags.type}-${flags.position ?? 0}`] += 1;
+        }
+        if ( (flags.type === "appendix") || (flags.type === "chapter") ) {
+          const sort = dnd5e.applications.journal.TableOfContentsCompendium.TYPES[flags.type] + (flags.position ?? 0);
+          arr.push({ label: game.i18n.format("DND5E.TABLEOFCONTENTS.Special.After", { chapter: doc.name }), sort });
+        }
+        return arr;
+      }, [{ value: null, label: game.i18n.localize("DND5E.TABLEOFCONTENTS.Special.End"), rule: true }])
+      .sort((lhs, rhs) => lhs.sort - rhs.sort)
+      .map((option, value) => ({ ...option, value }));
+
+    context.folders = [];
+    const traverse = node => {
+      if ( !node ) return;
+      context.folders.push({
+        name: node.folder?.name ?? game.i18n.localize("DND5E.TABLEOFCONTENTS.NoFolder"),
+        entries: node.entries.map(o => {
+          const entry = this.compendium.get(o._id);
+          const data = entry.flags?.dnd5e ?? {};
+          const fields = [{
+            field: new StringField(),
+            name: `${entry._id}.type`,
+            options: [
+              { value: "chapter", label: game.i18n.localize("DND5E.TABLEOFCONTENTS.Type.Chapter") },
+              { value: "appendix", label: game.i18n.localize("DND5E.TABLEOFCONTENTS.Type.Appendix") },
+              { value: "header", label: game.i18n.localize("DND5E.TABLEOFCONTENTS.Type.Header") },
+              { value: "special", label: game.i18n.localize("DND5E.TABLEOFCONTENTS.Type.Special") }
+            ],
+            value: data.type
+          }];
+
+          switch ( data.type ) {
+            case "appendix":
+            case "chapter":
+              fields.push({
+                field: new NumberField({ integer: true }),
+                name: `${entry._id}.position`,
+                value: data.position
+              });
+              break;
+            case "special":
+              fields.push({
+                field: new NumberField(),
+                name: `${entry._id}.append`,
+                options: chapterOptions,
+                value: data.append
+              });
+              break;
+          }
+
+          const warn = data.type && (data.type !== "special") && (counts[`${data.type}-${data.position ?? 0}`] > 1);
+          return {
+            data, entry, fields,
+            warning: warn ? game.i18n.localize(
+              `DND5E.TABLEOFCONTENTS.Warning.Duplicate${data.type === "header" ? "Header" : "Position"}`
+            ) : null
+          };
+        })
+      });
+      node.children.forEach(traverse);
+    };
+    traverse(this.compendium.tree);
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle form submission.
+   * @this {CompendiumTOCConfig}
+   * @param {SubmitEvent} event          Triggering submit event.
+   * @param {HTMLFormElement} form       The form that was submitted.
+   * @param {FormDataExtended} formData  Data from the submitted form.
+   */
+  static async #onSubmitForm(event, form, formData) {
+    const submitData = foundry.utils.expandObject(formData.object);
+    const updates = [];
+    for ( const [id, flags] of Object.entries(submitData) ) {
+      const update = { _id: id };
+      for ( const key of ["type", "position", "append"] ) {
+        if ( flags[key] ) update[`flags.dnd5e.${key}`] = flags[key];
+        else update[`flags.dnd5e.-=${key}`] = null;
+      }
+      updates.push(update);
+    }
+    await JournalEntry.updateDocuments(updates, { pack: this.compendium.collection });
+    this.compendium.render();
+    this.render();
+  }
+}

--- a/module/applications/journal/config/compendium-toc-config.mjs
+++ b/module/applications/journal/config/compendium-toc-config.mjs
@@ -75,9 +75,7 @@ export default class CompendiumTOCConfig extends Application5e {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
 
-    // TODO: Ideally this would be `getIndex({ fields: ["flags.dnd5e.type", "flags.dnd5e.position"] })`
-    // but that doesn't seem to properly update the flags when they are updated
-    const docs = await this.compendium.getDocuments();
+    const docs = await this.compendium.getIndex({ fields: ["flags.dnd5e.type", "flags.dnd5e.position"] });
     const counts = {};
     const chapterOptions = docs
       .reduce((arr, doc) => {

--- a/module/applications/journal/config/compendium-toc-config.mjs
+++ b/module/applications/journal/config/compendium-toc-config.mjs
@@ -75,7 +75,9 @@ export default class CompendiumTOCConfig extends Application5e {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
 
-    const docs = await this.compendium.getIndex({ fields: ["flags.dnd5e.type", "flags.dnd5e.position"] });
+    const docs = await this.compendium.getIndex({
+      fields: ["flags.dnd5e.type", "flags.dnd5e.append", "flags.dnd5e.position"]
+    });
     const counts = {};
     const chapterOptions = docs
       .reduce((arr, doc) => {
@@ -91,7 +93,7 @@ export default class CompendiumTOCConfig extends Application5e {
         return arr;
       }, [{ value: null, label: game.i18n.localize("DND5E.TABLEOFCONTENTS.Special.End"), rule: true }])
       .sort((lhs, rhs) => lhs.sort - rhs.sort)
-      .map((option, value) => ({ ...option, value }));
+      .map((option, value) => ({ ...option, value: option.value === null ? null : value }));
 
     context.folders = [];
     const traverse = node => {
@@ -99,7 +101,7 @@ export default class CompendiumTOCConfig extends Application5e {
       context.folders.push({
         name: node.folder?.name ?? game.i18n.localize("DND5E.TABLEOFCONTENTS.NoFolder"),
         entries: node.entries.map(o => {
-          const entry = this.compendium.get(o._id);
+          const entry = this.compendium.index.get(o._id);
           const data = entry.flags?.dnd5e ?? {};
           const fields = [{
             field: new StringField(),
@@ -164,8 +166,8 @@ export default class CompendiumTOCConfig extends Application5e {
     for ( const [id, flags] of Object.entries(submitData) ) {
       const update = { _id: id };
       for ( const key of ["type", "position", "append"] ) {
-        if ( flags[key] || (flags[key] === 0) ) update[`flags.dnd5e.${key}`] = flags[key];
-        else update[`flags.dnd5e.-=${key}`] = null;
+        if ( (flags[key] || (flags[key] === 0)) && flags.type ) update[`flags.dnd5e.${key}`] = flags[key];
+        else update[`flags.dnd5e.${key}`] = _del;
       }
       updates.push(update);
     }

--- a/module/applications/journal/table-of-contents.mjs
+++ b/module/applications/journal/table-of-contents.mjs
@@ -1,20 +1,31 @@
+import CompendiumTOCConfig from "./config/compendium-toc-config.mjs";
+
 /**
  * Compendium that renders pages as a table of contents.
  */
 export default class TableOfContentsCompendium extends foundry.applications.sidebar.apps.Compendium {
   /** @override */
   static DEFAULT_OPTIONS = {
-    classes: ["table-of-contents"],
-    window: {
-      resizable: true,
-      contentTag: "article"
+    actions: {
+      activateEntry: this.prototype._onClickLink,
+      configureTableOfContents: TableOfContentsCompendium.#onConfigureTableOfContents
     },
+    classes: ["table-of-contents"],
     position: {
       width: 800,
       height: 950
     },
-    actions: {
-      activateEntry: this.prototype._onClickLink
+    window: {
+      contentTag: "article",
+      controls: [
+        {
+          action: "configureTableOfContents",
+          icon: "fa-solid fa-bars-staggered",
+          label: "DND5E.TABLEOFCONTENTS.Action.Configure",
+          visible: TableOfContentsCompendium.#canConfigureTableOfContents
+        }
+      ],
+      resizable: true
     }
   };
 
@@ -155,6 +166,29 @@ export default class TableOfContentsCompendium extends foundry.applications.side
 
   /* -------------------------------------------- */
   /*  Event Handlers                              */
+  /* -------------------------------------------- */
+
+  /**
+   * Whether it's possible to configure the table of contents.
+   * @this {TableOfContentsCompendium}
+   * @returns {boolean}
+   */
+  static #canConfigureTableOfContents() {
+    return !this.collection.locked && this.collection.testUserPermission(game.user, "OWNER");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle opening the configuration application.
+   * @this {TableOfContentsCompendium}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static async #onConfigureTableOfContents(event, target) {
+    new CompendiumTOCConfig({ compendium: this.collection }).render({ force: true });
+  }
+
   /* -------------------------------------------- */
 
   /**

--- a/templates/journal/config/compendium-toc-config.hbs
+++ b/templates/journal/config/compendium-toc-config.hbs
@@ -1,0 +1,27 @@
+<section class="flexcol">
+    {{#each folders}}
+    <fieldset class="card">
+        <legend>{{ localize name }}</legend>
+        <div class="header">
+            <div class="form-group split-group">
+                <span>{{ localize "DND5E.TABLEOFCONTENTS.JournalEntry" }}</span>
+                <div class="form-fields">
+                    <span>{{ localize "DND5E.TABLEOFCONTENTS.FIELDS.type.label" }}</span>
+                    <span>{{ localize "DND5E.TABLEOFCONTENTS.FIELDS.position.label" }}</span>
+                </div>
+            </div>
+        </div>
+        {{#each entries}}
+        <div class="form-group split-group">
+            <label>{{ entry.name }}</label>
+            <div class="form-fields">
+                {{> "dnd5e.fieldlist" fields }}
+                {{#if warning}}
+                <i class="fa-solid fa-triangle-exclamation" data-tooltip aria-label="{{ warning }}"></i>
+                {{/if}}
+            </div>
+        </div>
+        {{/each}}
+    </fieldset>
+    {{/each}}
+</section>


### PR DESCRIPTION
Adds a new configuration application available from the header of the table of contents window that displays all of the journal entries in the pack grouped by folder and allows for setting the `type` and `position` flag.

<img width="620" height="796" alt="Table of Contents Compendium Config" src="https://github.com/user-attachments/assets/b7e2516e-5677-4a8f-8050-4134f9d22a7e" />

Configuration of the other entry flags (`order`, `title`, & `showPages`) as well as the individual page flags (`tocHidden`) will be left to a separate config application accessible from the individual entry sheets.