### PR TITLE
[#6780] Adjust formula field multiplication

### DIFF
--- a/module/data/fields/formula-field.mjs
+++ b/module/data/fields/formula-field.mjs
@@ -59,8 +59,8 @@ export default class FormulaField extends foundry.data.fields.StringField {
   /** @override */
   _applyChangeMultiply(value, delta, model, change) {
     if ( !value ) return value;
-    if (new Roll(value).terms.length > 1) value = `(${value})`;
-    if (new Roll(delta).terms.length > 1) delta = `(${delta})`;
+    if ( new Roll(value).terms.length > 1 ) value = `(${value})`;
+    if ( new Roll(delta).terms.length > 1 ) delta = `(${delta})`;
     return `${value} * ${delta}`;
   }
 


### PR DESCRIPTION
Unless there's a reason we only sometimes want the parentheses that I do not see, I think it would make sense to just always return `(${value}) * (${delta})`.