### PR TITLE
Use direct assignment of item flags property rather than spread operator

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -858,7 +858,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     if ( this.system.getRollData ) data = this.system.getRollData({ deterministic });
     else data = { ...(this.actor?.getRollData({ deterministic }) ?? {}), item: { ...this.system } };
     if ( data?.item ) {
-      data.item.flags = { ...this.flags };
+      data.item.flags = this.flags;
       data.item.name = this.name;
     }
     data.labels = this.labels;


### PR DESCRIPTION
If an item is enchanted with an effect such as

```
flags.world.foo | Override | 3
system.price.value | Multiply | @item.flags.world.foo
```
This never takes effect because `flags.world` did not exist on the item beforehand. Due to the spread operator when assigning `flags` to the rolldata in the item document class, new properties added this way are entirely ignored.

This change just performs a direct assignment instead, meaning the an enchantment like the above modifies the item's direct `flags` property which is also in the rolldata, and thus it should work as hoped.

Alternatively, one could call `this.getRollData()` for every applied change in `Item5e#applyActiveEffects` but this seems excessive.