### PR TITLE
[#6121, #6646] Add support for multiple AC formulas

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -826,22 +826,74 @@
   }
 },
 "DND5E.Armor": "Armor",
+
+"DND5E.ARMORCLASS": {
+  "Action": {
+    "Configure": "Configure Armor",
+    "CreateFormula": "Create Custom Formula",
+    "DeleteFormula": "Delete Custom Formula"
+  },
+  "Calculation": {
+    "Armored": "Equipped Armor",
+    "Draconic": "Draconic Resilience",
+    "Label": "Calculation",
+    "Mage": "Mage Armor",
+    "Natural": "Natural Armor",
+    "Unarmored": "Unarmored",
+    "UnarmoredBarbarian": "Unarmored Defense (Barbarian)",
+    "UnarmoredBard": "Unarmored Defense (Bard)",
+    "UnarmoredMonk": "Unarmored Defense (Monk)"
+  },
+  "Condition": {
+    "Positive": "Must have {type}",
+    "Negative": "Must not have {type}"
+  },
+  "Configuration": "Configuration",
+  "CurrentFormula": "Current Formula",
+  "CustomFormulas": {
+    "Empty": "No custom formulas. Use the <i class=\"fas fa-plus\"></i> button above to create one."
+  },
+  "FIELDS": {
+    "attributes": {
+      "ac": {
+        "flat": {
+          "hint": "Number that can be used in an armor class by using @attributes.ac.flat in the formula.",
+          "label": "Flat Value"
+        },
+        "formulas": {
+          "element": {
+            "armored": {
+              "label": "Armored"
+            },
+            "formula": {
+              "label": "Formula"
+            },
+            "label": {
+              "label": "Label"
+            },
+            "shielded": {
+              "label": "Shielded"
+            }
+          },
+          "label": "Formulas"
+        },
+        "label": "Armor Class",
+        "override": {
+          "hint": "Value that will be used in place of calulated armor class, ignoring cover, shield, and any other bonuses.",
+          "label": "Override"
+        },
+        "selectedFormulas": {
+          "hint": "These formulas will be used when calculating armor class.",
+          "label": "Selected Formulas"
+        }
+      }
+    }
+  },
+  "Flat": "Flat",
+  "Formula": "Formula"
+},
+
 "DND5E.ArmorClass": "Armor Class",
-"DND5E.ArmorClassEquipment": "Equipped Armor",
-"DND5E.ArmorClassFlat": "Flat",
-"DND5E.ArmorClassUnarmored": "Unarmored",
-"DND5E.ArmorClassNatural": "Natural Armor",
-"DND5E.ArmorClassMage": "Mage Armor",
-"DND5E.ArmorClassMotionless": "Armor Class while Motionless",
-"DND5E.ArmorClassDraconic": "Draconic Resilience",
-"DND5E.ArmorClassUnarmoredMonk": "Unarmored Defense (Monk)",
-"DND5E.ArmorClassUnarmoredBarbarian": "Unarmored Defense (Barbarian)",
-"DND5E.ArmorClassUnarmoredBard": "Unarmored Defense (Bard)",
-"DND5E.ArmorClassCustom": "Custom Formula",
-"DND5E.ArmorConfig": "Configure Armor",
-"DND5E.ArmorConfigHint": "Fill in the above box to override automatically calculated armor class.",
-"DND5E.ArmorClassCalculation": "Calculation",
-"DND5E.ArmorClassFormula": "Formula",
 "DND5E.ArmorHeavyProficiency": "Heavy",
 "DND5E.ArmorLightProficiency": "Light",
 "DND5E.ArmorMediumProficiency": "Medium",

--- a/lang/en.json
+++ b/lang/en.json
@@ -934,7 +934,9 @@
         "formulas": {
           "element": {
             "armored": {
-              "label": "Armored"
+              "excluded": "Not Armored",
+              "label": "Armored",
+              "required": "Armor Required"
             },
             "formula": {
               "label": "Formula"
@@ -943,7 +945,9 @@
               "label": "Label"
             },
             "shielded": {
-              "label": "Shielded"
+              "excluded": "No Shield",
+              "label": "Shielded",
+              "required": "Shield Required"
             }
           },
           "label": "Formulas"

--- a/lang/en.json
+++ b/lang/en.json
@@ -897,22 +897,74 @@
   }
 },
 "DND5E.Armor": "Armor",
+
+"DND5E.ARMORCLASS": {
+  "Action": {
+    "Configure": "Configure Armor",
+    "CreateFormula": "Create Custom Formula",
+    "DeleteFormula": "Delete Custom Formula"
+  },
+  "Calculation": {
+    "Armored": "Equipped Armor",
+    "Draconic": "Draconic Resilience",
+    "Label": "Calculation",
+    "Mage": "Mage Armor",
+    "Natural": "Natural Armor",
+    "Unarmored": "Unarmored",
+    "UnarmoredBarbarian": "Unarmored Defense (Barbarian)",
+    "UnarmoredBard": "Unarmored Defense (Bard)",
+    "UnarmoredMonk": "Unarmored Defense (Monk)"
+  },
+  "Condition": {
+    "Positive": "Must have {type}",
+    "Negative": "Must not have {type}"
+  },
+  "Configuration": "Configuration",
+  "CurrentFormula": "Current Formula",
+  "CustomFormulas": {
+    "Empty": "No custom formulas. Use the <i class=\"fas fa-plus\"></i> button above to create one."
+  },
+  "FIELDS": {
+    "attributes": {
+      "ac": {
+        "flat": {
+          "hint": "Number that can be used in an armor class by using @attributes.ac.flat in the formula.",
+          "label": "Flat Value"
+        },
+        "formulas": {
+          "element": {
+            "armored": {
+              "label": "Armored"
+            },
+            "formula": {
+              "label": "Formula"
+            },
+            "label": {
+              "label": "Label"
+            },
+            "shielded": {
+              "label": "Shielded"
+            }
+          },
+          "label": "Formulas"
+        },
+        "label": "Armor Class",
+        "override": {
+          "hint": "Value that will be used in place of calulated armor class, ignoring cover, shield, and any other bonuses.",
+          "label": "Override"
+        },
+        "selectedFormulas": {
+          "hint": "These formulas will be used when calculating armor class.",
+          "label": "Selected Formulas"
+        }
+      }
+    }
+  },
+  "Flat": "Flat",
+  "Formula": "Formula"
+},
+
 "DND5E.ArmorClass": "Armor Class",
-"DND5E.ArmorClassEquipment": "Equipped Armor",
-"DND5E.ArmorClassFlat": "Flat",
-"DND5E.ArmorClassUnarmored": "Unarmored",
-"DND5E.ArmorClassNatural": "Natural Armor",
-"DND5E.ArmorClassMage": "Mage Armor",
-"DND5E.ArmorClassMotionless": "Armor Class while Motionless",
-"DND5E.ArmorClassDraconic": "Draconic Resilience",
-"DND5E.ArmorClassUnarmoredMonk": "Unarmored Defense (Monk)",
-"DND5E.ArmorClassUnarmoredBarbarian": "Unarmored Defense (Barbarian)",
-"DND5E.ArmorClassUnarmoredBard": "Unarmored Defense (Bard)",
-"DND5E.ArmorClassCustom": "Custom Formula",
-"DND5E.ArmorConfig": "Configure Armor",
-"DND5E.ArmorConfigHint": "Fill in the above box to override automatically calculated armor class.",
-"DND5E.ArmorClassCalculation": "Calculation",
-"DND5E.ArmorClassFormula": "Formula",
 "DND5E.ArmorHeavyProficiency": "Heavy",
 "DND5E.ArmorLightProficiency": "Light",
 "DND5E.ArmorMediumProficiency": "Medium",

