### PR TITLE
[#6956] Fix vehicle action thresholds not working

### DIFF
--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -297,7 +297,7 @@ export default class VehicleData extends CommonTemplate {
     const crew = this.crew.value.length;
 
     if ( !actions.stations && actions.max ) {
-      for ( let i = actions; i--; actions.max-- ) {
+      for ( let i = actions.max; i--; actions.max-- ) {
         const threshold = actions.thresholds[i];
         if ( Number.isFinite(threshold) && (crew >= threshold) ) break;
       }


### PR DESCRIPTION
Proposing a fix for the Bug reported by me here https://github.com/foundryvtt/dnd5e/issues/6956

After this change, the action count scales with crew count using the configured thresholds as expected. I have only verified this specific scenario and have not tested other vehicle action workflows.

<img width="1402" height="554" alt="Corrected 4 Crew" src="https://github.com/user-attachments/assets/99e176a9-ed56-4a6c-8dab-c50b19b94ef9" />
<img width="1401" height="553" alt="Corrected 3 Crew" src="https://github.com/user-attachments/assets/01c950fc-4f39-4767-993e-af1eb7f30390" />
<img width="1399" height="552" alt="Corrected 2 Crew" src="https://github.com/user-attachments/assets/d035997a-df3c-4a95-a5f6-e47b73c0165e" />
<img width="1398" height="553" alt="Corrected 1 Crew" src="https://github.com/user-attachments/assets/e142fa51-a9e5-4169-8096-8df8daf37081" />
<img width="1398" height="537" alt="Corrected 0 Crew" src="https://github.com/user-attachments/assets/c9988b47-6a95-48d4-980e-9506788cc673" />
