### PR TITLE
[#4612] Add `unidentifiedContents` property to containers.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3855,6 +3855,7 @@
     "Thrown": "Thrown",
     "Trait": "Passive Trait",
     "TwoHanded": "Two-Handed",
+    "UnidentifiedContents": "Hidden Until Identified",
     "Versatile": "Versatile",
     "Verbal": "Verbal",
     "WeightlessContents": "Weightless Contents"

--- a/lang/en.json
+++ b/lang/en.json
@@ -1724,6 +1724,10 @@
     "properties": {
       "label": "Container Properties"
     }
+  },
+  "UnidentifiedContentsWarning": {
+    "Title": "Unidentified Container",
+    "Message": "This container is unidentified. Anything you add to it will be hidden until it's identified. Continue?"
   }
 },
 
@@ -3855,7 +3859,7 @@
     "Thrown": "Thrown",
     "Trait": "Passive Trait",
     "TwoHanded": "Two-Handed",
-    "UnidentifiedContents": "Hidden Until Identified",
+    "UnidentifiedContents": "Hide Unidentified Contents",
     "Versatile": "Versatile",
     "Verbal": "Verbal",
     "WeightlessContents": "Weightless Contents"

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1746,13 +1746,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     }
 
     // Warn before adding to a container whose contents the player cannot see
-    if ( !game.user.isGM && !container.system.canViewContents ) {
-      const confirmed = await foundry.applications.api.DialogV2.confirm({
-        content: `<p>${_loc("DND5E.CONTAINER.UnidentifiedContentsWarning.Message")}</p>`,
-        window: { title: "DND5E.CONTAINER.UnidentifiedContentsWarning.Title", icon: "fa-solid fa-box" }
-      });
-      if ( !confirmed ) return;
-    }
+    if ( await container.system.canDropContents() === false ) return;
 
     // If the item is from the same actor, move it into the container
     if ( (event._behavior === "move") && (this.inventorySource.uuid === item.parent?.uuid) ) {

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1746,7 +1746,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     }
 
     // Warn before adding to a container whose contents the player cannot see
-    if ( await container.system.canDropContents() === false ) return;
+    if ( !(await container.system.canDropContents()) ) return;
 
     // If the item is from the same actor, move it into the container
     if ( (event._behavior === "move") && (this.inventorySource.uuid === item.parent?.uuid) ) {

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -1745,6 +1745,15 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       }
     }
 