--- a/lang/en.json
+++ b/lang/en.json
@@ -950,7 +950,7 @@
         },
         "label": "Armor Class",
         "override": {
-          "hint": "Value that will be used in place of calulated armor class, ignoring cover, shield, and any other bonuses.",
+          "hint": "Value that will be used in place of calculated armor class, ignoring cover, shield, and any other bonuses.",
           "label": "Override"
         },
         "selectedFormulas": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -906,6 +906,7 @@
   },
   "Calculation": {
     "Armored": "Equipped Armor",
+    "Custom": "Custom",
     "Draconic": "Draconic Resilience",
     "Label": "Calculation",
     "Mage": "Mage Armor",

--- a/less/v2/tooltips.less
+++ b/less/v2/tooltips.less
@@ -266,7 +266,7 @@
       border-top: 1px solid var(--dnd5e-color-tan);
     }
     td.attribution-value {
-      width: 20%;
+      inline-size: 5ch;
       padding-right: 5px;
       text-align: right;
       font-weight: 600;

--- a/module/applications/actor/config/armor-class-config.mjs
+++ b/module/applications/actor/config/armor-class-config.mjs
@@ -1,12 +1,18 @@
 import { formatNumber, simplifyBonus } from "../../../utils.mjs";
 import BaseConfigSheet from "../api/base-config-sheet.mjs";
 
+const { StringField } = foundry.data.fields;
+
 /**
  * Configuration application for armor class calculation.
  */
 export default class ArmorClassConfig extends BaseConfigSheet {
   /** @override */
   static DEFAULT_OPTIONS = {
+    actions: {
+      addFormula: ArmorClassConfig.#onAddFormula,
+      deleteFormula: ArmorClassConfig.#onDeleteFormula
+    },
     classes: ["armor-class"],
     position: {
       width: 420
@@ -17,6 +23,9 @@ export default class ArmorClassConfig extends BaseConfigSheet {
 
   /** @override */
   static PARTS = {
+    calculation: {
+      template: "systems/dnd5e/templates/actors/config/armor-class-calculation.hbs"
+    },
     config: {
       template: "systems/dnd5e/templates/actors/config/armor-class-config.hbs"
     }
@@ -36,30 +45,46 @@ export default class ArmorClassConfig extends BaseConfigSheet {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  async _prepareContext(options) {
+    return {
+      ...await super._prepareContext(options),
+      data: this.document.system.attributes.ac,
+      fields: this.document.system.schema.fields.attributes.fields.ac.fields,
+      source: this.document.system._source.attributes.ac
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   async _preparePartContext(partId, context, options) {
     context = await super._preparePartContext(partId, context, options);
-    context.data = this.document.system.attributes.ac;
-    context.fields = this.document.system.schema.fields.attributes.fields.ac.fields;
-    context.source = this.document.system._source.attributes.ac;
+    switch ( partId ) {
+      case "calculation": return this._prepareCalculationContext(context, options);
+      case "config": return this._prepareConfigurationContext(context, options);
+    }
+    return context;
+  }
 
-    context.calculationOptions = Object.entries(CONFIG.DND5E.armorClasses).reduce((arr, [value, config]) => {
-      if ( value === "custom" ) arr.push({ rule: true });
-      arr.push({ value, label: config.label });
-      if ( value === "natural" ) arr.push({ rule: true });
-      return arr;
-    }, []);
+  /* -------------------------------------------- */
 
-    const config = CONFIG.DND5E.armorClasses[context.source.calc];
-    context.formula = {
-      disabled: context.source.calc !== "custom",
-      showFlat: ["flat", "natural"].includes(context.source.calc),
-      value: (context.source.calc === "custom" ? context.source.formula : config?.formula) ?? ""
-    };
-
-    if ( context.formula.value.includes("@attributes.ac.dex") ) context.dexterity = context.data.dex;
+  /**
+   * Prepare rendering context for the calculation section.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {ApplicationRenderContext}
+   * @protected
+   */
+  async _prepareCalculationContext(context, options) {
+    if ( context.data.formula.includes("@attributes.ac.dex") ) {
+      context.ability = { label: CONFIG.DND5E.abilities.dex?.label, value: context.data.dex };
+    } else if ( context.data.formula.includes("@attributes.ac.clamped.") ) {
+      const ability = context.data.formula.match(/@attributes\.ac\.clamped\.([a-zA-Z]+)/);
+      context.ability = { label: CONFIG.DND5E.abilities[ability[1]]?.label, value: context.data.clamped[ability[1]] };
+    }
 
     context.calculations = [];
-    if ( context.formula.value.includes("@attributes.ac.armor") ) {
+    if ( context.data.formula.includes("@attributes.ac.armor") ) {
       for ( const key of ["armor", "shield"] ) {
         const item = context.data[`equipped${key.capitalize()}`];
         if ( !item ) continue;
@@ -74,7 +99,7 @@ export default class ArmorClassConfig extends BaseConfigSheet {
         });
       }
     }
-    if ( context.source.calc !== "flat" ) {
+    if ( !context.data.override ) {
       for ( const bonus of this.document._prepareActiveEffectAttributions("system.attributes.ac.bonus") ) {
         if ( bonus.mode !== CONST.ACTIVE_EFFECT_MODES.ADD ) continue;
         context.calculations.push({
@@ -87,6 +112,55 @@ export default class ArmorClassConfig extends BaseConfigSheet {
       }
     }
 
+    context.formulaLabel = context.data.activeFormula?.label ?? context.data.label;
+
     return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the configuration section.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {ApplicationRenderContext}
+   * @protected
+   */
+  async _prepareConfigurationContext(context, options) {
+    context.customFormulas = (context.source.formulas ?? []).map((source, index) => ({
+      source, fields: context.fields.formulas.element.fields
+    }));
+    context.formulaOptions = Object.entries(CONFIG.DND5E.armorClasses).map(([value, { label }]) => ({ value, label }));
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle adding a new custom formula.
+   * @this {ArmorClassConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #onAddFormula(event, target) {
+    this.document.update({
+      "system.attributes.ac.formulas": [...(this.document.system.toObject().attributes.ac.formulas ?? []), {}]
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle removing a custom formula.
+   * @this {ArmorClassConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #onDeleteFormula(event, target) {
+    const formulas = this.document.system.toObject().attributes.ac.formulas;
+    formulas.splice(target.closest("[data-index]").dataset.index, 1);
+    this.document.update({ "system.attributes.ac.formulas": formulas });
   }
 }

--- a/module/applications/actor/config/armor-class-config.mjs
+++ b/module/applications/actor/config/armor-class-config.mjs
@@ -1,12 +1,18 @@
 import { formatNumber, simplifyBonus } from "../../../utils.mjs";
 import BaseConfigSheet from "../api/base-config-sheet.mjs";
 
+const { StringField } = foundry.data.fields;
+
 /**
  * Configuration application for armor class calculation.
  */
 export default class ArmorClassConfig extends BaseConfigSheet {
   /** @override */
   static DEFAULT_OPTIONS = {
+    actions: {
+      addFormula: ArmorClassConfig.#onAddFormula,
+      deleteFormula: ArmorClassConfig.#onDeleteFormula
+    },
     classes: ["armor-class"],
     position: {
       width: 420
@@ -17,6 +23,9 @@ export default class ArmorClassConfig extends BaseConfigSheet {
 
   /** @override */
   static PARTS = {
+    calculation: {
+      template: "systems/dnd5e/templates/actors/config/armor-class-calculation.hbs"
+    },
     config: {
       template: "systems/dnd5e/templates/actors/config/armor-class-config.hbs"
     }
@@ -36,30 +45,46 @@ export default class ArmorClassConfig extends BaseConfigSheet {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  async _prepareContext(options) {
+    return {
+      ...await super._prepareContext(options),
+      data: this.document.system.attributes.ac,
+      fields: this.document.system.schema.fields.attributes.fields.ac.fields,
+      source: this.document.system._source.attributes.ac
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   async _preparePartContext(partId, context, options) {
     context = await super._preparePartContext(partId, context, options);
-    context.data = this.document.system.attributes.ac;
-    context.fields = this.document.system.schema.fields.attributes.fields.ac.fields;
-    context.source = this.document.system._source.attributes.ac;
+    switch ( partId ) {
+      case "calculation": return this._prepareCalculationContext(context, options);
+      case "config": return this._prepareConfigurationContext(context, options);
+    }
+    return context;
+  }
 
-    context.calculationOptions = Object.entries(CONFIG.DND5E.armorClasses).reduce((arr, [value, config]) => {
-      if ( value === "custom" ) arr.push({ rule: true });
-      arr.push({ value, label: config.label });
-      if ( value === "natural" ) arr.push({ rule: true });
-      return arr;
-    }, []);
+  /* -------------------------------------------- */
 
-    const config = CONFIG.DND5E.armorClasses[context.source.calc];
-    context.formula = {
-      disabled: context.source.calc !== "custom",
-      showFlat: ["flat", "natural"].includes(context.source.calc),
-      value: (context.source.calc === "custom" ? context.source.formula : config?.formula) ?? ""
-    };
-
-    if ( context.formula.value.includes("@attributes.ac.dex") ) context.dexterity = context.data.dex;
+  /**
+   * Prepare rendering context for the calculation section.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {ApplicationRenderContext}
+   * @protected
+   */
+  async _prepareCalculationContext(context, options) {
+    if ( context.data.formula.includes("@attributes.ac.dex") ) {
+      context.ability = { label: CONFIG.DND5E.abilities.dex?.label, value: context.data.dex };
+    } else if ( context.data.formula.includes("@attributes.ac.clamped.") ) {
+      const ability = context.data.formula.match(/@attributes\.ac\.clamped\.([a-zA-Z]+)/);
+      context.ability = { label: CONFIG.DND5E.abilities[ability[1]]?.label, value: context.data.clamped[ability[1]] };
+    }
 
     context.calculations = [];
-    if ( context.formula.value.includes("@attributes.ac.armor") ) {
+    if ( context.data.formula.includes("@attributes.ac.armor") ) {
       for ( const key of ["armor", "shield"] ) {
         const item = context.data[`equipped${key.capitalize()}`];
         if ( !item ) continue;
@@ -74,7 +99,7 @@ export default class ArmorClassConfig extends BaseConfigSheet {
         });
       }
     }
-    if ( context.source.calc !== "flat" ) {
+    if ( !context.data.override ) {
       for ( const bonus of this.document._prepareActiveEffectAttributions("system.attributes.ac.bonus") ) {
         if ( bonus.type !== "add" ) continue;
         context.calculations.push({
@@ -87,6 +112,55 @@ export default class ArmorClassConfig extends BaseConfigSheet {
       }
     }
 
+    context.formulaLabel = context.data.activeFormula?.label ?? context.data.label;
+
     return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the configuration section.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {ApplicationRenderContext}
+   * @protected
+   */
+  async _prepareConfigurationContext(context, options) {
+    context.customFormulas = (context.source.formulas ?? []).map((source, index) => ({
+      source, fields: context.fields.formulas.element.fields
+    }));
+    context.formulaOptions = Object.entries(CONFIG.DND5E.armorClasses).map(([value, { label }]) => ({ value, label }));
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle adding a new custom formula.
+   * @this {ArmorClassConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #onAddFormula(event, target) {
+    this.document.update({
+      "system.attributes.ac.formulas": [...(this.document.system.toObject().attributes.ac.formulas ?? []), {}]
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle removing a custom formula.
+   * @this {ArmorClassConfig}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #onDeleteFormula(event, target) {
+    const formulas = this.document.system.toObject().attributes.ac.formulas;
+    formulas.splice(target.closest("[data-index]").dataset.index, 1);
+    this.document.update({ "system.attributes.ac.formulas": formulas });
   }
 }

--- a/module/applications/actor/config/armor-class-config.mjs
+++ b/module/applications/actor/config/armor-class-config.mjs
@@ -128,7 +128,23 @@ export default class ArmorClassConfig extends BaseConfigSheet {
    */
   async _prepareConfigurationContext(context, options) {
     context.customFormulas = (context.source.formulas ?? []).map((source, index) => ({
-      source, fields: context.fields.formulas.element.fields
+      source,
+      fields: context.fields.formulas.element.fields,
+      limitFields: ["armored", "shielded"].map(k => ({
+        classes: "label-top",
+        field: new StringField({
+          required: true, blank: false,
+          label: _loc(`DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.${k}.label`)
+        }),
+        name: `system.attributes.ac.formulas.${index}.${k}`,
+        options: [
+          { value: null, label: "" },
+          { value: true, label: _loc(`DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.${k}.required`) },
+          { value: false, label: _loc(`DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.${k}.excluded`) }
+        ],
+        value: source[k]
+      })),
+      prefix: `system.attributes.ac.formulas.${index}.`
     }));
     context.formulaOptions = Object.entries(CONFIG.DND5E.armorClasses).map(([value, { label }]) => ({ value, label }));
     return context;
@@ -162,5 +178,20 @@ export default class ArmorClassConfig extends BaseConfigSheet {
     const formulas = this.document.system.toObject().attributes.ac.formulas;
     formulas.splice(target.closest("[data-index]").dataset.index, 1);
     this.document.update({ "system.attributes.ac.formulas": formulas });
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _processFormData(event, form, formData) {
+    const submitData = super._processFormData(event, form, formData);
+    for ( const formula of Object.values(submitData.system?.attributes?.ac?.formulas) ?? [] ) {
+      for ( const field of ["armored", "shielded"] ) {
+        formula[field] = formula[field] === "null" ? null : formula[field];
+      }
+    }
+    return submitData;
   }
 }

--- a/module/applications/property-attribution.mjs
+++ b/module/applications/property-attribution.mjs
@@ -1,3 +1,4 @@
+import { getHumanReadableAttributeLabel } from "../utils.mjs";
 import Application5e from "./api/application.mjs";
 
 /**
@@ -94,11 +95,13 @@ export default class PropertyAttribution extends Application5e {
     const parts = property.split(".");
     if ( parts[0] === "abilities" && parts[1] ) {
       return CONFIG.DND5E.abilities[parts[1]]?.label ?? property;
+    } else if ( property.startsWith("attributes.ac.clamped.") ) {
+      return CONFIG.DND5E.abilities[parts[3]]?.label ?? property;
     } else if ( (property === "attributes.ac.dex") && CONFIG.DND5E.abilities.dex ) {
       return CONFIG.DND5E.abilities.dex.label;
     } else if ( (parts[0] === "prof") || (property === "attributes.prof") ) {
       return game.i18n.localize("DND5E.Proficiency");
     }
-    return property;
+    return getHumanReadableAttributeLabel(property);
   }
 }

--- a/module/applications/property-attribution.mjs
+++ b/module/applications/property-attribution.mjs
@@ -1,3 +1,4 @@
+import { getHumanReadableAttributeLabel } from "../utils.mjs";
 import Application5e from "./api/application.mjs";
 
 /**
@@ -102,11 +103,13 @@ export default class PropertyAttribution extends Application5e {
     const parts = property.split(".");
     if ( parts[0] === "abilities" && parts[1] ) {
       return CONFIG.DND5E.abilities[parts[1]]?.label ?? property;
+    } else if ( property.startsWith("attributes.ac.clamped.") ) {
+      return CONFIG.DND5E.abilities[parts[3]]?.label ?? property;
     } else if ( (property === "attributes.ac.dex") && CONFIG.DND5E.abilities.dex ) {
       return CONFIG.DND5E.abilities.dex.label;
     } else if ( (parts[0] === "prof") || (property === "attributes.prof") ) {
       return _loc("DND5E.Proficiency");
     }
-    return property;
+    return getHumanReadableAttributeLabel(property);
   }
 }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1592,42 +1592,42 @@ DND5E.shieldIds = {
  */
 DND5E.armorClasses = {
   natural: {
-    label: "DND5E.ArmorClassNatural",
+    label: "DND5E.ARMORCLASS.Calculation.Natural",
     formula: "@attributes.ac.flat"
   },
   armored: {
-    label: "DND5E.ArmorClassEquipment",
+    label: "DND5E.ARMORCLASS.Calculation.Armored",
     formula: "@attributes.ac.armor + @attributes.ac.clamped.dex",
     armored: true
   },
   unarmored: {
-    label: "DND5E.ArmorClassUnarmored",
+    label: "DND5E.ARMORCLASS.Calculation.Unarmored",
     formula: "10 + @abilities.dex.mod",
     armored: false
   },
   mage: {
-    label: "DND5E.ArmorClassMage",
+    label: "DND5E.ARMORCLASS.Calculation.Mage",
     formula: "13 + @abilities.dex.mod",
     armored: false
   },
   draconic: {
-    label: "DND5E.ArmorClassDraconic",
+    label: "DND5E.ARMORCLASS.Calculation.Draconic",
     formula: "13 + @abilities.dex.mod",
     armored: false
   },
   unarmoredMonk: {
-    label: "DND5E.ArmorClassUnarmoredMonk",
+    label: "DND5E.ARMORCLASS.Calculation.UnarmoredMonk",
     formula: "10 + @abilities.dex.mod + @abilities.wis.mod",
     armored: false,
     shielded: false
   },
   unarmoredBarb: {
-    label: "DND5E.ArmorClassUnarmoredBarbarian",
+    label: "DND5E.ARMORCLASS.Calculation.UnarmoredBarbarian",
     formula: "10 + @abilities.dex.mod + @abilities.con.mod",
     armored: false
   },
   unarmoredBard: {
-    label: "DND5E.ArmorClassUnarmoredBard",
+    label: "DND5E.ARMORCLASS.Calculation.UnarmoredBard",
     formula: "10 + @abilities.dex.mod + @abilities.cha.mod",
     armored: false
   }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1588,43 +1588,48 @@ DND5E.shieldIds = {
 
 /**
  * Common armor class calculations.
- * @enum {{ label: string, [formula]: string }}
+ * @enum {{ label: string, [formula]: string, [armored]: boolean, [shielded]: boolean }}
  */
 DND5E.armorClasses = {
-  flat: {
-    label: "DND5E.ArmorClassFlat",
-    formula: "@attributes.ac.flat"
-  },
   natural: {
     label: "DND5E.ArmorClassNatural",
     formula: "@attributes.ac.flat"
   },
-  default: {
+  armored: {
     label: "DND5E.ArmorClassEquipment",
-    formula: "@attributes.ac.armor + @attributes.ac.dex"
+    formula: "@attributes.ac.armor + @attributes.ac.clamped.dex",
+    armored: true
+  },
+  unarmored: {
+    label: "DND5E.ArmorClassUnarmored",
+    formula: "10 + @abilities.dex.mod",
+    armored: false
   },
   mage: {
     label: "DND5E.ArmorClassMage",
-    formula: "13 + @abilities.dex.mod"
+    formula: "13 + @abilities.dex.mod",
+    armored: false
   },
   draconic: {
     label: "DND5E.ArmorClassDraconic",
-    formula: "13 + @abilities.dex.mod"
+    formula: "13 + @abilities.dex.mod",
+    armored: false
   },
   unarmoredMonk: {
     label: "DND5E.ArmorClassUnarmoredMonk",
-    formula: "10 + @abilities.dex.mod + @abilities.wis.mod"
+    formula: "10 + @abilities.dex.mod + @abilities.wis.mod",
+    armored: false,
+    shielded: false
   },
   unarmoredBarb: {
     label: "DND5E.ArmorClassUnarmoredBarbarian",
-    formula: "10 + @abilities.dex.mod + @abilities.con.mod"
+    formula: "10 + @abilities.dex.mod + @abilities.con.mod",
+    armored: false
   },
   unarmoredBard: {
     label: "DND5E.ArmorClassUnarmoredBard",
-    formula: "10 + @abilities.dex.mod + @abilities.cha.mod"
-  },
-  custom: {
-    label: "DND5E.ArmorClassCustom"
+    formula: "10 + @abilities.dex.mod + @abilities.cha.mod",
+    armored: false
   }
 };
 preLocalize("armorClasses", { key: "label" });

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1587,43 +1587,48 @@ DND5E.shieldIds = {
 
 /**
  * Common armor class calculations.
- * @enum {{ label: string, [formula]: string }}
+ * @enum {{ label: string, [formula]: string, [armored]: boolean, [shielded]: boolean }}
  */
 DND5E.armorClasses = {
-  flat: {
-    label: "DND5E.ArmorClassFlat",
-    formula: "@attributes.ac.flat"
-  },
   natural: {
     label: "DND5E.ArmorClassNatural",
     formula: "@attributes.ac.flat"
   },
-  default: {
+  armored: {
     label: "DND5E.ArmorClassEquipment",
-    formula: "@attributes.ac.armor + @attributes.ac.dex"
+    formula: "@attributes.ac.armor + @attributes.ac.clamped.dex",
+    armored: true
+  },
+  unarmored: {
+    label: "DND5E.ArmorClassUnarmored",
+    formula: "10 + @abilities.dex.mod",
+    armored: false
   },
   mage: {
     label: "DND5E.ArmorClassMage",
-    formula: "13 + @abilities.dex.mod"
+    formula: "13 + @abilities.dex.mod",
+    armored: false
   },
   draconic: {
     label: "DND5E.ArmorClassDraconic",
-    formula: "13 + @abilities.dex.mod"
+    formula: "13 + @abilities.dex.mod",
+    armored: false
   },
   unarmoredMonk: {
     label: "DND5E.ArmorClassUnarmoredMonk",
-    formula: "10 + @abilities.dex.mod + @abilities.wis.mod"
+    formula: "10 + @abilities.dex.mod + @abilities.wis.mod",
+    armored: false,
+    shielded: false
   },
   unarmoredBarb: {
     label: "DND5E.ArmorClassUnarmoredBarbarian",
-    formula: "10 + @abilities.dex.mod + @abilities.con.mod"
+    formula: "10 + @abilities.dex.mod + @abilities.con.mod",
+    armored: false
   },
   unarmoredBard: {
     label: "DND5E.ArmorClassUnarmoredBard",
-    formula: "10 + @abilities.dex.mod + @abilities.cha.mod"
-  },
-  custom: {
-    label: "DND5E.ArmorClassCustom"
+    formula: "10 + @abilities.dex.mod + @abilities.cha.mod",
+    armored: false
   }
 };
 preLocalize("armorClasses", { key: "label" });

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1591,42 +1591,42 @@ DND5E.shieldIds = {
  */
 DND5E.armorClasses = {
   natural: {
-    label: "DND5E.ArmorClassNatural",
+    label: "DND5E.ARMORCLASS.Calculation.Natural",
     formula: "@attributes.ac.flat"
   },
   armored: {
-    label: "DND5E.ArmorClassEquipment",
+    label: "DND5E.ARMORCLASS.Calculation.Armored",
     formula: "@attributes.ac.armor + @attributes.ac.clamped.dex",
     armored: true
   },
   unarmored: {
-    label: "DND5E.ArmorClassUnarmored",
+    label: "DND5E.ARMORCLASS.Calculation.Unarmored",
     formula: "10 + @abilities.dex.mod",
     armored: false
   },
   mage: {
-    label: "DND5E.ArmorClassMage",
+    label: "DND5E.ARMORCLASS.Calculation.Mage",
     formula: "13 + @abilities.dex.mod",
     armored: false
   },
   draconic: {
-    label: "DND5E.ArmorClassDraconic",
+    label: "DND5E.ARMORCLASS.Calculation.Draconic",
     formula: "13 + @abilities.dex.mod",
     armored: false
   },
   unarmoredMonk: {
-    label: "DND5E.ArmorClassUnarmoredMonk",
+    label: "DND5E.ARMORCLASS.Calculation.UnarmoredMonk",
     formula: "10 + @abilities.dex.mod + @abilities.wis.mod",
     armored: false,
     shielded: false
   },
   unarmoredBarb: {
-    label: "DND5E.ArmorClassUnarmoredBarbarian",
+    label: "DND5E.ARMORCLASS.Calculation.UnarmoredBarbarian",
     formula: "10 + @abilities.dex.mod + @abilities.con.mod",
     armored: false
   },
   unarmoredBard: {
-    label: "DND5E.ArmorClassUnarmoredBard",
+    label: "DND5E.ARMORCLASS.Calculation.UnarmoredBard",
     formula: "10 + @abilities.dex.mod + @abilities.cha.mod",
     armored: false
   }

--- a/module/data/actor/_module.mjs
+++ b/module/data/actor/_module.mjs
@@ -12,6 +12,7 @@ export {
   VehicleData
 };
 export {default as GroupSystemFlags} from "./group-system-flags.mjs";
+export {default as ACFormulasField} from "./fields/ac-formulas-field.mjs";
 export {default as DamageTraitField} from "./fields/damage-trait-field.mjs";
 export {default as SimpleTraitField} from "./fields/simple-trait-field.mjs";
 export {default as TravelField} from "./fields/travel-field.mjs";

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -137,6 +137,7 @@ export default class CharacterData extends CreatureTemplate {
   /** @inheritDoc */
   static _migrateData(source) {
     super._migrateData(source);
+    AttributesFields._migrateArmorClass(source.attributes);
     AttributesFields._migrateInitiative(source.attributes);
   }
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -149,6 +149,7 @@ export default class CharacterData extends CreatureTemplate {
   /** @inheritDoc */
   static _migrateData(source) {
     super._migrateData(source);
+    AttributesFields._migrateArmorClass(source.attributes);
     AttributesFields._migrateInitiative(source.attributes);
     return source;
   }

--- a/module/data/actor/fields/_types.mjs
+++ b/module/data/actor/fields/_types.mjs
@@ -1,4 +1,12 @@
 /**
+ * @typedef ACFormulaData
+ * @property {boolean|null} armored   Require character be armored or not armored to use this formula.
+ * @property {string} formula         Formula to use to calculate armor class.
+ * @property {string} label           Label used for calculation in the attribution tooltip & config dialog.
+ * @property {boolean|null} shielded  Require character to have a shield or not have a shield to use this formula.
+ */
+
+/**
  * @typedef SimpleTraitData
  * @property {Set<string>} value  Keys for currently selected traits.
  * @property {string} custom      Semicolon-separated list of custom traits.

--- a/module/data/actor/fields/ac-formulas-field.mjs
+++ b/module/data/actor/fields/ac-formulas-field.mjs
@@ -27,7 +27,7 @@ export default class ACFormulasField extends ArrayField {
 
   /** @inheritDoc */
   applyChange(value, model, change, options) {
-    if ( (change.type === "add") && (foundry.utils.getType(change.value) === "string") ) change.value = {
+    if ( (change.type === "add") && (typeof change.value === "string") ) change.value = {
       formula: change.value, label: change.effect?.name ?? _loc("DND5E.ARMORCLASS.Calculation.Custom")
     };
     return super.applyChange(value, model, change, options);

--- a/module/data/actor/fields/ac-formulas-field.mjs
+++ b/module/data/actor/fields/ac-formulas-field.mjs
@@ -1,0 +1,35 @@
+import FormulaField from "../../fields/formula-field.mjs";
+
+const { ArrayField, BooleanField, SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * Field for storing AC formulas with some special handling to cast string formulas to full objects.
+ */
+export default class ACFormulasField extends ArrayField {
+  constructor() {
+    super(new SchemaField({
+      armored: new BooleanField({
+        nullable: true, initial: null, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.armored.label"
+      }),
+      formula: new FormulaField({
+        deterministic: true, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.formula.label"
+      }),
+      label: new StringField({ label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.label.label" }),
+      shielded: new BooleanField({
+        nullable: true, initial: null, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.shielded.label"
+      })
+    }));
+  }
+
+  /* -------------------------------------------- */
+  /*  Active Effect Integration                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  applyChange(value, model, change, options) {
+    if ( (change.type === "add") && (foundry.utils.getType(change.value) === "string") ) change.value = {
+      formula: change.value, label: change.effect?.name ?? _loc("DND5E.ARMORCLASS.Calculation.Custom")
+    };
+    return super.applyChange(value, model, change, options);
+  }
+}

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -214,6 +214,7 @@ export default class NPCData extends CreatureTemplate {
     NPCData.#migrateSource(source);
     NPCData.#migrateSpellLevel(source);
     NPCData.#migrateTypeData(source);
+    AttributesFields._migrateArmorClass(source.attributes);
     AttributesFields._migrateInitiative(source.attributes);
   }
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -226,6 +226,7 @@ export default class NPCData extends CreatureTemplate {
     NPCData.#migrateSource(source);
     NPCData.#migrateSpellLevel(source);
     NPCData.#migrateTypeData(source);
+    AttributesFields._migrateArmorClass(source.attributes);
     AttributesFields._migrateInitiative(source.attributes);
     return source;
   }

--- a/module/data/actor/templates/_types.mjs
+++ b/module/data/actor/templates/_types.mjs
@@ -1,6 +1,6 @@
 /**
  * @import { MovementData, RollConfigData, SensesData } from "../../shared/_types.mjs";
- * @import { DamageTraitData, SimpleTraitData } from "../fields/_types.mjs";
+ * @import { ACFormulaData, DamageTraitData, SimpleTraitData } from "../fields/_types.mjs";
  */
 
 /**
@@ -30,9 +30,18 @@
 
 /**
  * @typedef ArmorClassData
- * @property {string} calc     Name of one of the built-in formulas to use.
- * @property {number} flat     Flat value used for flat or natural armor calculation.
- * @property {string} formula  Custom formula to use.
+ * @property {number} armor     AC value provided by equipped armor (not persisted).
+ * @property {number} base      Base AC value originating from the formula (not persisted).
+ * @property {string} bonus     Bonus AC provided by active effects (not persisted).
+ * @property {string} calc      Name of one of the built-in formulas being used or "custom" (not persisted).
+ * @property {number} cover     Bonus AC provided by the cover status effect (not persisted).
+ * @property {number} flat      Flat value usable by any armor class calculation.
+ * @property {string} formula   Extra formula added by legacy active effects (not persisted).
+ * @property {ACFormulaData[]} formulas  Available armor class formulas, the highest of which is used.
+ * @property {string} min       Minimum armor class value after all bonuses have been added (not persisted).
+ * @property {number} override  Unmodifiable armor class value that supersedes any entered formulas.
+ * @property {Set<string>} selectedFormulas  Which of the base formulas defined by the system should be usable.
+ * @property {number} shield    AC value provided by equipped shield (not persisted).
  */
 
 /**

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -7,7 +7,7 @@ import MovementField from "../../shared/movement-field.mjs";
 import RollConfigField from "../../shared/roll-config-field.mjs";
 import SensesField from "../../shared/senses-field.mjs";
 
-const { NumberField, SchemaField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { ArmorClassData, AttributesCommonData, AttributesCreatureData, HitPointsData } from "./_types.mjs";
@@ -23,9 +23,15 @@ export default class AttributesFields {
    */
   static get armorClass() {
     return {
-      calc: new StringField({ initial: "default", label: "DND5E.ArmorClassCalculation" }),
       flat: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.ArmorClassFlat" }),
-      formula: new FormulaField({ deterministic: true, label: "DND5E.ArmorClassFormula" })
+      formulas: new ArrayField(new SchemaField({
+        armored: new BooleanField({ nullable: true, initial: null }),
+        formula: new FormulaField({ deterministic: true }),
+        label: new StringField(),
+        shielded: new BooleanField({ nullable: true, initial: null })
+      })),
+      override: new NumberField({ min: 0, integer: true }),
+      selectedFormulas: new SetField(new StringField(), { initial: ["unarmored", "armored"] })
     };
   }
 
@@ -99,8 +105,41 @@ export default class AttributesFields {
   /* -------------------------------------------- */
 
   /**
+   * Migrate the old single armor formula into formulas.
+   * @param {object} [source]  The source attributes object.
+   * @internal
+   */
+  static _migrateArmorClass(source) {
+    const ac = source?.ac ?? {};
+    if ( Number.isNumeric(ac.value) && !CONFIG.DND5E.armorClasses[ac.calc] ) {
+      ac.override = Number(ac.value);
+      delete ac.value;
+    }
+
+    if ( !ac.calc ) return;
+    switch ( ac.calc ) {
+      case "custom":
+        ac.formulas ??= [];
+        ac.formulas.push(ac.formula);
+        break;
+      case "flat":
+        ac.override = ac.flat;
+        break;
+      case "default": break;
+      default:
+        ac.selectedFormulas ??= ["unarmored", "armored"];
+        ac.selectedFormulas.push(ac.calc);
+        break;
+    }
+    delete ac.calc;
+    delete ac.formula;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Migrate the old init.value and incorporate it into init.bonus.
-   * @param {object} source  The source attributes object.
+   * @param {object} [source]  The source attributes object.
    * @internal
    */
   static _migrateInitiative(source) {
@@ -121,6 +160,7 @@ export default class AttributesFields {
   static prepareBaseArmorClass() {
     const ac = this.attributes.ac;
     ac.armor = 10;
+    ac.base = -Infinity;
     ac.shield = ac.cover = 0;
     ac.min = ac.bonus = "";
   }
@@ -147,13 +187,11 @@ export default class AttributesFields {
   static prepareArmorClass(rollData) {
     const ac = this.attributes.ac;
 
-    // Apply automatic migrations for older data structures
-    let cfg = CONFIG.DND5E.armorClasses[ac.calc];
-    if ( !cfg ) {
-      ac.calc = "flat";
-      if ( Number.isNumeric(ac.value) ) ac.flat = Number(ac.value);
-      cfg = CONFIG.DND5E.armorClasses.flat;
-    }
+    // Add selected formulas
+    const baseFormulas = Object.entries(CONFIG.DND5E.armorClasses)
+      .filter(([id, data]) => ac.selectedFormulas.has(id))
+      .map(([id, data]) => ({ ...data, id, type: "base" }));
+    ac.formulas.unshift(...baseFormulas);
 
     // Identify Equipped Items
     const { armors, shields } = this.parent.itemTypes.equipment.reduce((obj, equip) => {
@@ -163,56 +201,16 @@ export default class AttributesFields {
       return obj;
     }, { armors: [], shields: [] });
 
-    // Set stealth disadvantage
-    if ( armors[0]?.system.properties.has("stealthDisadvantage") ) {
-      AdvantageModeField.setMode(this, "skills.ste.roll.mode", -1);
-    }
-
-    ac.label = !["custom", "flat"].includes(ac.calc) ? CONFIG.DND5E.armorClasses[ac.calc]?.label : null;
-
-    // Determine base AC
-    switch ( ac.calc ) {
-
-      // Flat AC (no additional bonuses)
-      case "flat":
-        ac.value = Number(ac.flat);
-        return;
-
-      // Natural AC (includes bonuses)
-      case "natural":
-        ac.base = Number(ac.flat);
-        break;
-
-      default:
-        let formula = ac.calc === "custom" ? ac.formula : cfg.formula;
-        if ( armors.length ) {
-          if ( armors.length > 1 ) this.parent._preparationWarnings.push({
-            message: game.i18n.localize("DND5E.WarnMultipleArmor"), type: "warning"
-          });
-          const armorData = armors[0].system.armor;
-          const isHeavy = armors[0].system.type.value === "heavy";
-          ac.armor = armorData.value ?? ac.armor;
-          ac.dex = isHeavy ? 0 : Math.min(armorData.dex ?? Infinity, this.abilities.dex?.mod ?? 0);
-          ac.equippedArmor = armors[0];
-        }
-        else ac.dex = this.abilities.dex?.mod ?? 0;
-
-        if ( !ac.equippedArmor ) ac.label = null;
-
-        rollData.attributes.ac = ac;
-        try {
-          const replaced = replaceFormulaData(formula, rollData, {
-            actor: this, missing: null, property: game.i18n.localize("DND5E.ArmorClass")
-          });
-          ac.base = replaced ? new Roll(replaced).evaluateSync().total : 0;
-        } catch(err) {
-          this.parent._preparationWarnings.push({
-            message: game.i18n.format("DND5E.WarnBadACFormula", { formula }), link: "armor", type: "error"
-          });
-          const replaced = Roll.replaceFormulaData(CONFIG.DND5E.armorClasses.default.formula, rollData);
-          ac.base = new Roll(replaced).evaluateSync().total;
-        }
-        break;
+    // Equipped Armor
+    if ( armors.length ) {
+      if ( armors.length > 1 ) this.parent._preparationWarnings.push({
+        message: game.i18n.localize("DND5E.WarnMultipleArmor"), type: "warning"
+      });
+      ac.equippedArmor = armors[0];
+      ac.armor = ac.equippedArmor.system.armor.value ?? ac.armor;
+      if ( ac.equippedArmor.system.properties.has("stealthDisadvantage") ) {
+        AdvantageModeField.setMode(this, "skills.ste.roll.mode", -1);
+      }
     }
 
     // Equipped Shield
@@ -220,17 +218,55 @@ export default class AttributesFields {
       if ( shields.length > 1 ) this.parent._preparationWarnings.push({
         message: game.i18n.localize("DND5E.WarnMultipleShields"), type: "warning"
       });
-      ac.shield = shields[0].system.armor.value ?? 0;
       ac.equippedShield = shields[0];
+      ac.shield = ac.equippedShield.system.armor.value ?? 0;
     }
 
-    // Compute cover.
-    ac.cover = Math.max(ac.cover, this.parent.coverBonus);
+    // If armor is equipped, prepare clamped abilities
+    const isHeavy = ac.equippedArmor?.system.type.value === "heavy";
+    ac.clamped = Object.entries(this.abilities).reduce((obj, [k, v]) => {
+      obj[k] = isHeavy ? 0 : Math.min(v.mod, ac.equippedArmor?.system.armor.dex ?? Infinity);
+      return obj;
+    }, {});
+    ac.dex = ac.clamped.dex;
 
-    // Compute total AC and return
+    const validFormulas = ac.formulas.filter(formula => {
+      if ( (typeof formula.armored === "boolean") && (formula.armored !== !!ac.equippedArmor) ) return false;
+      if ( (typeof formula.shielded === "boolean") && (formula.shielded !== !!ac.equippedShield) ) return false;
+      return true;
+    });
+
+    for ( const [index, config] of validFormulas.entries() ) {
+      try {
+        const replaced = replaceFormulaData(config.formula, rollData, {
+          actor: this, missing: null, property: game.i18n.localize("DND5E.ArmorClass")
+        });
+        const result = replaced ? new Roll(replaced).evaluateSync().total : 0;
+        if ( result > ac.base ) {
+          ac.base = result;
+          ac.calc = config.id;
+          ac.formula = config.formula;
+          if ( config.id === "armored" ) ac.label = ac.equippedArmor.name;
+          else ac.label = config.label ?? "";
+        }
+      } catch(error) {
+        this.parent._preparationWarnings.push({
+          message: game.i18n.format("DND5E.WarnBadACFormula", { formula: config.formula }), link: "armor", type: "error"
+        });
+      }
+    }
+
+    if ( !Number.isFinite(ac.base) ) {
+      ac.base = ac.flat ?? 0;
+      ac.calc = "natural";
+      ac.formula = "@attributes.ac.flat";
+    }
+
+    ac.cover = Math.max(ac.cover, this.parent.coverBonus);
     ac.min = simplifyBonus(ac.min, rollData);
     ac.bonus = simplifyBonus(ac.bonus, rollData);
-    ac.value = Math.max(ac.min, ac.base + ac.shield + ac.bonus + ac.cover);
+    if ( ac.override ) ac.value = ac.override;
+    else ac.value = Math.max(ac.min, ac.base + ac.shield + ac.bonus + ac.cover);
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -6,6 +6,7 @@ import FormulaField from "../../fields/formula-field.mjs";
 import MovementField from "../../shared/movement-field.mjs";
 import RollConfigField from "../../shared/roll-config-field.mjs";
 import SensesField from "../../shared/senses-field.mjs";
+import ACFormulasField from "../fields/ac-formulas-field.mjs";
 
 const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
@@ -34,18 +35,7 @@ export default class AttributesFields {
         hint: "DND5E.ARMORCLASS.FIELDS.attributes.ac.flat.hint"
       }),
       formula: new StringField({ persisted: false }),
-      formulas: new ArrayField(new SchemaField({
-        armored: new BooleanField({
-          nullable: true, initial: null, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.armored.label"
-        }),
-        formula: new FormulaField({
-          deterministic: true, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.formula.label"
-         }),
-        label: new StringField({ label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.label.label" }),
-        shielded: new BooleanField({
-          nullable: true, initial: null, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.shielded.label"
-        })
-      })),
+      formulas: new ACFormulasField(),
       min: new FormulaField({ deterministic: true, persisted: false }),
       override: new NumberField({
         min: 0, integer: true, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.override.label",
@@ -228,8 +218,10 @@ export default class AttributesFields {
 
     // Add formulas set by old-style AEs
     if ( ac.calc === "flat" ) ac.override = ac.flat;
-    else if ( (ac.calc === "custom") && ac.formula ) ac.formulas.push({ formula: ac.formula });
-    else if ( ac.calc in CONFIG.DND5E.armorClasses ) ac.selectedFormulas.push(ac.calc);
+    else if ( (ac.calc === "custom") && ac.formula ) ac.formulas.push({
+      formula: ac.formula, label: _loc("DND5E.ARMORCLASS.Calculation.Custom")
+    });
+    else if ( ac.calc in CONFIG.DND5E.armorClasses ) ac.selectedFormulas.add(ac.calc);
 
     // Add selected formulas
     const baseFormulas = foundry.utils.iterateEntries(CONFIG.DND5E.armorClasses)
@@ -281,7 +273,7 @@ export default class AttributesFields {
       return true;
     });
 
-    for ( const [index, config] of validFormulas.entries() ) {
+    for ( const config of validFormulas ) {
       try {
         const replaced = replaceFormulaData(config.formula, rollData, {
           actor: this, missing: null, property: _loc("DND5E.ArmorClass")

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -28,16 +28,31 @@ export default class AttributesFields {
       base: new NumberField({ integer: true, initial: -Infinity, persisted: false }),
       bonus: new FormulaField({ deterministic: true, persisted: false }),
       cover: new NumberField({ integer: true, min: 0, initial: 0, persisted: false }),
-      flat: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.ArmorClassFlat" }),
+      flat: new NumberField({
+        required: true, integer: true, min: 0, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.flat.label",
+        hint: "DND5E.ARMORCLASS.FIELDS.attributes.ac.flat.hint"
+      }),
       formulas: new ArrayField(new SchemaField({
-        armored: new BooleanField({ nullable: true, initial: null }),
-        formula: new FormulaField({ deterministic: true }),
-        label: new StringField(),
-        shielded: new BooleanField({ nullable: true, initial: null })
+        armored: new BooleanField({
+          nullable: true, initial: null, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.armored.label"
+        }),
+        formula: new FormulaField({
+          deterministic: true, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.formula.label"
+         }),
+        label: new StringField({ label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.label.label" }),
+        shielded: new BooleanField({
+          nullable: true, initial: null, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.shielded.label"
+        })
       })),
       min: new FormulaField({ deterministic: true, persisted: false }),
-      override: new NumberField({ min: 0, integer: true }),
-      selectedFormulas: new SetField(new StringField(), { initial: ["unarmored", "armored"] }),
+      override: new NumberField({
+        min: 0, integer: true, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.override.label",
+        hint: "DND5E.ARMORCLASS.FIELDS.attributes.ac.override.hint"
+      }),
+      selectedFormulas: new SetField(new StringField(), {
+        initial: ["unarmored", "armored"], label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.selectedFormulas.label",
+        hint: "DND5E.ARMORCLASS.FIELDS.attributes.ac.selectedFormulas.hint"
+      }),
       shield: new NumberField({ integer: true, min: 0, initial: 0, persisted: false })
     };
   }
@@ -147,7 +162,7 @@ export default class AttributesFields {
     switch ( ac.calc ) {
       case "custom":
         ac.formulas ??= [];
-        ac.formulas.push(ac.formula);
+        ac.formulas.push({ formula: ac.formula });
         break;
       case "flat":
         ac.override = ac.flat;
@@ -203,6 +218,7 @@ export default class AttributesFields {
    */
   static prepareArmorClass(rollData) {
     const ac = this.attributes.ac;
+    ac.flat ||= 0;
 
     // Add selected formulas
     const baseFormulas = Object.entries(CONFIG.DND5E.armorClasses)
@@ -248,6 +264,7 @@ export default class AttributesFields {
     ac.dex = ac.clamped.dex;
 
     const validFormulas = ac.formulas.filter(formula => {
+      if ( !formula.formula ) return false;
       if ( (typeof formula.armored === "boolean") && (formula.armored !== !!ac.equippedArmor) ) return false;
       if ( (typeof formula.shielded === "boolean") && (formula.shielded !== !!ac.equippedShield) ) return false;
       return true;
@@ -260,8 +277,9 @@ export default class AttributesFields {
         });
         const result = replaced ? new Roll(replaced).evaluateSync().total : 0;
         if ( result > ac.base ) {
+          ac.activeFormula = config;
           ac.base = result;
-          ac.calc = config.id;
+          ac.calc = config.id ?? "custom";
           ac.formula = config.formula;
           if ( config.id === "armored" ) ac.label = ac.equippedArmor.name;
           else ac.label = config.label ?? "";

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -168,6 +168,9 @@ export default class AttributesFields {
         ac.override = ac.flat;
         break;
       case "default": break;
+      case "natural":
+        ac.selectedFormulas = ["natural"];
+        break;
       default:
         ac.selectedFormulas ??= ["unarmored", "armored"];
         ac.selectedFormulas.push(ac.calc);
@@ -221,7 +224,7 @@ export default class AttributesFields {
     ac.flat ||= 0;
 
     // Add selected formulas
-    const baseFormulas = Object.entries(CONFIG.DND5E.armorClasses)
+    const baseFormulas = foundry.utils.iterateEntries(CONFIG.DND5E.armorClasses)
       .filter(([id, data]) => ac.selectedFormulas.has(id))
       .map(([id, data]) => ({ ...data, id, type: "base" }));
     ac.formulas.unshift(...baseFormulas);
@@ -300,7 +303,7 @@ export default class AttributesFields {
     ac.cover = Math.max(ac.cover, this.parent.coverBonus);
     ac.min = simplifyBonus(ac.min, rollData);
     ac.bonus = simplifyBonus(ac.bonus, rollData);
-    if ( ac.override ) ac.value = ac.override;
+    if ( Number.isFinite(ac.override) ) ac.value = ac.override;
     else ac.value = Math.max(ac.min, ac.base + ac.shield + ac.bonus + ac.cover);
   }
 

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -27,11 +27,13 @@ export default class AttributesFields {
       armor: new NumberField({ integer: true, min: 0, initial: 10, persisted: false }),
       base: new NumberField({ integer: true, initial: -Infinity, persisted: false }),
       bonus: new FormulaField({ deterministic: true, persisted: false }),
+      calc: new StringField({ persisted: false }),
       cover: new NumberField({ integer: true, min: 0, initial: 0, persisted: false }),
       flat: new NumberField({
         required: true, integer: true, min: 0, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.flat.label",
         hint: "DND5E.ARMORCLASS.FIELDS.attributes.ac.flat.hint"
       }),
+      formula: new StringField({ persisted: false }),
       formulas: new ArrayField(new SchemaField({
         armored: new BooleanField({
           nullable: true, initial: null, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formulas.element.armored.label"
@@ -221,7 +223,13 @@ export default class AttributesFields {
    */
   static prepareArmorClass(rollData) {
     const ac = this.attributes.ac;
+    ac.label = "";
     ac.flat ||= 0;
+
+    // Add formulas set by old-style AEs
+    if ( ac.calc === "flat" ) ac.override = ac.flat;
+    else if ( (ac.calc === "custom") && ac.formula ) ac.formulas.push({ formula: ac.formula });
+    else if ( ac.calc in CONFIG.DND5E.armorClasses ) ac.selectedFormulas.push(ac.calc);
 
     // Add selected formulas
     const baseFormulas = foundry.utils.iterateEntries(CONFIG.DND5E.armorClasses)

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -7,7 +7,7 @@ import MovementField from "../../shared/movement-field.mjs";
 import RollConfigField from "../../shared/roll-config-field.mjs";
 import SensesField from "../../shared/senses-field.mjs";
 
-const { NumberField, SchemaField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { ActorRollData } from "../../../documents/_types.mjs";
@@ -25,12 +25,19 @@ export default class AttributesFields {
   static get armorClass() {
     return {
       armor: new NumberField({ integer: true, min: 0, initial: 10, persisted: false }),
+      base: new NumberField({ integer: true, initial: -Infinity, persisted: false }),
       bonus: new FormulaField({ deterministic: true, persisted: false }),
-      calc: new StringField({ initial: "default", label: "DND5E.ArmorClassCalculation" }),
-      flat: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.ArmorClassFlat" }),
       cover: new NumberField({ integer: true, min: 0, initial: 0, persisted: false }),
-      formula: new FormulaField({ deterministic: true, label: "DND5E.ArmorClassFormula" }),
+      flat: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.ArmorClassFlat" }),
+      formulas: new ArrayField(new SchemaField({
+        armored: new BooleanField({ nullable: true, initial: null }),
+        formula: new FormulaField({ deterministic: true }),
+        label: new StringField(),
+        shielded: new BooleanField({ nullable: true, initial: null })
+      })),
       min: new FormulaField({ deterministic: true, persisted: false }),
+      override: new NumberField({ min: 0, integer: true }),
+      selectedFormulas: new SetField(new StringField(), { initial: ["unarmored", "armored"] }),
       shield: new NumberField({ integer: true, min: 0, initial: 0, persisted: false })
     };
   }
@@ -125,8 +132,41 @@ export default class AttributesFields {
   /* -------------------------------------------- */
 
   /**
+   * Migrate the old single armor formula into formulas.
+   * @param {object} [source]  The source attributes object.
+   * @internal
+   */
+  static _migrateArmorClass(source) {
+    const ac = source?.ac ?? {};
+    if ( Number.isNumeric(ac.value) && !CONFIG.DND5E.armorClasses[ac.calc] ) {
+      ac.override = Number(ac.value);
+      delete ac.value;
+    }
+
+    if ( !ac.calc ) return;
+    switch ( ac.calc ) {
+      case "custom":
+        ac.formulas ??= [];
+        ac.formulas.push(ac.formula);
+        break;
+      case "flat":
+        ac.override = ac.flat;
+        break;
+      case "default": break;
+      default:
+        ac.selectedFormulas ??= ["unarmored", "armored"];
+        ac.selectedFormulas.push(ac.calc);
+        break;
+    }
+    delete ac.calc;
+    delete ac.formula;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Migrate the old init.value and incorporate it into init.bonus.
-   * @param {object} source  The source attributes object.
+   * @param {object} [source]  The source attributes object.
    * @internal
    */
   static _migrateInitiative(source) {
@@ -164,13 +204,11 @@ export default class AttributesFields {
   static prepareArmorClass(rollData) {
     const ac = this.attributes.ac;
 
-    // Apply automatic migrations for older data structures
-    let cfg = CONFIG.DND5E.armorClasses[ac.calc];
-    if ( !cfg ) {
-      ac.calc = "flat";
-      if ( Number.isNumeric(ac.value) ) ac.flat = Number(ac.value);
-      cfg = CONFIG.DND5E.armorClasses.flat;
-    }
+    // Add selected formulas
+    const baseFormulas = Object.entries(CONFIG.DND5E.armorClasses)
+      .filter(([id, data]) => ac.selectedFormulas.has(id))
+      .map(([id, data]) => ({ ...data, id, type: "base" }));
+    ac.formulas.unshift(...baseFormulas);
 
     // Identify Equipped Items
     const { armors, shields } = this.parent.itemTypes.equipment.reduce((obj, equip) => {
@@ -180,56 +218,16 @@ export default class AttributesFields {
       return obj;
     }, { armors: [], shields: [] });
 
-    // Set stealth disadvantage
-    if ( armors[0]?.system.properties.has("stealthDisadvantage") && this.skills ) {
-      AdvantageModeField.setMode(this, "skills.ste.roll.mode", -1);
-    }
-
-    ac.label = !["custom", "flat"].includes(ac.calc) ? CONFIG.DND5E.armorClasses[ac.calc]?.label : null;
-
-    // Determine base AC
-    switch ( ac.calc ) {
-
-      // Flat AC (no additional bonuses)
-      case "flat":
-        ac.value = Number(ac.flat);
-        return;
-
-      // Natural AC (includes bonuses)
-      case "natural":
-        ac.base = Number(ac.flat);
-        break;
-
-      default:
-        let formula = ac.calc === "custom" ? ac.formula : cfg.formula;
-        if ( armors.length ) {
-          if ( armors.length > 1 ) this.parent._preparationWarnings.push({
-            message: _loc("DND5E.WarnMultipleArmor"), type: "warning"
-          });
-          const armorData = armors[0].system.armor;
-          const isHeavy = armors[0].system.type.value === "heavy";
-          ac.armor = armorData.value ?? ac.armor;
-          ac.dex = isHeavy ? 0 : Math.min(armorData.dex ?? Infinity, this.abilities.dex?.mod ?? 0);
-          ac.equippedArmor = armors[0];
-        }
-        else ac.dex = this.abilities.dex?.mod ?? 0;
-
-        if ( !ac.equippedArmor ) ac.label = null;
-
-        rollData.attributes.ac = ac;
-        try {
-          const replaced = replaceFormulaData(formula, rollData, {
-            actor: this, missing: null, property: _loc("DND5E.ArmorClass")
-          });
-          ac.base = replaced ? new Roll(replaced).evaluateSync().total : 0;
-        } catch(err) {
-          this.parent._preparationWarnings.push({
-            message: _loc("DND5E.WarnBadACFormula", { formula }), link: "armor", type: "error"
-          });
-          const replaced = Roll.replaceFormulaData(CONFIG.DND5E.armorClasses.default.formula, rollData);
-          ac.base = new Roll(replaced).evaluateSync().total;
-        }
-        break;
+    // Equipped Armor
+    if ( armors.length ) {
+      if ( armors.length > 1 ) this.parent._preparationWarnings.push({
+        message: _loc("DND5E.WarnMultipleArmor"), type: "warning"
+      });
+      ac.equippedArmor = armors[0];
+      ac.armor = ac.equippedArmor.system.armor.value ?? ac.armor;
+      if ( ac.equippedArmor.system.properties.has("stealthDisadvantage") && this.skills ) {
+        AdvantageModeField.setMode(this, "skills.ste.roll.mode", -1);
+      }
     }
 
     // Equipped Shield
@@ -237,17 +235,55 @@ export default class AttributesFields {
       if ( shields.length > 1 ) this.parent._preparationWarnings.push({
         message: _loc("DND5E.WarnMultipleShields"), type: "warning"
       });
-      ac.shield = shields[0].system.armor.value ?? 0;
       ac.equippedShield = shields[0];
+      ac.shield = ac.equippedShield.system.armor.value ?? 0;
     }
 
-    // Compute cover.
-    ac.cover = Math.max(ac.cover, this.parent.coverBonus);
+    // If armor is equipped, prepare clamped abilities
+    const isHeavy = ac.equippedArmor?.system.type.value === "heavy";
+    ac.clamped = Object.entries(this.abilities).reduce((obj, [k, v]) => {
+      obj[k] = isHeavy ? 0 : Math.min(v.mod, ac.equippedArmor?.system.armor.dex ?? Infinity);
+      return obj;
+    }, {});
+    ac.dex = ac.clamped.dex;
 
-    // Compute total AC and return
+    const validFormulas = ac.formulas.filter(formula => {
+      if ( (typeof formula.armored === "boolean") && (formula.armored !== !!ac.equippedArmor) ) return false;
+      if ( (typeof formula.shielded === "boolean") && (formula.shielded !== !!ac.equippedShield) ) return false;
+      return true;
+    });
+
+    for ( const [index, config] of validFormulas.entries() ) {
+      try {
+        const replaced = replaceFormulaData(config.formula, rollData, {
+          actor: this, missing: null, property: _loc("DND5E.ArmorClass")
+        });
+        const result = replaced ? new Roll(replaced).evaluateSync().total : 0;
+        if ( result > ac.base ) {
+          ac.base = result;
+          ac.calc = config.id;
+          ac.formula = config.formula;
+          if ( config.id === "armored" ) ac.label = ac.equippedArmor.name;
+          else ac.label = config.label ?? "";
+        }
+      } catch(error) {
+        this.parent._preparationWarnings.push({
+          message: _loc("DND5E.WarnBadACFormula", { formula: config.formula }), link: "armor", type: "error"
+        });
+      }
+    }
+
+    if ( !Number.isFinite(ac.base) ) {
+      ac.base = ac.flat ?? 0;
+      ac.calc = "natural";
+      ac.formula = "@attributes.ac.flat";
+    }
+
+    ac.cover = Math.max(ac.cover, this.parent.coverBonus);
     ac.min = simplifyBonus(ac.min, rollData);
     ac.bonus = simplifyBonus(ac.bonus, rollData);
-    ac.value = Math.max(ac.min, ac.base + ac.shield + ac.bonus + ac.cover);
+    if ( ac.override ) ac.value = ac.override;
+    else ac.value = Math.max(ac.min, ac.base + ac.shield + ac.bonus + ac.cover);
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -149,6 +149,7 @@ export default class VehicleData extends CommonTemplate {
   /** @inheritDoc */
   static _migrateData(source) {
     super._migrateData(source);
+    AttributesFields._migrateArmorClass(source.attributes);
     AttributesFields._migrateInitiative(source.attributes);
     VehicleData.#migrateSource(source);
     VehicleData.#migrateMovement(source);

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -41,7 +41,7 @@ export default class VehicleData extends CommonTemplate {
         ...AttributesFields.common,
         ac: new SchemaField({
           ...AttributesFields.armorClass,
-          calc: new StringField({ initial: "flat", label: "DND5E.ArmorClassCalculation" })
+          calc: new StringField({ initial: "flat", label: "DND5E.ARMORCLASS.Calculation.Label" })
         }, { label: "DND5E.ArmorClass" }),
         hp: new SchemaField({
           ...AttributesFields.hitPoints,

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -162,6 +162,7 @@ export default class VehicleData extends CommonTemplate {
   /** @inheritDoc */
   static _migrateData(source) {
     super._migrateData(source);
+    AttributesFields._migrateArmorClass(source.attributes);
     AttributesFields._migrateInitiative(source.attributes);
     VehicleData.#migrateSource(source);
     VehicleData.#migrateMovement(source);

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -40,7 +40,7 @@ export default class VehicleData extends CommonTemplate {
         ...AttributesFields.common,
         ac: new SchemaField({
           ...AttributesFields.armorClass,
-          calc: new StringField({ initial: "flat", label: "DND5E.ArmorClassCalculation" })
+          calc: new StringField({ initial: "flat", label: "DND5E.ARMORCLASS.Calculation.Label" })
         }, { label: "DND5E.ArmorClass" }),
         hp: new SchemaField({
           ...AttributesFields.hitPoints,

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -50,9 +50,11 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /**
    * Active effect fields that should be redirected to another field, optionally with a compatibility warning.
    * Optional warning object contains options passed to `foundry.utils.logCompatibilityWarning`.
-   * @type {Record<string, { key: string, [warning]: object }>}
+   * @type {Record<string, { key: string, [mode]: CONST.ACTIVE_EFFECT_MODES, [warning]: object }>}
    */
   static SHIM_FIELDS = {
+    "system.attributes.ac.calc": { key: "system.attributes.ac.selectedFormulas", mode: CONST.ACTIVE_EFFECT_MODES.ADD },
+    "system.attributes.ac.formula": { key: "system.attributes.ac.formulas", mode: CONST.ACTIVE_EFFECT_MODES.ADD },
     "system.attributes.movement.speed": { key: "system.attributes.movement.walk" },
     "system.attributes.senses.darkvision": { key: "system.attributes.senses.ranges.darkvision" },
     "system.attributes.senses.blindsight": { key: "system.attributes.senses.ranges.blindsight" },
@@ -311,7 +313,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       `The active effect key "${change.key}" has been deprecated and should be changed to "${shim.key}".`,
       shim.warning
     );
-    return { ...change, key: shim.key };
+    return { ...change, key: shim.key, mode: shim.mode ?? change.mode };
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -56,9 +56,11 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /**
    * Active effect fields that should be redirected to another field, optionally with a compatibility warning.
    * Optional warning object contains options passed to `foundry.utils.logCompatibilityWarning`.
-   * @type {Record<string, { key: string, [warning]: object }>}
+   * @type {Record<string, { key: string, [mode]: CONST.ACTIVE_EFFECT_MODES, [warning]: object }>}
    */
   static SHIM_FIELDS = {
+    "system.attributes.ac.calc": { key: "system.attributes.ac.selectedFormulas", mode: CONST.ACTIVE_EFFECT_MODES.ADD },
+    "system.attributes.ac.formula": { key: "system.attributes.ac.formulas", mode: CONST.ACTIVE_EFFECT_MODES.ADD },
     "system.attributes.movement.speed": { key: "system.attributes.movement.walk" },
     "system.attributes.senses.darkvision": { key: "system.attributes.senses.ranges.darkvision" },
     "system.attributes.senses.blindsight": { key: "system.attributes.senses.ranges.blindsight" },
@@ -327,7 +329,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       `The active effect key "${change.key}" has been deprecated and should be changed to "${shim.key}".`,
       shim.warning
     );
-    return { ...change, key: shim.key };
+    return { ...change, key: shim.key, mode: shim.mode ?? change.mode };
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -56,11 +56,9 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /**
    * Active effect fields that should be redirected to another field, optionally with a compatibility warning.
    * Optional warning object contains options passed to `foundry.utils.logCompatibilityWarning`.
-   * @type {Record<string, { key: string, [mode]: CONST.ACTIVE_EFFECT_MODES, [warning]: object }>}
+   * @type {Record<string, { key: string, [type]: string, [value]: Function, [warning]: object }>}
    */
   static SHIM_FIELDS = {
-    "system.attributes.ac.calc": { key: "system.attributes.ac.selectedFormulas", mode: CONST.ACTIVE_EFFECT_MODES.ADD },
-    "system.attributes.ac.formula": { key: "system.attributes.ac.formulas", mode: CONST.ACTIVE_EFFECT_MODES.ADD },
     "system.attributes.movement.speed": { key: "system.attributes.movement.walk" },
     "system.attributes.senses.darkvision": { key: "system.attributes.senses.ranges.darkvision" },
     "system.attributes.senses.blindsight": { key: "system.attributes.senses.ranges.blindsight" },
@@ -329,7 +327,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       `The active effect key "${change.key}" has been deprecated and should be changed to "${shim.key}".`,
       shim.warning
     );
-    return { ...change, key: shim.key, mode: shim.mode ?? change.mode };
+    return { ...change, key: shim.key, type: shim.type ?? change.type };
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2659,51 +2659,36 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const cfg = CONFIG.DND5E.armorClasses[ac.calc];
     const attribution = [];
 
-    if ( ac.calc === "flat" ) {
+    if ( ac.override ) {
       attribution.push({
-        label: _loc("DND5E.ArmorClassFlat"),
+        label: _loc("DND5E.ARMORCLASS.Flat"),
         type: "override",
-        value: ac.flat
+        value: ac.override
       });
       return new PropertyAttribution(this, attribution, "attributes.ac", { title }).renderTooltip();
     }
 
     // Base AC Attribution
-    switch ( ac.calc ) {
-
-      // Natural armor
-      case "natural":
-        attribution.push({
-          label: _loc("DND5E.ArmorClassNatural"),
-          type: "override",
-          value: ac.flat
-        });
-        break;
-
-      default:
-        const formula = ac.calc === "custom" ? ac.formula : cfg.formula;
-        let base = ac.base;
-        const dataRgx = new RegExp(/@([a-z.0-9_-]+)/gi);
-        for ( const [match, term] of formula.matchAll(dataRgx) ) {
-          const value = String(foundry.utils.getProperty(rollData, term));
-          if ( (term === "attributes.ac.armor") || (value === "0") ) continue;
-          if ( Number.isNumeric(value) ) base -= Number(value);
-          attribution.push({
-            label: match,
-            type: "add",
-            value
-          });
-        }
-        const armorInFormula = formula.includes("@attributes.ac.armor");
-        let label = _loc("DND5E.PropertyBase");
-        if ( armorInFormula ) label = this.armor?.name ?? _loc("DND5E.ArmorClassUnarmored");
-        attribution.unshift({
-          label,
-          type: "override",
-          value: base
-        });
-        break;
+    let base = ac.base;
+    const dataRgx = new RegExp(/@([a-z.0-9_-]+)/gi);
+    for ( const [match, term] of ac.formula.matchAll(dataRgx) ) {
+      const value = String(foundry.utils.getProperty(rollData, term));
+      if ( (term === "attributes.ac.armor") || (value === "0") ) continue;
+      if ( Number.isNumeric(value) ) base -= Number(value);
+      attribution.push({
+        label: match,
+        type: "add",
+        value
+      });
     }
+    const armorInFormula = ac.formula.includes("@attributes.ac.armor");
+    let label = ac.label || _loc("DND5E.PropertyBase");
+    if ( armorInFormula ) label = this.armor?.name ?? _loc("DND5E.ARMORCLASS.Calculation.Unarmored");
+    attribution.unshift({
+      label,
+      type: "override",
+      value: base
+    });
 
     // Shield
     if ( ac.shield !== 0 ) attribution.push({

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2659,7 +2659,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const cfg = CONFIG.DND5E.armorClasses[ac.calc];
     const attribution = [];
 
-    if ( ac.override ) {
+    if ( Number.isFinite(ac.override) ) {
       attribution.push({
         label: _loc("DND5E.ARMORCLASS.Flat"),
         type: "override",
@@ -2684,11 +2684,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const armorInFormula = ac.formula.includes("@attributes.ac.armor");
     let label = ac.label || _loc("DND5E.PropertyBase");
     if ( armorInFormula ) label = this.armor?.name ?? _loc("DND5E.ARMORCLASS.Calculation.Unarmored");
-    attribution.unshift({
+    if ( base ) attribution.unshift({
       label,
       type: "override",
       value: base
     });
+    else if ( attribution[0]?.label === "@attributes.ac.flat" ) attribution[0].label = label;
 
     // Shield
     if ( ac.shield !== 0 ) attribution.push({

--- a/module/documents/advancement/modify-item.mjs
+++ b/module/documents/advancement/modify-item.mjs
@@ -18,8 +18,8 @@ export default class ModifyItemAdvancement extends Advancement {
       order: 55,
       icon: "icons/skills/trades/smithing-anvil-silver-red.webp",
       typeIcon: "systems/dnd5e/icons/svg/advancement/modify-item.svg",
-      title: game.i18n.localize("DND5E.ADVANCEMENT.ModifyItem.Title"),
-      hint: game.i18n.localize("DND5E.ADVANCEMENT.ModifyItem.Hint"),
+      title: _loc("DND5E.ADVANCEMENT.ModifyItem.Title"),
+      hint: _loc("DND5E.ADVANCEMENT.ModifyItem.Hint"),
       apps: {
         config: ModifyItemConfig,
         flow: ModifyItemFlow

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1245,8 +1245,8 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   else if ( attr === "attributes.spell.dc" ) label = "DND5E.SpellDC";
 
   // Abilities.
-  else if ( attr.startsWith("abilities.") ) {
-    const [, key] = attr.split(".");
+  else if ( attr.startsWith("abilities.") || attr.startsWith("attributes.ac.clamped.") ) {
+    const key = attr.split(".")[attr.startsWith("abilities.") ? 1 : 3];
     label = game.i18n.format("DND5E.AbilityScoreL", { ability: CONFIG.DND5E.abilities[key].label });
   }
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1306,8 +1306,8 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   else if ( attr === "attributes.spell.dc" ) label = "DND5E.SpellDC";
 
   // Abilities.
-  else if ( attr.startsWith("abilities.") ) {
-    const [, key] = attr.split(".");
+  else if ( attr.startsWith("abilities.") || attr.startsWith("attributes.ac.clamped.") ) {
+    const key = attr.split(".")[attr.startsWith("abilities.") ? 1 : 3];
     label = _loc("DND5E.AbilityScoreL", { ability: CONFIG.DND5E.abilities[key].label });
   }
 

--- a/templates/actors/character-sidebar.hbs
+++ b/templates/actors/character-sidebar.hbs
@@ -57,8 +57,8 @@
                 <div class="ac-badge badge" aria-label="{{ localize 'DND5E.ArmorClass' }}">
                     {{#if editable}}
                     <button type="button" class="config-button unbutton" data-action="showConfiguration"
-                            data-config="armorClass" data-tooltip="DND5E.ArmorConfig"
-                            aria-label="{{ localize 'DND5E.ArmorConfig' }}">
+                            data-config="armorClass" data-tooltip
+                            aria-label="{{ localize 'DND5E.ARMORCLASS.Action.Configure' }}">
                         <i class="fas fa-cog" inert></i>
                     </button>
                     {{else}}

--- a/templates/actors/config/armor-class-calculation.hbs
+++ b/templates/actors/config/armor-class-calculation.hbs
@@ -1,0 +1,50 @@
+<section class="flexcol">
+    <div class="final-value">{{ dnd5e-numberFormat data.value }}</div>
+    <fieldset class="card">
+        <legend>{{ localize "DND5E.ARMORCLASS.CurrentFormula" }}</legend>
+        <div class="form-group">
+            <label>{{ localize "DND5E.ARMORCLASS.Calculation.Label" }}</label>
+            <div class="form-fields">
+                {{ formulaLabel }}
+            </div>
+        </div>
+        <div class="form-group">
+            <label>{{ localize "DND5E.ARMORCLASS.Formula" }}</label>
+            <div class="form-fields">
+                <input type="text" value="{{ data.formula }}" readonly>
+            </div>
+        </div>
+        {{#if ability}}
+        <div class="form-group">
+            <label>{{ localize ability.label }}</label>
+            <div class="form-fields">
+                {{{ dnd5e-numberParts ability.value signDisplay="always" }}}
+            </div>
+        </div>
+        {{/if}}
+    </fieldset>
+    {{#if calculations.length}}
+    <fieldset class="card table equipped">
+        <legend>{{ localize "DND5E.ARMORCLASS.Calculation.Label" }}</legend>
+        <div class="header">
+            <div class="armor-value">
+                <i class="fa-solid fa-shield" data-tooltip aria-label="{{ localize 'DND5E.ArmorValue' }}"></i>
+            </div>
+            <div class="magical-bonus">
+                <i class="fa-solid fa-wand-sparkles" data-tooltip
+                aria-label="{{ localize 'DND5E.EquipmentBonus' }}"></i>
+            </div>
+        </div>
+        {{#each calculations}}
+        <div class="form-group">
+            <div class="name">
+                <img src="{{ img }}" class="gold-icon" alt="{{ name }}">
+                {{{ anchor }}}
+            </div>
+            <span class="armor-value {{#if (eq value "—")}}empty{{/if}}">{{ value }}</span>
+            <span class="magical-bonus {{#if (eq magicalBonus "—")}}empty{{/if}}">{{ magicalBonus }}</span>
+        </div>
+        {{/each}}
+    </fieldset>
+    {{/if}}
+</section>

--- a/templates/actors/config/armor-class-config.hbs
+++ b/templates/actors/config/armor-class-config.hbs
@@ -1,43 +1,37 @@
-<section class="flexcol">
-    <div class="final-value">{{ dnd5e-numberFormat data.value }}</div>
-    <fieldset class="card">
-        <legend>{{ localize "DND5E.ArmorClassFormula" }}</legend>
-        {{ formField fields.calc value=source.calc options=calculationOptions localize=true blank=false }}
-        {{ formField fields.formula value=formula.value disabled=formula.disabled localize=true }}
-        {{#if dexterity}}
-        <div class="form-group">
-            <label>{{ localize CONFIG.abilities.dex.label }}</label>
-            <div class="form-fields">
-                {{{ dnd5e-numberParts dexterity signDisplay="always" }}}
+<fieldset>
+    <legend>
+        <span>{{ localize "DND5E.ARMORCLASS.Configuration" }}</span>
+        <button class="unbutton control-button" data-action="addFormula" data-tooltip
+                aria-label="{{ localize 'DND5E.ARMORCLASS.Action.CreateFormula' }}">
+            <i class="fa-solid fa-plus" inert></i>
+        </button>
+    </legend>
+
+    {{ formField fields.selectedFormulas value=source.selectedFormulas options=formulaOptions localize=true
+                 rootId=partId }}
+    {{ formField fields.flat value=source.flat localize=true rootId=partId }}
+    {{ formField fields.override value=source.override localize=true rootId=partId }}
+
+    {{#each customFormulas}}
+    <div class="form-group split-group full-width card" data-index="{{ @index }}">
+        <div class="form-fields field-groups">
+            <div class="field-group">
+                {{ formField fields.formula name=(concat "system.attributes.ac.formulas." @index ".formula")
+                             value=source.formula classes="label-top" localize=true rootId=@root.partId }}
+                <button class="unbutton control-button" type="button" data-action="deleteFormula" data-tooltip
+                        aria-label="{{ localize 'DND5E.ARMORCLASS.Action.DeleteFormula' }}">
+                    <i class="fa-solid fa-minus" inert></i>
+                </button>
+            </div>
+            <div class="field-group">
+                {{ formField fields.label name=(concat "system.attributes.ac.formulas." @index ".label")
+                             value=source.label classes="label-top" localize=true rootId=@root.partId }}
             </div>
         </div>
-        {{/if}}
-        {{#if formula.showFlat}}
-        {{ formField fields.flat value=source.flat localize=true }}
-        {{/if}}
-    </fieldset>
-    {{#if calculations.length}}
-    <fieldset class="card table equipped">
-        <legend>{{ localize "DND5E.ArmorClassCalculation" }}</legend>
-        <div class="header">
-            <div class="armor-value">
-                <i class="fa-solid fa-shield" data-tooltip aria-label="{{ localize 'DND5E.ArmorValue' }}"></i>
-            </div>
-            <div class="magical-bonus">
-                <i class="fa-solid fa-wand-sparkles" data-tooltip
-                   aria-label="{{ localize 'DND5E.EquipmentBonus' }}"></i>
-            </div>
-        </div>
-        {{#each calculations}}
-        <div class="form-group">
-            <div class="name">
-                <img src="{{ img }}" class="gold-icon" alt="{{ name }}">
-                {{{ anchor }}}
-            </div>
-            <span class="armor-value {{#if (eq value "—")}}empty{{/if}}">{{ value }}</span>
-            <span class="magical-bonus {{#if (eq magicalBonus "—")}}empty{{/if}}">{{ magicalBonus }}</span>
-        </div>
-        {{/each}}
-    </fieldset>
-    {{/if}}
-</section>
+    </div>
+    {{else}}
+    <div class="empty">
+        {{{ localize "DND5E.ARMORCLASS.CustomFormulas.Empty" }}}
+    </div>
+    {{/each}}
+</fieldset>

--- a/templates/actors/config/armor-class-config.hbs
+++ b/templates/actors/config/armor-class-config.hbs
@@ -16,16 +16,21 @@
     <div class="form-group split-group full-width card" data-index="{{ @index }}">
         <div class="form-fields field-groups">
             <div class="field-group">
-                {{ formField fields.formula name=(concat "system.attributes.ac.formulas." @index ".formula")
-                             value=source.formula classes="label-top" localize=true rootId=@root.partId }}
+                {{ formField fields.formula name=(concat prefix "formula") value=source.formula
+                             classes="label-top" localize=true rootId=@root.partId }}
                 <button class="unbutton control-button" type="button" data-action="deleteFormula" data-tooltip
                         aria-label="{{ localize 'DND5E.ARMORCLASS.Action.DeleteFormula' }}">
                     <i class="fa-solid fa-minus" inert></i>
                 </button>
             </div>
             <div class="field-group">
-                {{ formField fields.label name=(concat "system.attributes.ac.formulas." @index ".label")
-                             value=source.label classes="label-top" localize=true rootId=@root.partId }}
+                {{ formField fields.label name=(concat prefix "label") value=source.label
+                             classes="label-top" localize=true rootId=@root.partId }}
+            </div>
+            <div class="field-group split-group">
+                <div class="form-fields">
+                    {{> "dnd5e.fieldlist" limitFields }}
+                </div>
             </div>
         </div>
     </div>

--- a/templates/actors/npc-header.hbs
+++ b/templates/actors/npc-header.hbs
@@ -113,8 +113,8 @@
                 <div class="ac-badge badge" aria-label="{{ localize 'DND5E.ArmorClass' }}">
                     {{#if editable}}
                     <button type="button" class="config-button unbutton" data-action="showConfiguration"
-                            data-config="armorClass" data-tooltip="DND5E.ArmorConfig"
-                            aria-label="{{ localize 'DND5E.ArmorConfig' }}">
+                            data-config="armorClass" data-tooltip
+                            aria-label="{{ localize 'DND5E.ARMORCLASS.Action.Configure' }}">
                         <i class="fas fa-cog" inert></i>
                     </button>
                     {{else}}

--- a/templates/actors/vehicle/sidebar.hbs
+++ b/templates/actors/vehicle/sidebar.hbs
@@ -154,7 +154,7 @@
     {{!-- Armor Class --}}
     {{#if (or editable system.attributes.ac.value)}}
     {{> "systems/dnd5e/templates/actors/parts/actor-trait-line.hbs" icon="fa-solid fa-shield" label="DND5E.ArmorClass"
-        configAction="armorClass" configLabel="DND5E.ArmorConfig" data=system.attributes.ac }}
+        configAction="armorClass" configLabel="DND5E.ARMORCLASS.Action.Configure" data=system.attributes.ac }}
     {{/if}}
 
     {{!-- Speed --}}

--- a/templates/actors/vehicle/sidebar.hbs
+++ b/templates/actors/vehicle/sidebar.hbs
@@ -155,7 +155,7 @@
     {{!-- Armor Class --}}
     {{#if (or editable system.attributes.ac.value)}}
     {{> "systems/dnd5e/templates/actors/parts/actor-trait-line.hbs" icon="fa-solid fa-shield" label="DND5E.ArmorClass"
-        configAction="armorClass" configLabel="DND5E.ArmorConfig" data=system.attributes.ac }}
+        configAction="armorClass" configLabel="DND5E.ARMORCLASS.Action.Configure" data=system.attributes.ac }}
     {{/if}}
 
     {{!-- Speed --}}


### PR DESCRIPTION
Modifies how armor class data is stored to use multiple formulas rather than only having a single formula that is evaluated. This change means that all enabled formulas are evaluated fully and the one that provides the highest base AC is used.

This also allows armor class formulas to define whether they are usable when the character is wearing armor or wielding a shield. This makes all of the existing unarmoed defense formulas work as expected.

In order to ensure that the previous `flat` calculation properly overrides the full AC it has been moved to a separate `override` value. The existing `flat` input is retained to provide a place for players to manually enter a value that can be used in formulas (like the Natural Armor formula).

<img width="877" height="573" alt="Armor Class Configuration Formulas" src="https://github.com/user-attachments/assets/d41be14a-2546-4718-96aa-7fed962dbcf3" />

Migrations are in place to move the existing actor data to use the new data structure and shims are added to ensure existing active effects that target AC will continue working. The removed `calc` and `formula` fields are still set by the winning calculation so no shims are required.

Closes #6121
Closes #6646