### PR TITLE
Add migration progress bars for packs

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -578,7 +578,7 @@ Hooks.once("ready", function() {
 
   // Perform the migration
   if ( cv && foundry.utils.isNewerVersion(game.system.flags.compatibleMigrationVersion, cv) ) {
-    ui.notifications.error("MIGRATION.5eVersionTooOldWarning", { permanent: true });
+    ui.notifications.error("MIGRATION.DND5E.Warning.VersionTooOld", { permanent: true });
   }
   migrations.migrateWorld();
 });

--- a/lang/en.json
+++ b/lang/en.json
@@ -5828,6 +5828,7 @@
 
 "MIGRATION.DND5E": {
   "Compendium": {
+    "Failed": "Migration failed for compendium {compendium}.",
     "Migrate": "Migrating compendium {compendium} for version {version}.",
     "Refresh": "Refreshing compendium {compendium}."
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -5826,9 +5826,19 @@
 "MACRO.5eNoActorSelected": "No selected or assigned actor could be found to target with macro.",
 "MACRO.5eUnownedWarn": "You can only create macro buttons for owned Items",
 
-"MIGRATION.5eBegin": "Applying D&D 5e System Migration for version {version}. Please be patient and do not close your game or shut down your server.",
-"MIGRATION.5eComplete": "D&D 5e System Migration to version {version} completed!",
-"MIGRATION.5eVersionTooOldWarning": "Your D&D 5e system data is from too old a Foundry version and cannot be reliably migrated to the latest version. The process will be attempted, but errors may occur.",
+"MIGRATION.DND5E": {
+  "Compendium": {
+    "Migrate": "Migrating compendium {compendium} for version {version}.",
+    "Refresh": "Refreshing compendium {compendium}."
+  },
+  "World": {
+    "Begin": "Applying D&D 5e System Migration for version {version}. Please be patient and do not close your game or shut down your server.",
+    "Complete": "D&D 5e System Migration to version {version} completed!"
+  },
+  "Warning": {
+    "VersionTooOld": "Your D&D 5e system data is from too old a Foundry version and cannot be reliably migrated to the latest version. The process will be attempted, but errors may occur."
+  }
+},
 
 "SETTINGS.5eAutoCollapseCardL": "Automatically collapse Item Card descriptions in the Chat Log",
 "SETTINGS.5eAutoCollapseCardN": "Collapse Item Cards in Chat",

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -286,7 +286,11 @@ export async function migrateCompendium(pack, { bypassVersionCheck=false, increm
         err.message = `Failed dnd5e system migration for document ${doc.name} in pack ${pack.collection}: ${err.message}`;
         console.error(err);
         hasErrors = true;
-        if ( strict ) throw err;
+        if ( strict ) {
+          progress.element?.classList.add("error");
+          progress.update({ format, message: "MIGRATION.DND5E.Compendium.Failed" });
+          throw err;
+        }
       }
 
       finally {
@@ -354,7 +358,7 @@ export function reparentCompendiums(from, to) {
  * @param {boolean} [options.migrate=true]  Also perform a system migration before refreshing.
  * @param {string} [options.package]        Only update compendiums belonging to this package.
  */
-export async function refreshAllCompendiums(options) {
+export async function refreshAllCompendiums(options={}) {
   for ( const pack of game.packs ) {
     if ( options.package && (options.package !== pack.metadata.packageName) ) continue;
     await refreshCompendium(pack, options);

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -9,7 +9,7 @@ import { formatIdentifier, log } from "./utils.mjs";
  */
 export async function migrateWorld({ bypassVersionCheck=false }={}) {
   const version = game.system.version;
-  const progress = ui.notifications.info("MIGRATION.5eBegin", {
+  const progress = ui.notifications.info("MIGRATION.DND5E.World.Begin", {
     console: false, format: { version }, permanent: true, progress: true
   });
   const { packs, packDocuments } = game.packs.reduce((obj, pack) => {
@@ -191,7 +191,7 @@ export async function migrateWorld({ bypassVersionCheck=false }={}) {
   // Set the migration as complete
   game.settings.set("dnd5e", "systemMigrationVersion", game.system.version);
   progress.element?.classList.add(hasErrors ? "warning" : "success");
-  progress.update({ message: "MIGRATION.5eComplete", format: { version }, pct: 1 });
+  progress.update({ message: "MIGRATION.DND5E.World.Complete", format: { version }, pct: 1 });
 }
 
 /* -------------------------------------------- */
@@ -229,6 +229,13 @@ function _shouldMigrateCompendium(pack) {
 export async function migrateCompendium(pack, { bypassVersionCheck=false, incrementProgress, strict=false }={}) {
   const documentName = pack.documentName;
   if ( !["Actor", "Item", "Scene"].includes(documentName) ) return;
+
+  const format = { compendium: pack.collection, version: game.system.version };
+  const progress = ui.notifications.info("MIGRATION.DND5E.Compendium.Migrate", {
+    console: false, format, permanent: true, progress: true
+  });
+  let hasErrors = false;
+  let migrated = 0;
 
   const migrationData = await getMigrationData();
 
@@ -278,20 +285,25 @@ export async function migrateCompendium(pack, { bypassVersionCheck=false, increm
       catch(err) {
         err.message = `Failed dnd5e system migration for document ${doc.name} in pack ${pack.collection}: ${err.message}`;
         console.error(err);
+        hasErrors = true;
         if ( strict ) throw err;
       }
 
       finally {
         incrementProgress?.();
+        progress.update({ pct: ++migrated / pack.index.size });
       }
     }
 
     log(`Migrated all ${documentName} documents from Compendium ${pack.collection}`);
   } finally {
     // Apply the original locked status for the pack
-    await pack.configure({locked: wasLocked});
+    await pack.configure({ locked: wasLocked });
     game.compendiumArt.enabled = true;
   }
+
+  progress.element?.classList.add(hasErrors ? "warning" : "success");
+  progress.update({ format, message: "MIGRATION.DND5E.Compendium.Migrate", pct: 1 });
 }
 
 /* -------------------------------------------- */
@@ -340,9 +352,11 @@ export function reparentCompendiums(from, to) {
  * @param {boolean} [options.bypassVersionCheck=false]  Bypass certain migration restrictions gated behind system
  *                                                      version stored in item stats.
  * @param {boolean} [options.migrate=true]  Also perform a system migration before refreshing.
+ * @param {string} [options.package]        Only update compendiums belonging to this package.
  */
 export async function refreshAllCompendiums(options) {
   for ( const pack of game.packs ) {
+    if ( options.package && (options.package !== pack.metadata.packageName) ) continue;
     await refreshCompendium(pack, options);
   }
 }
@@ -369,21 +383,31 @@ export async function refreshCompendium(pack, { bypassVersionCheck, migrate=true
     }
   }
 
+  const format = { compendium: pack.collection };
+  const progress = ui.notifications.info("MIGRATION.DND5E.Compendium.Refresh", {
+    console: false, format, permanent: true, progress: true
+  });
+  let migrated = 0;
+
   game.compendiumArt.enabled = false;
   const DocumentClass = CONFIG[pack.documentName].documentClass;
   const wasLocked = pack.locked;
-  await pack.configure({locked: false});
+  await pack.configure({ locked: false });
 
-  ui.notifications.info(`Beginning to refresh Compendium ${pack.collection}`);
   const documents = await pack.getDocuments();
   for ( const doc of documents ) {
     const data = doc.toObject();
     await doc.delete();
     await DocumentClass.create(data, {keepId: true, keepEmbeddedIds: true, pack: pack.collection});
+    log(`Refreshed ${pack.documentName} document ${doc.name} in Compendium ${pack.collection}`);
+    progress.update({ pct: ++migrated / pack.index.size });
   }
-  await pack.configure({locked: wasLocked});
+
+  await pack.configure({ locked: wasLocked });
   game.compendiumArt.enabled = true;
-  ui.notifications.info(`Refreshed all documents from Compendium ${pack.collection}`);
+
+  progress.element?.classList.add("success");
+  progress.update({ format, message: "MIGRATION.DND5E.Compendium.Refresh", pct: 1 });
 }
 
 /* -------------------------------------------- */


### PR DESCRIPTION
Adds progress bars for the compendium migration & refresh methods to give a better idea of the progress. Also added console logs in the refresh method to make it clear what document is currently being refreshed in case of errors.

Also adds an option to `refreshAllCompendiums` to specify a package ID and only migrate the compendiums from that package.