### PR TITLE
Guard `Activity.rollDamage` against empty `rollConfig.rolls` in module-driven calls

### DIFF
--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -868,6 +868,8 @@ export default function ActivityMixin(Base) {
      */
     async rollDamage(config={}, dialog={}, message={}) {
       const rollConfig = this.getDamageConfig(config);
+      if (!rollConfig?.rolls?.length) return;
+      
       rollConfig.hookNames = [...(config.hookNames ?? []), "damage"];
       rollConfig.subject = this;
 


### PR DESCRIPTION
Add early return if no rolls are configured for damage.
