### PR TITLE
Ranger changes for new content patterns

### DIFF
--- a/packs/_source/actors24/premades/level-1/quillathe.yml
+++ b/packs/_source/actors24/premades/level-1/quillathe.yml
@@ -404,7 +404,18 @@ system:
       value: >-
         <p>Quillathe cleanses monsters from her woods as a hobby, but now a new
         force menaces her land and she must band with adventurers to defeat
-        it.</p>
+        it.</p><p><em>Token artwork by </em><a
+        href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener"><em>Forgotten
+        Adventures</em></a><em>.</em></p><p><em>Token artwork by </em><a
+        href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener"><em>Forgotten
+        Adventures</em></a><em>.</em></p><p><em>Token artwork by </em><a
+        href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener"><em>Forgotten
+        Adventures</em></a><em>.</em></p><p><em>Token artwork by </em><a
+        href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener"><em>Forgotten Adventures</em></a><em>.</em></p>
       public: ''
     alignment: Chaotic Neutral
     ideal: ''
@@ -494,9 +505,6 @@ system:
     - type: item
       id: .Item.WiXfB8xRlPdC7kiB
       sort: 0
-    - type: item
-      id: .Item.iCf450qECu1PRkAZ
-      sort: 50000
 prototypeToken:
   name: Quillathe
   displayName: 20
@@ -742,8 +750,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     _id: WSfqg4qp13LFdc3N
     ownership:
       default: 0
@@ -843,8 +852,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.6156HtS7RvjQ7nhJ'
@@ -1049,8 +1059,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     sort: 0
     ownership:
       default: 0
@@ -1101,8 +1112,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     sort: 0
     ownership:
       default: 0
@@ -1155,8 +1167,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     sort: 0
     ownership:
       default: 0
@@ -1208,8 +1221,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     sort: 0
     ownership:
       default: 0
@@ -1277,8 +1291,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     sort: 0
     ownership:
       default: 0
@@ -1338,9 +1353,10 @@ items:
       source:
         custom: ''
         rules: '2024'
-        revision: 1
+        revision: 2
         license: CC-BY-4.0
         book: ''
+        page: ''
       startingEquipment:
         - type: AND
           requiresProficiency: false
@@ -1437,8 +1453,8 @@ items:
           value:
             added:
               HAXlit2SO8luWUtO: Compendium.dnd5e.classes24.Item.phbrgrSpellcasti
-              o0bC09CnUpZ4wvDt: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
               uHY0uPusihtnVQkp: Compendium.dnd5e.classes24.Item.phbrgrWeaponMast
+              2p1sA50BWv2AdBYe: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
           level: 1
           title: Class Features
           flags: {}
@@ -1686,29 +1702,6 @@ items:
           title: ''
           flags: {}
           hint: ''
-        DOENALOWWjAUHzb7:
-          _id: DOENALOWWjAUHzb7
-          type: ItemGrant
-          configuration:
-            items:
-              - optional: false
-                uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-            optional: false
-            spell:
-              ability: []
-              uses:
-                max: '@scale.ranger.favored-enemy'
-                per: lr
-                requireSlot: false
-              method: spell
-              prepared: 2
-          value:
-            added:
-              iCf450qECu1PRkAZ: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-          level: 1
-          title: Favored Enemy
-          hint: ''
-          flags: {}
         FksFWNV4X4lTFlvO:
           _id: FksFWNV4X4lTFlvO
           type: ScaleValue
@@ -2055,8 +2048,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     sort: 0
     ownership:
       default: 0
@@ -2101,6 +2095,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: ft
         special: ''
@@ -2151,6 +2146,7 @@ items:
               type: cube
               size: '5'
               count: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -2194,8 +2190,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.kEjBWiTMcmhrI5w4'
@@ -2277,74 +2274,13 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.HAXlit2SO8luWUtO'
-  - _id: o0bC09CnUpZ4wvDt
-    name: Favored Enemy
-    type: feat
-    folder: h5OUzaJcZzsNsOGc
-    img: icons/creatures/abilities/dragon-breath-purple.webp
-    system:
-      description:
-        value: >-
-          <p>You always have the
-          @UUID[Compendium.dnd5e.spells24.Item.phbsplHuntersMar]{Hunter's Mark}
-          spell prepared. You can cast it twice without expending a spell slot,
-          and you regain all expended uses of this ability when you finish a
-          Long Rest.</p><p>The number of times you can cast the spell without a
-          spell slot increases when you reach certain Ranger levels, as shown in
-          the Favored Enemy column of the Ranger Features table.</p><section
-          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
-          Note</strong></p><p>The spell is granted to you at this level and will
-          increase the number of free uses available automatically as you level
-          up.</p></section>
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        revision: 1
-        license: CC-BY-4.0
-        book: ''
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: class
-        subtype: ''
-      prerequisites:
-        level: 1
-        items: []
-        repeatable: false
-      properties: []
-      requirements: ''
-      activities: {}
-      enchant: {}
-      identifier: favored-enemy
-      advancement: {}
-      crewed: false
-    effects: []
-    flags:
-      dnd5e:
-        sourceId: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
-        advancementOrigin: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
-        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
-    _stats:
-      compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
-      duplicateSource: null
-      exportSource: null
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    sort: 0
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv01000.o0bC09CnUpZ4wvDt'
   - _id: uHY0uPusihtnVQkp
     name: Weapon Mastery
     type: feat
@@ -2396,322 +2332,13 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.uHY0uPusihtnVQkp'
-  - name: Hunter's Mark
-    system:
-      description:
-        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        license: CC-BY-4.0
-        book: ''
-        revision: 2
-      activation:
-        type: bonus
-        condition: ''
-        value: null
-      duration:
-        value: '1'
-        units: hour
-      target:
-        affects:
-          type: creature
-          count: '1'
-          choice: false
-          special: ''
-        template:
-          units: ft
-          contiguous: false
-          type: ''
-      range:
-        value: '90'
-        units: ft
-        special: ''
-      uses:
-        max: '@scale.ranger.favored-enemy'
-        recovery:
-          - period: lr
-            type: recoverAll
-          - period: lr
-            type: recoverAll
-        spent: 0
-      level: 1
-      school: div
-      properties:
-        - vocal
-        - concentration
-      materials:
-        value: ''
-        consumed: false
-        cost: 0
-        supply: 0
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: damage
-          activation:
-            type: ''
-            value: null
-            override: true
-            condition: ''
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: false
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            override: true
-            concentration: false
-          effects: []
-          range:
-            override: true
-            units: any
-            special: ''
-          target:
-            prompt: true
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-          damage:
-            critical:
-              allow: true
-              bonus: ''
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 1
-                denomination: 6
-                bonus: ''
-                types:
-                  - force
-                scaling:
-                  mode: ''
-                  number: 1
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 200000
-          name: Bonus Mark Damage
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        vxr2JKuQ3jyMDTwb:
-          type: utility
-          _id: vxr2JKuQ3jyMDTwb
-          activation:
-            type: action
-            value: null
-            override: false
-          consumption:
-            scaling:
-              allowed: false
-            spellSlot: true
-            targets: []
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            concentration: false
-            override: false
-          effects:
-            - _id: vPkln6UeePHnbLr4
-              level: {}
-          range:
-            override: false
-            units: self
-          target:
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-            prompt: true
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 100000
-          roll:
-            prompt: false
-            visible: false
-            name: ''
-            formula: ''
-          name: Mark Creature
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        NQtVK0T5uwfMPGQL:
-          type: utility
-          activation:
-            type: bonus
-            value: null
-            override: true
-            condition: when the currently marked target drops to 0 Hit Points
-          consumption:
-            scaling:
-              allowed: false
-            spellSlot: false
-            targets: []
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            concentration: false
-            override: true
-          effects:
-            - _id: vPkln6UeePHnbLr4
-              level: {}
-          range:
-            override: true
-            units: any
-            special: ''
-          target:
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-            prompt: true
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 300000
-          roll:
-            prompt: false
-            visible: false
-            name: ''
-            formula: ''
-          name: Move Mark
-          _id: NQtVK0T5uwfMPGQL
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        72GB8kfgMJgPVbY0:
-          _id: 72GB8kfgMJgPVbY0
-          type: forward
-          name: Mark Creature (free casting)
-          sort: 100001
-          activity:
-            id: vxr2JKuQ3jyMDTwb
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling: {}
-            scaling:
-              allowed: false
-            spellSlot: true
-          activation:
-            type: action
-            override: false
-          description: {}
-          flags: {}
-          uses:
-            spent: 0
-            recovery: []
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-      identifier: hunters-mark
-      method: spell
-      prepared: 2
-      sourceClass: ranger
-    _id: iCf450qECu1PRkAZ
-    type: spell
-    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
-    effects:
-      - name: Hunter's Mark
-        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
-        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-        transfer: false
-        _id: vPkln6UeePHnbLr4
-        type: base
-        system: {}
-        changes: []
-        disabled: false
-        duration:
-          startTime: null
-          combat: null
-          seconds: 3600
-          rounds: null
-          turns: null
-          startRound: null
-          startTurn: null
-        description: >-
-          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
-          force]] damage to the target whenever they hit it with an attack
-          roll.</p>
-        tint: '#ffffff'
-        statuses:
-          - marked
-        sort: 0
-        flags:
-          dnd5e:
-            riders:
-              statuses: []
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv01000.iCf450qECu1PRkAZ.vPkln6UeePHnbLr4
-    folder: pBaAAtXBCq9FVEnL
-    sort: 1900000
-    flags:
-      dnd5e:
-        sourceId: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-        advancementOrigin: NuNBKjUuSNIRsF9M.DOENALOWWjAUHzb7
-        advancementRoot: NuNBKjUuSNIRsF9M.DOENALOWWjAUHzb7
-    _stats:
-      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-      duplicateSource: null
-      exportSource: null
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv01000.iCf450qECu1PRkAZ'
   - name: Cure Wounds
     system:
       description:
@@ -2744,6 +2371,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -2790,6 +2418,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -2819,8 +2448,8 @@ items:
           img: null
       identifier: cure-wounds
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: 2KxozSkbJhhPD7Zb
     type: spell
     img: icons/magic/nature/leaf-drip-light-green.webp
@@ -2834,8 +2463,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.2KxozSkbJhhPD7Zb'
@@ -2879,6 +2509,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: self
         special: ''
@@ -2928,6 +2559,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -2992,6 +2624,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -3030,8 +2663,8 @@ items:
           img: null
       identifier: ensnaring-strike
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: EBgpZ648SEfydQRq
     type: spell
     img: icons/magic/nature/root-vines-grow-brown.webp
@@ -3086,8 +2719,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.EBgpZ648SEfydQRq'
@@ -3171,6 +2805,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -3214,8 +2849,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.unYsJXqTKiLwFGEu'
@@ -3287,8 +2923,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.8OhoDlMp6n7S6vkp'
@@ -3381,6 +3018,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -3450,6 +3088,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -3522,8 +3161,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.kokZ2ulFQRGtAwaU'
@@ -3566,6 +3206,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -3692,8 +3333,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     sort: 0
     ownership:
       default: 0
@@ -3764,8 +3406,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.zLB9qhJw8z2FSbCO'
@@ -3877,6 +3520,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -3932,8 +3576,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.D3zED6xcDPkysnuj'
@@ -4045,6 +3690,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -4100,8 +3746,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.lERu2Skz1q5s9egL'
@@ -4214,6 +3861,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -4270,8 +3918,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.qdxxGDu9tguu68Fu'
@@ -4330,8 +3979,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.nTW4gFU6HZR5aZXL'
@@ -4403,8 +4053,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.WiXfB8xRlPdC7kiB'
@@ -4478,8 +4129,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.pie1jETwfFOgm3Ea'
@@ -4548,8 +4200,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.friHHTqUU9vmohfg'
@@ -4639,6 +4292,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4677,8 +4331,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.hc8MggfBaxwCzCHA'
@@ -4772,6 +4427,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4827,6 +4483,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4882,6 +4539,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4920,8 +4578,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.NQXrw78HaPfjDwCR'
@@ -4970,8 +4629,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.lSEr732XDGJKNopc'
@@ -5030,8 +4690,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.KaPzoh8WPLzQEWMu'
@@ -5074,6 +4735,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -5151,8 +4813,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     _id: 6kKffxM60Oq7uyzV
     sort: 100000
     ownership:
@@ -5247,6 +4910,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -5306,8 +4970,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.sMFxms44gxWpPEzK'
@@ -5413,6 +5078,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -5478,6 +5144,7 @@ items:
               type: square
               size: '5'
               count: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -5524,8 +5191,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.IllhigPdXlPBx5Mu'
@@ -5592,11 +5260,764 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923364225
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv01000.biyQChEtJrhkkj9X'
+  - _id: 2p1sA50BWv2AdBYe
+    name: Favored Enemy
+    type: feat
+    folder: h5OUzaJcZzsNsOGc
+    img: icons/creatures/abilities/dragon-breath-purple.webp
+    system:
+      description:
+        value: >-
+          <p>You always have the
+          @UUID[Compendium.dnd5e.spells24.Item.phbsplHuntersMar]{Hunter's Mark}
+          spell prepared. You can cast it twice without expending a spell slot,
+          and you regain all expended uses of this ability when you finish a
+          Long Rest.</p><p>The number of times you can cast the spell without a
+          spell slot increases when you reach certain Ranger levels, as shown in
+          the Favored Enemy column of the Ranger Features table.</p><section
+          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
+          Note</strong></p><p>The spell is granted to you at this level and will
+          increase the number of free uses available automatically as you level
+          up.</p></section>
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        revision: 2
+        license: CC-BY-4.0
+        book: ''
+      uses:
+        max: '@scale.ranger.favored-enemy'
+        spent: 0
+        recovery:
+          - period: lr
+            type: recoverAll
+      type:
+        value: class
+        subtype: ''
+      prerequisites:
+        level: 1
+        items: []
+        repeatable: false
+      properties:
+        - mgc
+      requirements: ''
+      activities:
+        18OW4UKZ5cSPPLhC:
+          type: cast
+          spell:
+            uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+            challenge:
+              override: false
+            properties: []
+            spellbook: true
+            ability: ''
+            level: 1
+          _id: 18OW4UKZ5cSPPLhC
+          img: ''
+          sort: 0
+          activation:
+            type: bonus
+            override: true
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          flags: {}
+          range:
+            units: self
+            override: false
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: Hunter's Mark (Free)
+      enchant: {}
+      identifier: favored-enemy
+      advancement:
+        DOENALOWWjAUHzb7:
+          _id: DOENALOWWjAUHzb7
+          type: ItemGrant
+          configuration:
+            items:
+              - optional: false
+                uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+            optional: false
+            spell:
+              ability: []
+              uses:
+                max: ''
+                per: ''
+                requireSlot: false
+              method: spell
+              prepared: 2
+          value:
+            added:
+              YzOlWHzPeyRC3sDu: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+          level: 1
+          title: Favored Enemy
+          hint: ''
+          flags: {}
+      crewed: false
+    effects: []
+    flags:
+      dnd5e:
+        sourceId: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
+        advancementOrigin: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923364210
+      modifiedTime: 1777923430706
+      lastModifiedBy: dnd5ebuilder0000
+    sort: 0
+    ownership:
+      default: 0
+    _key: '!actors.items!QuillatheLv01000.2p1sA50BWv2AdBYe'
+  - name: Hunter's Mark
+    system:
+      description:
+        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        license: CC-BY-4.0
+        book: ''
+        revision: 2
+      activation:
+        type: bonus
+        condition: ''
+        value: null
+      duration:
+        value: '1'
+        units: hour
+      target:
+        affects:
+          type: creature
+          count: '1'
+          choice: false
+          special: ''
+        template:
+          units: ft
+          contiguous: false
+          type: ''
+          stationary: false
+      range:
+        value: '90'
+        units: ft
+        special: ''
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      level: 1
+      school: div
+      properties:
+        - vocal
+        - concentration
+      materials:
+        value: ''
+        consumed: false
+        cost: 0
+        supply: 0
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: damage
+          activation:
+            type: ''
+            value: null
+            override: true
+            condition: ''
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: false
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            override: true
+            concentration: false
+          effects: []
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            prompt: true
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+          damage:
+            critical:
+              allow: true
+              bonus: ''
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: 6
+                bonus: ''
+                types:
+                  - force
+                scaling:
+                  mode: ''
+                  number: 1
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 200000
+          name: Bonus Mark Damage
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        vxr2JKuQ3jyMDTwb:
+          type: utility
+          _id: vxr2JKuQ3jyMDTwb
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: false
+            units: self
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 100000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Mark Creature
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        NQtVK0T5uwfMPGQL:
+          type: utility
+          activation:
+            type: bonus
+            value: null
+            override: true
+            condition: when the currently marked target drops to 0 Hit Points
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: false
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: true
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 300000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Move Mark
+          _id: NQtVK0T5uwfMPGQL
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      identifier: hunters-mark
+      method: spell
+      prepared: 2
+      sourceItem: feat:favored-enemy
+    _id: YzOlWHzPeyRC3sDu
+    type: spell
+    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+    effects:
+      - name: Hunter's Mark
+        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        transfer: false
+        _id: vPkln6UeePHnbLr4
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          combat: null
+          seconds: 3600
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
+          force]] damage to the target whenever they hit it with an attack
+          roll.</p>
+        tint: '#ffffff'
+        statuses:
+          - marked
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv01000.YzOlWHzPeyRC3sDu.vPkln6UeePHnbLr4
+    folder: pBaAAtXBCq9FVEnL
+    sort: 1900000
+    ownership:
+      default: 0
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
+        sourceId: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        advancementOrigin: 2p1sA50BWv2AdBYe.DOENALOWWjAUHzb7
+        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923364210
+      modifiedTime: 1777923364210
+      lastModifiedBy: dnd5ebuilder0000
+    _key: '!actors.items!QuillatheLv01000.YzOlWHzPeyRC3sDu'
+  - name: Hunter's Mark
+    system:
+      description:
+        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        license: CC-BY-4.0
+        book: ''
+        revision: 2
+      activation:
+        type: bonus
+        condition: ''
+        value: null
+      duration:
+        value: '1'
+        units: hour
+      target:
+        affects:
+          type: creature
+          count: '1'
+          choice: false
+          special: ''
+        template:
+          units: ft
+          contiguous: false
+          type: ''
+          stationary: false
+      range:
+        value: '90'
+        units: ft
+        special: ''
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      level: 1
+      school: div
+      properties:
+        - vocal
+        - concentration
+      materials:
+        value: ''
+        consumed: false
+        cost: 0
+        supply: 0
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: damage
+          activation:
+            type: ''
+            value: null
+            override: true
+            condition: ''
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: false
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            override: true
+            concentration: false
+          effects: []
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            prompt: true
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+          damage:
+            critical:
+              allow: true
+              bonus: ''
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: 6
+                bonus: ''
+                types:
+                  - force
+                scaling:
+                  mode: ''
+                  number: 1
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 200000
+          name: Bonus Mark Damage
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        vxr2JKuQ3jyMDTwb:
+          type: utility
+          _id: vxr2JKuQ3jyMDTwb
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: false
+            units: self
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 100000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Mark Creature
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        NQtVK0T5uwfMPGQL:
+          type: utility
+          activation:
+            type: bonus
+            value: null
+            override: true
+            condition: when the currently marked target drops to 0 Hit Points
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: false
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: true
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 300000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Move Mark
+          _id: NQtVK0T5uwfMPGQL
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      identifier: hunters-mark
+      method: spell
+      prepared: 0
+      sourceItem: feat:favored-enemy
+    type: spell
+    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+    effects:
+      - name: Hunter's Mark
+        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        transfer: false
+        _id: vPkln6UeePHnbLr4
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          combat: null
+          seconds: 3600
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
+          force]] damage to the target whenever they hit it with an attack
+          roll.</p>
+        tint: '#ffffff'
+        statuses:
+          - marked
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv01000.WMKaTlBSGK1PCDTF.vPkln6UeePHnbLr4
+      - _id: dnd5espellchange
+        type: enchantment
+        name: Spell Changes
+        img: systems/dnd5e/icons/svg/activity/cast.svg
+        origin: >-
+          Compendium.dnd5e.actors24.Actor.QuillatheLv01000.Item.2p1sA50BWv2AdBYe.Activity.18OW4UKZ5cSPPLhC
+        changes:
+          - key: system.method
+            mode: 5
+            value: spell
+          - key: system.activation
+            mode: 5
+            value: '{"type":"bonus","condition":""}'
+        system: {}
+        disabled: false
+        duration:
+          startTime: 0
+          combat: null
+          startRound: 0
+          startTurn: 0
+        description: ''
+        tint: '#ffffff'
+        transfer: true
+        statuses: []
+        sort: 0
+        flags: {}
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv01000.WMKaTlBSGK1PCDTF.dnd5espellchange
+    folder: pBaAAtXBCq9FVEnL
+    sort: 1900000
+    ownership:
+      default: 0
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
+        cachedFor: .Item.2p1sA50BWv2AdBYe.Activity.18OW4UKZ5cSPPLhC
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923364273
+      modifiedTime: 1777923364273
+      lastModifiedBy: dnd5ebuilder0000
+    _id: WMKaTlBSGK1PCDTF
+    _key: '!actors.items!QuillatheLv01000.WMKaTlBSGK1PCDTF'
 effects: []
 folder: Yg8rxL4JuMi44szP
 flags: {}
@@ -5605,9 +6026,9 @@ _stats:
   exportSource: null
   coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 5.3.0
+  systemVersion: 5.3.2
   createdTime: 1771452688099
-  modifiedTime: 1771452688099
+  modifiedTime: 1777923512420
   lastModifiedBy: dnd5ebuilder0000
 ownership:
   default: 0

--- a/packs/_source/actors24/premades/level-1/quillathe.yml
+++ b/packs/_source/actors24/premades/level-1/quillathe.yml
@@ -404,18 +404,7 @@ system:
       value: >-
         <p>Quillathe cleanses monsters from her woods as a hobby, but now a new
         force menaces her land and she must band with adventurers to defeat