+    // Warn before adding to a container whose contents the player cannot see
+    if ( !game.user.isGM && !container.system.canViewContents ) {
+      const confirmed = await foundry.applications.api.DialogV2.confirm({
+        content: `<p>${_loc("DND5E.CONTAINER.UnidentifiedContentsWarning.Message")}</p>`,
+        window: { title: "DND5E.CONTAINER.UnidentifiedContentsWarning.Title", icon: "fa-solid fa-box" }
+      });
+      if ( !confirmed ) return;
+    }
+
     // If the item is from the same actor, move it into the container
     if ( (event._behavior === "move") && (this.inventorySource.uuid === item.parent?.uuid) ) {
       return item.update({ "system.container": container.id });

--- a/module/applications/api/primary-sheet-mixin.mjs
+++ b/module/applications/api/primary-sheet-mixin.mjs
@@ -213,7 +213,7 @@ export default function PrimarySheetMixin(Base) {
      * @protected
      */
     _getTabs() {
-      return this.constructor.TABS.reduce((tabs, { tab, condition, ...config }) => {
+      const tabs = this.constructor.TABS.reduce((tabs, { tab, condition, ...config }) => {
         if ( !condition || condition(this.document) ) tabs[tab] = {
           ...config,
           id: tab,
@@ -223,6 +223,20 @@ export default function PrimarySheetMixin(Base) {
         };
         return tabs;
       }, {});
+
+      if ( !(this.tabGroups.primary in tabs) ) {
+        if ( this.rendered ) {
+          this.element.querySelector(`[data-application-part="${this.tabGroups.primary}"]`)?.remove();
+        }
+        const id = Object.keys(tabs)[0];
+        this.tabGroups.primary = id;
+        Object.assign(tabs[id], {
+          active: true,
+          cssClass: "active"
+        });
+      }
+
+      return tabs;
     }
 
     /* -------------------------------------------- */

--- a/module/applications/api/primary-sheet-mixin.mjs
+++ b/module/applications/api/primary-sheet-mixin.mjs
@@ -229,11 +229,10 @@ export default function PrimarySheetMixin(Base) {
           this.element.querySelector(`[data-application-part="${this.tabGroups.primary}"]`)?.remove();
         }
         const id = Object.keys(tabs)[0];
-        this.tabGroups.primary = id;
-        Object.assign(tabs[id], {
-          active: true,
-          cssClass: "active"
-        });
+        if ( id ) {
+          this.tabGroups.primary = id;
+          Object.assign(tabs[id], { active: true, cssClass: "active" });
+        }
       }
 
       return tabs;

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -44,17 +44,6 @@ export default class ContainerSheet extends ItemSheet5e {
   };
 
   /* -------------------------------------------- */
-
-  /**
-   * Determine whether the current user can view a container's contents.
-   * @param {Item5e} item  The Item.
-   * @returns {boolean}
-   */
-  static canViewContents(item) {
-    return item.system.canViewContents;
-  }
-
-  /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
 
@@ -433,5 +422,18 @@ export default class ContainerSheet extends ItemSheet5e {
   _sortChildren(collection, mode) {
     if ( collection === "items" ) return this._sortItems(this._items, mode);
     return [];
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Determine whether the current user can view a container's contents.
+   * @param {Item5e} item  The Item.
+   * @returns {boolean}
+   */
+  static canViewContents(item) {
+    return item.system.canViewContents;
   }
 }

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -200,6 +200,9 @@ export default class ContainerSheet extends ItemSheet5e {
     const folder = await Folder.implementation.fromDropData(data);
     if ( !this.item.isOwner || (folder.type !== "Item") ) return [];
 
+    // Warn before adding to a container whose contents the player cannot see
+    if ( await this.item.system.canDropContents() === false ) return [];
+
     let recursiveWarning = false;
     const parentContainers = await this.item.system.allContainers();
     const containers = new Set();
@@ -242,6 +245,9 @@ export default class ContainerSheet extends ItemSheet5e {
     const behavior = this._dropBehavior(event, data);
     let item = await Item.implementation.fromDropData(data);
     if ( !this.item.isOwner || !item || (behavior === "none") ) return false;
+
+    // Warn before adding to a container whose contents the player cannot see
+    if ( await this.item.system.canDropContents() === false ) return false;
 
     // If item already exists in this container, just adjust its sorting
     if ( (behavior === "move") && (item.system.container === this.item.id) ) {

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -105,7 +105,8 @@ export default class ContainerSheet extends ItemSheet5e {
 
     // Contents
     const Inventory = customElements.get(this.options.elements.inventory);
-    for ( const item of await this.item.system.contents ) {
+    const contents = this.item.system.canViewContents ? await this.item.system.contents : [];
+    for ( const item of contents ) {
       const ctx = context.itemContext[item.id] ??= {};
       ctx.totalWeight = (await item.system.totalWeight).toNearest(0.1);
       ctx.isExpanded = this.expandedSections.get(`items.${item.id}`);

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -190,7 +190,7 @@ export default class ContainerSheet extends ItemSheet5e {
     if ( !this.item.isOwner || (folder.type !== "Item") ) return [];
 
     // Warn before adding to a container whose contents the player cannot see
-    if ( await this.item.system.canDropContents() === false ) return [];
+    if ( !(await this.item.system.canDropContents()) ) return [];
 
     let recursiveWarning = false;
     const parentContainers = await this.item.system.allContainers();
@@ -235,9 +235,6 @@ export default class ContainerSheet extends ItemSheet5e {
     let item = await Item.implementation.fromDropData(data);
     if ( !this.item.isOwner || !item || (behavior === "none") ) return false;
 
-    // Warn before adding to a container whose contents the player cannot see
-    if ( await this.item.system.canDropContents() === false ) return false;
-
     // If item already exists in this container, just adjust its sorting
     if ( (behavior === "move") && (item.system.container === this.item.id) ) {
       return this._onSortItem(event, item);
@@ -249,6 +246,9 @@ export default class ContainerSheet extends ItemSheet5e {
       ui.notifications.error("DND5E.ContainerRecursiveError");
       return;
     }
+
+    // Warn before adding to a container whose contents the player cannot see
+    if ( !(await this.item.system.canDropContents()) ) return false;
 
     // If item already exists in same DocumentCollection, just adjust its container property
     if ( (behavior === "move") && (item.actor === this.item.actor) && (item.pack === this.item.pack) ) {

--- a/module/applications/item/container-sheet.mjs
+++ b/module/applications/item/container-sheet.mjs
@@ -32,7 +32,7 @@ export default class ContainerSheet extends ItemSheet5e {
 
   /** @override */
   static TABS = [
-    { tab: "contents", label: "DND5E.ITEM.SECTIONS.Contents" },
+    { tab: "contents", label: "DND5E.ITEM.SECTIONS.Contents", condition: this.canViewContents.bind(this) },
     ...super.TABS
   ];
 
@@ -42,6 +42,17 @@ export default class ContainerSheet extends ItemSheet5e {
   tabGroups = {
     primary: "contents"
   };
+
+  /* -------------------------------------------- */
+
+  /**
+   * Determine whether the current user can view a container's contents.
+   * @param {Item5e} item  The Item.
+   * @returns {boolean}
+   */
+  static canViewContents(item) {
+    return item.system.canViewContents;
+  }
 
   /* -------------------------------------------- */
   /*  Properties                                  */
@@ -105,8 +116,7 @@ export default class ContainerSheet extends ItemSheet5e {
 
     // Contents
     const Inventory = customElements.get(this.options.elements.inventory);
-    const contents = this.item.system.canViewContents ? await this.item.system.contents : [];
-    for ( const item of contents ) {
+    for ( const item of await this.item.system.contents ) {
       const ctx = context.itemContext[item.id] ??= {};
       ctx.totalWeight = (await item.system.totalWeight).toNearest(0.1);
       ctx.isExpanded = this.expandedSections.get(`items.${item.id}`);

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -2016,6 +2016,9 @@ DND5E.itemProperties = {
   two: {
     label: "DND5E.ITEM.Property.TwoHanded"
   },
+  unidentifiedContents: {
+    label: "DND5E.ITEM.Property.UnidentifiedContents"
+  },
   ver: {
     label: "DND5E.ITEM.Property.Versatile"
   },
@@ -2045,6 +2048,7 @@ DND5E.validProperties = {
   ]),
   container: new Set([
     "mgc",
+    "unidentifiedContents",
     "weightlessContents"
   ]),
   equipment: new Set([

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -253,7 +253,7 @@ export default class ContainerData extends ItemDataModel.mixin(
       context.max = this.capacity.weight.value;
       context.units = CONFIG.DND5E.weightUnits[this.capacity.weight.units]?.label ?? "";
     }
-    context.value = context.value.toNearest(0.1);
+    context.value = this.canViewContents ? context.value.toNearest(0.1) : 0;
     context.pct = Math.clamp(context.max ? (context.value / context.max) * 100 : 0, 0, 100);
     return context;
   }

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -125,6 +125,17 @@ export default class ContainerData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /**
+   * Can the current user view this container's contents? Hidden from non-GMs when the container is unidentified and
+   * has the "unidentifiedContents" property.
+   * @type {boolean}
+   */
+  get canViewContents() {
+    return game.user.isGM || (this.identified !== false) || !this.properties.has("unidentifiedContents");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Get all of the items in this container and any sub-containers. A promise if item is within a compendium.
    * @type {Collection<Item5e>|Promise<Collection<Item5e>>}
    */

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -401,4 +401,20 @@ export default class ContainerData extends ItemDataModel.mixin(
       parent: this.parent.parent
     });
   }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Confirm with user when trying to add items to an unidentified container.
+   * @returns {Promise<boolean}
+   */
+  canDropContents() {
+    if ( game.user.isGM || this.canViewContents ) return true;
+    return foundry.applications.api.DialogV2.confirm({
+      content: `<p>${_loc("DND5E.CONTAINER.UnidentifiedContentsWarning.Message")}</p>`,
+      window: { title: "DND5E.CONTAINER.UnidentifiedContentsWarning.Title", icon: "fa-solid fa-box" }
+    });
+  }
 }

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -232,10 +232,11 @@ export default class ContainerData extends ItemDataModel.mixin(
 
   /**
    * @typedef {object} Item5eCapacityDescriptor
-   * @property {number} value  The current total weight or number of items in the container.
-   * @property {number} max    The maximum total weight or number of items in the container.
-   * @property {number} pct    The percentage of total capacity.
-   * @property {string} units  The units label.
+   * @property {number} value    The current total weight or number of items in the container.
+   * @property {number} max      The maximum total weight or number of items in the container.
+   * @property {number} pct      The percentage of total capacity.
+   * @property {string} units    The units label.
+   * @property {boolean} hidden  Should this capacity be hidden from the current user?
    */
 
   /**
@@ -253,7 +254,8 @@ export default class ContainerData extends ItemDataModel.mixin(
       context.max = this.capacity.weight.value;
       context.units = CONFIG.DND5E.weightUnits[this.capacity.weight.units]?.label ?? "";
     }
-    context.value = this.canViewContents ? context.value.toNearest(0.1) : 0;
+    context.value = context.value.toNearest(0.1);
+    context.hidden = !this.canViewContents;
     context.pct = Math.clamp(context.max ? (context.value / context.max) * 100 : 0, 0, 100);
     return context;
   }

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -408,10 +408,10 @@ export default class ContainerData extends ItemDataModel.mixin(
 
   /**
    * Confirm with user when trying to add items to an unidentified container.
-   * @returns {Promise<boolean}
+   * @returns {Promise<boolean>|boolean}
    */
   canDropContents() {
-    if ( game.user.isGM || this.canViewContents ) return true;
+    if ( this.canViewContents ) return true;
     return foundry.applications.api.DialogV2.confirm({
       content: `<p>${_loc("DND5E.CONTAINER.UnidentifiedContentsWarning.Message")}</p>`,
       window: { title: "DND5E.CONTAINER.UnidentifiedContentsWarning.Title", icon: "fa-solid fa-box" }

--- a/templates/actors/character-sidebar.hbs
+++ b/templates/actors/character-sidebar.hbs
@@ -282,7 +282,7 @@
                 <div class="info">
                     <div class="primary {{ css }}">
                         {{!-- Item Uses & Capacity --}}
-                        {{#if uses.max}}
+                        {{#if (and uses.max (not uses.hidden))}}
                         {{#with uses}}
                         {{#if (and name @root.actor.isOwner)}}
                         <input type="text" class="uninput value" value="{{ value }}"

--- a/templates/inventory/columns/capacity.hbs
+++ b/templates/inventory/columns/capacity.hbs
@@ -1,6 +1,6 @@
 {{#with ctx.capacity}}
-{{#unless hidden}}
-<div class="item-detail item-capacity always-visible" data-column-id="capacity">
+<div class="item-detail item-capacity always-visible {{#if hidden}}empty{{/if}}" data-column-id="capacity">
+    {{#unless hidden}}
     <div class="meter progress" role="meter" aria-valuemin="0" aria-valuenow="{{ pct }}" aria-valuetext="{{ value }}"
          aria-valuemax="{{ max }}" style="--bar-percentage: {{ pct }}%">
         <div class="label">
@@ -10,6 +10,6 @@
             <span class="max">{{{ maxLabel }}}</span>
         </div>
     </div>
+    {{/unless}}
 </div>
-{{/unless}}
 {{/with}}

--- a/templates/inventory/columns/capacity.hbs
+++ b/templates/inventory/columns/capacity.hbs
@@ -1,4 +1,5 @@
 {{#with ctx.capacity}}
+{{#unless hidden}}
 <div class="item-detail item-capacity always-visible" data-column-id="capacity">
     <div class="meter progress" role="meter" aria-valuemin="0" aria-valuenow="{{ pct }}" aria-valuetext="{{ value }}"
          aria-valuemax="{{ max }}" style="--bar-percentage: {{ pct }}%">
@@ -10,4 +11,5 @@
         </div>
     </div>
 </div>
+{{/unless}}
 {{/with}}

--- a/templates/inventory/containers.hbs
+++ b/templates/inventory/containers.hbs
@@ -4,9 +4,11 @@
         <a class="item-action" data-action="showDocument" data-tooltip aria-label="{{ name }}">
             {{#dnd5e-itemContext this as |ctx|}}
             {{#with ctx.capacity}}
+            {{#unless hidden}}
             <div class="meter progress" role="meter" aria-valuemin="0" aria-valuenow="{{ pct }}"
                  aria-valuetext="{{ value }}" aria-valuemax="{{ max }}"
                  style="--bar-percentage: {{ pct }}%"></div>
+            {{/unless}}
             {{/with}}
             {{/dnd5e-itemContext}}
             <img src="{{ img }}" alt="{{ name }}" draggable="false">

--- a/templates/inventory/encumbrance.hbs
+++ b/templates/inventory/encumbrance.hbs
@@ -1,5 +1,4 @@
 {{#with encumbrance}}
-{{#unless hidden}}
 <div class="meter progress" role="meter" aria-valuemin="0" aria-valuenow="{{ pct }}"
      aria-valuetext="{{ value }}" aria-valuemax="{{ max }}"
      style="--bar-percentage: {{ pct }}%; --breakpoint-low: {{ stops.encumbered }}%; --breakpoint-high: {{ stops.heavilyEncumbered }}%;">
@@ -22,5 +21,4 @@
     <i class="breakpoint breakpoint-high arrow-down" role="presentation"></i>
     {{/if}}
 </div>
-{{/unless}}
 {{/with}}

--- a/templates/inventory/encumbrance.hbs
+++ b/templates/inventory/encumbrance.hbs
@@ -1,4 +1,5 @@
 {{#with encumbrance}}
+{{#unless hidden}}
 <div class="meter progress" role="meter" aria-valuemin="0" aria-valuenow="{{ pct }}"
      aria-valuetext="{{ value }}" aria-valuemax="{{ max }}"
      style="--bar-percentage: {{ pct }}%; --breakpoint-low: {{ stops.encumbered }}%; --breakpoint-high: {{ stops.heavilyEncumbered }}%;">
@@ -21,4 +22,5 @@
     <i class="breakpoint breakpoint-high arrow-down" role="presentation"></i>
     {{/if}}
 </div>
+{{/unless}}
 {{/with}}


### PR DESCRIPTION
- Add `unidentifiedContents` container property hiding contents from non-GMs while the container is unidentified
- Gate the container sheet contents list on a new `canViewContents` getter
- Report a zeroed value from `computeCapacity` when contents are concealed, so the capacity bar, thumbnail, and favorites chip show 0/X

**Not covered**: contents weight still counts toward the actor's encumbrance, and the container delete dialog still shows its item count. GMs always see contents and real capacity.

Closes #4612