### PR TITLE
[#6552] Add option to spell embeds to list more spell info

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4007,6 +4007,21 @@
 },
 "DND5E.Speed": "Speed",
 "DND5E.SpeedSpecial": "Special Movement",
+
+"DND5E.SPELL": {
+  "Embed": {
+    "CastingTimeTrigger": "{castingTime}, which you take {trigger}",
+    "Tag": {
+      "Cantrip": "{school} Cantrip",
+      "CantripLegacy": "{school} cantrip",
+      "Classes": "{levelSchool} ({classes})",
+      "Leveled": "Level {level} {school}",
+      "LeveledLegacy": "{levelOrdinal}-level {school}",
+      "Ritual": "{levelSchool} (ritual)"
+    }
+  }
+},
+
 "DND5E.SpellAbility": "Spellcasting Ability",
 "DND5E.SpellAbilitySet": "Set as Primary Spellcasting Ability",
 "DND5E.SpellAdd": "Add Spell",
@@ -4078,6 +4093,7 @@
 "DND5E.SpellcastingClass": "{class} Spellcasting",
 "DND5E.SpellComponent": "Spell Component",
 "DND5E.SpellComponents": "Spell Components",
+"DND5E.SpellComponentsMaterial": "{components} ({materials})",
 "DND5E.SpellCreate": "Create Spell",
 "DND5E.SpellDC": "Spell DC",
 "DND5E.SpellDetails": "Spell Details",

--- a/less/v2/blocks.less
+++ b/less/v2/blocks.less
@@ -194,4 +194,18 @@
       }
     }
   }
+
+  .item-entry-details {
+    .item-entry-tag { font-style: italic; }
+    .item-entry-specifics {
+      :is(dt, dd) { display: inline; }
+      dt {
+        color: inherit;
+        text-shadow: none;
+        font-weight: bold;
+        &::after { content: ": "; }
+      }
+      dd { margin-inline-start: 0; }
+    }
+  }
 }

--- a/module/data/shared/range-field.mjs
+++ b/module/data/shared/range-field.mjs
@@ -33,13 +33,22 @@ export default class RangeField extends SchemaField {
       prepareFormulaValue(this, "range.value", "DND5E.RANGE.FIELDS.range.value.label", rollData);
     } else this.range.value = null;
 
-    if ( labels && this.range.units ) {
+    this.range.labels ??= {};
+    if ( this.range.units ) {
       if ( this.range.scalar && this.range.value ) {
-        labels.range = formatLength(this.range.value, this.range.units);
-        labels.rangeParts = formatLength(this.range.value, this.range.units, { parts: true });
+        this.range.labels.range = formatLength(this.range.value, this.range.units);
+        this.range.labels.rangeParts = formatLength(this.range.value, this.range.units, { parts: true });
+        this.range.labels.description = formatLength(this.range.value, this.range.units, { unitDisplay: "long" });
       } else if ( !this.range.scalar ) {
-        labels.range = CONFIG.DND5E.distanceUnits[this.range.units];
+        this.range.labels.range = CONFIG.DND5E.distanceUnits[this.range.units];
       }
-    } else if ( labels ) labels.range = game.i18n.localize("DND5E.DistSelf");
+    } else this.range.labels.range = game.i18n.localize("DND5E.DistSelf");
+
+    if ( labels ) {
+      labels.description ??= {};
+      labels.description.range ||= this.range.labels.description;
+      labels.range ||= this.range.labels.range;
+      labels.rangeParts ||= this.range.labels.rangeParts;
+    }
   }
 }


### PR DESCRIPTION
Adds the `details` option when embedding spells that will include the standard spell level, school, classes, casting time, range, components, and duration in addition to the spell's description. This respects the current rules version to adjust to match modern and legacy presentations of this data.

<img width="479" height="825" alt="Spell Embed Details Modern" src="https://github.com/user-attachments/assets/d120e66d-7bd1-4fc3-a0e4-3b83539ab7a2" />
<img width="479" height="828" alt="Spell Embed Details Legacy" src="https://github.com/user-attachments/assets/2248910b-7781-486e-ad3b-3aa6fc3588ba" />

Closes #6552