-        it.</p><p><em>Token artwork by </em><a
-        href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener"><em>Forgotten
-        Adventures</em></a><em>.</em></p><p><em>Token artwork by </em><a
-        href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener"><em>Forgotten
-        Adventures</em></a><em>.</em></p><p><em>Token artwork by </em><a
-        href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener"><em>Forgotten
-        Adventures</em></a><em>.</em></p><p><em>Token artwork by </em><a
-        href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener"><em>Forgotten Adventures</em></a><em>.</em></p>
+        it.</p>
       public: ''
     alignment: Chaotic Neutral
     ideal: ''
@@ -6028,7 +6017,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 5.3.2
   createdTime: 1771452688099
-  modifiedTime: 1777923512420
+  modifiedTime: 1777993813614
   lastModifiedBy: dnd5ebuilder0000
 ownership:
   default: 0

--- a/packs/_source/actors24/premades/level-1/quillathe.yml
+++ b/packs/_source/actors24/premades/level-1/quillathe.yml
@@ -5269,11 +5269,7 @@ items:
           and you regain all expended uses of this ability when you finish a
           Long Rest.</p><p>The number of times you can cast the spell without a
           spell slot increases when you reach certain Ranger levels, as shown in
-          the Favored Enemy column of the Ranger Features table.</p><section
-          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
-          Note</strong></p><p>The spell is granted to you at this level and will
-          increase the number of free uses available automatically as you level
-          up.</p></section>
+          the Favored Enemy column of the Ranger Features table.</p>
         chat: ''
       source:
         custom: ''
@@ -5355,7 +5351,7 @@ items:
             requireIdentification: false
             requireMagic: false
             identifier: ''
-          name: Hunter's Mark (Free)
+          name: ''
       enchant: {}
       identifier: favored-enemy
       advancement:

--- a/packs/_source/actors24/premades/level-11/quillathe.yml
+++ b/packs/_source/actors24/premades/level-11/quillathe.yml
@@ -403,7 +403,15 @@ system:
       value: >-
         <p>Quillathe cleanses monsters from her woods as a hobby, but now a new
         force menaces her land and she must band with adventurers to defeat
-        it.</p>
+        it.</p><p><em>Token artwork by </em><a
+        href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener"><em>Forgotten
+        Adventures</em></a><em>.</em></p><p><em>Token artwork by </em><a
+        href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener"><em>Forgotten
+        Adventures</em></a><em>.</em></p><p><em>Token artwork by </em><a
+        href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener"><em>Forgotten Adventures</em></a><em>.</em></p>
       public: ''
     alignment: Chaotic Neutral
     ideal: ''
@@ -455,6 +463,8 @@ system:
       communication: {}
     weaponProf:
       value:
+        - longbow
+        - shortbow
         - sim
         - mar
       custom: ''
@@ -495,9 +505,6 @@ system:
     - type: item
       id: .Item.WiXfB8xRlPdC7kiB
       sort: 0
-    - type: item
-      id: .Item.iCf450qECu1PRkAZ
-      sort: 250000
     - type: activity
       id: .Item.xge2yOOVa1Iql8ni.Activity.Ek6m8ZY5Df7Mp6DO
       sort: 200000
@@ -749,8 +756,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     _id: WSfqg4qp13LFdc3N
     ownership:
       default: 0
@@ -850,8 +858,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.6156HtS7RvjQ7nhJ'
@@ -1061,8 +1070,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -1113,8 +1123,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -1167,8 +1178,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -1220,8 +1232,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -1289,8 +1302,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -1459,8 +1473,8 @@ items:
           value:
             added:
               HAXlit2SO8luWUtO: Compendium.dnd5e.classes24.Item.phbrgrSpellcasti
-              o0bC09CnUpZ4wvDt: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
               uHY0uPusihtnVQkp: Compendium.dnd5e.classes24.Item.phbrgrWeaponMast
+              XRWmmuGpQM5LZ4lN: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
           level: 1
           title: Class Features
           flags: {}
@@ -1726,29 +1740,6 @@ items:
           title: ''
           flags: {}
           hint: ''
-        DOENALOWWjAUHzb7:
-          _id: DOENALOWWjAUHzb7
-          type: ItemGrant
-          configuration:
-            items:
-              - optional: false
-                uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-            optional: false
-            spell:
-              ability: []
-              uses:
-                max: '@scale.ranger.favored-enemy'
-                per: lr
-                requireSlot: false
-              method: spell
-              prepared: 2
-          value:
-            added:
-              iCf450qECu1PRkAZ: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-          level: 1
-          title: Favored Enemy
-          hint: ''
-          flags: {}
         FksFWNV4X4lTFlvO:
           _id: FksFWNV4X4lTFlvO
           type: ScaleValue
@@ -2100,8 +2091,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -2146,6 +2138,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: ft
         special: ''
@@ -2196,6 +2189,7 @@ items:
               type: cube
               size: '5'
               count: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -2239,8 +2233,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.kEjBWiTMcmhrI5w4'
@@ -2322,74 +2317,13 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.HAXlit2SO8luWUtO'
-  - _id: o0bC09CnUpZ4wvDt
-    name: Favored Enemy
-    type: feat
-    folder: h5OUzaJcZzsNsOGc
-    img: icons/creatures/abilities/dragon-breath-purple.webp
-    system:
-      description:
-        value: >-
-          <p>You always have the
-          @UUID[Compendium.dnd5e.spells24.Item.phbsplHuntersMar]{Hunter's Mark}
-          spell prepared. You can cast it twice without expending a spell slot,
-          and you regain all expended uses of this ability when you finish a
-          Long Rest.</p><p>The number of times you can cast the spell without a
-          spell slot increases when you reach certain Ranger levels, as shown in
-          the Favored Enemy column of the Ranger Features table.</p><section
-          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
-          Note</strong></p><p>The spell is granted to you at this level and will
-          increase the number of free uses available automatically as you level
-          up.</p></section>
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        revision: 1
-        license: CC-BY-4.0
-        book: ''
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: class
-        subtype: ''
-      prerequisites:
-        level: 1
-        items: []
-        repeatable: false
-      properties: []
-      requirements: ''
-      activities: {}
-      enchant: {}
-      identifier: favored-enemy
-      advancement: {}
-      crewed: false
-    effects: []
-    flags:
-      dnd5e:
-        sourceId: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
-        advancementOrigin: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
-        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
-    _stats:
-      compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
-      duplicateSource: null
-      exportSource: null
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    sort: 0
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv11000.o0bC09CnUpZ4wvDt'
   - _id: uHY0uPusihtnVQkp
     name: Weapon Mastery
     type: feat
@@ -2441,322 +2375,13 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.uHY0uPusihtnVQkp'
-  - name: Hunter's Mark
-    system:
-      description:
-        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        license: CC-BY-4.0
-        book: ''
-        revision: 2
-      activation:
-        type: bonus
-        condition: ''
-        value: null
-      duration:
-        value: '1'
-        units: hour
-      target:
-        affects:
-          type: creature
-          count: '1'
-          choice: false
-          special: ''
-        template:
-          units: ft
-          contiguous: false
-          type: ''
-      range:
-        value: '90'
-        units: ft
-        special: ''
-      uses:
-        max: '@scale.ranger.favored-enemy'
-        recovery:
-          - period: lr
-            type: recoverAll
-          - period: lr
-            type: recoverAll
-        spent: 0
-      level: 1
-      school: div
-      properties:
-        - vocal
-        - concentration
-      materials:
-        value: ''
-        consumed: false
-        cost: 0
-        supply: 0
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: damage
-          activation:
-            type: ''
-            value: null
-            override: true
-            condition: ''
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: false
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            override: true
-            concentration: false
-          effects: []
-          range:
-            override: true
-            units: any
-            special: ''
-          target:
-            prompt: true
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-          damage:
-            critical:
-              allow: true
-              bonus: ''
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 1
-                denomination: 6
-                bonus: ''
-                types:
-                  - force
-                scaling:
-                  mode: ''
-                  number: 1
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 200000
-          name: Bonus Mark Damage
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        vxr2JKuQ3jyMDTwb:
-          type: utility
-          _id: vxr2JKuQ3jyMDTwb
-          activation:
-            type: action
-            value: null
-            override: false
-          consumption:
-            scaling:
-              allowed: false
-            spellSlot: true
-            targets: []
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            concentration: false
-            override: false
-          effects:
-            - _id: vPkln6UeePHnbLr4
-              level: {}
-          range:
-            override: false
-            units: self
-          target:
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-            prompt: true
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 100000
-          roll:
-            prompt: false
-            visible: false
-            name: ''
-            formula: ''
-          name: Mark Creature
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        NQtVK0T5uwfMPGQL:
-          type: utility
-          activation:
-            type: bonus
-            value: null
-            override: true
-            condition: when the currently marked target drops to 0 Hit Points
-          consumption:
-            scaling:
-              allowed: false
-            spellSlot: false
-            targets: []
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            concentration: false
-            override: true
-          effects:
-            - _id: vPkln6UeePHnbLr4
-              level: {}
-          range:
-            override: true
-            units: any
-            special: ''
-          target:
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-            prompt: true
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 300000
-          roll:
-            prompt: false
-            visible: false
-            name: ''
-            formula: ''
-          name: Move Mark
-          _id: NQtVK0T5uwfMPGQL
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        72GB8kfgMJgPVbY0:
-          _id: 72GB8kfgMJgPVbY0
-          type: forward
-          name: Mark Creature (free casting)
-          sort: 100001
-          activity:
-            id: vxr2JKuQ3jyMDTwb
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling: {}
-            scaling:
-              allowed: false
-            spellSlot: true
-          activation:
-            type: action
-            override: false
-          description: {}
-          flags: {}
-          uses:
-            spent: 0
-            recovery: []
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-      identifier: hunters-mark
-      method: spell
-      prepared: 2
-      sourceClass: ranger
-    _id: iCf450qECu1PRkAZ
-    type: spell
-    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
-    effects:
-      - name: Hunter's Mark
-        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
-        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-        transfer: false
-        _id: vPkln6UeePHnbLr4
-        type: base
-        system: {}
-        changes: []
-        disabled: false
-        duration:
-          startTime: null
-          combat: null
-          seconds: 3600
-          rounds: null
-          turns: null
-          startRound: null
-          startTurn: null
-        description: >-
-          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
-          force]] damage to the target whenever they hit it with an attack
-          roll.</p>
-        tint: '#ffffff'
-        statuses:
-          - marked
-        sort: 0
-        flags:
-          dnd5e:
-            riders:
-              statuses: []
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv11000.iCf450qECu1PRkAZ.vPkln6UeePHnbLr4
-    folder: pBaAAtXBCq9FVEnL
-    sort: 1900000
-    flags:
-      dnd5e:
-        sourceId: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-        advancementOrigin: NuNBKjUuSNIRsF9M.DOENALOWWjAUHzb7
-        advancementRoot: NuNBKjUuSNIRsF9M.DOENALOWWjAUHzb7
-    _stats:
-      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-      duplicateSource: null
-      exportSource: null
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv11000.iCf450qECu1PRkAZ'
   - name: Cure Wounds
     system:
       description:
@@ -2789,6 +2414,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -2835,6 +2461,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -2864,8 +2491,8 @@ items:
           img: null
       identifier: cure-wounds
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: 2KxozSkbJhhPD7Zb
     type: spell
     img: icons/magic/nature/leaf-drip-light-green.webp
@@ -2879,8 +2506,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.2KxozSkbJhhPD7Zb'
@@ -2924,6 +2552,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: self
         special: ''
@@ -2973,6 +2602,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -3037,6 +2667,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -3075,8 +2706,8 @@ items:
           img: null
       identifier: ensnaring-strike
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: EBgpZ648SEfydQRq
     type: spell
     img: icons/magic/nature/root-vines-grow-brown.webp
@@ -3131,8 +2762,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.EBgpZ648SEfydQRq'
@@ -3216,6 +2848,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -3259,8 +2892,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.unYsJXqTKiLwFGEu'
@@ -3332,8 +2966,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.8OhoDlMp6n7S6vkp'
@@ -3376,6 +3011,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -3502,8 +3138,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -3633,8 +3270,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.zLB9qhJw8z2FSbCO'
@@ -3746,6 +3384,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -3801,8 +3440,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.D3zED6xcDPkysnuj'
@@ -3914,6 +3554,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -3969,8 +3610,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.lERu2Skz1q5s9egL'
@@ -4083,6 +3725,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -4202,8 +3845,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.qdxxGDu9tguu68Fu'
@@ -4275,8 +3919,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.WiXfB8xRlPdC7kiB'
@@ -4350,8 +3995,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.pie1jETwfFOgm3Ea'
@@ -4420,8 +4066,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.friHHTqUU9vmohfg'
@@ -4511,6 +4158,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4549,8 +4197,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.hc8MggfBaxwCzCHA'
@@ -4644,6 +4293,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4699,6 +4349,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4754,6 +4405,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4792,8 +4444,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.NQXrw78HaPfjDwCR'
@@ -4842,8 +4495,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.lSEr732XDGJKNopc'
@@ -4902,8 +4556,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.KaPzoh8WPLzQEWMu'
@@ -4946,6 +4601,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -5023,8 +4679,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     _id: 6kKffxM60Oq7uyzV
     sort: 100000
     ownership:
@@ -5119,6 +4776,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -5178,8 +4836,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.sMFxms44gxWpPEzK'
@@ -5285,6 +4944,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -5350,6 +5010,7 @@ items:
               type: square
               size: '5'
               count: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -5396,8 +5057,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.IllhigPdXlPBx5Mu'
@@ -5464,8 +5126,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.biyQChEtJrhkkj9X'
@@ -5522,8 +5185,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrDeftExplor
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -5579,8 +5243,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFightingSt
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -5673,8 +5338,9 @@ items:
       compendiumSource: Compendium.dnd5e.feats24.Item.phbfstArchery000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.1eURR2YWZ0hqplDM'
@@ -5710,6 +5376,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -5761,6 +5428,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -5816,7 +5484,7 @@ items:
       method: spell
       prepared: 2
       ability: wis
-      sourceClass: ranger
+      sourceItem: class:ranger
     _id: XtHfUCHDXdBgFfic
     type: spell
     img: icons/equipment/feet/boots-leather-laced-brown.webp
@@ -5870,8 +5538,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplLongstride
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.XtHfUCHDXdBgFfic'
@@ -5977,8 +5646,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrHunter0000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 500000
     ownership:
       default: 0
@@ -6033,8 +5703,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrHuntersLor
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 300000
     ownership:
       default: 0
@@ -6113,6 +5784,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -6178,8 +5850,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrHuntersPre
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 400000
     ownership:
       default: 0
@@ -6214,6 +5887,7 @@ items:
         template:
           units: ft
           contiguous: false
+          stationary: false
       range:
         units: self
       uses:
@@ -6265,6 +5939,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -6317,7 +5992,7 @@ items:
       identifier: pass-without-trace
       method: spell
       prepared: 2
-      sourceClass: ranger
+      sourceItem: class:ranger
     _id: fG9QhmaWPRLmAgpi
     type: spell
     img: icons/creatures/mammals/humanoid-cat-skulking-teal.webp
@@ -6374,8 +6049,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplPasswithou
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.fG9QhmaWPRLmAgpi'
@@ -6426,8 +6102,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrExtraAttac
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -6580,8 +6257,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgBracersOfArch
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 4400000
     ownership:
       default: 0
@@ -6649,8 +6327,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgQuiverOfEhlon
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 1000000
     ownership:
       default: 0
@@ -6709,8 +6388,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.fj90XA0PYmbUpym3'
@@ -6772,8 +6452,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.W80ByYTQXyznvRPq'
@@ -6835,8 +6516,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.KdY2pwORMXFr6Y0B'
@@ -6873,6 +6555,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: ft
         special: ''
@@ -6951,6 +6634,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -6984,8 +6668,8 @@ items:
           img: null
       identifier: aid
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: AmZK3JT82HiCjW57
     type: spell
     img: icons/magic/life/cross-flared-green.webp
@@ -7294,8 +6978,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplAid0000000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.AmZK3JT82HiCjW57'
@@ -7332,6 +7017,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: self
         special: ''
@@ -7379,6 +7065,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -7402,8 +7089,8 @@ items:
             requireMagic: false
       identifier: goodberry
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: EIeR4p90ul518qTq
     type: spell
     img: icons/consumables/fruit/berries-hanging-red.webp
@@ -7417,8 +7104,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplGoodberry0
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.EIeR4p90ul518qTq'
@@ -7454,6 +7142,7 @@ items:
         template:
           units: ft
           contiguous: false
+          stationary: false
       range:
         units: touch
       uses:
@@ -7523,6 +7212,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -7546,8 +7236,8 @@ items:
           img: null
       identifier: magic-weapon
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: IvRfwU6y7Jd3myjn
     type: spell
     img: icons/skills/melee/sword-engraved-glow-purple.webp
@@ -7723,8 +7413,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplMagicWeapo
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.IvRfwU6y7Jd3myjn'
@@ -7768,6 +7459,7 @@ items:
           size: '20'
           contiguous: false
           count: ''
+          stationary: false
       range:
         value: '150'
         units: ft
@@ -7817,6 +7509,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -7851,8 +7544,8 @@ items:
           img: null
       identifier: spike-growth
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: HkKCPTwzsExcVcTc
     type: spell
     img: icons/creatures/abilities/stinger-spine-horn-blood.webp
@@ -7866,8 +7559,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplSpikeGrowt
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.HkKCPTwzsExcVcTc'
@@ -7928,8 +7622,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.phbagCaseMaporSc
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.6k1oSbzdfLUgU6DB'
@@ -7978,6 +7673,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -8047,8 +7743,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgSpellScroll1s
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     _id: QBcSv9jLpl0ySf5L
     sort: 0
     ownership:
@@ -8089,6 +7786,7 @@ items:
           type: radius
           size: '30'
           count: ''
+          stationary: false
       range:
         value: ''
         units: self
@@ -8141,6 +7839,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -8165,7 +7864,7 @@ items:
       identifier: detect-poison-and-disease
       method: spell
       prepared: 0
-      sourceClass: ranger
+      sourceItem: class:ranger
     type: spell
     img: icons/skills/toxins/poison-bottle-open-fire-purple.webp
     effects:
@@ -8271,8 +7970,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplDetectPois
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     _id: jpgUr2RWhFZ7fH8o
     ownership:
       default: 0
@@ -8318,6 +8018,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -8405,8 +8106,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgPotionOfHeali
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 100000
     ownership:
       default: 0
@@ -8497,9 +8199,6 @@ items:
           !actors.items.effects!QuillatheLv11000.FQhcgSTOwqlAuxp2.J9RWCSmYGnP0fkn1
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrRoving0000
         advancementOrigin: NuNBKjUuSNIRsF9M.fEmkkyi2Z6qGfYOZ
         advancementRoot: NuNBKjUuSNIRsF9M.fEmkkyi2Z6qGfYOZ
@@ -8509,8 +8208,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrRoving0000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -8590,6 +8290,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -8665,8 +8366,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrDefensiveT
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 100000
     ownership:
       default: 0
@@ -8712,9 +8414,6 @@ items:
     effects: []
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrExpertise0
         advancementOrigin: NuNBKjUuSNIRsF9M.fy2LFc8UC9PTq4aF
         advancementRoot: NuNBKjUuSNIRsF9M.fy2LFc8UC9PTq4aF
@@ -8724,8 +8423,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrExpertise0
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -8805,6 +8505,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -8870,6 +8571,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -8901,9 +8603,6 @@ items:
     effects: []
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrTireless00
         advancementOrigin: NuNBKjUuSNIRsF9M.tfv4CeK2F4fdZMMi
         advancementRoot: NuNBKjUuSNIRsF9M.tfv4CeK2F4fdZMMi
@@ -8913,8 +8612,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrTireless00
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
@@ -8985,6 +8685,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -9026,9 +8727,6 @@ items:
     effects: []
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrSuperiorHu
         advancementOrigin: BOFrG8LewBiASB6i.gBE1JZA0jf6dglQu
         advancementRoot: BOFrG8LewBiASB6i.gBE1JZA0jf6dglQu
@@ -9038,8 +8736,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrSuperiorHu
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 500000
     ownership:
       default: 0
@@ -9086,6 +8785,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         value: '60'
         units: ft
@@ -9133,6 +8833,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9202,6 +8903,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9239,27 +8941,24 @@ items:
           img: null
       identifier: conjure-animals
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: oYAmk1jbUd7U1vSK
     type: spell
     img: icons/creatures/abilities/wolf-heads-swirl-purple.webp
     effects: []
     folder: HCovEE4VoPGlIbKi
     sort: 3100000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplConjureAni
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.oYAmk1jbUd7U1vSK'
@@ -9295,6 +8994,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -9342,6 +9042,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9375,28 +9076,25 @@ items:
           img: null
       identifier: revivify
       method: spell
-      sourceClass: ranger
       prepared: 1
       ability: ''
+      sourceItem: class:ranger
     _id: DNZTeQjm6FkjOu0N
     type: spell
     img: icons/magic/holy/chalice-glowing-gold-water.webp
     effects: []
     folder: HCovEE4VoPGlIbKi
     sort: 200000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplRevivify00
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.DNZTeQjm6FkjOu0N'
@@ -9433,6 +9131,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -9482,6 +9181,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9503,8 +9203,8 @@ items:
           img: null
       identifier: jump
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: wA3SrliOxfMNxk4K
     type: spell
     img: icons/creatures/mammals/deer-movement-leap-green.webp
@@ -9545,19 +9245,16 @@ items:
           !actors.items.effects!QuillatheLv11000.wA3SrliOxfMNxk4K.Esyd01OZ3NCv8gtp
     folder: pBaAAtXBCq9FVEnL
     sort: 1400000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplJump000000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.wA3SrliOxfMNxk4K'
