### PR TITLE
[#5559, #6436] Create proper emanations, attach to tokens

### DIFF
--- a/module/canvas/_types.mjs
+++ b/module/canvas/_types.mjs
@@ -23,6 +23,7 @@
 
 /**
  * @typedef {BaseShapeData} TemplatePlacementData
+ * @property {string} [token]  ID of attached token.
  */
 
 /* -------------------------------------------- */

--- a/module/canvas/template-placement.mjs
+++ b/module/canvas/template-placement.mjs
@@ -58,7 +58,10 @@ export default class TemplatePlacement extends BasePlacement {
       case "circle": return { ...data, radius: size };
       case "cone": return { ...data, angle: CONFIG.MeasuredTemplate.defaults.angle, radius: size };
       case "emanation": return {
-        base: { ...data, width: 1, height: 1, shape: 4, type: "token" },
+        base: {
+          ...data, width: 1, height: 1, type: "token",
+          shape: canvas.grid.isHexagonal ? CONST.TOKEN_SHAPES.ELLIPSE_1 : CONST.TOKEN_SHAPES.RECTANGLE_1
+        },
         radius: size, type: "emanation"
       };
       case "ray":

--- a/module/canvas/template-placement.mjs
+++ b/module/canvas/template-placement.mjs
@@ -20,6 +20,7 @@ export default class TemplatePlacement extends BasePlacement {
   /** @override */
   async _place() {
     const results = [];
+    const attachToToken = this.config.shapes.some(s => s.type === "emanation");
     await canvas.regions.placeRegion({
       name: RegionDocument.implementation.defaultName({ parent: canvas.scene }),
       color: this.config.color,
@@ -28,15 +29,14 @@ export default class TemplatePlacement extends BasePlacement {
       shapes: this.config.shapes.map(s => this.#createShapeData(s)),
       "flags.core.MeasuredTemplate": true
     }, {
-      // TODO: `attachToToken: true` if emanation
+      attachToToken,
       create: false,
       onRotate: ({ shape }) => {
         if ( (shape.type === "rectangle") && dnd5e.settings.gridAlignedSquareTemplates ) return false;
       },
       preConfirm: ({ document, index }) => {
         const obj = document.toObject();
-        results.push({ ...obj.shapes.at(-1) });
-        // TODO: Set token ID if emanation attached to token
+        results.push({ ...obj.shapes.at(-1), token: obj.attachment.token });
       }
     });
     return results;
@@ -57,7 +57,10 @@ export default class TemplatePlacement extends BasePlacement {
     switch ( type ) {
       case "circle": return { ...data, radius: size };
       case "cone": return { ...data, angle: CONFIG.MeasuredTemplate.defaults.angle, radius: size };
-      case "emanation": return { base: { ...data }, radius: size }; // TODO: Make this work properly
+      case "emanation": return {
+        base: { ...data, width: 1, height: 1, shape: 4, type: "token" },
+        radius: size, type: "emanation"
+      };
       case "ray":
       case "line": return { ...data, length: size, width, type: "line" };
       case "rect":
@@ -108,18 +111,27 @@ export default class TemplatePlacement extends BasePlacement {
      */
     if ( Hooks.call("dnd5e.preCreateMeasuredTemplate", activity, config) === false ) return null;
 
-    const shapes = await TemplatePlacement.place(config);
-    if ( !shapes?.length ) return null;
+    const placements = await TemplatePlacement.place(config);
+    if ( !placements?.length ) return null;
 
-    // TODO: If type=emanation and stationary=false, create multiple templates
-    // Otherwise only a single template is created with multiple shapes
+    const combinedShapes = [];
+    const splitShapes = [];
+    for ( const placement of placements ) {
+      if ( placement.token ) {
+        const { x, y, width, height, shape } = canvas.scene.tokens.get(placement.token);
+        Object.assign(placement.base, { x, y, width, height, shape });
+      }
+      if ( !placement.token || target.stationary ) combinedShapes.push(placement);
+      else splitShapes.push([placement]);
+    }
 
     const rollData = activity.getRollData();
-    const regionData = [foundry.utils.mergeObject({
+    const regionData = [combinedShapes, ...splitShapes].map(shapes => shapes.length ? foundry.utils.mergeObject({
       // TODO: Should the activity name be included?
+      // TODO: Include count if more than one created?
       name: `${activity.item.name} [${game.user.name}]`,
       color: game.user.color,
-      shapes: shapes.map(({ index, ...data }) => data),
+      shapes: shapes.map(({ index, token, ...data }) => data),
       // TODO: Set elevation based on shape's height
       levels: [canvas.level.id],
       restriction: {
@@ -128,7 +140,9 @@ export default class TemplatePlacement extends BasePlacement {
         // TODO: What about templates like Fireball that flow around walls?
         type: "move"
       },
-      // TODO: Set attachedToken if type=emanation and stationary=false and token clicked on
+      attachment: {
+        token: target.stationary ? undefined : shapes[0].token
+      },
       visibility: CONST.REGION_VISIBILITY.ALWAYS,
       highlightMode: "coverage",
       flags: {
@@ -144,7 +158,7 @@ export default class TemplatePlacement extends BasePlacement {
           spellLevel: rollData.item.level
         }
       }
-    }, createData)];
+    }, createData) : null).filter(_ => _);
 
     /**
      * A hook event that fires after templates have been placed by the player but before they have been created.

--- a/module/canvas/template-placement.mjs
+++ b/module/canvas/template-placement.mjs
@@ -21,14 +21,14 @@ export default class TemplatePlacement extends BasePlacement {
   async _place() {
     const results = [];
     const attachToToken = this.config.shapes.some(s => s.type === "emanation");
-    await canvas.regions.placeRegion({
+    await canvas.regions.placeRegions(this.config.shapes.map(s => ({
       name: RegionDocument.implementation.defaultName({ parent: canvas.scene }),
       color: this.config.color,
       displayMeasurements: true,
       highlightMode: "coverage",
-      shapes: this.config.shapes.map(s => this.#createShapeData(s)),
+      shapes: [this.#createShapeData(s)],
       "flags.core.MeasuredTemplate": true
-    }, {
+    })), {
       attachToToken,
       create: false,
       onRotate: ({ shape }) => {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2838,7 +2838,7 @@ DND5E.areaTargetTypes = {
   radius: {
     label: "DND5E.TARGET.Type.Emanation.Label",
     counted: "DND5E.TARGET.Type.Emanation.Counted",
-    template: "circle",
+    template: "emanation",
     standard: true
   },
   ring: {


### PR DESCRIPTION
Swaps the Emanation area of effect type to use `emanation` shapes under the hood, adapting the behavior for when tokens are moused over during placement to associate a token with the emanation. This leads to the base size of the emanation being adjusted to match the size of the token.

When an emanation is not marked as stationary and placed over a token it will be automatically attached to the token it is placed over, creating an aura that moves with that token.

https://github.com/user-attachments/assets/98d3c3a0-0d2b-4285-8b24-1f3b185c5147

Closes #6436