### PR TITLE
[#6881] Reverse the damage bonus enchantment shim

### DIFF
--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -40,8 +40,8 @@ export default class EnchantmentData extends (ActiveEffectTypeDataModel ?? TypeD
           );
         }
         return false;
-      case "system.damage.bonus":
-        change.key = "system.damageBonus";
+      case "system.damageBonus":
+        change.key = "system.damage.bonus";
         break;
       case "system.damage.parts":
         try {

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -763,7 +763,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       const actionType = this.getActionType(rollConfig.attackMode);
       const bonus = foundry.utils.getProperty(this.actor ?? {}, `system.bonuses.${actionType}.damage`);
       if ( bonus && !/^0+$/.test(bonus) ) parts.push(bonus);
-      if ( this.item.system.damageBonus ) parts.push(String(this.item.system.damageBonus));
+      if ( this.item.system.damage?.bonus ) parts.push(String(this.item.system.damage.bonus));
     }
 
     const lastType = this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`);

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -52,7 +52,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     "system.attributes.encumbrance.multipliers.heavilyEncumbered",
     "system.attributes.encumbrance.multipliers.maximum",
     "system.attributes.encumbrance.multipliers.overall",
-    "system.damageBonus",
+    "system.damage.bonus",
     "save.dc.bonus"
   ]);
 
@@ -198,7 +198,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     change = change.effect._applyChangeShim(change);
     if ( change.key.startsWith("flags.dnd5e.") ) change = change.effect._prepareFlagChange(model, change);
     if ( ActiveEffect5e.FORMULA_FIELDS.has(change.key) ) {
-      const field = new FormulaField({ deterministic: change.key !== "system.damageBonus" });
+      const field = new FormulaField({ deterministic: change.key !== "system.damage.bonus" });
       return { [change.key]: this.applyChangeField(model, change, { field }) };
     }
     if ( (change.key.startsWith("activities[") || change.key.startsWith("system.activities."))
@@ -324,7 +324,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
     // Double-check whether the target should be treated as a formula if the key has been modified
     if ( ActiveEffect5e.FORMULA_FIELDS.has(change.key) ) {
-      const field = new FormulaField({ deterministic: change.key !== "system.damageBonus" });
+      const field = new FormulaField({ deterministic: change.key !== "system.damage.bonus" });
       return { [change.key]: this.applyChangeField(actor, change, { field }) };
     }
 


### PR DESCRIPTION
- Redirect `system.damageBonus` to `system.damage.bonus` in the enchantment shim
- Move the active effect key back to `system.damage.bonus` (`FORMULA_FIELDS`, deterministic checks, activity damage formula)

Closes #6881