### PR TITLE
[#6631] Add non-persisted fields in data models for AE hints

### DIFF
--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -31,6 +31,7 @@ export default class BaseSaveActivityData extends BaseActivityData {
         ability: new SetField(new StringField()),
         bonus: new FormulaField(),
         dc: new SchemaField({
+          bonus: new FormulaField({ deterministic: true, persisted: false }),
           calculation: new StringField({ initial: "initial" }),
           formula: new FormulaField({ deterministic: true })
         }),
@@ -95,7 +96,6 @@ export default class BaseSaveActivityData extends BaseActivityData {
   prepareData() {
     super.prepareData();
     if ( this.save.dc.calculation === "initial" ) this.save.dc.calculation = this.isSpell ? "spellcasting" : "";
-    this.save.dc.bonus = "";
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -160,8 +160,6 @@ export default class CharacterData extends CreatureTemplate {
   /** @inheritDoc */
   prepareBaseData() {
     this.attributes.hd = new HitDice(this.parent);
-    this.details.level = 0;
-    this.attributes.attunement.value = 0;
 
     for ( const item of this.parent.items ) {
       if ( item.type === "class" ) this.details.level += item.system.levels;

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -348,9 +348,6 @@ export default class NPCData extends CreatureTemplate {
 
   /** @inheritDoc */
   prepareBaseData() {
-    this.details.level = 0;
-    this.attributes.attunement.value = 0;
-
     // Determine hit dice denomination & max from hit points formula
     const [, max, denomination] = this.attributes.hp.formula?.match(/(\d*)d(\d+)/i) ?? [];
     this.attributes.hd.max = Number(max ?? 0);

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -24,9 +24,14 @@ export default class AttributesFields {
    */
   static get armorClass() {
     return {
+      armor: new NumberField({ integer: true, min: 0, initial: 10, persisted: false }),
+      bonus: new FormulaField({ deterministic: true, persisted: false }),
       calc: new StringField({ initial: "default", label: "DND5E.ArmorClassCalculation" }),
       flat: new NumberField({ required: true, integer: true, min: 0, label: "DND5E.ArmorClassFlat" }),
-      formula: new FormulaField({ deterministic: true, label: "DND5E.ArmorClassFormula" })
+      cover: new NumberField({ integer: true, min: 0, initial: 0, persisted: false }),
+      formula: new FormulaField({ deterministic: true, label: "DND5E.ArmorClassFormula" }),
+      min: new FormulaField({ deterministic: true, persisted: false }),
+      shield: new NumberField({ integer: true, min: 0, initial: 0, persisted: false })
     };
   }
 
@@ -56,6 +61,20 @@ export default class AttributesFields {
   static get common() {
     return {
       ac: new SchemaField(this.armorClass, { label: "DND5E.ArmorClass" }),
+      encumbrance: new SchemaField({
+        bonuses: new SchemaField({
+          encumbered: new FormulaField({ deterministic: true }),
+          heavilyEncumbered: new FormulaField({ deterministic: true }),
+          maximum: new FormulaField({ deterministic: true }),
+          overall: new FormulaField({ deterministic: true })
+        }),
+        multipliers: new SchemaField({
+          encumbered: new FormulaField({ deterministic: true, initial: "1" }),
+          heavilyEncumbered: new FormulaField({ deterministic: true, initial: "1" }),
+          maximum: new FormulaField({ deterministic: true, initial: "1" }),
+          overall: new FormulaField({ deterministic: true, initial: "1" })
+        })
+      }, { persisted: false }),
       init: new RollConfigField({
         ability: "",
         bonus: new FormulaField({ required: true, label: "DND5E.InitiativeBonus" })
@@ -75,9 +94,15 @@ export default class AttributesFields {
       attunement: new SchemaField({
         max: new NumberField({
           required: true, nullable: false, integer: true, min: 0, initial: 3, label: "DND5E.AttunementMax"
-        })
+        }),
+        value: new NumberField({ integer: true, min: 0, initial: 0, persisted: false })
       }, { label: "DND5E.Attunement" }),
       senses: new SensesField(),
+      spell: new SchemaField({
+        attack: new NumberField({ integer: true }),
+        dc: new NumberField({ integer: true }),
+        mod: new NumberField({ integer: true })
+      }, { persisted: false }),
       spellcasting: new StringField({ required: true, blank: true, label: "DND5E.SpellAbility" }),
       exhaustion: new NumberField({
         required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.Exhaustion"
@@ -119,12 +144,7 @@ export default class AttributesFields {
    * Initialize derived AC fields for Active Effects to target.
    * @this {CharacterData|NPCData|VehicleData}
    */
-  static prepareBaseArmorClass() {
-    const ac = this.attributes.ac;
-    ac.armor = 10;
-    ac.shield = ac.cover = 0;
-    ac.min = ac.bonus = "";
-  }
+  static prepareBaseArmorClass() {}
 
   /* -------------------------------------------- */
 
@@ -132,11 +152,7 @@ export default class AttributesFields {
    * Initialize base encumbrance fields to be targeted by active effects.
    * @this {CharacterData|NPCData|VehicleData}
    */
-  static prepareBaseEncumbrance() {
-    const encumbrance = this.attributes.encumbrance ??= {};
-    encumbrance.multipliers = { encumbered: "1", heavilyEncumbered: "1", maximum: "1", overall: "1" };
-    encumbrance.bonuses = { encumbered: "", heavilyEncumbered: "", maximum: "", overall: "" };
-  }
+  static prepareBaseEncumbrance() {}
 
   /* -------------------------------------------- */
 

--- a/module/data/actor/templates/details.mjs
+++ b/module/data/actor/templates/details.mjs
@@ -1,5 +1,5 @@
 import LocalDocumentField from "../../fields/local-document-field.mjs";
-const { HTMLField, SchemaField, StringField } = foundry.data.fields;
+const { HTMLField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
  * @import { DetailsCommonData, DetailsCreatureData } from "./_types.mjs";
@@ -16,8 +16,8 @@ export default class DetailsField {
   static get common() {
     return {
       biography: new SchemaField({
-        value: new HTMLField({label: "DND5E.Biography"}),
-        public: new HTMLField({label: "DND5E.BiographyPublic"})
+        value: new HTMLField({ label: "DND5E.Biography" }),
+        public: new HTMLField({ label: "DND5E.BiographyPublic" })
       }, {label: "DND5E.Biography"})
     };
   }
@@ -30,10 +30,11 @@ export default class DetailsField {
    */
   static get creature() {
     return {
-      alignment: new StringField({required: true, label: "DND5E.Alignment"}),
-      ideal: new StringField({required: true, label: "DND5E.Ideals"}),
-      bond: new StringField({required: true, label: "DND5E.Bonds"}),
-      flaw: new StringField({required: true, label: "DND5E.Flaws"}),
+      alignment: new StringField({ required: true, label: "DND5E.Alignment" }),
+      ideal: new StringField({ required: true, label: "DND5E.Ideals" }),
+      level: new NumberField({ integer: true, min: 0, initial: 0, persisted: false }),
+      bond: new StringField({ required: true, label: "DND5E.Bonds" }),
+      flaw: new StringField({ required: true, label: "DND5E.Flaws" }),
       race: new LocalDocumentField(foundry.documents.BaseItem, {
         required: true, fallback: true, label: "DND5E.Species"
       })

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -56,6 +56,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
     return this.mergeSchema(super.defineSchema(), {
       damage: new SchemaField({
         base: new DamageField(),
+        bonus: new FormulaField({ persisted: false }),
         replace: new BooleanField()
       }),
       magicalBonus: new FormulaField({ deterministic: true }),

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -1,7 +1,10 @@
 import CastActivity from "../../../documents/activity/cast.mjs";
 import SystemDataModel from "../../abstract/system-data-model.mjs";
 import { ActivitiesField } from "../../fields/activities-field.mjs";
+import FormulaField from "../../fields/formula-field.mjs";
 import UsesField from "../../shared/uses-field.mjs";
+
+const { SchemaField } = foundry.data.fields;
 
 /**
  * @import { ItemRollData } from "../../../documents/_types.mjs";
@@ -28,6 +31,9 @@ export default class ActivitiesTemplate extends SystemDataModel {
   static defineSchema() {
     return {
       activities: new ActivitiesField(),
+      damage: new SchemaField({
+        bonus: new FormulaField()
+      }, { persisted: false }),
       uses: new UsesField()
     };
   }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -63,6 +63,7 @@ export default class WeaponData extends ItemDataModel.mixin(
       }),
       damage: new SchemaField({
         base: new DamageField(),
+        bonus: new FormulaField({ persisted: false }),
         versatile: new DamageField()
       }),
       magicalBonus: new FormulaField({ deterministic: true, label: "DND5E.MagicalBonus" }),

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -41,9 +41,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * Additional key paths to properties added during base data preparation that should be treated as formula fields.
    * @type {Set<string>}
    */
-  static FORMULA_FIELDS = new Set([
-    "system.damageBonus" // TODO: Remove once `system.damageBonus` shim is moved to `system.damage.bonus`
-  ]);
+  static FORMULA_FIELDS = new Set(["system.damage.bonus"]);
 
   /* -------------------------------------------- */
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -41,7 +41,15 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * Additional key paths to properties added during base data preparation that should be treated as formula fields.
    * @type {Set<string>}
    */
-  static FORMULA_FIELDS = new Set(["system.damage.bonus"]);
+  static FORMULA_FIELDS = new class extends Set {
+    add(value) {
+      foundry.utils.logCompatibilityWarning(
+        "`ActiveEffect5e#FOMRULA_FIELDS` has been deprecated in favor of non-persisted fields.",
+        { since: "DnD5e 6.0", until: "DnD5e 6.2" }
+      );
+      super.add(value);
+    }
+  }();
 
   /* -------------------------------------------- */
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -42,18 +42,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @type {Set<string>}
    */
   static FORMULA_FIELDS = new Set([
-    "system.attributes.ac.bonus",
-    "system.attributes.ac.min",
-    "system.attributes.encumbrance.bonuses.encumbered",
-    "system.attributes.encumbrance.bonuses.heavilyEncumbered",
-    "system.attributes.encumbrance.bonuses.maximum",
-    "system.attributes.encumbrance.bonuses.overall",
-    "system.attributes.encumbrance.multipliers.encumbered",
-    "system.attributes.encumbrance.multipliers.heavilyEncumbered",
-    "system.attributes.encumbrance.multipliers.maximum",
-    "system.attributes.encumbrance.multipliers.overall",
-    "system.damage.bonus",
-    "save.dc.bonus"
+    "system.damageBonus" // TODO: Remove once `system.damageBonus` shim is moved to `system.damage.bonus`
   ]);
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Adds several non-persisted fields to actor & activity data models to replace places where the system was previously pre-populating values in `prepareBaseData` and using `ActiveEffect.FORMULA_FIELDS` to provide type hints.

Closes #6631