### PR TITLE
[#6627] Fix `getActorCurrencyUpdates` not working in some instances

### DIFF
--- a/module/applications/currency-manager.mjs
+++ b/module/applications/currency-manager.mjs
@@ -275,15 +275,16 @@ export default class CurrencyManager extends Application5e {
     const { currency } = actor.system;
     if ( amount <= 0 ) return { system: { currency: { ...currency } }, remainder: amount, item: [] };
 
-    const currencies = Object.entries(CONFIG.DND5E.currencies).map(([denom, { conversion }]) => {
-      return [denom, conversion];
-    }).sort(([, a], [, b]) => priority === "high" ? a - b : b - a);
+    const currencies = Object.entries(CONFIG.DND5E.currencies)
+      .filter(([denom]) => !exact || (denom !== denomination))
+      .map(([denom, { conversion }]) => [denom, conversion])
+      .sort(([, a], [, b]) => priority === "high" ? a - b : b - a);
     const baseConversion = CONFIG.DND5E.currencies[denomination].conversion;
     if ( exact ) currencies.unshift([denomination, baseConversion]);
 
     let passes = currencies.length;
     let updates;
-    while ( passes > 0 ) {
+    while ( passes ) {
       updates = { system: { currency: { ...currency } }, remainder: amount, item: [] };
       for ( const [denom, conversion] of currencies ) {
         const multiplier = conversion / baseConversion;
@@ -292,7 +293,6 @@ export default class CurrencyManager extends Application5e {
         updates.system.currency[denom] -= deduct;
         if ( !updates.remainder ) return updates;
       }
-      if ( !updates.remainder ) break;
       currencies.push(currencies.shift());
       passes--;
     }


### PR DESCRIPTION
Modifies how `getActorCurrencyUpdates` works to now perform additional passes in an attempt to find the correct currency to deduce without resulting in a remainder. Previously, if you had a character with 100 gp, 5 sp, and 20 cp, and you asked to deduce 100 cp, it would return a remainder of 30 despite having enough currency to complete the request. This is because the loop would start at the lowest currency (100 - 20 = 80), then go to the next currency up (80 - (5 * 10) = 30), and then continue up through the denominations not finding any more that would be able to be deducted.

This change causes it to instead perform several loops over the list of currencies. If on the first pass ends with a remainder, then it will move the first entry in the currencies list to the end and re-perform the calculation. It will continue until it ends up with a remainder of `0` or has used each currency denomination as its first entry.

Closed #6627