### PR TITLE
[#6344] Add field to make actor sizes support AE changes better

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1201,6 +1201,7 @@ DND5E.actorSizes = {
   sm: {
     label: "DND5E.SizeSmall",
     abbreviation: "DND5E.SizeSmallAbbr",
+    fullKey: "small",
     hitDie: 6,
     dynamicTokenScale: 0.8,
     numerical: 1
@@ -1208,12 +1209,14 @@ DND5E.actorSizes = {
   med: {
     label: "DND5E.SizeMedium",
     abbreviation: "DND5E.SizeMediumAbbr",
+    fullKey: "medium",
     hitDie: 8,
     numerical: 2
   },
   lg: {
     label: "DND5E.SizeLarge",
     abbreviation: "DND5E.SizeLargeAbbr",
+    fullKey: "large",
     hitDie: 10,
     token: 2,
     capacityMultiplier: 2,
@@ -1222,6 +1225,7 @@ DND5E.actorSizes = {
   huge: {
     label: "DND5E.SizeHuge",
     abbreviation: "DND5E.SizeHugeAbbr",
+    fullKey: "huge",
     hitDie: 12,
     token: 3,
     capacityMultiplier: 4,
@@ -1230,6 +1234,7 @@ DND5E.actorSizes = {
   grg: {
     label: "DND5E.SizeGargantuan",
     abbreviation: "DND5E.SizeGargantuanAbbr",
+    fullKey: "gargantuan",
     hitDie: 20,
     token: 4,
     capacityMultiplier: 8,
@@ -1237,6 +1242,29 @@ DND5E.actorSizes = {
   }
 };
 preLocalize("actorSizes", { keys: ["label", "abbreviation"] });
+
+Object.defineProperty(DND5E.actorSizes, "fullKeys", {
+  get() {
+    const value = Object.entries(this).reduce((obj, [key, config]) => {
+      obj[config.fullKey ?? key] = key;
+      return obj;
+    }, {});
+    Object.defineProperty(DND5E.actorSizes, "fullKeys", { value });
+    return value;
+  },
+  configurable: true
+});
+
+Object.defineProperty(DND5E.actorSizes, "orderedKeys", {
+  get() {
+    const value = Object.entries(this)
+      .sort((lhs, rhs) => (lhs[1].numerical ?? Infinity) - (rhs[1].numerical ?? Infinity))
+      .map(([key]) => key);
+    Object.defineProperty(DND5E.actorSizes, "orderedKeys", { value });
+    return value;
+  },
+  configurable: true
+});
 
 /* -------------------------------------------- */
 /*  Canvas                                      */

--- a/module/data/actor/_module.mjs
+++ b/module/data/actor/_module.mjs
@@ -13,6 +13,7 @@ export {
 };
 export {default as GroupSystemFlags} from "./group-system-flags.mjs";
 export {default as ACFormulasField} from "./fields/ac-formulas-field.mjs";
+export {default as ActorSizeField} from "./fields/actor-size-field.mjs";
 export {default as DamageTraitField} from "./fields/damage-trait-field.mjs";
 export {default as SimpleTraitField} from "./fields/simple-trait-field.mjs";
 export {default as TravelField} from "./fields/travel-field.mjs";

--- a/module/data/actor/fields/actor-size-field.mjs
+++ b/module/data/actor/fields/actor-size-field.mjs
@@ -1,0 +1,61 @@
+/**
+ * Custom string field with some special handling for increasing and decreasing sizes.
+ */
+export default class ActorSizeField extends foundry.data.fields.StringField {
+  /* -------------------------------------------- */
+  /*  Field Cleaning                              */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _cast(value) {
+    value = super._cast(value);
+    return CONFIG.DND5E.actorSizes.fullKeys[value] ?? value;
+  }
+
+  /* -------------------------------------------- */
+  /*  Active Effect Integration                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _castChangeDelta(delta, replacementData={}) {
+    if ( Number.isNumeric(delta) ) return parseInt(delta);
+    return super._castChangeDelta(delta, replacementData);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _applyChangeAdd(value, delta, model, change) {
+    if ( !Number.isNumeric(delta) ) return value;
+    const idx = CONFIG.DND5E.actorSizes.orderedKeys.findIndex(k => k === value);
+    return CONFIG.DND5E.actorSizes.orderedKeys[
+      Math.clamp(idx + delta, 0, CONFIG.DND5E.actorSizes.orderedKeys.length - 1)
+    ];
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _applyChangeSubtract(value, delta, model, change) {
+    if ( !Number.isNumeric(delta) ) return value;
+    return this._applyChangeAdd(value, delta * -1, model, change);;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _applyChangeUpgrade(value, delta, model, change) {
+    const valueN = CONFIG.DND5E.actorSizes[value]?.numerical ?? -Infinity;
+    const deltaN = CONFIG.DND5E.actorSizes[delta]?.numerical ?? -Infinity;
+    return deltaN > valueN ? delta : value;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _applyChangeDowngrade(value, delta, model, change) {
+    const valueN = CONFIG.DND5E.actorSizes[value]?.numerical ?? -Infinity;
+    const deltaN = CONFIG.DND5E.actorSizes[delta]?.numerical ?? -Infinity;
+    return deltaN < valueN ? delta : value;
+  }
+}

--- a/module/data/actor/fields/actor-size-field.mjs
+++ b/module/data/actor/fields/actor-size-field.mjs
@@ -38,7 +38,7 @@ export default class ActorSizeField extends foundry.data.fields.StringField {
   /** @override */
   _applyChangeSubtract(value, delta, model, change) {
     if ( !Number.isNumeric(delta) ) return value;
-    return this._applyChangeAdd(value, delta * -1, model, change);;
+    return this._applyChangeAdd(value, delta * -1, model, change);
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -398,7 +398,7 @@ export default class AttributesFields {
     }
 
     // Determine the Encumbrance size class
-    const keys = Object.keys(CONFIG.DND5E.actorSizes);
+    const keys = CONFIG.DND5E.actorSizes.orderedKeys;
     const index = keys.findIndex(k => k === this.traits.size);
     const sizeConfig = CONFIG.DND5E.actorSizes[
       keys[this.parent.flags.dnd5e?.powerfulBuild ? Math.min(index + 1, keys.length - 1) : index]

--- a/module/data/actor/templates/traits.mjs
+++ b/module/data/actor/templates/traits.mjs
@@ -1,6 +1,7 @@
 import { defaultUnits, formatLength, splitSemicolons } from "../../../utils.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 import MappingField from "../../fields/mapping-field.mjs";
+import ActorSizeField from "../fields/actor-size-field.mjs";
 import DamageTraitField from "../fields/damage-trait-field.mjs";
 import SimpleTraitField from "../fields/simple-trait-field.mjs";
 
@@ -20,7 +21,7 @@ export default class TraitsField {
    */
   static get common() {
     return {
-      size: new StringField({ required: true, initial: "med", label: "DND5E.Size" }),
+      size: new ActorSizeField({ required: true, initial: "med", label: "DND5E.Size" }),
       di: new DamageTraitField({}, { label: "DND5E.DamImm" }),
       dr: new DamageTraitField({}, { label: "DND5E.DamRes" }),
       dv: new DamageTraitField({}, { label: "DND5E.DamVuln" }),


### PR DESCRIPTION
Adds a custom field to handle modifying actor sizes using active effects. This adds support for `add`, `subtract`, `upgrade`, and `downgrade` active effect modes.

This also adds support for using full size names in active effects rather than the short versions (e.g. `large` instead of `lg`).

Closes #6344