@@ -9604,6 +9301,7 @@ items:
           size: '100'
           contiguous: false
           count: ''
+          stationary: false
       range:
         value: '150'
         units: ft
@@ -9654,6 +9352,7 @@ items:
               type: sphere
               size: '100'
               count: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -9705,6 +9404,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9729,27 +9429,24 @@ items:
             requireMagic: false
       identifier: plant-growth
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: HGL0BpVEzCKL2oJy
     type: spell
     img: icons/magic/nature/plant-sproud-hands-dirt-green.webp
     effects: []
     folder: HCovEE4VoPGlIbKi
     sort: 400000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplPlantGrowt
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.HGL0BpVEzCKL2oJy'
@@ -9791,8 +9488,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.2VAKB4eAj5aqjEEr'
@@ -9893,19 +9591,16 @@ items:
           lastModifiedBy: null
         _key: >-
           !actors.items.effects!QuillatheLv11000.YSOKmqFKv3L5CjDC.LsvHisOX7EGZ8oQg
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgCloakOfProtec
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 8100000
     ownership:
       default: 0
@@ -9955,6 +9650,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -10017,19 +9713,16 @@ items:
         - mgc
     effects: []
     folder: a2UFIyuviRp94dzx
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgSpellScroll3r
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     _id: HNapttFM9XtXh3yZ
     sort: 0
     ownership:
@@ -10070,6 +9763,7 @@ items:
           type: sphere
           size: '60'
           contiguous: false
+          stationary: false
       range:
         value: '60'
         units: ft
@@ -10116,6 +9810,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -10138,7 +9833,7 @@ items:
       identifier: daylight
       method: spell
       prepared: 0
-      sourceClass: ranger
+      sourceItem: class:ranger
     type: spell
     img: icons/magic/light/orb-beams-green.webp
     effects:
@@ -10204,9 +9899,6 @@ items:
     sort: 2600000
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         cachedFor: .Item.HNapttFM9XtXh3yZ.Activity.dnd5escrollspell
     _stats:
       duplicateSource: null
@@ -10214,8 +9906,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplDaylight00
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     _id: BAH8d6zDklJLKUKW
     ownership:
       default: 0
@@ -10265,6 +9958,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -10327,19 +10021,16 @@ items:
         - mgc
     effects: []
     folder: a2UFIyuviRp94dzx
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgSpellScroll2n
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     _id: sQxo9ZuqIBneBxrb
     sort: 0
     ownership:
@@ -10377,6 +10068,7 @@ items:
           type: sphere
           size: '20'
           contiguous: false
+          stationary: false
       range:
         value: '120'
         units: ft
@@ -10427,6 +10119,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -10449,7 +10142,7 @@ items:
       identifier: silence
       method: spell
       prepared: 0
-      sourceClass: ranger
+      sourceItem: class:ranger
     type: spell
     img: icons/magic/control/debuff-chains-orb-movement-blue.webp
     effects:
@@ -10557,9 +10250,6 @@ items:
     sort: 500000
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         cachedFor: .Item.sQxo9ZuqIBneBxrb.Activity.dnd5escrollspell
     _stats:
       duplicateSource: null
@@ -10567,8 +10257,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplSilence000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     _id: uxOMNRcu2iOeylo6
     ownership:
       default: 0
@@ -10618,6 +10309,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -10680,244 +10372,21 @@ items:
         - mgc
     effects: []
     folder: a2UFIyuviRp94dzx
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgSpellScroll2n
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     _id: pc1OhjXAcaglfiFO
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.pc1OhjXAcaglfiFO'
-  - name: Protection from Poison
-    system:
-      description:
-        value: >-
-          <p>You touch a creature and end the &amp;Reference[poisoned] condition
-          on it. For the duration, the target has Advantage on saving throws to
-          avoid or end the Poisoned condition, and it has Resistance to Poison
-          damage.</p>
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        license: CC-BY-4.0
-        book: ''
-        revision: 1
-      activation:
-        type: action
-        condition: ''
-        value: null
-      duration:
-        value: '1'
-        units: hour
-      target:
-        affects:
-          type: creature
-          count: '1'
-          choice: false
-        template:
-          units: ft
-          contiguous: false
-      range:
-        units: touch
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      level: 2
-      school: abj
-      properties:
-        - vocal
-        - somatic
-      materials:
-        value: ''
-        consumed: false
-        cost: 0
-        supply: 0
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: null
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            override: false
-            concentration: false
-          effects:
-            - _id: zTci2V6Iij0r0IIg
-              level: {}
-          range:
-            override: false
-            units: self
-          target:
-            prompt: true
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          uses:
-            spent: 0
-            recovery: []
-          sort: 0
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-      identifier: protection-from-poison
-      method: spell
-      prepared: 0
-      sourceClass: ranger
-    type: spell
-    img: icons/skills/toxins/cup-glass-poisoned-held.webp
-    effects:
-      - name: Poison Protection
-        origin: Compendium.dnd5e.spells24.Item.phbsplProtection
-        duration:
-          rounds: null
-          startTime: null
-          seconds: 3600
-          combat: null
-          turns: null
-          startRound: null
-          startTurn: null
-        disabled: false
-        flags: {}
-        img: icons/equipment/head/mask-plague-leather-brown.webp
-        _id: zTci2V6Iij0r0IIg
-        type: base
-        system: {}
-        changes:
-          - key: system.traits.dr.value
-            mode: 2
-            value: poison
-            priority: null
-        description: >-
-          <p><span style="font-family:Signika, sans-serif">For the duration, the
-          target has Advantage on saving throws to avoid or end the Poisoned
-          condition, and it has Resistance to Poison damage.</span></p>
-        tint: '#ffffff'
-        transfer: false
-        statuses: []
-        sort: 0
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv11000.gRtGvsb8FEvgcJfy.zTci2V6Iij0r0IIg
-      - _id: dnd5espellchange
-        type: enchantment
-        name: Spell Changes
-        img: systems/dnd5e/icons/svg/activity/cast.svg
-        origin: >-
-          Compendium.dnd5e.actors24.Actor.QuillatheLv11000.Item.pc1OhjXAcaglfiFO.Activity.dnd5escrollspell
-        changes:
-          - key: system.method
-            mode: 5
-            value: spell
-          - key: system.properties
-            mode: 2
-            value: '-vocal'
-          - key: system.properties
-            mode: 2
-            value: '-somatic'
-          - key: system.properties
-            mode: 2
-            value: '-material'
-          - key: activities[attack].attack.bonus
-            mode: 5
-            value: '5'
-          - key: activities[attack].attack.flat
-            mode: 5
-            value: 'true'
-          - key: activities[summon].flat.attack
-            mode: 5
-            value: '5'
-          - key: activities[save].save.dc.calculation
-            mode: 5
-            value: ''
-          - key: activities[save].save.dc.formula
-            mode: 5
-            value: '13'
-          - key: activities[summon].flat.save
-            mode: 5
-            value: '13'
-        system: {}
-        disabled: false
-        duration:
-          startTime: 0
-          combat: null
-        description: ''
-        tint: '#ffffff'
-        transfer: true
-        statuses: []
-        sort: 0
-        flags: {}
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv11000.gRtGvsb8FEvgcJfy.dnd5espellchange
-    folder: 3SjcO2acsFnWegp4
-    sort: 1200000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-        cachedFor: .Item.pc1OhjXAcaglfiFO.Activity.dnd5escrollspell
-    _stats:
-      duplicateSource: null
-      exportSource: null
-      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplProtection
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    _id: gRtGvsb8FEvgcJfy
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv11000.gRtGvsb8FEvgcJfy'
   - _id: WyVga5iUa1gmsOHD
     name: Potion of Growth
     type: consumable
@@ -10969,6 +10438,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -11037,328 +10507,20 @@ items:
       attuned: false
       equipped: false
     effects: []
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgPotionOfGrowt
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.WyVga5iUa1gmsOHD'
-  - name: Enlarge/Reduce
-    system:
-      description:
-        value: >-
-          <p>For the duration, the spell enlarges or reduces a creature or an
-          object you can see within range (see the chosen effect below). A
-          targeted object must be neither worn nor carried. If the target is an
-          unwilling creature, it can make a Constitution saving throw. On a
-          successful save, the spell has no effect.</p><p>Everything that a
-          targeted creature is wearing and carrying changes size with it. Any
-          item it drops returns to normal size at once. A thrown weapon or piece
-          of ammunition returns to normal size immediately after it hits or
-          misses a target.</p><p><strong>Enlarge.</strong> The target's size
-          increases by one category—from Medium to Large, for example. The
-          target also has Advantage on Strength checks and Strength saving
-          throws. The target's attacks with its enlarged weapons or Unarmed
-          Strikes deal an extra 1d4 damage on a
-          hit.</p><p><strong>Reduce.</strong> The target's size decreases by one
-          category—from Medium to Small, for example. The target also has
-          Disadvantage on Strength checks and Strength saving throws. The
-          target's attacks with its reduced weapons or Unarmed Strikes deal 1d4
-          less damage on a hit (this can't reduce the damage below 1).</p>
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        license: CC-BY-4.0
-        book: ''
-        revision: 2
-      activation:
-        type: action
-        condition: ''
-        value: null
-      duration:
-        value: '1'
-        units: minute
-      target:
-        affects:
-          type: creatureOrObject
-          count: '1'
-          choice: false
-          special: ''
-        template:
-          units: ft
-          contiguous: false
-          type: ''
-      range:
-        value: '30'
-        units: ft
-        special: ''
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      level: 2
-      school: trs
-      properties:
-        - vocal
-        - somatic
-        - material
-        - concentration
-      materials:
-        value: a pinch of powdered iron
-        consumed: false
-        cost: 0
-        supply: 0
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: null
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            override: false
-            concentration: false
-          effects:
-            - _id: Wi2E10l7n6Ka8k6u
-              onSave: false
-              level: {}
-            - _id: NXdtOxX4HvPeodml
-              onSave: false
-              level: {}
-          range:
-            override: false
-            units: self
-          target:
-            prompt: true
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability:
-              - con
-            dc:
-              calculation: spellcasting
-              formula: ''
-          uses:
-            spent: 0
-            recovery: []
-          sort: 0
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-      identifier: enlarge-reduce
-      method: spell
-      prepared: 0
-      sourceClass: ranger
-    type: spell
-    img: icons/consumables/mushrooms/mushroom-spotted-red.webp
-    effects:
-      - name: Enlarged
-        origin: Compendium.dnd5e.spells24.Item.phbsplEnlargeRed
-        duration:
-          rounds: null
-          startTime: null
-          seconds: 60
-          combat: null
-          turns: null
-          startRound: null
-          startTurn: null
-        disabled: false
-        flags:
-          dnd5e:
-            riders:
-              statuses: []
-        img: icons/magic/control/silhouette-grow-shrink-tan.webp
-        _id: Wi2E10l7n6Ka8k6u
-        type: base
-        system: {}
-        changes:
-          - key: system.bonuses.mwak.damage
-            mode: 2
-            value: 1d4
-            priority: null
-          - key: system.bonuses.rwak.damage
-            mode: 2
-            value: 1d4
-            priority: null
-          - key: system.abilities.str.check.roll.mode
-            mode: 2
-            value: '1'
-            priority: null
-          - key: system.abilities.str.save.roll.mode
-            mode: 2
-            value: '1'
-            priority: null
-        description: >-
-          <p>The target’s size increases by one category—from Medium to Large,
-          for example. The target also has Advantage on Strength checks and
-          Strength saving throws. The target’s attacks with its enlarged weapons
-          or Unarmed Strikes deal an extra 1d4 damage on a hit.</p>
-        tint: '#ffffff'
-        transfer: false
-        statuses: []
-        sort: 0
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv11000.1AjUB13d58Xc0f1I.Wi2E10l7n6Ka8k6u
-      - name: Reduced
-        origin: Compendium.dnd5e.spells24.Item.phbsplEnlargeRed
-        duration:
-          rounds: null
-          startTime: null
-          seconds: 60
-          combat: null
-          turns: null
-          startRound: null
-          startTurn: null
-        disabled: false
-        flags:
-          dnd5e:
-            riders:
-              statuses: []
-        img: icons/magic/control/silhouette-grow-shrink-blue.webp
-        _id: NXdtOxX4HvPeodml
-        type: base
-        system: {}
-        changes:
-          - key: system.bonuses.mwak.damage
-            mode: 2
-            value: '- 1d4'
-            priority: null
-          - key: system.bonuses.rwak.damage
-            mode: 2
-            value: '- 1d4'
-            priority: null
-          - key: system.abilities.str.check.roll.mode
-            mode: 2
-            value: '-1'
-            priority: null
-          - key: system.abilities.str.save.roll.mode
-            mode: 2
-            value: '-1'
-            priority: null
-        description: >-
-          <p>The target’s size decreases by one category—from Medium to Small,
-          for example. The target also has Disadvantage on Strength checks and
-          Strength saving throws. The target’s attacks with its reduced weapons
-          or Unarmed Strikes deal 1d4 less damage on a hit (this can’t reduce
-          the damage below 1).</p>
-        tint: '#ffffff'
-        transfer: false
-        statuses: []
-        sort: 0
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv11000.1AjUB13d58Xc0f1I.NXdtOxX4HvPeodml
-      - _id: dnd5espellchange
-        type: enchantment
-        name: Spell Changes
-        img: systems/dnd5e/icons/svg/activity/cast.svg
-        origin: >-
-          Compendium.dnd5e.actors24.Actor.QuillatheLv11000.Item.WyVga5iUa1gmsOHD.Activity.o9I0OYuD6EkLaGCR
-        changes:
-          - key: system.method
-            mode: 5
-            value: spell
-          - key: system.activation
-            mode: 5
-            value: '{"type":"bonus","value":null,"condition":""}'
-          - key: system.properties
-            mode: 2
-            value: '-vocal'
-          - key: system.properties
-            mode: 2
-            value: '-somatic'
-          - key: system.properties
-            mode: 2
-            value: '-material'
-          - key: system.properties
-            mode: 2
-            value: '-concentration'
-        system: {}
-        disabled: false
-        duration:
-          startTime: 0
-          combat: null
-        description: ''
-        tint: '#ffffff'
-        transfer: true
-        statuses: []
-        sort: 0
-        flags: {}
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv11000.1AjUB13d58Xc0f1I.dnd5espellchange
-    folder: 3SjcO2acsFnWegp4
-    sort: 3700000
-    flags:
-      dnd5e:
-        cachedFor: .Item.WyVga5iUa1gmsOHD.Activity.o9I0OYuD6EkLaGCR
-    _stats:
-      duplicateSource: null
-      exportSource: null
-      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplEnlargeRed
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    _id: 1AjUB13d58Xc0f1I
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv11000.1AjUB13d58Xc0f1I'
   - _id: yaCDtthLiWjvYRwT
     name: Potion of Fire Resistance
     type: consumable
@@ -11441,6 +10603,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -11565,12 +10728,765 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgPotionOfResis
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923618815
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv11000.yaCDtthLiWjvYRwT'
+  - _id: XRWmmuGpQM5LZ4lN
+    name: Favored Enemy
+    type: feat
+    folder: h5OUzaJcZzsNsOGc
+    img: icons/creatures/abilities/dragon-breath-purple.webp
+    system:
+      description:
+        value: >-
+          <p>You always have the
+          @UUID[Compendium.dnd5e.spells24.Item.phbsplHuntersMar]{Hunter's Mark}
+          spell prepared. You can cast it twice without expending a spell slot,
+          and you regain all expended uses of this ability when you finish a
+          Long Rest.</p><p>The number of times you can cast the spell without a
+          spell slot increases when you reach certain Ranger levels, as shown in
+          the Favored Enemy column of the Ranger Features table.</p><section
+          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
+          Note</strong></p><p>The spell is granted to you at this level and will
+          increase the number of free uses available automatically as you level
+          up.</p></section>
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        revision: 2
+        license: CC-BY-4.0
+        book: ''
+      uses:
+        max: '@scale.ranger.favored-enemy'
+        spent: 0
+        recovery:
+          - period: lr
+            type: recoverAll
+      type:
+        value: class
+        subtype: ''
+      prerequisites:
+        level: 1
+        items: []
+        repeatable: false
+      properties:
+        - mgc
+      requirements: ''
+      activities:
+        18OW4UKZ5cSPPLhC:
+          type: cast
+          spell:
+            uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+            challenge:
+              override: false
+            properties: []
+            spellbook: true
+            ability: ''
+            level: 1
+          _id: 18OW4UKZ5cSPPLhC
+          img: ''
+          sort: 0
+          activation:
+            type: bonus
+            override: true
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          flags: {}
+          range:
+            units: self
+            override: false
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: Hunter's Mark (Free)
+      enchant: {}
+      identifier: favored-enemy
+      advancement:
+        DOENALOWWjAUHzb7:
+          _id: DOENALOWWjAUHzb7
+          type: ItemGrant
+          configuration:
+            items:
+              - optional: false
+                uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+            optional: false
+            spell:
+              ability: []
+              uses:
+                max: ''
+                per: ''
+                requireSlot: false
+              method: spell
+              prepared: 2
+          value:
+            added:
+              QxSGmZF7XhRMNuOl: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+          level: 1
+          title: Favored Enemy
+          hint: ''
+          flags: {}
+      crewed: false
+    effects: []
+    flags:
+      dnd5e:
+        sourceId: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
+        advancementOrigin: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923618737
+      modifiedTime: 1777923618737
+      lastModifiedBy: dnd5ebuilder0000
+    sort: 0
+    ownership:
+      default: 0
+    _key: '!actors.items!QuillatheLv11000.XRWmmuGpQM5LZ4lN'
+  - name: Hunter's Mark
+    system:
+      description:
+        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        license: CC-BY-4.0
+        book: ''
+        revision: 2
+      activation:
+        type: bonus
+        condition: ''
+        value: null
+      duration:
+        value: '1'
+        units: hour
+      target:
+        affects:
+          type: creature
+          count: '1'
+          choice: false
+          special: ''
+        template:
+          units: ft
+          contiguous: false
+          type: ''
+          stationary: false
+      range:
+        value: '90'
+        units: ft
+        special: ''
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      level: 1
+      school: div
+      properties:
+        - vocal
+        - concentration
+      materials:
+        value: ''
+        consumed: false
+        cost: 0
+        supply: 0
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: damage
+          activation:
+            type: ''
+            value: null
+            override: true
+            condition: ''
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: false
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            override: true
+            concentration: false
+          effects: []
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            prompt: true
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+          damage:
+            critical:
+              allow: true
+              bonus: ''
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: 6
+                bonus: ''
+                types:
+                  - force
+                scaling:
+                  mode: ''
+                  number: 1
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 200000
+          name: Bonus Mark Damage
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        vxr2JKuQ3jyMDTwb:
+          type: utility
+          _id: vxr2JKuQ3jyMDTwb
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: false
+            units: self
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 100000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Mark Creature
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        NQtVK0T5uwfMPGQL:
+          type: utility
+          activation:
+            type: bonus
+            value: null
+            override: true
+            condition: when the currently marked target drops to 0 Hit Points
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: false
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: true
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 300000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Move Mark
+          _id: NQtVK0T5uwfMPGQL
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      identifier: hunters-mark
+      method: spell
+      prepared: 2
+      sourceItem: feat:favored-enemy
+    _id: QxSGmZF7XhRMNuOl
+    type: spell
+    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+    effects:
+      - name: Hunter's Mark
+        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        transfer: false
+        _id: vPkln6UeePHnbLr4
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          combat: null
+          seconds: 3600
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
+          force]] damage to the target whenever they hit it with an attack
+          roll.</p>
+        tint: '#ffffff'
+        statuses:
+          - marked
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv11000.QxSGmZF7XhRMNuOl.vPkln6UeePHnbLr4
+    folder: pBaAAtXBCq9FVEnL
+    sort: 1900000
+    ownership:
+      default: 0
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
+        sourceId: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        advancementOrigin: XRWmmuGpQM5LZ4lN.DOENALOWWjAUHzb7
+        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923618737
+      modifiedTime: 1777923618737
+      lastModifiedBy: dnd5ebuilder0000
+    _key: '!actors.items!QuillatheLv11000.QxSGmZF7XhRMNuOl'
+  - name: Hunter's Mark
+    system:
+      description:
+        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        license: CC-BY-4.0
+        book: ''
+        revision: 2
+      activation:
+        type: bonus
+        condition: ''
+        value: null
+      duration:
+        value: '1'
+        units: hour
+      target:
+        affects:
+          type: creature
+          count: '1'
+          choice: false
+          special: ''
+        template:
+          units: ft
+          contiguous: false
+          type: ''
+          stationary: false
+      range:
+        value: '90'
+        units: ft
+        special: ''
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      level: 1
+      school: div
+      properties:
+        - vocal
+        - concentration
+      materials:
+        value: ''
+        consumed: false
+        cost: 0
+        supply: 0
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: damage
+          activation:
+            type: ''
+            value: null
+            override: true
+            condition: ''
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: false
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            override: true
+            concentration: false
+          effects: []
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            prompt: true
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+          damage:
+            critical:
+              allow: true
+              bonus: ''
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: 6
+                bonus: ''
+                types:
+                  - force
+                scaling:
+                  mode: ''
+                  number: 1
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 200000
+          name: Bonus Mark Damage
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        vxr2JKuQ3jyMDTwb:
+          type: utility
+          _id: vxr2JKuQ3jyMDTwb
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: false
+            units: self
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 100000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Mark Creature
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        NQtVK0T5uwfMPGQL:
+          type: utility
+          activation:
+            type: bonus
+            value: null
+            override: true
+            condition: when the currently marked target drops to 0 Hit Points
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: false
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: true
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 300000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Move Mark
+          _id: NQtVK0T5uwfMPGQL
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      identifier: hunters-mark
+      method: spell
+      prepared: 0
+      sourceItem: feat:favored-enemy
+    type: spell
+    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+    effects:
+      - name: Hunter's Mark
+        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        transfer: false
+        _id: vPkln6UeePHnbLr4
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          combat: null
+          seconds: 3600
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
+          force]] damage to the target whenever they hit it with an attack
+          roll.</p>
+        tint: '#ffffff'
+        statuses:
+          - marked
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv11000.Ucj4K2EafF7bnHmL.vPkln6UeePHnbLr4
+      - _id: dnd5espellchange
+        type: enchantment
+        name: Spell Changes
+        img: systems/dnd5e/icons/svg/activity/cast.svg
+        origin: >-
+          Compendium.dnd5e.actors24.Actor.QuillatheLv11000.Item.XRWmmuGpQM5LZ4lN.Activity.18OW4UKZ5cSPPLhC
+        changes:
+          - key: system.method
+            mode: 5
+            value: spell
+          - key: system.activation
+            mode: 5
+            value: '{"type":"bonus","condition":""}'
+        system: {}
+        disabled: false
+        duration:
+          startTime: 0
+          combat: null
+          startRound: 0
+          startTurn: 0
+        description: ''
+        tint: '#ffffff'
+        transfer: true
+        statuses: []
+        sort: 0
+        flags: {}
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv11000.Ucj4K2EafF7bnHmL.dnd5espellchange
+    folder: pBaAAtXBCq9FVEnL
+    sort: 1900000
+    ownership:
+      default: 0
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
+        cachedFor: .Item.XRWmmuGpQM5LZ4lN.Activity.18OW4UKZ5cSPPLhC
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923618887
+      modifiedTime: 1777923618887
+      lastModifiedBy: dnd5ebuilder0000
+    _id: Ucj4K2EafF7bnHmL
+    _key: '!actors.items!QuillatheLv11000.Ucj4K2EafF7bnHmL'
 effects: []
 flags: {}
 _stats:
@@ -11578,9 +11494,9 @@ _stats:
   exportSource: null
   coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 5.3.0
+  systemVersion: 5.3.2
   createdTime: 1771452688484
-  modifiedTime: 1771452688484
+  modifiedTime: 1777923657813
   lastModifiedBy: dnd5ebuilder0000
 img: null
 folder: 1EDP5HqqwXarG88N

--- a/packs/_source/actors24/premades/level-11/quillathe.yml
+++ b/packs/_source/actors24/premades/level-11/quillathe.yml
@@ -403,15 +403,7 @@ system:
       value: >-
         <p>Quillathe cleanses monsters from her woods as a hobby, but now a new
         force menaces her land and she must band with adventurers to defeat
-        it.</p><p><em>Token artwork by </em><a
-        href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener"><em>Forgotten
-        Adventures</em></a><em>.</em></p><p><em>Token artwork by </em><a
-        href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener"><em>Forgotten
-        Adventures</em></a><em>.</em></p><p><em>Token artwork by </em><a
-        href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener"><em>Forgotten Adventures</em></a><em>.</em></p>
+        it.</p>
       public: ''
     alignment: Chaotic Neutral
     ideal: ''
@@ -11496,7 +11488,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 5.3.2
   createdTime: 1771452688484
-  modifiedTime: 1777923657813
+  modifiedTime: 1777994555602
   lastModifiedBy: dnd5ebuilder0000
 img: null
 folder: 1EDP5HqqwXarG88N

--- a/packs/_source/actors24/premades/level-11/quillathe.yml
+++ b/packs/_source/actors24/premades/level-11/quillathe.yml
@@ -10741,11 +10741,7 @@ items:
           and you regain all expended uses of this ability when you finish a
           Long Rest.</p><p>The number of times you can cast the spell without a
           spell slot increases when you reach certain Ranger levels, as shown in
-          the Favored Enemy column of the Ranger Features table.</p><section
-          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
-          Note</strong></p><p>The spell is granted to you at this level and will
-          increase the number of free uses available automatically as you level
-          up.</p></section>
+          the Favored Enemy column of the Ranger Features table.</p>
         chat: ''
       source:
         custom: ''
@@ -10827,7 +10823,7 @@ items:
             requireIdentification: false
             requireMagic: false
             identifier: ''
-          name: Hunter's Mark (Free)
+          name: ''
       enchant: {}
       identifier: favored-enemy
       advancement:

--- a/packs/_source/actors24/premades/level-17/quillathe.yml
+++ b/packs/_source/actors24/premades/level-17/quillathe.yml
@@ -403,7 +403,13 @@ system:
       value: >-
         <p>Quillathe cleanses monsters from her woods as a hobby, but now a new
         force menaces her land and she must band with adventurers to defeat
-        it.</p>
+        it.</p><p><em>Token artwork by <a
+        href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener">Forgotten Adventures</a>.</em></p><p><em>Token artwork by
+        <a href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener">Forgotten Adventures</a>.</em></p><p><em>Token artwork by
+        <a href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener">Forgotten Adventures</a>.</em></p>
       public: ''
     alignment: Chaotic Neutral
     ideal: ''
@@ -455,6 +461,8 @@ system:
       communication: {}
     weaponProf:
       value:
+        - longbow
+        - shortbow
         - sim
         - mar
       custom: ''
@@ -495,9 +503,6 @@ system:
     - type: item
       id: .Item.WiXfB8xRlPdC7kiB
       sort: 0
-    - type: item
-      id: .Item.iCf450qECu1PRkAZ
-      sort: 250000
     - type: activity
       id: .Item.xge2yOOVa1Iql8ni.Activity.Ek6m8ZY5Df7Mp6DO
       sort: 200000
@@ -758,8 +763,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     _id: WSfqg4qp13LFdc3N
     ownership:
       default: 0
@@ -859,8 +865,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.6156HtS7RvjQ7nhJ'
@@ -1070,8 +1077,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -1122,8 +1130,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -1176,8 +1185,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -1229,8 +1239,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -1298,8 +1309,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -1474,8 +1486,8 @@ items:
           value:
             added:
               HAXlit2SO8luWUtO: Compendium.dnd5e.classes24.Item.phbrgrSpellcasti
-              o0bC09CnUpZ4wvDt: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
               uHY0uPusihtnVQkp: Compendium.dnd5e.classes24.Item.phbrgrWeaponMast
+              6vb3a5mNmA9pMuVw: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
           level: 1
           title: Class Features
           flags: {}
@@ -1751,29 +1763,6 @@ items:
           title: ''
           flags: {}
           hint: ''
-        DOENALOWWjAUHzb7:
-          _id: DOENALOWWjAUHzb7
-          type: ItemGrant
-          configuration:
-            items:
-              - optional: false
-                uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-            optional: false
-            spell:
-              ability: []
-              uses:
-                max: '@scale.ranger.favored-enemy'
-                per: lr
-                requireSlot: false
-              method: spell
-              prepared: 2
-          value:
-            added:
-              iCf450qECu1PRkAZ: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-          level: 1
-          title: Favored Enemy
-          hint: ''
-          flags: {}
         FksFWNV4X4lTFlvO:
           _id: FksFWNV4X4lTFlvO
           type: ScaleValue
@@ -2125,8 +2114,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -2171,6 +2161,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: ft
         special: ''
@@ -2221,6 +2212,7 @@ items:
               type: cube
               size: '5'
               count: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -2264,8 +2256,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.kEjBWiTMcmhrI5w4'
@@ -2347,74 +2340,13 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.HAXlit2SO8luWUtO'
-  - _id: o0bC09CnUpZ4wvDt
-    name: Favored Enemy
-    type: feat
-    folder: h5OUzaJcZzsNsOGc
-    img: icons/creatures/abilities/dragon-breath-purple.webp
-    system:
-      description:
-        value: >-
-          <p>You always have the
-          @UUID[Compendium.dnd5e.spells24.Item.phbsplHuntersMar]{Hunter's Mark}
-          spell prepared. You can cast it twice without expending a spell slot,
-          and you regain all expended uses of this ability when you finish a
-          Long Rest.</p><p>The number of times you can cast the spell without a
-          spell slot increases when you reach certain Ranger levels, as shown in
-          the Favored Enemy column of the Ranger Features table.</p><section
-          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
-          Note</strong></p><p>The spell is granted to you at this level and will
-          increase the number of free uses available automatically as you level
-          up.</p></section>
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        revision: 1
-        license: CC-BY-4.0
-        book: ''
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: class
-        subtype: ''
-      prerequisites:
-        level: 1
-        items: []
-        repeatable: false
-      properties: []
-      requirements: ''
-      activities: {}
-      enchant: {}
-      identifier: favored-enemy
-      advancement: {}
-      crewed: false
-    effects: []
-    flags:
-      dnd5e:
-        sourceId: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
-        advancementOrigin: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
-        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
-    _stats:
-      compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
-      duplicateSource: null
-      exportSource: null
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    sort: 0
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv17000.o0bC09CnUpZ4wvDt'
   - _id: uHY0uPusihtnVQkp
     name: Weapon Mastery
     type: feat
@@ -2466,322 +2398,13 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.uHY0uPusihtnVQkp'
-  - name: Hunter's Mark
-    system:
-      description:
-        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        license: CC-BY-4.0
-        book: ''
-        revision: 2
-      activation:
-        type: bonus
-        condition: ''
-        value: null
-      duration:
-        value: '1'
-        units: hour
-      target:
-        affects:
-          type: creature
-          count: '1'
-          choice: false
-          special: ''
-        template:
-          units: ft
-          contiguous: false
-          type: ''
-      range:
-        value: '90'
-        units: ft
-        special: ''
-      uses:
-        max: '@scale.ranger.favored-enemy'
-        recovery:
-          - period: lr
-            type: recoverAll
-          - period: lr
-            type: recoverAll
-        spent: 0
-      level: 1
-      school: div
-      properties:
-        - vocal
-        - concentration
-      materials:
-        value: ''
-        consumed: false
-        cost: 0
-        supply: 0
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: damage
-          activation:
-            type: ''
-            value: null
-            override: true
-            condition: ''
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: false
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            override: true
-            concentration: false
-          effects: []
-          range:
-            override: true
-            units: any
-            special: ''
-          target:
-            prompt: true
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-          damage:
-            critical:
-              allow: true
-              bonus: ''
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 1
-                denomination: 6
-                bonus: ''
-                types:
-                  - force
-                scaling:
-                  mode: ''
-                  number: 1
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 200000
-          name: Bonus Mark Damage
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        vxr2JKuQ3jyMDTwb:
-          type: utility
-          _id: vxr2JKuQ3jyMDTwb
-          activation:
-            type: action
-            value: null
-            override: false
-          consumption:
-            scaling:
-              allowed: false
-            spellSlot: true
-            targets: []
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            concentration: false
-            override: false
-          effects:
-            - _id: vPkln6UeePHnbLr4
-              level: {}
-          range:
-            override: false
-            units: self
-          target:
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-            prompt: true
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 100000
-          roll:
-            prompt: false
-            visible: false
-            name: ''
-            formula: ''
-          name: Mark Creature
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        NQtVK0T5uwfMPGQL:
-          type: utility
-          activation:
-            type: bonus
-            value: null
-            override: true
-            condition: when the currently marked target drops to 0 Hit Points
-          consumption:
-            scaling:
-              allowed: false
-            spellSlot: false
-            targets: []
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            concentration: false
-            override: true
-          effects:
-            - _id: vPkln6UeePHnbLr4
-              level: {}
-          range:
-            override: true
-            units: any
-            special: ''
-          target:
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-            prompt: true
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 300000
-          roll:
-            prompt: false
-            visible: false
-            name: ''
-            formula: ''
-          name: Move Mark
-          _id: NQtVK0T5uwfMPGQL
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        72GB8kfgMJgPVbY0:
-          _id: 72GB8kfgMJgPVbY0
-          type: forward
-          name: Mark Creature (free casting)
-          sort: 100001
-          activity:
-            id: vxr2JKuQ3jyMDTwb
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling: {}
-            scaling:
-              allowed: false
-            spellSlot: true
-          activation:
-            type: action
-            override: false
-          description: {}
-          flags: {}
-          uses:
-            spent: 0
-            recovery: []
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-      identifier: hunters-mark
-      method: spell
-      prepared: 2
-      sourceClass: ranger
-    _id: iCf450qECu1PRkAZ
-    type: spell
-    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
-    effects:
-      - name: Hunter's Mark
-        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
-        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-        transfer: false
-        _id: vPkln6UeePHnbLr4
-        type: base
-        system: {}
-        changes: []
-        disabled: false
-        duration:
-          startTime: null
-          combat: null
-          seconds: 3600
-          rounds: null
-          turns: null
-          startRound: null
-          startTurn: null
-        description: >-
-          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
-          force]] damage to the target whenever they hit it with an attack
-          roll.</p>
-        tint: '#ffffff'
-        statuses:
-          - marked
-        sort: 0
-        flags:
-          dnd5e:
-            riders:
-              statuses: []
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv17000.iCf450qECu1PRkAZ.vPkln6UeePHnbLr4
-    folder: pBaAAtXBCq9FVEnL
-    sort: 1900000
-    flags:
-      dnd5e:
-        sourceId: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-        advancementOrigin: NuNBKjUuSNIRsF9M.DOENALOWWjAUHzb7
-        advancementRoot: NuNBKjUuSNIRsF9M.DOENALOWWjAUHzb7
-    _stats:
-      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-      duplicateSource: null
-      exportSource: null
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv17000.iCf450qECu1PRkAZ'
   - name: Cure Wounds
     system:
       description:
@@ -2814,6 +2437,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -2860,6 +2484,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -2889,8 +2514,8 @@ items:
           img: null
       identifier: cure-wounds
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: 2KxozSkbJhhPD7Zb
     type: spell
     img: icons/magic/nature/leaf-drip-light-green.webp
@@ -2904,8 +2529,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.2KxozSkbJhhPD7Zb'
@@ -2949,6 +2575,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: self
         special: ''
@@ -2998,6 +2625,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -3062,6 +2690,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -3100,8 +2729,8 @@ items:
           img: null
       identifier: ensnaring-strike
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: EBgpZ648SEfydQRq
     type: spell
     img: icons/magic/nature/root-vines-grow-brown.webp
@@ -3156,8 +2785,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.EBgpZ648SEfydQRq'
@@ -3241,6 +2871,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -3284,8 +2915,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.unYsJXqTKiLwFGEu'
@@ -3357,8 +2989,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.8OhoDlMp6n7S6vkp'
@@ -3401,6 +3034,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -3527,8 +3161,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -3658,8 +3293,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.zLB9qhJw8z2FSbCO'
@@ -3771,6 +3407,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -3889,8 +3526,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.lERu2Skz1q5s9egL'
@@ -4003,6 +3641,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -4122,8 +3761,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.qdxxGDu9tguu68Fu'
@@ -4253,8 +3893,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.WiXfB8xRlPdC7kiB'
@@ -4328,8 +3969,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.pie1jETwfFOgm3Ea'
@@ -4398,8 +4040,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.friHHTqUU9vmohfg'
@@ -4489,6 +4132,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4527,8 +4171,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.hc8MggfBaxwCzCHA'
@@ -4622,6 +4267,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4677,6 +4323,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4732,6 +4379,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4770,8 +4418,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.NQXrw78HaPfjDwCR'
@@ -4820,8 +4469,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.lSEr732XDGJKNopc'
@@ -4880,8 +4530,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.KaPzoh8WPLzQEWMu'
@@ -4924,6 +4575,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -5001,8 +4653,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     _id: 6kKffxM60Oq7uyzV
     sort: 100000
     ownership:
@@ -5097,6 +4750,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -5156,8 +4810,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.sMFxms44gxWpPEzK'
@@ -5263,6 +4918,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -5328,6 +4984,7 @@ items:
               type: square
               size: '5'
               count: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -5374,8 +5031,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.IllhigPdXlPBx5Mu'
@@ -5442,8 +5100,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.biyQChEtJrhkkj9X'
@@ -5500,8 +5159,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrDeftExplor
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -5557,8 +5217,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFightingSt
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -5651,8 +5312,9 @@ items:
       compendiumSource: Compendium.dnd5e.feats24.Item.phbfstArchery000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.1eURR2YWZ0hqplDM'
@@ -5688,6 +5350,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -5739,6 +5402,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -5794,7 +5458,7 @@ items:
       method: spell
       prepared: 2
       ability: wis
-      sourceClass: ranger
+      sourceItem: class:ranger
     _id: XtHfUCHDXdBgFfic
     type: spell
     img: icons/equipment/feet/boots-leather-laced-brown.webp
@@ -5848,8 +5512,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplLongstride
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.XtHfUCHDXdBgFfic'
@@ -5957,8 +5622,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrHunter0000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 500000
     ownership:
       default: 0
@@ -6013,8 +5679,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrHuntersLor
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 300000
     ownership:
       default: 0
@@ -6093,6 +5760,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -6158,8 +5826,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrHuntersPre
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 400000
     ownership:
       default: 0
@@ -6194,6 +5863,7 @@ items:
         template:
           units: ft
           contiguous: false
+          stationary: false
       range:
         units: self
       uses:
@@ -6245,6 +5915,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -6297,7 +5968,7 @@ items:
       identifier: pass-without-trace
       method: spell
       prepared: 2
-      sourceClass: ranger
+      sourceItem: class:ranger
     _id: fG9QhmaWPRLmAgpi
     type: spell
     img: icons/creatures/mammals/humanoid-cat-skulking-teal.webp
@@ -6354,8 +6025,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplPasswithou
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.fG9QhmaWPRLmAgpi'
@@ -6406,8 +6078,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrExtraAttac
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -6560,8 +6233,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgBracersOfArch
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 4400000
     ownership:
       default: 0
@@ -6629,8 +6303,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgQuiverOfEhlon
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 1000000
     ownership:
       default: 0
@@ -6689,8 +6364,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.fj90XA0PYmbUpym3'
@@ -6752,8 +6428,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.W80ByYTQXyznvRPq'
@@ -6815,8 +6492,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.KdY2pwORMXFr6Y0B'
@@ -6853,6 +6531,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: ft
         special: ''
@@ -6931,6 +6610,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -6964,8 +6644,8 @@ items:
           img: null
       identifier: aid
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: AmZK3JT82HiCjW57
     type: spell
     img: icons/magic/life/cross-flared-green.webp
@@ -7274,8 +6954,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplAid0000000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.AmZK3JT82HiCjW57'
@@ -7312,6 +6993,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: self
         special: ''
@@ -7359,6 +7041,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -7382,8 +7065,8 @@ items:
             requireMagic: false
       identifier: goodberry
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: EIeR4p90ul518qTq
     type: spell
     img: icons/consumables/fruit/berries-hanging-red.webp
@@ -7397,8 +7080,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplGoodberry0
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.EIeR4p90ul518qTq'
@@ -7434,6 +7118,7 @@ items:
         template:
           units: ft
           contiguous: false
+          stationary: false
       range:
         units: touch
       uses:
@@ -7503,6 +7188,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -7526,8 +7212,8 @@ items:
           img: null
       identifier: magic-weapon
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: IvRfwU6y7Jd3myjn
     type: spell
     img: icons/skills/melee/sword-engraved-glow-purple.webp
@@ -7703,8 +7389,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplMagicWeapo
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.IvRfwU6y7Jd3myjn'
@@ -7748,6 +7435,7 @@ items:
           size: '20'
           contiguous: false
           count: ''
+          stationary: false
       range:
         value: '150'
         units: ft
@@ -7797,6 +7485,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -7831,8 +7520,8 @@ items:
           img: null
       identifier: spike-growth
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: HkKCPTwzsExcVcTc
     type: spell
     img: icons/creatures/abilities/stinger-spine-horn-blood.webp
@@ -7846,8 +7535,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplSpikeGrowt
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.HkKCPTwzsExcVcTc'
@@ -7908,8 +7598,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.phbagCaseMaporSc
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.6k1oSbzdfLUgU6DB'
@@ -7958,6 +7649,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -8027,8 +7719,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgSpellScroll1s
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     _id: QBcSv9jLpl0ySf5L
     sort: 0
     ownership:
@@ -8069,6 +7762,7 @@ items:
           type: radius
           size: '30'
           count: ''
+          stationary: false
       range:
         value: ''
         units: self
@@ -8121,6 +7815,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -8145,7 +7840,7 @@ items:
       identifier: detect-poison-and-disease
       method: spell
       prepared: 0
-      sourceClass: ranger
+      sourceItem: class:ranger
     type: spell
     img: icons/skills/toxins/poison-bottle-open-fire-purple.webp
     effects:
@@ -8251,8 +7946,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplDetectPois
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     _id: jpgUr2RWhFZ7fH8o
     ownership:
       default: 0
@@ -8298,6 +7994,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -8385,8 +8082,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgPotionOfHeali
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 100000
     ownership:
       default: 0
@@ -8486,8 +8184,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrRoving0000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -8567,6 +8266,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -8642,8 +8342,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrDefensiveT
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 100000
     ownership:
       default: 0
@@ -8698,8 +8399,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrExpertise0
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -8779,6 +8481,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -8844,6 +8547,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -8884,8 +8588,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrTireless00
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -8956,6 +8661,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -9006,8 +8712,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrSuperiorHu
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 500000
     ownership:
       default: 0
@@ -9054,6 +8761,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         value: '60'
         units: ft
@@ -9101,6 +8809,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9170,6 +8879,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9207,9 +8917,9 @@ items:
           img: null
       identifier: conjure-animals
       method: spell
-      sourceClass: ranger
       prepared: 1
       ability: ''
+      sourceItem: class:ranger
     _id: oYAmk1jbUd7U1vSK
     type: spell
     img: icons/creatures/abilities/wolf-heads-swirl-purple.webp
@@ -9223,8 +8933,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplConjureAni
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.oYAmk1jbUd7U1vSK'
@@ -9260,6 +8971,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -9307,6 +9019,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9340,9 +9053,9 @@ items:
           img: null
       identifier: revivify
       method: spell
-      sourceClass: ranger
       prepared: 1
       ability: ''
+      sourceItem: class:ranger
     _id: DNZTeQjm6FkjOu0N
     type: spell
     img: icons/magic/holy/chalice-glowing-gold-water.webp
