### PR TITLE
[#1581] fix: Barbarian Rages scale value increases to 6 at level 17, not 16

### DIFF
--- a/packs/_source/classes24/barbarian/barbarian.yml
+++ b/packs/_source/classes24/barbarian/barbarian.yml
@@ -513,7 +513,7 @@ system:
             value: 4
           '12':
             value: 5
-          '16':
+          '17':
             value: 6
       value: {}
       title: Rages


### PR DESCRIPTION
Description: Corrects the 2024 Barbarian class advancement table where the Rages ScaleValue incorrectly granted 6 uses at level 16. Per the 2024 PHB, this upgrade should occur at level 17.

D&D Beyond reference: https://www.dndbeyond.com/classes/2190875-barbarian