### PR TITLE
[#6660] Add transform mode for changing forms on single actor

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5401,15 +5401,20 @@
         "label": "Customize",
         "hint": "Use custom transformation settings rather than the defaults provided by the selected preset."
       },
+      "formless": {
+        "hint": "Allow creature to remove all forms and return to a default state.",
+        "label": "Formless"
+      },
       "identifier": {
         "label": "Class Identifier",
         "hint": "Identifier used to determine whether the character level or a specific class level should be used for profile level limits."
       },
       "mode": {
         "label": "Mode",
-        "hint": "Sets how the transformation source creatures are selected.",
-        "CR": "By Challenge Rating",
-        "Direct": "By Direct Link"
+        "hint": "Sets how the transformation changes are determined.",
+        "CR": "Creature Stats (by Challenge Rating)",
+        "Direct": "Creature Stats (by Direct Link)",
+        "Form": "Select Form"
       },
       "preset": {
         "label": "Preset"
@@ -5417,6 +5422,7 @@
     }
   },
   "Hint": "Change an actor using the stats of another.",
+  "NoForm": "No Form",
   "Preset": {
     "Appearance": {
       "Label": "Appearance Only"

--- a/lang/en.json
+++ b/lang/en.json
@@ -5580,6 +5580,7 @@
   "TemporaryClass": "Temporary Class",
   "Title": "Transform",
   "Warning": {
+    "FormActive": "{form} already active on {actor}.",
     "NoOwnership": "You do not have permission to transform this actor.",
     "NoPermission": "Transformation permission haven't been granted to players.",
     "OriginalActor": "No original actor was found with ID '{reference}'.",

--- a/module/applications/activity/transform-sheet.mjs
+++ b/module/applications/activity/transform-sheet.mjs
@@ -75,7 +75,8 @@ export default class TransformSheet extends ActivitySheet {
 
     context.profileModes = [
       { value: "", label: _loc("DND5E.TRANSFORM.FIELDS.transform.mode.Direct") },
-      { value: "cr", label: _loc("DND5E.TRANSFORM.FIELDS.transform.mode.CR") }
+      { value: "cr", label: _loc("DND5E.TRANSFORM.FIELDS.transform.mode.CR"), rule: true },
+      { value: "form", label: _loc("DND5E.TRANSFORM.FIELDS.transform.mode.Form") }
     ];
     context.profiles = context.source.profiles.map((data, index) => ({
       data, index,
@@ -85,6 +86,24 @@ export default class TransformSheet extends ActivitySheet {
       prefix: `profiles.${index}.`,
       source: context.source.profiles[index] ?? data
     })).sort((lhs, rhs) => (lhs.name || "").localeCompare(rhs.name || "", game.i18n.lang));
+
+    context.effects = {
+      labels: {
+        legend: "DND5E.TRANSFORM.FIELDS.profiles.label"
+      },
+      fields: [
+        {
+          field: context.fields.transform.fields.mode,
+          options: context.profileModes,
+          value: context.source.transform.mode
+        },
+        {
+          field: context.fields.transform.fields.formless,
+          input: dnd5e.applications.fields.createCheckboxInput,
+          value: context.source.transform.formless
+        }
+      ]
+    };
 
     return context;
   }
@@ -116,7 +135,7 @@ export default class TransformSheet extends ActivitySheet {
   /** @inheritDoc */
   async _onRender(context, options) {
     await super._onRender(context, options);
-    this.element.querySelector(".activity-profiles").addEventListener("drop", this.#onDrop.bind(this));
+    this.element.querySelector(".activity-profiles")?.addEventListener("drop", this.#onDrop.bind(this));
   }
 
   /* -------------------------------------------- */

--- a/module/applications/activity/transform-usage-dialog.mjs
+++ b/module/applications/activity/transform-usage-dialog.mjs
@@ -34,6 +34,9 @@ export default class TransformUsageDialog extends ActivityUsageDialog {
       let options = profiles.map(profile => ({
         value: profile._id, label: this.getProfileLabel(profile, rollData)
       }));
+      if ( (this.activity.transform.mode === "form") && this.activity.transform.formless ) options.unshift({
+        value: "", label: _loc("DND5E.TRANSFORM.NoForm"), rule: true
+      });
       context.hasCreation = true;
       context.transformFields = [{
         field: new StringField({
@@ -54,8 +57,8 @@ export default class TransformUsageDialog extends ActivityUsageDialog {
 
   /**
    * Determine the label for a profile in the ability use dialog.
-   * @param {SummonsProfile} profile     Profile for which to generate the label.
-   * @param {ActivityRollData} rollData  Roll data used to prepare the count.
+   * @param {EffectApplicationData|TransformProfile} profile  Profile for which to generate the label.
+   * @param {ActivityRollData} rollData                       Roll data used to prepare the count.
    * @returns {string}
    */
   getProfileLabel(profile, rollData) {

--- a/module/applications/activity/transform-usage-dialog.mjs
+++ b/module/applications/activity/transform-usage-dialog.mjs
@@ -67,6 +67,10 @@ export default class TransformUsageDialog extends ActivityUsageDialog {
       case "cr":
         const cr = simplifyBonus(profile.cr, rollData);
         return _loc("DND5E.TRANSFORM.Profile.ChallengeRatingLabel", { cr: formatCR(cr) });
+      case "form":
+        const effect = profile.getEffect();
+        if ( effect ) return effect.name;
+        break;
       default:
         const doc = fromUuidSync(profile.uuid);
         if ( doc ) return doc.name;

--- a/module/data/activity/transform-data.mjs
+++ b/module/data/activity/transform-data.mjs
@@ -37,6 +37,7 @@ export default class BaseTransformActivityData extends BaseActivityData {
       settings: new EmbeddedDataField(TransformationSetting, { nullable: true, initial: null }),
       transform: new SchemaField({
         customize: new BooleanField(),
+        formless: new BooleanField(),
         mode: new StringField({ initial: "cr" }),
         preset: new StringField()
       })
@@ -47,20 +48,25 @@ export default class BaseTransformActivityData extends BaseActivityData {
   /*  Properties                                  */
   /* -------------------------------------------- */
 
-  /** @override */
-  get applicableEffects() {
-    return null;
+  /**
+   * Transform profiles that can be performed based on spell/character/class level.
+   * @type {EffectApplicationData[]|TransformProfile[]}
+   */
+  get availableProfiles() {
+    if ( this.transform.mode === "form" ) return this.applicableEffects;
+    const level = this.relevantLevel;
+    return this.profiles.filter(e => ((e.level.min ?? -Infinity) <= level) && (level <= (e.level.max ?? Infinity)));
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Transform profiles that can be performed based on spell/character/class level.
-   * @type {TransformProfile[]}
+   * When using the form mode, what is the ID of the currently active form if any.
+   * @type {string|null}
    */
-  get availableProfiles() {
-    const level = this.relevantLevel;
-    return this.profiles.filter(e => ((e.level.min ?? -Infinity) <= level) && (level <= (e.level.max ?? Infinity)));
+  get currentProfile() {
+    if ( this.transform.mode !== "form" ) return null;
+    return this.effects.find(e => !e.effect?.disabled && e.effect?.transfer)?._id ?? "";
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/transform-data.mjs
+++ b/module/data/activity/transform-data.mjs
@@ -66,7 +66,11 @@ export default class BaseTransformActivityData extends BaseActivityData {
    */
   get currentProfile() {
     if ( this.transform.mode !== "form" ) return null;
-    return this.effects.find(e => !e.effect?.disabled && e.effect?.transfer)?._id ?? "";
+    const active = this.effects.find(e => {
+      const effect = e.getEffect();
+      return !effect?.disabled && effect?.transfer;
+    })?._id;
+    return active ?? (this.transform.formless ? "" : null);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -27,6 +27,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
       hint: "DND5E.ENCHANT.Hint",
       sheetClass: EnchantSheet,
       usage: {
+        applyEffectsInChat: false,
         dialog: EnchantUsageDialog
       }
     }, { inplace: false })
@@ -83,7 +84,6 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
   /** @inheritDoc */
   _finalizeMessageConfig(usageConfig, messageConfig, results) {
     super._finalizeMessageConfig(usageConfig, messageConfig, results);
-    delete messageConfig.data.system?.effects;
 
     // Store selected enchantment profile in message flag
     if ( usageConfig.enchantmentProfile ) foundry.utils.setProperty(

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -39,6 +39,7 @@ export default function ActivityMixin(Base) {
       sheetClass: ActivitySheet,
       usage: {
         actions: {},
+        applyEffectsInChat: true,
         chatCard: "systems/dnd5e/templates/chat/activity-card.hbs",
         dialog: ActivityUsageDialog
       }
@@ -202,9 +203,6 @@ export default function ActivityMixin(Base) {
         data: {
           flags: {
             dnd5e: this.messageFlags
-          },
-          system: {
-            effects: this.applicableEffects?.map(e => e.relativeUUID)
           }
         },
         hasConsumption: usageConfig.hasConsumption
@@ -719,8 +717,10 @@ export default function ActivityMixin(Base) {
      */
     _finalizeMessageConfig(usageConfig, messageConfig, results) {
       messageConfig.data.rolls = (messageConfig.data.rolls ?? []).concat(results.updates.rolls);
-      const effects = this.applicableEffects?.map(e => e.relativeUUID);
-      if ( effects ) foundry.utils.setProperty(messageConfig.data, "system.effects", effects);
+      if ( this.metadata.usage.applyEffectsInChat ) {
+        const effects = this.applicableEffects?.map(e => e.relativeUUID);
+        if ( effects ) foundry.utils.setProperty(messageConfig.data, "system.effects", effects);
+      }
     }
 
     /* -------------------------------------------- */

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -37,6 +37,7 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
         actions: {
           placeSummons: SummonActivity.#placeSummons
         },
+        applyEffectsInChat: false,
         dialog: SummonUsageDialog
       }
     }, { inplace: false })
@@ -71,14 +72,6 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
     config.summons.creatureSize ??= this.creatureSizes.first() ?? null;
     config.summons.creatureType ??= this.creatureTypes.first() ?? null;
     return config;
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  _finalizeMessageConfig(usageConfig, messageConfig, results) {
-    super._finalizeMessageConfig(usageConfig, messageConfig, results);
-    delete messageConfig.data.system?.effects;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/transform.mjs
+++ b/module/documents/activity/transform.mjs
@@ -34,6 +34,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
         actions: {
           transformActor: TransformActivity.#transformActor
         },
+        applyEffectsInChat: false,
         dialog: TransformUsageDialog
       }
     }, { inplace: false })
@@ -79,7 +80,6 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
     if ( usageConfig.transform?.profile ) {
       foundry.utils.setProperty(messageConfig.data, "flags.dnd5e.transform.profile", usageConfig.transform.profile);
     }
-    delete messageConfig.data.flags?.dnd5e?.use?.effects;
   }
 
   /* -------------------------------------------- */
@@ -88,7 +88,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
   _usageChatButtons(message) {
     if ( !this.availableProfiles.length ) return super._usageChatButtons(message);
     const form = this.transform.mode === "form"
-      ? this.effects.find(e => e._id === message.data?.flags?.dnd5e?.transform?.profile)?.effect?.name
+      ? this.effects.find(e => e._id === message.data?.flags?.dnd5e?.transform?.profile)?.getEffect()?.name
         ?? _loc("DND5E.TRANSFORM.NoForm") : null;
     return [{
       label: form ?? _loc("DND5E.TRANSFORM.Action.Transform"),
@@ -114,7 +114,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
     if ( this.transform.mode !== "form" ) {
       const profile = this.profiles.find(p => p._id === config.transform?.profile);
       if ( profile ) {
-        const uuid = !this.transform.mode ? profile.uuid : await this.queryActor(profile);
+        const uuid = this.transform.mode ? await this.queryActor(profile) : profile.uuid;
         if ( uuid ) {
           if ( results.message instanceof ChatMessage ) results.message.setFlag("dnd5e", "transform.uuid", uuid);
           else foundry.utils.setProperty(results.message, "flags.dnd5e.transform.uuid", uuid);
@@ -152,7 +152,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
   async _triggerSubsequentActions(config, results) {
     if ( this.transform.mode !== "form" ) return;
     const profile = results.message?.flags?.dnd5e?.transform?.profile
-      ?? results.message?.data?.flags?.dnd5e?.transform?.profile
+      ?? results.message?.data?.flags?.dnd5e?.transform?.profile;
     this.#transformToForm(profile);
   }
 
@@ -169,7 +169,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
    */
   static async #transformActor(event, target, message) {
     if ( this.transform.mode === "form" ) {
-      this.#transformToForm(message.getFlag("dnd5e", "transform.profile"));
+      await this.#transformToForm(message.getFlag("dnd5e", "transform.profile"));
       return;
     }
 
@@ -205,17 +205,27 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
   async #transformToForm(profileId) {
     if ( this.transform.mode !== "form" ) return;
     const profile = this.applicableEffects.find(e => e._id === profileId);
-    // TODO: Not sure this is the best actor selection logic
-    const targets = getSceneTargets(this.actor).map(t => t.actor);
+    if ( !profile && !this.transform.forrmless ) return;
+
+    let targets = getSceneTargets(this.actor, { checkBaseActor: true }).map(t => t.actor);
     if ( !targets.length ) targets.push(this.actor);
     for ( const target of targets ) {
       const item = target.items.get(this.item.id);
       if ( !item ) continue;
-      await item.updateEmbeddedDocuments("ActiveEffect", this.effects
-        .map(e => e.effect
-          ? { _id: e.effect.id, disabled: e.effect.id !== profileId, transfer: e.effect.id === profileId } : null)
-        .filter(_ => _)
-      );
+      const updates = [];
+      for ( const profile of this.effects ) {
+        const effect = item.effects.get(profile._id);
+        if ( !effect ) continue;
+        const enabledEffect = effect.id === profileId;
+        if ( enabledEffect && effect.transfer && !effect.disabled ) {
+          ui.notifications.info("DND5E.TRANSFORM.Warning.FormActive", {
+            format: { form: effect.name, actor: target.token?.name ?? target.name }
+          });
+        } else {
+          updates.push({ _id: effect.id, disabled: !enabledEffect, transfer: enabledEffect });
+        }
+      }
+      if ( updates.length ) await item.updateEmbeddedDocuments("ActiveEffect", updates);
     }
   }
 }

--- a/module/documents/activity/transform.mjs
+++ b/module/documents/activity/transform.mjs
@@ -205,7 +205,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
   async #transformToForm(profileId) {
     if ( this.transform.mode !== "form" ) return;
     const profile = this.applicableEffects.find(e => e._id === profileId);
-    if ( !profile && !this.transform.forrmless ) return;
+    if ( !profile && !this.transform.formless ) return;
 
     let targets = getSceneTargets(this.actor, { checkBaseActor: true }).map(t => t.actor);
     if ( !targets.length ) targets.push(this.actor);

--- a/module/documents/activity/transform.mjs
+++ b/module/documents/activity/transform.mjs
@@ -48,6 +48,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
    * @type {boolean}
    */
   get canTransform() {
+    if ( this.transform.mode === "form" ) return this.actor.isOwner;
     return game.user.can("ACTOR_CREATE") && (game.user.isGM || game.settings.get("dnd5e", "allowPolymorphing"));
   }
 
@@ -59,7 +60,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
   _prepareUsageConfig(config) {
     config = super._prepareUsageConfig(config);
     config.transform ??= {};
-    config.transform.profile ??= this.availableProfiles[0]?._id ?? null;
+    config.transform.profile ??= this.currentProfile ?? this.availableProfiles[0]?._id ?? null;
     return config;
   }
 
@@ -78,6 +79,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
     if ( usageConfig.transform?.profile ) {
       foundry.utils.setProperty(messageConfig.data, "flags.dnd5e.transform.profile", usageConfig.transform.profile);
     }
+    delete messageConfig.data.flags?.dnd5e?.use?.effects;
   }
 
   /* -------------------------------------------- */
@@ -85,8 +87,11 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
   /** @override */
   _usageChatButtons(message) {
     if ( !this.availableProfiles.length ) return super._usageChatButtons(message);
+    const form = this.transform.mode === "form"
+      ? this.effects.find(e => e._id === message.data?.flags?.dnd5e?.transform?.profile)?.effect?.name
+        ?? _loc("DND5E.TRANSFORM.NoForm") : null;
     return [{
-      label: _loc("DND5E.TRANSFORM.Action.Transform"),
+      label: form ?? _loc("DND5E.TRANSFORM.Action.Transform"),
       icon: '<i class="fa-solid fa-frog" inert></i>',
       dataset: {
         action: "transformActor"
@@ -106,12 +111,14 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
 
   /** @inheritDoc */
   async _finalizeUsage(config, results) {
-    const profile = this.profiles.find(p => p._id === config.transform?.profile);
-    if ( profile ) {
-      const uuid = !this.transform.mode ? profile.uuid : await this.queryActor(profile);
-      if ( uuid ) {
-        if ( results.message instanceof ChatMessage ) results.message.setFlag("dnd5e", "transform.uuid", uuid);
-        else foundry.utils.setProperty(results.message, "flags.dnd5e.transform.uuid", uuid);
+    if ( this.transform.mode !== "form" ) {
+      const profile = this.profiles.find(p => p._id === config.transform?.profile);
+      if ( profile ) {
+        const uuid = !this.transform.mode ? profile.uuid : await this.queryActor(profile);
+        if ( uuid ) {
+          if ( results.message instanceof ChatMessage ) results.message.setFlag("dnd5e", "transform.uuid", uuid);
+          else foundry.utils.setProperty(results.message, "flags.dnd5e.transform.uuid", uuid);
+        }
       }
     }
     await super._finalizeUsage(config, results);
@@ -140,6 +147,16 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
   }
 
   /* -------------------------------------------- */
+
+  /** @override */
+  async _triggerSubsequentActions(config, results) {
+    if ( this.transform.mode !== "form" ) return;
+    const profile = results.message?.flags?.dnd5e?.transform?.profile
+      ?? results.message?.data?.flags?.dnd5e?.transform?.profile
+    this.#transformToForm(profile);
+  }
+
+  /* -------------------------------------------- */
   /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 
@@ -151,6 +168,11 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
    * @param {ChatMessage5e} message  Message associated with the activation.
    */
   static async #transformActor(event, target, message) {
+    if ( this.transform.mode === "form" ) {
+      this.#transformToForm(message.getFlag("dnd5e", "transform.profile"));
+      return;
+    }
+
     const targets = getSceneTargets();
     if ( !targets.length && game.user.character ) targets.push(game.user.character);
     if ( !targets.length ) {
@@ -171,6 +193,29 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
       const actor = token instanceof Actor ? token : token.actor;
       await actor.transformInto(source, this.settings);
       // TODO: Create message for transformed actors
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle transforming the actor to a specific form.
+   * @param {string} [profileId]  ID of the profile into which to transform.
+   */
+  async #transformToForm(profileId) {
+    if ( this.transform.mode !== "form" ) return;
+    const profile = this.applicableEffects.find(e => e._id === profileId);
+    // TODO: Not sure this is the best actor selection logic
+    const targets = getSceneTargets(this.actor).map(t => t.actor);
+    if ( !targets.length ) targets.push(this.actor);
+    for ( const target of targets ) {
+      const item = target.items.get(this.item.id);
+      if ( !item ) continue;
+      await item.updateEmbeddedDocuments("ActiveEffect", this.effects
+        .map(e => e.effect
+          ? { _id: e.effect.id, disabled: e.effect.id !== profileId, transfer: e.effect.id === profileId } : null)
+        .filter(_ => _)
+      );
     }
   }
 }

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -728,7 +728,7 @@ export function getTargetDescriptors() {
  * Get currently selected tokens in the scene or user's character's tokens.
  * @param {Actor5e} [actor]                   Only allow tokens associated with this specific actor.
  * @param {object} [options={}]
- * @param {boolean} [options=checkBaseActor]  Also include tokens whose base actor matches the provided actor.
+ * @param {boolean} [options.checkBaseActor]  Also include tokens whose base actor matches the provided actor.
  * @returns {Token5e[]}
  */
 export function getSceneTargets(actor, { checkBaseActor }={}) {

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -730,7 +730,8 @@ export function getTargetDescriptors() {
  * @returns {Token5e[]}
  */
 export function getSceneTargets(actor) {
-  let targets = canvas.tokens?.controlled.filter(t => t.actor && (!actor || t.actor === actor)) ?? [];
+  let targets = canvas.tokens?.controlled
+    .filter(t => t.actor && (!actor || (t.actor === actor) || (t.document.baseActor === actor))) ?? [];
   if ( !targets.length && actor ) targets = actor.getActiveTokens();
   else if ( !targets.length && game.user.character ) targets = game.user.character.getActiveTokens();
   return targets;

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -726,12 +726,15 @@ export function getTargetDescriptors() {
 
 /**
  * Get currently selected tokens in the scene or user's character's tokens.
- * @param {Actor5e} [actor]  Only allow tokens associated with this specific actor.
+ * @param {Actor5e} [actor]                   Only allow tokens associated with this specific actor.
+ * @param {object} [options={}]
+ * @param {boolean} [options=checkBaseActor]  Also include tokens whose base actor matches the provided actor.
  * @returns {Token5e[]}
  */
-export function getSceneTargets(actor) {
-  let targets = canvas.tokens?.controlled
-    .filter(t => t.actor && (!actor || (t.actor === actor) || (t.document.baseActor === actor))) ?? [];
+export function getSceneTargets(actor, { checkBaseActor }={}) {
+  let targets = canvas.tokens?.controlled.filter(t =>
+    t.actor && (!actor || (t.actor === actor) || (checkBaseActor && (t.document.baseActor === actor)))
+  ) ?? [];
   if ( !targets.length && actor ) targets = actor.getActiveTokens();
   else if ( !targets.length && game.user.character ) targets = game.user.character.getActiveTokens();
   return targets;

--- a/templates/activity/parts/activity-effects.hbs
+++ b/templates/activity/parts/activity-effects.hbs
@@ -22,8 +22,10 @@
         </li>
         {{/each}}
     </ul>
+    {{#unless (eq remote false)}}
     <document-tags name="appliedRemoteEffects" class="hidden-tags drop-area" type="ActiveEffect"
                    data-drop-hint="{{ localize (ifThen labels.drop labels.drop "DND5E.EFFECT.DropHint") }}"></document-tags>
+    {{/unless}}
 </fieldset>
 
 {{#*inline ".effect"}}

--- a/templates/activity/parts/activity-effects.hbs
+++ b/templates/activity/parts/activity-effects.hbs
@@ -6,6 +6,9 @@
             <i class="fas fa-plus" inert></i>
         </button>
     </legend>
+    {{#if effects.fields.length}}
+    {{> "dnd5e.fieldlist" effects.fields }}
+    {{/if}}
     <multi-select name="appliedLocalEffects" class="hidden-tags">{{ selectOptions allEffects }}</multi-select>
     <ul class="separated-list effects-list flexcol unlist">
         {{#each appliedEffects}}

--- a/templates/activity/transform-effect.hbs
+++ b/templates/activity/transform-effect.hbs
@@ -1,7 +1,7 @@
 <section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
     {{#if (eq activity.transform.mode "form")}}
 
-    {{> "systems/dnd5e/templates/activity/parts/activity-effects.hbs" labels=effects.labels }}
+    {{> "systems/dnd5e/templates/activity/parts/activity-effects.hbs" labels=effects.labels remote=false }}
 
     {{else}}
 

--- a/templates/activity/transform-effect.hbs
+++ b/templates/activity/transform-effect.hbs
@@ -1,5 +1,13 @@
 <section class="tab activity-{{ tab.id }} {{ tab.cssClass }}" data-tab="{{ tab.id }}" data-group="{{ tab.group }}">
+    {{#if (eq activity.transform.mode "form")}}
+
+    {{> "systems/dnd5e/templates/activity/parts/activity-effects.hbs" labels=effects.labels }}
+
+    {{else}}
+
     {{> "templates/generic/tab-navigation.hbs" tabs=tabs.effect.tabs }}
     {{> "systems/dnd5e/templates/activity/parts/transform-profiles.hbs" tab=tabs.effect.tabs.profiles }}
     {{> "systems/dnd5e/templates/activity/parts/transform-settings.hbs" tab=tabs.effect.tabs.settings }}
+
+    {{/if}}
 </section>


### PR DESCRIPTION
Adds a new mode to the Transform activity that allows for changing between different forms defined using active effects on a single actor. When the form is changed, the effect for the selected form is enabled and transfered to the actor while the effects for all other forms are diabled and no longer transfered.

This mode also adds a "Formless" option, which allows for disabling all forms. Using the formless option is good for spells like Disguise Self where the actor should go back to normal once the spell ends while creatures like Werewolves should not use this option, since they are always in one of three distinct forms.

Closes #6660