@@ -9356,8 +9069,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplRevivify00
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.DNZTeQjm6FkjOu0N'
@@ -9394,6 +9108,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -9443,6 +9158,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9464,8 +9180,8 @@ items:
           img: null
       identifier: jump
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: wA3SrliOxfMNxk4K
     type: spell
     img: icons/creatures/mammals/deer-movement-leap-green.webp
@@ -9513,8 +9229,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplJump000000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.wA3SrliOxfMNxk4K'
@@ -9561,6 +9278,7 @@ items:
           size: '100'
           contiguous: false
           count: ''
+          stationary: false
       range:
         value: '150'
         units: ft
@@ -9611,6 +9329,7 @@ items:
               type: sphere
               size: '100'
               count: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -9662,6 +9381,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9686,8 +9406,8 @@ items:
             requireMagic: false
       identifier: plant-growth
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: HGL0BpVEzCKL2oJy
     type: spell
     img: icons/magic/nature/plant-sproud-hands-dirt-green.webp
@@ -9701,8 +9421,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplPlantGrowt
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.HGL0BpVEzCKL2oJy'
@@ -9744,8 +9465,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.2VAKB4eAj5aqjEEr'
@@ -9853,8 +9575,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgCloakOfProtec
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 8100000
     ownership:
       default: 0
@@ -9904,6 +9627,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -9973,8 +9697,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgSpellScroll3r
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     _id: HNapttFM9XtXh3yZ
     sort: 0
     ownership:
@@ -10015,6 +9740,7 @@ items:
           type: sphere
           size: '60'
           contiguous: false
+          stationary: false
       range:
         value: '60'
         units: ft
@@ -10061,6 +9787,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -10083,7 +9810,7 @@ items:
       identifier: daylight
       method: spell
       prepared: 0
-      sourceClass: ranger
+      sourceItem: class:ranger
     type: spell
     img: icons/magic/light/orb-beams-green.webp
     effects:
@@ -10156,8 +9883,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplDaylight00
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     _id: BAH8d6zDklJLKUKW
     ownership:
       default: 0
@@ -10207,6 +9935,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -10276,8 +10005,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgSpellScroll2n
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     _id: sQxo9ZuqIBneBxrb
     sort: 0
     ownership:
@@ -10315,6 +10045,7 @@ items:
           type: sphere
           size: '20'
           contiguous: false
+          stationary: false
       range:
         value: '120'
         units: ft
@@ -10365,6 +10096,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -10387,7 +10119,7 @@ items:
       identifier: silence
       method: spell
       prepared: 0
-      sourceClass: ranger
+      sourceItem: class:ranger
     type: spell
     img: icons/magic/control/debuff-chains-orb-movement-blue.webp
     effects:
@@ -10502,8 +10234,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplSilence000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     _id: uxOMNRcu2iOeylo6
     ownership:
       default: 0
@@ -10553,6 +10286,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -10622,230 +10356,14 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgSpellScroll2n
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     _id: pc1OhjXAcaglfiFO
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.pc1OhjXAcaglfiFO'
-  - name: Protection from Poison
-    system:
-      description:
-        value: >-
-          <p>You touch a creature and end the &amp;Reference[poisoned] condition
-          on it. For the duration, the target has Advantage on saving throws to
-          avoid or end the Poisoned condition, and it has Resistance to Poison
-          damage.</p>
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        license: CC-BY-4.0
-        book: ''
-        revision: 1
-      activation:
-        type: action
-        condition: ''
-        value: null
-      duration:
-        value: '1'
-        units: hour
-      target:
-        affects:
-          type: creature
-          count: '1'
-          choice: false
-        template:
-          units: ft
-          contiguous: false
-      range:
-        units: touch
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      level: 2
-      school: abj
-      properties:
-        - vocal
-        - somatic
-      materials:
-        value: ''
-        consumed: false
-        cost: 0
-        supply: 0
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: null
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            override: false
-            concentration: false
-          effects:
-            - _id: zTci2V6Iij0r0IIg
-              level: {}
-          range:
-            override: false
-            units: self
-          target:
-            prompt: true
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          uses:
-            spent: 0
-            recovery: []
-          sort: 0
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-      identifier: protection-from-poison
-      method: spell
-      prepared: 0
-      sourceClass: ranger
-    type: spell
-    img: icons/skills/toxins/cup-glass-poisoned-held.webp
-    effects:
-      - name: Poison Protection
-        origin: Compendium.dnd5e.spells24.Item.phbsplProtection
-        duration:
-          rounds: null
-          startTime: null
-          seconds: 3600
-          combat: null
-          turns: null
-          startRound: null
-          startTurn: null
-        disabled: false
-        flags: {}
-        img: icons/equipment/head/mask-plague-leather-brown.webp
-        _id: zTci2V6Iij0r0IIg
-        type: base
-        system: {}
-        changes:
-          - key: system.traits.dr.value
-            mode: 2
-            value: poison
-            priority: null
-        description: >-
-          <p><span style="font-family:Signika, sans-serif">For the duration, the
-          target has Advantage on saving throws to avoid or end the Poisoned
-          condition, and it has Resistance to Poison damage.</span></p>
-        tint: '#ffffff'
-        transfer: false
-        statuses: []
-        sort: 0
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv17000.gRtGvsb8FEvgcJfy.zTci2V6Iij0r0IIg
-      - _id: dnd5espellchange
-        type: enchantment
-        name: Spell Changes
-        img: systems/dnd5e/icons/svg/activity/cast.svg
-        origin: >-
-          Compendium.dnd5e.actors24.Actor.QuillatheLv11000.Item.pc1OhjXAcaglfiFO.Activity.dnd5escrollspell
-        changes:
-          - key: system.method
-            mode: 5
-            value: spell
-          - key: system.properties
-            mode: 2
-            value: '-vocal'
-          - key: system.properties
-            mode: 2
-            value: '-somatic'
-          - key: system.properties
-            mode: 2
-            value: '-material'
-          - key: activities[attack].attack.bonus
-            mode: 5
-            value: '5'
-          - key: activities[attack].attack.flat
-            mode: 5
-            value: 'true'
-          - key: activities[summon].flat.attack
-            mode: 5
-            value: '5'
-          - key: activities[save].save.dc.calculation
-            mode: 5
-            value: ''
-          - key: activities[save].save.dc.formula
-            mode: 5
-            value: '13'
-          - key: activities[summon].flat.save
-            mode: 5
-            value: '13'
-        system: {}
-        disabled: false
-        duration:
-          startTime: 0
-          combat: null
-        description: ''
-        tint: '#ffffff'
-        transfer: true
-        statuses: []
-        sort: 0
-        flags: {}
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv17000.gRtGvsb8FEvgcJfy.dnd5espellchange
-    folder: 3SjcO2acsFnWegp4
-    sort: 1200000
-    flags:
-      dnd5e:
-        cachedFor: .Item.pc1OhjXAcaglfiFO.Activity.dnd5escrollspell
-    _stats:
-      duplicateSource: null
-      exportSource: null
-      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplProtection
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    _id: gRtGvsb8FEvgcJfy
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv17000.gRtGvsb8FEvgcJfy'
   - _id: WyVga5iUa1gmsOHD
     name: Potion of Growth
     type: consumable
@@ -10897,6 +10415,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -10972,317 +10491,13 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgPotionOfGrowt
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.WyVga5iUa1gmsOHD'
-  - name: Enlarge/Reduce
-    system:
-      description:
-        value: >-
-          <p>For the duration, the spell enlarges or reduces a creature or an
-          object you can see within range (see the chosen effect below). A
-          targeted object must be neither worn nor carried. If the target is an
-          unwilling creature, it can make a Constitution saving throw. On a
-          successful save, the spell has no effect.</p><p>Everything that a
-          targeted creature is wearing and carrying changes size with it. Any
-          item it drops returns to normal size at once. A thrown weapon or piece
-          of ammunition returns to normal size immediately after it hits or
-          misses a target.</p><p><strong>Enlarge.</strong> The target's size
-          increases by one category—from Medium to Large, for example. The
-          target also has Advantage on Strength checks and Strength saving
-          throws. The target's attacks with its enlarged weapons or Unarmed
-          Strikes deal an extra 1d4 damage on a
-          hit.</p><p><strong>Reduce.</strong> The target's size decreases by one
-          category—from Medium to Small, for example. The target also has
-          Disadvantage on Strength checks and Strength saving throws. The
-          target's attacks with its reduced weapons or Unarmed Strikes deal 1d4
-          less damage on a hit (this can't reduce the damage below 1).</p>
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        license: CC-BY-4.0
-        book: ''
-        revision: 2
-      activation:
-        type: action
-        condition: ''
-        value: null
-      duration:
-        value: '1'
-        units: minute
-      target:
-        affects:
-          type: creatureOrObject
-          count: '1'
-          choice: false
-          special: ''
-        template:
-          units: ft
-          contiguous: false
-          type: ''
-      range:
-        value: '30'
-        units: ft
-        special: ''
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      level: 2
-      school: trs
-      properties:
-        - vocal
-        - somatic
-        - material
-        - concentration
-      materials:
-        value: a pinch of powdered iron
-        consumed: false
-        cost: 0
-        supply: 0
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: null
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            override: false
-            concentration: false
-          effects:
-            - _id: Wi2E10l7n6Ka8k6u
-              onSave: false
-              level: {}
-            - _id: NXdtOxX4HvPeodml
-              onSave: false
-              level: {}
-          range:
-            override: false
-            units: self
-          target:
-            prompt: true
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability:
-              - con
-            dc:
-              calculation: spellcasting
-              formula: ''
-          uses:
-            spent: 0
-            recovery: []
-          sort: 0
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-      identifier: enlarge-reduce
-      method: spell
-      prepared: 0
-      sourceClass: ranger
-    type: spell
-    img: icons/consumables/mushrooms/mushroom-spotted-red.webp
-    effects:
-      - name: Enlarged
-        origin: Compendium.dnd5e.spells24.Item.phbsplEnlargeRed
-        duration:
-          rounds: null
-          startTime: null
-          seconds: 60
-          combat: null
-          turns: null
-          startRound: null
-          startTurn: null
-        disabled: false
-        flags:
-          dnd5e:
-            riders:
-              statuses: []
-        img: icons/magic/control/silhouette-grow-shrink-tan.webp
-        _id: Wi2E10l7n6Ka8k6u
-        type: base
-        system: {}
-        changes:
-          - key: system.bonuses.mwak.damage
-            mode: 2
-            value: 1d4
-            priority: null
-          - key: system.bonuses.rwak.damage
-            mode: 2
-            value: 1d4
-            priority: null
-          - key: system.abilities.str.check.roll.mode
-            mode: 2
-            value: '1'
-            priority: null
-          - key: system.abilities.str.save.roll.mode
-            mode: 2
-            value: '1'
-            priority: null
-        description: >-
-          <p>The target’s size increases by one category—from Medium to Large,
-          for example. The target also has Advantage on Strength checks and
-          Strength saving throws. The target’s attacks with its enlarged weapons
-          or Unarmed Strikes deal an extra 1d4 damage on a hit.</p>
-        tint: '#ffffff'
-        transfer: false
-        statuses: []
-        sort: 0
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv17000.1AjUB13d58Xc0f1I.Wi2E10l7n6Ka8k6u
-      - name: Reduced
-        origin: Compendium.dnd5e.spells24.Item.phbsplEnlargeRed
-        duration:
-          rounds: null
-          startTime: null
-          seconds: 60
-          combat: null
-          turns: null
-          startRound: null
-          startTurn: null
-        disabled: false
-        flags:
-          dnd5e:
-            riders:
-              statuses: []
-        img: icons/magic/control/silhouette-grow-shrink-blue.webp
-        _id: NXdtOxX4HvPeodml
-        type: base
-        system: {}
-        changes:
-          - key: system.bonuses.mwak.damage
-            mode: 2
-            value: '- 1d4'
-            priority: null
-          - key: system.bonuses.rwak.damage
-            mode: 2
-            value: '- 1d4'
-            priority: null
-          - key: system.abilities.str.check.roll.mode
-            mode: 2
-            value: '-1'
-            priority: null
-          - key: system.abilities.str.save.roll.mode
-            mode: 2
-            value: '-1'
-            priority: null
-        description: >-
-          <p>The target’s size decreases by one category—from Medium to Small,
-          for example. The target also has Disadvantage on Strength checks and
-          Strength saving throws. The target’s attacks with its reduced weapons
-          or Unarmed Strikes deal 1d4 less damage on a hit (this can’t reduce
-          the damage below 1).</p>
-        tint: '#ffffff'
-        transfer: false
-        statuses: []
-        sort: 0
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv17000.1AjUB13d58Xc0f1I.NXdtOxX4HvPeodml
-      - _id: dnd5espellchange
-        type: enchantment
-        name: Spell Changes
-        img: systems/dnd5e/icons/svg/activity/cast.svg
-        origin: >-
-          Compendium.dnd5e.actors24.Actor.QuillatheLv11000.Item.WyVga5iUa1gmsOHD.Activity.o9I0OYuD6EkLaGCR
-        changes:
-          - key: system.method
-            mode: 5
-            value: spell
-          - key: system.activation
-            mode: 5
-            value: '{"type":"bonus","value":null,"condition":""}'
-          - key: system.properties
-            mode: 2
-            value: '-vocal'
-          - key: system.properties
-            mode: 2
-            value: '-somatic'
-          - key: system.properties
-            mode: 2
-            value: '-material'
-          - key: system.properties
-            mode: 2
-            value: '-concentration'
-        system: {}
-        disabled: false
-        duration:
-          startTime: 0
-          combat: null
-        description: ''
-        tint: '#ffffff'
-        transfer: true
-        statuses: []
-        sort: 0
-        flags: {}
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv17000.1AjUB13d58Xc0f1I.dnd5espellchange
-    folder: 3SjcO2acsFnWegp4
-    sort: 3700000
-    flags:
-      dnd5e:
-        cachedFor: .Item.WyVga5iUa1gmsOHD.Activity.o9I0OYuD6EkLaGCR
-    _stats:
-      duplicateSource: null
-      exportSource: null
-      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplEnlargeRed
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    _id: 1AjUB13d58Xc0f1I
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv17000.1AjUB13d58Xc0f1I'
   - _id: yaCDtthLiWjvYRwT
     name: Potion of Fire Resistance
     type: consumable
@@ -11365,6 +10580,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -11489,8 +10705,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgPotionOfResis
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -11531,9 +10748,6 @@ items:
     effects: []
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrRelentless
         advancementOrigin: NuNBKjUuSNIRsF9M.yMKZmo7nE6oSFMD0
         advancementRoot: NuNBKjUuSNIRsF9M.yMKZmo7nE6oSFMD0
@@ -11543,8 +10757,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrRelentless
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -11623,6 +10838,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -11688,9 +10904,6 @@ items:
           !actors.items.effects!QuillatheLv17000.10WHYbMxQT3Pkvvn.NOSQczI2MCQ5Ha8F
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrNaturesVei
         advancementOrigin: NuNBKjUuSNIRsF9M.zurYQjBBNQW92SAz
         advancementRoot: NuNBKjUuSNIRsF9M.zurYQjBBNQW92SAz
@@ -11700,8 +10913,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrNaturesVei
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -11799,6 +11013,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -12299,9 +11514,6 @@ items:
     folder: GWWL7NqfCEyqwfhZ
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrSuperiorDe
         advancementOrigin: BOFrG8LewBiASB6i.1P4RbYyrzFoutFrj
         advancementRoot: BOFrG8LewBiASB6i.1P4RbYyrzFoutFrj
@@ -12311,8 +11523,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrSuperiorDe
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 200000
     ownership:
       default: 0
@@ -12355,9 +11568,6 @@ items:
     effects: []
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrPreciseHun
         advancementOrigin: NuNBKjUuSNIRsF9M.c3CqyzFeTFA5Yq8u
         advancementRoot: NuNBKjUuSNIRsF9M.c3CqyzFeTFA5Yq8u
@@ -12367,8 +11577,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrPreciseHun
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -12413,6 +11624,7 @@ items:
           size: '10'
           contiguous: false
           count: ''
+          stationary: false
       range:
         units: self
         special: ''
@@ -12460,6 +11672,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -12527,6 +11740,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -12580,6 +11794,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -12623,27 +11838,24 @@ items:
             requireMagic: false
       identifier: conjure-woodland-beings
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: HUnVgoa8kvjAJWUf
     type: spell
     img: icons/magic/nature/instrument-recorder-leaves.webp
     effects: []
     folder: qi3IbnEwap7mRw4b
     sort: 3000000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplConjureWoo
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.HUnVgoa8kvjAJWUf'
@@ -12686,6 +11898,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -12735,6 +11948,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -12758,8 +11972,8 @@ items:
           img: null
       identifier: freedom-of-movement
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: 49e3TnqIESzb2GJO
     type: spell
     img: icons/magic/water/elemental-water.webp
@@ -12817,19 +12031,16 @@ items:
           !actors.items.effects!QuillatheLv17000.49e3TnqIESzb2GJO.bcTPZ6dJ4kHwaBRD
     folder: qi3IbnEwap7mRw4b
     sort: 2000000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplFreedomofM
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.49e3TnqIESzb2GJO'
@@ -12875,6 +12086,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: self
         special: ''
@@ -12922,6 +12134,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -12943,27 +12156,24 @@ items:
           img: null
       identifier: commune-with-nature
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: eG05TtcPOORGXdI4
     type: spell
     img: icons/magic/nature/tree-spirit-glow-black-yellow.webp
     effects: []
     folder: beZ8MTpWY2cMEUlp
     sort: 3100000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplCommunewit
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.eG05TtcPOORGXdI4'
@@ -13000,6 +12210,7 @@ items:
         template:
           units: ft
           contiguous: false
+          stationary: false
       range:
         units: touch
       uses:
@@ -13046,6 +12257,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -13067,27 +12279,24 @@ items:
           img: null
       identifier: greater-restoration
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: lRBFgh2CaamaP6fP
     type: spell
     img: icons/magic/life/heart-hand-gold-green-light.webp
     effects: []
     folder: beZ8MTpWY2cMEUlp
     sort: 1800000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplGreaterRes
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.lRBFgh2CaamaP6fP'
@@ -13126,6 +12335,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -13239,19 +12449,16 @@ items:
       equipped: false
     effects: []
     folder: kie870i5kr7yuxO8
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgScimitarOfSpe
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 10300000
     ownership:
       default: 0
@@ -13419,8 +12626,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgsupRingofResi
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -13467,6 +12675,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -13582,8 +12791,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgBrazierOfComm
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 4700000
     ownership:
       default: 0
@@ -13662,8 +12872,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgBagOfHolding0
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 300000
     ownership:
       default: 0
@@ -13787,19 +12998,16 @@ items:
         _key: >-
           !actors.items.effects!QuillatheLv17000.gFkeCeFDSffdlH3p.tptcsnQAGMErdXAT
     sort: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.equipment24.Item.phbamoArrows0000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.gFkeCeFDSffdlH3p'
@@ -13845,6 +13053,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -13988,8 +13197,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgPotionOfHeroi
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -14040,6 +13250,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -14157,8 +13368,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgPotionOfWater
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     sort: 0
     ownership:
       default: 0
@@ -14201,11 +13413,764 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923772670
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv17000.9LP3L2mGnZ2KEDwx'
+  - _id: 6vb3a5mNmA9pMuVw
+    name: Favored Enemy
+    type: feat
+    folder: h5OUzaJcZzsNsOGc
+    img: icons/creatures/abilities/dragon-breath-purple.webp
+    system:
+      description:
+        value: >-
+          <p>You always have the
+          @UUID[Compendium.dnd5e.spells24.Item.phbsplHuntersMar]{Hunter's Mark}
+          spell prepared. You can cast it twice without expending a spell slot,
+          and you regain all expended uses of this ability when you finish a
+          Long Rest.</p><p>The number of times you can cast the spell without a
+          spell slot increases when you reach certain Ranger levels, as shown in
+          the Favored Enemy column of the Ranger Features table.</p><section
+          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
+          Note</strong></p><p>The spell is granted to you at this level and will
+          increase the number of free uses available automatically as you level
+          up.</p></section>
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        revision: 2
+        license: CC-BY-4.0
+        book: ''
+      uses:
+        max: '@scale.ranger.favored-enemy'
+        spent: 0
+        recovery:
+          - period: lr
+            type: recoverAll
+      type:
+        value: class
+        subtype: ''
+      prerequisites:
+        level: 1
+        items: []
+        repeatable: false
+      properties:
+        - mgc
+      requirements: ''
+      activities:
+        18OW4UKZ5cSPPLhC:
+          type: cast
+          spell:
+            uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+            challenge:
+              override: false
+            properties: []
+            spellbook: true
+            ability: ''
+            level: 1
+          _id: 18OW4UKZ5cSPPLhC
+          img: ''
+          sort: 0
+          activation:
+            type: bonus
+            override: true
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          flags: {}
+          range:
+            units: self
+            override: false
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: Hunter's Mark (Free)
+      enchant: {}
+      identifier: favored-enemy
+      advancement:
+        DOENALOWWjAUHzb7:
+          _id: DOENALOWWjAUHzb7
+          type: ItemGrant
+          configuration:
+            items:
+              - optional: false
+                uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+            optional: false
+            spell:
+              ability: []
+              uses:
+                max: ''
+                per: ''
+                requireSlot: false
+              method: spell
+              prepared: 2
+          value:
+            added:
+              dcq7baHQ84R0bx0W: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+          level: 1
+          title: Favored Enemy
+          hint: ''
+          flags: {}
+      crewed: false
+    effects: []
+    flags:
+      dnd5e:
+        sourceId: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
+        advancementOrigin: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923772565
+      modifiedTime: 1777923772565
+      lastModifiedBy: dnd5ebuilder0000
+    sort: 0
+    ownership:
+      default: 0
+    _key: '!actors.items!QuillatheLv17000.6vb3a5mNmA9pMuVw'
+  - name: Hunter's Mark
+    system:
+      description:
+        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        license: CC-BY-4.0
+        book: ''
+        revision: 2
+      activation:
+        type: bonus
+        condition: ''
+        value: null
+      duration:
+        value: '1'
+        units: hour
+      target:
+        affects:
+          type: creature
+          count: '1'
+          choice: false
+          special: ''
+        template:
+          units: ft
+          contiguous: false
+          type: ''
+          stationary: false
+      range:
+        value: '90'
+        units: ft
+        special: ''
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      level: 1
+      school: div
+      properties:
+        - vocal
+        - concentration
+      materials:
+        value: ''
+        consumed: false
+        cost: 0
+        supply: 0
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: damage
+          activation:
+            type: ''
+            value: null
+            override: true
+            condition: ''
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: false
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            override: true
+            concentration: false
+          effects: []
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            prompt: true
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+          damage:
+            critical:
+              allow: true
+              bonus: ''
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: 6
+                bonus: ''
+                types:
+                  - force
+                scaling:
+                  mode: ''
+                  number: 1
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 200000
+          name: Bonus Mark Damage
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        vxr2JKuQ3jyMDTwb:
+          type: utility
+          _id: vxr2JKuQ3jyMDTwb
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: false
+            units: self
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 100000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Mark Creature
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        NQtVK0T5uwfMPGQL:
+          type: utility
+          activation:
+            type: bonus
+            value: null
+            override: true
+            condition: when the currently marked target drops to 0 Hit Points
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: false
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: true
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 300000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Move Mark
+          _id: NQtVK0T5uwfMPGQL
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      identifier: hunters-mark
+      method: spell
+      prepared: 2
+      sourceItem: feat:favored-enemy
+    _id: dcq7baHQ84R0bx0W
+    type: spell
+    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+    effects:
+      - name: Hunter's Mark
+        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        transfer: false
+        _id: vPkln6UeePHnbLr4
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          combat: null
+          seconds: 3600
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
+          force]] damage to the target whenever they hit it with an attack
+          roll.</p>
+        tint: '#ffffff'
+        statuses:
+          - marked
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv17000.dcq7baHQ84R0bx0W.vPkln6UeePHnbLr4
+    folder: pBaAAtXBCq9FVEnL
+    sort: 1900000
+    ownership:
+      default: 0
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
+        sourceId: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        advancementOrigin: 6vb3a5mNmA9pMuVw.DOENALOWWjAUHzb7
+        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923772565
+      modifiedTime: 1777923772565
+      lastModifiedBy: dnd5ebuilder0000
+    _key: '!actors.items!QuillatheLv17000.dcq7baHQ84R0bx0W'
+  - name: Hunter's Mark
+    system:
+      description:
+        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        license: CC-BY-4.0
+        book: ''
+        revision: 2
+      activation:
+        type: bonus
+        condition: ''
+        value: null
+      duration:
+        value: '1'
+        units: hour
+      target:
+        affects:
+          type: creature
+          count: '1'
+          choice: false
+          special: ''
+        template:
+          units: ft
+          contiguous: false
+          type: ''
+          stationary: false
+      range:
+        value: '90'
+        units: ft
+        special: ''
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      level: 1
+      school: div
+      properties:
+        - vocal
+        - concentration
+      materials:
+        value: ''
+        consumed: false
+        cost: 0
+        supply: 0
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: damage
+          activation:
+            type: ''
+            value: null
+            override: true
+            condition: ''
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: false
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            override: true
+            concentration: false
+          effects: []
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            prompt: true
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+          damage:
+            critical:
+              allow: true
+              bonus: ''
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: 6
+                bonus: ''
+                types:
+                  - force
+                scaling:
+                  mode: ''
+                  number: 1
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 200000
+          name: Bonus Mark Damage
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        vxr2JKuQ3jyMDTwb:
+          type: utility
+          _id: vxr2JKuQ3jyMDTwb
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: false
+            units: self
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 100000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Mark Creature
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        NQtVK0T5uwfMPGQL:
+          type: utility
+          activation:
+            type: bonus
+            value: null
+            override: true
+            condition: when the currently marked target drops to 0 Hit Points
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: false
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: true
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 300000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Move Mark
+          _id: NQtVK0T5uwfMPGQL
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      identifier: hunters-mark
+      method: spell
+      prepared: 0
+      sourceItem: feat:favored-enemy
+    type: spell
+    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+    effects:
+      - name: Hunter's Mark
+        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        transfer: false
+        _id: vPkln6UeePHnbLr4
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          combat: null
+          seconds: 3600
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
+          force]] damage to the target whenever they hit it with an attack
+          roll.</p>
+        tint: '#ffffff'
+        statuses:
+          - marked
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv17000.8oGjpP1SMBN3LR2S.vPkln6UeePHnbLr4
+      - _id: dnd5espellchange
+        type: enchantment
+        name: Spell Changes
+        img: systems/dnd5e/icons/svg/activity/cast.svg
+        origin: >-
+          Compendium.dnd5e.actors24.Actor.QuillatheLv17000.Item.6vb3a5mNmA9pMuVw.Activity.18OW4UKZ5cSPPLhC
+        changes:
+          - key: system.method
+            mode: 5
+            value: spell
+          - key: system.activation
+            mode: 5
+            value: '{"type":"bonus","condition":""}'
+        system: {}
+        disabled: false
+        duration:
+          startTime: 0
+          combat: null
+          startRound: 0
+          startTurn: 0
+        description: ''
+        tint: '#ffffff'
+        transfer: true
+        statuses: []
+        sort: 0
+        flags: {}
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv17000.8oGjpP1SMBN3LR2S.dnd5espellchange
+    folder: pBaAAtXBCq9FVEnL
+    sort: 1900000
+    ownership:
+      default: 0
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
+        cachedFor: .Item.6vb3a5mNmA9pMuVw.Activity.18OW4UKZ5cSPPLhC
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923772760
+      modifiedTime: 1777923772760
+      lastModifiedBy: dnd5ebuilder0000
+    _id: 8oGjpP1SMBN3LR2S
+    _key: '!actors.items!QuillatheLv17000.8oGjpP1SMBN3LR2S'
 effects: []
 flags: {}
 _stats:
@@ -14213,9 +14178,9 @@ _stats:
   exportSource: null
   coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 5.3.0
+  systemVersion: 5.3.2
   createdTime: 1771452688753
-  modifiedTime: 1771452688753
+  modifiedTime: 1777923772704
   lastModifiedBy: dnd5ebuilder0000
 img: null
 folder: mxujixfhj5hEnENw

--- a/packs/_source/actors24/premades/level-17/quillathe.yml
+++ b/packs/_source/actors24/premades/level-17/quillathe.yml
@@ -403,13 +403,7 @@ system:
       value: >-
         <p>Quillathe cleanses monsters from her woods as a hobby, but now a new
         force menaces her land and she must band with adventurers to defeat
-        it.</p><p><em>Token artwork by <a
-        href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener">Forgotten Adventures</a>.</em></p><p><em>Token artwork by
-        <a href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener">Forgotten Adventures</a>.</em></p><p><em>Token artwork by
-        <a href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener">Forgotten Adventures</a>.</em></p>
+        it.</p>
       public: ''
     alignment: Chaotic Neutral
     ideal: ''
@@ -14180,7 +14174,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 5.3.2
   createdTime: 1771452688753
-  modifiedTime: 1777923772704
+  modifiedTime: 1777994653892
   lastModifiedBy: dnd5ebuilder0000
 img: null
 folder: mxujixfhj5hEnENw

--- a/packs/_source/actors24/premades/level-17/quillathe.yml
+++ b/packs/_source/actors24/premades/level-17/quillathe.yml
@@ -13427,11 +13427,7 @@ items:
           and you regain all expended uses of this ability when you finish a
           Long Rest.</p><p>The number of times you can cast the spell without a
           spell slot increases when you reach certain Ranger levels, as shown in
-          the Favored Enemy column of the Ranger Features table.</p><section
-          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
-          Note</strong></p><p>The spell is granted to you at this level and will
-          increase the number of free uses available automatically as you level
-          up.</p></section>
+          the Favored Enemy column of the Ranger Features table.</p>
         chat: ''
       source:
         custom: ''
@@ -13513,7 +13509,7 @@ items:
             requireIdentification: false
             requireMagic: false
             identifier: ''
-          name: Hunter's Mark (Free)
+          name: ''
       enchant: {}
       identifier: favored-enemy
       advancement:

--- a/packs/_source/actors24/premades/level-5/quillathe.yml
+++ b/packs/_source/actors24/premades/level-5/quillathe.yml
@@ -403,7 +403,13 @@ system:
       value: >-
         <p>Quillathe cleanses monsters from her woods as a hobby, but now a new
         force menaces her land and she must band with adventurers to defeat
-        it.</p>
+        it.</p><p><em>Token artwork by <a
+        href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener">Forgotten Adventures</a>.</em></p><p><em>Token artwork by
+        <a href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener">Forgotten Adventures</a>.</em></p><p><em>Token artwork by
+        <a href="https://www.forgotten-adventures.net/" target="_blank"
+        rel="noopener">Forgotten Adventures</a>.</em></p>
       public: ''
     alignment: Chaotic Neutral
     ideal: ''
@@ -455,6 +461,8 @@ system:
       communication: {}
     weaponProf:
       value:
+        - longbow
+        - shortbow
         - sim
         - mar
       custom: ''
@@ -495,9 +503,6 @@ system:
     - type: item
       id: .Item.WiXfB8xRlPdC7kiB
       sort: 0
-    - type: item
-      id: .Item.iCf450qECu1PRkAZ
-      sort: 250000
     - type: activity
       id: .Item.xge2yOOVa1Iql8ni.Activity.Ek6m8ZY5Df7Mp6DO
       sort: 200000
@@ -746,8 +751,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     _id: WSfqg4qp13LFdc3N
     ownership:
       default: 0
@@ -847,8 +853,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.6156HtS7RvjQ7nhJ'
@@ -1058,8 +1065,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
@@ -1110,8 +1118,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
@@ -1164,8 +1173,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
@@ -1217,8 +1227,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
@@ -1286,8 +1297,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
@@ -1450,8 +1462,8 @@ items:
           value:
             added:
               HAXlit2SO8luWUtO: Compendium.dnd5e.classes24.Item.phbrgrSpellcasti
-              o0bC09CnUpZ4wvDt: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
               uHY0uPusihtnVQkp: Compendium.dnd5e.classes24.Item.phbrgrWeaponMast
+              mzu2oIvnAowoczjS: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
           level: 1
           title: Class Features
           flags: {}
@@ -1706,29 +1718,6 @@ items:
           title: ''
           flags: {}
           hint: ''
-        DOENALOWWjAUHzb7:
-          _id: DOENALOWWjAUHzb7
-          type: ItemGrant
-          configuration:
-            items:
-              - optional: false
-                uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-            optional: false
-            spell:
-              ability: []
-              uses:
-                max: '@scale.ranger.favored-enemy'
-                per: lr
-                requireSlot: false
-              method: spell
-              prepared: 2
-          value:
-            added:
-              iCf450qECu1PRkAZ: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-          level: 1
-          title: Favored Enemy
-          hint: ''
-          flags: {}
         FksFWNV4X4lTFlvO:
           _id: FksFWNV4X4lTFlvO
           type: ScaleValue
@@ -2080,8 +2069,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
@@ -2126,6 +2116,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: ft
         special: ''
@@ -2176,6 +2167,7 @@ items:
               type: cube
               size: '5'
               count: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -2219,8 +2211,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.kEjBWiTMcmhrI5w4'
@@ -2302,74 +2295,13 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.HAXlit2SO8luWUtO'
-  - _id: o0bC09CnUpZ4wvDt
-    name: Favored Enemy
-    type: feat
-    folder: h5OUzaJcZzsNsOGc
-    img: icons/creatures/abilities/dragon-breath-purple.webp
-    system:
-      description:
-        value: >-
-          <p>You always have the
-          @UUID[Compendium.dnd5e.spells24.Item.phbsplHuntersMar]{Hunter's Mark}
-          spell prepared. You can cast it twice without expending a spell slot,
-          and you regain all expended uses of this ability when you finish a
-          Long Rest.</p><p>The number of times you can cast the spell without a
-          spell slot increases when you reach certain Ranger levels, as shown in
-          the Favored Enemy column of the Ranger Features table.</p><section
-          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
-          Note</strong></p><p>The spell is granted to you at this level and will
-          increase the number of free uses available automatically as you level
-          up.</p></section>
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        revision: 1
-        license: CC-BY-4.0
-        book: ''
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: class
-        subtype: ''
-      prerequisites:
-        level: 1
-        items: []
-        repeatable: false
-      properties: []
-      requirements: ''
-      activities: {}
-      enchant: {}
-      identifier: favored-enemy
-      advancement: {}
-      crewed: false
-    effects: []
-    flags:
-      dnd5e:
-        sourceId: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
-        advancementOrigin: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
-        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
-    _stats:
-      compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
-      duplicateSource: null
-      exportSource: null
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    sort: 0
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv05000.o0bC09CnUpZ4wvDt'
   - _id: uHY0uPusihtnVQkp
     name: Weapon Mastery
     type: feat
@@ -2421,322 +2353,13 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.uHY0uPusihtnVQkp'
-  - name: Hunter's Mark
-    system:
-      description:
-        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        license: CC-BY-4.0
-        book: ''
-        revision: 2
-      activation:
-        type: bonus
-        condition: ''
-        value: null
-      duration:
-        value: '1'
-        units: hour
-      target:
-        affects:
-          type: creature
-          count: '1'
-          choice: false
-          special: ''
-        template:
-          units: ft
-          contiguous: false
-          type: ''
-      range:
-        value: '90'
-        units: ft
-        special: ''
-      uses:
-        max: '@scale.ranger.favored-enemy'
-        recovery:
-          - period: lr
-            type: recoverAll
-          - period: lr
-            type: recoverAll
-        spent: 0
-      level: 1
-      school: div
-      properties:
-        - vocal
-        - concentration
-      materials:
-        value: ''
-        consumed: false
-        cost: 0
-        supply: 0
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: damage
-          activation:
-            type: ''
-            value: null
-            override: true
-            condition: ''
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: false
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            override: true
-            concentration: false
-          effects: []
-          range:
-            override: true
-            units: any
-            special: ''
-          target:
-            prompt: true
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-          damage:
-            critical:
-              allow: true
-              bonus: ''
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 1
-                denomination: 6
-                bonus: ''
-                types:
-                  - force
-                scaling:
-                  mode: ''
-                  number: 1
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 200000
-          name: Bonus Mark Damage
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        vxr2JKuQ3jyMDTwb:
-          type: utility
-          _id: vxr2JKuQ3jyMDTwb
-          activation:
-            type: action
-            value: null
-            override: false
-          consumption:
-            scaling:
-              allowed: false
-            spellSlot: true
-            targets: []
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            concentration: false
-            override: false
-          effects:
-            - _id: vPkln6UeePHnbLr4
-              level: {}
-          range:
-            override: false
-            units: self
-          target:
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-            prompt: true
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 100000
-          roll:
-            prompt: false
-            visible: false
-            name: ''
-            formula: ''
-          name: Mark Creature
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        NQtVK0T5uwfMPGQL:
-          type: utility
-          activation:
-            type: bonus
-            value: null
-            override: true
-            condition: when the currently marked target drops to 0 Hit Points
-          consumption:
-            scaling:
-              allowed: false
-            spellSlot: false
-            targets: []
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            concentration: false
-            override: true
-          effects:
-            - _id: vPkln6UeePHnbLr4
-              level: {}
-          range:
-            override: true
-            units: any
-            special: ''
-          target:
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-            prompt: true
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 300000
-          roll:
-            prompt: false
-            visible: false
-            name: ''
-            formula: ''
-          name: Move Mark
-          _id: NQtVK0T5uwfMPGQL
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-        72GB8kfgMJgPVbY0:
-          _id: 72GB8kfgMJgPVbY0
-          type: forward
-          name: Mark Creature (free casting)
-          sort: 100001
-          activity:
-            id: vxr2JKuQ3jyMDTwb
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling: {}
-            scaling:
-              allowed: false
-            spellSlot: true
-          activation:
-            type: action
-            override: false
-          description: {}
-          flags: {}
-          uses:
-            spent: 0
-            recovery: []
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-      identifier: hunters-mark
-      method: spell
-      prepared: 2
-      sourceClass: ranger
-    _id: iCf450qECu1PRkAZ
-    type: spell
-    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
-    effects:
-      - name: Hunter's Mark
-        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
-        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-        transfer: false
-        _id: vPkln6UeePHnbLr4
-        type: base
-        system: {}
-        changes: []
-        disabled: false
-        duration:
-          startTime: null
-          combat: null
-          seconds: 3600
-          rounds: null
-          turns: null
-          startRound: null
-          startTurn: null
-        description: >-
-          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
-          force]] damage to the target whenever they hit it with an attack
-          roll.</p>
-        tint: '#ffffff'
-        statuses:
-          - marked
-        sort: 0
-        flags:
-          dnd5e:
-            riders:
-              statuses: []
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv05000.iCf450qECu1PRkAZ.vPkln6UeePHnbLr4
-    folder: pBaAAtXBCq9FVEnL
-    sort: 1900000
-    flags:
-      dnd5e:
-        sourceId: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-        advancementOrigin: NuNBKjUuSNIRsF9M.DOENALOWWjAUHzb7
-        advancementRoot: NuNBKjUuSNIRsF9M.DOENALOWWjAUHzb7
-    _stats:
-      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-      duplicateSource: null
-      exportSource: null
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv05000.iCf450qECu1PRkAZ'
   - name: Cure Wounds
     system:
       description:
@@ -2769,6 +2392,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -2815,6 +2439,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -2844,8 +2469,8 @@ items:
           img: null
       identifier: cure-wounds
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: 2KxozSkbJhhPD7Zb
     type: spell
     img: icons/magic/nature/leaf-drip-light-green.webp
@@ -2859,8 +2484,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.2KxozSkbJhhPD7Zb'
@@ -2904,6 +2530,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: self
         special: ''
@@ -2953,6 +2580,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -3017,6 +2645,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -3055,8 +2684,8 @@ items:
           img: null
       identifier: ensnaring-strike
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: EBgpZ648SEfydQRq
     type: spell
     img: icons/magic/nature/root-vines-grow-brown.webp
@@ -3111,8 +2740,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.EBgpZ648SEfydQRq'
@@ -3196,6 +2826,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -3239,8 +2870,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.unYsJXqTKiLwFGEu'
@@ -3312,8 +2944,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.8OhoDlMp6n7S6vkp'
@@ -3356,6 +2989,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -3482,8 +3116,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
@@ -3554,8 +3189,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.zLB9qhJw8z2FSbCO'
@@ -3667,6 +3303,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -3722,8 +3359,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.D3zED6xcDPkysnuj'
@@ -3835,6 +3473,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -3890,8 +3529,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.lERu2Skz1q5s9egL'
@@ -4004,6 +3644,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -4060,8 +3701,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.qdxxGDu9tguu68Fu'
@@ -4133,8 +3775,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.WiXfB8xRlPdC7kiB'
@@ -4208,8 +3851,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.pie1jETwfFOgm3Ea'
@@ -4278,8 +3922,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.friHHTqUU9vmohfg'
@@ -4369,6 +4014,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4407,8 +4053,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.hc8MggfBaxwCzCHA'
@@ -4502,6 +4149,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4557,6 +4205,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4612,6 +4261,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4650,8 +4300,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.NQXrw78HaPfjDwCR'
@@ -4700,8 +4351,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.lSEr732XDGJKNopc'
@@ -4760,8 +4412,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.KaPzoh8WPLzQEWMu'
@@ -4804,6 +4457,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -4881,8 +4535,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     _id: 6kKffxM60Oq7uyzV
     sort: 100000
     ownership:
@@ -4977,6 +4632,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -5036,8 +4692,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.sMFxms44gxWpPEzK'
@@ -5143,6 +4800,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -5208,6 +4866,7 @@ items:
               type: square
               size: '5'
               count: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -5254,8 +4913,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.IllhigPdXlPBx5Mu'
@@ -5322,8 +4982,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.biyQChEtJrhkkj9X'
@@ -5371,9 +5032,6 @@ items:
     effects: []
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrDeftExplor
         advancementOrigin: NuNBKjUuSNIRsF9M.0XJhkNDTm9P3K5n3
         advancementRoot: NuNBKjUuSNIRsF9M.0XJhkNDTm9P3K5n3
@@ -5383,8 +5041,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrDeftExplor
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
@@ -5431,9 +5090,6 @@ items:
     effects: []
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrFightingSt
         advancementOrigin: NuNBKjUuSNIRsF9M.0XJhkNDTm9P3K5n3
         advancementRoot: NuNBKjUuSNIRsF9M.0XJhkNDTm9P3K5n3
@@ -5443,8 +5099,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFightingSt
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
@@ -5528,9 +5185,6 @@ items:
     sort: 100000
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.feats24.Item.phbfstArchery000
         advancementOrigin: NuNBKjUuSNIRsF9M.AtKKnCoTLBqSxhCh
         advancementRoot: NuNBKjUuSNIRsF9M.AtKKnCoTLBqSxhCh
@@ -5540,8 +5194,9 @@ items:
       compendiumSource: Compendium.dnd5e.feats24.Item.phbfstArchery000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.1eURR2YWZ0hqplDM'
@@ -5577,6 +5232,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: touch
         special: ''
@@ -5628,6 +5284,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -5683,7 +5340,7 @@ items:
       method: spell
       prepared: 2
       ability: wis
-      sourceClass: ranger
+      sourceItem: class:ranger
     _id: XtHfUCHDXdBgFfic
     type: spell
     img: icons/equipment/feet/boots-leather-laced-brown.webp
@@ -5728,9 +5385,6 @@ items:
     sort: 1300000
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.spells24.Item.phbsplLongstride
         advancementOrigin: tFVkCkuuFo4ucCrc.FRJszO7cYchbaGzt
         advancementRoot: tFVkCkuuFo4ucCrc.FRJszO7cYchbaGzt
