### PR TITLE
Add sort density to `sort` of newly created activities

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -911,7 +911,10 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const activity = new cls({ type, ...data }, { parent: this });
     if ( activity._preCreate(createData) === false ) return;
 
-    await this.update({ [`system.activities.${activity.id}`]: activity.toObject() });
+    const sort = this.system.activities.size
+      ? Math.max(...this.system.activities.map(a => a.sort)) + CONST.SORT_INTEGER_DENSITY
+      : 0;
+    await this.update({ [`system.activities.${activity.id}`]: { ...activity.toObject(), sort } });
     const created = this.system.activities.get(activity.id);
     if ( renderSheet ) return created.sheet?.render({ force: true });
   }


### PR DESCRIPTION
All activities have initially `sort: 0` which means sometimes a new activity is at the top, sometimes at the bottom, sometimes in the middle, it's a toss-up depending on the sort values which can be negative or positive.

This PR increments newly added activities so the newest is always a higher `sort` (works with manual creation and drag-drop).