### PR TITLE
[#6866] Split advantage modifier evaluation into two phases. Eagerly expand dice terms to present to RollResolver.

### DIFF
--- a/module/dice/basic-die.mjs
+++ b/module/dice/basic-die.mjs
@@ -16,31 +16,23 @@ export default class BasicDie extends Die {
   /* -------------------------------------------- */
 
   /**
-   * Handle rolling advantage and disadvantage for a die.
-   * @param {string} modifier        The matched modifier query.
-   * @returns {Promise<false|void>}  False if modifier was unmatched.
+   * Handle rolling advantage and disadvantage for a die. The extra rolls have already been performed by the main roll
+   * loop (pre-expansion inflated the dice count before the resolver opened), so this handler just partitions results
+   * into count + 1 sets of size, keeps the set with the best (adv) or worst (dis) total, and discards the others.
+   * @param {string} modifier  The matched modifier query.
    */
   async advantage(modifier) {
-    const match = modifier.match(/\w{3}(\d+)?/i);
-    const count = parseInt(match[1] ?? 1);
-    const adv = modifier.startsWith("a");
-
-    // Roll die again up to the count required
-    const rollCount = count * this.number;
-    for ( let i=0; i<rollCount; i++ ) await this.roll();
-
-    // Partition results based on count
+    const expansion = this.options.pending?.advantage;
+    if ( !expansion ) return;
+    const { count, adv, size } = expansion;
     const sets = Array(count + 1);
-    const sliceSize = this.results.length / sets.length;
     let targetTotal = adv ? -Infinity : Infinity;
     for ( const index of sets.keys() ) {
-      const startIndex = sliceSize * index;
-      sets[index] = { results: this.results.slice(startIndex, startIndex + sliceSize) };
+      const startIndex = size * index;
+      sets[index] = { results: this.results.slice(startIndex, startIndex + size) };
       sets[index].total = sets[index].results.reduce((total, { result }) => total + result, 0);
       targetTotal = Math[adv ? "max" : "min"](targetTotal, sets[index].total);
     }
-
-    // Discard any results not included in the selected set
     let kept = false;
     for ( const { results, total } of sets ) {
       if ( !kept && (total === targetTotal) ) kept = true;
@@ -49,6 +41,53 @@ export default class BasicDie extends Die {
         r.active = false;
       });
     }
+    delete this.options.pending.advantage;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Pre-expand any adv/dis modifier on this term so that the resolver sees the final dice count up-front. Multiplies
+   * _number by count + 1 and stashes partition data in options.pending.advantage for the advantage handler to consume.
+   * No-op for complex terms that have a Roll for a number.
+   */
+  expandAdvantage() {
+    if ( this.options.pending?.advantage ) return;
+    if ( typeof this.number !== "number" ) return;
+    let match;
+    for ( const modifier of this.modifiers ) {
+      match = modifier.match(/^(adv|dis)(\d*)/i);
+      if ( match ) break;
+    }
+    if ( !match ) return;
+    let [, token, count] = match;
+    count = parseInt(count || 1);
+    const adv = token.toLowerCase() === "adv";
+    const size = this.number;
+    this._number = (count + 1) * size;
+    this.options.pending ??= {};
+    this.options.pending.advantage = { adv, count, size };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _evaluateAsync(options={}) {
+    // Have to duplicate most of the core code here in order to insert advantage expansion at the point where we have
+    // the evaluated complex number term but before the terms are passed back to the resolver.
+    for ( const roll of [this._faces, this._number] ) {
+      if ( !(roll instanceof foundry.dice.Roll) ) continue;
+      if ( this._root ) roll._root = this._root;
+      await roll.evaluate(options);
+    }
+    if ( Math.abs(this.number) > 999 ) {
+      throw new Error("You may not evaluate a DiceTerm with more than 999 requested results");
+    }
+    this.expandAdvantage();
+    if ( this.resolver && !this._id ) await this.resolver.addTerm(this);
+    for ( let n = this.results.length; n < Math.abs(this.number); n++ ) await this.roll(options);
+    await this._evaluateModifiers();
+    return this;
   }
 
   /* -------------------------------------------- */

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -1,4 +1,5 @@
 import RollConfigurationDialog from "../applications/dice/roll-configuration-dialog.mjs";
+import BasicDie from "./basic-die.mjs";
 
 const { DiceTerm, NumericTerm } = foundry.dice.terms;
 
@@ -278,6 +279,9 @@ export default class BasicRoll extends Roll {
   /** @inheritDoc */
   async evaluate(options={}) {
     this.preCalculateDiceTerms(options);
+    for ( const term of this.terms ) {
+      if ( term instanceof BasicDie ) term.expandAdvantage();
+    }
     return super.evaluate(options);
   }
 
@@ -286,6 +290,9 @@ export default class BasicRoll extends Roll {
   /** @inheritDoc */
   evaluateSync(options={}) {
     this.preCalculateDiceTerms(options);
+    for ( const term of this.terms ) {
+      if ( term instanceof BasicDie ) term.expandAdvantage();
+    }
     return super.evaluateSync(options);
   }
 


### PR DESCRIPTION
- Closes #6866 

Bit of a tricky one. There's quite a lot required to support this modifier, and I think there are still some bugs that I didn't address. Having to copy most of `_evaluateAsync` is a particular wart. Some other options available to us:

1. Revert to using `kh/dl` for d20 rolls and leave `adv` just for some special damage roll mechanics. They will still have the RollResolver issue but they're much rarer than d20 rolls.
2. We could make some extensions to the core API. Something that allows `DiceTerm`s to advertise some additional `number` would clean this up almost entirely.

In order to advocate (2) though I would need to understand why `adv` is preferable to just using `kh` and I'm not sure I quite understand it enough to defend it yet.