### PR TITLE
Fix aria-label for toggleable effect control

### DIFF
--- a/templates/shared/active-effects.hbs
+++ b/templates/shared/active-effects.hbs
@@ -145,7 +145,7 @@
     {{else if toggleable}}
     {{!-- Toggling --}}
     <a class="effect-control item-control {{#unless disabled}}active{{/unless}}" data-action="toggle" data-tooltip
-       aria-label="{{ localize (ifThen disabled "DND5E.EffectEnabled" "DND5E.EffectDisable") }}">
+       aria-label="{{ localize (ifThen disabled "DND5E.EffectEnable" "DND5E.EffectDisable") }}">
         <i class="fa-solid fa-toggle-{{ ifThen disabled "off" "on" }}"></i>
     </a>
 


### PR DESCRIPTION
Translation string reference was broken on this.

<img width="208" height="130" alt="image" src="https://github.com/user-attachments/assets/dcfd794b-a522-4c66-b0f3-2cfdf63cdc99" />

Opted to change the template over the translation string so the verb tense was the same.