### PR TITLE
[#6839] Add placed encounter members to combat

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5890,6 +5890,16 @@
     "Name": "Default Skills",
     "Hint": "The default skills that appear on NPC sheets regardless of level of proficiency."
   },
+  "ENCOUNTERS": {
+    "Name": "Encounters",
+    "EncounterPlacementBehavior": {
+      "Name": "Placement Options",
+      "Hint": "Configure whether to add encounter members to combat when placed on a scene.",
+      "CreateCombatants": "Add to Combat",
+      "None": "Do Nothing",
+      "RollInitiative": "Add to Combat and Roll Initiative"
+    }
+  },
   "General": "General",
   "LOYALTY": {
     "Hint": "Enable optional Loyalty tracking.",

--- a/module/applications/settings/combat-settings.mjs
+++ b/module/applications/settings/combat-settings.mjs
@@ -24,6 +24,9 @@ export default class CombatSettingsConfig extends BaseSettingsConfig {
     npcs: {
       template: "systems/dnd5e/templates/settings/base-config.hbs"
     },
+    encounterPlacement: {
+      template: "systems/dnd5e/templates/settings/base-config.hbs"
+    },
     footer: {
       template: "templates/generic/form-footer.hbs"
     }
@@ -57,6 +60,12 @@ export default class CombatSettingsConfig extends BaseSettingsConfig {
           this.createSettingField("autoRollNPCHP")
         ];
         context.legend = game.i18n.localize("SETTINGS.DND5E.NPCS.Name");
+        break;
+      case "encounterPlacement":
+        context.fields = [
+          this.createSettingField("encounterPlacementBehavior")
+        ];
+        context.legend = game.i18n.localize("SETTINGS.DND5E.ENCOUNTERS.Name");
         break;
     }
     return context;

--- a/module/data/actor/encounter.mjs
+++ b/module/data/actor/encounter.mjs
@@ -4,6 +4,7 @@ import FormulaField from "../fields/formula-field.mjs";
 const { ArrayField, DocumentUUIDField, NumberField, SchemaField } = foundry.data.fields;
 
 /**
+ * @import { EncounterPlacementSettingData } from "../settings/_types.mjs";
  * @import { EncounterActorSystemData } from "./_types.mjs";
  */
 
@@ -157,6 +158,26 @@ export default class EncounterData extends GroupTemplate {
       }
       return member;
     }))).filter(m => m.quantity.value);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Place all members in the encounter on the current scene and return the associated token documents.
