### PR TITLE
[#6723] Add Stationary option for Emanation template type

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4489,6 +4489,10 @@
           "label": "Area Size",
           "hint": "Size of the area of effect on its primary axis."
         },
+        "stationary": {
+          "label": "Stationary",
+          "hint": "Emanation cannot be moved once placed."
+        },
         "type": {
           "label": "Area Type",
           "hint": "Type of area of effect targeted."

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -12,6 +12,7 @@ export default class TargetField extends SchemaField {
       template: new SchemaField({
         count: new FormulaField({ deterministic: true }),
         contiguous: new BooleanField(),
+        stationary: new BooleanField(),
         type: new StringField(),
         size: new FormulaField({ deterministic: true }),
         width: new FormulaField({ deterministic: true }),

--- a/packs/_source/spells/3rd-level/tiny-hut.yml
+++ b/packs/_source/spells/3rd-level/tiny-hut.yml
@@ -35,13 +35,17 @@ system:
   target:
     affects:
       choice: false
+      type: ''
     template:
       units: ft
-      type: sphere
+      type: radius
       size: '10'
       contiguous: false
+      count: ''
+      stationary: true
   range:
     units: self
+    special: ''
   uses:
     max: ''
     recovery: []
@@ -109,11 +113,11 @@ effects: []
 folder: 5Si35RRLLaaoWvC3
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 5.3.0
   createdTime: 1725037355072
-  modifiedTime: 1725992719492
+  modifiedTime: 1772145870594
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!NXWWWgHtWb7Nv21F'

--- a/packs/_source/spells24/3rd-level/tiny-hut.yml
+++ b/packs/_source/spells24/3rd-level/tiny-hut.yml
@@ -41,6 +41,7 @@ system:
       size: '10'
       contiguous: false
       count: ''
+      stationary: true
   range:
     units: self
     special: ''
@@ -117,11 +118,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 5.1.0
+  systemVersion: 5.3.0
   createdTime: 1724425961075
-  modifiedTime: 1753380812382
+  modifiedTime: 1772145792278
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplLeomundsTi'

--- a/templates/shared/fields/field-targets.hbs
+++ b/templates/shared/fields/field-targets.hbs
@@ -41,8 +41,22 @@
     <legend>{{ localize "DND5E.TargetTypeArea" }}</legend>
 
     {{!-- Template Type --}}
-    {{ formField fields.template.fields.type value=data.template.type label="DND5E.Shape" localize=true hint=false
-                 options=CONFIG.areaTargetOptions rootId=partId }}
+    <div class="form-group split-group">
+        <label>{{ localize "DND5E.Shape" }}</label>
+        <div class="form-fields">
+
+            {{!-- Type --}}
+            {{ formField fields.template.fields.type value=data.template.type label="DND5E.Type" localize=true
+                         hint=false classes="label-top" options=CONFIG.areaTargetOptions rootId=partId }}
+
+            {{!-- Stationary --}}
+            {{#if (eq data.template.type "radius")}}
+            {{ formField fields.template.fields.stationary value=data.template.stationary localize=true
+                         hint=false input=inputs.createCheckboxInput classes="checkbox" rootId=partId }}
+            {{/if}}
+
+        </div>
+    </div>
 
     {{!-- Dimensions --}}
     {{#if data.template.type}}


### PR DESCRIPTION
Adds a new `stationary` option to `target.template` to indicate that an emanation cannot be moved after being placed. This option only appears if the emanation template type is selected.

<img width="513" height="157" alt="Stationary Emanation" src="https://github.com/user-attachments/assets/2a29f49a-fa7b-4c54-9b1d-4a4839eab824" />

This option has been set for both the 2014 & 2024 versions of Tiny Hut in the SRD.

Closes #6723