### PR TITLE
[#6846] Add fractional currency support on actor sheets, conversion

### DIFF
--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -227,6 +227,8 @@
  * @property {string} label         Localized label for the currency.
  * @property {string} abbreviation  Localized abbreviation for the currency.
  * @property {number} conversion    Number by which this currency should be multiplied to arrive at a standard value.
+ * @property {integer} [fractionalDigits=0]  Number of digits to round currency values of this denomination to. Set to
+ *                                           Infinity to prevent any rounding of the value.
  * @property {string} icon          Icon representing the currency in the interface.
  */
 

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -227,8 +227,8 @@
  * @property {string} label         Localized label for the currency.
  * @property {string} abbreviation  Localized abbreviation for the currency.
  * @property {number} conversion    Number by which this currency should be multiplied to arrive at a standard value.
- * @property {integer} [fractionalDigits=0]  Number of digits to round currency values of this denomination to. Set to
- *                                           Infinity to prevent any rounding of the value.
+ * @property {number} [fractionalDigits=0]  Number of digits to round currency values of this denomination to. Set to
+ *                                          Infinity to prevent any rounding of the value.
  * @property {string} icon          Icon representing the currency in the interface.
  */
 

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -291,7 +291,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
 
     // Currency
     context.currency = Object.fromEntries(
-      Object.keys(CONFIG.DND5E.currencies).map(k => [k, this.inventorySource.system._source.currency[k] ?? 0])
+      Object.keys(CONFIG.DND5E.currencies).map(k => [k, this.inventorySource.system.currency[k] ?? 0])
     );
 
     // Containers

--- a/module/applications/award.mjs
+++ b/module/applications/award.mjs
@@ -1,4 +1,4 @@
-import { filteredKeys, formatNumber } from "../utils.mjs";
+import { filteredKeys, formatNumber, roundCurrency } from "../utils.mjs";
 import Application5e from "./api/application.mjs";
 
 /**
@@ -231,7 +231,7 @@ export default class Award extends Application5e {
         if ( !amount ) continue;
         amount = Math.clamp(
           // Divide amount between remaining destinations
-          Math.floor(amount / remainingDestinations),
+          roundCurrency(amount / remainingDestinations, key),
           // Ensure negative amounts aren't more than is contained in destination
           -destination.system.currency[key],
           // Ensure positive amounts aren't more than is contained in origin

--- a/module/applications/currency-manager.mjs
+++ b/module/applications/currency-manager.mjs
@@ -1,4 +1,4 @@
-import { filteredKeys } from "../utils.mjs";
+import { filteredKeys, roundCurrency } from "../utils.mjs";
 import Award from "./award.mjs";
 import Application5e from "./api/application.mjs";
 
@@ -228,7 +228,7 @@ export default class CurrencyManager extends Application5e {
     // Convert base units into the highest denomination possible
     for ( const [denomination, config] of currencies) {
       const ratio = smallestConversion / config.conversion;
-      currency[denomination] = Math.floor(amount / ratio);
+      currency[denomination] = roundCurrency(amount / ratio, denomination);
       amount -= currency[denomination] * ratio;
     }
 
@@ -288,10 +288,10 @@ export default class CurrencyManager extends Application5e {
       updates = { system: { currency: { ...currency } }, remainder: amount, item: [] };
       for ( const [denom, conversion] of currencies ) {
         const multiplier = conversion / baseConversion;
-        const deduct = Math.min(updates.system.currency[denom], Math.floor(updates.remainder * multiplier));
+        const deduct = Math.min(updates.system.currency[denom], roundCurrency(updates.remainder * multiplier, denom));
         // Handle normal deduction first.
         updates.remainder -= deduct / multiplier;
-        updates.system.currency[denom] -= deduct;
+        updates.system.currency[denom] = roundCurrency(updates.system.currency[denom] - deduct, denom);
         // If there's still a remainder, break the denomination into change.
         if ( updates.remainder && makeChange && (conversion < baseConversion) && updates.system.currency[denom] ) {
           const rate = Math.floor(baseConversion / conversion);
@@ -300,7 +300,9 @@ export default class CurrencyManager extends Application5e {
           updates.system.currency[denomination] += breaks * rate;
           const change = Math.min(updates.system.currency[denomination], updates.remainder);
           updates.remainder -= change;
-          updates.system.currency[denomination] -= change;
+          updates.system.currency[denomination] = roundCurrency(
+            updates.system.currency[denomination] - change, denomination
+          );
         }
         if ( !updates.remainder ) return updates;
       }

--- a/module/applications/currency-manager.mjs
+++ b/module/applications/currency-manager.mjs
@@ -148,7 +148,7 @@ export default class CurrencyManager extends Application5e {
    */
   static #setTransferValue(event, target) {
     for ( let [key, value] of Object.entries(this.document.system.currency) ) {
-      if ( target.dataset.action === "setHalf" ) value = Math.floor(value / 2);
+      if ( target.dataset.action === "setHalf" ) value = roundCurrency(value / 2, key);
       const input = this.element.querySelector(`[name="amount.${key}"]`);
       if ( input && value ) input.value = value;
     }
@@ -293,7 +293,8 @@ export default class CurrencyManager extends Application5e {
         updates.remainder -= deduct / multiplier;
         updates.system.currency[denom] = roundCurrency(updates.system.currency[denom] - deduct, denom);
         // If there's still a remainder, break the denomination into change.
-        if ( updates.remainder && makeChange && (conversion < baseConversion) && updates.system.currency[denom] ) {
+        if ( !updates.remainder.almostEqual(0) && makeChange && (conversion < baseConversion)
+          && updates.system.currency[denom] ) {
           const rate = Math.floor(baseConversion / conversion);
           const breaks = Math.min(updates.system.currency[denom], Math.ceil(updates.remainder / rate));
           updates.system.currency[denom] -= breaks;
@@ -304,7 +305,7 @@ export default class CurrencyManager extends Application5e {
             updates.system.currency[denomination] - change, denomination
           );
         }
-        if ( !updates.remainder ) return updates;
+        if ( updates.remainder.almostEqual(0) ) return updates;
       }
       currencies.push(currencies.shift());
       passes--;

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -135,7 +135,7 @@ export default class ContainerSheet extends ItemSheet5e {
     inventory.forEach(s => s.minWidth = 190);
     context.inventory = Inventory.prepareSections(inventory);
     context.listControls = foundry.utils.deepClone(ItemListControlsElement.CONFIG.inventory);
-    context.currency = context.source.currency;
+    context.currency = context.currency;
     context.showCurrency = true;
     this._items = context.items;
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -223,6 +223,7 @@ export default class CharacterData extends CreatureTemplate {
 
     AttributesFields.prepareExhaustionLevel.call(this);
     this.prepareAbilities({ rollData, originalSaves });
+    this.prepareCurrency();
     this.prepareSkills({ rollData, originalSkills });
     this.prepareTools({ rollData });
     AttributesFields.prepareArmorClass.call(this, rollData);

--- a/module/data/actor/encounter.mjs
+++ b/module/data/actor/encounter.mjs
@@ -70,6 +70,14 @@ export default class EncounterData extends GroupTemplate {
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    this.prepareCurrency();
+  }
+
+  /* -------------------------------------------- */
   /*  Methods                                     */
   /* -------------------------------------------- */
 

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -176,6 +176,7 @@ export default class GroupData extends GroupTemplate {
   /** @inheritDoc */
   prepareDerivedData() {
     const rollData = this.parent.getRollData({ deterministic: true });
+    this.prepareCurrency();
     TravelField.prepareData.call(this, rollData);
   }
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -415,6 +415,7 @@ export default class NPCData extends CreatureTemplate {
     const { originalSaves, originalSkills } = this.parent.getOriginalStats();
 
     this.prepareAbilities({ rollData, originalSaves });
+    this.prepareCurrency();
     this.prepareSkills({ rollData, originalSkills });
     this.prepareTools({ rollData });
     AttributesFields.prepareArmorClass.call(this, rollData);

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -272,6 +272,7 @@ export default class VehicleData extends CommonTemplate {
     const { originalSaves } = this.parent.getOriginalStats();
 
     this.prepareAbilities({ rollData, originalSaves });
+    this.prepareCurrency();
     AttributesFields.prepareArmorClass.call(this, rollData);
     if ( this.attributes.ac.value ) {
       this.attributes.ac.motionless = this.attributes.ac.value - Math.max(0, this.abilities.dex?.mod ?? 0);

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -306,6 +306,7 @@ export default class ContainerData extends ItemDataModel.mixin(
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+    this.prepareCurrency();
     this.prepareDescriptionData();
     this.prepareIdentifiable();
     this.preparePhysicalData();

--- a/module/data/shared/currency.mjs
+++ b/module/data/shared/currency.mjs
@@ -1,3 +1,4 @@
+import { roundCurrency } from "../../utils.mjs";
 import SystemDataModel from "../abstract/system-data-model.mjs";
 import MappingField from "../fields/mapping-field.mjs";
 
@@ -10,8 +11,8 @@ export default class CurrencyTemplate extends SystemDataModel {
   static defineSchema() {
     return {
       currency: new MappingField(new foundry.data.fields.NumberField({
-        required: true, nullable: false, integer: true, min: 0, initial: 0
-      }), {initialKeys: CONFIG.DND5E.currencies, initialKeysOnly: true, label: "DND5E.Currency"})
+        required: true, nullable: false, min: 0, initial: 0
+      }), { initialKeys: CONFIG.DND5E.currencies, initialKeysOnly: true, label: "DND5E.Currency" })
     };
   }
 
@@ -30,5 +31,18 @@ export default class CurrencyTemplate extends SystemDataModel {
       ? CONFIG.DND5E.encumbrance.currencyPerWeight.metric
       : CONFIG.DND5E.encumbrance.currencyPerWeight.imperial;
     return count / currencyPerWeight;
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare currencies, rounding non-fractional currencies.
+   */
+  prepareCurrency() {
+    for ( const [key, value] of Object.entries(this.currency) ) {
+      this.currency[key] = roundCurrency(value, key);
+    }
   }
 }

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -32,6 +32,24 @@ export function getCollectionDocumentOptions(collection, { disabled }={}) {
 }
 
 /* -------------------------------------------- */
+/*  Currencies                                  */
+/* -------------------------------------------- */
+
+/**
+ * Round a specific denomination to the number of digits specified in the configuration.
+ * @param {number} value         Currency value to round.
+ * @param {string} denomination  Denomination that the value represents.
+ * @returns {number}
+ */
+export function roundCurrency(value, denomination) {
+  const fractionalDigits = CONFIG.DND5E.currencies[denomination]?.fractionalDigits;
+  if ( !fractionalDigits ) return Math.floor(value);
+  if ( !Number.isFinite(fractionalDigits) ) return value;
+  const pow = Math.pow(10, fractionalDigits);
+  return Math.floor(value * pow) / pow;
+}
+
+/* -------------------------------------------- */
 /*  Formatters                                  */
 /* -------------------------------------------- */
 


### PR DESCRIPTION
Allows specific currency denominations to specify a number of fractional digits they support. If set, this will allow those denominations to use decimals on the actor sheets and all rounding during currency conversions and adjustments will take those values into account.

Currently doesn't enforce this within item data because they allow fractional values already and enforcing this value now might lead to existing items having the incorrect prices.

Closes #6846