+   * @param {object} [config]                                        Configuration options for the encounter placement.
+   * @param {EncounterPlacementSettingData} [config.combatBehavior]  Combat tracker options for the placed tokens.
+   * @returns {Promise<TokenDocument[]>}
+   */
+  async placeMembers(config={}) {
+    const tokenDocuments = await super.placeMembers();
+    config.combatBehavior ??= game.settings.get("dnd5e", "encounterPlacementBehavior");
+    if ( tokenDocuments.length && config.combatBehavior !== "none" ) {
+      const combatants = await TokenDocument.implementation.createCombatants(tokenDocuments);
+      if ( config.combatBehavior === "rollInitiative" ) {
+        await game.combats.viewed.rollInitiative(combatants.map(c => c.id));
+      }
+    }
+    return tokenDocuments;
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/encounter.mjs
+++ b/module/data/actor/encounter.mjs
@@ -171,7 +171,7 @@ export default class EncounterData extends GroupTemplate {
   async placeMembers(config={}) {
     const tokenDocuments = await super.placeMembers();
     config.combatBehavior ??= game.settings.get("dnd5e", "encounterPlacementBehavior");
-    if ( tokenDocuments.length && config.combatBehavior !== "none" ) {
+    if ( tokenDocuments.length && (config.combatBehavior !== "none") ) {
       const combatants = await TokenDocument.implementation.createCombatants(tokenDocuments);
       if ( config.combatBehavior === "rollInitiative" ) {
         await game.combats.viewed.rollInitiative(combatants.map(c => c.id));

--- a/module/data/actor/templates/group.mjs
+++ b/module/data/actor/templates/group.mjs
@@ -60,7 +60,8 @@ export default class GroupTemplate extends ActorDataModel.mixin(CurrencyTemplate
   /* -------------------------------------------- */
 
   /**
-   * Place all members in the group on the current scene.
+   * Place all members in the group on the current scene and return the associated token documents.
+   * @returns {Promise<TokenDocument[]>}
    */
   async placeMembers() {
     if ( !game.user.isGM || !canvas.scene ) return;
@@ -94,6 +95,6 @@ export default class GroupTemplate extends ActorDataModel.mixin(CurrencyTemplate
       if ( minimized ) this.parent.sheet.maximize();
     }
 
-    await canvas.scene.createEmbeddedDocuments("Token", tokensData);
+    return await canvas.scene.createEmbeddedDocuments("Token", tokensData);
   }
 }

--- a/module/data/actor/templates/group.mjs
+++ b/module/data/actor/templates/group.mjs
@@ -64,9 +64,9 @@ export default class GroupTemplate extends ActorDataModel.mixin(CurrencyTemplate
    * @returns {Promise<TokenDocument[]>}
    */
   async placeMembers() {
-    if ( !game.user.isGM || !canvas.scene ) return;
+    if ( !game.user.isGM || !canvas.scene ) return [];
     const members = await this.getPlaceableMembers();
-    if ( !members.length ) return;
+    if ( !members.length ) return [];
     const minimized = !this.parent.sheet.minimized;
     await this.parent.sheet.minimize();
     const tokensData = [];
@@ -95,6 +95,6 @@ export default class GroupTemplate extends ActorDataModel.mixin(CurrencyTemplate
       if ( minimized ) this.parent.sheet.maximize();
     }
 
-    return await canvas.scene.createEmbeddedDocuments("Token", tokensData);
+    return canvas.scene.createEmbeddedDocuments("Token", tokensData);
   }
 }

--- a/module/data/settings/_types.mjs
+++ b/module/data/settings/_types.mjs
@@ -61,6 +61,12 @@
 /* -------------------------------------------- */
 
 /**
+ * @typedef {"none"|"createCombatants"|"rollInitiative"} EncounterPlacementSettingData
+ */
+
+/* -------------------------------------------- */
+
+/**
  * @typedef PrimaryPartySettingData
  * @property {Actor5e} actor  Group actor representing the primary party.
  */

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -399,6 +399,20 @@ export function registerSystemSettings() {
     default: false
   });
 
+  game.settings.register("dnd5e", "encounterPlacementBehavior", {
+    name: "SETTINGS.DND5E.ENCOUNTERS.EncounterPlacementBehavior.Name",
+    hint: "SETTINGS.DND5E.ENCOUNTERS.EncounterPlacementBehavior.Hint",
+    scope: "world",
+    config: false,
+    default: "none",
+    type: String,
+    choices: {
+      none: "SETTINGS.DND5E.ENCOUNTERS.EncounterPlacementBehavior.None",
+      createCombatants: "SETTINGS.DND5E.ENCOUNTERS.EncounterPlacementBehavior.CreateCombatants",
+      rollInitiative: "SETTINGS.DND5E.ENCOUNTERS.EncounterPlacementBehavior.RollInitiative"
+    }
+  });
+
   game.settings.register("dnd5e", "initiativeDexTiebreaker", {
     name: "SETTINGS.DND5E.COMBAT.DexTiebreaker.Name",
     hint: "SETTINGS.DND5E.COMBAT.DexTiebreaker.Hint",


### PR DESCRIPTION
While creating combatants and rolling initiative for placed members is fairly straightforward, I think the main point of contention on the feature would be how to present the option and where it is actually stored. I opted for a client-setting-backed little dialog, shown right before the actual placement of the encounter members.

Closes #6839 