### PR TITLE
[#4934] Use roller's spellcasting ability from check activity

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -5037,6 +5037,8 @@ Object.defineProperty(DND5E, "enrichmentLookup", {
       addFullKeys("spellSchools");
       addFullKeys("tools");
       Object.entries(DND5E.vehicleTypes).forEach(([k, label]) => _enrichmentLookup.tools[k] = { label, key: k });
+
+      _enrichmentLookup.abilities.spellcasting = { label: _loc("DND5E.Spellcasting") };
     }
     return _enrichmentLookup;
   },

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -5038,7 +5038,11 @@ Object.defineProperty(DND5E, "enrichmentLookup", {
       addFullKeys("tools");
       Object.entries(DND5E.vehicleTypes).forEach(([k, label]) => _enrichmentLookup.tools[k] = { label, key: k });
 
-      _enrichmentLookup.abilities.spellcasting = { label: _loc("DND5E.Spellcasting") };
+      _enrichmentLookup.abilities.spellcasting = {
+        abbreviation: _loc("DND5E.Spellcasting"),
+        key: "spellcasting",
+        label: _loc("DND5E.Spellcasting")
+      };
     }
     return _enrichmentLookup;
   },

--- a/module/data/activity/check-data.mjs
+++ b/module/data/activity/check-data.mjs
@@ -64,8 +64,6 @@ export default class BaseCheckActivityData extends BaseActivityData {
     rollData ??= this.getRollData({ deterministic: true });
     super.prepareFinalData(rollData);
 
-    if ( this.check.ability === "spellcasting" ) this.check.ability = this.spellcastingAbility;
-
     let ability;
     if ( this.check.dc.calculation ) ability = this.ability;
     else this.check.dc.value = simplifyBonus(this.check.dc.formula, rollData);

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -281,7 +281,7 @@ export default class GroupData extends GroupTemplate {
    */
   async rollSavingThrow(config) {
     if ( !config.ability ) return;
-    const abilityLabel = CONFIG.DND5E.abilities[config.ability]?.label ?? "";
+    const abilityLabel = CONFIG.DND5E.enrichmentLookup.abilities[config.ability]?.label ?? "";
     await foundry.documents.ChatMessage.implementation.create({
       flavor: _loc("DND5E.SavePromptTitle", { ability: abilityLabel }),
       speaker: ChatMessage.getSpeaker({ actor: this.parent, alias: this.parent.name }),
@@ -311,7 +311,7 @@ export default class GroupData extends GroupTemplate {
     const skillConfig = CONFIG.DND5E.skills[config.skill];
     const ability = config.ability ?? skillConfig?.ability ?? "";
     const skillLabel = skillConfig?.label ?? "";
-    const abilityLabel = CONFIG.DND5E.abilities[ability]?.label ?? "";
+    const abilityLabel = CONFIG.DND5E.enrichmentLookup.abilities[ability]?.label ?? "";
     await foundry.documents.ChatMessage.implementation.create({
       flavor: _loc("DND5E.SkillPromptTitle", { skill: skillLabel, ability: abilityLabel }),
       speaker: ChatMessage.getSpeaker({ actor: this.parent, alias: this.parent.name }),

--- a/module/documents/activity/check.mjs
+++ b/module/documents/activity/check.mjs
@@ -53,7 +53,8 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
     const dc = this.check.dc.value;
 
     const createButton = (abilityKey, associated) => {
-      const ability = CONFIG.DND5E.abilities[abilityKey]?.label;
+      const ability = abilityKey === "spellcasting"
+        ? _loc("DND5E.Spellcasting") : CONFIG.DND5E.abilities[abilityKey]?.label;
       const checkType = (associated in CONFIG.DND5E.skills) ? "skill"
         : (associated in CONFIG.DND5E.tools) ? "tool": "ability";
       const dataset = { ability: abilityKey };
@@ -107,7 +108,7 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
     const { ability, dc, skill, tool } = message.system.getButton(target)?.dataset ?? {};
     const rollData = { event, target: Number.isFinite(dc) ? dc : this.check.dc.value };
     const bonusData = CONFIG.Dice.BasicRoll.constructParts({ activityBonus: this.check.bonus }, this.getRollData());
-    if ( ability in CONFIG.DND5E.abilities ) rollData.ability = ability;
+    if ( (ability in CONFIG.DND5E.abilities) || (ability === "spellcasting") ) rollData.ability = ability;
 
     for ( const token of targets ) {
       const actor = token instanceof Actor ? token : token.actor;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1287,7 +1287,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       && (await this.system.rollSkill(config, dialog, message) === false) ) return null;
     if ( !this.system.skills ) return null;
     const skillLabel = CONFIG.DND5E.skills[config.skill]?.label ?? "";
-    if ( config.ability === "spellcasting" ) config.ability = this.spellcastingAbility;
+    if ( config.ability === "spellcasting" ) config = { ...config, ability: this.spellcastingAbility };
     const ability = config.ability ?? this.system.skills[config.skill]?.ability
       ?? CONFIG.DND5E.skills[config.skill]?.ability ?? "";
     const abilityLabel = CONFIG.DND5E.abilities[ability]?.label ?? "";
@@ -1312,7 +1312,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<D20Roll[]|null>}                          A Promise which resolves to the created Roll instance.
    */
   async rollToolCheck(config={}, dialog={}, message={}) {
-    if ( config.ability === "spellcasting" ) config.ability = this.spellcastingAbility;
+    if ( config.ability === "spellcasting" ) config = { ...config, ability: this.spellcastingAbility };
     const toolLabel = Trait.keyLabel(config.tool, { trait: "tool" }) ?? "";
     const dialogConfig = foundry.utils.mergeObject({
       options: {
@@ -1444,7 +1444,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @param {number} index                                 Index of the roll within all rolls being prepared.
    */
   _buildSkillToolConfig(type, hostActor, process, config, formData, index) {
-    const relevant = type === "skill" ? this.system.skills?.[process.skill] : this.system.tools?.[process.tool];
     const abilityId = formData?.get("ability") ?? process.ability;
     const ability = this.system.abilities?.[abilityId];
     const { calculateSkillToolProficiency } = dnd5e.dataModels.actor.CommonTemplate;
@@ -1523,7 +1522,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<D20Roll[]|null>}                        A Promise which resolves to the created Roll instance.
    */
   async rollAbilityCheck(config={}, dialog={}, message={}) {
-    if ( config.ability === "spellcasting" ) config.ability = this.spellcastingAbility;
+    if ( config.ability === "spellcasting" ) config = { ...config, ability: this.spellcastingAbility };
     const abilityLabel = CONFIG.DND5E.abilities[config.ability]?.label ?? "";
     const dialogConfig = foundry.utils.mergeObject({
       options: {
@@ -1549,7 +1548,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( (typeof this.system.rollSavingThrow === "function")
       && (await this.system.rollSavingThrow(config, dialog, message) === false) ) return null;
     if ( !this.system.abilities ) return null;
-    if ( config.ability === "spellcasting" ) config.ability = this.spellcastingAbility;
+    if ( config.ability === "spellcasting" ) config = { ...config, ability: this.spellcastingAbility };
     const abilityLabel = CONFIG.DND5E.abilities[config.ability]?.label ?? "";
     const dialogConfig = foundry.utils.mergeObject({
       options: {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1287,7 +1287,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       && (await this.system.rollSkill(config, dialog, message) === false) ) return null;
     if ( !this.system.skills ) return null;
     const skillLabel = CONFIG.DND5E.skills[config.skill]?.label ?? "";
-    const ability = config.ability ?? this.system.skills[config.skill]?.ability ?? CONFIG.DND5E.skills[config.skill]?.ability ?? "";
+    if ( config.ability === "spellcasting" ) config.ability = this.spellcastingAbility;
+    const ability = config.ability ?? this.system.skills[config.skill]?.ability
+      ?? CONFIG.DND5E.skills[config.skill]?.ability ?? "";
     const abilityLabel = CONFIG.DND5E.abilities[ability]?.label ?? "";
     const dialogConfig = foundry.utils.mergeObject({
       options: {
@@ -1310,6 +1312,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<D20Roll[]|null>}                          A Promise which resolves to the created Roll instance.
    */
   async rollToolCheck(config={}, dialog={}, message={}) {
+    if ( config.ability === "spellcasting" ) config.ability = this.spellcastingAbility;
     const toolLabel = Trait.keyLabel(config.tool, { trait: "tool" }) ?? "";
     const dialogConfig = foundry.utils.mergeObject({
       options: {
@@ -1520,6 +1523,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @returns {Promise<D20Roll[]|null>}                        A Promise which resolves to the created Roll instance.
    */
   async rollAbilityCheck(config={}, dialog={}, message={}) {
+    if ( config.ability === "spellcasting" ) config.ability = this.spellcastingAbility;
     const abilityLabel = CONFIG.DND5E.abilities[config.ability]?.label ?? "";
     const dialogConfig = foundry.utils.mergeObject({
       options: {
@@ -1545,6 +1549,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( (typeof this.system.rollSavingThrow === "function")
       && (await this.system.rollSavingThrow(config, dialog, message) === false) ) return null;
     if ( !this.system.abilities ) return null;
+    if ( config.ability === "spellcasting" ) config.ability = this.spellcastingAbility;
     const abilityLabel = CONFIG.DND5E.abilities[config.ability]?.label ?? "";
     const dialogConfig = foundry.utils.mergeObject({
       options: {

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -878,7 +878,7 @@ export function parseSaveConfig(config, options={}) {
 async function rollCheckSave(config, event) {
   const { type, ability, skill, tool, dc } = config;
   const options = { event };
-  if ( ability in CONFIG.DND5E.abilities ) options.ability = ability;
+  if ( (ability in CONFIG.DND5E.abilities) || (ability === "spellcasting") ) options.ability = ability;
   if ( dc ) options.target = Number(dc);
 
   const actors = config.actor ? [config.actor] : getSceneTargets().map(t => t.actor);
@@ -1587,8 +1587,8 @@ function createPassiveTag(label, dataset) {
  * @returns {string}
  */
 export function createRollLabel(config) {
-  const { label: ability, abbreviation } = CONFIG.DND5E.abilities[config.ability] ?? {};
-  const skill = CONFIG.DND5E.skills[config.skill]?.label;
+  const { label: ability, abbreviation } = CONFIG.DND5E.enrichmentLookup.abilities[config.ability] ?? {};
+  const skill = CONFIG.DND5E.enrichmentLookup.skills[config.skill]?.label;
   const toolUUID = CONFIG.DND5E.enrichmentLookup.tools[config.tool];
   const tool = toolUUID?.id ? Trait.getBaseItem(toolUUID.id, { indexOnly: true })?.name : toolUUID?.label ?? null;
   const longSuffix = config.format === "long" ? "Long" : "Short";

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -519,8 +519,7 @@ export async function enrichCheck(config, label, options) {
     delete config.activity;
   }
 
-  // TODO: Support "spellcasting" ability
-  let abilityConfig = CONFIG.DND5E.abilities[config.ability];
+  let abilityConfig = CONFIG.DND5E.enrichmentLookup.abilities[config.ability];
   if ( config.ability && !abilityConfig ) {
     logWarning(`Ability "${config.ability}" not found while enriching ${config._input}.`, options);
     invalid = true;
@@ -591,7 +590,7 @@ export async function enrichCheck(config, label, options) {
       // Multiple associated proficiencies, link each individually
       if ( associated.length > 1 ) parts.push(
         _loc("EDITOR.DND5E.Inline.SpecificCheck", {
-          ability: CONFIG.DND5E.abilities[ability].label,
+          ability: CONFIG.DND5E.enrichmentLookup.abilities[ability].label,
           type: formatter.format(associated.map(a => createRollLink(a.label, makeConfig(a)).outerHTML ))
         })
       );

--- a/module/tooltips.mjs
+++ b/module/tooltips.mjs
@@ -166,16 +166,19 @@ export default class Tooltips5e {
     const abilityConfig = CONFIG.DND5E.abilities[ability ?? skillConfig.ability];
 
     let label;
+    const isSpellcasting = ability === "spellcasting";
+    const abilityLabel = isSpellcasting ? _loc("DND5E.Spellcasting") : abilityConfig.label;
     if ( skillConfig ) {
-      label = _loc("DND5E.SkillPassiveSpecificHint", { skill: skillConfig.label, ability: abilityConfig.label });
+      label = _loc("DND5E.SkillPassiveSpecificHint", { skill: skillConfig.label, ability: abilityLabel });
     } else {
       // If no skill was provided, we're doing a passive ability check.
       // This isn't technically a thing in the rules, but we can support it anyway if people want to use it.
-      label = _loc("DND5E.SkillPassiveHint", { skill: abilityConfig.label });
+      label = _loc("DND5E.SkillPassiveHint", { skill: abilityLabel });
     }
 
     this._onHoverPassive({ label }, actor => {
       const systemData = actor.system;
+      if ( isSpellcasting ) ability = actor.spellcastingAbility;
       let passive;
       if ( skill && (!ability || (ability === skillConfig.ability)) ) {
         // Default passive skill check


### PR DESCRIPTION
When the check ability for a Check activity is set to "Spellcasting Ability" this will now use the roller's spellcasting ability rather than that of the actor who used the activity.

Adds support for `spellcasting` as an ability in all of the rolling methods on actor.

Also allows using `spellcasting` as an ability option in check and save enrichers, adapting the work from @krbz999's PR here: https://github.com/foundryvtt/dnd5e/pull/4883

Closes #4934