### PR TITLE
[#6813] Add expanded section showing effect changes & description

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2020,6 +2020,9 @@
           "label": "Base Damage Types"
         }
       },
+      "bonus": {
+        "label": "Damage Bonus"
+      },
       "label": "Ammunition Damage",
       "replace": {
         "label": "Replace Weapon Damage",
@@ -2545,12 +2548,12 @@
 "DND5E.Dusk": "Dusk",
 
 "DND5E.Effect": "Effect",
-
 "DND5E.EFFECT": {
   "Action": {
-    "Create": "Create Effect",
-    "Delete": "Delete Effect",
-    "Dissociate": "Dissociate Effect",
+    "CreateEffect": "Create Effect",
+    "DeleteEffect": "Delete Effect",
+    "DissociateEffect": "Dissociate Effect",
+    "EditEffect": "Edit Effect",
     "Search": "Search effects"
   },
   "Application": {
@@ -2571,9 +2574,16 @@
       }
     }
   },
+  "Category": {
+    "Temporary": "Temporary Effects",
+    "Passive": "Passive Effects",
+    "Inactive": "Inactive Effects",
+    "Unavailable": "Unavailable Effects"
+  },
   "DropHint": "Drop an Active Effect here",
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
   "Label": "Available Effects",
+  "New": "New Effect",
   "RIDER": {
     "Activity": "Enchantment Rider Activity",
     "Effect": "Enchantment Rider Effect",
@@ -2586,9 +2596,17 @@
       }
     }
   },
+  "Status": {
+    "Inactive": "Inactive",
+    "Passive": "Passive",
+    "Temporary": "Temporary",
+    "Unavailable": "Unavailable"
+  },
+  "Suppressed": {
+    "Hint": "Source item must be equipped or attuned to activate these"
+  },
   "Tab": "Effects"
 },
-
 
 "DND5E.ENCHANT": {
   "FIELDS": {
@@ -2732,6 +2750,44 @@
   }
 },
 
+"DND5E.Encumbrance": "Encumbrance",
+"DND5E.ENCUMBRANCE": {
+  "FIELDS": {
+    "attributes": {
+      "encumbrance": {
+        "bonuses": {
+          "encumbered": {
+            "label": "Bonus to Encumbered Threshold"
+          },
+          "heavilyEncumbered": {
+            "label": "Bonus to Heavily Encumbered Threshold"
+          },
+          "maximum": {
+            "label": "Bonus to Maximum Carrying Capacity"
+          },
+          "overall": {
+            "label": "Bonus to All Encumberance Thresholds"
+          }
+        },
+        "multipliers": {
+          "encumbered": {
+            "label": "Encumbered Threshold Multiplier"
+          },
+          "heavilyEncumbered": {
+            "label": "Heavily Encumbered Threshold Multiplier"
+          },
+          "maximum": {
+            "label": "Maximum Carrying Capacity Multiplier"
+          },
+          "overall": {
+            "label": "Multiplier for All Encumberance Thresholds"
+          }
+        }
+      }
+    }
+  }
+},
+
 "DND5E.Environment": "Environment",
 
 "DND5E.EQUIPMENT": {
@@ -2790,6 +2846,7 @@
 },
 
 "DND5E.Expertise": "Expertise",
+"DND5E.Eyes": "Eyes",
 
 "DND5E.FACILITY": {
   "Action": {
@@ -3154,26 +3211,6 @@
   }
 },
 
-"DND5E.EffectCreate": "Create Effect",
-"DND5E.EffectToggle": "Toggle Effect",
-"DND5E.EffectEdit": "Edit Effect",
-"DND5E.EffectEnable": "Enable Effect",
-"DND5E.EffectDelete": "Delete Effect",
-"DND5E.EffectDisable": "Disable Effect",
-"DND5E.EffectTemporary": "Temporary Effects",
-"DND5E.EffectPassive": "Passive Effects",
-"DND5E.EffectInactive": "Inactive Effects",
-"DND5E.EffectNew": "New Effect",
-"DND5E.EffectType": {
-  "Inactive": "Inactive",
-  "Passive": "Passive",
-  "Temporary": "Temporary",
-  "Unavailable": "Unavailable"
-},
-"DND5E.EffectUnavailable": "Unavailable Effects",
-"DND5E.EffectUnavailableInfo": "Source item must be equipped or attuned to activate these",
-"DND5E.Encumbrance": "Encumbrance",
-"DND5E.Eyes": "Eyes",
 "DND5E.Faith": "Faith",
 "DND5E.FeatureActive": "Active Abilities",
 "DND5E.FeatureAdd": "Create Feature",
@@ -4247,6 +4284,9 @@
       },
       "dc": {
         "label": "Difficulty Class",
+        "bonus": {
+          "label": "DC Bonus"
+        },
         "calculation": {
           "label": "DC Calculation",
           "hint": "Method or ability used to calculate the difficulty class."
@@ -4708,6 +4748,14 @@
     "creatureTypes": {
       "label": "Creature Types",
       "hint": "Summoned creature will be changed to this type. If more than one type is selected, then the player will be able to choose from these types when summoning."
+    },
+    "flat": {
+      "attack": {
+        "label": "Flat Attack To Hit"
+      },
+      "save": {
+        "label": "Flat Save DC"
+      }
     },
     "match": {
       "ability": {
@@ -6059,6 +6107,9 @@
         "types": {
           "label": "Base Damage Types"
         }
+      },
+      "bonus": {
+        "label": "Damage Bonus"
       },
       "hint": "Intrinsic damage dice from the weapon. Ability modifier and additional damage parts will be provided automatically when attacking."
     },

--- a/lang/en.json
+++ b/lang/en.json
@@ -95,16 +95,20 @@
     "Title": "Configure {ability}"
   },
   "Formatter": {
-    "CheckAdvantageMode": "{name} Check Advantage Mode",
-    "CheckBonus": "{name} Check Bonus",
-    "CheckMaximum": "Maximum {name} Check Roll",
-    "CheckMinimum": "Minimum {name} Check Roll",
+    "Check": {
+      "AdvantageMode": "{name} Check Advantage Mode",
+      "Bonus": "{name} Check Bonus",
+      "Maximum": "Maximum {name} Check Roll",
+      "Minimum": "Minimum {name} Check Roll"
+    },
     "Maximum": "Maximum {name}",
-    "SaveAdvantageMode": "{name} Save Advantage Mode",
-    "SaveBonus": "{name} Save Bonus",
-    "SaveMaximum": "Maximum {name} Save Roll",
-    "SaveMinimum": "Minimum {name} Save Roll",
-    "SaveProficiency": "{name} Save Proficiency",
+    "Save": {
+      "AdvantageMode": "{name} Save Advantage Mode",
+      "Bonus": "{name} Save Bonus",
+      "Maximum": "Maximum {name} Save Roll",
+      "Minimum": "Minimum {name} Save Roll",
+      "Proficiency": "{name} Save Proficiency"
+    },
     "Score": "{name} Score"
   },
   "SECTIONS": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -2597,6 +2597,8 @@
     }
   },
   "Status": {
+    "ChangeActive": "Change Active",
+    "ChangeInactive": "Change Inactive",
     "Inactive": "Inactive",
     "Passive": "Passive",
     "Temporary": "Temporary",

--- a/lang/en.json
+++ b/lang/en.json
@@ -94,6 +94,19 @@
     "SaveLabel": "{ability} Save",
     "Title": "Configure {ability}"
   },
