### PR TITLE
[#6495] Allow for effects to adjust the bloodied threshold

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3466,6 +3466,9 @@
 "DND5E.Height": "Height",
 
 "DND5E.HITPOINTS": {
+  "Bloodied": {
+    "label": "Bloodied Threshold"
+  },
   "Counted": {
     "one": "{number} hit point",
     "other": "{number} hit points"

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3887,7 +3887,7 @@ DND5E.neverBlockStatuses = new Set();
 DND5E.bloodied = {
   name: "EFFECT.DND5E.StatusBloodied",
   img: "systems/dnd5e/icons/svg/statuses/bloodied.svg",
-  threshold: .5
+  threshold: 50
 };
 
 /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3882,7 +3882,7 @@ DND5E.neverBlockStatuses = new Set();
 
 /**
  * Configuration for the special bloodied status effect.
- * @type {{ name: string, icon: string, threshold: number }}
+ * @type {{ name: string, img: string, threshold: number }}
  */
 DND5E.bloodied = {
   name: "EFFECT.DND5E.StatusBloodied",

--- a/module/data/actor/_types.mjs
+++ b/module/data/actor/_types.mjs
@@ -13,6 +13,7 @@
  * @typedef CharacterActorSystemData
  * @property {Union<AttributesCommonData, AttributesCreatureData>} attributes
  * @property {HitPointsData} attributes.hp
+ * @property {number} attributes.hp.bloodied              HP percentage at or below which the creature is bloodied.
  * @property {object} attributes.hp.bonuses
  * @property {string} attributes.hp.bonuses.level         Bonus formula applied for each class level.
  * @property {string} attributes.hp.bonuses.overall       Bonus formula applied to total HP.
@@ -132,6 +133,7 @@
  * @property {object} attributes.hd
  * @property {number} attributes.hd.spent        Number of hit dice spent.
  * @property {HitPointsData} attributes.hp
+ * @property {number} attributes.hp.bloodied     HP percentage at or below which the creature is bloodied.
  * @property {string} attributes.hp.formula      Formula used to determine hit points.
  * @property {Omit<RollConfigData, "ability">} attributes.death
  * @property {number} attributes.death.success        Number of successful death saves.

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -56,6 +56,10 @@ export default class CharacterData extends CreatureTemplate {
         ...AttributesFields.creature,
         hp: new SchemaField({
           ...AttributesFields.hitPoints,
+          bloodied: new NumberField({
+            nullable: false, min: 0, max: 100, persisted: false, initial: () => CONFIG.DND5E.bloodied.threshold,
+            label: "DND5E.HITPOINTS.Bloodied.label"
+          }),
           max: new NumberField({
             nullable: true, integer: true, min: 0, initial: null, label: "DND5E.HitPointsOverride",
             hint: "DND5E.HitPointsOverrideHint"

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -187,7 +187,6 @@ export default class CharacterData extends CreatureTemplate {
     }
 
     AttributesFields.prepareBaseArmorClass.call(this);
-    AttributesFields.prepareBaseBloodied.call(this);
     AttributesFields.prepareBaseEncumbrance.call(this);
     SensesField._shim(this.attributes.senses);
   }

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -187,6 +187,7 @@ export default class CharacterData extends CreatureTemplate {
     }
 
     AttributesFields.prepareBaseArmorClass.call(this);
+    AttributesFields.prepareBaseBloodied.call(this);
     AttributesFields.prepareBaseEncumbrance.call(this);
     SensesField._shim(this.attributes.senses);
   }

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -59,6 +59,10 @@ export default class NPCData extends CreatureTemplate {
         }, { label: "DND5E.HitDice" }),
         hp: new SchemaField({
           ...AttributesFields.hitPoints,
+          bloodied: new NumberField({
+            nullable: false, min: 0, max: 100, persisted: false, initial: () => CONFIG.DND5E.bloodied.threshold,
+            label: "DND5E.HITPOINTS.Bloodied.label"
+          }),
           formula: new FormulaField({ required: true, label: "DND5E.HPFormula" })
         }, { label: "DND5E.HitPoints" }),
         death: new RollConfigField({

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -385,6 +385,7 @@ export default class NPCData extends CreatureTemplate {
     }
 
     AttributesFields.prepareBaseArmorClass.call(this);
+    AttributesFields.prepareBaseBloodied.call(this);
     AttributesFields.prepareBaseEncumbrance.call(this);
     SensesField._shim(this.attributes.senses);
   }

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -385,7 +385,6 @@ export default class NPCData extends CreatureTemplate {
     }
 
     AttributesFields.prepareBaseArmorClass.call(this);
-    AttributesFields.prepareBaseBloodied.call(this);
     AttributesFields.prepareBaseEncumbrance.call(this);
     SensesField._shim(this.attributes.senses);
   }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -148,6 +148,9 @@ export default class AttributesFields {
         }),
         value: new NumberField({ integer: true, min: 0, initial: 0, persisted: false })
       }, { label: "DND5E.Attunement" }),
+      bloodiedThreshold: new NumberField({
+        nullable: false, min: 0, max: 100, persisted: false, initial: () => CONFIG.DND5E.bloodied.threshold
+      }),
       senses: new SensesField(),
       spell: new SchemaField({
         attack: new NumberField({ integer: true }),
@@ -236,16 +239,6 @@ export default class AttributesFields {
    * @this {CharacterData|NPCData|VehicleData}
    */
   static prepareBaseArmorClass() {}
-
-  /* -------------------------------------------- */
-
-  /**
-   * Prepare the bloodied threshold.
-   * @this {CharacterData|NPCData}
-   */
-  static prepareBaseBloodied() {
-    this.attributes.bloodiedThreshold = CONFIG.DND5E.bloodied.threshold;
-  }
 
   /* -------------------------------------------- */
 

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -240,6 +240,16 @@ export default class AttributesFields {
   /* -------------------------------------------- */
 
   /**
+   * Prepare the bloodied threshold.
+   * @this {CharacterData|NPCData}
+   */
+  static prepareBaseBloodied() {
+    this.attributes.bloodiedThreshold = CONFIG.DND5E.bloodied.threshold;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Initialize base encumbrance fields to be targeted by active effects.
    * @this {CharacterData|NPCData|VehicleData}
    */

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -148,9 +148,6 @@ export default class AttributesFields {
         }),
         value: new NumberField({ integer: true, min: 0, initial: 0, persisted: false })
       }, { label: "DND5E.Attunement" }),
-      bloodiedThreshold: new NumberField({
-        nullable: false, min: 0, max: 100, persisted: false, initial: () => CONFIG.DND5E.bloodied.threshold
-      }),
       senses: new SensesField(),
       spell: new SchemaField({
         attack: new NumberField({ integer: true }),

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -117,7 +117,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( this.target?.testUserPermission(game.user, "OBSERVER") ) return false;
 
     // Hide bloodied status effect from players unless the token is friendly
-    if ( (this.id === this.constructor.ID.BLOODIED) && (game.settings.get("dnd5e", "bloodied") === "player") ) {
+    if ( (this.id === this.constructor.ID.BLOODIED) && (dnd5e.settings.bloodied === "player") ) {
       return this.target?.token?.disposition !== foundry.CONST.TOKEN_DISPOSITIONS.FRIENDLY;
     }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3588,10 +3588,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   updateBloodied(options) {
     const hp = this.system.attributes?.hp;
-    if ( !hp?.effectiveMax || (game.settings.get("dnd5e", "bloodied") === "none") ) return;
+    if ( !this.system.isCreature || !hp?.effectiveMax || (dnd5e.settings.bloodied === "none") ) return;
 
     const effect = this.effects.get(ActiveEffect5e.ID.BLOODIED);
-    if ( (hp.pct === 100) || (hp.pct > this.system.attributes.bloodiedThreshold) ) return effect?.delete();
+    if ( (hp.pct === 100) || (hp.pct > hp.bloodied) ) return effect?.delete();
     if ( effect ) return;
 
     return ActiveEffect.implementation.create({

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3591,7 +3591,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( !hp?.effectiveMax || (game.settings.get("dnd5e", "bloodied") === "none") ) return;
 
     const effect = this.effects.get(ActiveEffect5e.ID.BLOODIED);
-    if ( hp.value > hp.effectiveMax * CONFIG.DND5E.bloodied.threshold ) return effect?.delete();
+    if ( (hp.pct === 100) || (hp.pct > this.system.attributes.bloodiedThreshold) ) return effect?.delete();
     if ( effect ) return;
 
     return ActiveEffect.implementation.create({


### PR DESCRIPTION
Stores a numeric value in `CharacterData/NPCData#attributes.bloodiedThreshold` during the base data prep cycle, grabbing the initial value from the CONFIG, which has been adjusted to be 50 instead of 0.5 for simplicity.

Adjusted to compare HP percentage using `attributes.hp.pct` instead of a calculation in the `updateBloodied` method using `hp.effectiveMax` (unsure why this was the way it was).

To allow for the edge case of "bloodied when missing *any* hit points" there's a comparison to `hp.pct === 100` such that an effect can be applied with `system.attributes.bloodiedThreshold | OVERRIDE | 100` to satisfy this requirement.

Closes #6495.