### PR TITLE
[#5444] Add `locked.exclusive` option to `CompendiumBrowser` filters

### DIFF
--- a/module/applications/_types.mjs
+++ b/module/applications/_types.mjs
@@ -39,7 +39,7 @@
 
 /**
  * @typedef CompendiumBrowserFilters
- * @property {boolean} [exclusive]    When used in locked filters, locks all choices within filter categories that have
+ * @property {boolean} [exclusive]     When used in locked filters, locks all choices within filter categories that have
  *                                     explicit values, preventing additional selections. Categories without values
  *                                     remain unlocked.
  * @property {string} [documentClass]  Document type to fetch (e.g. Actor or Item).

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -715,7 +715,7 @@ export default class CompendiumBrowser extends Application5e {
     if ( !sources.length ) return;
     const lockExclusive = this.options.filters?.locked?.exclusive === true;
     const lockedSource = this.options.filters?.locked?.additional?.source;
-    const locked = (lockExclusive && lockedSource !== undefined)
+    const locked = lockExclusive && (lockedSource !== undefined)
       ? Object.fromEntries(Object.keys(this.#sources).map(k => [k, true]))
       : Object.entries(lockedSource ?? {}).reduce((obj, [k, v]) => {
         obj[k.slugify({ strict: true })] = v;
@@ -725,7 +725,7 @@ export default class CompendiumBrowser extends Application5e {
       "systems/dnd5e/templates/compendium/browser-sidebar-filter-set.hbs",
       {
         locked,
-        value: (lockExclusive && lockedSource !== undefined) ? {} : locked,
+        value: lockExclusive && (lockedSource !== undefined) ? {} : locked,
         key: "source",
         expandId: "source",
         label: "DND5E.SOURCE.FIELDS.source.label",


### PR DESCRIPTION
## Summary

Adds a `locked.exclusive` option to `CompendiumBrowserFilters` that locks all choices within filter categories that have explicit values set, preventing additional selections. Categories without values remain unlocked.

Right now, locking filters requires specifying each one individually in `locked.additional`. This adds an `exclusive: true` flag that automatically locks down any category where a value is explicitly provided — preventing users from adding invalid combinations — while leaving unset categories fully interactive.

## Usage

```js
new dnd5e.applications.CompendiumBrowser({
  filters: {
    locked: {
      exclusive: true,
      documentClass: "Actor",
      types: new Set(["npc"]),
      additional: {
        size: { huge: 1 },
        "type.value": { dragon: 1 }
      }
    }
  }
});
```

Setting `locked.exclusive: true` locks Size and Creature Type (which have explicit values) while leaving Habitat, Source, and other filters open for the user to refine.

## Implementation

- `_prepareSidebarContext`: Reads `lockExclusive` from locked filter options
- `generateLocked`: Accepts the filter definition as a second parameter. When `exclusive` is set and the filter has a value, produces the correct locked shape per type (`{ min, max }` for range, all keys for set, `true` for boolean)
- `_renderSourceFilters`: Locks every available source key when `exclusive` is set and source has a locked value
- `currentFilters` getter: Strips `exclusive` from the merged filters so it doesn't leak into actual filter logic