### PR TITLE
Feature: Add "Available (No Cantrips)" option to Item Choice Advancement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -518,7 +518,8 @@
       },
       "restriction": {
         "level": {
-          "Available": "Any Available Level",
+          "Available": "Any Available Level (Including Cantrips)",
+          "AvailableNoCantrips": "Any Available Level (Excluding Cantrips)",
           "hint": "Only allow choices from spells of this level.",
           "label": "Spell Level"
         },

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -64,6 +64,10 @@ export default class ItemChoiceConfig extends AdvancementConfig {
         value: "available",
         label: _loc("DND5E.ADVANCEMENT.ItemChoice.FIELDS.restriction.level.Available")
       },
+      {
+        value: "availableNoCantrips",
+        label: _loc("DND5E.ADVANCEMENT.ItemChoice.FIELDS.restriction.level.AvailableNoCantrips")
+      },
       { rule: true },
       ...Object.entries(CONFIG.DND5E.spellLevels).map(([value, label]) => ({ value, label }))
     ];

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -129,7 +129,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
 
     const spellLevel = config.restriction.level;
     const maxSlot = this._maxSpellSlotLevel();
-    const minSpellLevel = spellLevel === "availableNoCantrips" ? 1 : 0;
+    const minSlot = spellLevel === "availableNoCantrips" ? 1 : 0;
     const validateSpellLevel = (config.type === "spell") && ["available", "availableNoCantrips"].includes(spellLevel);
 
     const added = [];
@@ -154,7 +154,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
           this.advancement.actor, { added, removed, level: this.featureLevel }
         ) === true);
         const validSpell = !validateSpellLevel
-          || ((item.system.level <= maxSlot) && (item.system.level >= minSpellLevel));
+          || ((item.system.level >= minSlot) && (item.system.level <= maxSlot));
         if ( validFeature && validSpell ) {
           const data = {
             id, img, name, uuid,
@@ -347,8 +347,8 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     const spellLevel = this.advancement.configuration.restriction.level;
     if ( (this.advancement.configuration.type === "spell") && ["available", "availableNoCantrips"].includes(spellLevel) ) {
       const maxSlot = this._maxSpellSlotLevel();
-      const minLevel = spellLevel === "availableNoCantrips" ? 1 : 0;
-      if ( (item.system.level > maxSlot) || (item.system.level < minLevel) ) {
+      const minSlot = spellLevel === "availableNoCantrips" ? 1 : 0;
+      if ( (item.system.level < minSlot) || (item.system.level > maxSlot) ) {
         ui.notifications.error("DND5E.ADVANCEMENT.ItemChoice.Warning.SpellLevelAvailable", {
           format: { level: CONFIG.DND5E.spellLevels[maxSlot] }
         });

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -129,7 +129,8 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
 
     const spellLevel = config.restriction.level;
     const maxSlot = this._maxSpellSlotLevel();
-    const validateSpellLevel = (config.type === "spell") && (spellLevel === "available");
+    const minSpellLevel = spellLevel === "availableNoCantrips" ? 1 : 0;
+    const validateSpellLevel = (config.type === "spell") && ["available", "availableNoCantrips"].includes(spellLevel);
 
     const added = [];
     const dropped = [];
@@ -152,7 +153,8 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
         const validFeature = !item.system.validatePrerequisites || (item.system.validatePrerequisites(
           this.advancement.actor, { added, removed, level: this.featureLevel }
         ) === true);
-        const validSpell = !validateSpellLevel || (item.system.level <= maxSlot);
+        const validSpell = !validateSpellLevel
+          || ((item.system.level <= maxSlot) && (item.system.level >= minSpellLevel));
         if ( validFeature && validSpell ) {
           const data = {
             id, img, name, uuid,
@@ -248,6 +250,8 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     } else if ( (config.type === "spell") && (config.restriction.level !== "") ) {
       if ( config.restriction.level === "available" ) {
         filters.locked.additional.level = { max: this._maxSpellSlotLevel() };
+      } else if ( config.restriction.level === "availableNoCantrips" ) {
+        filters.locked.additional.level = { min: 1, max: this._maxSpellSlotLevel() };
       } else {
         filters.locked.additional.level = {
           min: Number(config.restriction.level),
@@ -341,9 +345,10 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
 
     // If spell level is restricted to available level, ensure the spell is of the appropriate level
     const spellLevel = this.advancement.configuration.restriction.level;
-    if ( (this.advancement.configuration.type === "spell") && spellLevel === "available" ) {
+    if ( (this.advancement.configuration.type === "spell") && ["available", "availableNoCantrips"].includes(spellLevel) ) {
       const maxSlot = this._maxSpellSlotLevel();
-      if ( item.system.level > maxSlot ) {
+      const minLevel = spellLevel === "availableNoCantrips" ? 1 : 0;
+      if ( (item.system.level > maxSlot) || (item.system.level < minLevel) ) {
         ui.notifications.error("DND5E.ADVANCEMENT.ItemChoice.Warning.SpellLevelAvailable", {
           format: { level: CONFIG.DND5E.spellLevels[maxSlot] }
         });


### PR DESCRIPTION
This PR adds a new option Available (No Cantrips) (availableNoCantrips) to the Spell Level restriction in the Item Choice Advancement configuration.

Currently, the Available option allows players to choose spells of any level for which they have spell slots, but this includes Cantrips (0-level spells). There are cases (e.g., specific feats or class features) where a player should be allowed to choose from any leveled spell they can cast, but not Cantrips. This new option fills that gap.