### PR TITLE
[#7011] Use the encounter actor folder when importing member actors from a compendium

### DIFF
--- a/module/data/actor/encounter.mjs
+++ b/module/data/actor/encounter.mjs
@@ -149,7 +149,8 @@ export default class EncounterData extends GroupTemplate {
   /** @override */
   async getPlaceableMembers() {
     return (await Promise.all((await this.getMembers()).map(async member => {
-      member.actor = await dnd5e.documents.Actor5e.fetchExisting(member.actor.uuid);
+      const fetchOptions = { folderId: this.parent.folder?.id ?? null };
+      member.actor = await dnd5e.documents.Actor5e.fetchExisting(member.actor.uuid, fetchOptions);
       if ( (member.quantity.value === null) && member.quantity.formula ) {
         const roll = new Roll(member.quantity.formula);
         await roll.evaluate();

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -149,9 +149,11 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
     // Fetch the actor that will be summoned
     const summonUuid = this.summon.mode === "cr" ? await this.queryActor(profile) : profile.uuid;
     if ( !summonUuid ) return;
-    const actor = await dnd5e.documents.Actor5e.fetchExisting(summonUuid, {
+    const fetchOptions = {
+      folderId: this.actor?.folder?.id ?? null,
       origin: { key: "flags.dnd5e.summon.origin", value: this.item?.uuid }
-    });
+    };
+    const actor = await dnd5e.documents.Actor5e.fetchExisting(summonUuid, fetchOptions);
 
     // Verify ownership of actor
     if ( !actor.isOwner ) {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -419,6 +419,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       // A linked world actor was found. Create a copy to avoid affecting the original.
       return actor.clone({
         "flags.dnd5e.isAutoImported": true,
+        folder: game.folders.get(folderId) ?? null,
         "_stats.compendiumSource": actor._stats.compendiumSource,
         "_stats.duplicateSource": actor.uuid
       }, { save: true });

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -373,6 +373,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * version has already been imported before importing it again.
    * @param {string} uuid                  The Actor's UUID.
    * @param {object} [options]
+   * @param {object} [options.folderId]    Folder ID for importing the Actor from a compendium.
    * @param {object} [options.origin]      Optionally check if the Actor has a specific origin. If not supplied, any
    *                                       Actor that matches the criteria will be returned.
    * @param {string} [options.origin.key]  The origin property.
@@ -381,7 +382,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @throws {Error}                       If the Actor cannot be found, or cannot be imported.
    */
   static async fetchExisting(uuid, options={}) {
-    const { origin } = options;
+    const { origin, folderId } = options;
     const actor = await fromUuid(uuid);
     if ( !actor ) throw new Error(game.i18n.format("DND5E.ACTOR.Warning.NoActor", { uuid }));
 
@@ -411,7 +412,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( actor.pack ) {
       // Template actor resides only in a compendium, import the actor into the world.
       return game.actors.importFromCompendium(game.packs.get(actor.pack), actor.id, {
-        "flags.dnd5e.isAutoImported": true
+        "flags.dnd5e.isAutoImported": true,
+        folder: game.folders.get(folderId) ?? null
       });
     } else {
       // A linked world actor was found. Create a copy to avoid affecting the original.

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -373,7 +373,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * version has already been imported before importing it again.
    * @param {string} uuid                  The Actor's UUID.
    * @param {object} [options]
-   * @param {object} [options.folderId]    Folder ID for importing the Actor from a compendium.
+   * @param {string} [options.folderId]    Folder ID for importing the Actor from a compendium.
    * @param {object} [options.origin]      Optionally check if the Actor has a specific origin. If not supplied, any
    *                                       Actor that matches the criteria will be returned.
    * @param {string} [options.origin.key]  The origin property.


### PR DESCRIPTION
A small solution using `Actor5e.fetchExisting`'s existing `options` object.

Closes #7011 