### PR TITLE
[#6560] Allow formulas for magical bonus on items

### DIFF
--- a/module/applications/actor/config/armor-class-config.mjs
+++ b/module/applications/actor/config/armor-class-config.mjs
@@ -1,4 +1,4 @@
-import { formatNumber } from "../../../utils.mjs";
+import { formatNumber, simplifyBonus } from "../../../utils.mjs";
 import BaseConfigSheet from "../api/base-config-sheet.mjs";
 
 /**
@@ -63,12 +63,12 @@ export default class ArmorClassConfig extends BaseConfigSheet {
       for ( const key of ["armor", "shield"] ) {
         const item = context.data[`equipped${key.capitalize()}`];
         if ( !item ) continue;
-        const val = item.system.armor.value - (item.system.magicAvailable ? (item.system.armor.magicalBonus ?? 0) : 0);
+        const magicalBonus = simplifyBonus(item.system.armor.magicalBonus, item.getRollData({ deterministic: true }));
+        const val = item.system.armor.value - (item.system.magicAvailable ? magicalBonus : 0);
         context.calculations.push({
           anchor: item.toAnchor().outerHTML,
           img: item.img,
-          magicalBonus: item.system.properties.has("mgc")
-            ? formatNumber(item.system.armor.magicalBonus, { signDisplay: "always" }) : "—",
+          magicalBonus: item.system.properties.has("mgc") ? formatNumber(magicalBonus, { signDisplay: "always" }) : "—",
           name: item.name,
           value: formatNumber(val, { signDisplay: key === "shield" ? "always" : "auto" })
         });

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -1,5 +1,5 @@
 import simplifyRollFormula from "../../dice/simplify-roll-formula.mjs";
-import { convertLength, formatLength, formatNumber } from "../../utils.mjs";
+import { convertLength, formatLength, formatNumber, simplifyBonus } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
@@ -392,16 +392,18 @@ export default class BaseAttackActivityData extends BaseActivityData {
       if ( includeMod && !roll.parts.some(p => p.includes("@mod")) ) roll.parts.push("@mod");
 
       // Add magical bonus
-      if ( this.item.system.magicalBonus && this.item.system.magicAvailable ) {
+      const magicalBonus = simplifyBonus(this.item.system.magicalBonus, rollData);
+      if ( magicalBonus && this.item.system.magicAvailable ) {
         roll.parts.push("@magicalBonus");
-        roll.data.magicalBonus = this.item.system.magicalBonus;
+        roll.data.magicalBonus = magicalBonus;
       }
 
       // Add ammunition bonus
       const ammo = rollConfig.ammunition?.system;
-      if ( ammo?.magicAvailable && ammo.magicalBonus ) {
+      const ammoMagicalBonus = simplifyBonus(ammo?.magicalBonus, rollData);
+      if ( ammo?.magicAvailable && ammoMagicalBonus ) {
         roll.parts.push("@ammoBonus");
-        roll.data.ammoBonus = ammo.magicalBonus;
+        roll.data.ammoBonus = ammoMagicalBonus;
       }
     }
 

--- a/module/data/item/_types.mjs
+++ b/module/data/item/_types.mjs
@@ -28,7 +28,7 @@
  * @property {object} damage
  * @property {DamageData} damage.base               Damage caused by this ammunition.
  * @property {string} damage.replace                Should ammunition damage replace the base weapon's damage?
- * @property {number} magicalBonus                  Magical bonus added to attack & damage rolls by ammunition.
+ * @property {string} magicalBonus                  Magical bonus added to attack & damage rolls by ammunition.
  * @property {Set<string>} properties               Ammunition properties.
  * @property {Omit<ItemTypeData, "baseItem">} type  Ammunition type and subtype.
  * @property {UsesData} uses
@@ -48,7 +48,7 @@
  * @typedef EquipmentItemSystemData
  * @property {object} armor                        Armor details and equipment type information.
  * @property {number} armor.value                  Base armor class or shield bonus.
- * @property {number} armor.magicalBonus           Bonus added to AC from the armor's magical nature.
+ * @property {string} armor.magicalBonus           Bonus added to AC from the armor's magical nature.
  * @property {number} armor.dex                    Maximum dex bonus added to armor class.
  * @property {number} proficient                   Does the owner have proficiency in this piece of equipment?
  * @property {Set<string>} properties              Equipment properties.
@@ -174,7 +174,7 @@
  * @property {object} damage
  * @property {DamageData} damage.base              Weapon's base damage.
  * @property {DamageData} damage.versatile         Weapon's versatile damage.
- * @property {number} magicalBonus                 Magical bonus added to attack & damage rolls.
+ * @property {string} magicalBonus                 Magical bonus added to attack & damage rolls.
  * @property {string} mastery                      Mastery Property usable with this weapon.
  * @property {Set<string>} properties              Weapon's properties.
  * @property {number} proficient                   Does the weapon's owner have proficiency?

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -1,6 +1,7 @@
 import { filteredKeys } from "../../utils.mjs";
 import ItemDataModel from "../abstract/item-data-model.mjs";
 import BaseActivityData from "../activity/base-activity.mjs";
+import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import UsesField from "../shared/uses-field.mjs";
 import ItemTypeField from "./fields/item-type-field.mjs";
@@ -57,7 +58,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
         base: new DamageField(),
         replace: new BooleanField()
       }),
-      magicalBonus: new NumberField({ min: 0, integer: true }),
+      magicalBonus: new FormulaField({ deterministic: true }),
       properties: new SetField(new StringField()),
       type: new ItemTypeField({ baseItem: false }, { label: "DND5E.ItemConsumableType" }),
       uses: new UsesField({

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -1,4 +1,6 @@
+import { simplifyBonus } from "../../utils.mjs";
 import ItemDataModel from "../abstract/item-data-model.mjs";
+import FormulaField from "../fields/formula-field.mjs";
 import ActivitiesTemplate from "./templates/activities.mjs";
 import EquippableItemTemplate from "./templates/equippable-item.mjs";
 import IdentifiableTemplate from "./templates/identifiable.mjs";
@@ -53,7 +55,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
     return this.mergeSchema(super.defineSchema(), {
       armor: new SchemaField({
         value: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.ArmorClass" }),
-        magicalBonus: new NumberField({ min: 0, integer: true, label: "DND5E.MagicalBonus" }),
+        magicalBonus: new FormulaField({ deterministic: true, label: "DND5E.MagicalBonus" }),
         dex: new NumberField({ required: true, integer: true, label: "DND5E.ItemEquipmentDexMod" })
       }),
       proficient: new NumberField({
@@ -277,7 +279,8 @@ export default class EquipmentData extends ItemDataModel.mixin(
     this.prepareIdentifiable();
     this.preparePhysicalData();
     this.prepareMountableData();
-    if ( this.magicAvailable && this.armor.magicalBonus ) this.armor.value += this.armor.magicalBonus;
+    const magicalBonus = simplifyBonus(this.armor.magicalBonus, this.parent.getRollData());
+    if ( this.magicAvailable && magicalBonus ) this.armor.value += magicalBonus;
     this.type.label = CONFIG.DND5E.equipmentTypes[this.type.value]
       ?? game.i18n.localize(CONFIG.Item.typeLabels.equipment);
     this.type.identifier = this.type.value === "shield"

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -1,6 +1,7 @@
 import { convertLength, defaultUnits, filteredKeys, formatLength, formatNumber } from "../../utils.mjs";
 import ItemDataModel from "../abstract/item-data-model.mjs";
 import BaseActivityData from "../activity/base-activity.mjs";
+import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import ItemTypeField from "./fields/item-type-field.mjs";
 import ActivitiesTemplate from "./templates/activities.mjs";
@@ -64,7 +65,7 @@ export default class WeaponData extends ItemDataModel.mixin(
         base: new DamageField(),
         versatile: new DamageField()
       }),
-      magicalBonus: new NumberField({ min: 0, integer: true, label: "DND5E.MagicalBonus" }),
+      magicalBonus: new FormulaField({ deterministic: true, label: "DND5E.MagicalBonus" }),
       mastery: new StringField(),
       properties: new SetField(new StringField(), { label: "DND5E.ItemWeaponProperties" }),
       proficient: new NumberField({


### PR DESCRIPTION
Swaps from `NumberField` to `FormulaField` for all `magicalBonus` fields and adjusts how they are consumed to ensure all of the formulas are handled.

Closes #6560