### PR TITLE
[#6438] Add ring wall type to area of effect options

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4887,7 +4887,13 @@
       }
     },
     "Ring": {
-      "Label": "Wall (ring)"
+      "Label": "Ring",
+      "Counted": {
+        "one": "{number} ring",
+        "other": "{number} rings",
+        "oneSized": "{sizes} Ring",
+        "otherSized": "{number} {sizes} Rings"
+      }
     },
     "Self": {
       "Label": "Self"
@@ -4941,7 +4947,7 @@
       }
     },
     "Wall": {
-      "Label": "Wall (straight)",
+      "Label": "Wall",
       "Counted": {
         "one": "{number} wall",
         "other": "{number} walls",

--- a/lang/en.json
+++ b/lang/en.json
@@ -4886,6 +4886,9 @@
         "otherSized": "{number} {sizes} Radii"
       }
     },
+    "Ring": {
+      "Label": "Wall (ring)"
+    },
     "Self": {
       "Label": "Self"
     },
@@ -4938,7 +4941,7 @@
       }
     },
     "Wall": {
-      "Label": "Wall",
+      "Label": "Wall (straight)",
       "Counted": {
         "one": "{number} wall",
         "other": "{number} walls",

--- a/module/canvas/template-placement.mjs
+++ b/module/canvas/template-placement.mjs
@@ -62,7 +62,7 @@ export default class TemplatePlacement extends BasePlacement {
       case "line": return { ...data, length: size, width, type: "line" };
       case "rect":
       case "rectangle": return { ...data, width: size, height: size, type: "rectangle" };
-      case "ring": return { ...data, radius: size, outerWidth: width };
+      case "ring": return { ...data, radius: size, outerWidth: width, innerWidth: 0 };
     }
   }
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2843,7 +2843,7 @@ DND5E.areaTargetTypes = {
   },
   ring: {
     label: "DND5E.TARGET.Type.Ring.Label",
-    counted: "DND5E.TARGET.Type.Wall.Counted",
+    counted: "DND5E.TARGET.Type.Ring.Counted",
     template: "ring",
     sizes: ["radius", "thickness", "height"]
   },

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2841,6 +2841,12 @@ DND5E.areaTargetTypes = {
     template: "circle",
     standard: true
   },
+  ring: {
+    label: "DND5E.TARGET.Type.Ring.Label",
+    counted: "DND5E.TARGET.Type.Wall.Counted",
+    template: "ring",
+    sizes: ["radius", "thickness", "height"]
+  },
   sphere: {
     label: "DND5E.TARGET.Type.Sphere.Label",
     counted: "DND5E.TARGET.Type.Sphere.Counted",


### PR DESCRIPTION
Adds a new "Wall (ring)" area of effect type and renames the existing wall type to "Wall (straight)". The new wall type uses the `ring` shape using `outerWidth`, so the wall's thickness starts at the radius and goes outward.

<img width="1052" height="535" alt="Ring Wall Template" src="https://github.com/user-attachments/assets/17f4fbe5-ae48-4364-9864-58a2a3e8a0f8" />

Closes #6438