### PR TITLE
[#6868] Fix error thrown when updating unparented Advancements.

### DIFF
--- a/module/data/advancement/trait.mjs
+++ b/module/data/advancement/trait.mjs
@@ -50,6 +50,7 @@ export class TraitConfigurationData extends foundry.abstract.DataModel {
   /** @inheritDoc */
   static migrateData(source) {
     super.migrateData(source);
+    if ( !source ) return source;
     const version = dnd5e.settings.rulesVersion;
     const languageMap = LANGUAGE_MAP[version] ?? {};
     if ( source.grants?.length ) source.grants = source.grants.map(t => languageMap[t] ?? t);
@@ -80,6 +81,7 @@ export class TraitValueData extends foundry.abstract.DataModel {
   /** @inheritDoc */
   static migrateData(source) {
     super.migrateData(source);
+    if ( !source ) return source;
     const version = dnd5e.settings.rulesVersion;
     const languageMap = LANGUAGE_MAP[version] ?? {};
     if ( source.chosen?.length ) source.chosen = source.chosen.map(t => languageMap[t] ?? t);

--- a/module/documents/mixins/pseudo-document.mjs
+++ b/module/documents/mixins/pseudo-document.mjs
@@ -97,10 +97,12 @@ export default function PseudoDocumentMixin(Base) {
 
     /**
      * Globally unique identifier for this PseudoDocument.
-     * @type {string}
+     * @type {string|null}
      */
     get uuid() {
-      return `${this.item.uuid}.${this.documentName}.${this.id ?? this._source._id}`;
+      const id = this.id ?? this._source._id;
+      if ( !this.item || !id ) return null;
+      return `${this.item.uuid}.${this.documentName}.${id}`;
     }
 
     /* -------------------------------------------- */
@@ -110,7 +112,7 @@ export default function PseudoDocumentMixin(Base) {
      * @type {Item5e}
      */
     get item() {
-      return this.parent.parent;
+      return this.parent?.parent;
     }
 
     /* -------------------------------------------- */
@@ -120,7 +122,7 @@ export default function PseudoDocumentMixin(Base) {
      * @type {Actor5e|null}
      */
     get actor() {
-      return this.item.parent ?? null;
+      return this.item?.parent ?? null;
     }
 
     /* -------------------------------------------- */


### PR DESCRIPTION
- Closes foundryvtt/dnd5e#6868

Not sure how meaningful it is to have unparented advancements really, but it's a relatively trivial change to resolve.