### PR TITLE
[#6755] Fix Gelatinous Cube Engulf save ability and add 5.1 Escape Check

### DIFF
--- a/packs/_source/actors24/ooze/gelatinous-cube.yml
+++ b/packs/_source/actors24/ooze/gelatinous-cube.yml
@@ -1147,7 +1147,7 @@ items:
             onSave: none
           save:
             ability:
-              - str
+              - dex
             dc:
               calculation: str
               formula: '23'

--- a/packs/_source/monsters/ooze/gelatinous-cube.yml
+++ b/packs/_source/monsters/ooze/gelatinous-cube.yml
@@ -1003,6 +1003,52 @@ items:
               calculation: ''
               formula: '12'
           sort: 0
+        LMPyxWOrUotM7OLs:
+          type: check
+          name: Escape Check
+          _id: LMPyxWOrUotM7OLs
+          sort: 0
+          activation:
+            type: ''
+            value: null
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          range:
+            override: false
+          target:
+            template:
+              contiguous: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          check:
+            associated: []
+            dc:
+              calculation: ''
+              formula: '12'
+            ability: str
+          img: ''
+          appliedEffects: []
         sDRiVB3bhk4S5XZI:
           type: damage
           _id: sDRiVB3bhk4S5XZI


### PR DESCRIPTION
- Change 5.2 Engulf Save activity from STR to DEX saving throw
- Add missing Escape Check activity to 5.1 Engulf (DC 12 STR)

Closes #6755