### PR TITLE
[#7019] Fix broken and overriding localization keys

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1007,6 +1007,7 @@
 "DND5E.Background": "Background",
 "DND5E.BackgroundAdd": "Add Background",
 "DND5E.BackgroundName": "Background Name",
+"DND5E.BaseItem": "Base Item",
 
 "DND5E.Bastion": {
   "Action": {
@@ -1065,7 +1066,7 @@
 
 "DND5E.Biography": "Biography",
 "DND5E.BiographyPublic": "Public Biography",
-"DND5E.BiopgrahyPublicEdit": "Edit Public Biography",
+"DND5E.BiographyPublicEdit": "Edit Public Biography",
 "DND5E.Bonds": "Bonds",
 "DND5E.Bonus": "Bonus",
 "DND5E.BonusAction": "Bonus Action",

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -961,7 +961,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
       const result = await foundry.applications.api.DialogV2.confirm({
         content: `
           <p>
-            <strong>${_loc("AreYouSure")}</strong> ${_loc("DND5E.Bastion.Trade.Invalid")}
+            <strong>${_loc("COMMON.AreYouSure")}</strong> ${_loc("DND5E.Bastion.Trade.Invalid")}
           </p>
         `,
         window: {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2634,14 +2634,14 @@ preLocalize("distanceUnits");
 DND5E.volumeUnits = {
   cubicFoot: {
     label: "DND5E.UNITS.VOLUME.CubicFoot.Label",
-    abbreviation: "DND5E.UNITS.Volume.CubicFoot.Abbreviation",
-    counted: "DND5E.UNITS.Volume.CubicFoot.Counted",
+    abbreviation: "DND5E.UNITS.VOLUME.CubicFoot.Abbreviation",
+    counted: "DND5E.UNITS.VOLUME.CubicFoot.Counted",
     conversion: 1,
     type: "imperial"
   },
   liter: {
     label: "DND5E.UNITS.VOLUME.Liter.Label",
-    abbreviation: "DND5E.UNITS.Volume.Liter.Abbreviation",
+    abbreviation: "DND5E.UNITS.VOLUME.Liter.Abbreviation",
     conversion: 1 / 28.317,
     type: "metric"
   }

--- a/module/data/actor/encounter.mjs
+++ b/module/data/actor/encounter.mjs
@@ -22,7 +22,7 @@ export default class EncounterData extends GroupTemplate {
           value: new NumberField({ initial: 1, integer: true, min: 0, label: "DND5E.Quantity" }),
           formula: new FormulaField({ label: "DND5E.QuantityFormula" })
         })
-      }), { label: "DND5E.GroupMembers" })
+      }), { label: "DND5E.Group.Member.other" })
     });
   }
 

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -32,7 +32,7 @@ export default class GroupData extends GroupTemplate {
       }, { label: "DND5E.Details" }),
       members: new ArrayField(new SchemaField({
         actor: new ForeignDocumentField(foundry.documents.BaseActor)
-      }), { label: "DND5E.GroupMembers" }),
+      }), { label: "DND5E.Group.Member.other" }),
       primaryVehicle: new ForeignDocumentField(foundry.documents.BaseActor)
     });
   }

--- a/module/data/item/templates/starting-equipment.mjs
+++ b/module/data/item/templates/starting-equipment.mjs
@@ -170,7 +170,7 @@ export class EquipmentEntryData extends foundry.abstract.DataModel {
       type: new StringField({ required: true, initial: "OR", choices: this.TYPES }),
       count: new NumberField({ initial: undefined }),
       key: new StringField({ initial: undefined }),
-      requiresProficiency: new BooleanField({ label: "DND5E.StartingEquipment.Proficient.Label" })
+      requiresProficiency: new BooleanField()
     };
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -970,7 +970,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       position: { width: 400 },
       content: `
         <p>
-            <strong>${_loc("AreYouSure")}</strong> ${_loc("SIDEBAR.DeleteWarning", { type })}
+            <strong>${_loc("COMMON.AreYouSure")}</strong> ${_loc("SIDEBAR.DeleteWarning", { type })}
         </p>
       `,
       yes: { callback: () => this.delete(operation) }

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -264,7 +264,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
 
     if ( this.restrictions.properties.size
       && !this.restrictions.properties.intersection(item.system.properties ?? new Set()).size ) {
-      errors.push(new EnchantmentError(_loc("DND5E.Enchantment.Warning.MissingProperty", {
+      errors.push(new EnchantmentError(_loc("DND5E.ENCHANT.Warning.MissingProperty", {
         validProperties: game.i18n.getListFormatter({ type: "disjunction" }).format(
           Array.from(this.restrictions.properties).map(p => CONFIG.DND5E.itemProperties[p]?.label ?? p)
         )

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1183,7 +1183,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
         position: { width: 400 },
         content: `
           <p>
-            <strong>${_loc("AreYouSure")}</strong>
+            <strong>${_loc("COMMON.AreYouSure")}</strong>
             ${_loc("DND5E.ContainerDeleteMessage", { count })}
           </p>
           <label class="checkbox">
@@ -1207,7 +1207,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
         position: { width: 400 },
         content: `
           <p>
-            <strong>${_loc("AreYouSure")}</strong> ${_loc("SIDEBAR.DeleteWarning", { type })}
+            <strong>${_loc("COMMON.AreYouSure")}</strong> ${_loc("SIDEBAR.DeleteWarning", { type })}
           </p>
         `,
         yes: { callback: () => this.delete(operation) }


### PR DESCRIPTION
- Changed bare `"AreYouSure"` to `"COMMON.AreYouSure"` in the item, active effect, and character sheet confirm dialogs
- Changed `DND5E.UNITS.Volume` to `DND5E.UNITS.VOLUME` for the volume abbreviation and counted keys
- Changed `DND5E.Enchantment.Warning.MissingProperty` to `DND5E.ENCHANT.Warning.MissingProperty`
- Changed `DND5E.GroupMembers` to `DND5E.Group.Member.other` on the group and encounter member fields
- Renamed misspelled key `DND5E.BiopgrahyPublicEdit` to `DND5E.BiographyPublicEdit`
- Added missing `DND5E.BaseItem` key
- Removed the unused, broken `DND5E.StartingEquipment.Proficient.Label` field label

Closes #7019