@@ -5740,8 +5394,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplLongstride
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.XtHfUCHDXdBgFfic'
@@ -5843,8 +5498,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrHunter0000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 500000
     ownership:
       default: 0
@@ -5890,9 +5546,6 @@ items:
     effects: []
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrHuntersLor
         advancementOrigin: BOFrG8LewBiASB6i.wacj6x75L5ZaZUky
         advancementRoot: BOFrG8LewBiASB6i.wacj6x75L5ZaZUky
@@ -5902,8 +5555,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrHuntersLor
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 300000
     ownership:
       default: 0
@@ -5982,6 +5636,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -6047,8 +5702,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrHuntersPre
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 400000
     ownership:
       default: 0
@@ -6083,6 +5739,7 @@ items:
         template:
           units: ft
           contiguous: false
+          stationary: false
       range:
         units: self
       uses:
@@ -6134,6 +5791,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -6186,7 +5844,7 @@ items:
       identifier: pass-without-trace
       method: spell
       prepared: 2
-      sourceClass: ranger
+      sourceItem: class:ranger
     _id: fG9QhmaWPRLmAgpi
     type: spell
     img: icons/creatures/mammals/humanoid-cat-skulking-teal.webp
@@ -6234,9 +5892,6 @@ items:
     sort: 1400000
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.spells24.Item.phbsplPasswithou
         advancementOrigin: tFVkCkuuFo4ucCrc.zFsEPXauTgmYxqiJ
         advancementRoot: tFVkCkuuFo4ucCrc.zFsEPXauTgmYxqiJ
@@ -6246,8 +5901,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplPasswithou
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.fG9QhmaWPRLmAgpi'
@@ -6289,9 +5945,6 @@ items:
     effects: []
     flags:
       dnd5e:
-        riders:
-          activity: []
-          effect: []
         sourceId: Compendium.dnd5e.classes24.Item.phbrgrExtraAttac
         advancementOrigin: NuNBKjUuSNIRsF9M.onoWzEIWhrrG4QJt
         advancementRoot: NuNBKjUuSNIRsF9M.onoWzEIWhrrG4QJt
@@ -6301,8 +5954,9 @@ items:
       compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrExtraAttac
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 0
     ownership:
       default: 0
@@ -6448,19 +6102,16 @@ items:
           lastModifiedBy: null
         _key: >-
           !actors.items.effects!QuillatheLv05000.Px3TIzuYqwF0x8wB.PSGGfFEy4CjBVzyX
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgBracersOfArch
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 4400000
     ownership:
       default: 0
@@ -6528,8 +6179,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgQuiverOfEhlon
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 1000000
     ownership:
       default: 0
@@ -6588,8 +6240,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.fj90XA0PYmbUpym3'
@@ -6651,8 +6304,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.W80ByYTQXyznvRPq'
@@ -6714,8 +6368,9 @@ items:
       exportSource: null
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.KdY2pwORMXFr6Y0B'
@@ -6752,6 +6407,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: ft
         special: ''
@@ -6830,6 +6486,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -6863,8 +6520,8 @@ items:
           img: null
       identifier: aid
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: AmZK3JT82HiCjW57
     type: spell
     img: icons/magic/life/cross-flared-green.webp
@@ -7173,8 +6830,9 @@ items:
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplAid0000000
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.AmZK3JT82HiCjW57'
@@ -7211,6 +6869,7 @@ items:
           units: ft
           contiguous: false
           type: ''
+          stationary: false
       range:
         units: self
         special: ''
@@ -7258,6 +6917,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -7281,27 +6941,24 @@ items:
             requireMagic: false
       identifier: goodberry
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: EIeR4p90ul518qTq
     type: spell
     img: icons/consumables/fruit/berries-hanging-red.webp
     effects: []
     folder: pBaAAtXBCq9FVEnL
     sort: 2700000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplGoodberry0
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.EIeR4p90ul518qTq'
@@ -7337,6 +6994,7 @@ items:
         template:
           units: ft
           contiguous: false
+          stationary: false
       range:
         units: touch
       uses:
@@ -7406,6 +7064,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -7429,8 +7088,8 @@ items:
           img: null
       identifier: magic-weapon
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: IvRfwU6y7Jd3myjn
     type: spell
     img: icons/skills/melee/sword-engraved-glow-purple.webp
@@ -7599,19 +7258,16 @@ items:
           !actors.items.effects!QuillatheLv05000.IvRfwU6y7Jd3myjn.AJQwm1dgXz7D333k
     folder: 3SjcO2acsFnWegp4
     sort: 2000000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplMagicWeapo
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.IvRfwU6y7Jd3myjn'
@@ -7655,6 +7311,7 @@ items:
           size: '20'
           contiguous: false
           count: ''
+          stationary: false
       range:
         value: '150'
         units: ft
@@ -7704,6 +7361,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -7738,27 +7396,24 @@ items:
           img: null
       identifier: spike-growth
       method: spell
-      sourceClass: ranger
       prepared: 1
+      sourceItem: class:ranger
     _id: HkKCPTwzsExcVcTc
     type: spell
     img: icons/creatures/abilities/stinger-spine-horn-blood.webp
     effects: []
     folder: 3SjcO2acsFnWegp4
     sort: 300000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.spells24.Item.phbsplSpikeGrowt
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.HkKCPTwzsExcVcTc'
@@ -7819,8 +7474,9 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.phbagCaseMaporSc
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.6k1oSbzdfLUgU6DB'
@@ -7869,6 +7525,7 @@ items:
             template:
               contiguous: false
               units: ft
+              stationary: false
             affects:
               choice: false
             override: false
@@ -7931,250 +7588,21 @@ items:
       equipped: false
     effects: []
     folder: null
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       duplicateSource: null
       exportSource: null
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgSpellScroll1s
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     _id: QBcSv9jLpl0ySf5L
     sort: 0
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.QBcSv9jLpl0ySf5L'
-  - name: Detect Poison and Disease
-    system:
-      description:
-        value: >-
-          <p>For the duration, you sense the location of poisons, poisonous or
-          venomous creatures, and magical contagions within 30 feet of yourself.
-          You sense the kind of poison, creature, or contagion in each
-          case.</p><p>The spell is blocked by 1 foot of stone, dirt, or wood; 1
-          inch of metal; or a thin sheet of lead.</p>
-        chat: ''
-      source:
-        custom: ''
-        rules: '2024'
-        license: CC-BY-4.0
-        book: ''
-        revision: 1
-      activation:
-        type: action
-        condition: ''
-        value: null
-      duration:
-        value: '10'
-        units: minute
-      target:
-        affects:
-          type: self
-          count: ''
-          choice: false
-          special: ''
-        template:
-          units: ft
-          contiguous: false
-          type: radius
-          size: '30'
-          count: ''
-      range:
-        value: ''
-        units: self
-        special: ''
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      level: 1
-      school: div
-      properties:
-        - vocal
-        - somatic
-        - material
-        - concentration
-        - ritual
-      materials:
-        value: a yew leaf
-        consumed: false
-        cost: 0
-        supply: 0
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: null
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            override: false
-            concentration: false
-          effects:
-            - _id: zSS8rmsXm5JCaM5x
-              level: {}
-          range:
-            override: false
-            units: self
-          target:
-            prompt: false
-            template:
-              contiguous: false
-              units: ft
-            affects:
-              choice: false
-            override: false
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          sort: 0
-          name: ''
-          flags: {}
-          visibility:
-            level: {}
-            requireAttunement: false
-            requireIdentification: false
-            requireMagic: false
-          img: null
-      identifier: detect-poison-and-disease
-      method: spell
-      prepared: 0
-      sourceClass: ranger
-    type: spell
-    img: icons/skills/toxins/poison-bottle-open-fire-purple.webp
-    effects:
-      - name: Detect Poison and Disease
-        origin: Compendium.dnd5e.spells24.Item.phbsplDetectPois
-        duration:
-          rounds: null
-          startTime: null
-          seconds: 600
-          combat: null
-          turns: null
-          startRound: null
-          startTurn: null
-        disabled: false
-        flags: {}
-        img: icons/skills/toxins/poison-bottle-open-fire-purple.webp
-        _id: zSS8rmsXm5JCaM5x
-        type: base
-        system: {}
-        changes: []
-        description: ''
-        tint: '#ffffff'
-        transfer: false
-        statuses: []
-        sort: 0
-        _stats:
-          compendiumSource: >-
-            Compendium.dnd5e.spells24.Item.phbsplDetectEvil.ActiveEffect.pOgbtXbKVGdbwjjE
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv05000.jpgUr2RWhFZ7fH8o.zSS8rmsXm5JCaM5x
-      - _id: dnd5espellchange
-        type: enchantment
-        name: Spell Changes
-        img: systems/dnd5e/icons/svg/activity/cast.svg
-        origin: >-
-          Compendium.dnd5e.actors24.Actor.QuillatheLv05000.Item.QBcSv9jLpl0ySf5L.Activity.dnd5escrollspell
-        changes:
-          - key: system.method
-            mode: 5
-            value: spell
-          - key: system.properties
-            mode: 2
-            value: '-vocal'
-          - key: system.properties
-            mode: 2
-            value: '-somatic'
-          - key: system.properties
-            mode: 2
-            value: '-material'
-          - key: activities[attack].attack.bonus
-            mode: 5
-            value: '5'
-          - key: activities[attack].attack.flat
-            mode: 5
-            value: 'true'
-          - key: activities[summon].flat.attack
-            mode: 5
-            value: '5'
-          - key: activities[save].save.dc.calculation
-            mode: 5
-            value: ''
-          - key: activities[save].save.dc.formula
-            mode: 5
-            value: '13'
-          - key: activities[summon].flat.save
-            mode: 5
-            value: '13'
-        system: {}
-        disabled: false
-        duration:
-          startTime: 0
-          combat: null
-        description: ''
-        tint: '#ffffff'
-        transfer: true
-        statuses: []
-        sort: 0
-        flags: {}
-        _stats:
-          compendiumSource: null
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '13.351'
-          systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-        _key: >-
-          !actors.items.effects!QuillatheLv05000.jpgUr2RWhFZ7fH8o.dnd5espellchange
-    folder: pBaAAtXBCq9FVEnL
-    sort: 4000000
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-        cachedFor: .Item.QBcSv9jLpl0ySf5L.Activity.dnd5escrollspell
-    _stats:
-      duplicateSource: null
-      exportSource: null
-      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplDetectPois
-      coreVersion: '13.351'
-      systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-    _id: jpgUr2RWhFZ7fH8o
-    ownership:
-      default: 0
-    _key: '!actors.items!QuillatheLv05000.jpgUr2RWhFZ7fH8o'
   - _id: 9SKBTfr7czOhqNux
     name: Potion of Healing
     type: consumable
@@ -8216,6 +7644,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: ''
@@ -8303,12 +7732,997 @@ items:
       compendiumSource: Compendium.dnd5e.equipment24.Item.dmgPotionOfHeali
       coreVersion: '13.351'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
+      systemVersion: 5.3.2
+      lastModifiedBy: dnd5ebuilder0000
+      modifiedTime: 1777923236692
     sort: 100000
     ownership:
       default: 0
     _key: '!actors.items!QuillatheLv05000.9SKBTfr7czOhqNux'
+  - _id: mzu2oIvnAowoczjS
+    name: Favored Enemy
+    type: feat
+    folder: h5OUzaJcZzsNsOGc
+    img: icons/creatures/abilities/dragon-breath-purple.webp
+    system:
+      description:
+        value: >-
+          <p>You always have the
+          @UUID[Compendium.dnd5e.spells24.Item.phbsplHuntersMar]{Hunter's Mark}
+          spell prepared. You can cast it twice without expending a spell slot,
+          and you regain all expended uses of this ability when you finish a
+          Long Rest.</p><p>The number of times you can cast the spell without a
+          spell slot increases when you reach certain Ranger levels, as shown in
+          the Favored Enemy column of the Ranger Features table.</p><section
+          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
+          Note</strong></p><p>The spell is granted to you at this level and will
+          increase the number of free uses available automatically as you level
+          up.</p></section>
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        revision: 2
+        license: CC-BY-4.0
+        book: ''
+      uses:
+        max: '@scale.ranger.favored-enemy'
+        spent: 0
+        recovery:
+          - period: lr
+            type: recoverAll
+      type:
+        value: class
+        subtype: ''
+      prerequisites:
+        level: 1
+        items: []
+        repeatable: false
+      properties:
+        - mgc
+      requirements: ''
+      activities:
+        18OW4UKZ5cSPPLhC:
+          type: cast
+          spell:
+            uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+            challenge:
+              override: false
+            properties: []
+            spellbook: true
+            ability: ''
+            level: 1
+          _id: 18OW4UKZ5cSPPLhC
+          img: ''
+          sort: 0
+          activation:
+            type: bonus
+            override: true
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          flags: {}
+          range:
+            units: self
+            override: false
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: Hunter's Mark (Free)
+      enchant: {}
+      identifier: favored-enemy
+      advancement:
+        DOENALOWWjAUHzb7:
+          _id: DOENALOWWjAUHzb7
+          type: ItemGrant
+          configuration:
+            items:
+              - optional: false
+                uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+            optional: false
+            spell:
+              ability: []
+              uses:
+                max: ''
+                per: ''
+                requireSlot: false
+              method: spell
+              prepared: 2
+          value:
+            added:
+              g6kyry2aDjpWgdj6: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+          level: 1
+          title: Favored Enemy
+          hint: ''
+          flags: {}
+      crewed: false
+    effects: []
+    flags:
+      dnd5e:
+        sourceId: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
+        advancementOrigin: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.classes24.Item.phbrgrFavoredEne
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923236651
+      modifiedTime: 1777923236651
+      lastModifiedBy: dnd5ebuilder0000
+    sort: 0
+    ownership:
+      default: 0
+    _key: '!actors.items!QuillatheLv05000.mzu2oIvnAowoczjS'
+  - name: Hunter's Mark
+    system:
+      description:
+        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        license: CC-BY-4.0
+        book: ''
+        revision: 2
+      activation:
+        type: bonus
+        condition: ''
+        value: null
+      duration:
+        value: '1'
+        units: hour
+      target:
+        affects:
+          type: creature
+          count: '1'
+          choice: false
+          special: ''
+        template:
+          units: ft
+          contiguous: false
+          type: ''
+          stationary: false
+      range:
+        value: '90'
+        units: ft
+        special: ''
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      level: 1
+      school: div
+      properties:
+        - vocal
+        - concentration
+      materials:
+        value: ''
+        consumed: false
+        cost: 0
+        supply: 0
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: damage
+          activation:
+            type: ''
+            value: null
+            override: true
+            condition: ''
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: false
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            override: true
+            concentration: false
+          effects: []
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            prompt: true
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+          damage:
+            critical:
+              allow: true
+              bonus: ''
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: 6
+                bonus: ''
+                types:
+                  - force
+                scaling:
+                  mode: ''
+                  number: 1
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 200000
+          name: Bonus Mark Damage
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        vxr2JKuQ3jyMDTwb:
+          type: utility
+          _id: vxr2JKuQ3jyMDTwb
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: false
+            units: self
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 100000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Mark Creature
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        NQtVK0T5uwfMPGQL:
+          type: utility
+          activation:
+            type: bonus
+            value: null
+            override: true
+            condition: when the currently marked target drops to 0 Hit Points
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: false
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: true
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 300000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Move Mark
+          _id: NQtVK0T5uwfMPGQL
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      identifier: hunters-mark
+      method: spell
+      prepared: 2
+      sourceItem: feat:favored-enemy
+    _id: g6kyry2aDjpWgdj6
+    type: spell
+    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+    effects:
+      - name: Hunter's Mark
+        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        transfer: false
+        _id: vPkln6UeePHnbLr4
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          combat: null
+          seconds: 3600
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
+          force]] damage to the target whenever they hit it with an attack
+          roll.</p>
+        tint: '#ffffff'
+        statuses:
+          - marked
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv05000.g6kyry2aDjpWgdj6.vPkln6UeePHnbLr4
+    folder: pBaAAtXBCq9FVEnL
+    sort: 1900000
+    ownership:
+      default: 0
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
+        sourceId: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        advancementOrigin: mzu2oIvnAowoczjS.DOENALOWWjAUHzb7
+        advancementRoot: NuNBKjUuSNIRsF9M.R77BAIzMfcPq0urg
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923236651
+      modifiedTime: 1777923236651
+      lastModifiedBy: dnd5ebuilder0000
+    _key: '!actors.items!QuillatheLv05000.g6kyry2aDjpWgdj6'
+  - name: Hunter's Mark
+    system:
+      description:
+        value: "<p>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra [[/damage]] damage to the target whenever you hit it with an attack roll. You also have Advantage on any [[/check ability=wis skill=prc]] or [[/check ability=wis skill=sur]] check you make to find it.</p><p>If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Your Concentration can last longer with a spell slot of level 3–4 (up to 8 hours) or 5+ (up to 24 hours).</p>"
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        license: CC-BY-4.0
+        book: ''
+        revision: 2
+      activation:
+        type: bonus
+        condition: ''
+        value: null
+      duration:
+        value: '1'
+        units: hour
+      target:
+        affects:
+          type: creature
+          count: '1'
+          choice: false
+          special: ''
+        template:
+          units: ft
+          contiguous: false
+          type: ''
+          stationary: false
+      range:
+        value: '90'
+        units: ft
+        special: ''
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      level: 1
+      school: div
+      properties:
+        - vocal
+        - concentration
+      materials:
+        value: ''
+        consumed: false
+        cost: 0
+        supply: 0
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: damage
+          activation:
+            type: ''
+            value: null
+            override: true
+            condition: ''
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: false
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            override: true
+            concentration: false
+          effects: []
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            prompt: true
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+          damage:
+            critical:
+              allow: true
+              bonus: ''
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: 6
+                bonus: ''
+                types:
+                  - force
+                scaling:
+                  mode: ''
+                  number: 1
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 200000
+          name: Bonus Mark Damage
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        vxr2JKuQ3jyMDTwb:
+          type: utility
+          _id: vxr2JKuQ3jyMDTwb
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: false
+            units: self
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 100000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Mark Creature
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        NQtVK0T5uwfMPGQL:
+          type: utility
+          activation:
+            type: bonus
+            value: null
+            override: true
+            condition: when the currently marked target drops to 0 Hit Points
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: false
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: true
+          effects:
+            - _id: vPkln6UeePHnbLr4
+              level: {}
+          range:
+            override: true
+            units: any
+            special: ''
+          target:
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 300000
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+          name: Move Mark
+          _id: NQtVK0T5uwfMPGQL
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      identifier: hunters-mark
+      method: spell
+      prepared: 0
+      sourceItem: feat:favored-enemy
+    type: spell
+    img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+    effects:
+      - name: Hunter's Mark
+        img: icons/skills/targeting/crosshair-scope-sniper-green.webp
+        origin: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        transfer: false
+        _id: vPkln6UeePHnbLr4
+        type: base
+        system: {}
+        changes: []
+        disabled: false
+        duration:
+          startTime: null
+          combat: null
+          seconds: 3600
+          rounds: null
+          turns: null
+          startRound: null
+          startTurn: null
+        description: >-
+          <p>Until the spell ends, the caster deals an extra [[/damage 1d6
+          force]] damage to the target whenever they hit it with an attack
+          roll.</p>
+        tint: '#ffffff'
+        statuses:
+          - marked
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv05000.PuyImwrTF6MASf5z.vPkln6UeePHnbLr4
+      - _id: dnd5espellchange
+        type: enchantment
+        name: Spell Changes
+        img: systems/dnd5e/icons/svg/activity/cast.svg
+        origin: >-
+          Compendium.dnd5e.actors24.Actor.QuillatheLv05000.Item.mzu2oIvnAowoczjS.Activity.18OW4UKZ5cSPPLhC
+        changes:
+          - key: system.method
+            mode: 5
+            value: spell
+          - key: system.activation
+            mode: 5
+            value: '{"type":"bonus","condition":""}'
+        system: {}
+        disabled: false
+        duration:
+          startTime: 0
+          combat: null
+          startRound: 0
+          startTurn: 0
+        description: ''
+        tint: '#ffffff'
+        transfer: true
+        statuses: []
+        sort: 0
+        flags: {}
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv05000.PuyImwrTF6MASf5z.dnd5espellchange
+    folder: pBaAAtXBCq9FVEnL
+    sort: 1900000
+    ownership:
+      default: 0
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
+        cachedFor: .Item.mzu2oIvnAowoczjS.Activity.18OW4UKZ5cSPPLhC
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923236741
+      modifiedTime: 1777923236741
+      lastModifiedBy: dnd5ebuilder0000
+    _id: PuyImwrTF6MASf5z
+    _key: '!actors.items!QuillatheLv05000.PuyImwrTF6MASf5z'
+  - name: Detect Poison and Disease
+    system:
+      description:
+        value: >-
+          <p>For the duration, you sense the location of poisons, poisonous or
+          venomous creatures, and magical contagions within 30 feet of yourself.
+          You sense the kind of poison, creature, or contagion in each
+          case.</p><p>The spell is blocked by 1 foot of stone, dirt, or wood; 1
+          inch of metal; or a thin sheet of lead.</p>
+        chat: ''
+      source:
+        custom: ''
+        rules: '2024'
+        license: CC-BY-4.0
+        book: ''
+        revision: 1
+      activation:
+        type: action
+        condition: ''
+        value: null
+      duration:
+        value: '10'
+        units: minute
+      target:
+        affects:
+          type: self
+          count: ''
+          choice: false
+          special: ''
+        template:
+          units: ft
+          contiguous: false
+          type: radius
+          size: '30'
+          count: ''
+          stationary: false
+      range:
+        value: ''
+        units: self
+        special: ''
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      level: 1
+      school: div
+      properties:
+        - vocal
+        - somatic
+        - material
+        - concentration
+        - ritual
+      materials:
+        value: a yew leaf
+        consumed: false
+        cost: 0
+        supply: 0
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            override: false
+            concentration: false
+          effects:
+            - _id: zSS8rmsXm5JCaM5x
+              level: {}
+          range:
+            override: false
+            units: self
+          target:
+            prompt: false
+            template:
+              contiguous: false
+              units: ft
+              stationary: false
+            affects:
+              choice: false
+            override: false
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          sort: 0
+          name: ''
+          img: ''
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      identifier: detect-poison-and-disease
+      method: spell
+      prepared: 0
+      sourceItem: consumable:spell-scroll
+    type: spell
+    img: icons/skills/toxins/poison-bottle-open-fire-purple.webp
+    effects:
+      - name: Detect Poison and Disease
+        origin: Compendium.dnd5e.spells24.Item.phbsplDetectPois
+        duration:
+          rounds: null
+          startTime: null
+          seconds: 600
+          combat: null
+          turns: null
+          startRound: null
+          startTurn: null
+        disabled: false
+        flags: {}
+        img: icons/skills/toxins/poison-bottle-open-fire-purple.webp
+        _id: zSS8rmsXm5JCaM5x
+        type: base
+        system: {}
+        changes: []
+        description: ''
+        tint: '#ffffff'
+        transfer: false
+        statuses: []
+        sort: 0
+        _stats:
+          compendiumSource: >-
+            Compendium.dnd5e.spells24.Item.phbsplDetectEvil.ActiveEffect.pOgbtXbKVGdbwjjE
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv05000.yaq88tfac9Bfa9lp.zSS8rmsXm5JCaM5x
+      - _id: dnd5espellchange
+        type: enchantment
+        name: Spell Changes
+        img: systems/dnd5e/icons/svg/activity/cast.svg
+        origin: >-
+          Compendium.dnd5e.actors24.Actor.QuillatheLv05000.Item.QBcSv9jLpl0ySf5L.Activity.dnd5escrollspell
+        changes:
+          - key: system.method
+            mode: 5
+            value: spell
+          - key: system.properties
+            mode: 2
+            value: '-vocal'
+          - key: system.properties
+            mode: 2
+            value: '-somatic'
+          - key: system.properties
+            mode: 2
+            value: '-material'
+          - key: activities[attack].attack.bonus
+            mode: 5
+            value: '5'
+          - key: activities[attack].attack.flat
+            mode: 5
+            value: 'true'
+          - key: activities[summon].flat.attack
+            mode: 5
+            value: '5'
+          - key: activities[save].save.dc.calculation
+            mode: 5
+            value: ''
+          - key: activities[save].save.dc.formula
+            mode: 5
+            value: '13'
+          - key: activities[summon].flat.save
+            mode: 5
+            value: '13'
+        system: {}
+        disabled: false
+        duration:
+          startTime: 0
+          combat: null
+          startRound: 0
+          startTurn: 0
+        description: ''
+        tint: '#ffffff'
+        transfer: true
+        statuses: []
+        sort: 0
+        flags: {}
+        _stats:
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '13.351'
+          systemId: dnd5e
+          systemVersion: 5.3.2
+          lastModifiedBy: null
+        _key: >-
+          !actors.items.effects!QuillatheLv05000.yaq88tfac9Bfa9lp.dnd5espellchange
+    folder: pBaAAtXBCq9FVEnL
+    sort: 4000000
+    ownership:
+      default: 0
+    flags:
+      dnd5e:
+        riders:
+          activity: []
+          effect: []
+        cachedFor: .Item.QBcSv9jLpl0ySf5L.Activity.dnd5escrollspell
+    _stats:
+      duplicateSource: null
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.spells24.Item.phbsplDetectPois
+      coreVersion: '13.351'
+      systemId: dnd5e
+      systemVersion: 5.3.2
+      createdTime: 1777923237754
+      modifiedTime: 1777923237754
+      lastModifiedBy: dnd5ebuilder0000
+    _id: yaq88tfac9Bfa9lp
+    _key: '!actors.items!QuillatheLv05000.yaq88tfac9Bfa9lp'
 effects: []
 flags: {}
 _stats:
@@ -8316,9 +8730,9 @@ _stats:
   exportSource: null
   coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 5.3.0
+  systemVersion: 5.3.2
   createdTime: 1771452688268
-  modifiedTime: 1771452688268
+  modifiedTime: 1777923236713
   lastModifiedBy: dnd5ebuilder0000
 ownership:
   default: 0

--- a/packs/_source/actors24/premades/level-5/quillathe.yml
+++ b/packs/_source/actors24/premades/level-5/quillathe.yml
@@ -403,13 +403,7 @@ system:
       value: >-
         <p>Quillathe cleanses monsters from her woods as a hobby, but now a new
         force menaces her land and she must band with adventurers to defeat
-        it.</p><p><em>Token artwork by <a
-        href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener">Forgotten Adventures</a>.</em></p><p><em>Token artwork by
-        <a href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener">Forgotten Adventures</a>.</em></p><p><em>Token artwork by
-        <a href="https://www.forgotten-adventures.net/" target="_blank"
-        rel="noopener">Forgotten Adventures</a>.</em></p>
+        it.</p>
       public: ''
     alignment: Chaotic Neutral
     ideal: ''
@@ -8732,11 +8726,11 @@ _stats:
   systemId: dnd5e
   systemVersion: 5.3.2
   createdTime: 1771452688268
-  modifiedTime: 1777923236713
+  modifiedTime: 1777994507987
   lastModifiedBy: dnd5ebuilder0000
 ownership:
   default: 0
 sort: 200000
-img: ''
+img: null
 folder: JRPsXXWuBa56FSZb
 _key: '!actors!QuillatheLv05000'

--- a/packs/_source/actors24/premades/level-5/quillathe.yml
+++ b/packs/_source/actors24/premades/level-5/quillathe.yml
@@ -7747,11 +7747,7 @@ items:
           and you regain all expended uses of this ability when you finish a
           Long Rest.</p><p>The number of times you can cast the spell without a
           spell slot increases when you reach certain Ranger levels, as shown in
-          the Favored Enemy column of the Ranger Features table.</p><section
-          id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
-          Note</strong></p><p>The spell is granted to you at this level and will
-          increase the number of free uses available automatically as you level
-          up.</p></section>
+          the Favored Enemy column of the Ranger Features table.</p>
         chat: ''
       source:
         custom: ''
@@ -7833,7 +7829,7 @@ items:
             requireIdentification: false
             requireMagic: false
             identifier: ''
-          name: Hunter's Mark (Free)
+          name: ''
       enchant: {}
       identifier: favored-enemy
       advancement:

--- a/packs/_source/classes24/ranger/class-features/favored-enemy.yml
+++ b/packs/_source/classes24/ranger/class-features/favored-enemy.yml
@@ -21,36 +21,114 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     license: CC-BY-4.0
     book: ''
   uses:
-    max: ''
+    max: '@scale.ranger.favored-enemy'
     spent: 0
-    recovery: []
+    recovery:
+      - period: lr
+        type: recoverAll
   type:
     value: class
     subtype: ''
   prerequisites:
     level: 1
-  properties: []
+  properties:
+    - mgc
   requirements: ''
-  activities: {}
+  activities:
+    18OW4UKZ5cSPPLhC:
+      type: cast
+      spell:
+        uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        challenge:
+          override: false
+        properties: []
+        spellbook: true
+        ability: ''
+        level: 1
+      _id: 18OW4UKZ5cSPPLhC
+      img: ''
+      sort: 0
+      activation:
+        type: bonus
+        override: true
+        condition: ''
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: true
+        targets:
+          - type: itemUses
+            value: '1'
+            target: ''
+      description:
+        chatFlavor: ''
+      duration:
+        units: inst
+        concentration: false
+        override: false
+      flags: {}
+      range:
+        units: self
+        override: false
+      target:
+        template:
+          contiguous: false
+          stationary: false
+          units: ft
+        affects:
+          choice: false
+        override: false
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      name: Hunter's Mark (Free)
   enchant: {}
   identifier: favored-enemy
+  advancement:
+    DOENALOWWjAUHzb7:
+      _id: DOENALOWWjAUHzb7
+      type: ItemGrant
+      configuration:
+        items:
+          - optional: false
+            uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
+        optional: false
+        spell:
+          ability: []
+          uses:
+            max: ''
+            per: ''
+            requireSlot: false
+          method: spell
+          prepared: 2
+      value: {}
+      level: 1
+      title: Favored Enemy
+      hint: ''
+      flags: {}
 effects: []
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1735932734523
-  modifiedTime: 1745256764837
+  systemVersion: 5.3.1
+  createdTime: 1724425982601
+  modifiedTime: 1777656565578
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/ranger/class-features/favored-enemy.yml
+++ b/packs/_source/classes24/ranger/class-features/favored-enemy.yml
@@ -12,11 +12,7 @@ system:
       you regain all expended uses of this ability when you finish a Long
       Rest.</p><p>The number of times you can cast the spell without a spell
       slot increases when you reach certain Ranger levels, as shown in the
-      Favored Enemy column of the Ranger Features table.</p><section
-      id="secret-cyuZuzwxsQg01vVN" class="secret"><p><strong>Foundry
-      Note</strong></p><p>The spell is granted to you at this level and will
-      increase the number of free uses available automatically as you level
-      up.</p></section>
+      Favored Enemy column of the Ranger Features table.</p>
     chat: ''
   source:
     custom: ''
@@ -95,7 +91,7 @@ system:
         requireIdentification: false
         requireMagic: false
         identifier: ''
-      name: Hunter's Mark (Free)
+      name: ''
   enchant: {}
   identifier: favored-enemy
   advancement:
@@ -126,9 +122,9 @@ _stats:
   duplicateSource: null
   coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 5.3.1
+  systemVersion: 5.3.2
   createdTime: 1724425982601
-  modifiedTime: 1777656565578
+  modifiedTime: 1778088166342
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0

--- a/packs/_source/classes24/ranger/ranger.yml
+++ b/packs/_source/classes24/ranger/ranger.yml
@@ -49,9 +49,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     license: CC-BY-4.0
     book: ''
+    page: ''
   startingEquipment:
     - type: AND
       requiresProficiency: false
@@ -124,11 +125,15 @@ system:
   identifier: ranger
   levels: 1
   advancement:
-    - _id: tGf0hPcdu2TIQdgN
+    tGf0hPcdu2TIQdgN:
+      _id: tGf0hPcdu2TIQdgN
       type: HitPoints
       configuration: {}
       value: {}
-    - _id: R77BAIzMfcPq0urg
+      flags: {}
+      hint: ''
+    R77BAIzMfcPq0urg:
+      _id: R77BAIzMfcPq0urg
       type: ItemGrant
       configuration:
         items:
@@ -143,7 +148,10 @@ system:
       value: {}
       level: 1
       title: Class Features
-    - _id: 0XJhkNDTm9P3K5n3
+      flags: {}
+      hint: ''
+    0XJhkNDTm9P3K5n3:
+      _id: 0XJhkNDTm9P3K5n3
       type: ItemGrant
       configuration:
         items:
@@ -156,7 +164,10 @@ system:
       value: {}
       level: 2
       title: Class Features
-    - _id: onoWzEIWhrrG4QJt
+      flags: {}
+      hint: ''
+    onoWzEIWhrrG4QJt:
+      _id: onoWzEIWhrrG4QJt
       type: ItemGrant
       configuration:
         items:
@@ -167,7 +178,10 @@ system:
       value: {}
       level: 5
       title: Class Features
-    - _id: fEmkkyi2Z6qGfYOZ
+      flags: {}
+      hint: ''
+    fEmkkyi2Z6qGfYOZ:
+      _id: fEmkkyi2Z6qGfYOZ
       type: ItemGrant
       configuration:
         items:
@@ -178,7 +192,10 @@ system:
       value: {}
       level: 6
       title: Class Features
-    - _id: fy2LFc8UC9PTq4aF
+      flags: {}
+      hint: ''
+    fy2LFc8UC9PTq4aF:
+      _id: fy2LFc8UC9PTq4aF
       type: ItemGrant
       configuration:
         items:
@@ -189,7 +206,10 @@ system:
       value: {}
       level: 9
       title: Class Features
-    - _id: Yscwm2LPBUNjW0pk
+      flags: {}
+      hint: ''
+    Yscwm2LPBUNjW0pk:
+      _id: Yscwm2LPBUNjW0pk
       type: Trait
       configuration:
         mode: expertise
@@ -203,7 +223,10 @@ system:
         chosen: []
       level: 9
       title: Expertise
-    - _id: tfv4CeK2F4fdZMMi
+      flags: {}
+      hint: ''
+    tfv4CeK2F4fdZMMi:
+      _id: tfv4CeK2F4fdZMMi
       type: ItemGrant
       configuration:
         items:
@@ -214,7 +237,10 @@ system:
       value: {}
       level: 10
       title: Class Features
-    - _id: yMKZmo7nE6oSFMD0
+      flags: {}
+      hint: ''
+    yMKZmo7nE6oSFMD0:
+      _id: yMKZmo7nE6oSFMD0
       type: ItemGrant
       configuration:
         items:
@@ -225,7 +251,10 @@ system:
       value: {}
       level: 13
       title: Class Features
-    - _id: zurYQjBBNQW92SAz
+      flags: {}
+      hint: ''
+    zurYQjBBNQW92SAz:
+      _id: zurYQjBBNQW92SAz
       type: ItemGrant
       configuration:
         items:
@@ -236,7 +265,10 @@ system:
       value: {}
       level: 14
       title: Class Features
-    - _id: c3CqyzFeTFA5Yq8u
+      flags: {}
+      hint: ''
+    c3CqyzFeTFA5Yq8u:
+      _id: c3CqyzFeTFA5Yq8u
       type: ItemGrant
       configuration:
         items:
@@ -247,7 +279,10 @@ system:
       value: {}
       level: 17
       title: Class Features
-    - _id: e1EWIvBos04kIm4n
+      flags: {}
+      hint: ''
+    e1EWIvBos04kIm4n:
+      _id: e1EWIvBos04kIm4n
       type: ItemGrant
       configuration:
         items:
@@ -258,7 +293,10 @@ system:
       value: {}
       level: 18
       title: Class Features
-    - _id: M9VOxnHqo0qYtwGb
+      flags: {}
+      hint: ''
+    M9VOxnHqo0qYtwGb:
+      _id: M9VOxnHqo0qYtwGb
       type: ItemGrant
       configuration:
         items:
@@ -269,7 +307,10 @@ system:
       value: {}
       level: 20
       title: Class Features
-    - _id: bwCLOdauuzoHofil
+      flags: {}
+      hint: ''
+    bwCLOdauuzoHofil:
+      _id: bwCLOdauuzoHofil
       type: AbilityScoreImprovement
       configuration:
         points: 2
@@ -286,7 +327,10 @@ system:
       value: {}
       level: 4
       title: ''
-    - _id: mRSh9oUVjLU33e7p
+      flags: {}
+      hint: ''
+    mRSh9oUVjLU33e7p:
+      _id: mRSh9oUVjLU33e7p
       type: AbilityScoreImprovement
       configuration:
         points: 2
@@ -303,7 +347,10 @@ system:
       value: {}
       level: 8
       title: ''
-    - _id: mhZh3LfLMa15tXee
+      flags: {}
+      hint: ''
+    mhZh3LfLMa15tXee:
+      _id: mhZh3LfLMa15tXee
       type: AbilityScoreImprovement
       configuration:
         points: 2
@@ -320,7 +367,10 @@ system:
       value: {}
       level: 12
       title: ''
-    - _id: FOf5CkGnSs0OlppY
+      flags: {}
+      hint: ''
+    FOf5CkGnSs0OlppY:
+      _id: FOf5CkGnSs0OlppY
       type: AbilityScoreImprovement
       configuration:
         points: 2
@@ -337,26 +387,10 @@ system:
       value: {}
       level: 16
       title: ''
-    - _id: DOENALOWWjAUHzb7
-      type: ItemGrant
-      configuration:
-        items:
-          - optional: false
-            uuid: Compendium.dnd5e.spells24.Item.phbsplHuntersMar
-        optional: false
-        spell:
-          ability: []
-          uses:
-            max: '@scale.ranger.favored-enemy'
-            per: lr
-            requireSlot: false
-          method: spell
-          prepared: 2
-      value: {}
-      level: 1
-      title: Favored Enemy
+      flags: {}
       hint: ''
-    - _id: FksFWNV4X4lTFlvO
+    FksFWNV4X4lTFlvO:
+      _id: FksFWNV4X4lTFlvO
       type: ScaleValue
       configuration:
         identifier: ''
@@ -377,7 +411,9 @@ system:
       value: {}
       title: Favored Enemy
       hint: ''
-    - _id: PLqssMc398jEsEW4
+      flags: {}
+    PLqssMc398jEsEW4:
+      _id: PLqssMc398jEsEW4
       type: Trait
       configuration:
         mode: expertise
@@ -392,7 +428,9 @@ system:
       level: 2
       title: Deft Explorer
       hint: ''
-    - _id: wzh6lW4bOlQy4geS
+      flags: {}
+    wzh6lW4bOlQy4geS:
+      _id: wzh6lW4bOlQy4geS
       type: Trait
       configuration:
         mode: default
@@ -408,7 +446,9 @@ system:
       level: 2
       title: Deft Explorer
       hint: ''
-    - _id: 2Wma1d7xii6GUWC9
+      flags: {}
+    2Wma1d7xii6GUWC9:
+      _id: 2Wma1d7xii6GUWC9
       type: ScaleValue
       configuration:
         identifier: mark
@@ -427,7 +467,9 @@ system:
       value: {}
       title: Hunter's Mark Damage
       hint: ''
-    - _id: iYdu1uOqAnHGWIZY
+      flags: {}
+    iYdu1uOqAnHGWIZY:
+      _id: iYdu1uOqAnHGWIZY
       type: ScaleValue
       configuration:
         identifier: max-prepared
@@ -462,7 +504,9 @@ system:
       value: {}
       title: Max Prepared Spells
       hint: ''
-    - _id: eJTiCO9yVqCP1Ptd
+      flags: {}
+    eJTiCO9yVqCP1Ptd:
+      _id: eJTiCO9yVqCP1Ptd
       type: Subclass
       configuration: {}
       value:
@@ -471,7 +515,9 @@ system:
       level: 3
       title: ''
       hint: ''
-    - _id: 3trTn2JpXbZ6X24q
+      flags: {}
+    3trTn2JpXbZ6X24q:
+      _id: 3trTn2JpXbZ6X24q
       type: Trait
       configuration:
         mode: default
@@ -486,7 +532,9 @@ system:
       title: Saving Throw Proficiencies
       hint: ''
       classRestriction: primary
-    - _id: H1iv8RH9TOVH30qO
+      flags: {}
+    H1iv8RH9TOVH30qO:
+      _id: H1iv8RH9TOVH30qO
       type: Trait
       configuration:
         mode: default
@@ -509,7 +557,9 @@ system:
       title: Skill Proficiencies
       hint: ''
       classRestriction: primary
-    - _id: knFte4PvZAtHAcFJ
+      flags: {}
+    knFte4PvZAtHAcFJ:
+      _id: knFte4PvZAtHAcFJ
       type: Trait
       configuration:
         mode: default
@@ -524,7 +574,9 @@ system:
       title: Weapon Proficiencies
       hint: ''
       classRestriction: primary
-    - _id: TehnIJlh1drGLjpj
+      flags: {}
+    TehnIJlh1drGLjpj:
+      _id: TehnIJlh1drGLjpj
       type: Trait
       configuration:
         mode: default
@@ -539,7 +591,9 @@ system:
       level: 1
       title: Armor Training
       hint: ''
-    - _id: 491B9spyMvoNt2ij
+      flags: {}
+    491B9spyMvoNt2ij:
+      _id: 491B9spyMvoNt2ij
       type: Trait
       configuration:
         mode: default
@@ -562,7 +616,9 @@ system:
       title: Skill Proficiencies
       hint: ''
       classRestriction: secondary
-    - _id: AtKKnCoTLBqSxhCh
+      flags: {}
+    AtKKnCoTLBqSxhCh:
+      _id: AtKKnCoTLBqSxhCh
       type: ItemChoice
       configuration:
         choices:
@@ -587,7 +643,9 @@ system:
         replaced: {}
       title: Fighting Style
       hint: ''
-    - _id: cvPNAaphQTdoQqAb
+      flags: {}
+    cvPNAaphQTdoQqAb:
+      _id: cvPNAaphQTdoQqAb
       type: Trait
       configuration:
         mode: mastery
@@ -602,7 +660,9 @@ system:
       level: 1
       title: Weapon Mastery
       hint: ''
-    - _id: wXbfWOQp62GRMMlZ
+      flags: {}
+    wXbfWOQp62GRMMlZ:
+      _id: wXbfWOQp62GRMMlZ
       type: Trait
       configuration:
         mode: default
@@ -616,7 +676,9 @@ system:
       title: Weapon Proficiencies
       hint: ''
       classRestriction: secondary
-    - type: AbilityScoreImprovement
+      flags: {}
+    Fu3uIg8onmQ45JBX:
+      type: AbilityScoreImprovement
       _id: Fu3uIg8onmQ45JBX
       configuration:
         cap: 2
@@ -635,6 +697,7 @@ system:
       level: 19
       title: ''
       hint: ''
+      flags: {}
   spellcasting:
     progression: half
     ability: wis
@@ -654,11 +717,11 @@ effects: []
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.348'
+  coreVersion: '13.351'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 5.3.2
   createdTime: 1735932734523
-  modifiedTime: 1757541658137
+  modifiedTime: 1777921202246
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 sort: 0


### PR DESCRIPTION
Modifies base ranger class and favored enemy to operate similar to channel divinity and wild shape -- e.g. configured with item uses to be consumed by other features.

Moves free castings of Hunter's Mark to a Cast activity on Favored Enemy, consuming item uses.

Updates ranger class/favored enemy on example characters.