### PR TITLE
[#6528] Support magical gear using templates, unique named gear

### DIFF
--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -323,18 +323,21 @@ export default class NPCActorSheet extends BaseActorSheet {
     const { attributes, details } = context.system;
 
     // Gear
-    const gear = await this.actor.system.getGear();
-    if ( gear.length ) context.gear = gear.map(item => ({
-      draggable: true,
-      label: item.name,
-      link: {
-        action: "showDocument",
-        itemId: foundry.utils.parseUuid(item.getFlag("dnd5e", "gearSource"))?.id,
-        quantity: item.system.quantity,
-        uuid: item.uuid
-      },
-      value: item.system.quantity > 1 ? item.system.quantity : undefined
-    }));
+    const gear = await this.actor.items.filter(i => i.system.quantity && i.system.properties?.has("gear"));
+    if ( gear.length ) context.gear = gear.map(item => {
+      const { name, uuid } = item.system.gearPresentationData();
+      return {
+        draggable: true,
+        label: name,
+        link: {
+          action: "showDocument",
+          itemId: item.id,
+          quantity: item.system.quantity,
+          uuid
+        },
+        value: item.system.quantity > 1 ? item.system.quantity : undefined
+      };
+    });
 
     // Habitat
     if ( details.habitat.value.length || details.habitat.custom ) {

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -492,10 +492,9 @@ export default class NPCData extends CreatureTemplate {
    */
   async getGear() {
     return (await Promise.all(this.parent.items
-      .filter(i => i.system.quantity && i.system.properties?.has("gear"))
-      .map(i => i.system.asGear?.())
-    )).filter(_ => _)
-      .toSorted((lhs, rhs) => lhs.name.localeCompare(rhs.name, game.i18n.lang));
+      .filter(i => i.system.quantity && i.system.properties?.has("gear") && i.system.asGear)
+      .map(i => i.system.asGear())
+    )).toSorted((lhs, rhs) => lhs.name.localeCompare(rhs.name, game.i18n.lang));
   }
 
   /* -------------------------------------------- */
@@ -671,9 +670,13 @@ export default class NPCData extends CreatureTemplate {
         cr: `${o.cr ?? formatCR(this.details.cr, { narrow: false })} (${xp})`,
 
         // Gear
-        gear: o.gear ?? formatter.format((await this.getGear()).map(item =>
-          item.system.quantity > 1 ? `${item.name} (${formatNumber(item.system.quantity)})` : item.name
-        )),
+        gear: o.gear ?? formatter.format(this.parent.items
+          .filter(item => item.system.quantity && item.system.properties?.has("gear"))
+          .map(item => {
+            const { nameHTML } = item.system.gearPresentationData();
+            return item.system.quantity > 1 ? `${nameHTML} (${formatNumber(item.system.quantity)})` : nameHTML;
+          })
+        ),
 
         // Initiative (e.g. `+0 (10)`)
         initiative: o.initiative ?? `${formatNumber(this.attributes.init.total, { signDisplay: "always" })} (${
@@ -775,7 +778,7 @@ export default class NPCData extends CreatureTemplate {
         summary.vulnerabilities ? { label: "DND5E.Vulnerabilities", definitions: [summary.vulnerabilities] } : null,
         summary.resistances ? { label: "DND5E.Resistances", definitions: [summary.resistances] } : null,
         summary.immunities ? { label: "DND5E.Immunities", definitions: [summary.immunities] } : null,
-        summary.gear ? { label: "DND5E.Gear.Label", definitions: [summary.gear] } : null,
+        summary.gear ? { label: "DND5E.Gear.Label", definitions: [summary.gear], allowHTML: !o.gear } : null,
         { label: "DND5E.Senses", definitions: [summary.senses] },
         { label: "DND5E.Languages", definitions: [summary.languages] },
         { label: "DND5E.AbbreviationCR", definitions: [summary.cr] }

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -309,12 +309,22 @@ export default class PhysicalItemTemplate extends SystemDataModel {
   async asGear() {
     const change = { "flags.dnd5e.gearSource": this.parent.uuid };
     let clone;
-    if ( this.metadata.compendiumGearSource && this.parent._stats.compendiumSource
-      && !this.parent.getFlag("dnd5e", "gear.preserve") ) {
+    const flags = this.parent.getFlag("dnd5e", "gear") ?? {};
+    if ( this.metadata.compendiumGearSource && this.parent._stats.compendiumSource && (flags.preserve !== true) ) {
       const item = await fromUuid(this.parent._stats.compendiumSource);
-      if ( item ) clone = item.clone({ ...change, "system.quantity": this.quantity }, { keepId: true });
+      const name = (flags.preserveName === true ? this.parent._source.name : flags.preserveName) ?? item.name;
+      if ( item ) clone = item.clone({ ...change, name, "system.quantity": this.quantity }, { keepId: true });
     }
     clone ??= this.parent.clone(change, { keepId: true });
+
+    let enchantment = this.parent.effects.get(flags.effectId);
+    if ( enchantment ) {
+      if ( !flags.preserveEffect ) enchantment = await fromUuid(enchantment._stats.compendiumSource) ?? enchantment;
+      clone.updateSource({
+        effects: [{ ...enchantment.toObject(), disabled: false, origin: enchantment.parent.uuid }]
+      });
+      // TODO: Add rider activities & effects once https://github.com/foundryvtt/dnd5e/issues/6357 is merged
+    }
 
     /**
      * A hook event that fires when retrieving an item as gear.
@@ -326,6 +336,47 @@ export default class PhysicalItemTemplate extends SystemDataModel {
     Hooks.callAll("dnd5e.getAsGear", this.parent, clone);
 
     return clone;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieve information needed to present this item's name as gear on sheets and in embeds.
+   * @returns {{ name: string, nameHTML: string, uuid: string }}
+   */
+  gearPresentationData() {
+    const compendiumSrc = fromUuidSync(this.parent._stats.compendiumSource);
+    const flags = this.parent.getFlag("dnd5e", "gear") ?? {};
+    const useCompendiumCopy = this.metadata.compendiumGearSource && compendiumSrc && (flags.preserve !== true);
+    const enchantment = this.parent.effects.get(flags.effectId);
+
+    const data = { uuid: useCompendiumCopy ? this.parent._stats.compendiumSource : this.parent.uuid };
+    const magical = this.properties.has("mgc");
+
+    // If nothing specified, just display base weapon name (e.g. "Longsword")
+    const name = data.name = data.nameHTML = useCompendiumCopy ? compendiumSrc.name : this.parent._source.name;
+
+    // If persevered name specified, display preserved name outside with special name(?) inside
+    //   (e.g. "Stacy (Longsword +1)")
+    if ( flags.preserveName ) {
+      const namePattern = enchantment?.flags.dnd5e?.namePattern;
+      const nameOuter = flags.preserveName === true ? this.parent._source.name : flags.preserveName;
+      const nameInner = namePattern ? namePattern.replace("{}", name) : name;
+      if ( nameOuter !== nameInner ) {
+        data.name = data.nameHTML = `${nameOuter} (${nameInner})`;
+        if ( magical && namePattern ) data.nameHTML = `<em>${nameOuter}</em> (<em>${nameInner}</em>)`;
+        else if ( magical ) data.nameHTML = `<em>${nameOuter}</em> (${nameInner})`;
+      }
+    }
+
+    // If enchantment is specified, display enchantment name outside with base name inside
+    //   (e.g. "Silvered Weapon (Longsword)", "Weapon +1 (Longsword)")
+    else if ( enchantment ) {
+      data.name = data.nameHTML = `${enchantment.name} (${name})`;
+      if ( magical ) data.nameHTML = `<em>${enchantment.name}</em> (${name})`;
+    }
+
+    return data;
   }
 
   /* -------------------------------------------- */

--- a/templates/actors/embeds/npc-embed.hbs
+++ b/templates/actors/embeds/npc-embed.hbs
@@ -58,7 +58,9 @@
     {{#each entries}}
     <div {{~#if classes}} class="{{ classes }}"{{/if}}>
         <dt>{{ localize label }}</dt>
-        {{~#each definitions}}{{#unless (eq this undefined)}}<dd>{{ this }}</dd>{{/unless}}{{/each}}
+        {{~#each definitions}}{{#unless (eq this undefined)~}}
+        <dd>{{#if ../allowHTML}}{{{ this }}}{{else}}{{ this }}{{/if}}</dd>
+        {{~/unless}}{{/each}}
     </div>
     {{/each}}
 </dl>


### PR DESCRIPTION
Adds support for magical gear using enchantments as well as unique named gear.

Magical gear is handled using a pair of new flags pointing to an enchantment representing the magical properties of the weapon:
- `gear.effectId`: ID of an enchantment effect on the item
- `gear.preserveEffect`: Use the local copy of the effect rather than the effect's compendium source

When these flags are set the gear is presented on the NPC sheet and in embeds with the effect name (e.g. "Silvered Weapon (Longsword)" or "Weapon +1 (Longbow)"). The enchantment will be in italics in the embed to indicate the magical nature of the item.

<img width="407" height="70" alt="Stat Block Gear, Enchantment" src="https://github.com/user-attachments/assets/50841b71-0037-41ff-b5d3-71e1c91d3ac7" />

Special named items are handled by another flag that informs the system to retain the item's name:
- `gear.preserveName`: Either `true` to preseve the source name of the item on the NPC sheet or a string for a specific name.

These items are presented with the unique name followed by the base item's name in parenthesis (e.g. `Sting (Shortsword)`). If the item also has a presevered enchantment it can be used to adjust the base name (e.g. `Excalibur (+3 Longsword)`) using the `namePattern` flag on the enchantment local copy of the effect.
- `namePattern`: Pattern indicating how the base weapon name should be modified to reflect the name of this enchantment. This follows the same format as using an override AE change. For a +3 weapon enchantment this would be `+3 {}` for a result of `+3 Longsword`.

When a unique name is used then the stat block shows italics on both parts of the name if the weapon is magical.

<img width="407" height="70" alt="Stat Block Gear, Named" src="https://github.com/user-attachments/assets/8597a600-ae6e-4f4e-9b8c-6be93f465c7c" />
