### PR TITLE
[#6823] Call recover uses at top of combat round

### DIFF
--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -117,6 +117,14 @@ export default class Combat5e extends Combat {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  async _onStartRound(combatant) {
+    await super._onStartRound(combatant);
+    this._recoverUses({ round: true });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   async _onStartTurn(combatant) {
     await super._onStartTurn(combatant);
     this._recoverUses({ turn: true, turnStart: combatant });


### PR DESCRIPTION
Calls the combat recovery system at the top of the combat round for all combatants using the `round` recovery.

Closes #6823