### PR TITLE
[#6408] Generalize leveled conditions

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -74,6 +74,7 @@ Hooks.once("init", function() {
   CONFIG.Item.documentClass = documents.Item5e;
   CONFIG.JournalEntryPage.documentClass = documents.JournalEntryPage5e;
   CONFIG.Token.documentClass = documents.TokenDocument5e;
+  CONFIG.Token.hudClass = applications.hud.TokenHUD5e;
   CONFIG.Token.objectClass = canvas.Token5e;
   CONFIG.Token.rulerClass = canvas.TokenRuler5e;
   CONFIG.Token.movement.TerrainData = dataModels.TerrainData5e;
@@ -228,9 +229,6 @@ Hooks.once("init", function() {
 
   // Enrichers
   enrichers.registerCustomEnrichers();
-
-  // Exhaustion handling
-  documents.ActiveEffect5e.registerHUDListeners();
 
   // Set up token movement actions
   documents.TokenDocument5e.registerMovementActions();

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -552,6 +552,8 @@
  *                                                           when using the modern rules. Speed reduction is measured
  *                                                           in the default imperial units and converted to metric
  *                                                           if necessary.
+ * @property {Record<number, string[]>} [conditions]  Additional statuses applied at given
+ *                                                    levels of a condition, e.g., 'dead' at Exhaustion 6.
  */
 
 /**

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -7,6 +7,7 @@ export * as combat from "./combat/_module.mjs";
 export * as components from "./components/_module.mjs";
 export * as dice from "./dice/_module.mjs";
 export * as fields from "./fields.mjs";
+export * as hud from "./hud/_module.mjs";
 export * as item from "./item/_module.mjs";
 export * as journal from "./journal/_module.mjs";
 export * as regionBehavior from "./region-behavior/_module.mjs";

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -524,7 +524,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
    * @protected
    */
   async _prepareSidebarContext(context, options) {
-    const { attributes } = this.actor.system;
+    const { attributes, conditions={} } = this.actor.system;
     context.portrait = await this._preparePortrait(context);
 
     // Death Saves
@@ -556,7 +556,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
       context.exhaustion = Array.fromRange(max, 1).reduce((acc, n) => {
         const label = _loc("DND5E.ExhaustionLevel", { n });
         const classes = ["pip"];
-        const filled = attributes.exhaustion >= n;
+        const filled = conditions.exhaustion >= n;
         if ( filled ) classes.push("filled");
         if ( n === max ) classes.push("death");
         const pip = { n, label, filled, tooltip: label, classes: classes.join(" ") };

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -524,7 +524,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
    * @protected
    */
   async _prepareSidebarContext(context, options) {
-    const { attributes, conditions={} } = this.actor.system;
+    const { attributes, conditions } = this.actor.system;
     context.portrait = await this._preparePortrait(context);
 
     // Death Saves

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -179,6 +179,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
     // Iterate over active effects, classifying them into categories
     for ( const e of effects ) {
       if ( e.isConcealed ) continue;
+      if ( e.type === "condition" ) continue;
       if ( e.isAppliedEnchantment ) {
         if ( e.disabled ) categories.enchantmentInactive.effects.push(e);
         else categories.enchantmentActive.effects.push(e);

--- a/module/applications/hud/_module.mjs
+++ b/module/applications/hud/_module.mjs
@@ -1,0 +1,1 @@
+export { default as TokenHUD5e } from "./token-hud.mjs";

--- a/module/applications/hud/token-hud.mjs
+++ b/module/applications/hud/token-hud.mjs
@@ -1,0 +1,69 @@
+import ActiveEffect5e from "../../documents/active-effect.mjs";
+import ConditionData from "../../data/active-effect/condition.mjs";
+
+export default class TokenHUD5e extends foundry.applications.hud.TokenHUD {
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    actions: {
+      effect: {
+        handler: TokenHUD5e.#onToggleEffect,
+        buttons: [0, 2]
+      }
+    }
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    this.#adjustConditionIcons();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Replace condition icons with leveled icons.
+   */
+  #adjustConditionIcons() {
+    const actor = this.object.actor;
+    if ( !actor ) return;
+
+    const conditions = actor.effects.documentsByType.condition;
+    for ( const c of conditions ) {
+      if ( !c.system.hasLevels ) continue;
+      const { level, type } = c.system;
+      const img = ConditionData.getIconByLevel(type, level);
+      const icon = this.element.querySelector(`[data-status-id="${type}"]`);
+      if ( !icon ) continue;
+      icon.style.objectPosition = "-100px";
+      icon.style.background = `url("${img}") no-repeat center / contain`;
+    }
+  }
+
+  /* -------------------------------------------------- */
+  /*   Event handlers                                   */
+  /* -------------------------------------------------- */
+
+  /**
+   * Toggle a condition via the HUD.
+   * @param {PointerEvent} event    The triggering event.
+   * @param {HTMLElement} target    The element that defined the [data-action].
+   */
+  static async #onToggleEffect(event, target) {
+    if ( !this.actor ) {
+      ui.notifications.warn("HUD.WarningEffectNoActor", { localize: true });
+      return;
+    }
+
+    const id = target.dataset.statusId;
+
+    let resolved = false;
+    if ( id === "concentrating" ) resolved = ActiveEffect5e._manageConcentration(event, this.actor);
+
+    if ( !resolved ) this.actor.toggleStatusEffect(id, {
+      overlay: event.button === 2,
+      levels: event.button === 0 ? 1 : -1
+    });
+  }
+}

--- a/module/applications/hud/token-hud.mjs
+++ b/module/applications/hud/token-hud.mjs
@@ -47,6 +47,7 @@ export default class TokenHUD5e extends foundry.applications.hud.TokenHUD {
 
   /**
    * Toggle a condition via the HUD.
+   * @this TokenHUD5e
    * @param {PointerEvent} event    The triggering event.
    * @param {HTMLElement} target    The element that defined the [data-action].
    */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3658,7 +3658,10 @@ DND5E.conditionTypes = {
     img: "systems/dnd5e/icons/svg/statuses/exhaustion.svg",
     reference: "Compendium.dnd5e.content24.JournalEntry.phbAppendixCRule.JournalEntryPage.jSQtPgNm0i4f3Qi3",
     levels: 6,
-    reduction: { rolls: 2, speed: 5 }
+    reduction: { rolls: 2, speed: 5 },
+    conditions: {
+      6: ["dead"]
+    }
   },
   falling: {
     name: "EFFECT.DND5E.StatusFalling",
@@ -3761,23 +3764,23 @@ preLocalize("conditionTypes", { key: "name", sort: true });
 
 /**
  * Various effects of conditions and which conditions apply it. Either keys for the conditions,
- * and with a number appended for a level of exhaustion.
+ * and with a number appended for a level of a leveled condition.
  * @enum {Set<string>}
  */
 DND5E.conditionEffects = {
-  noMovement: new Set(["exhaustion-5", "grappled", "paralyzed", "petrified", "restrained", "unconscious"]),
-  halfMovement: new Set(["exhaustion-2"]),
+  noMovement: new Set(["grappled", "paralyzed", "petrified", "restrained", "unconscious"]),
+  halfMovement: new Set(),
   crawl: new Set(["prone", "exceedingCarryingCapacity"]),
   petrification: new Set(["petrified"]),
-  halfHealth: new Set(["exhaustion-4"]),
+  halfHealth: new Set(),
   dehydrated: new Set(["dehydration"]),
   malnourished: new Set(["malnutrition"]),
-  abilityCheckDisadvantage: new Set(["poisoned", "exhaustion-1"]),
+  abilityCheckDisadvantage: new Set(["poisoned"]),
   physicalCheckDisadvantage: new Set(["heavilyEncumbered"]),
-  abilitySaveDisadvantage: new Set(["exhaustion-3"]),
+  abilitySaveDisadvantage: new Set(),
   physicalSaveDisadvantage: new Set(["heavilyEncumbered"]),
   physicalAttackDisadvantage: new Set(["heavilyEncumbered"]),
-  attackDisadvantage: new Set(["poisoned", "exhaustion-3"]),
+  attackDisadvantage: new Set(["poisoned"]),
   dexteritySaveDisadvantage: new Set(["restrained"]),
   dexteritySaveAdvantage: new Set(["dodging"]),
   initiativeAdvantage: new Set(["invisible"]),

--- a/module/data/active-effect/_module.mjs
+++ b/module/data/active-effect/_module.mjs
@@ -1,12 +1,15 @@
 import BaseEffectData from "./base.mjs";
+import ConditionData from "./condition.mjs";
 import EnchantmentData from "./enchantment.mjs";
 
 export {
   BaseEffectData,
+  ConditionData,
   EnchantmentData
 };
 
 export const config = {
   base: BaseEffectData,
+  condition: ConditionData,
   enchantment: EnchantmentData
 };

--- a/module/data/active-effect/condition.mjs
+++ b/module/data/active-effect/condition.mjs
@@ -1,0 +1,169 @@
+const { ActiveEffectTypeDataModel } = foundry.data;
+const { TypeDataModel } = foundry.abstract;
+
+const { NumberField, StringField } = foundry.data.fields;
+
+/**
+ * System data model for condition active effects.
+ */
+export default class ConditionData extends (ActiveEffectTypeDataModel ?? TypeDataModel) {
+  /** @override */
+  static defineSchema() {
+    const schema = ActiveEffectTypeDataModel ? super.defineSchema() : {};
+    return Object.assign(schema, {
+      level: new NumberField({ nullable: true, integer: true, initial: null, min: 1 }),
+      type: new StringField({ required: true, blank: false })
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Does the given status have levels?
+   * @param {string} type   The primary status id.
+   * @returns {boolean}
+   */
+  static hasLevels(type) {
+    const config = CONFIG.DND5E.conditionTypes[type];
+    return !!config && ("levels" in config);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Does this condition have levels?
+   * @type {boolean}
+   */
+  get hasLevels() {
+    return ConditionData.hasLevels(this.type);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The max level of this condition.
+   * @type {number|null}
+   */
+  get maxLevel() {
+    return this.hasLevels
+      ? CONFIG.DND5E.conditionTypes[this.type].levels
+      : null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    if ( !this.hasLevels ) {
+      this.level = null;
+      return;
+    }
+
+    this.level = Math.clamp(this.level, 1, this.maxLevel);
+    this.parent.name = `${CONFIG.DND5E.conditionTypes[this.type].name} (${this.level})`;
+    this.parent.img = this.constructor.getIconByLevel(this.type, this.level);
+
+    for (let i=1; i <= this.level; i++) {
+      const statuses = CONFIG.DND5E.conditionTypes[this.type].conditions?.[i] ?? [];
+      statuses.forEach(s => this.parent.statuses.add(s));
+    }
+
+    const actor = this.parent.parent;
+    if ( this.parent.active && (actor instanceof Actor) ) {
+      actor.system.conditions ??= {};
+      actor.system.conditions[this.type] = this.level;
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Get the image used to represent a status of a given level.
+   * @param {string} type     The condition type.
+   * @param {number} level    The level of the condition.
+   * @returns {string}
+   */
+  static getIconByLevel(type, level) {
+    const { img } = CONFIG.DND5E.conditionTypes[type];
+    const split = img.split(".");
+    const ext = split.pop();
+    const path = split.join(".");
+    return `${path}-${level}.${ext}`;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Decrease the level of this condition.
+   * @param {number} [levels=1]   The increase in levels.
+   * @returns {Promise<ActiveEffect5e>}   A promise that resolves to the updaeed effect.
+   */
+  async decrease(levels=1) {
+    if ( !this.hasLevels ) return this;
+    await this.parent.update({ "system.level": this.level - levels }, { dnd5e: { originalLevel: this.level }});
+    return this.parent;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Increase the level of this condition.
+   * @param {number} [levels=1]   The increase in levels.
+   * @returns {Promise<ActiveEffect5e>}   A promise that resolves to the updaeed effect.
+   */
+  async increase(levels=1) {
+    if ( !this.hasLevels ) return this;
+    await this.parent.update({ "system.level": this.level + levels }, { dnd5e: { originalLevel: this.level }});
+    return this.parent;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Manage a change to levels of an actor's conditions.
+   * @param {string} statusId                   The status id.
+   * @param {Actor5e} actor                     The actor having a status applied, changed, or removed.
+   * @param {object} [options={}]
+   * @param {number} [options.levels=1]         The change in levels.
+   * @returns {Promise<ActiveEffect5e|void>}    A promise that resolves to a created, deleted, or updated
+   *                                            effect, or void if no operation was performed.
+   */
+  static async _applyDelta(statusId, actor, { levels=1 }={}) {
+    const effect = actor.effects.get(dnd5e.utils.staticID(`dnd5e${statusId}`));
+
+    // Increase level of existing effect.
+    if ( effect && (levels > 0) ) return effect.system.increase(levels);
+
+    // Create new effect with level.
+    if ( levels > 0 ) {
+      const effect = await getDocumentClass("ActiveEffect").fromStatusEffect(statusId);
+      const data = foundry.utils.mergeObject(effect.toObject(), {
+        _id: dnd5e.utils.staticID(`dnd5e${statusId}`),
+        "system.level": levels
+      });
+      return getDocumentClass("ActiveEffect").create(data, { parent: actor, keepId: true });
+    }
+
+    // Decrease level (possibly delete).
+    if ( effect && (levels < 0) ) {
+      const nLevel = effect.system.level + levels;
+      if ( nLevel <= 0 ) {
+        await effect.delete();
+        return false;
+      }
+      return effect.system.decrease(Math.abs(levels));
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritDoc */
+  _onUpdate(data, options, userId) {
+    super._onUpdate(data, options, userId);
+
+    if ( !this.hasLevels ) return;
+    const delta = this.level - options.dnd5e?.originalLevel;
+    if ( delta ) this.parent._displayScrollingStatus(delta);
+  }
+}

--- a/module/data/active-effect/condition.mjs
+++ b/module/data/active-effect/condition.mjs
@@ -161,4 +161,17 @@ export default class ConditionData extends foundry.data.ActiveEffectTypeDataMode
     const delta = this.level - options.dnd5e?.originalLevel;
     if ( Number.isFinite(delta) ) this.parent._displayScrollingStatus(delta > 0);
   }
+
+  /* -------------------------------------------- */
+  /*  Importing and Exporting                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Can an active effect of this type be added to the provided document?
+   * @param {Actor5e|Item5e} [doc]    Candidate document to which the active effect might be added.
+   * @returns {boolean}               Should this active effect be available?
+   */
+  static availableForItem(doc) {
+    return false;
+  }
 }

--- a/module/data/active-effect/condition.mjs
+++ b/module/data/active-effect/condition.mjs
@@ -1,16 +1,12 @@
-const { ActiveEffectTypeDataModel } = foundry.data;
-const { TypeDataModel } = foundry.abstract;
-
 const { NumberField, StringField } = foundry.data.fields;
 
 /**
  * System data model for condition active effects.
  */
-export default class ConditionData extends (ActiveEffectTypeDataModel ?? TypeDataModel) {
-  /** @override */
+export default class ConditionData extends foundry.data.ActiveEffectTypeDataModel {
+  /** @inheritDoc */
   static defineSchema() {
-    const schema = ActiveEffectTypeDataModel ? super.defineSchema() : {};
-    return Object.assign(schema, {
+    return Object.assign(super.defineSchema(), {
       level: new NumberField({ nullable: true, integer: true, initial: null, min: 1 }),
       type: new StringField({ required: true, blank: false })
     });
@@ -64,14 +60,13 @@ export default class ConditionData extends (ActiveEffectTypeDataModel ?? TypeDat
     this.parent.name = `${CONFIG.DND5E.conditionTypes[this.type].name} (${this.level})`;
     this.parent.img = this.constructor.getIconByLevel(this.type, this.level);
 
-    for (let i=1; i <= this.level; i++) {
+    for ( let i = 1; i <= this.level; i++ ) {
       const statuses = CONFIG.DND5E.conditionTypes[this.type].conditions?.[i] ?? [];
       statuses.forEach(s => this.parent.statuses.add(s));
     }
 
     const actor = this.parent.parent;
-    if ( this.parent.active && (actor instanceof Actor) ) {
-      actor.system.conditions ??= {};
+    if ( this.parent.active && (actor instanceof foundry.documents.Actor) ) {
       actor.system.conditions[this.type] = this.level;
     }
   }
@@ -96,8 +91,8 @@ export default class ConditionData extends (ActiveEffectTypeDataModel ?? TypeDat
 
   /**
    * Decrease the level of this condition.
-   * @param {number} [levels=1]   The increase in levels.
-   * @returns {Promise<ActiveEffect5e>}   A promise that resolves to the updaeed effect.
+   * @param {number} [levels=1]           The decrease in levels.
+   * @returns {Promise<ActiveEffect5e>}   A promise that resolves to the updated effect.
    */
   async decrease(levels=1) {
     if ( !this.hasLevels ) return this;
@@ -109,8 +104,8 @@ export default class ConditionData extends (ActiveEffectTypeDataModel ?? TypeDat
 
   /**
    * Increase the level of this condition.
-   * @param {number} [levels=1]   The increase in levels.
-   * @returns {Promise<ActiveEffect5e>}   A promise that resolves to the updaeed effect.
+   * @param {number} [levels=1]           The increase in levels.
+   * @returns {Promise<ActiveEffect5e>}   A promise that resolves to the updated effect.
    */
   async increase(levels=1) {
     if ( !this.hasLevels ) return this;
@@ -150,7 +145,7 @@ export default class ConditionData extends (ActiveEffectTypeDataModel ?? TypeDat
       const nLevel = effect.system.level + levels;
       if ( nLevel <= 0 ) {
         await effect.delete();
-        return false;
+        return effect;
       }
       return effect.system.decrease(Math.abs(levels));
     }
@@ -164,6 +159,6 @@ export default class ConditionData extends (ActiveEffectTypeDataModel ?? TypeDat
 
     if ( !this.hasLevels ) return;
     const delta = this.level - options.dnd5e?.originalLevel;
-    if ( delta ) this.parent._displayScrollingStatus(delta);
+    if ( Number.isFinite(delta) ) this.parent._displayScrollingStatus(delta > 0);
   }
 }

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -216,10 +216,10 @@ export default class EnchantmentData extends ActiveEffectDataModel {
 
   /**
    * Can an active effect of this type be added to the provided document?
-   * @param {Actor5e|Item5e} doc  Candidate document to which the active effect might be added.
-   * @returns {boolean}           Should this active effect be available?
+   * @param {Actor5e|Item5e} [doc]  Candidate document to which the active effect might be added.
+   * @returns {boolean}             Should this active effect be available?
    */
   static availableForItem(doc) {
-    return doc instanceof Item;
+    return !doc || (doc instanceof Item);
   }
 }

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -273,7 +273,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
     }, rollData);
 
     // Add exhaustion reduction
-    this.actor?.addRollExhaustion(parts, data);
+    this.actor?.addConditionRollReduction(parts, data);
 
     return { data, parts };
   }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -2,6 +2,7 @@ import ActiveEffect5e from "../../../documents/active-effect.mjs";
 import Proficiency from "../../../documents/actor/proficiency.mjs";
 import { convertLength, convertWeight, defaultUnits, replaceFormulaData, simplifyBonus } from "../../../utils.mjs";
 import AdvantageModeField from "../../fields/advantage-mode-field.mjs";
+import ConditionData from "../../active-effect/condition.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 import MovementField from "../../shared/movement-field.mjs";
 import RollConfigField from "../../shared/roll-config-field.mjs";
@@ -448,9 +449,7 @@ export default class AttributesFields {
    * @this {CharacterData|NPCData}
    */
   static prepareExhaustionLevel() {
-    const exhaustion = this.parent.effects.get(ActiveEffect5e.ID.EXHAUSTION);
-    const level = exhaustion?.getFlag("dnd5e", "exhaustionLevel");
-    this.attributes.exhaustion = Number.isFinite(level) ? level : 0;
+    this.attributes.exhaustion = this.conditions?.exhaustion ?? 0;
   }
 
   /* -------------------------------------------- */
@@ -541,12 +540,19 @@ export default class AttributesFields {
     const heavilyEncumbered = statuses.has("heavilyEncumbered");
     const exceedingCarryingCapacity = statuses.has("exceedingCarryingCapacity");
     const units = this.attributes.movement.units ??= defaultUnits("length");
-    let reduction = dnd5e.settings.rulesVersion === "modern" && !this.traits?.ci?.value?.has("exhaustion")
-      ? (this.attributes.exhaustion ?? 0) * (CONFIG.DND5E.conditionTypes.exhaustion?.reduction?.speed ?? 0) : 0;
+
+    let reduction = statuses.reduce((acc, status) => {
+      const speed = CONFIG.DND5E.conditionTypes[status]?.reduction?.speed ?? 0;
+      const level = ConditionData.hasLevels(status)
+        ? this.parent.system.conditions?.[status] ?? 0
+        : Boolean(statuses.has(status));
+      return acc + (level * speed);
+    }, 0);
     if ( ((this.attributes.ac?.equippedArmor?.system.strength ?? 0) > (this.abilities?.str?.value ?? Infinity))
       && !this.parent.flags.dnd5e?.ignoreArmorSpeedReduction && this.isCreature ) {
       reduction += CONFIG.DND5E.armorSpeedReduction;
     }
+
     reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, units);
     const bonus = simplifyBonus(this.attributes.movement.bonus, rollData);
     this.attributes.movement.max = 0;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -449,7 +449,7 @@ export default class AttributesFields {
    * @this {CharacterData|NPCData}
    */
   static prepareExhaustionLevel() {
-    this.attributes.exhaustion = this.conditions?.exhaustion ?? 0;
+    this.attributes.exhaustion = this.conditions.exhaustion ?? 0;
   }
 
   /* -------------------------------------------- */
@@ -555,7 +555,6 @@ export default class AttributesFields {
       && !this.parent.flags.dnd5e?.ignoreArmorSpeedReduction && this.isCreature ) {
       reduction += CONFIG.DND5E.armorSpeedReduction;
     }
-
     reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, units);
     const bonus = simplifyBonus(this.attributes.movement.bonus, rollData);
     this.attributes.movement.max = 0;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -542,9 +542,12 @@ export default class AttributesFields {
     const units = this.attributes.movement.units ??= defaultUnits("length");
 
     let reduction = statuses.reduce((acc, status) => {
+      const immune = this.traits?.ci?.value?.has(status);
+      if ( immune ) return acc;
+
       const speed = CONFIG.DND5E.conditionTypes[status]?.reduction?.speed ?? 0;
       const level = ConditionData.hasLevels(status)
-        ? this.parent.system.conditions?.[status] ?? 0
+        ? this.parent.system.conditions[status] ?? 0
         : Boolean(statuses.has(status));
       return acc + (level * speed);
     }, 0);

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -56,7 +56,8 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
       }), {
         initialKeys: CONFIG.DND5E.abilities, initialValue: this._initialAbilityValue.bind(this),
         initialKeysOnly: true, label: "DND5E.Abilities", entryLabel: key => CONFIG.DND5E.abilities[key]?.label
-      })
+      }),
+      conditions: new MappingField(new NumberField({ integer: true, min: 1 }), { persisted: false })
     });
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -181,7 +181,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
     }
 
-    else if ( CONFIG.statusEffects.some(e => e._id === data._id) ) {
+    else if ( Object.values(CONFIG.statusEffects).some(e => e._id === data._id) ) {
       foundry.utils.mergeObject(data, {
         type: "condition",
         "system.type": data.statuses[0],
@@ -422,14 +422,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   prepareBaseData() {
     this.origin = this.getFlag("core", "originText") ?? this.origin;
     super.prepareBaseData();
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  prepareDerivedData() {
-    super.prepareDerivedData();
-    if ( this.isAppliedEnchantment && this.uuid ) dnd5e.registry.enchantments.track(this.origin, this.uuid);
   }
 
   /* -------------------------------------------- */
@@ -698,6 +690,20 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( item.type === "spell" ) effectData["flags.dnd5e.spellLevel"] = item.system.level;
 
     return effectData;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Determine whether this effect applies a status that should prompt concentration to end.
+   * @returns {boolean}
+   * @protected
+   */
+  _shouldPromptConcentrationEnd() {
+    if ( !this.active || !(this.parent instanceof Actor) ) return false;
+    if ( dnd5e.settings.disableConcentration || !this.actor.concentration.effects.size ) return false;
+
+    return this.statuses.has("dead") || this.statuses.has("incapacitated");
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -163,7 +163,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   static async _fromStatusEffect(statusId, { reference, ...effectData }, options) {
     if ( !("description" in effectData) && reference ) effectData.description = `@Embed[${reference} inline]`;
-    return super._fromStatusEffect?.(statusId, effectData, options) ?? new this(effectData, options);
+    foundry.utils.mergeObject(effectData, { type: "condition", "system.type": statusId });
+    return super._fromStatusEffect(statusId, effectData, options);
   }
 
   /* -------------------------------------------- */
@@ -178,6 +179,14 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       data.type = "enchantment";
       delete data.flags.dnd5e.type;
       foundry.utils.setProperty(data, "flags.dnd5e.persistSourceMigration", true);
+    }
+
+    else if ( CONFIG.statusEffects.some(e => e._id === data._id) ) {
+      foundry.utils.mergeObject(data, {
+        type: "condition",
+        "system.type": data.statuses[0],
+        "flags.dnd5e.persistSourceMigration": true
+      });
     }
 
     return super._initializeSource(data, options);
@@ -420,25 +429,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    if ( this.id === this.constructor.ID.EXHAUSTION ) this._prepareExhaustionLevel();
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Modify the ActiveEffect's attributes based on the exhaustion level.
-   * @protected
-   */
-  _prepareExhaustionLevel() {
-    const config = CONFIG.DND5E.conditionTypes.exhaustion;
-    let level = this.getFlag("dnd5e", "exhaustionLevel");
-    if ( !Number.isFinite(level) ) level = 1;
-    this.img = this.constructor._getExhaustionImage(level);
-    this.name = `${_loc("DND5E.Exhaustion")} ${level}`;
-    if ( level >= config.levels ) {
-      this.statuses.add("dead");
-      CONFIG.DND5E.statusEffects.dead.statuses?.forEach(s => this.statuses.add(s));
-    }
+    if ( this.isAppliedEnchantment && this.uuid ) dnd5e.registry.enchantments.track(this.origin, this.uuid);
   }
 
   /* -------------------------------------------- */
@@ -620,24 +611,12 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   _onUpdate(data, options, userId) {
     super._onUpdate(data, options, userId);
-    const originalLevel = foundry.utils.getProperty(options, "dnd5e.originalExhaustion");
-    const newLevel = foundry.utils.getProperty(data, "flags.dnd5e.exhaustionLevel");
     const originalEncumbrance = foundry.utils.getProperty(options, "dnd5e.originalEncumbrance");
     const newEncumbrance = data.statuses?.[0];
     const name = this.name;
 
-    // Display proper scrolling status effects for exhaustion
-    if ( (this.id === this.constructor.ID.EXHAUSTION) && Number.isFinite(newLevel) && Number.isFinite(originalLevel) ) {
-      if ( newLevel === originalLevel ) return;
-      // Temporarily set the name for the benefit of _displayScrollingTextStatus. We should improve this method to
-      // accept a name parameter instead.
-      if ( newLevel < originalLevel ) this.name = `Exhaustion ${originalLevel}`;
-      this._displayScrollingStatus(newLevel > originalLevel);
-      this.name = name;
-    }
-
     // Display proper scrolling status effects for encumbrance
-    else if ( (this.id === this.constructor.ID.ENCUMBERED) && originalEncumbrance && newEncumbrance ) {
+    if ( (this.id === this.constructor.ID.ENCUMBERED) && originalEncumbrance && newEncumbrance ) {
       if ( newEncumbrance === originalEncumbrance ) return;
       const increase = !originalEncumbrance || ((originalEncumbrance === "encumbered") && newEncumbrance)
         || (newEncumbrance === "exceedingCarryingCapacity");
@@ -676,7 +655,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   }
 
   /* -------------------------------------------- */
-  /*  Exhaustion and Concentration Handling       */
+  /*  Concentration Handling                      */
   /* -------------------------------------------- */
 
   /**
@@ -710,37 +689,15 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
         }
       },
       origin: item.uuid,
-      statuses: [statusEffect.id].concat(statusEffect.statuses ?? [])
+      statuses: [statusEffect.id].concat(statusEffect.statuses ?? []),
+      system: {
+        type: "concentrating"
+      }
     }, data, {inplace: false});
     delete effectData.id;
     if ( item.type === "spell" ) effectData["flags.dnd5e.spellLevel"] = item.system.level;
 
     return effectData;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Determine whether this effect applies a status that should prompt concentration to end.
-   * @returns {boolean}
-   * @protected
-   */
-  _shouldPromptConcentrationEnd() {
-    if ( !this.active || !(this.parent instanceof Actor) ) return false;
-    if ( dnd5e.settings.disableConcentration || !this.actor.concentration.effects.size ) return false;
-
-    return this.statuses.has("dead") || this.statuses.has("incapacitated");
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Register listeners for custom handling in the TokenHUD.
-   */
-  static registerHUDListeners() {
-    Hooks.on("renderTokenHUD", this.onTokenHUDRender);
-    document.addEventListener("click", this.onClickTokenHUD.bind(this), { capture: true });
-    document.addEventListener("auxclick", this.onClickTokenHUD.bind(this), { capture: true });
   }
 
   /* -------------------------------------------- */
@@ -788,95 +745,26 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /* -------------------------------------------- */
 
   /**
-   * Adjust exhaustion icon display to match current level.
-   * @param {Application} app   The TokenHUD application.
-   * @param {HTMLElement} html  The TokenHUD HTML.
-   */
-  static onTokenHUDRender(app, html) {
-    const actor = app.object.actor;
-    const level = foundry.utils.getProperty(actor, "system.attributes.exhaustion");
-    if ( Number.isFinite(level) && (level > 0) ) {
-      const img = ActiveEffect5e._getExhaustionImage(level);
-      const elem = html.querySelector('[data-status-id="exhaustion"]');
-      if ( elem ) {
-        elem.style.objectPosition = "-100px";
-        elem.style.background = `url('${img}') no-repeat center / contain`;
-      }
-    }
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Get the image used to represent exhaustion at this level.
-   * @param {number} level
-   * @returns {string}
-   */
-  static _getExhaustionImage(level) {
-    const { img } = CONFIG.DND5E.conditionTypes.exhaustion;
-    const split = img.split(".");
-    const ext = split.pop();
-    const path = split.join(".");
-    return `${path}-${level}.${ext}`;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Implement custom behavior for select conditions on the token HUD.
-   * @param {PointerEvent} event        The triggering event.
-   */
-  static onClickTokenHUD(event) {
-    if ( (event.button !== 0) && (event.button !== 2) ) return;
-    const { target } = event;
-    if ( !target.classList?.contains("effect-control") ) return;
-
-    const actor = canvas.hud.token.object?.actor;
-    if ( !actor ) return;
-
-    const id = target.dataset?.statusId;
-    if ( id === "exhaustion" ) ActiveEffect5e._manageExhaustion(event, actor);
-    else if ( id === "concentrating" ) ActiveEffect5e._manageConcentration(event, actor);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Manage custom exhaustion cycling when interacting with the token HUD.
-   * @param {PointerEvent} event        The triggering event.
-   * @param {Actor5e} actor             The actor belonging to the token.
-   */
-  static _manageExhaustion(event, actor) {
-    let level = foundry.utils.getProperty(actor, "system.attributes.exhaustion");
-    if ( !Number.isFinite(level) ) return;
-    event.stopPropagation();
-    if ( event.button === 0 ) level++;
-    else level--;
-    const max = CONFIG.DND5E.conditionTypes.exhaustion.levels;
-    actor.update({ "system.attributes.exhaustion": Math.clamp(level, 0, max) });
-  }
-
-  /* -------------------------------------------- */
-
-  /**
    * Manage custom concentration handling when interacting with the token HUD.
    * @param {PointerEvent} event        The triggering event.
    * @param {Actor5e} actor             The actor belonging to the token.
+   * @returns {boolean}                 Whether the status was resolved via this method.
    */
   static _manageConcentration(event, actor) {
     const { effects } = actor.concentration;
-    if ( effects.size < 1 ) return;
+    if ( effects.size < 1 ) return false;
+    event.preventDefault();
     event.stopPropagation();
     if ( effects.size === 1 ) {
       actor.endConcentration(effects.first());
-      return;
+      return true;
     }
     const choices = effects.reduce((acc, effect) => {
       const data = effect.getFlag("dnd5e", "item");
       acc[effect.id] = data?.name ?? actor.items.get(data?.id)?.name ?? _loc("DND5E.CONCENTRATION.NoSource");
       return acc;
     }, {});
-    const options = HandlebarsHelpers.selectOptions(choices, { hash: { sort: true } });
+    const options = foundry.applications.handlebars.selectOptions(choices, { hash: { sort: true } });
     const content = `
     <p>${_loc("DND5E.CONCENTRATION.EndChoice")}</p>
     <div class="form-group">
@@ -896,6 +784,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
         }
       }
     });
+    return true;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -131,6 +131,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( super.isSuppressed ) return true;
     if ( this.system.magical && this.actor?.statuses.has("antimagic") ) return true;
     if ( this.type === "enchantment" ) return false;
+    if ( this.type === "condition" ) return false;
     if ( this.item ) {
       if ( this.item.areEffectsSuppressed ) return true;
       if ( this.dependentOrigin?.active === false ) return true;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -827,11 +827,16 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /* -------------------------------------------- */
 
-  /** @override */
+  /**
+   * Prepare default list of types if none are specified.
+   * @param {Actor5e} [parent]  Parent document within which this ActiveEffect will be created.
+   * @returns {string[]}
+   * @protected
+   */
   static _createDialogTypes(parent) {
-    return parent
-      ? ActiveEffect.TYPES.filter(t => CONFIG.ActiveEffect.dataModels[t]?.availableForItem?.(parent) ?? true)
-      : ActiveEffect.TYPES;
+    return ActiveEffect.TYPES.filter(type => {
+      return CONFIG.ActiveEffect.dataModels[type]?.availableForItem?.(parent) ?? true;
+    });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -17,6 +17,7 @@ import SystemDocumentMixin from "../mixins/document.mjs";
 import Proficiency from "./proficiency.mjs";
 import SelectChoices from "./select-choices.mjs";
 import * as Trait from "./trait.mjs";
+import ConditionData from "../../data/active-effect/condition.mjs";
 
 /**
  * @import { RequestOptions5e } from "../../_types.mjs";
@@ -527,9 +528,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     data.name = this.name;
     data.statuses = {};
     for ( const status of this.statuses ) {
-      data.statuses[status] = status === "exhaustion"
-        ? this.system.attributes?.exhaustion ?? 1
-        : status === "concentrating" ? this.concentration.effects.size : 1;
+      if ( ConditionData.hasLevels(status) ) data.statuses[status] = this.system.conditions[status];
+      else if ( status === "concentrating" ) data.statuses[status] = this.concentration.effects.size;
+      else data.statuses[status] = 1;
     }
     return data;
   }
@@ -537,27 +538,29 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
-   * Is this actor under the effect of this property from some status or due to its level of exhaustion?
+   * Is this actor under the effect of this property from some status or due to its level of a condition?
    * @param {string} key      A key in `DND5E.conditionEffects`.
    * @returns {boolean}       Whether the actor is affected.
    */
   hasConditionEffect(key) {
     const props = CONFIG.DND5E.conditionEffects[key] ?? new Set();
-    const level = this.system.attributes?.exhaustion ?? null;
+    const conditions = this.system.conditions ?? {};
     const imms = this.system.traits?.ci?.value ?? new Set();
-    const applyExhaustion = (level !== null) && !imms.has("exhaustion")
-      && (dnd5e.settings.rulesVersion === "legacy");
-    const statuses = this.statuses;
-    const isActiveSource = k => {
-      const l = Number(k.split("-").pop());
-      return (statuses.has(k) && !imms.has(k)) || (applyExhaustion && Number.isInteger(l) && (level >= l));
+
+    const applyCondition = prop => {
+      let [status, level] = prop.split("-");
+
+      // If immune, naturally never applied.
+      if ( imms.has(status) ) return false;
+
+      // If not leveled, or not requiring a level, need only check if status is active.
+      if ( !ConditionData.hasLevels(status) || !level ) return this.statuses.has(status);
+
+      // If leveled condition, needs to be high enough.
+      return Number(level) <= conditions[status];
     };
-    const applyDodging = !statuses.has("incapacitated")
-      && !(CONFIG.DND5E.conditionEffects.noMovement?.some(isActiveSource) ?? false);
-    return props.some(k => {
-      if ( (k === "dodging") && !applyDodging ) return false;
-      return isActiveSource(k);
-    });
+
+    return props.some(applyCondition);
   }
 
   /* -------------------------------------------- */
@@ -3499,9 +3502,27 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
   /* -------------------------------------------- */
 
-  /** @inheritDoc */
-  async toggleStatusEffect(statusId, options) {
-    const created = await super.toggleStatusEffect(statusId, options);
+  /**
+   * Toggle a configured status effect for the Actor.
+   * @override
+   * @param {string} statusId                 A status effect ID defined in CONFIG.statusEffects
+   * @param {object} [options={}]             Additional options which modify how the effect is created.
+   * @param {boolean} [options.active]        Force the effect to be active or inactive regardless of its current state.
+   * @param {boolean} [options.overlay=false] Display the toggled effect as an overlay.
+   * @param {number} [options.levels=1]       A potential level increase.
+   * @returns {Promise<ActiveEffect|boolean|undefined>}  A promise which resolves to one of the following values:
+   *                                 - ActiveEffect if a new effect need to be created or updated.
+   *                                 - true if was already an existing effect
+   *                                 - false if an existing effect needed to be removed
+   *                                 - undefined if no changes need to be made
+   */
+  async toggleStatusEffect(statusId, options={}) {
+    const hasLevels = ConditionData.hasLevels(statusId);
+    const ActiveEffect = getDocumentClass("ActiveEffect");
+    let created;
+
+    if ( hasLevels ) created = await ConditionData._applyDelta(statusId, this, { levels: options.levels ?? 1});
+    created ??= await super.toggleStatusEffect(statusId, options);
     const status = CONFIG.statusEffects.find(e => e.id === statusId);
     if ( !(created instanceof ActiveEffect) || !status.exclusiveGroup ) return created;
 
@@ -3523,18 +3544,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @protected
    */
   async _onUpdateExhaustion(data, options) {
+    const originalExhaustion = foundry.utils.getProperty(options, "dnd5e.originalExhaustion");
     const level = foundry.utils.getProperty(data, "system.attributes.exhaustion");
-    if ( !Number.isFinite(level) ) return;
-    let effect = this.effects.get(ActiveEffect5e.ID.EXHAUSTION);
-    if ( level < 1 ) return effect?.delete();
-    else if ( effect ) {
-      const originalExhaustion = foundry.utils.getProperty(options, "dnd5e.originalExhaustion");
-      return effect.update({ "flags.dnd5e.exhaustionLevel": level }, { dnd5e: { originalExhaustion } });
-    } else {
-      effect = await ActiveEffect.implementation.fromStatusEffect("exhaustion", { parent: this });
-      effect.updateSource({ "flags.dnd5e.exhaustionLevel": level });
-      return ActiveEffect.implementation.create(effect, { parent: this, keepId: true });
-    }
+    const delta = level - originalExhaustion;
+    if ( delta ) ConditionData._applyDelta("exhaustion", this, { levels: delta });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1222,7 +1222,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       const levels = ConditionData.hasLevels(status) ? (this.system.conditions[status] ?? 0) : 1;
       const penalty = levels * reduction;
 
-      if (penalty) {
+      if ( penalty ) {
         parts.push(`@reductions.${status}`);
         data.reductions ??= {};
         data.reductions[status] = -penalty;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -553,6 +553,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       // If immune, naturally never applied.
       if ( imms.has(status) ) return false;
 
+      // You cannot be dodging while incapacitated or while you have no movement.
+      if ( status === "dodging" ) {
+        if ( this.statuses.has("incapacitated") ) return false;
+        if ( CONFIG.DND5E.conditionEffects.noMovement?.some(applyCondition) ) return false;
+      }
+
       // If not leveled, or not requiring a level, need only check if status is active.
       if ( !ConditionData.hasLevels(status) || !level ) return this.statuses.has(status);
 
@@ -1188,18 +1194,40 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /* -------------------------------------------- */
 
   /**
-   * Add the reduction to this roll from exhaustion if using the modern rules.
+   * Add the reduction to this roll from conditions.
    * @param {string[]} parts  Roll parts.
    * @param {object} data     Roll data.
    */
   addRollExhaustion(parts, data) {
-    if ( (dnd5e.settings.rulesVersion !== "modern") || !this.system.attributes?.exhaustion
-      || this.system.traits?.ci?.value?.has("exhaustion") ) return;
-    const amount = this.system.attributes.exhaustion * (CONFIG.DND5E.conditionTypes.exhaustion?.reduction?.rolls ?? 0);
-    if ( amount ) {
-      parts.push("@exhaustion");
-      data.exhaustion = -amount;
-    }
+    foundry.utils.logCompatibilityWarning(
+      "The `addRollExhaustion` method has been deprecated in favor of a `addConditionRollReduction`.",
+      { since: "DnD5e 6.0", until: "DnD5e 6.2", once: true }
+    );
+    this.addConditionRollReduction(parts, data);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add the reduction to this roll from conditions.
+   * @param {string[]} parts  Roll parts.
+   * @param {object} data     Roll data.
+   */
+  addConditionRollReduction(parts, data) {
+    const immunities = this.system.traits?.ci?.value ?? new Set();
+    this.statuses.difference(immunities).forEach(status => {
+      const reduction = CONFIG.DND5E.conditionTypes[status]?.reduction?.rolls ?? 0;
+      if ( !reduction ) return;
+
+      const levels = ConditionData.hasLevels(status) ? (this.system.conditions[status] ?? 0) : 1;
+      const penalty = levels * reduction;
+
+      if (penalty) {
+        parts.push(`@reductions.${status}`);
+        data.reductions ??= {};
+        data.reductions[status] = -penalty;
+      }
+    });
   }
 
   /* -------------------------------------------- */
@@ -1404,8 +1432,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       abilityCheckBonus: this.system.bonuses?.abilities?.check
     }, { ...rollData });
 
-    // Add exhaustion reduction
-    this.addRollExhaustion(parts, data);
+    // Add condition reductions.
+    this.addConditionRollReduction(parts, data);
 
     config.parts = [...(config.parts ?? []), ...parts];
     config.data = { ...data, ...(config.data ?? {}) };
@@ -1526,7 +1554,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     rollConfig.rolls = [
       CONFIG.Dice.D20Roll.mergeConfigs({ parts, data, options }, config.rolls?.shift())
     ].concat(config.rolls ?? []);
-    rollConfig.rolls.forEach(({ parts, data }) => this.addRollExhaustion(parts, data));
+    rollConfig.rolls.forEach(({ parts, data }) => this.addConditionRollReduction(parts, data));
     rollConfig.subject = this;
 
     const dialogConfig = foundry.utils.deepClone(dialog);
@@ -1835,8 +1863,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       "attributes.init.roll.mode"
     ]);
 
-    // Add exhaustion reduction
-    this.addRollExhaustion(parts, data);
+    // Add condition reductions
+    this.addConditionRollReduction(parts, data);
 
     // Ability score tiebreaker
     const tiebreaker = game.settings.get("dnd5e", "initiativeDexTiebreaker");
@@ -3505,16 +3533,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Toggle a configured status effect for the Actor.
    * @override
-   * @param {string} statusId                 A status effect ID defined in CONFIG.statusEffects
-   * @param {object} [options={}]             Additional options which modify how the effect is created.
-   * @param {boolean} [options.active]        Force the effect to be active or inactive regardless of its current state.
-   * @param {boolean} [options.overlay=false] Display the toggled effect as an overlay.
-   * @param {number} [options.levels=1]       A potential level increase.
-   * @returns {Promise<ActiveEffect|boolean|undefined>}  A promise which resolves to one of the following values:
-   *                                 - ActiveEffect if a new effect need to be created or updated.
-   *                                 - true if was already an existing effect
-   *                                 - false if an existing effect needed to be removed
-   *                                 - undefined if no changes need to be made
+   * @param {string} statusId                       A status effect ID defined in CONFIG.statusEffects
+   * @param {object} [options={}]                   Additional options which modify how the effect is created.
+   * @param {boolean} [options.active]              Force the effect to be active or inactive
+   *                                                regardless of its current state.
+   * @param {boolean} [options.overlay=false]       Display the toggled effect as an overlay.
+   * @param {number} [options.levels=1]             A potential level increase.
+   * @returns {Promise<ActiveEffect|boolean|void>}  A promise which resolves to one of the following values:
+   *                                                - ActiveEffect if a new effect need to be created or updated.
+   *                                                - true if was already an existing effect.
+   *                                                - false if an existing effect needed to be removed.
+   *                                                - undefined if no changes need to be made.
    */
   async toggleStatusEffect(statusId, options={}) {
     const hasLevels = ConditionData.hasLevels(statusId);

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -744,6 +744,15 @@ export function applyLegacyRules() {
   DND5E.conditionEffects.initiativeDisadvantage.delete("incapacitated");
   DND5E.conditionEffects.initiativeDisadvantage.delete("surprised");
 
+  // Add exhaustion effects.
+  DND5E.conditionEffects.noMovement.add("exhaustion-5");
+  DND5E.conditionEffects.halfMovement.add("exhaustion-2");
+  DND5E.conditionEffects.halfHealth.add("exhaustion-4");
+  DND5E.conditionEffects.abilityCheckDisadvantage.add("exhaustion-1");
+  DND5E.conditionEffects.abilitySaveDisadvantage.add("exhaustion-3");
+  DND5E.conditionEffects.attackDisadvantage.add("exhaustion-3");
+  delete DND5E.conditionTypes.exhaustion.reduction;
+
   // Incapacitated creatures within 2 size categories still cannot be moved through in legacy
   delete DND5E.conditionTypes.incapacitated.neverBlockMovement;
 

--- a/system.json
+++ b/system.json
@@ -25,6 +25,7 @@
   ],
   "documentTypes": {
     "ActiveEffect": {
+      "condition": {},
       "enchantment": {}
     },
     "Actor": {


### PR DESCRIPTION
Adds a "Condition" ActiveEffect subtype which is responsible for storing levels and other data related to that on the actor.

Generalizes most of the handling surrounding exhaustion. The `attributes.exhaustion` property remains for backwards compatibility and for the ability to update the Exhaustion condition via an actor update. For other conditions with levels, one can call `actor.toggleStatusEffects(statusId, { levels: 1 })`.

For example, adding a new condition,
```js
DND5E.conditionTypes.contamination = {
  name: "Contamination",
  img: "modules/drakkenheim-scgd/assets/layout/meteor.svg",
  levels: 6,
  conditions: {
    4: ["weakened"],
    5: ["dazed", "incapacitated"],
  },
};
```
will add a new status with 6 levels, where "Weakened" (an unrelated example condition) is applied at 4 leves of Contamination or higher, and Dazed and Incapaciated are applied at 5 levels or higher.

The `reduction` property is also generalized and can be used by any condition, not just leveled ones.