### PR TITLE
[#5192, #5489] Allow configuration of initiative grouping

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5873,6 +5873,14 @@
       "All": "Use Score for Everyone",
       "None": "Always Roll for Initiative",
       "NPCs": "Use Score for GM NPCs"
+    },
+    "InitiativeGroupCombatants": {
+      "Name": "Group Combatants",
+      "Hint": "Group combatants with the same initiative score in the encounter tracker."
+    },
+    "InitiativeGroupRoll": {
+      "Name": "Roll Once per Creature",
+      "Hint": "Use the same initiative roll for identical creatures."
     }
   },
   "CRITICAL": {

--- a/module/applications/settings/combat-settings.mjs
+++ b/module/applications/settings/combat-settings.mjs
@@ -40,7 +40,9 @@ export default class CombatSettingsConfig extends BaseSettingsConfig {
       case "initiative":
         context.fields = [
           this.createSettingField("initiativeDexTiebreaker"),
-          this.createSettingField("initiativeScore")
+          this.createSettingField("initiativeScore"),
+          this.createSettingField("initiativeGroupRoll"),
+          this.createSettingField("initiativeGroupCombatants")
         ];
         context.legend = game.i18n.localize("DND5E.Initiative");
         break;

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -61,7 +61,25 @@ export default class Combat5e extends Combat {
 
   /** @inheritDoc */
   async rollInitiative(ids, options={}) {
-    await super.rollInitiative(ids, options);
+    const combatantsInfo = ids.reduce((info, id) => {
+      const rollGroupingKey = this.combatants.get(id).getInitiativeGroupingKey() ?? id;
+      if ( info.toBeRolled[rollGroupingKey] ) {
+        info.toBeDerived[id] = info.toBeRolled[rollGroupingKey][0];
+      } else {
+        info.toBeRolled[rollGroupingKey] ??= [];
+        info.toBeRolled[rollGroupingKey].push(id);
+      }
+      return info;
+    }, { toBeRolled: {}, toBeDerived: {} });
+
+    await super.rollInitiative(Object.values(combatantsInfo.toBeRolled).flat(), options);
+
+    const updates = Object.keys(combatantsInfo.toBeDerived).map(id => ({
+      _id: id, initiative: this.combatants.get(combatantsInfo.toBeDerived[id]).initiative
+    }));
+    if ( !updates.length ) return this;
+    await this.updateEmbeddedDocuments("Combatant", updates, { turnEvents: false });
+
     for ( const id of ids ) await this._recoverUses({ initiative: this.combatants.get(id) });
     return this;
   }

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -63,16 +63,19 @@ export default class Combat5e extends Combat {
   async rollInitiative(ids, options={}) {
     const combatantsInfo = ids.reduce((info, id) => {
       const rollGroupingKey = this.combatants.get(id).getInitiativeGroupingKey() ?? id;
-      if ( info.toBeRolled[rollGroupingKey] ) {
-        info.toBeDerived[id] = info.toBeRolled[rollGroupingKey][0];
-      } else {
-        info.toBeRolled[rollGroupingKey] ??= [];
-        info.toBeRolled[rollGroupingKey].push(id);
+      let deriveFrom = null;
+      if ( dnd5e.settings.initiativeGroupRoll && !this.started ) {
+        deriveFrom = this.combatants.find(c =>
+          (c.getInitiativeGroupingKey() === rollGroupingKey) && (Number.isFinite(c.initiative))
+        )?.id ?? null;
       }
+      deriveFrom ??= info.toBeRolled[rollGroupingKey];
+      if ( deriveFrom ) info.toBeDerived[id] = deriveFrom;
+      else info.toBeRolled[rollGroupingKey] = id;
       return info;
     }, { toBeRolled: {}, toBeDerived: {} });
 
-    await super.rollInitiative(Object.values(combatantsInfo.toBeRolled).flat(), options);
+    await super.rollInitiative(Object.values(combatantsInfo.toBeRolled), options);
 
     const updates = Object.keys(combatantsInfo.toBeDerived).map(id => ({
       _id: id, initiative: this.combatants.get(combatantsInfo.toBeDerived[id]).initiative

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -59,13 +59,27 @@ export default class Combatant5e extends Combatant {
   /* -------------------------------------------- */
 
   /**
-   * Key for the group to which this combatant should belong, or `null` if it can't be grouped.
+   * Key for the group to which this combatant should belong in the encounter tracker, or `null` if it can't be grouped.
    * @returns {string|null}
    */
   getGroupingKey() {
     if ( this.group ) return this.group.id;
-    if ( this.token?.actorLink || !this.token?.baseActor || (this.initiative === null) ) return null;
+    if ( this.token?.actorLink || !this.token?.baseActor || (this.initiative === null)
+      || !game.settings.get("dnd5e", "initiativeGroupCombatants") ) return null;
     return `${Math.floor(this.initiative).paddedString(4)}:${this.token.disposition}:${this.token.baseActor.id}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Key for the group to which this combatant should belong when rolling initiative, or `null` if it can't be grouped.
+   * @returns {string|null}
+   */
+  getInitiativeGroupingKey() {
+    if ( this.group ) return this.group.id;
+    if ( this.token?.actorLink || !this.token?.baseActor
+      || !game.settings.get("dnd5e", "initiativeGroupRoll") ) return null;
+    return `${this.getInitiativeRoll().formula}:${this.token.disposition}:${this.token.baseActor.id}`;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -65,7 +65,7 @@ export default class Combatant5e extends Combatant {
   getGroupingKey() {
     if ( this.group ) return this.group.id;
     if ( this.token?.actorLink || !this.token?.baseActor || (this.initiative === null)
-      || !game.settings.get("dnd5e", "initiativeGroupCombatants") ) return null;
+      || !dnd5e.settings.initiativeGroupCombatants ) return null;
     return `${Math.floor(this.initiative).paddedString(4)}:${this.token.disposition}:${this.token.baseActor.id}`;
   }
 
@@ -78,7 +78,7 @@ export default class Combatant5e extends Combatant {
   getInitiativeGroupingKey() {
     if ( this.group ) return this.group.id;
     if ( this.token?.actorLink || !this.token?.baseActor
-      || !game.settings.get("dnd5e", "initiativeGroupRoll") ) return null;
+      || !dnd5e.settings.initiativeGroupRoll ) return null;
     return `${this.getInitiativeRoll().formula}:${this.token.disposition}:${this.token.baseActor.id}`;
   }
 

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -64,9 +64,8 @@ export default class Combatant5e extends Combatant {
    */
   getGroupingKey() {
     if ( this.group ) return this.group.id;
-    if ( this.token?.actorLink || !this.token?.baseActor || (this.initiative === null)
-      || !dnd5e.settings.initiativeGroupCombatants ) return null;
-    return `${Math.floor(this.initiative).paddedString(4)}:${this.token.disposition}:${this.token.baseActor.id}`;
+    if ( (this.initiative === null) || !dnd5e.settings.initiativeGroupCombatants ) return null;
+    return this.getUniqueKey(Math.floor(this.initiative).paddedString(4));
   }
 
   /* -------------------------------------------- */
@@ -77,9 +76,8 @@ export default class Combatant5e extends Combatant {
    */
   getInitiativeGroupingKey() {
     if ( this.group ) return this.group.id;
-    if ( this.token?.actorLink || !this.token?.baseActor
-      || !dnd5e.settings.initiativeGroupRoll ) return null;
-    return `${this.getInitiativeRoll().formula}:${this.token.disposition}:${this.token.baseActor.id}`;
+    if ( !dnd5e.settings.initiativeGroupRoll ) return null;
+    return this.getUniqueKey(this.getInitiativeRoll().formula);
   }
 
   /* -------------------------------------------- */
@@ -88,6 +86,18 @@ export default class Combatant5e extends Combatant {
   getInitiativeRoll(formula) {
     if ( !this.actor ) return new CONFIG.Dice.D20Roll(formula ?? "1d20", {});
     return this.actor.getInitiativeRoll();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Key identifying a unique set of actors in the combat, optionally prefixed by a grouping discriminator.
+   * @param {string} [prefix]  Discriminator placed at the head of the key.
+   * @returns {string|null}
+   */
+  getUniqueKey(prefix) {
+    if ( this.token?.actorLink || !this.token?.baseActor ) return null;
+    return `${prefix === undefined ? "" : `${prefix}:`}${this.token.disposition}:${this.token.baseActor.id}`;
   }
 
   /* -------------------------------------------- */

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -408,6 +408,24 @@ export function registerSystemSettings() {
     type: Boolean
   });
 
+  game.settings.register("dnd5e", "initiativeGroupCombatants", {
+    name: "SETTINGS.DND5E.COMBAT.InitiativeGroupCombatants.Name",
+    hint: "SETTINGS.DND5E.COMBAT.InitiativeGroupCombatants.Hint",
+    scope: "world",
+    config: false,
+    default: true,
+    type: Boolean
+  });
+
+  game.settings.register("dnd5e", "initiativeGroupRoll", {
+    name: "SETTINGS.DND5E.COMBAT.InitiativeGroupRoll.Name",
+    hint: "SETTINGS.DND5E.COMBAT.InitiativeGroupRoll.Hint",
+    scope: "world",
+    config: false,
+    default: false,
+    type: Boolean
+  });
+
   game.settings.register("dnd5e", "initiativeScore", {
     name: "SETTINGS.DND5E.COMBAT.InitiativeScore.Name",
     hint: "SETTINGS.DND5E.COMBAT.InitiativeScore.Hint",

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -422,7 +422,7 @@ export function registerSystemSettings() {
     hint: "SETTINGS.DND5E.COMBAT.InitiativeGroupRoll.Hint",
     scope: "world",
     config: false,
-    default: false,
+    default: true,
     type: Boolean
   });
 


### PR DESCRIPTION
This change adds two settings to the Initiative section of the combat configuration:
1) Roll Once per Creature: actors of the same type (roll formula - disposition - base actor) share a single initiative roll;
2) Group Combatants: actors of the same type with the same rolled initiative are grouped in the tracker (the current default functionality, but it can now be disabled).

Closes #5192 
Closes #5489