### PR TITLE
[#6860] Add syntax for specifying limit when modifying number field

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -247,24 +247,19 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( (field instanceof NumberField)
       && (((change.type === "add") && change.value.includes?.("<="))
       || ((change.type === "subtract") && change.value.includes?.(">="))) ) {
-      let [value, limit] = change.value.split(/<=|>=/);
+      let [delta, limit] = change.value.split(/<=|>=/);
       try {
+        delta = simplifyBonus(field._replaceDataRefs(delta, replacementData), {}, { strict: true });
         limit = simplifyBonus(field._replaceDataRefs(limit, replacementData), {}, { strict: true });
       } catch(err) {
         const warningHeader = change.effect ? `Active Effect (${change.effect.uuid}) | ` : "";
         console.warn(`${warningHeader} "${change.type}" change to ${change.key} failed to resolve: ${err.message}`);
         return current;
       }
-      const newValue = super.applyChangeField(
-        model, { ...change, value }, { field, ...options, modifyTarget: false }
-      );
-      if ( (change.type === "add") && (newValue > limit) ) {
-        change.value = `max(0, ${value} - ${newValue - limit})`;
-      } else if ( (change.type === "subtract") && (newValue < limit) ) {
-        change.value = `min(0, ${value} + ${limit - newValue})`;
-      } else {
-        change.value = value;
-      }
+      const result = change.type === "add"
+        ? Math.max(current, Math.min(current + delta, limit))
+        : Math.min(current, Math.max(current - delta, limit));
+      return super.applyChangeField(model, { ...change, type: "override", value: result }, options);
     }
 
     // If current value is `null`, UPGRADE & DOWNGRADE should always just set the value

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -1,12 +1,12 @@
 import CreateDocumentDialog from "../applications/create-document-dialog.mjs";
 import FormulaField from "../data/fields/formula-field.mjs";
 import MappingField from "../data/fields/mapping-field.mjs";
-import { parseOrString, staticID } from "../utils.mjs";
+import { parseOrString, simplifyBonus, staticID } from "../utils.mjs";
 import Item5e from "./item.mjs";
 import DependentDocumentMixin from "./mixins/dependent.mjs";
 
 const TextEditor = foundry.applications.ux.TextEditor.implementation;
-const { ObjectField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { NumberField, ObjectField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { FavoriteData5e } from "../data/abstract/_types.mjs";
@@ -236,11 +236,35 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   static applyChangeField(model, change, options={}) {
     const current = foundry.utils.getProperty(model, change.key);
-    const { field } = options;
+    const { field, replacementData } = options;
 
     // Replace value when using string interpolation syntax
     if ( (field instanceof StringField) && (change.type === "override") && change.value?.includes?.("{}") ) {
       change.value = change.value.replace("{}", current ?? "");
+    }
+
+    // Handle `<=` when adding and `>=` when subtracting from number fields
+    if ( (field instanceof NumberField)
+      && (((change.type === "add") && change.value.includes?.("<="))
+      || ((change.type === "subtract") && change.value.includes?.(">="))) ) {
+      let [value, limit] = change.value.split(/<=|>=/);
+      try {
+        limit = simplifyBonus(field._replaceDataRefs(limit, replacementData), {}, { strict: true });
+      } catch(err) {
+        const warningHeader = change.effect ? `Active Effect (${change.effect.uuid}) | ` : "";
+        console.warn(`${warningHeader} "${change.type}" change to ${change.key} failed to resolve: ${err.message}`);
+        return current;
+      }
+      const newValue = super.applyChangeField(
+        model, { ...change, value }, { field, ...options, modifyTarget: false }
+      );
+      if ( (change.type === "add") && (newValue > limit) ) {
+        change.value = `max(0, ${value} - ${newValue - limit})`;
+      } else if ( (change.type === "subtract") && (newValue < limit) ) {
+        change.value = `min(0, ${value} + ${limit - newValue})`;
+      } else {
+        change.value = value;
+      }
     }
 
     // If current value is `null`, UPGRADE & DOWNGRADE should always just set the value

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -446,16 +446,19 @@ export function replaceFormulaData(formula, data, { actor, item, missing="0", pr
  * Convert a bonus value to a simple integer for displaying on the sheet.
  * @param {number|string|null} bonus  Bonus formula.
  * @param {object} [data={}]          Data to use for replacing @ strings.
+ * @param {object} [options={}]
+ * @param {boolean} [option.strict]   Throw error if evaluation fails.
  * @returns {number}                  Simplified bonus as an integer.
  * @protected
  */
-export function simplifyBonus(bonus, data={}) {
+export function simplifyBonus(bonus, data={}, { strict }={}) {
   if ( !bonus ) return 0;
   if ( Number.isNumeric(bonus) ) return Number(bonus);
   try {
     const roll = new Roll(bonus, data);
     return roll.isDeterministic ? roll.evaluateSync().total : 0;
   } catch(error) {
+    if ( strict ) throw error;
     console.error(error);
     return 0;
   }


### PR DESCRIPTION
Adds a new syntax to the change value for `NumberField` that allows for specifying a maximum or minimum when adding or subtracting:

- `system.abilities.str.value | ADD | 2 <= 20`
- `flags.dnd5e.weaponCriticalThreshold | SUBTRACT | 1 >= 16`

Also supports formulas within the limit:

- `system.abilities.str.value | ADD | 2 <= 18 + @prof`

Closes #6860