### PR TITLE
Add duration control to group rest dialog, "Until Sunrise" button

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3713,6 +3713,11 @@
 
 "DND5E.REST": {
   "Configuration": "Rest Configuration",
+  "Duration": {
+    "Hint": "Amount of time to pass during the rest.",
+    "Label": "Duration",
+    "UntilSunrise": "Rest Until Sunrise"
+  },
   "HitDice": {
     "AutoSpend": {
       "Hint": "Automatically spend hit dice until they run out or health is full.",

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -1,7 +1,7 @@
-import { filteredKeys } from "../../../utils.mjs";
+import { convertTime, filteredKeys } from "../../../utils.mjs";
 import Dialog5e from "../../api/dialog.mjs";
 
-const { BooleanField } = foundry.data.fields;
+const { BooleanField, NumberField, StringField } = foundry.data.fields;
 
 /**
  * @import { RestConfiguration } from "../../../documents/_types.mjs";
@@ -22,6 +22,9 @@ export default class BaseRestDialog extends Dialog5e {
 
   /** @override */
   static DEFAULT_OPTIONS = {
+    actions: {
+      setDurationSunrise: BaseRestDialog.#onSetDurationSunrise
+    },
     classes: ["rest"],
     config: null,
     document: null,
@@ -32,6 +35,7 @@ export default class BaseRestDialog extends Dialog5e {
       width: 380
     },
     templates: [
+      "systems/dnd5e/templates/actors/rest/parts/duration.hbs",
       "systems/dnd5e/templates/actors/rest/parts/hit-dice.hbs",
       "systems/dnd5e/templates/actors/rest/parts/rest-request.hbs"
     ]
@@ -72,6 +76,17 @@ export default class BaseRestDialog extends Dialog5e {
   /* -------------------------------------------- */
 
   /**
+   * Duration of the rest in minutes.
+   * @type {number}
+   */
+  get duration() {
+    return this.config.duration ?? CONFIG.DND5E.restTypes[this.config.type]
+      ?.duration?.[game.settings.get("dnd5e", "restVariant")] ?? 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Is the resting actor a party?
    * @type {boolean}
    */
@@ -86,10 +101,8 @@ export default class BaseRestDialog extends Dialog5e {
    * @type {boolean}
    */
   get promptNewDay() {
-    const duration = CONFIG.DND5E.restTypes[this.config.type]
-      ?.duration?.[game.settings.get("dnd5e", "restVariant")] ?? 0;
     // Only prompt if rest is longer than 10 minutes and less than 24 hours
-    return (duration > 10) && (duration < 1440);
+    return (this.duration > 10) && (this.duration < 1440);
   }
 
   /* -------------------------------------------- */
@@ -120,7 +133,7 @@ export default class BaseRestDialog extends Dialog5e {
       result: this.result,
       hd: this.actor.system.attributes?.hd,
       hp: this.actor.system.attributes?.hp,
-      isGroup: this.actor.type === "group",
+      isGroup: this.isPartyGroup,
       variant: game.settings.get("dnd5e", "restVariant")
     };
     if ( this.promptNewDay ) context.fields.push({
@@ -133,6 +146,29 @@ export default class BaseRestDialog extends Dialog5e {
       name: "newDay",
       value: context.config.newDay
     });
+
+    if ( context.isGroup && game.settings.get("dnd5e", "calendarConfig").enabled ) {
+      const duration = convertTime(this.duration, "minute", { strict: false });
+      context.duration = {
+        fields: [
+          {
+            field: new NumberField({ min: 0 }),
+            name: "duration.value",
+            value: duration.value
+          },
+          {
+            field: new StringField({ required: true, blank: false }),
+            name: "duration.unit",
+            options: Object.entries(CONFIG.DND5E.timeUnits)
+              .filter(([, c]) => !c.combat)
+              .map(([value, { label }]) => ({ value, label })),
+            value: duration.unit
+          }
+        ],
+        showSunriseButton: "sunrise" in game.time.calendar
+      };
+      context.fields.push({ template: "systems/dnd5e/templates/actors/rest/parts/duration.hbs" });
+    }
 
     const rest = CONFIG.DND5E.restTypes[this.config.type];
     if ( "recoverTemp" in rest ) context.hitPoints.push({
@@ -207,9 +243,28 @@ export default class BaseRestDialog extends Dialog5e {
       data.targets = filteredKeys(data.targets ?? {});
       this.actor.setFlag("dnd5e", "restSettings", data);
     }
+    if ( foundry.utils.getType(data.duration) === "Object" ) {
+      data.duration = convertTime(data.duration.value, data.duration.unit, { strict: false, to: "minute" }).value;
+    }
     foundry.utils.mergeObject(this.config, data);
     this.#rested = true;
     await this.close();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle setting the rest duration to end at the next sunrise.
+   * @this {BaseRestDialog}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static #onSetDurationSunrise(event, target) {
+    const sunrise = Math.round(game.time.calendar.sunrise());
+    const now = game.time.components.hour;
+    const hoursUntilSunrise = sunrise - now + (now > sunrise ? game.time.calendar.days.hoursPerDay : 0);
+    this.element.querySelector('[name="duration.value"]').value = hoursUntilSunrise;
+    this.element.querySelector('[name="duration.unit"]').value = "hour";
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -81,7 +81,7 @@ export default class BaseRestDialog extends Dialog5e {
    */
   get duration() {
     return this.config.duration ?? CONFIG.DND5E.restTypes[this.config.type]
-      ?.duration?.[game.settings.get("dnd5e", "restVariant")] ?? 0;
+      ?.duration?.[dnd5e.settings.restVariant] ?? 0;
   }
 
   /* -------------------------------------------- */
@@ -243,7 +243,7 @@ export default class BaseRestDialog extends Dialog5e {
       data.targets = filteredKeys(data.targets ?? {});
       this.actor.setFlag("dnd5e", "restSettings", data);
     }
-    if ( foundry.utils.getType(data.duration) === "Object" ) {
+    if ( foundry.utils.isPlainObject(data.duration) ) {
       data.duration = convertTime(data.duration.value, data.duration.unit, { strict: false, to: "minute" }).value;
     }
     foundry.utils.mergeObject(this.config, data);
@@ -263,8 +263,8 @@ export default class BaseRestDialog extends Dialog5e {
     const sunrise = Math.round(game.time.calendar.sunrise());
     const now = game.time.components.hour;
     const hoursUntilSunrise = sunrise - now + (now > sunrise ? game.time.calendar.days.hoursPerDay : 0);
-    this.element.querySelector('[name="duration.value"]').value = hoursUntilSunrise;
-    this.element.querySelector('[name="duration.unit"]').value = "hour";
+    this.form.elements["duration.value"].value = hoursUntilSunrise;
+    this.form.elements["duration.unit"].value = "hour";
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -319,6 +319,8 @@ export default class GroupData extends GroupTemplate {
       .map(({ actor }) => !config.targets || config.targets.includes(actor.id) ? actor : null)
       .filter(_ => _);
 
+    config.advanceTime = game.settings.get("dnd5e", "calendarConfig").enabled;
+
     // Create a rest chat message
     if ( !config.autoRest ) {
       const restConfig = CONFIG.DND5E.restTypes[config.type];

--- a/templates/actors/rest/parts/duration.hbs
+++ b/templates/actors/rest/parts/duration.hbs
@@ -1,0 +1,13 @@
+<div class="form-group split-group">
+    <label>{{ localize "DND5E.REST.Duration.Label" }}</label>
+    <div class="form-fields">
+        {{> "dnd5e.fieldlist" duration.fields }}
+        {{#if duration.showSunriseButton}}
+        <button type="button" class="dice-button" data-action="setDurationSunrise" data-tooltip
+                aria-label="{{ localize 'DND5E.REST.Duration.UntilSunrise' }}">
+            <i class="fa-solid fa-sun" inert></i>
+        </button>
+        {{/if}}
+    </div>
+    <p class="hint">{{ localize "DND5E.REST.Duration.Hint" }}</p>
+</div>

--- a/templates/actors/rest/short-rest.hbs
+++ b/templates/actors/rest/short-rest.hbs
@@ -6,25 +6,7 @@
     {{> "dnd5e.formlist" formSections }}
 
     {{#if hitDice}}
-    {{#if hitDice.canRoll}}
-    <fieldset>
-        <legend>{{ localize "DND5E.HitDice" }}</legend>
-        <div class="form-fields">
-            <select name="denom">
-                {{ selectOptions hitDice.options selected=hitDice.denomination }}
-            </select>
-            <button type="button" class="dice-button" data-action="rollHitDie" data-tooltip
-                    aria-label="{{ localize 'DND5E.Roll' }}">
-                <i class="fa-solid fa-dice-d20" inert></i>
-            </button>
-        </div>
-        {{ formField autoRoll name="autoHD" value=config.autoHD input=inputs.createCheckboxInput rootId=partId }}
-    </fieldset>
-    {{else}}
-    <div class="note warn">
-        {{ localize "DND5E.REST.HitDice.None" }}
-    </div>
-    {{/if}}
+    {{> "systems/dnd5e/templates/actors/rest/parts/hit-dice.hbs" }}
     {{/if}}
 
     {{#if request}}

--- a/templates/shared/fields/fieldlist.hbs
+++ b/templates/shared/fields/fieldlist.hbs
@@ -1,9 +1,19 @@
 {{#each this}}
+{{#if field}}
+
+{{!-- Normal Field --}}
 {{#if name}}{{!-- TODO: Work around core issue with providing undefined name --}}
 {{ formField field name=name value=value input=input options=options disabled=disabled localize=localize
              placeholder=placeholder label=label hint=hint classes=classes rootId=@root.partId }}
 {{else}}
 {{ formField field value=value input=input options=options disabled=disabled localize=localize
              placeholder=placeholder label=label hint=hint classes=classes rootId=@root.partId }}
+{{/if}}
+
+{{else if template}}
+
+{{!-- Template --}}
+{{> (lookup . 'template') @root }}
+
 {{/if}}
 {{/each}}


### PR DESCRIPTION
Adds a control for setting the amount of time that will be advanced during a rest that appears when the calendar is enabled. This is only shown when resting from the group sheet and will cause the rest to advance time by the set amount.

<img width="395" height="329" alt="Rest Duration" src="https://github.com/user-attachments/assets/370b4cce-8945-46c7-9e0d-3593ff03de52" />

There is a helper button that will automatically set the rest duration to the following sunrise.