### PR TITLE
[#6871] Force adv/dis modifiers to be evaluated first.

### DIFF
--- a/module/dice/basic-die.mjs
+++ b/module/dice/basic-die.mjs
@@ -50,4 +50,15 @@ export default class BasicDie extends Die {
       });
     }
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _evaluateModifiers() {
+    // Since adv/dis internally calls roll and modifies the count, they must be evaluated first in order for subsequent
+    // modifiers to operate on the correct dice.
+    const [rest, selection] = this.modifiers.partition(m => /^(adv|dis)\d*/i.test(m));
+    if ( selection.length ) this.modifiers = selection.concat(rest);
+    return super._evaluateModifiers();
+  }
 }


### PR DESCRIPTION
- Closes #6871

I wasn't really following very well some of the discussion on this issue about modifiers being dropped? It's not something I observed. The order-of-operations issue was clear though. This patch should resolve that.