### PR TITLE
[#6610] Add `data-no-toc` to header elements of npc stat block embeds

### DIFF
--- a/templates/actors/embeds/npc-embed.hbs
+++ b/templates/actors/embeds/npc-embed.hbs
@@ -1,5 +1,5 @@
 <div class="statblock npc rules-{{ rulesVersion }}">
-    <h4 class="statblock-title">{{#if anchor}}{{{ anchor }}}{{else}}{{ name }}{{/if}}</h4>
+    <h4 class="statblock-title" data-no-toc>{{#if anchor}}{{{ anchor }}}{{else}}{{ name }}{{/if}}</h4>
     <span class="statblock-tags">{{ summary.tag }}</span>
     <div class="statblock-content">
         <div class="statblock-header">
@@ -39,7 +39,7 @@
         </div>
         {{#each actionSections}}
         <div class="statblock-actions {{ @key }}">
-            {{#unless hideLabel}}<h5 class="statblock-actions-title">{{ label }}</h5>{{/unless}}
+            {{#unless hideLabel}}<h5 class="statblock-actions-title" data-no-toc>{{ label }}</h5>{{/unless}}
             {{{ description }}}
             {{#each actions}}
             <div class="statblock-action" {{ dnd5e-dataset dataset }}>


### PR DESCRIPTION
Using a text page with title disabled and nothing but an embed...

Before:

<img width="343" height="281" alt="image" src="https://github.com/user-attachments/assets/b15f16b9-5337-40be-b05a-a8d664b86d75" />

After:

<img width="358" height="418" alt="image" src="https://github.com/user-attachments/assets/a1177b8c-d976-42f4-ad71-360dd118bf6b" />
