### PR TITLE
fixed: SingleLevelSpellcasting Cantrips were slotting into single-level section

### DIFF
--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -600,7 +600,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       let method = spell.system.method;
       if ( !(method in CONFIG.DND5E.spellcasting) ) method = "innate";
       const spellcasting = CONFIG.DND5E.spellcasting[method];
-      const level = spellcasting instanceof dnd5e.dataModels.spellcasting.SingleLevelSpellcasting
+      const level = spellcasting instanceof dnd5e.dataModels.spellcasting.SingleLevelSpellcasting && spell.system.level !== 0
         ? null : (spell.system.level || 0);
       method = spellcasting?.getSpellSlotKey?.(level) ?? method;
 

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -540,6 +540,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
    * @protected
    */
   _prepareSpellbook(context) {
+    const { SingleLevelSpellcasting } = dnd5e.dataModels.spellcasting;
     const spellbook = {};
     const columns = customElements.get(this.options.elements.inventory).mapColumns([
       "school", "time", "range", "target", "roll", { id: "uses", order: 650, priority: 300 },
@@ -600,7 +601,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       let method = spell.system.method;
       if ( !(method in CONFIG.DND5E.spellcasting) ) method = "innate";
       const spellcasting = CONFIG.DND5E.spellcasting[method];
-      const level = spellcasting instanceof dnd5e.dataModels.spellcasting.SingleLevelSpellcasting && spell.system.level !== 0
+      const level = spellcasting instanceof SingleLevelSpellcasting && spell.system.level !== 0
         ? null : (spell.system.level || 0);
       method = spellcasting?.getSpellSlotKey?.(level) ?? method;
 


### PR DESCRIPTION
Updated spell level logic to prevent level 0 spells from being slotted into the single-level spell method section.

Resolves #6915 

Before:
<img width="678" height="231" alt="image" src="https://github.com/user-attachments/assets/f6a98784-58b0-4905-9978-ce00126ef4f7" />

After:
<img width="685" height="340" alt="image" src="https://github.com/user-attachments/assets/33b12416-21df-4cad-89b5-e129f46b4efc" />
