### PR TITLE
[#6488] Add AC and speed attribution tooltips for members in a group sheet

### DIFF
--- a/templates/actors/group/member.hbs
+++ b/templates/actors/group/member.hbs
@@ -86,11 +86,17 @@
         {{else}}
         <div class="info">
             <div>
-                <i class="fa-solid fa-shield" data-tooltip aria-label="{{ localize "DND5E.ArmorClass" }}"></i>
+                <i class="fa-solid fa-shield"
+                   data-attribution="attributes.ac" data-reference-tooltip="{{ uuid }}"
+                   data-attribution-caption="DND5E.ArmorClass" aria-label="{{ localize "DND5E.ArmorClass" }}">
+                </i>
                 <span class="value">{{ system.attributes.ac.value }}</span>
             </div>
             <div>
-                <i class="fa-solid fa-shoe-prints" data-tooltip aria-label="{{ localize "DND5E.Speed" }}"></i>
+                <i class="fa-solid fa-shoe-prints"
+                   data-attribution="attributes.movement" data-reference-tooltip="{{ uuid }}"
+                   aria-label="{{ localize "DND5E.Speed" }}">
+                </i>
                 <span class="value">
                     {{ system.attributes.movement.walk }}
                     {{#if system.attributes.movement.slowed}}

--- a/templates/actors/group/member.hbs
+++ b/templates/actors/group/member.hbs
@@ -85,17 +85,15 @@
         <div class="empty">???</div>
         {{else}}
         <div class="info">
-            <div>
-                <i class="fa-solid fa-shield"
-                   data-attribution="attributes.ac" data-reference-tooltip="{{ uuid }}"
-                   data-attribution-caption="DND5E.ArmorClass" aria-label="{{ localize "DND5E.ArmorClass" }}">
-                </i>
+            <div
+               data-attribution="attributes.ac" data-reference-tooltip="{{ uuid }}"
+               data-attribution-caption="DND5E.ArmorClass">
+                <i class="fa-solid fa-shield" aria-label="{{ localize "DND5E.ArmorClass" }}"></i>
                 <span class="value">{{ system.attributes.ac.value }}</span>
             </div>
-            <div>
-                <i class="fa-solid fa-shoe-prints"
-                   data-attribution="attributes.movement" data-reference-tooltip="{{ uuid }}"
-                   aria-label="{{ localize "DND5E.Speed" }}">
+            <div
+               data-attribution="attributes.movement" data-reference-tooltip="{{ uuid }}">
+                <i class="fa-solid fa-shoe-prints" aria-label="{{ localize "DND5E.Speed" }}">
                 </i>
                 <span class="value">
                     {{ system.attributes.movement.walk }}

--- a/templates/actors/group/member.hbs
+++ b/templates/actors/group/member.hbs
@@ -85,16 +85,13 @@
         <div class="empty">???</div>
         {{else}}
         <div class="info">
-            <div
-               data-attribution="attributes.ac" data-reference-tooltip="{{ uuid }}"
-               data-attribution-caption="DND5E.ArmorClass">
+            <div data-attribution="attributes.ac" data-reference-tooltip="{{ uuid }}"
+                 data-attribution-caption="DND5E.ArmorClass">
                 <i class="fa-solid fa-shield" aria-label="{{ localize "DND5E.ArmorClass" }}"></i>
                 <span class="value">{{ system.attributes.ac.value }}</span>
             </div>
-            <div
-               data-attribution="attributes.movement" data-reference-tooltip="{{ uuid }}">
-                <i class="fa-solid fa-shoe-prints" aria-label="{{ localize "DND5E.Speed" }}">
-                </i>
+            <div data-attribution="attributes.movement" data-reference-tooltip="{{ uuid }}">
+                <i class="fa-solid fa-shoe-prints" aria-label="{{ localize "DND5E.Speed" }}"></i>
                 <span class="value">
                     {{ system.attributes.movement.walk }}
                     {{#if system.attributes.movement.slowed}}


### PR DESCRIPTION
Closes #6488.