### PR TITLE
[#6665] Add ability to hide items using active effect

### DIFF
--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -440,6 +440,8 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     context.itemContext = {};
     context.items = Array.from(this.inventorySource.items).filter(i => !this.actor.items.has(i.system.container));
     await Promise.all(context.items.map(async item => {
+      if ( !this._isItemVisible(item) ) return;
+
       // Prepare item context
       const ctx = context.itemContext[item.id] ??= {};
       ctx.clickAction = "use";
@@ -743,12 +745,25 @@ export default class BaseActorSheet extends PrimarySheetMixin(
    * @protected
    */
   _assignItemCategories(item) {
-    const origin = item.dependentOrigin;
-    if ( (origin?.active === false) && (origin.parent !== item) ) return [];
     if ( item.type === "container" ) return new Set(["containers", "inventory"]);
     if ( item.type === "spell" ) return new Set(["spells"]);
     if ( "inventorySection" in item.system.constructor ) return new Set(["inventory"]);
     return new Set(["features"]);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Determine whether an item should be displayed on the sheet.
+   * @param {Item5e} item    Item being prepared for display.
+   * @returns {boolean}
+   * @protected
+   */
+  _isItemVisible(item) {
+    const origin = item.dependentOrigin;
+    if ( this.actor.hiddenItems.has(item.id) ) return false;
+    if ( (origin?.active === false) && (origin.parent !== item) ) return false;
+    return true;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -649,6 +649,9 @@ export default class CharacterActorSheet extends BaseActorSheet {
       const favorite = await fromUuid(id, { relative: this.actor });
       if ( !favorite && ((type === "item") || (type === "effect") || (type === "activity")) ) return arr;
       if ( favorite?.dependentOrigin?.active === false ) return arr;
+      if ( ((type === "item") && this.actor.hiddenItems.has(favorite.id))
+        || ((type === "effect") && this.actor.hiddenItems.has(favorite.parent?.id))
+        || ((type === "activity") && this.actor.hiddenItems.has(favorite.item?.id)) ) return arr;
       arr = await arr;
 
       let data;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -196,13 +196,32 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   static applyChange(model, change, options={}) {
     change = change.effect._applyChangeShim(change);
+
+    // Handle special actor flags
     if ( change.key.startsWith("flags.dnd5e.") ) change = change.effect._prepareFlagChange(model, change);
+
+    // Properly handle formulas that don't exist as part of the data model
     if ( ActiveEffect5e.FORMULA_FIELDS.has(change.key) ) {
       const field = new FormulaField({ deterministic: change.key !== "system.damage.bonus" });
       return { [change.key]: this.applyChangeField(model, change, { field }) };
     }
+
+    // Handle activity-targeted changes
     if ( (change.key.startsWith("activities[") || change.key.startsWith("system.activities."))
       && (model instanceof Item) ) return change.effect.applyActivity(model, change);
+
+    // Handle hiding items
+    if ( change.key === "items.hidden" && (doc instanceof Actor) ) {
+      if ( change.type === "add" ) {
+        if ( doc.items.has(change.value) ) doc.hiddenItems.add(change.value);
+        else doc.identifiedItems.get(change.value)?.forEach(i => doc.hiddenItems.add(i.id));
+      } else if ( change.mode === "subtract" ) {
+        if ( doc.items.has(change.value) ) doc.hiddenItems.delete(change.value);
+        else doc.identifiedItems.get(change.value)?.forEach(i => doc.hiddenItems.delete(i.id));
+      }
+      return;
+    }
+
     return super.applyChange(model, change, options);
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -211,13 +211,13 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       && (model instanceof Item) ) return change.effect.applyActivity(model, change);
 
     // Handle hiding items
-    if ( change.key === "items.hidden" && (doc instanceof Actor) ) {
+    if ( (change.key === "items.hidden") && (model instanceof Actor) ) {
       if ( change.type === "add" ) {
-        if ( doc.items.has(change.value) ) doc.hiddenItems.add(change.value);
-        else doc.identifiedItems.get(change.value)?.forEach(i => doc.hiddenItems.add(i.id));
-      } else if ( change.mode === "subtract" ) {
-        if ( doc.items.has(change.value) ) doc.hiddenItems.delete(change.value);
-        else doc.identifiedItems.get(change.value)?.forEach(i => doc.hiddenItems.delete(i.id));
+        if ( model.items.has(change.value) ) model.hiddenItems.add(change.value);
+        else model.identifiedItems.get(change.value)?.forEach(i => model.hiddenItems.add(i.id));
+      } else if ( change.type === "subtract" ) {
+        if ( model.items.has(change.value) ) model.hiddenItems.delete(change.value);
+        else model.identifiedItems.get(change.value)?.forEach(i => model.hiddenItems.delete(i.id));
       }
       return;
     }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -62,6 +62,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
+   * List of IDs of items that should be hidden on the sheet.
+   * @type {Set<string>}
+   */
+  hiddenItems = this.hiddenItems;
+
+  /* -------------------------------------------- */
+
+  /**
    * Mapping of item identifiers to the items.
    * @type {IdentifiedItemsMap<string, Set<Item5e>>}
    */
@@ -306,8 +314,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   prepareData() {
     if ( this.system.modelProvider !== dnd5e ) return super.prepareData();
     this._clearCachedValues();
-    this._preparationWarnings = [];
-    this.labels = {};
     super.prepareData();
     this.items.forEach(item => item.prepareFinalAttributes());
     this._prepareSpellcasting();
@@ -322,6 +328,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   _clearCachedValues() {
     this._lazy = {};
     this._preferredArtwork = null;
+    this._preparationWarnings = [];
+    this.labels = {};
+    this.hiddenItems = new Set();
     this.identifiedItems = new IdentifiedItemsMap();
     this.sourcedItems = new SourcedItemsMap();
   }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -481,6 +481,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @type {boolean}
    */
   get areEffectsSuppressed() {
+    if ( this.parent?.hiddenItems?.has(this.id) ) return true;
     const requireEquipped = (this.type !== "consumable")
       || ["rod", "trinket", "wand"].includes(this.system.type.value);
     if ( requireEquipped && (this.system.equipped === false) ) return true;


### PR DESCRIPTION
Adds `items.hidden` as an active effect key that can be used to hide items on the sheet. This value accepts either a specific item ID or an identifier (with support for type prefixes).

When an item is hidden in this way it is not displayed on the sheet, any of its effects are suppressed, and it is hidden in the character's favorites.

Closes #6665