### PR TITLE
[#6154] Add new Region Behavior type for condition AE application

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -70,12 +70,14 @@
 "TYPES.Item.weaponPl": "Weapons",
 
 "TYPES.RegionBehavior": {
+  "dnd5e.applyActiveEffect": "Apply Active Effect (5e)",
   "dnd5e.difficultTerrain": "Difficult Terrain",
   "dnd5e.rotateArea": "Rotate Area"
 },
 
 "TYPES.HINTS": {
   "RegionBehavior": {
+    "dnd5e.applyActiveEffect": "Apply Active Effects to Tokens while they are within the Region and meet certain criteria.",
     "dnd5e.difficultTerrain": "Mark a region as being difficult terrain and set its type and who it affects.",
     "dnd5e.rotateArea": "Rotate tokens, tiles, walls, and other objects around a central pivot point."
   }
@@ -3596,6 +3598,26 @@
 "DND5E.RecoveryFormula": "Recovery Formula",
 
 "DND5E.REGIONBEHAVIORS": {
+  "APPLYACTIVEEFFECT": {
+    "FIELDS": {
+      "dispositions": {
+        "hint": "If set, only apply effects to Tokens with these dispositions.",
+        "label": "Dispositions"
+      },
+      "effects": {
+        "hint": "The effects that are applied to Tokens within the Region.",
+        "label": "Effects"
+      },
+      "sizes": {
+        "hint": "If set, only apply effects to Tokens that are these sizes.",
+        "label": "Sizes"
+      },
+      "types": {
+        "hint": "If set, only apply effects to Tokens that are these creature types.",
+        "label": "Types"
+      }
+    }
+  },
   "DIFFICULTTERRAIN": {
     "FIELDS": {
       "ignoredDispositions": {

--- a/module/data/region-behavior/_module.mjs
+++ b/module/data/region-behavior/_module.mjs
@@ -1,17 +1,21 @@
+import {default as ApplyActiveEffect5eRegionBehaviorType} from "./apply-active-effect.mjs";
 import {default as DifficultTerrainRegionBehaviorType} from "./difficult-terrain.mjs";
 import {default as RotateAreaRegionBehaviorType} from "./rotate-area.mjs";
 
 export {
+  ApplyActiveEffect5eRegionBehaviorType,
   DifficultTerrainRegionBehaviorType,
   RotateAreaRegionBehaviorType
 };
 
 export const config = {
+  "dnd5e.applyActiveEffect": ApplyActiveEffect5eRegionBehaviorType,
   "dnd5e.difficultTerrain": DifficultTerrainRegionBehaviorType,
   "dnd5e.rotateArea": RotateAreaRegionBehaviorType
 };
 
 export const icons = {
+  "dnd5e.applyActiveEffect": "fa-solid fa-person-rays",
   "dnd5e.difficultTerrain": "fa-solid fa-hill-rockslide",
   "dnd5e.rotateArea": "fa-solid fa-arrows-spin"
 };

--- a/module/data/region-behavior/_types.mjs
+++ b/module/data/region-behavior/_types.mjs
@@ -1,9 +1,21 @@
 /**
+ * @typedef ApplyActiveEffectRegionBehaviorSystemData
+ * @property {Set<string>} effects       UUIDs of effects to apply.
+ * @property {Set<number>} dispositions  If not empty, only apply effects to tokens with these dispositions.
+ * @property {Set<string>} sizes         If not empty, only apply effects to tokens with these sizes.
+ * @property {Set<string>} types         If not empty, only apply effects to tokens with these creature types.
+ */
+
+/* ---------------------------------------- */
+
+/**
  * @typedef DifficultTerrainRegionBehaviorSystemData
  * @property {boolean} magical                  This difficult terrain is caused by magic.
  * @property {Set<string>} types                Types of difficult terrain represented.
  * @property {Set<number>} ignoredDispositions  Token dispositions that won't be affected by this difficult terrain.
  */
+
+/* ---------------------------------------- */
 
 /**
  * @typedef RotateAreaRegionBehaviorSystemData

--- a/module/data/region-behavior/apply-active-effect.mjs
+++ b/module/data/region-behavior/apply-active-effect.mjs
@@ -1,0 +1,112 @@
+const { DocumentUUIDField, NumberField, SetField, StringField } = foundry.data.fields;
+
+/**
+ * @import { ApplyActiveEffectRegionBehaviorSystemData } from "./_types.mjs";
+ */
+
+/**
+ * The data model for a region behavior that applies active effects to certain tokens.
+ * @extends {foundry.data.regionBehaviors.RegionBehaviorType<ApplyActiveEffectRegionBehaviorSystemData>}
+ * @mixes ApplyActiveEffectRegionBehaviorSystemData
+ */
+export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.regionBehaviors.RegionBehaviorType {
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.REGIONBEHAVIORS.APPLYACTIVEEFFECT"];
+
+  /* ---------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    const dispositions = { ...foundry.applications.sheets.TokenConfig.TOKEN_DISPOSITIONS };
+    delete dispositions[CONST.TOKEN_DISPOSITIONS.SECRET];
+    return {
+      effects: new SetField(new DocumentUUIDField({ type: "ActiveEffect", nullable: false })),
+      dispositions: new SetField(new NumberField({ choices: dispositions })),
+      sizes: new SetField(new StringField({ choices: () => CONFIG.DND5E.actorSizes })),
+      types: new SetField(new StringField({ choices: () => CONFIG.DND5E.creatureTypes }))
+      // TODO: Add FiltersField for arbitrary conditions once https://github.com/foundryvtt/dnd5e/issues/6672 is done
+    };
+  }
+
+  /* ---------------------------------------- */
+  /*  Methods                                 */
+  /* ---------------------------------------- */
+
+  /**
+   * Check the conditions to decide if effects should be added to this token.
+   * @param {TokenDocument5e} token  The token to which to add the effects.
+   * @returns {boolean}
+   */
+  #evaluateConditions(token) {
+    if ( this.dispositions.size && !this.dispositions.has(token.disposition) ) return false;
+    if ( this.sizes.size && !this.sizes.has(token.actor.system.traits?.size) ) return false;
+    if ( this.types.size && !this.types.has(token.actor.system.details?.type?.value) ) return false;
+    return true;
+  }
+
+  /* ---------------------------------------- */
+
+  /**
+   * Apply the Active Effects when the Token enters the Region.
+   * @param {RegionTokenEnterEvent} event
+   * @this {ApplyActiveEffect5eRegionBehaviorType}
+   */
+  static async #onTokenEnter(event) {
+    if ( !event.user.isSelf ) return;
+    const { token, movement } = event.data;
+    const actor = token.actor;
+    if ( !actor || !this.#evaluateConditions(token) ) return;
+    const resumeMovement = movement ? token.pauseMovement() : undefined;
+    const effects = await Promise.all(this.effects.map(fromUuid));
+    const toCreate = [];
+    for ( const effect of effects ) {
+      const data = effect.toObject();
+      delete data._id;
+      if ( effect.compendium ) {
+        data._stats.duplicateSource = null;
+        data._stats.compendiumSource = effect.uuid;
+      } else {
+        data._stats.duplicateSource = effect.uuid;
+        data._stats.compendiumSource = null;
+      }
+      data._stats.exportSource = null;
+      data.origin = this.parent.uuid;
+      toCreate.push(data);
+    }
+    if ( toCreate.length ) await actor.createEmbeddedDocuments("ActiveEffect", toCreate);
+    await resumeMovement?.();
+  }
+
+  /* ---------------------------------------- */
+
+  /**
+   * Un-apply the Active Effects when the Token exists the Region.
+   * @param {RegionTokenExitEvent} event
+   * @this {ApplyActiveEffect5eRegionBehaviorType}
+   */
+  static async #onTokenExit(event) {
+    if ( !event.user.isSelf ) return;
+    const { token, movement } = event.data;
+    const actor = token.actor;
+    if ( !actor ) return;
+    const toDelete = [];
+    for ( const effect of actor.effects ) {
+      if ( effect.origin === this.parent.uuid ) {
+        toDelete.push(effect.id);
+      }
+    }
+    if ( !toDelete.length ) return;
+    const resumeMovement = movement ? token.pauseMovement() : undefined;
+    await actor.deleteEmbeddedDocuments("ActiveEffect", toDelete);
+    await resumeMovement?.();
+  }
+
+  /* ---------------------------------------- */
+
+  /** @override */
+  static events = {
+    [CONST.REGION_EVENTS.TOKEN_ENTER]: this.#onTokenEnter,
+    [CONST.REGION_EVENTS.TOKEN_EXIT]: this.#onTokenExit
+  };
+}

--- a/module/data/region-behavior/apply-active-effect.mjs
+++ b/module/data/region-behavior/apply-active-effect.mjs
@@ -59,21 +59,7 @@ export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.
     if ( !actor || !this.#evaluateConditions(token) ) return;
     const resumeMovement = movement ? token.pauseMovement() : undefined;
     const effects = await Promise.all(this.effects.map(fromUuid));
-    const toCreate = [];
-    for ( const effect of effects ) {
-      const data = effect.toObject();
-      delete data._id;
-      if ( effect.compendium ) {
-        data._stats.duplicateSource = null;
-        data._stats.compendiumSource = effect.uuid;
-      } else {
-        data._stats.duplicateSource = effect.uuid;
-        data._stats.compendiumSource = null;
-      }
-      data._stats.exportSource = null;
-      data.origin = this.parent.uuid;
-      toCreate.push(data);
-    }
+    const toCreate = this.#getEffectsToCreate(actor, effects);
     if ( toCreate.length ) await actor.createEmbeddedDocuments("ActiveEffect", toCreate);
     await resumeMovement?.();
   }
@@ -81,7 +67,7 @@ export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.
   /* ---------------------------------------- */
 
   /**
-   * Un-apply the Active Effects when the Token exists the Region.
+   * Un-apply the Active Effects when the Token exits the Region.
    * @param {RegionTokenExitEvent} event
    * @this {ApplyActiveEffect5eRegionBehaviorType}
    */
@@ -90,12 +76,7 @@ export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.
     const { token, movement } = event.data;
     const actor = token.actor;
     if ( !actor ) return;
-    const toDelete = [];
-    for ( const effect of actor.effects ) {
-      if ( effect.origin === this.parent.uuid ) {
-        toDelete.push(effect.id);
-      }
-    }
+    const toDelete = this.#getEffectsToDelete(actor);
     if ( !toDelete.length ) return;
     const resumeMovement = movement ? token.pauseMovement() : undefined;
     await actor.deleteEmbeddedDocuments("ActiveEffect", toDelete);
@@ -109,4 +90,90 @@ export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.
     [CONST.REGION_EVENTS.TOKEN_ENTER]: this.#onTokenEnter,
     [CONST.REGION_EVENTS.TOKEN_EXIT]: this.#onTokenExit
   };
+
+  /* ---------------------------------------- */
+
+  /** @inheritDoc */
+  _onUpdate(changed, options, userId) {
+    super._onUpdate(changed, options, userId);
+    if ( !this.behavior.active || !("system" in changed) ) return;
+    this.#recreateEffectsForAllTokens();
+  }
+
+  /* ---------------------------------------- */
+
+  /**
+   * Recreate the effects of tokens within the region.
+   * @returns {Promise<void>}
+   */
+  async #recreateEffectsForAllTokens() {
+    const effects = await Promise.all(this.effects.map(fromUuid));
+    const operations = [];
+    for ( const token of this.region.tokens ) {
+      const actor = token.actor;
+      if ( !actor ) continue;
+      const toDelete = this.#getEffectsToDelete(actor);
+      if ( toDelete.length ) {
+        operations.push({
+          action: "delete",
+          documentName: "ActiveEffect",
+          ids: toDelete,
+          parent: actor
+        });
+      }
+      if ( !this.#evaluateConditions(token) ) continue;
+      const toCreate = this.#getEffectsToCreate(actor, effects);
+      if ( toCreate.length ) {
+        operations.push({
+          action: "create",
+          documentName: "ActiveEffect",
+          data: toCreate,
+          parent: actor
+        });
+      }
+    }
+    await foundry.documents.modifyBatch(operations);
+  }
+
+  /* ---------------------------------------- */
+
+  /**
+   * Get Active Effects that should be created for the Actor.
+   * @param {Actor54} actor            The actor the Active Effects should be created for.
+   * @param {ActiveEffect5e]} effects  The effects the Active Effects are created from.
+   * @returns {ActiveEffectData[]}     The data of Active Effects that should be created.
+   */
+  #getEffectsToCreate(actor, effects) {
+    const toCreate = [];
+    for ( const effect of effects ) {
+      if ( !effect ) continue;
+      const data = effect.toObject();
+      delete data._id;
+      if ( effect.compendium ) {
+        data._stats.duplicateSource = null;
+        data._stats.compendiumSource = effect.uuid;
+      } else {
+        data._stats.duplicateSource = effect.uuid;
+        data._stats.compendiumSource = null;
+      }
+      data._stats.exportSource = null;
+      data.origin = this.behavior.uuid;
+      toCreate.push(data);
+    }
+    return toCreate;
+  }
+
+  /* ---------------------------------------- */
+
+  /**
+   * Get Active Effects that should be deleted from the Actor.
+   * @param {Actor5e} actor  The actor the Active Effects should be deleted from.
+   * @returns {string[]}     The IDs of Active Effects that should be deleted.
+   */
+  #getEffectsToDelete(actor) {
+    return actor.effects.reduce((ids, effect) => {
+      if ( effect.origin === this.behavior.uuid ) ids.push(effect.id);
+      return ids;
+    }, []);
+  }
 }

--- a/system.json
+++ b/system.json
@@ -150,6 +150,7 @@
       }
     },
     "RegionBehavior": {
+      "dnd5e.applyActiveEffect": {},
       "dnd5e.difficultTerrain": {},
       "dnd5e.rotateArea": {}
     }


### PR DESCRIPTION
Adds a new Region Behavior that behaves the same as core's Apply Active Effect behavior but with some extra conditions that are evaluated before applying the effect. Tokens can be filtered by disposition, size, and creature type.

<img width="495" height="794" alt="Apply Effect Behavior" src="https://github.com/user-attachments/assets/454e602e-7dcf-4d5c-997b-3c05fb6e4d5a" />

Closes #6154