### PR TITLE
[#6909] Prevent non-gear items incorrectly returning their base item when dropped onto other sheets.

### DIFF
--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -307,8 +307,9 @@ export default class PhysicalItemTemplate extends SystemDataModel {
    * @returns {Promise<Item5e>}
    */
   async asGear() {
-    const change = { "flags.dnd5e.gearSource": this.parent.uuid };
+    if ( !this.properties?.has("gear") ) return this.parent;
     let clone;
+    const change = { "flags.dnd5e.gearSource": this.parent.uuid };
     const flags = this.parent.getFlag("dnd5e", "gear") ?? {};
     if ( this.metadata.compendiumGearSource && this.parent._stats.compendiumSource && (flags.preserve !== true) ) {
       const item = await fromUuid(this.parent._stats.compendiumSource);


### PR DESCRIPTION
- Closes #6909 