### PR TITLE
[#5647] Advance bastion orders based on calendar

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1122,7 +1122,8 @@
 
 "DND5E.Bastion": {
   "Action": {
-    "BastionTurn": "Advance Bastion Turn"
+    "Advance": "Advance Bastion Turn",
+    "Maintain": "Maintain Bastion"
   },
   "Attack": {
     "Automatic": "Resolve Automatically",
@@ -1149,7 +1150,10 @@
     "Label": "Configure Bastions",
     "Hint": "Various configuration options for the Bastion system as presented in the DMG 2024."
   },
-  "Confirm": "Advance one bastion turn?",
+  "Confirm": {
+    "Advance": "This will advance all bastion facility order progress by {duration}, issue the maintain order to all idle facilities, and repair any disabled facilities, would you like to continue?",
+    "Maintain": "This will issue the maintain order to all idle bastion facilities and repair any disabled facilities, would you like to continue?"
+  },
   "Duration": {
     "Label": "Bastion Turn Duration (days)"
   },

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -1347,8 +1347,6 @@ export default class CharacterActorSheet extends BaseActorSheet {
    * @returns {boolean}
    */
   static hasBastion(actor) {
-    const { basic, special } = CONFIG.DND5E.facilities.advancement;
-    const threshold = Math.min(...Object.keys(basic), ...Object.keys(special));
-    return game.settings.get("dnd5e", "bastionConfiguration")?.enabled && (actor.system.details.level >= threshold);
+    return dnd5e.settings.bastionConfiguration.availableForActor(actor);
   }
 }

--- a/module/data/calendar/calendar-data.mjs
+++ b/module/data/calendar/calendar-data.mjs
@@ -317,7 +317,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
       return 0;
     };
 
-    const days = CalendarData5e.dayDifference(previousTime, nowTime);
+    const days = CalendarData5e.#dayDifference(previousTime, nowTime);
     foundry.utils.setProperty(options, "dnd5e.deltas", {
       midnights: days,
       middays: days + passedHour(game.time.calendar.days.hoursPerDay / 2),
@@ -357,12 +357,12 @@ export default class CalendarData5e extends foundry.data.CalendarData {
 
     const changes = [];
     const rolls = [];
-    const operations = [];
 
     const bastion = dnd5e.settings.bastionConfiguration;
     const advanceFacilities = timePassageData.midnights > 0;
     const recoverUses = !dnd5e.settings.calendarConfig.manualRecovery && periods.size;
     if ( advanceFacilities || recoverUses ) {
+      const operations = [];
       for ( const actor of game.actors ) {
         const deltas = { deleted: [], item: {} };
         const deleted = [];
@@ -371,7 +371,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
         // Advance bastion facilities
         if ( advanceFacilities && bastion?.availableForActor(actor) && actor.itemTypes.facility.length ) {
           const results = await dnd5e.bastion.advanceAllFacilities(actor, {
-            duration: null, performUpdates: false, summary: "auto"
+            duration: timePassageData.midnights, performUpdates: false, summary: "auto", turn: false
           });
           updates.push(...results.updates);
         }
@@ -395,9 +395,8 @@ export default class CalendarData5e extends foundry.data.CalendarData {
         if ( updates.length ) operations.push({ action: "update", documentName: "Item", updates, parent: actor });
         if ( deltas.deleted.length || !foundry.utils.isEmpty(deltas.item) ) changes.push({ deltas, uuid: actor.uuid });
       }
+      await foundry.documents.modifyBatch(operations);
     }
-
-    if ( operations.length ) await foundry.documents.modifyBatch(operations);
 
     const messageConfig = {
       create: changes.length > 0,
@@ -466,7 +465,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
    * @param {Components} currentTime
    * @returns {number}
    */
-  static dayDifference(previousTime, currentTime) {
+  static #dayDifference(previousTime, currentTime) {
     // If years are the same, simple subtraction should work
     if ( previousTime.year === currentTime.year ) return currentTime.day - previousTime.day;
 

--- a/module/data/calendar/calendar-data.mjs
+++ b/module/data/calendar/calendar-data.mjs
@@ -317,7 +317,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
       return 0;
     };
 
-    const days = CalendarData5e.#dayDifference(previousTime, nowTime);
+    const days = CalendarData5e.dayDifference(previousTime, nowTime);
     foundry.utils.setProperty(options, "dnd5e.deltas", {
       midnights: days,
       middays: days + passedHour(game.time.calendar.days.hoursPerDay / 2),
@@ -357,30 +357,47 @@ export default class CalendarData5e extends foundry.data.CalendarData {
 
     const changes = [];
     const rolls = [];
+    const operations = [];
 
-    if ( !dnd5e.settings.calendarConfig.manualRecovery && periods.size ) {
-      const operations = [];
+    const bastion = dnd5e.settings.bastionConfiguration;
+    const advanceFacilities = timePassageData.midnights > 0;
+    const recoverUses = !dnd5e.settings.calendarConfig.manualRecovery && periods.size;
+    if ( advanceFacilities || recoverUses ) {
       for ( const actor of game.actors ) {
         const deltas = { deleted: [], item: {} };
         const deleted = [];
         const updates = [];
-        for ( const item of actor.items ) {
-          const result = await item.system.recoverUses?.(periods) ?? {};
-          if ( result?.rolls ) rolls.push(...result.rolls);
-          if ( result?.destroy ) {
-            deltas.deleted.push(item.toObject());
-            deleted.push(item.id);
-          } else if ( !foundry.utils.isEmpty(result?.updates) ) {
-            deltas.item[item.id] = IndividualDeltaField.getDeltas(item, result.updates);
-            updates.push({ _id: item.id, ...result.updates });
+
+        // Advance bastion facilities
+        if ( advanceFacilities && bastion?.availableForActor(actor) && actor.itemTypes.facility.length ) {
+          const results = await dnd5e.bastion.advanceAllFacilities(actor, {
+            duration: null, performUpdates: false, summary: "auto"
+          });
+          updates.push(...results.updates);
+        }
+
+        // Recover item & activity uses
+        if ( recoverUses ) {
+          for ( const item of actor.items ) {
+            const result = await item.system.recoverUses?.(periods) ?? {};
+            if ( result?.rolls ) rolls.push(...result.rolls);
+            if ( result?.destroy ) {
+              deltas.deleted.push(item.toObject());
+              deleted.push(item.id);
+            } else if ( !foundry.utils.isEmpty(result?.updates) ) {
+              deltas.item[item.id] = IndividualDeltaField.getDeltas(item, result.updates);
+              updates.push({ _id: item.id, ...result.updates });
+            }
           }
         }
+
         if ( deleted.length ) operations.push({ action: "delete", documentName: "Item", ids: deleted, parent: actor });
         if ( updates.length ) operations.push({ action: "update", documentName: "Item", updates, parent: actor });
         if ( deltas.deleted.length || !foundry.utils.isEmpty(deltas.item) ) changes.push({ deltas, uuid: actor.uuid });
       }
-      await foundry.documents.modifyBatch(operations);
     }
+
+    if ( operations.length ) await foundry.documents.modifyBatch(operations);
 
     const messageConfig = {
       create: changes.length > 0,
@@ -449,7 +466,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
    * @param {Components} currentTime
    * @returns {number}
    */
-  static #dayDifference(previousTime, currentTime) {
+  static dayDifference(previousTime, currentTime) {
     // If years are the same, simple subtraction should work
     if ( previousTime.year === currentTime.year ) return currentTime.day - previousTime.day;
 

--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -57,7 +57,8 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
       progress: new SchemaField({
         value: new NumberField({ required: true, integer: true, min: 0, nullable: false, initial: 0 }),
         max: new NumberField({ required: true, integer: true, positive: true }),
-        order: new StringField({ required: true })
+        order: new StringField({ required: true }),
+        updated: new NumberField()
       }),
       size: new StringField({ initial: "cramped", blank: false, nullable: false, required: true }),
       trade: new SchemaField({

--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -12,7 +12,6 @@ const { ArrayField, BooleanField, DocumentUUIDField, NumberField, SchemaField, S
  * @import { ActivitiesTemplateData, ItemDescriptionTemplateData } from "./templates/_types.mjs";
  */
 
-
 /**
  * The data definition for Facility items.
  * @extends {ItemDataModel<ActivitiesTemplate & ItemDescriptionTemplate & FacilityItemSystemData>}
@@ -57,8 +56,7 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
       progress: new SchemaField({
         value: new NumberField({ required: true, integer: true, min: 0, nullable: false, initial: 0 }),
         max: new NumberField({ required: true, integer: true, positive: true }),
-        order: new StringField({ required: true }),
-        updated: new NumberField()
+        order: new StringField({ required: true })
       }),
       size: new StringField({ initial: "cramped", blank: false, nullable: false, required: true }),
       trade: new SchemaField({

--- a/module/data/settings/bastion-setting.mjs
+++ b/module/data/settings/bastion-setting.mjs
@@ -24,4 +24,31 @@ export default class BastionSetting extends foundry.abstract.DataModel {
       })
     };
   }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Cached version of the minimum level required to have a bastion.
+   * @param {number}
+   */
+  static #threshold;
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Determine whether bastions are available for a specific actor.
+   * @param {Actor5e} actor  Actor that may have a bastion.
+   * @returns {boolean}
+   */
+  availableForActor(actor) {
+    if ( !BastionSetting.#threshold ) {
+      const { basic, special } = CONFIG.DND5E.facilities.advancement;
+      BastionSetting.#threshold = Math.min(...Object.keys(basic), ...Object.keys(special));
+    }
+    return this.enabled && (actor.system.details?.level >= BastionSetting.#threshold);
+  }
 }

--- a/module/data/settings/bastion-setting.mjs
+++ b/module/data/settings/bastion-setting.mjs
@@ -49,6 +49,6 @@ export default class BastionSetting extends foundry.abstract.DataModel {
       const { basic, special } = CONFIG.DND5E.facilities.advancement;
       BastionSetting.#threshold = Math.min(...Object.keys(basic), ...Object.keys(special));
     }
-    return this.enabled && (actor.system.details?.level >= BastionSetting.#threshold);
+    return this.enabled && actor.system.isCharacter && (actor.system.details?.level >= BastionSetting.#threshold);
   }
 }

--- a/module/data/settings/bastion-setting.mjs
+++ b/module/data/settings/bastion-setting.mjs
@@ -31,7 +31,7 @@ export default class BastionSetting extends foundry.abstract.DataModel {
 
   /**
    * Cached version of the minimum level required to have a bastion.
-   * @param {number}
+   * @type {number}
    */
   static #threshold;
 

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -8,6 +8,7 @@
  * @property {string} [order]             The order that was completed, if any.
  * @property {number} [gold]              Gold generated.
  * @property {BastionTurnItem[]} [items]  Items created.
+ * @property {object} updates             Updates applied to the facility.
  */
 
 /**

--- a/module/documents/activity/order.mjs
+++ b/module/documents/activity/order.mjs
@@ -81,7 +81,9 @@ export default class OrderActivity extends ActivityMixin(BaseOrderActivityData) 
    */
   _finalizeCosts(usageConfig, updates) {
     const { costs } = usageConfig;
-    if ( costs.days ) updates["system.progress"] = { value: 0, max: costs.days, order: this.order };
+    if ( costs.days ) updates["system.progress"] = {
+      value: 0, max: costs.days, order: this.order, updated: game.time.worldTime
+    };
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/order.mjs
+++ b/module/documents/activity/order.mjs
@@ -81,9 +81,7 @@ export default class OrderActivity extends ActivityMixin(BaseOrderActivityData) 
    */
   _finalizeCosts(usageConfig, updates) {
     const { costs } = usageConfig;
-    if ( costs.days ) updates["system.progress"] = {
-      value: 0, max: costs.days, order: this.order, updated: game.time.worldTime
-    };
+    if ( costs.days ) updates["system.progress"] = { value: 0, max: costs.days, order: this.order };
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/bastion.mjs
+++ b/module/documents/actor/bastion.mjs
@@ -1,3 +1,4 @@
+import CalendarData5e from "../../data/calendar/calendar-data.mjs";
 import BastionAttackDialog from "../../applications/actor/bastion-attack-dialog.mjs";
 import BastionAttackMessageData from "../../data/chat-message/bastion-attack-message-data.mjs";
 
@@ -29,64 +30,84 @@ export default class Bastion {
 
   /**
    * Advance all the facilities of a given Actor by one bastion turn.
-   * @param {Actor5e} actor                   The actor.
+   * @param {Actor5e} actor                          The actor.
    * @param {object} [options]
-   * @param {number} [options.duration=7]     The number of days the bastion turn spanned.
-   * @param {boolean} [options.summary=true]  Print a chat message summary of the turn.
-   * @returns {Promise<void>}
+   * @param {number|null} [options.duration=7]       The number of days the bastion turn spanned or `null` for auto.
+   * @param {boolean} [options.performUpdates=true]  Update the actor's facilities.
+   * @param {boolean|"auto"} [options.summary=true]  Print a chat message summary of the turn. If set to "auto" then
+   *                                                 the message will only be created if an order is completed.
+   * @returns {Promise<{ [message]: ChatMessage5e, updates: object[] }>}
    */
-  async advanceAllFacilities(actor, { duration=7, summary=true }={}) {
+  async advanceAllFacilities(actor, { duration=7, performUpdates=true, summary=true }={}) {
     const results = { orders: [], items: [], gold: 0 };
+    const itemUpdates = [];
     for ( const facility of actor.itemTypes.facility ) {
-      const { order, gold, items } = await this.advanceTurn(facility, { duration });
+      const { order, gold, items, updates } = await this.advanceTurn(facility, { duration, performUpdates: false });
+      if ( !foundry.utils.isEmpty(updates) ) itemUpdates.push({ _id: facility.id, ...updates });
       if ( !order || (order === "maintain") ) continue;
       if ( gold ) results.gold += gold;
       if ( items ) results.items.push(...items);
       results.orders.push({ id: facility.id, order });
     }
+    if ( performUpdates ) await actor.updateEmbeddedDocuments("Item", itemUpdates);
 
-    if ( summary ) {
+    let message;
+    if ( (summary === true) || ((summary === "auto") && results.orders.length) ) {
       results.gold = { value: results.gold, claimed: false };
-      await ChatMessage.implementation.create({
+      message = await ChatMessage.implementation.create({
         speaker: ChatMessage.implementation.getSpeaker({ actor }),
         system: results,
         type: "bastionTurn"
       });
     }
+
+    return { message, updates: itemUpdates };
   }
 
   /* -------------------------------------------- */
 
   /**
    * Advance the given facility by one bastion turn.
-   * @param {Item5e} facility              The facility.
+   * @param {Item5e} facility                        The facility.
    * @param {object} [options]
-   * @param {number} [options.duration=7]  The number of days the bastion turn spanned.
+   * @param {number|null} [options.duration=7]       The number of days the bastion turn spanned or `null` for auto.
+   * @param {boolean} [options.performUpdates=true]  Update the facility.
    * @returns {Promise<BastionTurnResult>}
    */
-  async advanceTurn(facility, { duration=7 }={}) {
+  async advanceTurn(facility, { duration=7, performUpdates=true }={}) {
     const { disabled, progress, type } = facility.system;
 
     // Case 1 - No order in progress.
     if ( !progress.max && !disabled ) {
-      await facility.update({ "system.progress.order": "" });
-      if ( type.value === "basic" ) return {}; // Basic facilities do nothing.
-      return { order: "maintain" }; // Special facilities are considered to have been issued the maintain order.
+      const updates = { "system.progress.order": "" };
+      if ( performUpdates ) await facility.update(updates);
+      if ( type.value === "basic" ) return { updates }; // Basic facilities do nothing.
+      return { order: "maintain", updates }; // Special facilities are considered to have been issued the maintain order.
+    }
+
+    // Calculate duration if automatic
+    if ( !duration && progress.updated ) {
+      const days = CalendarData5e.dayDifference(
+        game.time.calendar.timeToComponents(progress.updated),
+        game.time.components
+      );
+      if ( days > 0 ) duration = days;
     }
 
     const newProgress = Math.min(progress.value + duration, progress.max);
 
     // Case 2 - Order incomplete. Ongoing progress.
     if ( (newProgress < progress.max) && !disabled ) {
-      await facility.update({ "system.progress.value": newProgress });
-      return {};
+      const updates = { "system.progress": { value: newProgress, updated: game.time.worldTime } };
+      if ( performUpdates ) await facility.update(updates);
+      return { updates };
     }
 
     // Case 3 - Order complete.
-    const updates = { "system.progress": { value: 0, max: null, order: "" } };
+    const updates = { "system.progress": { value: 0, max: null, order: "", updated: null } };
     const { gold, items } = this.#evaluateOrder(facility, progress.order, updates);
-    await facility.update(updates);
-    return { gold, items, order: progress.order };
+    if ( performUpdates ) await facility.update(updates);
+    return { gold, items, order: progress.order, updates };
   }
 
   /* -------------------------------------------- */
@@ -114,7 +135,7 @@ export default class Bastion {
    * @param {Item5e} facility  The facility.
    * @param {string} order     The order that was completed.
    * @param {object} updates   Facility updates.
-   * @returns {Omit<BastionTurnResult, "order">}
+   * @returns {Omit<BastionTurnResult, "order"|"updates">}
    */
   #evaluateOrder(facility, order, updates) {
     switch ( order ) {
@@ -134,7 +155,7 @@ export default class Bastion {
    * Evaluate the completion of a build order.
    * @param {Item5e} facility  The facility.
    * @param {object} updates   Facility updates.
-   * @returns {Omit<BastionTurnResult, "order">}
+   * @returns {Omit<BastionTurnResult, "order"|"updates">}
    */
   #evaluateBuildOrder(facility, updates) {
     const { building } = facility.system;
@@ -149,7 +170,7 @@ export default class Bastion {
    * Evaluate the completion of a craft order.
    * @param {Item5e} facility          The facility.
    * @param {object} updates           Facility updates.
-   * @returns {Omit<BastionTurnResult, "order">}
+   * @returns {Omit<BastionTurnResult, "order"|"updates">}
    */
   #evaluateCraftOrder(facility, updates) {
     const { craft } = facility.system;
@@ -163,7 +184,7 @@ export default class Bastion {
    * Evaluate the completion of an enlarge order.
    * @param {Item5e} facility  The facility.
    * @param {object} updates   Facility updates.
-   * @returns {Omit<BastionTurnResult, "order">}
+   * @returns {Omit<BastionTurnResult, "order"|"updates">}
    */
   #evaluateEnlargeOrder(facility, updates) {
     const { size } = facility.system;
@@ -180,7 +201,7 @@ export default class Bastion {
    * Evaluate the completion of a harvest order.
    * @param {Item5e} facility  The facility.
    * @param {object} updates   Facility updates.
-   * @returns {Omit<BastionTurnResult, "order">}
+   * @returns {Omit<BastionTurnResult, "order"|"updates">}
    */
   #evaluateHarvestOrder(facility, updates) {
     const { craft } = facility.system;
@@ -193,7 +214,7 @@ export default class Bastion {
    * Evaluate the completion of a repair order.
    * @param {Item5e} facility  The facility.
    * @param {object} updates   Facility updates.
-   * @returns {Omit<BastionTurnResult, "order">}
+   * @returns {Omit<BastionTurnResult, "order"|"updates">}
    */
   #evaluateRepairOrder(facility, updates) {
     updates["system.disabled"] = false;
@@ -206,7 +227,7 @@ export default class Bastion {
    * Evaluate the completion of a trade order.
    * @param {Item5e} facility  The facility.
    * @param {object} updates   Facility updates.
-   * @returns {Omit<BastionTurnResult, "order">}
+   * @returns {Omit<BastionTurnResult, "order"|"updates">}
    */
   #evaluateTradeOrder(facility, updates) {
     const { trade } = facility.system;

--- a/module/documents/actor/bastion.mjs
+++ b/module/documents/actor/bastion.mjs
@@ -77,8 +77,18 @@ export default class Bastion {
   async advanceTurn(facility, { duration=7, performUpdates=true }={}) {
     const { disabled, progress, type } = facility.system;
 
+    // Case 0 - Facility damaged. A shut-down facility can't be used for one bastion turn, after which it is repaired
+    // and made operational again at no cost. Any order in progress is paused rather than canceled.
+    if ( disabled ) {
+      const updates = { "system.disabled": false };
+      // Bump the timestamp so the shut-down turn isn't later credited as progress under calendar advancement.
+      if ( progress.max ) updates["system.progress.updated"] = game.time.worldTime;
+      if ( performUpdates ) await facility.update(updates);
+      return { order: "repair", updates };
+    }
+
     // Case 1 - No order in progress.
-    if ( !progress.max && !disabled ) {
+    if ( !progress.max ) {
       const updates = { "system.progress.order": "" };
       if ( performUpdates ) await facility.update(updates);
       if ( type.value === "basic" ) return { updates }; // Basic facilities do nothing.
@@ -97,7 +107,7 @@ export default class Bastion {
     const newProgress = Math.min(progress.value + duration, progress.max);
 
     // Case 2 - Order incomplete. Ongoing progress.
-    if ( (newProgress < progress.max) && !disabled ) {
+    if ( newProgress < progress.max ) {
       const updates = { "system.progress": { value: newProgress, updated: game.time.worldTime } };
       if ( performUpdates ) await facility.update(updates);
       return { updates };
@@ -143,7 +153,6 @@ export default class Bastion {
       case "craft": return this.#evaluateCraftOrder(facility, updates);
       case "enlarge": return this.#evaluateEnlargeOrder(facility, updates);
       case "harvest": return this.#evaluateHarvestOrder(facility, updates);
-      case "repair": return this.#evaluateRepairOrder(facility, updates);
       case "trade": return this.#evaluateTradeOrder(facility, updates);
     }
     return {};
@@ -206,19 +215,6 @@ export default class Bastion {
   #evaluateHarvestOrder(facility, updates) {
     const { craft } = facility.system;
     return { items: [{ uuid: craft.item, quantity: craft.quantity }] };
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Evaluate the completion of a repair order.
-   * @param {Item5e} facility  The facility.
-   * @param {object} updates   Facility updates.
-   * @returns {Omit<BastionTurnResult, "order"|"updates">}
-   */
-  #evaluateRepairOrder(facility, updates) {
-    updates["system.disabled"] = false;
-    return {};
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/bastion.mjs
+++ b/module/documents/actor/bastion.mjs
@@ -1,6 +1,6 @@
-import CalendarData5e from "../../data/calendar/calendar-data.mjs";
 import BastionAttackDialog from "../../applications/actor/bastion-attack-dialog.mjs";
 import BastionAttackMessageData from "../../data/chat-message/bastion-attack-message-data.mjs";
+import { formatTime } from "../../utils.mjs";
 
 /**
  * @import { BastionTurnResult } from "../_types.mjs";
@@ -20,8 +20,7 @@ export default class Bastion {
    * @returns {Promise<void>}
    */
   async advanceAllBastions() {
-    // TODO: Should this advance game.time?
-    const { duration } = game.settings.get("dnd5e", "bastionConfiguration");
+    const duration = dnd5e.settings.calendarConfig.enabled ? 0 : dnd5e.settings.bastionConfiguration.duration;
     const haveBastions = game.actors.filter(a => a.system.isCharacter && a.itemTypes.facility.length);
     for ( const actor of haveBastions ) await this.advanceAllFacilities(actor, { duration });
   }
@@ -32,17 +31,20 @@ export default class Bastion {
    * Advance all the facilities of a given Actor by one bastion turn.
    * @param {Actor5e} actor                          The actor.
    * @param {object} [options]
-   * @param {number|null} [options.duration=7]       The number of days the bastion turn spanned or `null` for auto.
+   * @param {number} [options.duration=7]            The number of days the bastion turn spanned.
    * @param {boolean} [options.performUpdates=true]  Update the actor's facilities.
    * @param {boolean|"auto"} [options.summary=true]  Print a chat message summary of the turn. If set to "auto" then
    *                                                 the message will only be created if an order is completed.
+   * @param {boolean} [options.turn=true]            Trigger events like recovery that are tied to turns, not days.
    * @returns {Promise<{ [message]: ChatMessage5e, updates: object[] }>}
    */
-  async advanceAllFacilities(actor, { duration=7, performUpdates=true, summary=true }={}) {
+  async advanceAllFacilities(actor, { duration=7, performUpdates=true, summary=true, turn=true }={}) {
     const results = { orders: [], items: [], gold: 0 };
     const itemUpdates = [];
     for ( const facility of actor.itemTypes.facility ) {
-      const { order, gold, items, updates } = await this.advanceTurn(facility, { duration, performUpdates: false });
+      const { order, gold, items, updates } = await this.advanceTurn(facility, {
+        duration, turn, performUpdates: false
+      });
       if ( !foundry.utils.isEmpty(updates) ) itemUpdates.push({ _id: facility.id, ...updates });
       if ( !order || (order === "maintain") ) continue;
       if ( gold ) results.gold += gold;
@@ -70,51 +72,42 @@ export default class Bastion {
    * Advance the given facility by one bastion turn.
    * @param {Item5e} facility                        The facility.
    * @param {object} [options]
-   * @param {number|null} [options.duration=7]       The number of days the bastion turn spanned or `null` for auto.
+   * @param {number} [options.duration=7]            The number of days the bastion turn spanned.
    * @param {boolean} [options.performUpdates=true]  Update the facility.
+   * @param {boolean} [options.turn=true]            Trigger events like recovery that are tied to turns, not days.
    * @returns {Promise<BastionTurnResult>}
    */
-  async advanceTurn(facility, { duration=7, performUpdates=true }={}) {
+  async advanceTurn(facility, { duration=7, performUpdates=true, turn=true }={}) {
     const { disabled, progress, type } = facility.system;
 
     // Case 0 - Facility damaged. A shut-down facility can't be used for one bastion turn, after which it is repaired
     // and made operational again at no cost. Any order in progress is paused rather than canceled.
     if ( disabled ) {
+      if ( !turn ) return { updates: {} };
       const updates = { "system.disabled": false };
-      // Bump the timestamp so the shut-down turn isn't later credited as progress under calendar advancement.
-      if ( progress.max ) updates["system.progress.updated"] = game.time.worldTime;
       if ( performUpdates ) await facility.update(updates);
       return { order: "repair", updates };
     }
 
     // Case 1 - No order in progress.
     if ( !progress.max ) {
-      const updates = { "system.progress.order": "" };
+      const updates = progress.order ? { "system.progress.order": "" } : {};
       if ( performUpdates ) await facility.update(updates);
       if ( type.value === "basic" ) return { updates }; // Basic facilities do nothing.
       return { order: "maintain", updates }; // Special facilities are considered to have been issued the maintain order.
-    }
-
-    // Calculate duration if automatic
-    if ( !duration && progress.updated ) {
-      const days = CalendarData5e.dayDifference(
-        game.time.calendar.timeToComponents(progress.updated),
-        game.time.components
-      );
-      if ( days > 0 ) duration = days;
     }
 
     const newProgress = Math.min(progress.value + duration, progress.max);
 
     // Case 2 - Order incomplete. Ongoing progress.
     if ( newProgress < progress.max ) {
-      const updates = { "system.progress": { value: newProgress, updated: game.time.worldTime } };
+      const updates = { "system.progress": { value: newProgress } };
       if ( performUpdates ) await facility.update(updates);
       return { updates };
     }
 
     // Case 3 - Order complete.
-    const updates = { "system.progress": { value: 0, max: null, order: "", updated: null } };
+    const updates = { "system.progress": { value: 0, max: null, order: "" } };
     const { gold, items } = this.#evaluateOrder(facility, progress.order, updates);
     if ( performUpdates ) await facility.update(updates);
     return { gold, items, order: progress.order, updates };
@@ -267,10 +260,13 @@ export default class Bastion {
    */
   async confirmAdvance() {
     if ( !game.user.isGM ) return;
+    const mode = dnd5e.settings.calendarConfig.enabled ? "Maintain" : "Advance";
     const proceed = await foundry.applications.api.DialogV2.confirm({
-      content: _loc("DND5E.Bastion.Confirm"),
+      content: _loc(`DND5E.Bastion.Confirm.${mode}`, {
+        duration: formatTime(dnd5e.settings.bastionConfiguration.duration, "day")
+      }),
       rejectClose: false,
-      window: { icon: "fa-solid fa-chess-rook", title: "DND5E.Bastion.Action.BastionTurn" }
+      window: { icon: "fa-solid fa-chess-rook", title: `DND5E.Bastion.Action.${mode}` }
     });
     if ( proceed ) return this.advanceAllBastions();
   }
@@ -289,11 +285,14 @@ export default class Bastion {
       return;
     }
 
-    if ( !turnButton ) {
+    const mode = dnd5e.settings.calendarConfig.enabled ? "Maintain" : "Advance";
+    if ( turnButton ) {
+      turnButton.querySelector("span").innerText = _loc(`DND5E.Bastion.Action.${mode}`);
+    } else {
       document.querySelector("#controls, #scene-controls")?.insertAdjacentHTML("afterend", `
         <button type="button" id="bastion-turn" data-action="bastionTurn" class="dnd5e2 faded-ui">
-          <i class="fas fa-chess-rook"></i>
-          <span>${_loc("DND5E.Bastion.Action.BastionTurn")}</span>
+          <i class="fas fa-chess-rook" inert></i>
+          <span>${_loc(`DND5E.Bastion.Action.${mode}`)}</span>
         </button>
       `);
       document.getElementById("bastion-turn")?.addEventListener("click", this.confirmAdvance.bind(this));

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -321,7 +321,10 @@ export function registerSystemSettings() {
     scope: "world",
     config: false,
     type: CalendarConfigSetting,
-    onChange: () => dnd5e.ui.calendar?.onUpdateSettings?.()
+    onChange: () => {
+      dnd5e.bastion.initializeUI();
+      dnd5e.ui.calendar?.onUpdateSettings?.();
+    }
   });
 
   game.settings.register("dnd5e", "calendarPreferences", {


### PR DESCRIPTION
Automatically advance bastion orders based on when new days occur using the built-in calendar. Allows orders to complete without needing a bastion turn to be triggered. Each facility with an order in progress stores the time it was last updated and that is used to advance or complete the order when time passes.

 ### Todo
- [ ] Prompt for bastion turns on regular interval