### PR TITLE
[#6633] Use `<formula-input>` for `FormulaField`

### DIFF
--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -404,6 +404,8 @@
       padding-right: 20px;
     }
 
+    &.split-group .form-group.formula-input { flex: 1 1 min-content; }
+
     /* Full-Width Groups */
     &.full-width {
       padding: 6px;
@@ -460,9 +462,10 @@
   }
 
   formula-input {
+    overflow: hidden;
     &:focus-within { outline: none; }
     &:enabled {
-      &:has(> input:focus-visible, > input:hover) {
+      &:focus-within, &:hover {
         border-color: var(--input-hover-border-color);
         box-shadow: 0 0 6px var(--dnd5e-color-gold);
       }
@@ -480,6 +483,7 @@
     > button {
       background: none;
       box-shadow: none;
+      color: var(--formula-input-icon-color);
     }
   }
 

--- a/less/variables/dark.less
+++ b/less/variables/dark.less
@@ -139,6 +139,7 @@
   --multi-select-tag-background: var(--dnd5e-color-blue-gray-2);
   --multi-select-tag-border: var(--dnd5e-color-blue-gray-1);
   --radio-list-hover: var(--dnd5e-background-25);
+  --formula-input-icon-color: var(--dnd5e-color-gold);
 
   button {
     --button-border-color: var(--dnd5e-color-blue-gray-1);

--- a/less/variables/light.less
+++ b/less/variables/light.less
@@ -135,6 +135,7 @@
   --multi-select-tag-background: var(--dnd5e-color-card);
   --multi-select-tag-border: var(--dnd5e-color-gold);
   --radio-list-hover: var(--dnd5e-color-parchment);
+  --formula-input-icon-color: var(--color-text-primary);
 
   button {
     --button-border-color: var(--color-border-light-2);

--- a/module/applications/api/application-v2-mixin.mjs
+++ b/module/applications/api/application-v2-mixin.mjs
@@ -233,7 +233,8 @@ export default function ApplicationV2Mixin(Base) {
     _disableFields() {
       const selector = `.window-content :is(${[
         "INPUT", "SELECT", "TEXTAREA", "BUTTON", "DND5E-CHECKBOX", "COLOR-PICKER", "DOCUMENT-TAGS",
-        "FILE-PICKER", "HUE-SLIDER", "MULTI-SELECT", "PROSE-MIRROR", "RANGE-PICKER", "STRING-TAGS"
+        "FILE-PICKER", "HUE-SLIDER", "MULTI-SELECT", "PROSE-MIRROR", "RANGE-PICKER", "STRING-TAGS",
+        "FORMULA-INPUT"
       ].join(", ")}):not(.always-interactive)`;
       for ( const element of this.element.querySelectorAll(selector) ) {
         if ( element.closest("prose-mirror[open]") ) continue; // Skip active ProseMirror editors

--- a/module/data/fields/formula-field.mjs
+++ b/module/data/fields/formula-field.mjs
@@ -32,6 +32,15 @@ export default class FormulaField extends foundry.data.fields.StringField {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  toFormGroup(groupConfig={}, inputConfig={}) {
+    groupConfig.classes ||= [];
+    groupConfig.classes.push("formula-input");
+    return super.toFormGroup(groupConfig, inputConfig);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   _toInput(config) {
     const input = super._toInput(config);
     if ( (input.tagName !== "INPUT") || (game.release.generation < 14) ) return input;


### PR DESCRIPTION
`FormulaField` will automatically produce a `<formula-input>` unless it has choices set. Also styled `<formula-input>` to match the system's form styling.

<img width="486" height="94" alt="Formula Input" src="https://github.com/user-attachments/assets/a3b1949b-3428-437b-bfdf-9ea688e0ab56" />

Closes #6633