### PR TITLE
[#4505] Allow `0` as a numeric scale value

### DIFF
--- a/module/applications/activity/activity-usage-dialog.mjs
+++ b/module/applications/activity/activity-usage-dialog.mjs
@@ -292,6 +292,7 @@ export default class ActivityUsageDialog extends Dialog5e {
         const consume = foundry.utils.getProperty(this.config, keyPath);
         const isArray = Array.isArray(consume);
         for ( const [index, target] of targets.entries() ) {
+          if ( target.hasZeroCost(this.config) ) continue;
           const value = (isArray && consume.includes(index))
             || (!isArray && (consume !== false) && (this.config.consume !== false));
           const { label, hint, notes, warn } = target.getConsumptionLabels(this.config, value);

--- a/module/applications/advancement/scale-value-config.mjs
+++ b/module/applications/advancement/scale-value-config.mjs
@@ -132,7 +132,7 @@ export default class ScaleValueConfig extends AdvancementConfig {
     let lastValue = null;
     for ( const [lvl, value] of Object.entries(configuration.scale) ) {
       if ( this.advancement.testEquality(lastValue, value) ) configuration.scale[lvl] = null;
-      else if ( Object.keys(value ?? {}).some(k => value[k]) ) {
+      else if ( this.constructor._hasValue(value) ) {
         this._mergeScaleValues(value, lastValue);
         lastValue = value;
       }
@@ -165,10 +165,22 @@ export default class ScaleValueConfig extends AdvancementConfig {
 
   /* -------------------------------------------- */
 
+  /**
+   * Is a scale value entry non-empty?
+   * @param {object} value  Scale value entry.
+   * @returns {boolean}
+   * @protected
+   */
+  static _hasValue(value) {
+    return Object.keys(value ?? {}).some(k => (value[k] != null) && (value[k] !== ""));
+  }
+
+  /* -------------------------------------------- */
+
   /** @override */
   static _cleanedObject(object) {
     return Object.entries(object).reduce((obj, [key, value]) => {
-      if ( Object.keys(value ?? {}).some(k => value[k]) ) obj[key] = value;
+      if ( this._hasValue(value) ) obj[key] = value;
       else obj[key] = _del;
       return obj;
     }, {});

--- a/module/applications/advancement/scale-value-config.mjs
+++ b/module/applications/advancement/scale-value-config.mjs
@@ -165,6 +165,17 @@ export default class ScaleValueConfig extends AdvancementConfig {
 
   /* -------------------------------------------- */
 
+  /** @override */
+  static _cleanedObject(object) {
+    return Object.entries(object).reduce((obj, [key, value]) => {
+      if ( this._hasValue(value) ) obj[key] = value;
+      else obj[key] = _del;
+      return obj;
+    }, {});
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Is a scale value entry non-empty?
    * @param {object} value  Scale value entry.
@@ -173,16 +184,5 @@ export default class ScaleValueConfig extends AdvancementConfig {
    */
   static _hasValue(value) {
     return Object.keys(value ?? {}).some(k => (value[k] != null) && (value[k] !== ""));
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  static _cleanedObject(object) {
-    return Object.entries(object).reduce((obj, [key, value]) => {
-      if ( this._hasValue(value) ) obj[key] = value;
-      else obj[key] = _del;
-      return obj;
-    }, {});
   }
 }

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -712,6 +712,19 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Does this target's cost resolve to a fixed zero, meaning nothing is consumed? Non-deterministic
+   * costs (those containing dice) are never treated as zero.
+   * @param {ActivityUseConfiguration} [config={}]  Usage configuration.
+   * @returns {boolean}
+   */
+  hasZeroCost(config={}) {
+    const roll = this.resolveCost({ config, evaluate: false });
+    return roll.isDeterministic && (roll.evaluateSync().total === 0);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Resolve the spell level to consume, taking scaling into account.
    * @param {object} [options={}]
    * @param {ActivityUseConfiguration} [options.config]  Usage configuration.

--- a/module/data/activity/fields/consumption-targets-field.mjs
+++ b/module/data/activity/fields/consumption-targets-field.mjs
@@ -698,6 +698,19 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Does this target's cost resolve to a fixed zero, meaning nothing is consumed? Non-deterministic
+   * costs (those containing dice) are never treated as zero.
+   * @param {ActivityUseConfiguration} [config={}]  Usage configuration.
+   * @returns {boolean}
+   */
+  hasZeroCost(config={}) {
+    const roll = this.resolveCost({ config, evaluate: false });
+    return roll.isDeterministic && (roll.evaluateSync().total === 0);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Resolve the amount to consume, taking scaling into account.
    * @param {object} [options={}]
    * @param {ActivityUseConfiguration} [options.config]  Usage configuration.
@@ -707,19 +720,6 @@ export class ConsumptionTargetData extends foundry.abstract.DataModel {
    */
   resolveCost({ config={}, ...options }={}) {
     return this._resolveScaledRoll(this.value, this.scaling.mode === "amount" ? config.scaling ?? 0 : 0, options);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Does this target's cost resolve to a fixed zero, meaning nothing is consumed? Non-deterministic
-   * costs (those containing dice) are never treated as zero.
-   * @param {ActivityUseConfiguration} [config={}]  Usage configuration.
-   * @returns {boolean}
-   */
-  hasZeroCost(config={}) {
-    const roll = this.resolveCost({ config, evaluate: false });
-    return roll.isDeterministic && (roll.evaluateSync().total === 0);
   }
 
   /* -------------------------------------------- */

--- a/module/data/advancement/scale-value.mjs
+++ b/module/data/advancement/scale-value.mjs
@@ -204,7 +204,9 @@ export class ScaleValueType extends foundry.abstract.DataModel {
    * @returns {string}
    */
   static getPlaceholder(name, lastValue) {
-    return lastValue?.[name] ?? "";
+    const value = lastValue?.[name];
+    // Coerce to a string so a numeric 0 placeholder is rendered.
+    return value == null ? "" : String(value);
   }
 }
 

--- a/module/data/advancement/scale-value.mjs
+++ b/module/data/advancement/scale-value.mjs
@@ -204,9 +204,8 @@ export class ScaleValueType extends foundry.abstract.DataModel {
    * @returns {string}
    */
   static getPlaceholder(name, lastValue) {
-    const value = lastValue?.[name];
     // Coerce to a string so a numeric 0 placeholder is rendered.
-    return value == null ? "" : String(value);
+    return String(lastValue?.[name] ?? "");
   }
 }
 
@@ -245,7 +244,7 @@ export class ScaleValueTypeNumber extends ScaleValueType {
   /** @inheritDoc */
   static convertFrom(original, options) {
     const value = Number(original.formula);
-    if ( Number.isNaN(value) ) return null;
+    if ( (original.formula === null) || (original.formula === "") || Number.isNaN(value) ) return null;
     return new this({value}, options);
   }
 }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -427,7 +427,7 @@ export default function ActivityMixin(Base) {
         const activationConfig = CONFIG.DND5E.activityActivationTypes[this.activation.type] ?? {};
         const hasActionConsumption = activationConfig.consume
           && (activationConfig.consume.canConsume?.(this) !== false);
-        const hasResourceConsumption = this.consumption.targets.length > 0;
+        const hasResourceConsumption = !!this.consumption.targets.find(c => !c.hasZeroCost(config));
         const hasLinkedConsumption = (linked?.consumption.targets.length > 0) && !ignoreLinkedConsumption;
         const hasSpellSlotConsumption = this.requiresSpellSlot && this.consumption.spellSlot;
         config.consume ??= {};

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -568,6 +568,7 @@ export default function ActivityMixin(Base) {
           ? this.consumption.targets.keys() : config.consume.resources;
         for ( const index of indexes ) {
           const target = this.consumption.targets[index];
+          if ( target.hasZeroCost(config) ) continue;
           try {
             await target.consume(config, updates);
           } catch(err) {

--- a/module/documents/advancement/scale-value.mjs
+++ b/module/documents/advancement/scale-value.mjs
@@ -71,7 +71,7 @@ export default class ScaleValueAdvancement extends Advancement {
   /** @inheritDoc */
   titleForLevel(level, { configMode=false, legacyDisplay=false }={}) {
     const value = this.valueForLevel(level)?.display;
-    if ( (value == null) || (value === "") || !legacyDisplay ) return this.title;
+    if ( (value === null) || (value === "") || !legacyDisplay ) return this.title;
     return `${this.title}: <strong>${value}</strong>`;
   }
 

--- a/module/documents/advancement/scale-value.mjs
+++ b/module/documents/advancement/scale-value.mjs
@@ -71,7 +71,7 @@ export default class ScaleValueAdvancement extends Advancement {
   /** @inheritDoc */
   titleForLevel(level, { configMode=false, legacyDisplay=false }={}) {
     const value = this.valueForLevel(level)?.display;
-    if ( !value || !legacyDisplay ) return this.title;
+    if ( (value == null) || (value === "") || !legacyDisplay ) return this.title;
     return `${this.title}: <strong>${value}</strong>`;
   }
 

--- a/module/documents/advancement/scale-value.mjs
+++ b/module/documents/advancement/scale-value.mjs
@@ -71,7 +71,7 @@ export default class ScaleValueAdvancement extends Advancement {
   /** @inheritDoc */
   titleForLevel(level, { configMode=false, legacyDisplay=false }={}) {
     const value = this.valueForLevel(level)?.display;
-    if ( (value === null) || (value === "") || !legacyDisplay ) return this.title;
+    if ( (!value && (value !== 0)) || !legacyDisplay ) return this.title;
     return `${this.title}: <strong>${value}</strong>`;
   }
 


### PR DESCRIPTION
- Keep numeric scale value entries of `0` on save instead of stripping them as empty
- Inherit a `0` to later levels as a placeholder, like any non-zero value
- Show `0` in the legacy scale value title display
- Skip consumption when an activity's resolved cost is `0` (no dialog prompt, nothing consumed)

Closes #4505