### PR TITLE
[#6555] Rename normal healing type to "Hit Points"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3056,9 +3056,13 @@
       }
     }
   },
+  "HealingButton": "Healing",
+  "HealingRoll": "Healing Roll",
   "Hint": "Heal a creature",
   "Title": "Heal",
   "Type": {
+    "Healing": "Hit Points",
+    "HealingShort": "Healing",
     "Maximum": "Maximum Hit Points",
     "MaximumShort": "Max HP",
     "Temporary": "Temporary Hit Points",
@@ -3066,8 +3070,6 @@
   }
 },
 
-"DND5E.Healing": "Healing",
-"DND5E.HealingRoll": "Healing Roll",
 "DND5E.Height": "Height",
 
 "DND5E.HITPOINTS": {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2329,7 +2329,8 @@ DND5E.aggregateDamageDisplay = true;
  */
 DND5E.healingTypes = {
   healing: {
-    label: "DND5E.Healing",
+    label: "DND5E.HEAL.Type.Healing",
+    labelShort: "DND5E.HEAL.Type.HealingShort",
     icon: "systems/dnd5e/icons/svg/damage/healing.svg",
     color: new Color(0x46C252)
   },

--- a/module/documents/activity/heal.mjs
+++ b/module/documents/activity/heal.mjs
@@ -37,7 +37,7 @@ export default class HealActivity extends ActivityMixin(BaseHealActivityData) {
 
   /** @override */
   get damageFlavor() {
-    return game.i18n.localize("DND5E.HealingRoll");
+    return game.i18n.localize("DND5E.HEAL.HealingRoll");
   }
 
   /* -------------------------------------------- */
@@ -48,7 +48,7 @@ export default class HealActivity extends ActivityMixin(BaseHealActivityData) {
   _usageChatButtons(message) {
     if ( !this.healing.formula ) return super._usageChatButtons(message);
     return [{
-      label: game.i18n.localize("DND5E.Healing"),
+      label: game.i18n.localize("DND5E.HEAL.HealingButton"),
       icon: '<i class="dnd5e-icon" data-src="systems/dnd5e/icons/svg/damage/healing.svg"></i>',
       dataset: {
         action: "rollHealing"

--- a/packs/_source/equipment24/equipment/ioun-stones/ioun-stone-of-regeneration.yml
+++ b/packs/_source/equipment24/equipment/ioun-stones/ioun-stone-of-regeneration.yml
@@ -80,9 +80,9 @@ system:
       Utilize action, you can seize and stow any number of <em>Ioun Stones</em>
       orbiting your head. If your Attunement to an <em>Ioun Stone</em> ends
       while it's orbiting your head, the stone falls as though you had dropped
-      it.</p><p>You regain [[/healing 15 type=healing]]{15 Hit Points} at the
-      end of each hour this pearly white spindle orbits your head if you have at
-      least 1 Hit Point.</p>
+      it.</p><p>You regain [[/healing 15 type=healing]] at the end of each hour
+      this pearly white spindle orbits your head if you have at least 1 Hit
+      Point.</p>
     chat: ''
   identifier: regeneration-ioun-stone
   source:

--- a/packs/_source/equipment24/equipment/mysterious-deck-cards/sun.yml
+++ b/packs/_source/equipment24/equipment/mysterious-deck-cards/sun.yml
@@ -136,20 +136,22 @@ effects:
     description: >-
       <p><em>Source:
       @UUID[Compendium.dnd5e.equipment24.Item.dmgDmtSun0000000]{Sun}</em></p><p>You
-      gain [[/healing 10 type=temphp]]{10 Temporary Hit Points} daily at dawn
-      until you die.</p>
+      gain [[/healing 10 temp]] daily at dawn until you die.</p>
     tint: '#ffffff'
     statuses: []
     sort: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          statuses: []
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 4.1.0
+      systemVersion: 5.2.3
       createdTime: 1729205768672
-      modifiedTime: 1729205932148
+      modifiedTime: 1765823916155
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!items.effects!dmgDmtSun0000000.enZ79fOzsta0vlqK'


### PR DESCRIPTION
Renames "Healing" as the normal healing type to "Hit Points" to match the other "Temporary Hit Points" label and make it useful in the enricher.

Closes #6555