### PR TITLE
Refresh bars when updating limited item uses.

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3388,15 +3388,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     super._onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId);
 
     if ( collection === "items" ) {
-        let refreshBars = false;
-        for ( let i = 0; i < documents.length; i++ ) {
-            if ( documents[i].hasLimitedUses && changes[i]?.system?.uses?.hasOwnProperty("spent") ) {
-              refreshBars = true;
-              break;
-            }
-        }
-        
-        if ( refreshBars ) this.getActiveTokens().forEach(token => token.renderFlags.set({ refreshBars: true }));
+      const refreshBars = documents.some(
+        (doc, index) => doc.hasLimitedUses && changes[index]?.system?.uses?.hasOwnProperty("spent"));
+      if ( refreshBars ) this.getActiveTokens().forEach(token => token.renderFlags.set({ refreshBars: true }));
     }
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3396,7 +3396,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
             }
         }
         
-        if (refreshBars) this.getActiveTokens().forEach(token => token.renderFlags.set({ refreshBars: true }));
+        if ( refreshBars ) this.getActiveTokens().forEach(token => token.renderFlags.set({ refreshBars: true }));
     }
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3388,8 +3388,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     super._onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId);
 
     if ( collection === "items" ) {
-      const refreshBars = documents.some(
-        (doc, index) => doc.hasLimitedUses && changes[index]?.system?.uses?.hasOwnProperty("spent"));
+      const refreshBars = documents.some((doc, index) => {
+        return doc.hasLimitedUses && foundry.utils.hasProperty(changes[index], "system.uses.spent");
+      });
       if ( refreshBars ) this.getActiveTokens().forEach(token => token.renderFlags.set({ refreshBars: true }));
     }
   }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3386,6 +3386,18 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   async _onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId) {
     if ( (userId === game.userId) && (collection === "items") ) await this.updateEncumbrance(options);
     super._onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId);
+
+    if ( collection === "items" ) {
+        let refreshBars = false;
+        for ( let i = 0; i < documents.length; i++ ) {
+            if ( documents[i].hasLimitedUses && changes[i]?.system?.uses?.hasOwnProperty("spent") ) {
+              refreshBars = true;
+              break;
+            }
+        }
+        
+        if (refreshBars) this.getActiveTokens().forEach(token => token.renderFlags.set({ refreshBars: true }));
+    }
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
When using item uses/charges as token attributes, the bar currently doesn't refresh when the item's uses are modified. This PR aims to resolve the issue for updates from any source.