### PR TITLE
[#6923] Add system-specific adventure importer dialog with actions

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -176,6 +176,11 @@ Hooks.once("init", function() {
     label: "DND5E.SheetClass.Encounter"
   });
 
+  DocumentSheetConfig.registerSheet(Adventure, "dnd5e", applications.adventure.AdventureImporter5e, {
+    canBeDefault: false,
+    label: "DND5E.SheetClass.AdventureImporter"
+  });
+
   DocumentSheetConfig.unregisterSheet(Item, "core", foundry.appv1.sheets.ItemSheet);
   DocumentSheetConfig.registerSheet(Item, "dnd5e", applications.item.ItemSheet5e, {
     makeDefault: true,
@@ -552,7 +557,7 @@ Hooks.once("i18nInit", () => {
 /**
  * Once the entire VTT framework is initialized, check to see if we should perform a data migration
  */
-Hooks.once("ready", function() {
+Hooks.once("ready", async function() {
   // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
   Hooks.on("hotbarDrop", (bar, data, slot) => {
     if ( ["ActiveEffect", "Activity", "Item"].includes(data.type) ) {
@@ -580,7 +585,19 @@ Hooks.once("ready", function() {
     dnd5e.ui.calendar.render({ force: true });
   }
 
-  // Determine whether a system migration is required and feasible
+  // Run migrations
+  await _handleMigration();
+
+  // Handle post-import actions for quickstarted adventures
+  applications.adventure.AdventureQuickstartDialog.handleQuickstart();
+});
+
+/* -------------------------------------------- */
+
+/**
+ * Determine whether a system migration is required and feasible and run it.
+ */
+async function _handleMigration() {
   if ( !game.user.isGM ) return;
   const cv = game.settings.get("dnd5e", "systemMigrationVersion") || game.world.flags.dnd5e?.version;
   const totalDocuments = game.actors.size + game.scenes.size + game.items.size;
@@ -596,8 +613,8 @@ Hooks.once("ready", function() {
   if ( cv && foundry.utils.isNewerVersion(game.system.flags.compatibleMigrationVersion, cv) ) {
     ui.notifications.error("MIGRATION.5eVersionTooOldWarning", {localize: true, permanent: true});
   }
-  migrations.migrateWorld();
-});
+  await migrations.migrateWorld();
+}
 
 /* -------------------------------------------- */
 /*  System Styling                              */

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -161,6 +161,11 @@ Hooks.once("init", function() {
     label: "DND5E.SheetClass.Encounter"
   });
 
+  DocumentSheetConfig.registerSheet(Adventure, "dnd5e", applications.adventure.AdventureImporter5e, {
+    canBeDefault: false,
+    label: "DND5E.SheetClass.AdventureImporter"
+  });
+
   DocumentSheetConfig.unregisterSheet(Item, "core", foundry.appv1.sheets.ItemSheet);
   DocumentSheetConfig.registerSheet(Item, "dnd5e", applications.item.ItemSheet5e, {
     makeDefault: true,
@@ -566,8 +571,19 @@ Hooks.once("ready", function() {
     dnd5e.ui.calendar.render({ force: true });
   }
 
-  // Determine whether a system migration is required and feasible
+  // Run migrations & post-import actions for quickstarted adventures
+  _handleMigration()
+    .then(() => applications.adventure.AdventureQuickstartDialog.handleQuickstart());
+});
+
+/* -------------------------------------------- */
+
+/**
+ * Determine whether a system migration is required and feasible and run it.
+ */
+async function _handleMigration() {
   if ( !game.user.isGM ) return;
+
   const cv = game.settings.get("dnd5e", "systemMigrationVersion") || game.world.flags.dnd5e?.version;
   const totalDocuments = game.actors.size + game.scenes.size + game.items.size;
   if ( !cv && totalDocuments === 0 ) return game.settings.set("dnd5e", "systemMigrationVersion", game.system.version);
@@ -582,8 +598,9 @@ Hooks.once("ready", function() {
   if ( cv && foundry.utils.isNewerVersion(game.system.flags.compatibleMigrationVersion, cv) ) {
     ui.notifications.error("MIGRATION.DND5E.Warning.VersionTooOld", { permanent: true });
   }
-  migrations.migrateWorld();
-});
+
+  await migrations.migrateWorld();
+}
 
 /* -------------------------------------------- */
 /*  System Styling                              */

--- a/lang/en.json
+++ b/lang/en.json
@@ -825,6 +825,27 @@
 "DND5E.AdvancementTitle": "Advancement",
 "DND5E.Advantage": "Advantage",
 "DND5E.AdvantageMode": "Advantage Mode",
+
+"DND5E.ADVENTURE": {
+  "Action": {
+    "Configure": "Configure Adventure",
+    "Launch": "Launch Adventure"
+  },
+  "Finished": {
+    "one": "Finished preparing {adventure}.",
+    "other": "Finished preparing {number} adventures."
+  },
+  "ImportAction": {
+    "ActivateScene": "Activate Initial Scene",
+    "CustomizeWorld": "Customize World Details",
+    "DisplayJournal": "Display Getting Started Journal"
+  },
+  "Warning": {
+    "JournalMissing": "Journal entry `{id}` could not be found to display for {adventure}.",
+    "SceneMissing": "Scene `{id}` could not be found to activate for {adventure}."
+  }
+},
+
 "DND5E.Age": "Age",
 "DND5E.Alignment": "Alignment",
 "DND5E.AlignmentCE": "Chaotic Evil",
@@ -3922,6 +3943,7 @@
 "DND5E.Shape": "Shape",
 
 "DND5E.SheetClass": {
+  "AdventureImporter": "D&D 5e Adventure Importer",
   "Character": "D&D 5e Character Sheet",
   "ClassSummary": "D&D 5e Class Summary Sheet",
   "Container": "D&D 5e Container Sheet",

--- a/lang/en.json
+++ b/lang/en.json
@@ -915,6 +915,27 @@
 "DND5E.AdvancementTitle": "Advancement",
 "DND5E.Advantage": "Advantage",
 "DND5E.AdvantageMode": "Advantage Mode",
+
+"DND5E.ADVENTURE": {
+  "Action": {
+    "Configure": "Configure Adventure",
+    "Launch": "Launch Adventure"
+  },
+  "Finished": {
+    "one": "Finished preparing {adventure}.",
+    "other": "Finished preparing {number} adventures."
+  },
+  "ImportAction": {
+    "ActivateScene": "Activate Initial Scene",
+    "CustomizeWorld": "Customize World Details",
+    "DisplayJournal": "Display Getting Started Journal"
+  },
+  "Warning": {
+    "JournalMissing": "Journal entry `{id}` could not be found to display for {adventure}.",
+    "SceneMissing": "Scene `{id}` could not be found to activate for {adventure}."
+  }
+},
+
 "DND5E.Age": "Age",
 "DND5E.Alignment": "Alignment",
 "DND5E.AlignmentCE": "Chaotic Evil",
@@ -4346,6 +4367,7 @@
 "DND5E.Shape": "Shape",
 
 "DND5E.SheetClass": {
+  "AdventureImporter": "D&D 5e Adventure Importer",
   "Character": "D&D 5e Character Sheet",
   "ClassSummary": "D&D 5e Class Summary Sheet",
   "Container": "D&D 5e Container Sheet",

--- a/less/v2/sheets.less
+++ b/less/v2/sheets.less
@@ -281,6 +281,32 @@ body.detached .dnd5e2.sheet .tab { max-height: unset; }
 }
 
 /* ---------------------------------- */
+/*  Adventure Importer                */
+/* ---------------------------------- */
+
+.dnd5e2.adventure-importer {
+  [data-application-part="body"] { gap: 10px; }
+  .adventure-contents {
+    display: grid;
+    grid-template-areas:
+      "overview controls"
+      "overview options";
+    gap: 1rem 2rem;
+
+    .adventure-overview { grid-area: overview; }
+    .import-controls { grid-area: controls; }
+    .import-options { grid-area: options; }
+
+    h2 { font-size: var(--font-h2-size); }
+  }
+  .import-controls .form-group { margin-block-end: 4px; }
+}
+
+.dnd5e2.adventure-quickstart {
+  .standard-form .form-group label { flex: 6; }
+}
+
+/* ---------------------------------- */
 /*  Roll Table Sheets                 */
 /* ---------------------------------- */
 

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -129,6 +129,56 @@
 /* -------------------------------------------- */
 
 /**
+ * @typedef AdventureConfiguration
+ * @param {AdventureImportAction[]} importActions  Actions performed when the adventure is imported.
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * @typedef AdventureImportAction
+ * @property {string} id                   Unique ID for this import action.
+ * @property {string} label                Localized label for the option.
+ * @property {AdventureImportPreHandler|AdventureImportPostHandler} handler  Handler function to call.
+ * @property {"pre"|"post"} lifecycle      Should this handler be called before or after importing.
+ * @property {boolean} [default=false]     Should this option be checked by default on the adventure importer?
+ * @property {AdventureImportQuickstartHandler} [quickstartHandler]  Handler called when after quickstarting a module.
+ *                                                                   Must be set to use an action during quickstart.
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * @callback AdventureImportPostHandler
+ * @this {Adventure}
+ * @param {AdventureImportAction} config
+ * @param {AdventureImportResult} importResult
+ * @param {AdventureImportOptions} importOptions
+ * @returns {Promise<*>}
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * @callback AdventureImportPreHandler
+ * @this {Adventure}
+ * @param {AdventureImportAction} config
+ * @param {AdventureImportData} importData
+ * @param {AdventureImportOptions} importOptions
+ * @returns {Promise<*>}
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * @callback AdventureImportQuickstartHandler
+ * @param {{ adventure: Adventure, config: AdventureImportAction }[]} adventures
+ * @returns {Promise<*>}
+ */
+
+/* -------------------------------------------- */
+
+/**
  * Information needed to represent different area of effect target types.
  *
  * @typedef AreaTargetDefinition

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -137,6 +137,56 @@
 /* -------------------------------------------- */
 
 /**
+ * @typedef AdventureConfiguration
+ * @param {AdventureImportAction[]} importActions  Actions performed when the adventure is imported.
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * @typedef AdventureImportAction
+ * @property {string} id                   Unique ID for this import action.
+ * @property {string} label                Localized label for the option.
+ * @property {AdventureImportPreHandler|AdventureImportPostHandler} handler  Handler function to call.
+ * @property {"pre"|"post"} lifecycle      Should this handler be called before or after importing.
+ * @property {boolean} [default=false]     Should this option be checked by default on the adventure importer?
+ * @property {AdventureImportQuickstartHandler} [quickstartHandler]  Handler called when after quickstarting a module.
+ *                                                                   Must be set to use an action during quickstart.
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * @callback AdventureImportPostHandler
+ * @this {Adventure}
+ * @param {AdventureImportAction} config
+ * @param {AdventureImportResult} importResult
+ * @param {AdventureImportOptions} importOptions
+ * @returns {Promise<*>}
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * @callback AdventureImportPreHandler
+ * @this {Adventure}
+ * @param {AdventureImportAction} config
+ * @param {AdventureImportData} importData
+ * @param {AdventureImportOptions} importOptions
+ * @returns {Promise<*>}
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * @callback AdventureImportQuickstartHandler
+ * @param {{ adventure: Adventure, config: AdventureImportAction }[]} adventures
+ * @returns {Promise<*>}
+ */
+
+/* -------------------------------------------- */
+
+/**
  * Information needed to represent different area of effect target types.
  *
  * @typedef AreaTargetDefinition

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -138,7 +138,7 @@
 
 /**
  * @typedef AdventureConfiguration
- * @param {AdventureImportAction[]} importActions  Actions performed when the adventure is imported.
+ * @property {AdventureImportAction[]} importActions  Actions performed when the adventure is imported.
  */
 
 /* -------------------------------------------- */

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -1,6 +1,7 @@
 export * as activity from "./activity/_module.mjs";
 export * as actor from "./actor/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";
+export * as adventure from "./adventure/_module.mjs";
 export * as api from "./api/_module.mjs";
 export * as calendar from "./calendar/_module.mjs";
 export * as combat from "./combat/_module.mjs";

--- a/module/applications/adventure/_module.mjs
+++ b/module/applications/adventure/_module.mjs
@@ -1,0 +1,2 @@
+export {default as AdventureImporter5e} from "./importer.mjs";
+export {default as AdventureQuickstartDialog} from "./quickstart-dialog.mjs";

--- a/module/applications/adventure/importer.mjs
+++ b/module/applications/adventure/importer.mjs
@@ -1,0 +1,106 @@
+import { filteredKeys } from "../../utils.mjs";
+import ApplicationV2Mixin from "../api/application-v2-mixin.mjs";
+
+const { AdventureImporterV2 } = foundry.applications.sheets;
+const { BooleanField, SchemaField } = foundry.data.fields;
+
+/**
+ * Extension of the default adventure importer with system-specific design and pre/post action support.
+ */
+export default class AdventureImporter5e extends ApplicationV2Mixin(AdventureImporterV2, { handlebars: false }) {
+
+  /** @inheritDoc */
+  static PARTS = {
+    ...super.PARTS,
+    body: {
+      template: "systems/dnd5e/templates/adventure/importer.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get title() {
+    return this.document.name;
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _prepareImportOptionsSchema(options) {
+    const importActions = this.adventure.importActions;
+    if ( !importActions.length ) return;
+    const selected = game.settings.get("core", "adventureImports")[this.adventure.uuid]?.options?.actions ?? {};
+    const fields = {};
+    for ( const action of importActions ) {
+      fields[`actions.${action.id}`] = new BooleanField({
+        initial: selected[action.id] ?? action.default, label: action.label
+      });
+    }
+    return new SchemaField(fields);
+  }
+
+  /* -------------------------------------------- */
+  /*  Import Workflows                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _configureImport(importOptions) {
+    await super._configureImport(importOptions);
+    importOptions.actions = filteredKeys(importOptions.actions);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preImport(importData, importOptions) {
+    await super._preImport(importData, importOptions);
+    const actions = this.adventure.importActions
+      .filter(o => o.lifecycle === "pre" && importOptions.actions?.includes(o.id));
+    for ( const action of actions ) {
+      await action.handler.call(this.adventure, action, importData, importOptions);
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onImport(importResult, importOptions) {
+    await super._onImport(importResult, importOptions);
+    const actions = this.adventure.importActions
+      .filter(o => o.lifecycle === "post" && importOptions.actions?.includes(o.id));
+    for ( const action of actions ) {
+      await action.handler.call(this.adventure, action, importResult, importOptions);
+    }
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onChangeForm(formConfig, event) {
+    if ( (event.target.name === "importFields") && (event.target.getAttribute("value") === "all") ) {
+      this._onToggleImportAll(event);
+    }
+    super._onChangeForm(formConfig, event);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onToggleImportAll(event) {
+    const target = event.target;
+    const section = target.closest(".import-controls");
+    const checked = target.checked;
+    section.querySelectorAll("dnd5e-checkbox").forEach(input => {
+      if ( input === target ) return;
+      if ( input.value !== "folders" ) input.disabled = checked;
+      if ( checked ) input.checked = true;
+    });
+  }
+}

--- a/module/applications/adventure/importer.mjs
+++ b/module/applications/adventure/importer.mjs
@@ -82,16 +82,6 @@ export default class AdventureImporter5e extends ApplicationV2Mixin(AdventureImp
   /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 
-  /** @inheritDoc */
-  _onChangeForm(formConfig, event) {
-    if ( (event.target.name === "importFields") && (event.target.getAttribute("value") === "all") ) {
-      this._onToggleImportAll(event);
-    }
-    super._onChangeForm(formConfig, event);
-  }
-
-  /* -------------------------------------------- */
-
   /** @override */
   _onToggleImportAll(event) {
     const target = event.target;

--- a/module/applications/adventure/quickstart-dialog.mjs
+++ b/module/applications/adventure/quickstart-dialog.mjs
@@ -1,0 +1,133 @@
+import { getPluralRules } from "../../utils.mjs";
+import Dialog5e from "../api/dialog.mjs";
+import { createCheckboxInput } from "../fields.mjs";
+
+const { BooleanField } = foundry.data.fields;
+
+/**
+ * Dialog presented post-quickstart to allow for running import actions.
+ */
+export default class AdventureQuickstartDialog extends Dialog5e {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    adventures: [],
+    buttons: [{
+      action: "launch",
+      label: "DND5E.ADVENTURE.Action.Launch",
+      icon: "fa-solid fa-play",
+      default: true
+    }],
+    classes: ["adventure-quickstart"],
+    form: {
+      closeOnSubmit: true,
+      handler: AdventureQuickstartDialog.#handleFormSubmission
+    },
+    position: {
+      width: 420
+    },
+    window: {
+      title: "DND5E.ADVENTURE.Action.Configure",
+      icon: "fa-solid fa-compass"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContentContext(context, options) {
+    await super._prepareContentContext(context, options);
+
+    const importActions = {};
+    for ( const adventure of this.options.adventures ) {
+      for ( const action of adventure.importActions ) {
+        if ( !action.quickstartHandler || (action.id in importActions) ) continue;
+        importActions[action.id] = {
+          field: new BooleanField(),
+          input: createCheckboxInput,
+          label: action.label,
+          name: action.id,
+          value: action.default
+        };
+      }
+    }
+
+    context.content = await foundry.applications.handlebars.renderTemplate(
+      "systems/dnd5e/templates/shared/fields/formlist.hbs",
+      { actions: { legend: "ADVENTURE.ImportHeaderOptions", fields: Object.values(importActions) } }
+    );
+
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle submission of the dialog.
+   * @this {AdventureQuickstartDialog}
+   * @param {SubmitEvent} event          The form submission event.
+   * @param {HTMLFormElement} form       The submitted form.
+   * @param {FormDataExtended} formData  Data from the dialog.
+   * @returns {Promise}
+   */
+  static async #handleFormSubmission(event, form, formData) {
+    const button = this.element.querySelector('[data-action="launch"]');
+    button.disabled = true;
+    button.querySelector("i").className = "fa-solid fa-spinner fa-spin-pulse";
+
+    const adventureImports = game.settings.get("core", "adventureImports");
+    const importActions = {};
+    for ( const adventure of this.options.adventures ) {
+      for ( const action of adventure.importActions ) {
+        if ( !(action.id in formData.object) ) continue;
+        if ( formData.object[action.id] ) {
+          importActions[action.id] ??= { adventures: [], handler: action.quickstartHandler };
+          importActions[action.id].adventures.push({ adventure, config: action });
+        }
+        foundry.utils.setProperty(
+          adventureImports[adventure.uuid].options, `actions.${action.id}`, formData.object[action.id]
+        );
+      }
+    }
+
+    for ( const { adventures, handler } of Object.values(importActions) ) await handler(adventures);
+    await game.settings.set("core", "adventureImports", adventureImports);
+
+    const pr = getPluralRules();
+    ui.notifications.success(`DND5E.ADVENTURE.Finished.${pr.select(this.options.adventures.length)}`, {
+      format: { adventure: this.options.adventures[0].name, number: this.options.adventures.length }
+    });
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Run during the setup hook to present post-quickstart dialogs for each quickstarted adventure.
+   */
+  static async handleQuickstart() {
+    if ( !game.user.isGM ) return;
+
+    let adventures = Object.entries(game.settings.get("core", "adventureImports"))
+      .filter(([, { quickstart={} }]) => quickstart.quickstarted && !quickstart.postImport)
+      .map(([uuid]) => fromUuid(uuid));
+    if ( !adventures.length ) return;
+    adventures = (await Promise.all(adventures)).filter(_ => _);
+
+    try {
+      const dialog = new AdventureQuickstartDialog({ adventures });
+      const { promise, resolve } = Promise.withResolvers();
+      dialog.addEventListener("close", () => resolve());
+      dialog.render({ force: true });
+      await promise;
+    } finally {
+      const adventureImports = game.settings.get("core", "adventureImports");
+      adventures.forEach(a => adventureImports[a.uuid].quickstart.postImport = true);
+      await game.settings.set("core", "adventureImports", adventureImports);
+    }
+  }
+}

--- a/module/applications/adventure/quickstart-dialog.mjs
+++ b/module/applications/adventure/quickstart-dialog.mjs
@@ -107,7 +107,7 @@ export default class AdventureQuickstartDialog extends Dialog5e {
   /* -------------------------------------------- */
 
   /**
-   * Run during the setup hook to present post-quickstart dialogs for each quickstarted adventure.
+   * Run during the ready hook to present post-quickstart dialogs for each quickstarted adventure.
    */
   static async handleQuickstart() {
     if ( !game.user.isGM ) return;

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -11,12 +11,13 @@ import MappingField from "./data/fields/mapping-field.mjs";
 import * as activities from "./documents/activity/_module.mjs";
 import Actor5e from "./documents/actor/actor.mjs";
 import * as advancement from "./documents/advancement/_module.mjs";
+import Adventure5e from "./documents/adventure.mjs";
 import { preLocalize } from "./utils.mjs";
 
 /**
  * @import {
  *   AbilityConfiguration, ActivityActivationTypeConfiguration, ActivityConsumptionTargetConfiguration,
- *   ActivityTypeConfiguration, ActorSizeConfiguration, AdvancementTypeConfiguration,
+ *   ActivityTypeConfiguration, ActorSizeConfiguration, AdvancementTypeConfiguration, AdventureImportAction,
  *   AreaTargetDefinition, CalendarHUDConfiguration, CharacterFlagConfiguration, ConditionConfiguration,
  *   CraftingConfiguration, CreatureTypeConfiguration, CurrencyConfiguration, DamageTypeConfiguration,
  *   EncumbranceConfiguration, FacilityConfiguration, HabitatConfiguration5e,
@@ -4517,6 +4518,39 @@ DND5E.defaultArtwork = {
     weapon: "systems/dnd5e/icons/svg/items/weapon.svg"
   }
 };
+
+/* -------------------------------------------- */
+/*  Adventures                                  */
+/* -------------------------------------------- */
+
+/**
+ * Configuration for adventure handling by the system.
+ * @type {{ importActions: Record<string, Omit<AdventureImportAction, "id">> }}
+ */
+DND5E.adventure = {
+  importActions: {
+    activateScene: {
+      label: "DND5E.ADVENTURE.ImportAction.ActivateScene",
+      default: true,
+      handler: Adventure5e.activateScene,
+      quickstartHandler: Adventure5e.activateSceneQuickstart,
+      lifecycle: "post"
+    },
+    customizeWorld: {
+      label: "DND5E.ADVENTURE.ImportAction.CustomizeWorld",
+      handler: Adventure5e.customizeWorld,
+      lifecycle: "post"
+    },
+    displayJournal: {
+      label: "DND5E.ADVENTURE.ImportAction.DisplayJournal",
+      default: true,
+      handler: Adventure5e.displayJournal,
+      quickstartHandler: Adventure5e.displayJournalQuickstart,
+      lifecycle: "post"
+    }
+  }
+};
+preLocalize("adventure.importActions", { key: "label" });
 
 /* -------------------------------------------- */
 /*  Calendar                                    */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -12,12 +12,13 @@ import * as regionBehaviors from "./data/region-behavior/_module.mjs";
 import * as activities from "./documents/activity/_module.mjs";
 import Actor5e from "./documents/actor/actor.mjs";
 import * as advancement from "./documents/advancement/_module.mjs";
+import Adventure5e from "./documents/adventure.mjs";
 import { preLocalize } from "./utils.mjs";
 
 /**
  * @import {
  *   AbilityConfiguration, ActivityActivationTypeConfiguration, ActivityConsumptionTargetConfiguration,
- *   ActivityTypeConfiguration, ActorSizeConfiguration, AdvancementTypeConfiguration,
+ *   ActivityTypeConfiguration, ActorSizeConfiguration, AdvancementTypeConfiguration, AdventureImportAction,
  *   AreaTargetDefinition, CalendarHUDConfiguration, CharacterFlagConfiguration, ConditionConfiguration,
  *   CraftingConfiguration, CreatureTypeConfiguration, CurrencyConfiguration, DamageTypeConfiguration,
  *   EncumbranceConfiguration, FacilityConfiguration, HabitatConfiguration5e,
@@ -4522,6 +4523,39 @@ DND5E.defaultArtwork = {
     weapon: "systems/dnd5e/icons/svg/items/weapon.svg"
   }
 };
+
+/* -------------------------------------------- */
+/*  Adventures                                  */
+/* -------------------------------------------- */
+
+/**
+ * Configuration for adventure handling by the system.
+ * @type {{ importActions: Record<string, Omit<AdventureImportAction, "id">> }}
+ */
+DND5E.adventure = {
+  importActions: {
+    activateScene: {
+      label: "DND5E.ADVENTURE.ImportAction.ActivateScene",
+      default: true,
+      handler: Adventure5e.activateScene,
+      quickstartHandler: Adventure5e.activateSceneQuickstart,
+      lifecycle: "post"
+    },
+    customizeWorld: {
+      label: "DND5E.ADVENTURE.ImportAction.CustomizeWorld",
+      handler: Adventure5e.customizeWorld,
+      lifecycle: "post"
+    },
+    displayJournal: {
+      label: "DND5E.ADVENTURE.ImportAction.DisplayJournal",
+      default: true,
+      handler: Adventure5e.displayJournal,
+      quickstartHandler: Adventure5e.displayJournalQuickstart,
+      lifecycle: "post"
+    }
+  }
+};
+preLocalize("adventure.importActions", { key: "label" });
 
 /* -------------------------------------------- */
 /*  Calendar                                    */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -18,7 +18,8 @@ import { preLocalize } from "./utils.mjs";
 /**
  * @import {
  *   AbilityConfiguration, ActivityActivationTypeConfiguration, ActivityConsumptionTargetConfiguration,
- *   ActivityTypeConfiguration, ActorSizeConfiguration, AdvancementTypeConfiguration, AdventureImportAction,
+ *   ActivityTypeConfiguration, ActorSizeConfiguration, AdvancementTypeConfiguration,
+ *   AdventureConfiguration, AdventureImportAction,
  *   AreaTargetDefinition, CalendarHUDConfiguration, CharacterFlagConfiguration, ConditionConfiguration,
  *   CraftingConfiguration, CreatureTypeConfiguration, CurrencyConfiguration, DamageTypeConfiguration,
  *   EncumbranceConfiguration, FacilityConfiguration, HabitatConfiguration5e,
@@ -4530,9 +4531,13 @@ DND5E.defaultArtwork = {
 
 /**
  * Configuration for adventure handling by the system.
- * @type {{ importActions: Record<string, Omit<AdventureImportAction, "id">> }}
+ * @type {{
+ *   config: Record<string, AdventureConfiguration>,
+ *   importActions: Record<string, Omit<AdventureImportAction, "id">>
+ * }}
  */
 DND5E.adventure = {
+  config: {},
   importActions: {
     activateScene: {
       label: "DND5E.ADVENTURE.ImportAction.ActivateScene",

--- a/module/documents/adventure.mjs
+++ b/module/documents/adventure.mjs
@@ -1,8 +1,50 @@
 /**
+ * @import { AdventureImportAction } from "../_types.mjs";
+ */
+
+/**
  * Extend the base Adventure class to implement system-specific logic.
  * @extends {Adventure}
  */
 export default class Adventure5e extends foundry.documents.Adventure {
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * List of configuration data for each import action. Options can either be defined using the `dnd5e.importActions`
+   * flag on the adventure to use pre-defined actions or fetched from the adventure registry if custom actions or
+   * more complex configurations are required.
+   * @type {AdventureImportAction[]}
+   */
+  get importActions() {
+    const flag = this.getFlag("dnd5e", "importActions");
+    if ( flag ) return this.getFlag("dnd5e", "importActions")
+      .filter(id => id in CONFIG.DND5E.adventure.importActions)
+      .map(id => ({ ...CONFIG.DND5E.adventure.importActions[id], id }));
+    return dnd5e.registry.adventures.get(this.uuid).importActions;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The quickstart configuration data for the module in which this adventure appears. If `adventures` is defined in
+   * the quickstart configuration, will only return a result if this adventure is defined for this system.
+   * @type {QuickstartManifestData|null}
+   */
+  get quickstartConfig() {
+    if ( this.compendium?.metadata.packageType !== "module" ) return null;
+    const manifest = game.modules.get(this.compendium.metadata.packageName);
+    if ( !manifest.quickstart?.adventures?.[game.system.uuid]
+      || (manifest.quickstart.adventures[game.system.id].uuid === this.uuid) ) return manifest.quickstart;
+    return null;
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Migration                              */
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   static migrateData(source) {
     if ( source.actors?.length ) {
@@ -12,5 +54,92 @@ export default class Adventure5e extends foundry.documents.Adventure {
       }
     }
     return super.migrateData(source);
+  }
+
+  /* -------------------------------------------- */
+  /*  Import Actions                              */
+  /* -------------------------------------------- */
+
+  /**
+   * Post-import action that activates a specific scene defined by the adventure. The scene can be defined using
+   * an ID in the import action config as `initialScene` or using the `dnd5e.initialScene` flag on the adventure.
+   * @type {AdventureImportPostHandler}
+   */
+  static async activateScene(config, importResult, importOptions) {
+    const sceneId = config.initialScene ?? this.getFlag("dnd5e", "initialScene");
+    const scene = game.scenes.get(sceneId);
+    if ( !scene ) {
+      console.warn(_loc("DND5E.ADVENTURE.Warning.SceneMissing", { adventure: this.name, id: sceneId }));
+      return;
+    }
+    return scene.activate();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Post-quickstart that activates the first scene found in a quickstarted adventure.
+   * @type {AdventureImportQuickstartHandler}
+   */
+  static async activateSceneQuickstart(adventures) {
+    for ( const { adventure, config } of adventures ) {
+      const result = await Adventure5e.activateScene.call(adventure, config);
+      if ( result instanceof Scene ) return;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Post-import action that modifies the join page of the world with adventure-specific description and background.
+   * The join details can be defined in the import action config as `joinBackground` and `joinDescription` or using
+   * the `dnd5e.joinBackground` and `dnd5e.joinDescription` flags on the adventure. If neither of these are defined
+   * it will check to see if there is a `quickstart` flag defined for the module and use those values instead.
+   * @type {AdventureImportPostHandler}
+   */
+  static async customizeWorld(config, importResult, importOptions) {
+    const quickstart = this.quickstartConfig?.world ?? {};
+    const background = config.joinBackground ?? this.getFlag("dnd5e", "joinBackground") ?? quickstart.background;
+    const description = config.joinDescription ?? this.getFlag("dnd5e", "joinDescription") ?? quickstart.description;
+    if ( !background && !description ) return;
+    const worldData = { background, description, action: "editWorld", id: game.world.id };
+    await foundry.utils.fetchJsonWithTimeout(foundry.utils.getRoute("setup"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(worldData)
+    });
+    game.world.updateSource(worldData);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Post-import action that displays a specific journal defined by the adventure. The journal can be defined using
+   * either an ID or UUID specified in the import action config as `initialJournal` or using the `dnd5e.initialJournal`
+   * flag on the adventure.
+   * @type {AdventureImportPostHandler}
+   */
+  static async displayJournal(config, importResult, importOptions) {
+    const journalId = config.initialJournal ?? this.getFlag("dnd5e", "initialJournal");
+    const journal = journalId?.length === 16 ? game.journal.get(journalId) : await fromUuid(journalId);
+    if ( !journal || !((journal instanceof JournalEntry) || (journal instanceof JournalEntryPage)) ) {
+      console.warn(_loc("DND5E.ADVENTURE.Warning.JournalMissing", { adventure: this.name, id: journalId }));
+      return;
+    }
+    return journal instanceof JournalEntryPage
+      ? journal.parent.sheet.render({ force: true, pageId: journal.id })
+      : journal.sheet.render({ force: true });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Post-quickstart that displays all journals found in quickstarted adventures.
+   * @type {AdventureImportQuickstartHandler}
+   */
+  static async displayJournalQuickstart(adventures) {
+    for ( const { adventure, config } of adventures ) {
+      await Adventure5e.displayJournal.call(adventure, config);
+    }
   }
 }

--- a/module/documents/adventure.mjs
+++ b/module/documents/adventure.mjs
@@ -14,16 +14,25 @@ export default class Adventure5e extends foundry.documents.Adventure {
 
   /**
    * List of configuration data for each import action. Options can either be defined using the `dnd5e.importActions`
-   * flag on the adventure to use pre-defined actions or fetched from the adventure registry if custom actions or
-   * more complex configurations are required.
+   * flag on the adventure to use pre-defined actions or fetched from `CONFIG.DND5E.adventure.config` by adventure
+   * UUID or package name.
    * @type {AdventureImportAction[]}
    */
   get importActions() {
-    const flag = this.getFlag("dnd5e", "importActions");
-    if ( flag ) return this.getFlag("dnd5e", "importActions")
-      .filter(id => id in CONFIG.DND5E.adventure.importActions)
-      .map(id => ({ ...CONFIG.DND5E.adventure.importActions[id], id }));
-    return dnd5e.registry.adventures.get(this.uuid).importActions;
+    let actions = this.getFlag("dnd5e", "importActions")
+      ?? CONFIG.DND5E.adventure.config[this.uuid]?.importActions
+      ?? CONFIG.DND5E.adventure.config[this.compendium.metadata.packageName]?.importActions
+      ?? [];
+
+    actions = actions
+      .filter(a => a.id || (a in CONFIG.DND5E.adventure.importActions))
+      .map(a => {
+        if ( foundry.utils.getType(a) === "string" ) a = { id: a };
+        if ( !(a.id in CONFIG.DND5E.adventure.importActions) ) return { ...a, label: _loc(a.label) };
+        return { ...CONFIG.DND5E.adventure.importActions[a.id], ...a };
+      });
+
+    return actions;
   }
 
   /* -------------------------------------------- */
@@ -36,7 +45,7 @@ export default class Adventure5e extends foundry.documents.Adventure {
   get quickstartConfig() {
     if ( this.compendium?.metadata.packageType !== "module" ) return null;
     const manifest = game.modules.get(this.compendium.metadata.packageName);
-    if ( !manifest.quickstart?.adventures?.[game.system.uuid]
+    if ( !manifest.quickstart?.adventures?.[game.system.id]
       || (manifest.quickstart.adventures[game.system.id].uuid === this.uuid) ) return manifest.quickstart;
     return null;
   }

--- a/module/documents/adventure.mjs
+++ b/module/documents/adventure.mjs
@@ -21,7 +21,7 @@ export default class Adventure5e extends foundry.documents.Adventure {
   get importActions() {
     let actions = this.getFlag("dnd5e", "importActions")
       ?? CONFIG.DND5E.adventure.config[this.uuid]?.importActions
-      ?? CONFIG.DND5E.adventure.config[this.compendium.metadata.packageName]?.importActions
+      ?? CONFIG.DND5E.adventure.config[this.compendium?.metadata.packageName]?.importActions
       ?? [];
 
     actions = actions

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -2,8 +2,80 @@ import CompendiumBrowser from "./applications/compendium-browser.mjs";
 import { formatIdentifier } from "./utils.mjs";
 
 /**
- * @import { RegisteredItemData } from "./_types.mjs";
+ * @import { AdventureConfiguration, RegisteredItemData } from "./_types.mjs";
  */
+
+/* -------------------------------------------- */
+/*  Adventures                                  */
+/* -------------------------------------------- */
+
+class AdventureRegistry {
+  /**
+   * Registration of specific adventures by UUID with custom configuration.
+   * @type {Map<string, AdventureConfiguration>}
+   */
+  static #adventures = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Registration of configurations shared across all adventures in a module.
+   * @type {Map<string, AdventureConfiguration>}
+   */
+  static #modules = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieve the configuration for a specific adventure. Prefers configuration registered to a specific
+   * adventure over configuration for a module.
+   * @param {string} uuid               UUID of the adventure.
+   * @returns {AdventureConfiguration}
+   */
+  static get(uuid) {
+    // Retrieve the config
+    let config;
+    if ( this.#adventures.has(uuid) ) config = this.#adventures.get(uuid);
+    else {
+      const packageName = foundry.utils.parseUuid(uuid)?.collection.metadata.packageName;
+      if ( this.#modules.has(packageName) ) config = this.#modules.get(packageName);
+    }
+    config ??= { importActions: [] };
+
+    // Transform any partial import actions into their full counterparts
+    config.importActions = config.importActions
+      .filter(a => a.id || (a in CONFIG.DND5E.adventure.importActions))
+      .map(a => {
+        if ( foundry.utils.getType(a) === "string" ) a = { id: a };
+        if ( !(a.id in CONFIG.DND5E.adventure.importActions) ) return { ...a, label: _loc(a.label) };
+        return { ...CONFIG.DND5E.adventure.importActions[a.id], ...a };
+      });
+
+    return config;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Register configuration for a specific adventure.
+   * @param {string} uuid                    UUID of the adventure.
+   * @param {AdventureConfiguration} config  Configuration for the adventure.
+   */
+  static setAdventure(uuid, config) {
+    this.#adventures.set(uuid, config);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Register configuration for all modules in a module.
+   * @param {string} name                    Name of the module.
+   * @param {AdventureConfiguration} config  Configuration for all adventures in the module.
+   */
+  static setModule(name, config) {
+    this.#modules.set(name, config);
+  }
+}
 
 /* -------------------------------------------- */
 /*  Dependents                                  */
@@ -712,6 +784,7 @@ const RegistryStatus = new class extends Map {
 /* -------------------------------------------- */
 
 export default {
+  adventures: AdventureRegistry,
   classes: new ItemRegistry("class"),
   dependents: DependentsRegistry,
   enchantments: EnchantmentRegisty,

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -2,8 +2,80 @@ import CompendiumBrowser from "./applications/compendium-browser.mjs";
 import { formatIdentifier } from "./utils.mjs";
 
 /**
- * @import { RegisteredItemData } from "./_types.mjs";
+ * @import { AdventureConfiguration, RegisteredItemData } from "./_types.mjs";
  */
+
+/* -------------------------------------------- */
+/*  Adventures                                  */
+/* -------------------------------------------- */
+
+class AdventureRegistry {
+  /**
+   * Registration of specific adventures by UUID with custom configuration.
+   * @type {Map<string, AdventureConfiguration>}
+   */
+  static #adventures = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Registration of configurations shared across all adventures in a module.
+   * @type {Map<string, AdventureConfiguration>}
+   */
+  static #modules = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieve the configuration for a specific adventure. Prefers configuration registered to a specific
+   * adventure over configuration for a module.
+   * @param {string} uuid               UUID of the adventure.
+   * @returns {AdventureConfiguration}
+   */
+  static get(uuid) {
+    // Retrieve the config
+    let config;
+    if ( this.#adventures.has(uuid) ) config = this.#adventures.get(uuid);
+    else {
+      const packageName = foundry.utils.parseUuid(uuid)?.collection.metadata.packageName;
+      if ( this.#modules.has(packageName) ) config = this.#modules.get(packageName);
+    }
+    config ??= { importActions: [] };
+
+    // Transform any partial import actions into their full counterparts
+    config.importActions = config.importActions
+      .filter(a => a.id || (a in CONFIG.DND5E.adventure.importActions))
+      .map(a => {
+        if ( foundry.utils.getType(a) === "string" ) a = { id: a };
+        if ( !(a.id in CONFIG.DND5E.adventure.importActions) ) return { ...a, label: _loc(a.label) };
+        return { ...CONFIG.DND5E.adventure.importActions[a.id], ...a };
+      });
+
+    return config;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Register configuration for a specific adventure.
+   * @param {string} uuid                    UUID of the adventure.
+   * @param {AdventureConfiguration} config  Configuration for the adventure.
+   */
+  static setAdventure(uuid, config) {
+    this.#adventures.set(uuid, config);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Register configuration for all modules in a module.
+   * @param {string} name                    Name of the module.
+   * @param {AdventureConfiguration} config  Configuration for all adventures in the module.
+   */
+  static setModule(name, config) {
+    this.#modules.set(name, config);
+  }
+}
 
 /* -------------------------------------------- */
 /*  Dependents                                  */
@@ -735,6 +807,7 @@ const RegistryStatus = new class extends Map {
 /* -------------------------------------------- */
 
 export default {
+  adventures: AdventureRegistry,
   backgrounds: new ItemRegistry("background"),
   classes: new ItemRegistry("class"),
   dependents: DependentsRegistry,

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -2,80 +2,8 @@ import CompendiumBrowser from "./applications/compendium-browser.mjs";
 import { formatIdentifier } from "./utils.mjs";
 
 /**
- * @import { AdventureConfiguration, RegisteredItemData } from "./_types.mjs";
+ * @import { RegisteredItemData } from "./_types.mjs";
  */
-
-/* -------------------------------------------- */
-/*  Adventures                                  */
-/* -------------------------------------------- */
-
-class AdventureRegistry {
-  /**
-   * Registration of specific adventures by UUID with custom configuration.
-   * @type {Map<string, AdventureConfiguration>}
-   */
-  static #adventures = new Map();
-
-  /* -------------------------------------------- */
-
-  /**
-   * Registration of configurations shared across all adventures in a module.
-   * @type {Map<string, AdventureConfiguration>}
-   */
-  static #modules = new Map();
-
-  /* -------------------------------------------- */
-
-  /**
-   * Retrieve the configuration for a specific adventure. Prefers configuration registered to a specific
-   * adventure over configuration for a module.
-   * @param {string} uuid               UUID of the adventure.
-   * @returns {AdventureConfiguration}
-   */
-  static get(uuid) {
-    // Retrieve the config
-    let config;
-    if ( this.#adventures.has(uuid) ) config = this.#adventures.get(uuid);
-    else {
-      const packageName = foundry.utils.parseUuid(uuid)?.collection.metadata.packageName;
-      if ( this.#modules.has(packageName) ) config = this.#modules.get(packageName);
-    }
-    config ??= { importActions: [] };
-
-    // Transform any partial import actions into their full counterparts
-    config.importActions = config.importActions
-      .filter(a => a.id || (a in CONFIG.DND5E.adventure.importActions))
-      .map(a => {
-        if ( foundry.utils.getType(a) === "string" ) a = { id: a };
-        if ( !(a.id in CONFIG.DND5E.adventure.importActions) ) return { ...a, label: _loc(a.label) };
-        return { ...CONFIG.DND5E.adventure.importActions[a.id], ...a };
-      });
-
-    return config;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Register configuration for a specific adventure.
-   * @param {string} uuid                    UUID of the adventure.
-   * @param {AdventureConfiguration} config  Configuration for the adventure.
-   */
-  static setAdventure(uuid, config) {
-    this.#adventures.set(uuid, config);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Register configuration for all modules in a module.
-   * @param {string} name                    Name of the module.
-   * @param {AdventureConfiguration} config  Configuration for all adventures in the module.
-   */
-  static setModule(name, config) {
-    this.#modules.set(name, config);
-  }
-}
 
 /* -------------------------------------------- */
 /*  Dependents                                  */
@@ -807,7 +735,6 @@ const RegistryStatus = new class extends Map {
 /* -------------------------------------------- */
 
 export default {
-  adventures: AdventureRegistry,
   backgrounds: new ItemRegistry("background"),
   classes: new ItemRegistry("class"),
   dependents: DependentsRegistry,

--- a/templates/adventure/importer.hbs
+++ b/templates/adventure/importer.hbs
@@ -1,0 +1,61 @@
+<div class="standard-form scrollable">
+    {{~#if adventure.img}}
+    <figure class="adventure-banner">
+        <img src="{{ adventure.img }}" alt="{{ adventure.name }}">
+        {{#if adventure.caption}}<figcaption>{{{ adventure.caption }}}</figcaption>{{/if}}
+    </figure>
+    {{/if}}
+
+    <section class="adventure-contents">
+        <section class="adventure-overview">
+            <h2>{{ localize "ADVENTURE.ImportHeaderOverview" }}</h2>
+            {{{ description }}}
+        </section>
+        <section class="import-controls">
+            <h2>{{ localize "ADVENTURE.ImportHeaderContents" }}</h2>
+            {{#if loading}}
+            <p>
+                <i class="fa-solid fa-spinner fa-spin fa-spin-pulse" inert></i>
+                {{ localize "ADVENTURE.ImportLoading" }}
+            </p>
+            {{else if imported}}
+            <div class="form-group">
+                <label class="checkbox">
+                    <dnd5e-checkbox name="importFields" value="all" data-tooltip
+                                    aria-label="{{ localize 'ADVENTURE.ImportAll' }}" checked></dnd5e-checkbox>
+                    {{ localize "ADVENTURE.ImportAll" }}
+                </label>
+            </div>
+            {{#each contents}}
+            <div class="form-group">
+                <label class="checkbox">
+                    <dnd5e-checkbox name="importFields" value="{{ field }}" checked disabled data-tooltip
+                                    aria-label="{{ localize 'ADVENTURE.ImportContent' label=label }}"></dnd5e-checkbox>
+                    <i class="{{ icon }} fa-fw" inert></i>
+                    {{ count }} {{ label }}
+                </label>
+            </div>
+            {{/each}}
+            {{else}}
+            <ul class="plain">
+                {{#each contents}}
+                <li><i class="{{ icon }} fa-fw" inert></i> {{ count }} {{ label }}</li>
+                {{/each}}
+            </ul>
+            {{/if}}
+        </section>
+        {{#if optionsSchema}}
+        <section class="import-options">
+            <h2>{{ localize "ADVENTURE.ImportHeaderOptions" }}</h2>
+            {{#each optionsSchema.fields as |field|}}
+            <div class="form-group">
+                <label class="checkbox">
+                    {{ formInput field input=@root.inputs.createCheckboxInput value=field.initial }}
+                    {{ field.label }}
+                </label>
+            </div>
+            {{/each}}
+        </section>
+        {{/if}}
+    </section>
+</div>


### PR DESCRIPTION
Adds a new Adventure Importer sheet that follows the dnd5e design style. Following the example of core with its V2 importer, this sheet is not made default and instead must be opted into on a per-adventure basis.

<img width="936" height="730" alt="Adventure Importer 5e" src="https://github.com/user-attachments/assets/d617ca34-9fc4-4ca5-8373-89008160478a" />

The new sheet includes support for pre- and post-import actions which are presented as checkboxes on the importer sheet to give control to users. There are three actions initially provided by the system: "Activate Scene", "Display Journal", and "Customize World", but modules can add their own actions.

Each adventure can use flags to define which of the actions is run when that adventure is imported and customize their behavior. There is also a new `AdventureRegistry` that allows defining actions for a single adventure or for all adventures in a module. Actions added through the registry can support custom handlers without having to add to the global configuraiton.

```javascript
// These actions will be run across all adventures in the module
dnd5e.registry.adventures.setModule("dnd-adventures-faerun", {
  importActions: ["activateScene", "displayJournal"]
});

// This specific adventure has a different set of actions
dnd5e.registry.adventures.setAdventure("Compendium.dnd-adventures-faerun.adventures.Adventure.OJuc9WnDJDAETIFr", {
  importActions: [{ id: "displayJournal", journalId: "x0TaNijLJkanmufc" }]
});
```
<img width="437" height="287" alt="Adventure Quickstart Dialog" src="https://github.com/user-attachments/assets/ae625b42-d74f-4044-b9cd-c38888491f6f" />


The system also contains a dialog that presents actions available after using quickstart to load the adventure. By adding a separate quickstart handler actions can opt in to support on quickstarted adventures. These actions are passed all of the adventures that have that action and their configs so they can optimize if more than one adventure is quickstarted.