### PR TITLE
[#6672] Implement `FiltersField`, `FiltersEditor`, and input

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3082,7 +3082,7 @@
   "Invalid": "Invalid Filter",
   "Operator": {
     "And": "and",
-    "Not": "Not",
+    "Not": "not",
     "Or": "or"
   }
 },

--- a/lang/en.json
+++ b/lang/en.json
@@ -3073,6 +3073,20 @@
 "DND5E.FilterGroupOrigin": "Group by Origin",
 "DND5E.FilterGroupAction": "Group by Action",
 "DND5E.FilterNoSpells": "No spells found for this set of filters.",
+
+"DND5E.FILTER": {
+  "Action": {
+    "Edit": "Edit Filters"
+  },
+  "Empty": "No Filters",
+  "Invalid": "Invalid Filter",
+  "Operator": {
+    "And": "and",
+    "Not": "Not",
+    "Or": "or"
+  }
+},
+
 "DND5E.NoSpellLevels": "This character has no spellcaster levels, but you may add spells manually.",
 
 "DND5E.FLAGS": {

--- a/less/elements.less
+++ b/less/elements.less
@@ -96,6 +96,51 @@ filter-state {
 }
 
 /* ---------------------------------- */
+/*  Filters Input                     */
+/* ---------------------------------- */
+
+filters-input {
+  &, filter-comparison, filter-operator {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+  filters-breakdown {
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    font-family: var(--dnd5e-font-roboto);
+    font-size: var(--font-size-11);
+  }
+  filter-comparison {
+    border: var(--pill-border);
+    border-radius: 3px;
+    padding: 0.1875rem 0.375rem;
+
+    filter-key { display: contents; }
+    &[operator="exact"] filter-key::after { content: "="; }
+    &[operator="gt"] filter-key::after { content: ">"; }
+    &[operator="gte"] filter-key::after { content: "≥"; }
+    &[operator="lt"] filter-key::after { content: "<"; }
+    &[operator="lte"] filter-key::after { content: "≤"; }
+    &[operator$="startswith"] filter-key::after { content: "⋞"; }
+    &[operator$="endswith"] filter-key::after { content: "⋟"; }
+    &[operator$="contains"] filter-key::after { content: "⊂"; }
+    &[operator^="has"] filter-key::after { content: "∩"; }
+    &[operator="in"] filter-key::after { content: "⊂"; }
+  }
+  filter-operator {
+    flex-wrap: wrap;
+
+    &::before, &::after { font-size: var(--font-size-18); }
+    &:not([operator="NOT"]) {
+      &::before { content: "⟨"; }
+      &::after { content: "⟩"; }
+    }
+  }
+}
+
+/* ---------------------------------- */
 /*  Identifier Input                  */
 /* ---------------------------------- */
 

--- a/less/elements.less
+++ b/less/elements.less
@@ -118,16 +118,16 @@ filters-input {
     padding: 0.1875rem 0.375rem;
 
     filter-key { display: contents; }
-    &[operator="exact"] filter-key::after { content: "="; }
-    &[operator="gt"] filter-key::after { content: ">"; }
-    &[operator="gte"] filter-key::after { content: "≥"; }
-    &[operator="lt"] filter-key::after { content: "<"; }
-    &[operator="lte"] filter-key::after { content: "≤"; }
-    &[operator$="startswith"] filter-key::after { content: "⋞"; }
-    &[operator$="endswith"] filter-key::after { content: "⋟"; }
-    &[operator$="contains"] filter-key::after { content: "⊂"; }
-    &[operator^="has"] filter-key::after { content: "∩"; }
-    &[operator="in"] filter-key::after { content: "⊂"; }
+    &[operator="exact"] > filter-key::after { content: "="; }
+    &[operator="gt"] > filter-key::after { content: ">"; }
+    &[operator="gte"] > filter-key::after { content: "≥"; }
+    &[operator="lt"] > filter-key::after { content: "<"; }
+    &[operator="lte"] > filter-key::after { content: "≤"; }
+    &[operator$="startswith"] > filter-key::after { content: "⋞"; }
+    &[operator$="endswith"] > filter-key::after { content: "⋟"; }
+    &[operator$="contains"] > filter-key::after { content: "⊇"; }
+    &[operator^="has"] > filter-key::after { content: "∋"; }
+    &[operator="in"] > filter-key::after { content: "∈"; }
   }
   filter-operator {
     flex-wrap: wrap;

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1326,51 +1326,17 @@
   }
 }
 
-dialog.dnd5e2.application {
-  margin: 0;
-  padding: 0;
-}
-
 /* ---------------------------------- */
 /*  Dialogs                           */
 /* ---------------------------------- */
 
-.dnd5e2.dialog {
-  background: url("ui/texture-gray1.webp") no-repeat top left,
-    url("ui/texture-gray2.webp") no-repeat bottom right,
-    var(--dnd5e-color-parchment);
-  border: 1px solid var(--dnd5e-color-gold);
-
-  > .window-content { background: transparent; }
-
-  > .window-header .window-title { visibility: hidden; }
-
-  form {
-    padding: 0 .75rem .75rem;
-
-    > header {
-      font-family: var(--dnd5e-font-roboto-slab);
-      font-weight: bold;
-      font-size: var(--font-size-24);
-      text-align: center;
-      margin-bottom: .75rem;
-    }
+dialog.dnd5e2 {
+  &.application {
+    margin: 0;
+    padding: 0;
   }
 
-  .dialog-buttons {
-    padding: .5rem;
-    gap: .5rem;
-
-    button {
-      background: var(--dnd5e-color-card);
-      border: 1px solid var(--color-border-light-2);
-      &.default { border-color: var(--dnd5e-color-gold); }
-    }
-  }
-
-  &.create-document .document-name {
-    &:hover, &:focus { box-shadow: none; }
-  }
+  &.dialog > .window-header .window-title { visibility: hidden; }
 }
 
 .dnd5e2.dialog-lg {

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -20,6 +20,7 @@ export {default as ContextMenu5e} from "./context-menu.mjs";
 export {default as CreateDocumentDialog} from "./create-document-dialog.mjs";
 export {default as CurrencyManager} from "./currency-manager.mjs";
 export {default as DialogMixin} from "./dialog-mixin.mjs";
+export {default as FiltersEditor} from "./filters-editor.mjs";
 export {default as PropertyAttribution} from "./property-attribution.mjs";
 export {default as RollTableSheet5e} from "./roll-table-sheet.mjs";
 export {default as Tabs5e} from "./tabs.mjs";

--- a/module/applications/components/_module.mjs
+++ b/module/applications/components/_module.mjs
@@ -8,6 +8,7 @@ import EffectApplicationElement from "./effect-application.mjs";
 import EffectsElement from "./effects.mjs";
 import EnchantmentApplicationElement from "./enchantment-application.mjs";
 import FiligreeBoxElement from "./filigree-box.mjs";
+import FiltersInputElement from "./filters-input.mjs";
 import FilterStateElement from "./filter-state.mjs";
 import IconElement from "./icon.mjs";
 import IdentifierInputElement from "./identifier-input.mjs";
@@ -22,6 +23,7 @@ window.customElements.define(ActivitiesElement.tagName, ActivitiesElement);
 window.customElements.define(CheckboxElement.tagName, CheckboxElement);
 window.customElements.define(DoubleRangePickerElement.tagName, DoubleRangePickerElement);
 window.customElements.define(EffectsElement.tagName, EffectsElement);
+window.customElements.define(FiltersInputElement.tagName, FiltersInputElement);
 window.customElements.define(IconElement.tagName, IconElement);
 window.customElements.define(IdentifierInputElement.tagName, IdentifierInputElement);
 window.customElements.define(InventoryElement.tagName, InventoryElement);
@@ -36,6 +38,6 @@ window.customElements.define(SlideToggleElement.tagName, SlideToggleElement);
 export {
   ActivitiesElement, AdoptedStyleSheetMixin, CopyableTextElement, CheckboxElement, DamageApplicationElement,
   DoubleRangePickerElement, EffectApplicationElement, EffectsElement, EnchantmentApplicationElement,
-  FiligreeBoxElement, FilterStateElement, IconElement, IdentifierInputElement, InventoryElement,
-  ItemListControlsElement, ProficiencyCycleElement, SlideToggleElement
+  FiligreeBoxElement, FiltersInputElement, FilterStateElement, IconElement, IdentifierInputElement,
+  InventoryElement, ItemListControlsElement, ProficiencyCycleElement, SlideToggleElement
 };

--- a/module/applications/components/filters-input.mjs
+++ b/module/applications/components/filters-input.mjs
@@ -1,0 +1,209 @@
+import { COMPARISON_FUNCTIONS, OPERATOR_FUNCTIONS } from "../../filter.mjs";
+import { getHumanReadableAttributeLabel } from "../../utils.mjs";
+import FiltersEditor from "../filters-editor.mjs";
+
+/**
+ * Element for displaying and editing filters.
+ * @extends {AbstractFormInputElement}
+ */
+export default class FiltersInputElement extends foundry.applications.elements.AbstractFormInputElement {
+
+  /** @override */
+  static tagName = "filters-input";
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Element containing the filters breakdown.
+   * @type {HTMLElement}
+   */
+  #breakdown;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Element for opening the editor.
+   * @type {HTMLButtonElement}
+   */
+  #button;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Editor instance opened by this input.
+   * @type {FiltersConfig}
+   */
+  #editor;
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _toggleDisabled(disabled) {
+    this.#button.disabled = disabled;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _buildElements() {
+    this._value ??= this.getAttribute("value") || this.innerText || "{}";
+
+    // Create filter breakdown
+    this.#breakdown = document.createElement("filters-breakdown");
+    this.#refreshBreakdown();
+
+    // Create button for opening editor
+    const b = this.#button = document.createElement("button");
+    Object.assign(b, { ariaLabel: game.i18n.localize("DND5E.FILTER.Action.Edit"), type: "button" });
+    b.classList.add("icon", "fa-solid", "fa-filter");
+    b.dataset.tooltip = "";
+
+    return [this.#breakdown, this.#button];
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _refresh() {
+    this.#refreshBreakdown();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Render the filters breakdown.
+   */
+  #refreshBreakdown() {
+    let filters;
+    try {
+      filters = JSON.parse(this.value);
+    } catch(err) {
+      this.#breakdown.innerText = game.i18n.localize("DND5E.FILTER.Invalid");
+      return;
+    }
+
+    if ( foundry.utils.isEmpty(filters) ) {
+      this.#breakdown.innerText = game.i18n.localize("DND5E.FILTER.Empty");
+      return;
+    }
+
+    if ( !Array.isArray(filters) ) filters = [filters];
+    this.#breakdown.replaceChildren(...filters.map(f => this.#renderBreakdownNode(f)).filter(_ => _));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Turn a single filter node into an breakdown element.
+   * @param {FilterDescription} filter
+   * @returns {HTMLElement|void}
+   */
+  #renderBreakdownNode(filter) {
+    let { k: key, o: operator="exact", v: value } = filter;
+    if ( !value ) return;
+
+    // If in OPERATOR_FUNCTIONS, create group and recurse
+    if ( operator in OPERATOR_FUNCTIONS ) {
+      const node = document.createElement("filter-operator");
+      node.setAttribute("operator", operator);
+      if ( !Array.isArray(value) ) value = [value];
+      node.replaceChildren(...value.map(v => this.#renderBreakdownNode(v)).filter(_ => _));
+      return node;
+    }
+
+    // If in COMPARISON_FUNCTIONS, create entry
+    if ( operator in COMPARISON_FUNCTIONS ) {
+      const node = document.createElement("filter-comparison");
+      node.setAttribute("operator", operator);
+      const keyElement = document.createElement("filter-key");
+      keyElement.innerText = getHumanReadableAttributeLabel(key) ?? key;
+      const valueElement = document.createElement("filter-value");
+      valueElement.innerText = Array.isArray(value) ? value.join(", ") : value;
+      node.replaceChildren(keyElement, valueElement);
+      return node;
+    }
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _activateListeners() {
+    this.#button.addEventListener("click", this.#onOpenEditor.bind(this), { signal: this.abortSignal });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle opening the filters config application for this input.
+   * @param {PointerEvent} event  Triggering click event.
+   */
+  #onOpenEditor(event) {
+    event.preventDefault();
+    const edit = new Event("edit", { bubbles: true, cancelable: true });
+    this.dispatchEvent(edit);
+    if ( edit.defaultPrevent ) return;
+
+    this.#editor = new FiltersEditor({ value: this.value });
+    this.#editor.addEventListener("close", () => {
+      this.value = this.#editor.value;
+      this.#editor = undefined;
+    }, { once: true });
+    this.#editor.render({ force: true });
+  }
+
+  /* -------------------------------------------- */
+  /*  Factory Methods                             */
+  /* -------------------------------------------- */
+
+  /**
+   * Create a `<filters-input>` element for a FiltersField.
+   * @param {FormInputConfig<string>} config
+   * @returns {FiltersInputElement}
+   */
+  static create(config) {
+    const input = new this();
+    if ( config.value ) input.setAttribute("value", config.value);
+    foundry.applications.fields.setInputAttributes(input, config);
+    return input;
+  }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Small custom element to insert separators between elements in the comparison.
+ */
+class FilterOperatorElement extends HTMLElement {
+
+  static {
+    window.customElements.define("filter-operator", FilterOperatorElement);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  connectedCallback() {
+    const operator = this.getAttribute("operator");
+    const symbol = operator?.endsWith("AND") ? game.i18n.localize("DND5E.FILTER.Operator.And")
+      : operator?.endsWith("OR") ? game.i18n.localize("DND5E.FILTER.Operator.Or") : null;
+    if ( symbol ) this.querySelectorAll(":is(filter-comparison, filter-operator):not(:last-child)").forEach(e =>
+      e.insertAdjacentHTML("afterend", `<span class="seperator">${symbol}</span>`)
+    );
+    if ( operator?.startsWith("N") ) this.insertAdjacentHTML(
+      "afterbegin", `<span class="seperator">${game.i18n.localize("DND5E.FILTER.Operator.Not")}`
+    );
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  disconnectedCallback() {
+    this.querySelectorAll(".seperator").forEach(e => e.remove());
+  }
+}

--- a/module/applications/components/filters-input.mjs
+++ b/module/applications/components/filters-input.mjs
@@ -163,7 +163,7 @@ export default class FiltersInputElement extends foundry.applications.elements.A
       this.value = this.#editor.value;
       this.#editor = undefined;
     }, { once: true });
-    this.#editor.render({ force: true });
+    this.#editor.render({ force: true, window: { windowId: this.ownerDocument.defaultView.id } });
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/filters-input.mjs
+++ b/module/applications/components/filters-input.mjs
@@ -33,7 +33,7 @@ export default class FiltersInputElement extends foundry.applications.elements.A
 
   /**
    * Editor instance opened by this input.
-   * @type {FiltersConfig}
+   * @type {FiltersEditor}
    */
   #editor;
 
@@ -86,13 +86,16 @@ export default class FiltersInputElement extends foundry.applications.elements.A
       return;
     }
 
-    if ( foundry.utils.isEmpty(filters) ) {
+    const isEmpty = foundry.utils.isEmpty(filters);
+    this.#breakdown.classList.toggle("empty", isEmpty);
+    if ( isEmpty ) {
       this.#breakdown.innerText = game.i18n.localize("DND5E.FILTER.Empty");
       return;
     }
 
-    if ( !Array.isArray(filters) ) filters = [filters];
-    this.#breakdown.replaceChildren(...filters.map(f => this.#renderBreakdownNode(f)).filter(_ => _));
+    this.#breakdown.replaceChildren(this.#renderBreakdownNode(
+      Array.isArray(filters) ? { o: "AND", v: filters } : filters
+    ));
   }
 
   /* -------------------------------------------- */
@@ -104,7 +107,7 @@ export default class FiltersInputElement extends foundry.applications.elements.A
    */
   #renderBreakdownNode(filter) {
     let { k: key, o: operator="exact", v: value } = filter;
-    if ( !value ) return;
+    if ( value === undefined ) return;
 
     // If in OPERATOR_FUNCTIONS, create group and recurse
     if ( operator in OPERATOR_FUNCTIONS ) {
@@ -122,7 +125,12 @@ export default class FiltersInputElement extends foundry.applications.elements.A
       const keyElement = document.createElement("filter-key");
       keyElement.innerText = getHumanReadableAttributeLabel(key) ?? key;
       const valueElement = document.createElement("filter-value");
-      valueElement.innerText = Array.isArray(value) ? value.join(", ") : value;
+      if ( foundry.utils.isPlainObject(value) ) {
+        const innerNode = this.#renderBreakdownNode(value);
+        if ( innerNode ) valueElement.replaceChildren(innerNode);
+      } else {
+        valueElement.innerText = Array.isArray(value) ? value.join(", ") : value;
+      }
       node.replaceChildren(keyElement, valueElement);
       return node;
     }
@@ -147,8 +155,9 @@ export default class FiltersInputElement extends foundry.applications.elements.A
     event.preventDefault();
     const edit = new Event("edit", { bubbles: true, cancelable: true });
     this.dispatchEvent(edit);
-    if ( edit.defaultPrevent ) return;
+    if ( edit.defaultPrevented ) return;
 
+    this.#editor?.close();
     this.#editor = new FiltersEditor({ value: this.value });
     this.#editor.addEventListener("close", () => {
       this.value = this.#editor.value;
@@ -193,10 +202,10 @@ class FilterOperatorElement extends HTMLElement {
     const symbol = operator?.endsWith("AND") ? game.i18n.localize("DND5E.FILTER.Operator.And")
       : operator?.endsWith("OR") ? game.i18n.localize("DND5E.FILTER.Operator.Or") : null;
     if ( symbol ) this.querySelectorAll(":is(filter-comparison, filter-operator):not(:last-child)").forEach(e =>
-      e.insertAdjacentHTML("afterend", `<span class="seperator">${symbol}</span>`)
+      e.insertAdjacentHTML("afterend", `<span class="separator">${symbol}</span>`)
     );
     if ( operator?.startsWith("N") ) this.insertAdjacentHTML(
-      "afterbegin", `<span class="seperator">${game.i18n.localize("DND5E.FILTER.Operator.Not")}`
+      "afterbegin", `<span class="separator">${game.i18n.localize("DND5E.FILTER.Operator.Not")}</span>`
     );
   }
 
@@ -204,6 +213,6 @@ class FilterOperatorElement extends HTMLElement {
 
   /** @override */
   disconnectedCallback() {
-    this.querySelectorAll(".seperator").forEach(e => e.remove());
+    this.querySelectorAll(".separator").forEach(e => e.remove());
   }
 }

--- a/module/applications/filters-editor.mjs
+++ b/module/applications/filters-editor.mjs
@@ -1,0 +1,107 @@
+import Application5e from "./api/application.mjs";
+
+/**
+ * Application for creating and modifying filters.
+ */
+export default class FiltersEditor extends Application5e {
+
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["dialog", "filters-editor", "titlebar"],
+    id: "filters-editor",
+    position: {
+      width: 400,
+      height: 300
+    },
+    tag: "dialog",
+    value: null,
+    window: {
+      icon: "fa-solid fa-filter",
+      resizable: true,
+      minimizable: false
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    editor: {
+      template: "systems/dnd5e/templates/apps/filters-editor.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The active CodeMirror editor instance.
+   * @type {EditorView}
+   */
+  #editor;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The value of the filters.
+   * @type {string}
+   */
+  get value() {
+    return this.#editor.value;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.value = this.options.value;
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _renderFrame(options) {
+    const frame = await super._renderFrame(options);
+    this.window.close.classList.remove("fa-xmark");
+    this.window.close.classList.add("fa-floppy-disk");
+    return frame;
+  }
+
+  /* -------------------------------------------- */
+  /*  Detached Window API                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _canAttach() {
+    return false;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _canDetach() {
+    return false;
+  }
+
+  /* -------------------------------------------- */
+  /*  Life-Cycle Handlers                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _canRender(options) {
+    if ( this.rendered ) return false;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _onFirstRender(context, options) {
+    this.element.showModal();
+    this.#editor = this.element.querySelector("code-mirror");
+  }
+}

--- a/module/applications/filters-editor.mjs
+++ b/module/applications/filters-editor.mjs
@@ -37,7 +37,7 @@ export default class FiltersEditor extends Application5e {
 
   /**
    * The active CodeMirror editor instance.
-   * @type {EditorView}
+   * @type {HTMLCodeMirrorEditor}
    */
   #editor;
 

--- a/module/data/fields/_module.mjs
+++ b/module/data/fields/_module.mjs
@@ -3,6 +3,7 @@ export {default as AdvancementCollectionField} from "./advancement-collection-fi
 export {default as AdvancementDataField} from "./advancement-data-field.mjs";
 export {default as AdvancementField} from "./advancement-field.mjs";
 export {default as AdvantageModeField} from "./advantage-mode-field.mjs";
+export {default as FiltersField} from "./filters-field.mjs";
 export {default as FormulaField} from "./formula-field.mjs";
 export {default as IdentifierField} from "./identifier-field.mjs";
 export {default as LocalDocumentField} from "./local-document-field.mjs";

--- a/module/data/fields/filters-field.mjs
+++ b/module/data/fields/filters-field.mjs
@@ -1,0 +1,38 @@
+import FiltersInputElement from "../../applications/components/filters-input.mjs";
+import { Filter } from "../../filter.mjs";
+
+/**
+ * A field for storing filters configuration that initializes to a `Filter` instance.
+ */
+export default class FiltersField extends foundry.data.fields.JSONField {
+
+  /** @override */
+  static get _defaults() {
+    return Object.assign(super._defaults, {
+      initial: "{}"
+    });
+  }
+
+  /* -------------------------------------------- */
+  /*  Initialization and Updates                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  initialize(value, model, options={}) {
+    try {
+      return new Filter(JSON.parse(value));
+    } catch(err) {
+      return null;
+    }
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Field Integration                      */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _toInput(config) {
+    config.value ??= this.initial;
+    return FiltersInputElement.create(config);
+  }
+}

--- a/module/data/fields/filters-field.mjs
+++ b/module/data/fields/filters-field.mjs
@@ -8,9 +8,7 @@ export default class FiltersField extends foundry.data.fields.JSONField {
 
   /** @override */
   static get _defaults() {
-    return Object.assign(super._defaults, {
-      initial: "{}"
-    });
+    return Object.assign(super._defaults, { initial: "{}" });
   }
 
   /* -------------------------------------------- */

--- a/module/filter.mjs
+++ b/module/filter.mjs
@@ -3,6 +3,72 @@
  */
 
 /**
+ * Class for storing a filter definition for easy evaluation.
+ */
+export class Filter {
+  constructor(definition) {
+    this.#definition = definition;
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The underlying filter definition.
+   * @type {FilterDescription|FilterDescription[]}
+   */
+  #definition;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Cached result of the filter check.
+   * @type {boolean}
+   */
+  #result;
+
+  /* -------------------------------------------- */
+  /*  Methods                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Check some data against the filter to determine if it matches. Result will be cached between multiple calls.
+   * @param {object} data  Arbitrary data object to check.
+   * @returns {boolean}
+   * @throws
+   */
+  check(data) {
+    if ( this.#result !== undefined ) return this.#result;
+    try {
+      if ( foundry.utils.isEmpty(this.#definition) ) this.#result = true;
+      else this.#result = performCheck(data, this.#definition);
+      return this.#result;
+    } catch(err) {
+      console.error(err.message);
+      return false;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Clear the cached result of the filter check and perform the check again.
+   * @param {object} data  Arbitrary data object to check.
+   * @returns {boolean}
+   * @throws
+   */
+  recheck(data) {
+    this.#result = undefined;
+    return this.check(data);
+  }
+}
+
+/* -------------------------------------------- */
+/*  Checking Functions                          */
+/* -------------------------------------------- */
+
+/**
  * Check some data against a filter to determine if it matches.
  * @param {object} data                                   Data to check.
  * @param {FilterDescription|FilterDescription[]} filter  Filter to compare against.

--- a/module/filter.mjs
+++ b/module/filter.mjs
@@ -36,7 +36,6 @@ export class Filter {
    * Check some data against the filter to determine if it matches. Result will be cached between multiple calls.
    * @param {object} data  Arbitrary data object to check.
    * @returns {boolean}
-   * @throws
    */
   check(data) {
     if ( this.#result !== undefined ) return this.#result;
@@ -45,7 +44,7 @@ export class Filter {
       else this.#result = performCheck(data, this.#definition);
       return this.#result;
     } catch(err) {
-      console.error(err.message);
+      console.error(err);
       return false;
     }
   }
@@ -56,7 +55,6 @@ export class Filter {
    * Clear the cached result of the filter check and perform the check again.
    * @param {object} data  Arbitrary data object to check.
    * @returns {boolean}
-   * @throws
    */
   recheck(data) {
     this.#result = undefined;
@@ -105,15 +103,15 @@ export function uniqueKeys(filter=[]) {
 
 /**
  * Internal check implementation.
- * @param {object} data             Data to check.
- * @param {string} [keyPath]        Path to individual piece within data to check.
- * @param {*} value                 Value to compare against or additional filters.
- * @param {string} [operation="_"]  Checking function to use.
+ * @param {object} data                 Data to check.
+ * @param {string} [keyPath]            Path to individual piece within data to check.
+ * @param {*} value                     Value to compare against or additional filters.
+ * @param {string} [operation="exact"]  Checking function to use.
  * @returns {boolean}
  * @internal
  * @throws
  */
-function _check(data, keyPath, value, operation="_") {
+function _check(data, keyPath, value, operation="exact") {
   const operator = OPERATOR_FUNCTIONS[operation];
   if ( operator ) return operator(data, value);
 
@@ -222,7 +220,7 @@ export function NOT(data, filter) {
  * @enum {Function}
  */
 export const COMPARISON_FUNCTIONS = {
-  _: exact, exact, contains, icontains, startswith, istartswith, endswith,
+  exact, contains, icontains, startswith, istartswith, endswith, iendswith,
   has, hasany, hasall, in: in_, gt, gte, lt, lte
 };
 
@@ -296,6 +294,18 @@ export function istartswith(data, value) {
  */
 export function endswith(data, value) {
   return String(data).endsWith(String(value));
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Case-insensitive check that data ends with value.
+ * @param {*} data
+ * @param {*} value
+ * @returns {boolean}
+ */
+export function iendswith(data, value) {
+  return endswith(String(data).toLocaleLowerCase(game.i18n.lang), String(value).toLocaleLowerCase(game.i18n.lang));
 }
 
 /* -------------------------------------------- */

--- a/templates/apps/filters-editor.hbs
+++ b/templates/apps/filters-editor.hbs
@@ -1,0 +1,1 @@
+<code-mirror language="json" indent="2">{{ value }}</code-mirror>


### PR DESCRIPTION
Adds a new `FiltersField` that extends `JSONField` for handling filters. When this field is initialized it creates a new `Filter` object that makes it easy to check the filter and caches the result.

<img width="518" height="610" alt="Filter Input" src="https://github.com/user-attachments/assets/340c1968-636a-4114-b485-837086188f95" />

When placed into a form it displays a list of the filters and a button that opens the filter editor. The editor is currently just a `<code-mirror>` editor which will be replaced with a proper UI in the future.

Closes #6672