+  "Formatter": {
+    "CheckAdvantageMode": "{name} Check Advantage Mode",
+    "CheckBonus": "{name} Check Bonus",
+    "CheckMaximum": "Maximum {name} Check Roll",
+    "CheckMinimum": "Minimum {name} Check Roll",
+    "Maximum": "Maximum {name}",
+    "SaveAdvantageMode": "{name} Save Advantage Mode",
+    "SaveBonus": "{name} Save Bonus",
+    "SaveMaximum": "Maximum {name} Save Roll",
+    "SaveMinimum": "Minimum {name} Save Roll",
+    "SaveProficiency": "{name} Save Proficiency",
+    "Score": "{name} Score"
+  },
   "SECTIONS": {
     "Bonuses": {
       "Label": "{ability} Bonuses",
@@ -1139,6 +1152,11 @@
 "DND5E.BackgroundName": "Background Name",
 "DND5E.BaseItem": "Base Item",
 
+"DND5E.BASE": {
+  "Image": "Image",
+  "Name": "Name"
+},
+
 "DND5E.Bastion": {
   "Action": {
     "Advance": "Advance Bastion Turn",
@@ -1623,6 +1641,24 @@
 },
 "DND5E.Challenge": "Challenge",
 "DND5E.ChallengeRating": "Challenge Rating",
+
+"DND5E.CHARACTER": {
+  "FIELDS": {
+    "traits": {
+      "weaponProf": {
+        "mastery": {
+          "bonus": {
+            "label": "Bonus Weapon Masteries"
+          },
+          "value": {
+            "label": "Weapon Masteries"
+          }
+        }
+      }
+    }
+  }
+},
+
 "DND5E.Charged": "Charged",
 "DND5E.Charges": "Charges",
 "DND5E.ChatContextDamage": "Apply As Damage",
@@ -1898,6 +1934,39 @@
 "DND5E.CONSUMABLE": {
   "FIELDS": {
     "damage": {
+      "base": {
+        "bonus": {
+          "label": "Base Damage Bonus"
+        },
+        "custom": {
+          "enabled": {
+            "label": "Use Custom Base Damage Formula"
+          },
+          "formula": {
+            "label": "Custom Base Damage Formula"
+          }
+        },
+        "denomination": {
+          "label": "Base Damage Denomination"
+        },
+        "number": {
+          "label": "Base Damage Die Count"
+        },
+        "scaling": {
+          "formula": {
+            "label": "Base Damage Scaling Formula"
+          },
+          "mode": {
+            "label": "Base Damage Scaling Mode"
+          },
+          "number": {
+            "label": "Base Damage Scaling Value"
+          }
+        },
+        "types": {
+          "label": "Base Damage Types"
+        }
+      },
       "label": "Ammunition Damage",
       "replace": {
         "label": "Replace Weapon Damage",
@@ -4020,6 +4089,12 @@
 "DND5E.RitualAbbr": "R",
 
 "DND5E.ROLL": {
+  "Formatter": {
+    "AdvantageMode": "{name} Advantage Mode",
+    "Maximum": "Maximum {name} Roll",
+    "Minimum": "Minimum {name} Roll",
+    "ModifierAbility": "{name} Modifier Ability"
+  },
   "Range": {
     "Label": "Roll Range",
     "Maximum": "Maximum Roll",
@@ -4226,6 +4301,11 @@
 "DND5E.SizeTinyAbbr": "Tn",
 
 "DND5E.SKILL": {
+  "Formatter": {
+    "CheckBonus": "{name} Check Bonus",
+    "PassiveBonus": "Passive {name} Bonus",
+    "Proficiency": "{name} Proficiency"
+  },
   "SECTIONS": {
     "Details": "{label} Details",
     "Bonuses": {
@@ -5056,6 +5136,10 @@
 "DND5E.ToggleDescription": "Toggle Description",
 
 "DND5E.TOOL": {
+  "Formatter": {
+    "CheckBonus": "{name} Check Bonus",
+    "Proficiency": "{name} Proficiency"
+  },
   "SECTIONS": {
     "Details": "{label} Details",
     "Bonuses": {
@@ -5890,6 +5974,39 @@
       }
     },
     "damage": {
+      "base": {
+        "bonus": {
+          "label": "Base Damage Bonus"
+        },
+        "custom": {
+          "enabled": {
+            "label": "Use Custom Base Damage Formula"
+          },
+          "formula": {
+            "label": "Custom Base Damage Formula"
+          }
+        },
+        "denomination": {
+          "label": "Base Damage Denomination"
+        },
+        "number": {
+          "label": "Base Damage Die Count"
+        },
+        "scaling": {
+          "formula": {
+            "label": "Base Damage Scaling Formula"
+          },
+          "mode": {
+            "label": "Base Damage Scaling Mode"
+          },
+          "number": {
+            "label": "Base Damage Scaling Value"
+          }
+        },
+        "types": {
+          "label": "Base Damage Types"
+        }
+      },
       "hint": "Intrinsic damage dice from the weapon. Ability modifier and additional damage parts will be provided automatically when attacking."
     },
     "mastery": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -985,9 +985,27 @@
   "FIELDS": {
     "attributes": {
       "ac": {
+        "armor": {
+          "label": "Equipped Armor Value"
+        },
+        "base": {
+          "label": "Base Armor Class"
+        },
+        "bonus": {
+          "label": "AC Bonus"
+        },
+        "calc": {
+          "label": "AC Calculation Method"
+        },
+        "cover": {
+          "label": "AC from Cover"
+        },
         "flat": {
           "hint": "Number that can be used in an armor class by using @attributes.ac.flat in the formula.",
           "label": "Flat Value"
+        },
+        "formula": {
+          "label": "Extra AC Formula"
         },
         "formulas": {
           "element": {
@@ -1011,9 +1029,15 @@
           "label": "Formulas"
         },
         "label": "Armor Class",
+        "min": {
+          "label": "Minimum Armor Class"
+        },
         "override": {
           "hint": "Value that will be used in place of calculated armor class, ignoring cover, shield, and any other bonuses.",
           "label": "Override"
+        },
+        "shield": {
+          "label": "Equipped Shield Value"
         },
         "selectedFormulas": {
           "hint": "These formulas will be used when calculating armor class.",
@@ -1890,24 +1914,53 @@
 "DND5E.ConRestrained": "Restrained",
 "DND5E.ConStunned": "Stunned",
 "DND5E.ConUnconscious": "Unconscious",
+
 "DND5E.Concentration": "Concentration",
-"DND5E.ConcentrationAbbr": "C",
-"DND5E.ConcentrationBreak": "Break Concentration",
-"DND5E.ConcentrationBreakWarning": "Breaking concentration on an effect that is active on other creatures requires an active GM to be present.",
-"DND5E.ConcentrationBonus": "Concentration Bonus",
-"DND5E.ConcentrationDuration": "Concentration, up to {duration}",
-"DND5E.ConcentratingOn": "You are maintaining concentration on the effects of the '{name}' {type}.",
-"DND5E.ConcentratingEndChoice": "You are concentrating on effects from more than one source. Pick which effect to end.",
-"DND5E.ConcentratingMissingItem": "The effect that is concentrated on and to be replaced does not exist.",
-"DND5E.ConcentratingLimited": "You are not able to begin concentrating on an additional effect.",
-"DND5E.ConcentrationLimit": "Concentration Limit",
-"DND5E.ConcentrationLost": "Lost Concentration",
-"DND5E.ConcentratingEnd": "End Concentration",
-"DND5E.ConcentratingItemless": "Concentration With No Source",
-"DND5E.ConcentratingWarnLimit": "You cannot maintain concentration on more effects!",
-"DND5E.ConcentratingWarnLimitOptional": "You may end concentration on one of your maintained effects to use this item.",
-"DND5E.ConcentratingWarnLimitZero": "You are not able to maintain concentration on any effects!",
-"DND5E.ConcentrationConfigurationHint": "Configure concentration modifiers and bonuses which apply to this creature.",
+"DND5E.CONCENTRATION": {
+  "Abbreviation": "C",
+  "Action": {
+    "Break": "Break Concentration",
+    "End": "End Concentration"
+  },
+  "Description": "You are maintaining concentration on the effects of the '{name}' {type}.",
+  "Duration": "Concentration, up to {duration}",
+  "EndChoice": "You are concentrating on effects from more than one source. Pick which effect to end.",
+  "FIELDS": {
+    "attributes": {
+      "concentration": {
+        "bonuses": {
+          "label": "Concentration Bonuses",
+          "save": {
+            "label": "Concentration Bonus"
+          }
+        },
+        "label": "Concentration",
+        "limit": {
+          "label": "Concentration Limit"
+        },
+        "roll": {
+          "ability": "Concentration Save Ability",
+          "max": "Maximum Concentration Save Roll",
+          "min": "Minimum Concentration Save Roll",
+          "mode": "Concentration Save Advantage Mode"
+        }
+      }
+    }
+  },
+  "Limit": {
+    "Hard": "You cannot maintain concentration on more effects!",
+    "Optional": "You may end concentration on one of your maintained effects to use this item.",
+    "Reached": "You are not able to begin concentrating on an additional effect.",
+    "Zero": "You are not able to maintain concentration on any effects!"
+  },
+  "Lost": "Lost Concentration",
+  "NoSource": "Concentration With No Source",
+  "Warning": {
+    "BreakWithoutGM": "Breaking concentration on an effect that is active on other creatures requires an active GM to be present.",
+    "MissingItem": "The effect that is concentrated on and to be replaced does not exist."
+  }
+},
+
 "DND5E.ConsumeTitle": "Resource Consumption",
 "DND5E.ConsumeAmount": "Consumption Amount",
 "DND5E.ConsumeHint": {

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -2044,16 +2044,21 @@ dialog.dnd5e2.application {
 /* ---------------------------------- */
 
 .dnd5e2 .collapsible, .collapsible.dnd5e2-collapsible {
-  &.collapsed {
-    .fa-caret-down { transform: rotate(-90deg); }
-    .collapsible-content { grid-template-rows: 0fr; }
-  }
   .fa-caret-down { transition: transform 250ms ease; }
   .collapsible-content {
     display: grid;
-    grid-template-rows: 1fr;
     transition: grid-template-rows 250ms ease;
     > .wrapper { overflow: hidden; }
+  }
+}
+
+@scope (.dnd5e2 .collapsible, .dnd5e2-collapsible.collapsible) to (.collapsible) {
+  :scope:not(.collapsed) {
+    .collapsible-content { grid-template-rows: 1fr; }
+  }
+  :scope.collapsed {
+    .fa-caret-down { transform: rotate(-90deg); }
+    .collapsible-content { grid-template-rows: 0fr; }
   }
 }
 

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -361,8 +361,13 @@
         &.item-detail { color: var(--color-text-secondary); }
       }
 
+      /* Effect Value */
+      .effect-value {
+        width: 70px;
+      }
+
       /* Item Controls */
-      .item-controls {
+      .item-controls, .effect-controls {
         width: 70px;
         align-items: stretch;
         justify-content: center;
@@ -474,6 +479,36 @@
         min-height: 24px;
         border-width: 1px;
         border-radius: 3px;
+      }
+
+      .item-name .title { font-size: var(--font-size-12); }
+    }
+
+    .changes .change-row {
+      position: relative;
+      border-top: var(--activity-row-border);
+      padding-left: 20px;
+      min-block-size: 32px;
+
+      &:last-child { border-bottom: var(--activity-row-border); }
+
+      &::before {
+        content: "\f192";
+        position: absolute;
+        inset: 8px auto auto 5px;
+        font-family: var(--font-awesome);
+        font-size: var(--font-size-14);
+        font-weight: 900;
+        color: var(--activity-row-indent-color);
+      }
+      &[data-change-type="multiply"]::before { content: "\f057"; }
+      &[data-change-type="add"]::before { content: "\f055"; }
+      &[data-change-type="subtract"]::before { content: "\f056"; }
+      &[data-change-type="downgrade"]::before { content: "\f358"; }
+      &[data-change-type="upgrade"]::before { content: "\f35b"; }
+      &[data-change-type="override"]::before {
+        content: "\f28b";
+        rotate: 90deg;
       }
 
       .item-name .title { font-size: var(--font-size-12); }

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -487,7 +487,7 @@
     .changes .change-row {
       border-block-start: var(--activity-row-border);
       min-block-size: 32px;
-      padding-inline-start: 20px;
+      padding-inline-start: 29px;
       position: relative;
 
       &:last-child { border-block-end: var(--activity-row-border); }
@@ -495,9 +495,9 @@
       &::before {
         content: "\f192";
         position: absolute;
-        inset: 8px auto auto 5px;
+        inset: 8px auto auto 13px;
         font-family: var(--font-awesome);
-        font-size: var(--font-size-14);
+        font-size: var(--font-size-11);
         font-weight: 900;
         color: var(--activity-row-indent-color);
       }
@@ -511,8 +511,28 @@
         rotate: 90deg;
       }
 
-      .item-name .title { font-size: var(--font-size-12); }
+      .item-name .title {
+        font-family: var(--dnd5e-font-roboto);
+        font-size: var(--font-size-12);
+      }
+
       .application-status { align-content: center; }
+    }
+
+    .riders .changes {
+      position: relative;
+
+      &::before {
+        content: "";
+        position: absolute;
+        inset: 0 auto 0 12px;
+        border-inline-start: var(--dnd5e-border-dotted);
+      }
+
+      .change-row {
+        padding-inline-start: 39px;
+        &::before { inset-inline-start: 23px; }
+      }
     }
   }
 

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -495,7 +495,7 @@
       &::before {
         content: "\f192";
         position: absolute;
-        inset: 8px auto auto 13px;
+        inset: 9px auto auto 13px;
         font-family: var(--font-awesome);
         font-size: var(--font-size-11);
         font-weight: 900;

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -485,12 +485,12 @@
     }
 
     .changes .change-row {
-      position: relative;
-      border-top: var(--activity-row-border);
-      padding-left: 20px;
+      border-block-start: var(--activity-row-border);
       min-block-size: 32px;
+      padding-inline-start: 20px;
+      position: relative;
 
-      &:last-child { border-bottom: var(--activity-row-border); }
+      &:last-child { border-block-end: var(--activity-row-border); }
 
       &::before {
         content: "\f192";
@@ -512,6 +512,7 @@
       }
 
       .item-name .title { font-size: var(--font-size-12); }
+      .application-status { align-content: center; }
     }
   }
 

--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -206,25 +206,25 @@ export default class ActivityUsageDialog extends Dialog5e {
         return {
           value: effect.id,
           label: data?.data?.name ?? this.actor.items.get(data?.id)?.name
-            ?? _loc("DND5E.ConcentratingItemless")
+            ?? _loc("DND5E.CONCENTRATION.NoSource")
         };
       });
       if ( existingConcentration.length ) {
         const optional = existingConcentration.length < (this.actor.system.attributes?.concentration?.limit ?? 0);
         context.fields.push({
           field: new StringField({
-            required: true, label: _loc("DND5E.ConcentratingEnd"), blank: optional
+            required: true, label: _loc("DND5E.CONCENTRATION.Action.End"), blank: optional
           }),
           name: "concentration.end",
           value: this.config.concentration?.end,
           options: optional ? [{ value: "", label: "—" }, ...existingConcentration] : existingConcentration
         });
         context.notes.push({
-          type: "info", message: _loc(`DND5E.ConcentratingWarnLimit${optional ? "Optional" : ""}`)
+          type: "info", message: _loc(`DND5E.CONCENTRATION.Limit.${optional ? "Optional" : "Hard"}`)
         });
       } else if ( !this.actor.system.attributes?.concentration?.limit ) {
         context.notes.push({
-          type: "warn", message: _loc("DND5E.ConcentratingWarnLimitZero")
+          type: "warn", message: _loc("DND5E.CONCENTRATION.Limit.Zero")
         });
       }
     }

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -184,6 +184,10 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       parts.features.templates ??= [];
       parts.features.templates.push(...customElements.get(this.options.elements.inventory).templates);
     }
+    if ( "effects" in parts ) {
+      parts.effects.templates ??= [];
+      parts.effects.templates.push(...customElements.get(this.options.elements.effects).templates);
+    }
     return parts;
   }
 
@@ -249,26 +253,27 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       return arr;
     }, []);
 
+    const columns = [EffectsElement.COLUMNS.source, EffectsElement.COLUMNS.value, EffectsElement.COLUMNS.controls];
     for ( const category of Object.values(context.effects) ) {
+      category.columns = columns;
       category.effects = await category.effects.reduce(async (arr, effect) => {
-        effect.updateDuration();
         if ( conditionIds.has(effect.id) && !effect.duration.remaining ) return arr;
-        const { id, name, img, disabled, duration } = effect;
         const toggleable = !this._concentration?.effects.has(effect);
-        let source = await effect.getSource();
+        const isExpanded = this.expandedSections.get(`effects.${effect.id}`) === true;
+        const context = {
+          ...(await effect.getSheetContext()), toggleable, isExpanded,
+          parentId: effect.target === effect.parent ? null : effect.parent.id,
+          expanded: isExpanded ? await effect.getPreviewContext({ secrets: effect.isOwner }) : null
+        };
         // If the source is an ActiveEffect from another Actor, note the source as that Actor instead.
-        if ( source instanceof ActiveEffect ) {
-          source = source.target;
-          if ( (source instanceof Item) && source.parent && (source.parent !== this.object) ) source = source.parent;
+        context.hasTooltip = context.source instanceof dnd5e.documents.Item5e;
+        if ( context.source instanceof ActiveEffect ) {
+          const src = context.source;
+          context.source = src.target;
+          if ( (src instanceof Item) && src.parent && (src.parent !== this.object) ) context.source = src.parent;
         }
         arr = await arr;
-        arr.push({
-          id, name, img, disabled, duration, source, toggleable,
-          parentId: effect.target === effect.parent ? null : effect.parent.id,
-          durationParts: duration.remaining ? duration.label.split(", ") : [],
-          showDuration: Number.isFinite(duration.value),
-          hasTooltip: source instanceof dnd5e.documents.Item5e
-        });
+        arr.push(context);
         return arr;
       }, []);
     }
@@ -451,7 +456,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       else await this._prepareItemFeature(item, ctx);
 
       // Handle expanded data
-      ctx.isExpanded = this.expandedSections.get(item.id) === true;
+      ctx.isExpanded = this.expandedSections.get(`items.${item.id}`) === true;
       if ( ctx.isExpanded ) ctx.expanded = await item.getChatData({ secrets: item.isOwner });
 
       // Place the item into specific categories.

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -260,20 +260,20 @@ export default class BaseActorSheet extends PrimarySheetMixin(
         if ( conditionIds.has(effect.id) && !effect.duration.remaining ) return arr;
         const toggleable = !this._concentration?.effects.has(effect);
         const isExpanded = this.expandedSections.get(`effects.${effect.id}`) === true;
-        const context = {
+        const ctx = {
           ...(await effect.getSheetContext()), toggleable, isExpanded,
           parentId: effect.target === effect.parent ? null : effect.parent.id,
           expanded: isExpanded ? await effect.getPreviewContext({ secrets: effect.isOwner }) : null
         };
         // If the source is an ActiveEffect from another Actor, note the source as that Actor instead.
-        context.hasTooltip = context.source instanceof dnd5e.documents.Item5e;
-        if ( context.source instanceof ActiveEffect ) {
-          const src = context.source;
-          context.source = src.target;
-          if ( (src instanceof Item) && src.parent && (src.parent !== this.object) ) context.source = src.parent;
+        ctx.hasTooltip = ctx.source instanceof dnd5e.documents.Item5e;
+        if ( ctx.source instanceof ActiveEffect ) {
+          const src = ctx.source;
+          ctx.source = src.target;
+          if ( (src instanceof Item) && src.parent && (src.parent !== this.object) ) ctx.source = src.parent;
         }
         arr = await arr;
-        arr.push(context);
+        arr.push(ctx);
         return arr;
       }, []);
     }

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1194,7 +1194,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
   /** @override */
   _addDocument(event, target) {
     if ( this.tabGroups.primary === "effects" ) return ActiveEffect.implementation.create({
-      name: _loc("DND5E.EffectNew"),
+      name: _loc("DND5E.EFFECT.New"),
       icon: "icons/svg/aura.svg"
     }, { parent: this.actor, renderSheet: true });
 

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -359,7 +359,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
       }, { once: true });
       this.app.expandedSections.set(`effects.${effect.id}`, false);
     } else {
-      const context = await effect.getPreviewContext();
+      const context = await effect.getPreviewContext({ secrets: effect.isOwner });
       const template = "systems/dnd5e/templates/effects/parts/effect-summary.hbs";
       const content = await foundry.applications.handlebars.renderTemplate(template, context);
       summary.querySelectorAll(".item-summary").forEach(el => el.remove());

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -3,34 +3,46 @@ import {staticID} from "../../utils.mjs";
 import ContextMenu5e from "../context-menu.mjs";
 
 /**
+ * @import { InventoryColumnDescriptor } from "./_types.mjs";
+ */
+
+/**
  * Custom element that handles displaying active effects lists.
  */
 export default class EffectsElement extends (foundry.applications.elements.AdoptableHTMLElement ?? HTMLElement) {
-  connectedCallback() {
-    if ( this.#app ) return;
-    this.#app = foundry.applications.instances.get(this.closest(".application")?.id);
+  /* -------------------------------------------- */
+  /*  Configuration                               */
+  /* -------------------------------------------- */
 
-    for ( const control of this.querySelectorAll("[data-action]") ) {
-      control.addEventListener("click", event => {
-        this._onAction(event.currentTarget, event.currentTarget.dataset.action);
-      });
+  /**
+   * Well-known effects columns.
+   * @type {Record<string, InventoryColumnDescriptor>}
+   */
+  static COLUMNS = {
+    controls: {
+      id: "controls",
+      width: 70,
+      order: 1000,
+      priority: 1000,
+      template: "systems/dnd5e/templates/effects/columns/controls.hbs"
+    },
+    source: {
+      id: "source",
+      width: 150,
+      order: 100,
+      priority: 600,
+      label: "DND5E.SOURCE.FIELDS.source.label",
+      template: "systems/dnd5e/templates/effects/columns/source.hbs"
+    },
+    value: {
+      id: "value",
+      width: 70,
+      order: 200,
+      priority: 500,
+      label: "DND5E.Value",
+      template: "systems/dnd5e/templates/effects/columns/value.hbs"
     }
-
-    for ( const source of this.querySelectorAll(".effect-source a") ) {
-      source.addEventListener("click", this._onClickEffectSource.bind(this));
-    }
-
-    for ( const control of this.querySelectorAll("[data-context-menu]") ) {
-      control.addEventListener("click", ContextMenu5e.triggerEvent);
-    }
-
-    new ContextMenu5e(this, "[data-effect-id]", [], { onOpen: element => {
-      const effect = this.getEffect(element.dataset);
-      if ( !effect ) return;
-      ui.context.menuItems = this._getContextOptions(effect);
-      Hooks.call("dnd5e.getActiveEffectContextOptions", effect, ui.context.menuItems);
-    }, jQuery: false });
-  }
+  };
 
   /* -------------------------------------------- */
   /*  Properties                                  */
@@ -65,6 +77,47 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
    */
   get document() {
     return this.app.document;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieve the templates needed to render the effects.
+   * @type {string[]}
+   */
+  static get templates() {
+    return Object.values(this.COLUMNS).map(c => c.template);
+  }
+
+  /* -------------------------------------------- */
+  /*  Lifecycle                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  connectedCallback() {
+    if ( this.#app ) return;
+    this.#app = foundry.applications.instances.get(this.closest(".application")?.id);
+
+    for ( const control of this.querySelectorAll("[data-action]") ) {
+      control.addEventListener("click", event => {
+        this._onAction(event.currentTarget, event.currentTarget.dataset.action);
+      });
+    }
+
+    for ( const source of this.querySelectorAll(".effect-source a") ) {
+      source.addEventListener("click", this._onClickEffectSource.bind(this));
+    }
+
+    for ( const control of this.querySelectorAll("[data-context-menu]") ) {
+      control.addEventListener("click", ContextMenu5e.triggerEvent);
+    }
+
+    new ContextMenu5e(this, "[data-effect-id]", [], { onOpen: element => {
+      const effect = this.getEffect(element.dataset);
+      if ( !effect ) return;
+      ui.context.menuItems = this._getContextOptions(effect);
+      Hooks.call("dnd5e.getActiveEffectContextOptions", effect, ui.context.menuItems);
+    }, jQuery: false });
   }
 
   /* -------------------------------------------- */
@@ -160,6 +213,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
    */
   _getContextOptions(effect) {
     const isConcentrationEffect = (this.document instanceof Actor5e) && this.app._concentration?.effects.has(effect);
+    const expanded = this.app.expandedSections.get(`effects.${effect.id}`);
     const options = [
       {
         label: "DND5E.ContextMenuActionEdit",
@@ -192,6 +246,13 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
         group: "state",
         visible: () => isConcentrationEffect,
         onClick: () => this.document.endConcentration(effect)
+      },
+      {
+        label: expanded ? "APPLICATION.ACTIONS.Collapse" : "APPLICATION.ACTIONS.Expand",
+        icon: `<i class="fa-solid fa-${expanded ? "compress" : "expand"}"></i>`,
+        group: "collapsible",
+        visible: () => "canExpand" in this.app ? this.app.canExpand(effect) : true,
+        onClick: (_, target) => this._onAction(target, "toggleExpand")
       }
     ];
 
@@ -252,6 +313,8 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
         });
       case "toggle":
         return effect.update({ disabled: !effect.disabled });
+      case "toggleExpand":
+        return this._onToggleExpand(target, { effect });
       case "unfavorite":
         return this.document.system.removeFavorite(foundry.utils.buildRelativeUuid(effect, this.document));
     }
@@ -270,6 +333,44 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
     if ( existing ) return existing.delete();
     const effect = await ActiveEffect.implementation.fromStatusEffect(conditionId);
     return ActiveEffect.implementation.create(effect, { parent: this.document, keepId: true });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle toggling an effects's in-line description.
+   * @param {HTMLElement} target               The action target.
+   * @param {object} [options]
+   * @param {ActiveEffect5e} [options.effect]  The effect instance, otherwise it will be inferred from the target.
+   * @protected
+   */
+  async _onToggleExpand(target, { effect }={}) {
+    const row = target.closest("[data-uuid]");
+    const icon = row.querySelector('[data-action="toggleExpand"] > i');
+    const summary = row.querySelector(":scope > .item-description > .wrapper");
+    const { uuid } = row.dataset;
+    effect ??= await fromUuid(uuid);
+    if ( !effect ) return;
+
+    const expanded = this.app.expandedSections.get(`effects.${effect.id}`);
+    if ( expanded ) {
+      summary.parentElement.addEventListener("transitionend", () => {
+        if ( row.classList.contains("collapsed") ) summary.querySelector(".item-summary")?.remove();
+      }, { once: true });
+      this.app.expandedSections.set(`effects.${effect.id}`, false);
+    } else {
+      const context = await effect.getPreviewContext();
+      const template = "systems/dnd5e/templates/effects/parts/effect-summary.hbs";
+      const content = await foundry.applications.handlebars.renderTemplate(template, context);
+      summary.querySelectorAll(".item-summary").forEach(el => el.remove());
+      summary.insertAdjacentHTML("beforeend", content);
+      await new Promise(resolve => requestAnimationFrame(resolve));
+      this.app.expandedSections.set(`effects.${effect.id}`, true);
+    }
+
+    row.classList.toggle("collapsed", expanded);
+    icon.classList.toggle("fa-compress", !expanded);
+    icon.classList.toggle("fa-expand", expanded);
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -241,7 +241,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
         onClick: (_, target) => this._onAction(target, "toggle")
       },
       {
-        label: "DND5E.ConcentrationBreak",
+        label: "DND5E.CONCENTRATION.Action.Break",
         icon: '<dnd5e-icon src="systems/dnd5e/icons/svg/break-concentration.svg"></dnd5e-icon>',
         group: "state",
         visible: () => isConcentrationEffect,

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -142,7 +142,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
       },
       temporary: {
         type: "temporary",
-        label: _loc("DND5E.EffectTemporary"),
+        label: _loc("DND5E.EFFECT.Category.Temporary"),
         effects: []
       },
       enchantmentActive: {
@@ -153,7 +153,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
       },
       passive: {
         type: "passive",
-        label: _loc("DND5E.EffectPassive"),
+        label: _loc("DND5E.EFFECT.Category.Passive"),
         effects: []
       },
       enchantmentInactive: {
@@ -164,15 +164,15 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
       },
       inactive: {
         type: "inactive",
-        label: _loc("DND5E.EffectInactive"),
+        label: _loc("DND5E.EFFECT.Category.Inactive"),
         effects: []
       },
       suppressed: {
         type: "suppressed",
-        label: _loc("DND5E.EffectUnavailable"),
+        label: _loc("DND5E.EFFECT.Category.Unavailable"),
         effects: [],
         disabled: true,
-        info: [_loc("DND5E.EffectUnavailableInfo")]
+        info: [_loc("DND5E.EFFECT.Suppressed.Hint")]
       }
     };
 
@@ -386,7 +386,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
     const isEnchantment = li.dataset.effectType.startsWith("enchantment");
     return this.document.createEmbeddedDocuments("ActiveEffect", [{
       type: isEnchantment ? "enchantment" : "base",
-      name: isActor ? _loc("DND5E.EffectNew") : this.document.name,
+      name: isActor ? _loc("DND5E.EFFECT.New") : this.document.name,
       icon: isActor ? "icons/svg/aura.svg" : this.document.img,
       origin: isEnchantment ? undefined : this.document.uuid,
       "duration.rounds": li.dataset.effectType === "temporary" ? 1 : undefined,

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -356,8 +356,7 @@ export default class InventoryElement extends (foundry.applications.elements.Ado
 
     if ( !this.actor || this.actor.system.isGroup ) return options;
     const favorited = this.actor.system.hasFavorite?.(foundry.utils.buildRelativeUuid(item, this.actor));
-    const expanded = this.app.expandedSections ? this.app.expandedSections.get(item.id)
-      : this.app._expanded.has(item.id); // TODO: Remove when V1 sheets are gone
+    const expanded = this.app.expandedSections.get(`items.${item.id}`);
 
     // Owned item options.
     options.push({
@@ -750,12 +749,12 @@ export default class InventoryElement extends (foundry.applications.elements.Ado
     item ??= await fromUuid(uuid);
     if ( !item ) return;
 
-    const expanded = this.app.expandedSections.get(item.id);
+    const expanded = this.app.expandedSections.get(`items.${item.id}`);
     if ( expanded ) {
       summary.parentElement.addEventListener("transitionend", () => {
         if ( row.classList.contains("collapsed") ) summary.querySelector(".item-summary")?.remove();
       }, { once: true });
-      this.app.expandedSections.set(item.id, false);
+      this.app.expandedSections.set(`items.${item.id}`, false);
     } else {
       const context = await item.getChatData({ secrets: item.isOwner });
       const template = "systems/dnd5e/templates/items/parts/item-summary.hbs";
@@ -763,7 +762,7 @@ export default class InventoryElement extends (foundry.applications.elements.Ado
       summary.querySelectorAll(".item-summary").forEach(el => el.remove());
       summary.insertAdjacentHTML("beforeend", content);
       await new Promise(resolve => requestAnimationFrame(resolve));
-      this.app.expandedSections.set(item.id, true);
+      this.app.expandedSections.set(`items.${item.id}`, true);
     }
 
     row.classList.toggle("collapsed", expanded);

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -382,7 +382,7 @@ export default class InventoryElement extends (foundry.applications.elements.Ado
       },
       group: "action"
     }, {
-      label: "DND5E.ConcentrationBreak",
+      label: "DND5E.CONCENTRATION.Action.Break",
       icon: '<dnd5e-icon src="systems/dnd5e/icons/svg/break-concentration.svg"></dnd5e-icon>',
       group: "state",
       visible: () => this.actor?.concentration?.items.has(item),

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -108,9 +108,10 @@ export default class ContainerSheet extends ItemSheet5e {
     for ( const item of await this.item.system.contents ) {
       const ctx = context.itemContext[item.id] ??= {};
       ctx.totalWeight = (await item.system.totalWeight).toNearest(0.1);
-      ctx.isExpanded = this.expandedSections.get(item.id);
+      ctx.isExpanded = this.expandedSections.get(`items.${item.id}`);
       ctx.isStack = item.system.quantity > 1;
-      ctx.expanded = this.expandedSections.get(item.id) ? await item.getChatData({ secrets: this.item.isOwner }) : null;
+      ctx.expanded = this.expandedSections.get(`items.${item.id}`)
+        ? await item.getChatData({ secrets: this.item.isOwner }) : null;
       ctx.groups = { contents: "contents", type: item.type };
       ctx.dataset = { groupContents: "contents", groupType: item.type };
       context.items.push(item);

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -165,6 +165,18 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  _configureRenderParts(options) {
+    const parts = super._configureRenderParts(options);
+    if ( "effects" in parts ) {
+      parts.effects.templates ??= [];
+      parts.effects.templates.push(...customElements.get(this.options.elements.effects).templates);
+    }
+    return parts;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   _disableFields() {
     this.element.querySelectorAll(":is(document-embed, secret-block) button").forEach(el => {
       el.classList.add("always-interactive");
@@ -390,20 +402,19 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
     const riderIds = new Set(this.item.getFlag("dnd5e", "riders.effect") ?? []);
     context.tab = context.tabs.effects;
     context.effects = EffectsElement.prepareCategories(this.item.effects, { parent: this.item });
+    const columns = [EffectsElement.COLUMNS.source, EffectsElement.COLUMNS.value, EffectsElement.COLUMNS.controls];
     for ( const category of Object.values(context.effects) ) {
+      category.columns = columns;
       category.effects = await category.effects.reduce(async (arr, effect) => {
-        effect.updateDuration();
-        const { id, name, img, disabled, duration } = effect;
-        const source = await effect.getSource();
+        const isExpanded = this.expandedSections.get(`effects.${effect.id}`) === true;
         arr = await arr;
-        const ctx = effectMap[id] = {
-          id, name, img, disabled, duration, source, parent,
-          durationParts: duration.remaining ? duration.label.split(", ") : [],
-          showDuration: Number.isFinite(duration.value),
+        const ctx = effectMap[effect.id] = {
+          ...(await effect.getSheetContext({ maxKeyLength: 25 })), parent, isExpanded,
+          expanded: isExpanded ? await effect.getPreviewContext({ secrets: effect.isOwner }) : null,
           hasTooltip: true,
           riders: []
         };
-        if ( riderIds.has(id) ) riders.push(ctx);
+        if ( riderIds.has(effect.id) ) riders.push(ctx);
         else arr.push(ctx);
         return arr;
       }, []);

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1902,7 +1902,7 @@ DND5E.itemProperties = {
   },
   concentration: {
     label: "DND5E.ITEM.Property.Concentration",
-    abbreviation: "DND5E.ConcentrationAbbr",
+    abbreviation: "DND5E.CONCENTRATION.Abbreviation",
     icon: "systems/dnd5e/icons/svg/statuses/concentrating.svg",
     reference: "Compendium.dnd5e.rules.JournalEntry.NizgRXLNUqtdlC1s.JournalEntryPage.ow58p27ctAnr4VPH",
     isTag: true

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -32,7 +32,7 @@ export default class CharacterData extends CreatureTemplate {
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.BONUSES"];
+  static LOCALIZATION_PREFIXES = ["DND5E.BONUSES", "DND5E.CHARACTER"];
 
   /* -------------------------------------------- */
 

--- a/module/data/actor/fields/simple-trait-field.mjs
+++ b/module/data/actor/fields/simple-trait-field.mjs
@@ -6,7 +6,7 @@ const { SchemaField, SetField, StringField } = foundry.data.fields;
 export default class SimpleTraitField extends SchemaField {
   constructor(fields={}, { initialValue=[], ...options }={}) {
     fields = {
-      value: new SetField(new StringField(), { label: "DND5E.TraitsChosen", initial: initialValue }),
+      value: new SetField(new StringField(), { label: options.label ?? "DND5E.TraitsChosen", initial: initialValue }),
       custom: new StringField({ required: true, label: "DND5E.Special" }),
       ...fields
     };

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -89,16 +89,40 @@ export default class AttributesFields {
       ac: new SchemaField(this.armorClass, { label: "DND5E.ArmorClass" }),
       encumbrance: new SchemaField({
         bonuses: new SchemaField({
-          encumbered: new FormulaField({ deterministic: true }),
-          heavilyEncumbered: new FormulaField({ deterministic: true }),
-          maximum: new FormulaField({ deterministic: true }),
-          overall: new FormulaField({ deterministic: true })
+          encumbered: new FormulaField({
+            deterministic: true,
+            label: "DND5E.ENCUMBRANCE.FIELDS.attributes.encumbrance.bonuses.encumbered.label"
+          }),
+          heavilyEncumbered: new FormulaField({
+            deterministic: true,
+            label: "DND5E.ENCUMBRANCE.FIELDS.attributes.encumbrance.bonuses.heavilyEncumbered.label"
+          }),
+          maximum: new FormulaField({
+            deterministic: true,
+            label: "DND5E.ENCUMBRANCE.FIELDS.attributes.encumbrance.bonuses.maximum.label"
+          }),
+          overall: new FormulaField({
+            deterministic: true,
+            label: "DND5E.ENCUMBRANCE.FIELDS.attributes.encumbrance.bonuses.overall.label"
+          })
         }),
         multipliers: new SchemaField({
-          encumbered: new FormulaField({ deterministic: true, initial: "1" }),
-          heavilyEncumbered: new FormulaField({ deterministic: true, initial: "1" }),
-          maximum: new FormulaField({ deterministic: true, initial: "1" }),
-          overall: new FormulaField({ deterministic: true, initial: "1" })
+          encumbered: new FormulaField({
+            deterministic: true, initial: "1",
+            label: "DND5E.ENCUMBRANCE.FIELDS.attributes.encumbrance.multipliers.encumbered.label"
+          }),
+          heavilyEncumbered: new FormulaField({
+            deterministic: true, initial: "1",
+            label: "DND5E.ENCUMBRANCE.FIELDS.attributes.encumbrance.multipliers.heavilyEncumbered.label"
+          }),
+          maximum: new FormulaField({
+            deterministic: true, initial: "1",
+            label: "DND5E.ENCUMBRANCE.FIELDS.attributes.encumbrance.multipliers.maximum.label"
+          }),
+          overall: new FormulaField({
+            deterministic: true, initial: "1",
+            label: "DND5E.ENCUMBRANCE.FIELDS.attributes.encumbrance.multipliers.overall.label"
+          })
         })
       }, { persisted: false }),
       init: new RollConfigField({

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -8,7 +8,7 @@ import RollConfigField from "../../shared/roll-config-field.mjs";
 import SensesField from "../../shared/senses-field.mjs";
 import ACFormulasField from "../fields/ac-formulas-field.mjs";
 
-const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { ActorRollData } from "../../../documents/_types.mjs";
@@ -25,18 +25,28 @@ export default class AttributesFields {
    */
   static get armorClass() {
     return {
-      armor: new NumberField({ integer: true, min: 0, initial: 10, persisted: false }),
-      base: new NumberField({ integer: true, initial: -Infinity, persisted: false }),
-      bonus: new FormulaField({ deterministic: true, persisted: false }),
-      calc: new StringField({ persisted: false }),
-      cover: new NumberField({ integer: true, min: 0, initial: 0, persisted: false }),
+      armor: new NumberField({
+        integer: true, min: 0, initial: 10, persisted: false, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.armor.label"
+      }),
+      base: new NumberField({
+        integer: true, initial: -Infinity, persisted: false, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.base.label"
+      }),
+      bonus: new FormulaField({
+        deterministic: true, persisted: false, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.bonus.label"
+      }),
+      calc: new StringField({ persisted: false, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.calc.label" }),
+      cover: new NumberField({
+        integer: true, min: 0, initial: 0, persisted: false, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.cover.label"
+      }),
       flat: new NumberField({
         required: true, integer: true, min: 0, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.flat.label",
         hint: "DND5E.ARMORCLASS.FIELDS.attributes.ac.flat.hint"
       }),
-      formula: new StringField({ persisted: false }),
+      formula: new StringField({ persisted: false, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.formula.label" }),
       formulas: new ACFormulasField(),
-      min: new FormulaField({ deterministic: true, persisted: false }),
+      min: new FormulaField({
+        deterministic: true, persisted: false, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.min.label"
+      }),
       override: new NumberField({
         min: 0, integer: true, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.override.label",
         hint: "DND5E.ARMORCLASS.FIELDS.attributes.ac.override.hint"
@@ -45,7 +55,9 @@ export default class AttributesFields {
         initial: ["unarmored", "armored"], label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.selectedFormulas.label",
         hint: "DND5E.ARMORCLASS.FIELDS.attributes.ac.selectedFormulas.hint"
       }),
-      shield: new NumberField({ integer: true, min: 0, initial: 0, persisted: false })
+      shield: new NumberField({
+        integer: true, min: 0, initial: 0, persisted: false, label: "DND5E.ARMORCLASS.FIELDS.attributes.ac.shield.label"
+      })
     };
   }
 
@@ -124,9 +136,13 @@ export default class AttributesFields {
       concentration: new RollConfigField({
         ability: "",
         bonuses: new SchemaField({
-          save: new FormulaField({ required: true, label: "DND5E.ConcentrationBonus" })
+          save: new FormulaField({
+            required: true, label: "DND5E.CONCENTRATION.FIELDS.attributes.concentration.bonuses.save.label"
+          })
         }),
-        limit: new NumberField({ integer: true, min: 0, initial: 1, label: "DND5E.ConcentrationLimit" })
+        limit: new NumberField({
+          integer: true, min: 0, initial: 1, label: "DND5E.CONCENTRATION.FIELDS.attributes.concentration.limit.label"
+        })
       }, { label: "DND5E.Concentration" }),
       loyalty: new SchemaField({
         value: new NumberField({ integer: true, min: 0, max: 20, label: "DND5E.Loyalty" })

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -32,23 +32,30 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
     return this.mergeSchema(super.defineSchema(), {
       abilities: new MappingField(new SchemaField({
         value: new NumberField({
-          required: true, nullable: false, integer: true, min: 0, initial: 10, label: "DND5E.AbilityScore"
+          required: true, nullable: false, integer: true, min: 0, initial: 10, label: "DND5E.AbilityScore",
+          labelFormatter: "DND5E.ABILITY.Formatter.Score"
         }),
         proficient: new NumberField({
-          required: true, integer: true, min: 0, max: 1, initial: 0, label: "DND5E.ProficiencyLevel"
+          required: true, integer: true, min: 0, max: 1, initial: 0, label: "DND5E.ProficiencyLevel",
+          labelFormatter: "DND5E.ABILITY.Formatter.SaveProficiency"
         }),
         max: new NumberField({
-          required: true, integer: true, nullable: true, min: 0, initial: null, label: "DND5E.AbilityScoreMax"
+          required: true, integer: true, nullable: true, min: 0, initial: null, label: "DND5E.AbilityScoreMax",
+          labelFormatter: "DND5E.ABILITY.Formatter.Maxmimum"
         }),
         bonuses: new SchemaField({
-          check: new FormulaField({ required: true, label: "DND5E.AbilityCheckBonus" }),
-          save: new FormulaField({ required: true, label: "DND5E.SaveBonus" })
+          check: new FormulaField({
+            required: true, label: "DND5E.AbilityCheckBonus", labelFormatter: "DND5E.ABILITY.Formatter.CheckBonus"
+          }),
+          save: new FormulaField({
+            required: true, label: "DND5E.SaveBonus", labelFormatter: "DND5E.ABILITY.Formatter.SaveBonus"
+          })
         }, { label: "DND5E.AbilityBonuses" }),
-        check: new RollConfigField({ ability: false }),
-        save: new RollConfigField({ ability: false })
+        check: new RollConfigField({ ability: false, labelFormatterPrefix: "DND5E.ABILITY.Formatter.Check" }),
+        save: new RollConfigField({ ability: false, labelFormatterPrefix: "DND5E.ABILITY.Formatter.Save" })
       }), {
         initialKeys: CONFIG.DND5E.abilities, initialValue: this._initialAbilityValue.bind(this),
-        initialKeysOnly: true, label: "DND5E.Abilities"
+        initialKeysOnly: true, label: "DND5E.Abilities", entryLabel: key => CONFIG.DND5E.abilities[key]?.label
       })
     });
   }

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -37,22 +37,22 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
         }),
         proficient: new NumberField({
           required: true, integer: true, min: 0, max: 1, initial: 0, label: "DND5E.ProficiencyLevel",
-          labelFormatter: "DND5E.ABILITY.Formatter.SaveProficiency"
+          labelFormatter: "DND5E.ABILITY.Formatter.Save.Proficiency"
         }),
         max: new NumberField({
           required: true, integer: true, nullable: true, min: 0, initial: null, label: "DND5E.AbilityScoreMax",
-          labelFormatter: "DND5E.ABILITY.Formatter.Maxmimum"
+          labelFormatter: "DND5E.ABILITY.Formatter.Maximum"
         }),
         bonuses: new SchemaField({
           check: new FormulaField({
-            required: true, label: "DND5E.AbilityCheckBonus", labelFormatter: "DND5E.ABILITY.Formatter.CheckBonus"
+            required: true, label: "DND5E.AbilityCheckBonus", labelFormatter: "DND5E.ABILITY.Formatter.Check.Bonus"
           }),
           save: new FormulaField({
-            required: true, label: "DND5E.SaveBonus", labelFormatter: "DND5E.ABILITY.Formatter.SaveBonus"
+            required: true, label: "DND5E.SaveBonus", labelFormatter: "DND5E.ABILITY.Formatter.Save.Bonus"
           })
         }, { label: "DND5E.AbilityBonuses" }),
-        check: new RollConfigField({ ability: false, labelFormatterPrefix: "DND5E.ABILITY.Formatter.Check" }),
-        save: new RollConfigField({ ability: false, labelFormatterPrefix: "DND5E.ABILITY.Formatter.Save" })
+        check: new RollConfigField({ ability: false, labelFormatterPrefix: "DND5E.ABILITY.Formatter.Check." }),
+        save: new RollConfigField({ ability: false, labelFormatterPrefix: "DND5E.ABILITY.Formatter.Save." })
       }), {
         initialKeys: CONFIG.DND5E.abilities, initialValue: this._initialAbilityValue.bind(this),
         initialKeysOnly: true, label: "DND5E.Abilities", entryLabel: key => CONFIG.DND5E.abilities[key]?.label

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -1,3 +1,4 @@
+import * as Trait from "../../../documents/actor/trait.mjs";
 import { simplifyBonus } from "../../../utils.mjs";
 import AdvantageModeField from "../../fields/advantage-mode-field.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
@@ -43,26 +44,34 @@ export default class CreatureTemplate extends CommonTemplate {
       }),
       skills: new MappingField(new RollConfigField({
         value: new NumberField({
-          required: true, nullable: false, min: 0, max: 2, step: 0.5, initial: 0, label: "DND5E.ProficiencyLevel"
+          required: true, nullable: false, min: 0, max: 2, step: 0.5, initial: 0, label: "DND5E.ProficiencyLevel",
+          labelFormatter: "DND5E.SKILL.Formatter.Proficiency"
         }),
         ability: "dex",
         bonuses: new SchemaField({
-          check: new FormulaField({ required: true, label: "DND5E.SkillBonusCheck" }),
-          passive: new FormulaField({ required: true, label: "DND5E.SkillBonusPassive" })
+          check: new FormulaField({
+            required: true, label: "DND5E.SkillBonusCheck", labelFormatter: "DND5E.SKILL.Formatter.CheckBonus"
+          }),
+          passive: new FormulaField({
+            required: true, label: "DND5E.SkillBonusPassive", labelFormatter: "DND5E.SKILL.Formatter.PassiveBonus"
+          })
         }, { label: "DND5E.SkillBonuses" })
       }), {
         initialKeys: CONFIG.DND5E.skills, initialValue: this._initialSkillValue,
-        initialKeysOnly: true, label: "DND5E.Skills"
+        initialKeysOnly: true, label: "DND5E.Skills", entryLabel: key => CONFIG.DND5E.skills[key]?.label
       }),
       tools: new MappingField(new RollConfigField({
         value: new NumberField({
-          required: true, nullable: false, min: 0, max: 2, step: 0.5, initial: 0, label: "DND5E.ProficiencyLevel"
+          required: true, nullable: false, min: 0, max: 2, step: 0.5, initial: 0, label: "DND5E.ProficiencyLevel",
+          labelFormatter: "DND5E.TOOL.Formatter.Proficiency"
         }),
         ability: "int",
         bonuses: new SchemaField({
-          check: new FormulaField({ required: true, label: "DND5E.CheckBonus" })
+          check: new FormulaField({
+            required: true, label: "DND5E.CheckBonus", labelFormatter: "DND5E.TOOL.Formatter.CheckBonus"
+          })
         }, { label: "DND5E.ToolBonuses" })
-      })),
+      }), { entryLabel: key => Trait.keyLabel(key, { trait: "tool" }) }),
       spells: new MappingField(new SchemaField({
         value: new NumberField({
           nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.SpellProgAvailable"

--- a/module/data/actor/templates/traits.mjs
+++ b/module/data/actor/templates/traits.mjs
@@ -25,7 +25,9 @@ export default class TraitsField {
       dr: new DamageTraitField({}, { label: "DND5E.DamRes" }),
       dv: new DamageTraitField({}, { label: "DND5E.DamVuln" }),
       dm: new SchemaField({
-        amount: new MappingField(new FormulaField({ deterministic: true }), { label: "DND5E.DamMod" }),
+        amount: new MappingField(new FormulaField({ deterministic: true }), {
+          label: "DND5E.DamMod", labels: { value: "DND5E.DamMod" }
+        }),
         bypasses: new SetField(new StringField(), {
           label: "DND5E.DAMAGE.PhysicalBypass.Label", hint: "DND5E.DAMAGE.PhysicalBypass.Hint"
         })

--- a/module/data/fields/_types.mjs
+++ b/module/data/fields/_types.mjs
@@ -36,6 +36,12 @@
  */
 
 /**
+ * @callback MappingFieldEntryLabelBuilder
+ * @param {string} key       The key within the object.
+ * @returns {object}         Label used to describe this entry.
+ */
+
+/**
  * @callback MappingFieldInitialValueBuilder
  * @param {string} key       The key within the object where this new value is being generated.
  * @param {*} initial        The generic initial data provided by the contained model.

--- a/module/data/fields/mapping-field.mjs
+++ b/module/data/fields/mapping-field.mjs
@@ -105,6 +105,6 @@ export default class MappingField extends foundry.data.fields.TypedObjectField {
     if ( !field ) return;
     const name = this.entryLabel?.(key);
     if ( !field.options.labelFormatter || !name ) return field.label;
-    return game.i18n.format(field.options.labelFormatter, { name });
+    return _loc(field.options.labelFormatter, { name });
   }
 }

--- a/module/data/fields/mapping-field.mjs
+++ b/module/data/fields/mapping-field.mjs
@@ -1,5 +1,5 @@
 /**
- * @import { MappingFieldInitialValueBuilder, MappingFieldOptions } from "./_types.mjs";
+ * @import { MappingFieldEntryLabelBuilder, MappingFieldInitialValueBuilder, MappingFieldOptions } from "./_types.mjs";
  */
 
 const { DataField } = foundry.data.fields;
@@ -11,6 +11,7 @@ const { DataField } = foundry.data.fields;
  * @param {MappingFieldOptions} [options={}]   Options which configure the behavior of the field.
  * @property {string[]} [initialKeys]          Keys that will be created if no data is provided.
  * @property {MappingFieldInitialValueBuilder} [initialValue]  Function to calculate the initial value for a key.
+ * @property {MappingFieldEntryLabelBuilder} [entryLabel]      Function to calculate the label for a key.
  * @property {boolean} [initialKeysOnly=false]  Should the keys in the initialized data be limited to the keys provided
  *                                              by `options.initialKeys`?
  */
@@ -36,6 +37,7 @@ export default class MappingField extends foundry.data.fields.TypedObjectField {
       initialKeys: null,
       initialValue: null,
       initialKeysOnly: false,
+      entryLabel: null,
       expandKeys: false
     });
   }
@@ -87,5 +89,22 @@ export default class MappingField extends foundry.data.fields.TypedObjectField {
     if ( path.length === 0 ) return this;
     path.pop();
     return this.element._getField(path, options);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the formatted label for the specified field within the element of the provided key.
+   * @param {string} key     Key of the entry listing in the `MappingField` (e.g. `dex`, `str`).
+   * @param {string[]} path  Path parts to a field within the field's element (e.g. `["mode", "roll", "save"]`).
+   * @returns {string|void}  Formatted name for the field if a formatter is provided. Falls back to the field's generic
+   *                         label if no formatter is provided, or nothing if field isn't found or it isn't labeled.
+   */
+  getFieldLabel(key, path) {
+    const field = this.element._getField(path);
+    if ( !field ) return;
+    const name = this.entryLabel?.(key);
+    if ( !field.options.labelFormatter || !name ) return field.label;
+    return game.i18n.format(field.options.labelFormatter, { name });
   }
 }

--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -42,7 +42,7 @@ export default class DurationField extends SchemaField {
         labels.duration = formatTime(this.duration.value, this.duration.units);
       } else labels.duration = CONFIG.DND5E.timePeriods[this.duration.units] ?? "";
       labels.concentrationDuration = this.duration.concentration || this.properties?.has("concentration")
-        ? _loc("DND5E.ConcentrationDuration", { duration: labels.duration }) : labels.duration;
+        ? _loc("DND5E.CONCENTRATION.Duration", { duration: labels.duration }) : labels.duration;
     }
 
     Object.defineProperty(this.duration, "getEffectData", {

--- a/module/data/shared/roll-config-field.mjs
+++ b/module/data/shared/roll-config-field.mjs
@@ -6,18 +6,23 @@ const { StringField, NumberField, SchemaField } = foundry.data.fields;
  * Field for storing data for a specific type of roll.
  */
 export default class RollConfigField extends foundry.data.fields.SchemaField {
-  constructor({ roll={}, ability="", ...fields }={}, options={}) {
+  constructor({ roll={}, ability="", labelFormatterPrefix="DND5E.ROLL.Formatter.", ...fields }={}, options={}) {
     const opts = { initial: null, nullable: true, min: 1, max: 20, integer: true };
     fields = {
       ability: (ability === false) ? null : new StringField({
         required: true,
         initial: ability,
-        label: "DND5E.AbilityModifier"
+        label: "DND5E.AbilityModifier",
+        labelFormatter: `${labelFormatterPrefix}ModifierAbility`
       }),
       roll: new SchemaField({
-        min: new NumberField({...opts, label: "DND5E.ROLL.Range.Minimum"}),
-        max: new NumberField({...opts, label: "DND5E.ROLL.Range.Maximum"}),
-        mode: new AdvantageModeField(),
+        min: new NumberField({
+          ...opts, label: "DND5E.ROLL.Range.Minimum", labelFormatter: `${labelFormatterPrefix}Minimum`
+        }),
+        max: new NumberField({
+          ...opts, label: "DND5E.ROLL.Range.Maximum", labelFormatter: `${labelFormatterPrefix}Maximum`
+        }),
+        mode: new AdvantageModeField({ labelFormatter: `${labelFormatterPrefix}AdvantageMode` }),
         ...roll
       }),
       ...fields

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -1,7 +1,7 @@
 import CreateDocumentDialog from "../applications/create-document-dialog.mjs";
 import FormulaField from "../data/fields/formula-field.mjs";
 import MappingField from "../data/fields/mapping-field.mjs";
-import { parseOrString, staticID } from "../utils.mjs";
+import { getHumanReadableAttributeLabel, parseOrString, staticID } from "../utils.mjs";
 import Item5e from "./item.mjs";
 import DependentDocumentMixin from "./mixins/dependent.mjs";
 
@@ -973,11 +973,11 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /* -------------------------------------------- */
 
   /**
-   * Render a rich tooltip for this effect.
+   * Prepare an object of chat data used to display a card for the Item in the chat log.
    * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
-   * @returns {Promise<{content: string, classes: string[]}>}
+   * @returns {object}              An object of chat data to render.
    */
-  async richTooltip(enrichmentOptions={}) {
+  async getPreviewContext(enrichmentOptions={}) {
     let properties = [];
     if ( this.isSuppressed ) properties.push("DND5E.EffectType.Unavailable");
     else if ( this.disabled ) properties.push("DND5E.EffectType.Inactive");
@@ -989,14 +989,65 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     properties.unshift(...this.statuses.map(id => CONFIG.statusEffects[id]?.name).filter(_ => _));
 
     return {
-      content: await foundry.applications.handlebars.renderTemplate(
-        "systems/dnd5e/templates/effects/parts/effect-tooltip.hbs", {
-          effect: this,
-          description: await TextEditor.enrichHTML(this.description ?? "", { relativeTo: this, ...enrichmentOptions }),
-          durationParts: this.duration.remaining ? this.duration.label.split(", ") : [],
-          showDuration: Number.isFinite(this.duration.value),
-          properties
+      properties,
+      description: await TextEditor.enrichHTML(this.description ?? "", {
+        relativeTo: this
+        // TODO: Use this once https://github.com/foundryvtt/dnd5e/issues/5758 is resolved
+        // rollData: this.getRollData()
+      }),
+      effect: this
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the context used to display an effect on an actor or item sheet.
+   * @param {object} [options={}]
+   * @param {number} [options.maxKeyLength=35]  Maximum length of the attribute key displayed.
+   * @returns {object}  An object of chat data to render.
+   */
+  async getSheetContext({ maxKeyLength=35 }={}) {
+    this.updateDuration();
+    const { id, name, img, disabled, duration } = this;
+    const source = await this.getSource();
+    const attributeCtx = this.type === "enchantment"
+      ? { item: this.isAppliedEnchantment ? this.item : true }
+      : { actor: this.actor };
+    return {
+      id, name, img, disabled, duration, source,
+      changes: this.changes.map(change => {
+        let displayKey = change.key;
+        if ( displayKey.length > (maxKeyLength + 5) ) {
+          displayKey = displayKey.replace(/^systems.|^flags.|^activities\[/, "");
+          if ( displayKey.length > maxKeyLength ) displayKey = displayKey.slice(1 - maxKeyLength);
+          displayKey = `…${displayKey}`;
         }
+        return {
+          ...change, displayKey,
+          name: getHumanReadableAttributeLabel(change.key, { ...attributeCtx, prefixItemName: false })
+        };
+      }),
+      durationParts: Number.isFinite(duration.remaining) ? duration.label.split(", ") : [],
+      showDuration: Number.isFinite(duration.value),
+      effect: this
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Render a rich tooltip for this effect.
+   * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
+   * @returns {Promise<{content: string, classes: string[]}>}
+   */
+  async richTooltip(enrichmentOptions={}) {
+    const context = await this.getPreviewContext(enrichmentOptions);
+    context.durationParts = this.duration.remaining ? this.duration.label.split(", ") : [];
+
+    return {
+      content: await foundry.applications.handlebars.renderTemplate(
+        "systems/dnd5e/templates/effects/parts/effect-tooltip.hbs", context
       ),
       classes: ["dnd5e2", "dnd5e-tooltip", "effect-tooltip", "themed", "theme-light"]
     };

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -653,7 +653,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   async _preDelete(options, user) {
     const dependents = this.getDependents();
     if ( dependents.length && !game.users.activeGM ) {
-      ui.notifications.warn("DND5E.ConcentrationBreakWarning");
+      ui.notifications.warn("DND5E.CONCENTRATION.Warning.BreakWithoutGM");
       return false;
     }
     return super._preDelete(options, user);
@@ -695,7 +695,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     const effectData = foundry.utils.mergeObject({
       ...statusEffect,
       name: `${_loc("EFFECT.DND5E.StatusConcentrating")}: ${item.name}`,
-      description: `<p>${_loc("DND5E.ConcentratingOn", {
+      description: `<p>${_loc("DND5E.CONCENTRATION.Description", {
         name: item.name,
         type: _loc(`TYPES.Item.${item.type}`)
       })}</p><hr><p>@Embed[${item.uuid} inline]</p>`,
@@ -873,12 +873,12 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     }
     const choices = effects.reduce((acc, effect) => {
       const data = effect.getFlag("dnd5e", "item");
-      acc[effect.id] = data?.name ?? actor.items.get(data?.id)?.name ?? _loc("DND5E.ConcentratingItemless");
+      acc[effect.id] = data?.name ?? actor.items.get(data?.id)?.name ?? _loc("DND5E.CONCENTRATION.NoSource");
       return acc;
     }, {});
     const options = HandlebarsHelpers.selectOptions(choices, { hash: { sort: true } });
     const content = `
-    <p>${_loc("DND5E.ConcentratingEndChoice")}</p>
+    <p>${_loc("DND5E.CONCENTRATION.EndChoice")}</p>
     <div class="form-group">
       <label>${_loc("DND5E.SOURCE.FIELDS.source.label")}</label>
       <div class="form-fields">

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -979,10 +979,10 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    */
   async getPreviewContext(enrichmentOptions={}) {
     let properties = [];
-    if ( this.isSuppressed ) properties.push("DND5E.EffectType.Unavailable");
-    else if ( this.disabled ) properties.push("DND5E.EffectType.Inactive");
-    else if ( this.isTemporary ) properties.push("DND5E.EffectType.Temporary");
-    else properties.push("DND5E.EffectType.Passive");
+    if ( this.isSuppressed ) properties.push("DND5E.EFFECT.Status.Unavailable");
+    else if ( this.disabled ) properties.push("DND5E.EFFECT.Status.Inactive");
+    else if ( this.isTemporary ) properties.push("DND5E.EFFECT.Status.Temporary");
+    else properties.push("DND5E.EFFECT.Status.Passive");
     if ( this.type === "enchantment" ) properties.push("DND5E.ENCHANTMENT.Label");
     if ( this.system.magical ) properties.push("DND5E.ITEM.Property.Magical");
     properties = properties.map(p => _loc(p));

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -991,6 +991,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     return {
       properties,
       description: await TextEditor.enrichHTML(this.description ?? "", {
+        ...enrichmentOptions,
         relativeTo: this
         // TODO: Use this once https://github.com/foundryvtt/dnd5e/issues/5758 is resolved
         // rollData: this.getRollData()
@@ -1043,7 +1044,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    */
   async richTooltip(enrichmentOptions={}) {
     const context = await this.getPreviewContext(enrichmentOptions);
-    context.durationParts = this.duration.remaining ? this.duration.label.split(", ") : [];
+    context.durationParts = Number.isFinite(this.duration.remaining) ? this.duration.label.split(", ") : [];
+    context.showDuration = Number.isFinite(this.duration.value);
 
     return {
       content: await foundry.applications.handlebars.renderTemplate(

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -636,13 +636,13 @@ export default function ActivityMixin(Base) {
         if ( config.concentration.end ) {
           const replacedEffect = effects.find(i => i.id === config.concentration.end);
           if ( !replacedEffect ) errors.push(
-            new ConsumptionError(_loc("DND5E.ConcentratingMissingItem"))
+            new ConsumptionError(_loc("DND5E.CONCENTRATION.Warning.MissingItem"))
           );
         }
 
         // Cannot begin more concentrations than the limit
         else if ( effects.size >= this.actor.system.attributes?.concentration?.limit ) errors.push(
-          new ConsumptionError(_loc("DND5E.ConcentratingLimited"))
+          new ConsumptionError(_loc("DND5E.CONCENTRATION.Limit.Reached"))
         );
       }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1148,7 +1148,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( !isConcentrating ) return null;
 
     const label = `<i class="fa-solid fa-ban" inert></i>${
-      _loc("DND5E.ConcentrationBreak")
+      _loc("DND5E.CONCENTRATION.Action.Break")
     }`;
 
     return ChatMessage.implementation.create({

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -689,7 +689,7 @@ export default class ChatMessage5e extends ChatMessage {
     if ( roll?.concentrationBroken ) content.insertAdjacentHTML("beforeend", `
       <p class="supplement">
         <strong>${_loc("DND5E.ROLL.Status")}</strong>
-        ${_loc("DND5E.ConcentrationLost")}
+        ${_loc("DND5E.CONCENTRATION.Lost")}
       </p>
     `);
 
@@ -699,7 +699,7 @@ export default class ChatMessage5e extends ChatMessage {
         <div class="card-buttons">
           <button type="button">
             <i class="fa-solid fa-ban" inert></i>
-            ${_loc("DND5E.ConcentrationBreak")}
+            ${_loc("DND5E.CONCENTRATION.Action.Break")}
           </button>
         </div>
       `);

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1390,11 +1390,6 @@ export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemNa
   }
 
   // Senses
-  else if ( attr.startsWith("attributes.senses.ranges.") ) {
-    const key = attr.split(".")[3];
-    label = CONFIG.DND5E.senses[key]?.label;
-  }
-  // Senses
   else if ( attr.startsWith("attributes.senses.ranges.") ) label = CONFIG.DND5E.senses[attr.split(".")[3]]?.label;
   else if ( attr.startsWith("attributes.senses.") ) label = CONFIG.DND5E.senses[attr.split(".")[2]]?.label;
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -918,6 +918,10 @@ export async function preloadHandlebarsTemplates() {
     "systems/dnd5e/templates/apps/parts/trait-list.hbs",
     "systems/dnd5e/templates/apps/parts/traits-list.hbs",
 
+    // Active Effect Partials
+    "systems/dnd5e/templates/effects/parts/effect-change-row.hbs",
+    "systems/dnd5e/templates/effects/parts/effect-summary.hbs",
+
     // Actor Sheet Partials
     "systems/dnd5e/templates/actors/parts/actor-classes.hbs",
     "systems/dnd5e/templates/actors/parts/actor-trait-pills.hbs",
@@ -1278,13 +1282,14 @@ const _attributeLabelCache = {
 /**
  * Convert an attribute path to a human-readable label. Assumes paths are on an actor unless an reference item
  * is provided.
- * @param {string} attr              The attribute path.
+ * @param {string} attr                       The attribute path.
  * @param {object} [options]
- * @param {Actor5e} [options.actor]  An optional reference actor.
- * @param {Item5e} [options.item]    An optional reference item.
+ * @param {Actor5e} [options.actor]           An optional reference actor.
+ * @param {Item5e|true} [options.item]        An optional reference item, or `true` to treat it as a generic item.
+ * @param {boolean} [options.prefixItemName]  Prefix label with item name when applied to item or activity.
  * @returns {string|void}
  */
-export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
+export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemName=true }={}) {
   if ( attr.startsWith("system.") ) attr = attr.slice(7);
 
   // Check any actor-specific names first.
@@ -1327,7 +1332,9 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   let type = "actor";
 
   const getSchemaLabel = (attr, type, doc) => {
-    if ( doc ) return doc.system.schema.getField(attr)?.label;
+    if ( attr === "name" ) return "DND5E.BASE.Name";
+    if ( attr === "img" ) return "DND5E.BASE.Image";
+    if ( doc instanceof foundry.abstract.Document ) return doc.system.schema.getField(attr)?.label;
     for ( const model of Object.values(CONFIG[type].dataModels) ) {
       const field = model.schema.getField(attr);
       if ( field ) return field.label;
@@ -1335,20 +1342,27 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   };
 
   // Activity labels
-  if ( item && attr.startsWith("activities.") ) {
+  if ( (item instanceof Item) && attr.startsWith("activities.") ) {
     let [, activityId, ...keyPath] = attr.split(".");
     const activity = item.system.activities?.get(activityId);
     if ( !activity ) return attr;
     attr = keyPath.join(".");
-    name = `${item.name}: ${activity.name}`;
+    name = prefixItemName ? `${item.name}: ${activity.name}` : activity.name;
     type = "activity";
     if ( _attributeLabelCache.activity.has(attr) ) label = _attributeLabelCache.activity.get(attr);
     else if ( attr === "uses.spent" ) label = "DND5E.Uses";
   }
+  else if ( attr.startsWith("activities[") ) {
+    let [type, ...keyPath] = attr.split(".");
+    type = type.replace("activities[", "").replace("]", "");
+    const field = CONFIG.DND5E.activityTypes[type]?.documentClass?.schema.getField(keyPath.join("."));
+    label = field?.label;
+    type = "activity";
+  }
 
   // Item labels
   else if ( item ) {
-    name = item.name;
+    if ( prefixItemName && (item instanceof Item) ) name = item.name;
     type = "item";
     if ( _attributeLabelCache.item.has(attr) ) label = _attributeLabelCache.item.get(attr);
     else if ( attr === "hd.spent" ) label = "DND5E.HitDice";
@@ -1356,7 +1370,13 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
     else label = getSchemaLabel(attr, "Item", item);
   }
 
-  // Derived fields.
+  // Flags
+  else if ( attr.startsWith("flags.dnd5e.") ) {
+    const key = attr.replace("flags.dnd5e.", "");
+    if ( key in CONFIG.DND5E.characterFlags ) label = CONFIG.DND5E.characterFlags[key].name;
+  }
+
+  // Derived fields
   else if ( attr === "attributes.init.total" ) label = "DND5E.InitiativeBonus";
   else if ( (attr === "attributes.ac.value") || (attr === "attributes.ac.flat") ) label = "DND5E.ArmorClass";
   else if ( attr === "attributes.spell.attack" ) label = "DND5E.SpellAttackBonus";
@@ -1364,8 +1384,9 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
 
   // Abilities.
   else if ( attr.startsWith("abilities.") || attr.startsWith("attributes.ac.clamped.") ) {
-    const key = attr.split(".")[attr.startsWith("abilities.") ? 1 : 3];
-    label = _loc("DND5E.AbilityScoreL", { ability: CONFIG.DND5E.abilities[key].label });
+    const [key, ...keyPath] = attr.split(".").slice(attr.statsWith("abilities.") ? 1 : 3);
+    const mapping = dnd5e.dataModels.actor.CharacterData.schema.getField("abilities");
+    label = mapping.getFieldLabel(key, keyPath.toReversed());
   }
 
   // Senses
@@ -1373,6 +1394,9 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
     const key = attr.split(".")[3];
     label = CONFIG.DND5E.senses[key]?.label;
   }
+  // Senses
+  else if ( attr.startsWith("attributes.senses.ranges.") ) label = CONFIG.DND5E.senses[attr.split(".")[3]];
+  else if ( attr.startsWith("attributes.senses.") ) label = CONFIG.DND5E.senses[attr.split(".")[2]];
 
   // Resources
   else if ( attr === "resources.legact.spent" ) label = "DND5E.LegendaryAction.LabelPl";
@@ -1381,10 +1405,22 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   else if ( attr === "resources.legres.value" ) label = "DND5E.LegendaryResistance.Remaining";
   else if ( attr === "attributes.actions.value" ) label = "DND5E.VEHICLE.FIELDS.attributes.actions.label";
 
-  // Skills.
+  // Skills
   else if ( attr.startsWith("skills.") ) {
-    const [, key] = attr.split(".");
-    label = _loc("DND5E.SkillPassiveScore", { skill: CONFIG.DND5E.skills[key].label });
+    const [, key, ...keyPath] = attr.split(".");
+    if ( keyPath.at(-1) === "passive" ) {
+      label = _loc("DND5E.SkillPassiveScore", { skill: CONFIG.DND5E.skills[key]?.label });
+    } else {
+      const mapping = dnd5e.dataModels.actor.CharacterData.schema.getField("skills");
+      label = mapping.getFieldLabel(key, keyPath.toReversed());
+    }
+  }
+
+  // Tools
+  else if ( attr.startsWith("tools.") ) {
+    const [, key, ...keyPath] = attr.split(".");
+    const mapping = dnd5e.dataModels.actor.CharacterData.schema.getField("tools");
+    label = mapping.getFieldLabel(key, keyPath.toReversed());
   }
 
   // Spell slots.
@@ -1405,7 +1441,7 @@ export function getHumanReadableAttributeLabel(attr, { actor, item }={}) {
   }
 
   // Attempt to find the attribute in a data model.
-  if ( !label ) label = getSchemaLabel(attr, "Actor", actor);
+  if ( !label && (type === "actor") ) label = getSchemaLabel(attr, "Actor", actor);
 
   // Call hook if no label is available
   if ( !label ) label = getUnknownLabel(attr, { actor, item });

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1384,7 +1384,7 @@ export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemNa
 
   // Abilities.
   else if ( attr.startsWith("abilities.") || attr.startsWith("attributes.ac.clamped.") ) {
-    const [key, ...keyPath] = attr.split(".").slice(attr.statsWith("abilities.") ? 1 : 3);
+    const [key, ...keyPath] = attr.split(".").slice(attr.startsWith("abilities.") ? 1 : 3);
     const mapping = dnd5e.dataModels.actor.CharacterData.schema.getField("abilities");
     label = mapping.getFieldLabel(key, keyPath.toReversed());
   }
@@ -1395,8 +1395,8 @@ export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemNa
     label = CONFIG.DND5E.senses[key]?.label;
   }
   // Senses
-  else if ( attr.startsWith("attributes.senses.ranges.") ) label = CONFIG.DND5E.senses[attr.split(".")[3]];
-  else if ( attr.startsWith("attributes.senses.") ) label = CONFIG.DND5E.senses[attr.split(".")[2]];
+  else if ( attr.startsWith("attributes.senses.ranges.") ) label = CONFIG.DND5E.senses[attr.split(".")[3]]?.label;
+  else if ( attr.startsWith("attributes.senses.") ) label = CONFIG.DND5E.senses[attr.split(".")[2]]?.label;
 
   // Resources
   else if ( attr === "resources.legact.spent" ) label = "DND5E.LegendaryAction.LabelPl";
@@ -1447,7 +1447,7 @@ export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemNa
   if ( !label ) label = getUnknownLabel(attr, { actor, item });
 
   if ( label ) {
-    label = _loc(label);
+    label = _loc(String(label));
     _attributeLabelCache[type].set(attr, label);
     if ( name ) label = `${name} ${label}`;
   }

--- a/templates/activity/parts/activity-effects.hbs
+++ b/templates/activity/parts/activity-effects.hbs
@@ -2,7 +2,7 @@
     <legend>
         <span>{{ localize (ifThen labels.legend labels.legend "DND5E.ACTIVITY.FIELDS.effects.label") }}</span>
         <button type="button" class="unbutton control-button" data-action="addEffect"
-                data-tooltip aria-label="{{ localize (ifThen labels.add labels.add 'DND5E.EFFECT.Action.Create') }}">
+                data-tooltip aria-label="{{ localize (ifThen labels.add labels.add 'DND5E.EFFECT.Action.CreateEffect') }}">
             <i class="fas fa-plus" inert></i>
         </button>
     </legend>
@@ -29,12 +29,12 @@
     {{{ contentLink }}}
     <div class="list-controls flexrow">
         <button type="button" class="unbutton control-button" data-action="dissociateEffect" data-tooltip
-                aria-label="{{ localize (ifThen labels.dissociate labels.dissociate 'DND5E.EFFECT.Action.Dissociate') }}">
+                aria-label="{{ localize (ifThen labels.dissociate labels.dissociate 'DND5E.EFFECT.Action.DissociateEffect') }}">
             <i class="fa-solid fa-minus" inert></i>
         </button>
         {{#unless data.uuid}}
         <button type="button" class="unbutton control-button" data-action="deleteEffect" data-tooltip
-                aria-label="{{ localize (ifThen labels.delete labels.delete 'DND5E.EFFECT.Action.Delete') }}">
+                aria-label="{{ localize (ifThen labels.delete labels.delete 'DND5E.EFFECT.Action.DeleteEffect') }}">
             <i class="fa-solid fa-trash" inert></i>
         </button>
         {{/unless}}

--- a/templates/advancement/modify-item-config-changes.hbs
+++ b/templates/advancement/modify-item-config-changes.hbs
@@ -31,7 +31,7 @@
     <div class="list-controls flexrow">
         {{#if (or data.uuid @root.hasEffectsTab)}}
         <button type="button" class="unbutton control-button" data-action="dissociateEffect"
-                data-tooltip aria-label="{{ localize 'DND5E.EFFECT.Action.Dissociate' }}">
+                data-tooltip aria-label="{{ localize 'DND5E.EFFECT.Action.DissociateEffect' }}">
             <i class="fa-solid fa-minus" inert></i>
         </button>
         {{/if}}

--- a/templates/effects/columns/controls.hbs
+++ b/templates/effects/columns/controls.hbs
@@ -1,0 +1,40 @@
+<div class="item-detail effect-controls always-visible" data-column-id="controls">
+
+    {{#if isEffect}}
+    {{#if @root.editable}}
+    {{!-- Editing --}}
+    <button type="button" class="unbutton config-button effect-control item-control item-action" data-action="edit"
+            data-tooltip aria-label="{{ localize 'DND5E.EffectEdit' }}">
+        <i class="fa-solid fa-pen-to-square" inert></i>
+    </button>
+
+    {{!-- Deleting --}}
+    <button type="button" class="unbutton config-button effect-control item-control item-action" data-action="delete"
+            data-tooltip aria-label="{{ localize 'DND5E.EffectDelete' }}">
+        <i class="fa-solid fa-trash" inert></i>
+    </button>
+
+    {{else if ctx.toggleable}}
+    {{!-- Toggling --}}
+    <button type="button" class="unbutton config-button effect-control item-control item-action
+            {{~#unless ctx.disabled}} active{{/unless}}" data-action="toggle" data-tooltip
+            aria-label="{{ localize (ifThen ctx.disabled 'DND5E.EffectEnable' 'DND5E.EffectDisable') }}">
+        <i class="fa-solid fa-toggle-{{ ifThen disabled 'off' 'on' }}" inert></i>
+    </button>
+
+    {{/if}}
+
+    {{!-- Expand/Collapse --}}
+    <button type="button" class="unbutton config-button effect-control item-control item-action always-interactive"
+            data-toggle-description data-action="toggleExpand" aria-label="{{ localize 'DND5E.ToggleDescription' }}">
+        <i class="fa-solid fa-{{ ifThen ctx.isExpanded 'compress' 'expand' }}" inert></i>
+    </button>
+
+    {{!-- Context Menu --}}
+    <button type="button" class="unbutton config-button effect-control item-control always-interactive"
+            data-context-menu aria-label="{{ localize 'DND5E.AdditionalControls' }}">
+        <i class="fa-solid fa-ellipsis-vertical" inert></i>
+    </button>
+    {{/if}}
+
+</div>

--- a/templates/effects/columns/controls.hbs
+++ b/templates/effects/columns/controls.hbs
@@ -35,6 +35,15 @@
             data-context-menu aria-label="{{ localize 'DND5E.AdditionalControls' }}">
         <i class="fa-solid fa-ellipsis-vertical" inert></i>
     </button>
+
+    {{else if isChange}}
+
+    <span class="application-status">
+        <!-- TODO: Change this to checking `entry.applied` once conditions are merged -->
+        <i class="fa-solid fa-{{ ifThen effect.active 'check' 'xmark' }}"
+           aria-label="{{ localize (concat 'DND5E.EFFECT.Status.Change' (ifThen effect.active 'Active' 'Inactive')) }}"></i>
+    </span>
+
     {{/if}}
 
 </div>

--- a/templates/effects/columns/controls.hbs
+++ b/templates/effects/columns/controls.hbs
@@ -4,13 +4,13 @@
     {{#if @root.editable}}
     {{!-- Editing --}}
     <button type="button" class="unbutton config-button effect-control item-control item-action" data-action="edit"
-            data-tooltip aria-label="{{ localize 'DND5E.EffectEdit' }}">
+            data-tooltip aria-label="{{ localize 'DND5E.EFFECT.Action.EditEffect' }}">
         <i class="fa-solid fa-pen-to-square" inert></i>
     </button>
 
     {{!-- Deleting --}}
     <button type="button" class="unbutton config-button effect-control item-control item-action" data-action="delete"
-            data-tooltip aria-label="{{ localize 'DND5E.EffectDelete' }}">
+            data-tooltip aria-label="{{ localize 'DND5E.EFFECT.Action.DeleteEffect' }}">
         <i class="fa-solid fa-trash" inert></i>
     </button>
 
@@ -18,7 +18,7 @@
     {{!-- Toggling --}}
     <button type="button" class="unbutton config-button effect-control item-control item-action
             {{~#unless ctx.disabled}} active{{/unless}}" data-action="toggle" data-tooltip
-            aria-label="{{ localize (ifThen ctx.disabled 'DND5E.EffectEnable' 'DND5E.EffectDisable') }}">
+            aria-label="{{ localize (concat 'DND5E.EFFECT.Action.' (ifThen ctx.disabled 'Enable' 'Disable') 'Effect' ) }}">
         <i class="fa-solid fa-toggle-{{ ifThen disabled 'off' 'on' }}" inert></i>
     </button>
 

--- a/templates/effects/columns/source.hbs
+++ b/templates/effects/columns/source.hbs
@@ -1,0 +1,10 @@
+<div class="item-detail effect-source {{#unless ctx.source}}empty{{/unless}}" data-column-id="source">
+    {{#if ctx.source}}
+    {{#if ctx.hasTooltip}}
+    <a class="item-tooltip" data-uuid="{{ ctx.source.uuid }}"
+       data-tooltip-direction="RIGHT">{{ ctx.source.name }}</a>
+    {{else}}
+    {{ ctx.source.name }}
+    {{/if}}
+    {{/if}}
+</div>

--- a/templates/effects/columns/value.hbs
+++ b/templates/effects/columns/value.hbs
@@ -1,0 +1,9 @@
+<div class="item-detail effect-value {{#unless ctx.value}}empty{{/unless}}" data-column-id="value">
+    {{#if ctx.value}}
+    {{#if (gt ctx.value.length 15)}}
+    <i class="fa-solid fa-database" data-tooltip aria-label="{{ ctx.value }}"></i>
+    {{else}}
+    <span class="condensed">{{ ctx.value }}</span>
+    {{/if}}
+    {{/if}}
+</div>

--- a/templates/effects/parts/effect-change-row.hbs
+++ b/templates/effects/parts/effect-change-row.hbs
@@ -1,0 +1,19 @@
+<li class="change-row item-row" data-change-type="{{ type }}">
+
+    {{!-- Name --}}
+    <div class="change-name item-name" role="button" aria-label="{{ name }}">
+
+        <div class="name name-stacked">
+            <span class="title">{{ name }}</span>
+            <span class="subtitle"
+                  {{~#if (ne key displayKey)}} data-tooltip aria-label="{{ key }}"{{/if}}>{{ displayKey }}</span>
+        </div>
+
+    </div>
+
+    {{!-- Columns --}}
+    {{#each columns}}
+        {{> (lookup . "template") ctx=.. entry=.. effect=../effect isChange=true }}
+    {{/each}}
+
+</li>

--- a/templates/effects/parts/effect-change-row.hbs
+++ b/templates/effects/parts/effect-change-row.hbs
@@ -4,9 +4,7 @@
     <div class="change-name item-name" role="button" aria-label="{{ name }}">
 
         <div class="name name-stacked">
-            <span class="title">{{ name }}</span>
-            <span class="subtitle"
-                  {{~#if (ne key displayKey)}} data-tooltip aria-label="{{ key }}"{{/if}}>{{ displayKey }}</span>
+            <span class="title" data-tooltip="{{ key }}">{{ name }}</span>
         </div>
 
     </div>

--- a/templates/effects/parts/effect-summary.hbs
+++ b/templates/effects/parts/effect-summary.hbs
@@ -1,0 +1,7 @@
+<div class="item-summary">
+    {{{ description }}}
+
+    <div class="item-properties pills">
+        {{#each properties}}<span class="tag pill transparent pill-xs">{{this}}</span>{{/each}}
+    </div>
+</div>

--- a/templates/shared/active-effects.hbs
+++ b/templates/shared/active-effects.hbs
@@ -14,14 +14,12 @@
             {{!-- Section Header --}}
             <div class="items-header header {{#if disabled}}disabled{{/if}}">
                 <h3 class="item-name effect-name">{{ localize label }}</h3>
-                <div class="item-header effect-source">{{ localize "DND5E.SOURCE.FIELDS.source.label" }}</div>
-                <div class="item-header item-controls effect-controls">
-                    {{#if info}}
-                    <a class="info-control" data-tooltip aria-label="{{ info }}">
-                        <i class="fas fa-circle-question" inert></i>
-                    </a>
-                    {{/if}}
+                {{#each columns}}
+                <div class="item-header effect-{{ id }}" data-column-id="{{ id }}" data-column-width="{{ width }}"
+                     data-column-priority="{{ priority }}">
+                    {{~#if label}}{{ localize label }}{{/if~}}
                 </div>
+                {{/each}}
             </div>
 
             {{!-- Section Contents --}}
@@ -29,29 +27,34 @@
                 {{#each effects}}
 
                 {{!-- Effects --}}
-                <li class="item effect" data-effect-id="{{ id }}" data-entry-id="{{ id }}"
-                    data-item-name="{{ name }}" {{#if parentId}}data-parent-id="{{ parentId }}"{{/if}}>
+                <li class="item effect collapsible {{~#unless isExpanded}} collapsed{{/unless}}"
+                    data-uuid="{{ uuid }}" data-effect-id="{{ id }}" data-entry-id="{{ id }}"
+                    data-item-name="{{ name }}" {{~#if parentId}} data-parent-id="{{ parentId }}"{{/if}}>
 
                     {{!-- Primary Effect --}}
                     <div class="item-row draggable">
-                        {{> ".effect" }}
+                        {{> ".effect" columns=../columns }}
                     </div>
+
+                    {{> ".expanded" columns=../columns }}
 
                     {{!-- Rider Effects --}}
-                    <div class="item-description collapsible-content">
-                        <div class="wrapper">
+                    <ol class="activities riders unlist">
+                        {{#each riders}}
 
-                            <ol class="activities riders unlist">
-                                {{#each riders}}
-                                <li class="activity-row item-row" data-effect-id="{{ id }}" data-entry-id="{{ id }}"
-                                    {{#if parentId}}data-parent-id="{{ parentId }}"{{/if}}>
-                                    {{> ".effect" }}
-                                </li>
-                                {{/each}}
-                            </ol>
+                        <li class="collapsible {{~#unless isExpanded}} collapsed{{/unless}}"
+                            data-uuid="{{ uuid }}" data-effect-id="{{ id }}" data-entry-id="{{ id }}"
+                            {{~#if parentId}} data-parent-id="{{ parentId }}"{{/if}}>
 
-                        </div>
-                    </div>
+                            <div class="activity-row item-row">
+                                {{> ".effect" columns=../../columns }}
+                            </div>
+
+                            {{> ".expanded" columns=../../columns }}
+                        </li>
+
+                        {{/each}}
+                    </ol>
 
                 </li>
 
@@ -115,48 +118,34 @@
     {{/if}}
 </div>
 
-{{!-- Effect Source --}}
-<div class="item-detail effect-source {{#unless source}}empty{{/unless}}">
-    {{#if source}}
-    {{#if hasTooltip}}
-    <a class="item-tooltip" data-uuid="{{ source.uuid }}" data-tooltip-direction="RIGHT">{{ source.name }}</a>
-    {{else}}
-    {{ source.name }}
-    {{/if}}
-    {{/if}}
-</div>
+{{!-- Columns --}}
+{{#each columns}}
+{{> (lookup . "template") ctx=.. entry=.. effect=../effect isEffect=true }}
+{{/each}}
 
-{{!-- Effect Status --}}
-<div class="item-detail item-controls effect-controls">
+{{/inline}}
 
-    {{#if @root.editable}}
-    {{!-- Editing --}}
-    <a class="effect-control item-control" data-action="edit" data-tooltip
-       aria-label="{{ localize "DND5E.EffectEdit" }}">
-        <i class="fa-solid fa-pen-to-square"></i>
-    </a>
+{{#*inline ".expanded"}}
 
-    {{!-- Deleting --}}
-    <a class="effect-control item-control" data-action="delete" data-tooltip
-       aria-label="{{ localize "DND5E.EffectDelete" }}">
-        <i class="fa-solid fa-trash"></i>
-    </a>
+{{!-- Extended Description & Changes --}}
+<div class="item-description collapsible-content">
+    <div class="wrapper">
 
-    {{else if toggleable}}
-    {{!-- Toggling --}}
-    <a class="effect-control item-control {{#unless disabled}}active{{/unless}}" data-action="toggle" data-tooltip
-       aria-label="{{ localize (ifThen disabled "DND5E.EffectEnable" "DND5E.EffectDisable") }}">
-        <i class="fa-solid fa-toggle-{{ ifThen disabled "off" "on" }}"></i>
-    </a>
+        {{!-- Changes --}}
+        {{#if changes.length}}
+        <ol class="changes unlist">
+            {{#each changes}}
+            {{> "dnd5e.effect-change-row" columns=../columns effect=../effect }}
+            {{/each}}
+        </ol>
+        {{/if}}
 
-    {{/if}}
+        {{!-- Effect Description --}}
+        {{#if isExpanded}}
+        {{> "dnd5e.effect-summary" expanded }}
+        {{/if}}
 
-    {{!-- Context Menu --}}
-    <a class="effect-control item-control always-interactive" data-context-menu
-       aria-label="{{ localize "DND5E.AdditionalControls" }}">
-        <i class="fa-solid fa-ellipsis-vertical"></i>
-    </a>
-
+    </div>
 </div>
 
 {{/inline}}


### PR DESCRIPTION
Adds the ability to expand active effects on actor and items sheets to display a list of their changes as well as the effect's description and tags.

<img width="533" height="457" alt="Effect Changes Breakout - Actor" src="https://github.com/user-attachments/assets/56fb87fa-8abe-4953-9b3a-c613cbead516" />

The change rows display the key (with a human-readable name if available), the change type indicated by a symbol, and the value (displayed as tooltip instead if too long).

<img width="483" height="512" alt="Effect Changes Breakout - Enchantment w: Riders" src="https://github.com/user-attachments/assets/150e960e-3952-4ede-8dd8-ca128f97dbf5" />

This includes improvements to `getHumanReadableAttributeLabel` to support displaying as many active effect change keys as possible and to improve how certain keys are displayed:
- Support `activities[attack]...` style keys
- Support generic item keys that search through all item schemas
- Improved labels within `MappingField` to include entry name

Closes #6813