### PR TITLE
[#6656] Add `CONFIG.DND5E.defaultCurrency` to replace GP assumption

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2110,6 +2110,14 @@ preLocalize("currencies", { keys: ["label", "abbreviation"] });
 /* -------------------------------------------- */
 
 /**
+ * Default currency used for data model defaults, starting wealth, and facility prices.
+ * @enum {string}
+ */
+DND5E.defaultCurrency = "gp";
+
+/* -------------------------------------------- */
+
+/**
  * Configuration data for crafting costs.
  * @type {CraftingConfiguration}
  */

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -75,7 +75,7 @@ export default class NPCData extends CreatureTemplate {
         }, { label: "DND5E.DeathSave" }),
         price: new SchemaField({
           value: new NumberField({ initial: null, min: 0 }),
-          denomination: new StringField({ required: true, blank: false, initial: "gp" })
+          denomination: new StringField({ required: true, blank: false, initial: () => CONFIG.DND5E.defaultCurrency })
         }),
         spell: new SchemaField({
           level: new NumberField({

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -86,7 +86,9 @@ export default class VehicleData extends CommonTemplate {
         }, { label: "DND5E.VEHICLE.FIELDS.attributes.capacity.label" }),
         price: new SchemaField({
           value: new NumberField({ initial: null, min: 0, label: "DND5E.Price" }),
-          denomination: new StringField({ required: true, blank: false, initial: "gp", label: "DND5E.Currency" })
+          denomination: new StringField({
+            required: true, blank: false, initial: () => CONFIG.DND5E.defaultCurrency, label: "DND5E.Currency"
+          })
         }, { label: "DND5E.Price" }),
         quality: new SchemaField({
           value: new NumberField({ required: true, nullable: false, integer: true, min: -10, max: 10, initial: 4 })

--- a/module/data/chat-message/bastion-turn-message-data.mjs
+++ b/module/data/chat-message/bastion-turn-message-data.mjs
@@ -135,9 +135,9 @@ export default class BastionTurnMessageData extends ChatMessageDataModel {
    * @param {HTMLElement} target  Button that was clicked.
    */
   static async #onClaimGold(event, target) {
-    const { gp } = this.actor?.system.currency ?? {};
+    const gp = this.actor?.system.currency?.[CONFIG.DND5E.defaultCurrency];
     if ( !this.gold.value || this.gold.claimed || (gp === undefined) ) return;
-    await this.actor.update({ "system.currency.gp": gp + this.gold.value });
+    await this.actor.update({ [`system.currency.${CONFIG.DND5E.defaultCurrency}`]: gp + this.gold.value });
     this.parent.update({ "system.gold.claimed": true });
   }
 

--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -162,7 +162,7 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
     // Price
     if ( this.type.value === "basic" ) {
       const { value, days } = CONFIG.DND5E.facilities.sizes[this.size];
-      this.price = { value, days, denomination: "gp" };
+      this.price = { value, days, denomination: CONFIG.DND5E.defaultCurrency };
     }
 
     // Squares
@@ -203,6 +203,7 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
       { label: this.type.label },
       { label: CONFIG.DND5E.facilities.sizes[this.size].label }
     ];
+    context.currency = { ...CONFIG.DND5E.currencies[CONFIG.DND5E.defaultCurrency], key: CONFIG.DND5E.defaultCurrency };
 
     context.parts = ["dnd5e.details-facility"];
     context.facilitySubtypes = CONFIG.DND5E.facilities.types[this.type.value]?.subtypes ?? {};

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -36,7 +36,7 @@ export default class PhysicalItemTemplate extends SystemDataModel {
           required: true, nullable: false, initial: 0, min: 0, label: "DND5E.Price"
         }),
         denomination: new StringField({
-          required: true, blank: false, initial: "gp", label: "DND5E.Currency"
+          required: true, blank: false, initial: () => CONFIG.DND5E.defaultCurrency, label: "DND5E.Currency"
         })
       }, { label: "DND5E.Price" }),
       rarity: new StringField({ required: true, blank: true, label: "DND5E.Rarity" })
@@ -184,12 +184,12 @@ export default class PhysicalItemTemplate extends SystemDataModel {
    * Prepare physical item properties.
    */
   preparePhysicalData() {
-    if ( !("gp" in CONFIG.DND5E.currencies) ) return;
+    if ( !(CONFIG.DND5E.defaultCurrency in CONFIG.DND5E.currencies) ) return;
     const { value, denomination } = this.price;
     const { conversion } = CONFIG.DND5E.currencies[denomination] ?? {};
-    const { gp } = CONFIG.DND5E.currencies;
+    const defaultCurrency = CONFIG.DND5E.currencies[CONFIG.DND5E.defaultCurrency];
     if ( conversion ) {
-      const multiplier = gp.conversion / conversion;
+      const multiplier = defaultCurrency.conversion / conversion;
       this.price.valueInGP = Math.floor(value * multiplier);
     }
   }

--- a/module/data/item/templates/starting-equipment.mjs
+++ b/module/data/item/templates/starting-equipment.mjs
@@ -61,7 +61,9 @@ export default class StartingEquipmentTemplate extends SystemDataModel {
       || (!this.source.rules && (dnd5e.settings.rulesVersion === "modern"));
     if ( modernStyle ) {
       const entries = topLevel[0].type === "OR" ? topLevel[0].children : topLevel;
-      if ( this.wealth ) entries.push(new EquipmentEntryData({ type: "currency", key: "gp", count: this.wealth }));
+      if ( this.wealth ) entries.push(new EquipmentEntryData({
+        type: "currency", key: CONFIG.DND5E.defaultCurrency, count: this.wealth
+      }));
       if ( entries.length > 1 ) {
         const usedPrefixes = [];
         const choices = EquipmentEntryData.prefixOrEntries(

--- a/module/documents/activity/order.mjs
+++ b/module/documents/activity/order.mjs
@@ -242,7 +242,7 @@ export default class OrderActivity extends ActivityMixin(BaseOrderActivityData) 
     if ( trade?.stock?.value && trade.sell ) supplements.push(`
       <strong>${game.i18n.localize("DND5E.FACILITY.Trade.Sell.Supplement")}</strong>
       ${formatNumber(trade.stock.value)}
-      ${CONFIG.DND5E.currencies.gp?.abbreviation ?? ""}
+      ${CONFIG.DND5E.currencies[CONFIG.DND5E.defaultCurrency]?.abbreviation ?? ""}
     `);
     if ( trade?.creatures ) {
       const creatures = [];
@@ -289,7 +289,7 @@ export default class OrderActivity extends ActivityMixin(BaseOrderActivityData) 
     const config = foundry.utils.expandObject({ "data.flags.dnd5e.order": order });
     if ( method === "automatic" ) {
       try {
-        await CurrencyManager.deductActorCurrency(this.actor, order.costs.gold, "gp", {
+        await CurrencyManager.deductActorCurrency(this.actor, order.costs.gold, CONFIG.DND5E.defaultCurrency, {
           recursive: true,
           priority: "high"
         });

--- a/templates/items/header.hbs
+++ b/templates/items/header.hbs
@@ -93,7 +93,7 @@
         {{#if (eq system.type.value "basic")}}
         <div class="price">
             <span class="value">{{ dnd5e-numberFormat system.price.value }}</span>
-            <i class="currency gp" aria-label="{{ CONFIG.currencies.gp.label }}"></i>
+            <i class="currency {{ currency.key }}" aria-label="{{ currency.label }}"></i>
         </div>
         {{/if}}
         {{/if}}


### PR DESCRIPTION
Adds `CONFIG.DND5E.defaultCurrency` that modules can override when they remove `gp` from the currency config to avoid breaking parts of the system that previously assumed `gp` was always available.

Closes #6656