### PR TITLE
[#5926] Rename the Cast activity spellbook toggle to "Display in Spells Tab"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1399,7 +1399,7 @@
       },
       "spellbook": {
         "label": "Display in Spells Tab",
-        "hint": "Display spell in the Spells tab of the character sheet. Equippable items must have the Magical property and be attuned if they require attunement."
+        "hint": "Display spell in the Spells tab of the character sheet. Items must have the Magical property and be attuned if they require attunement."
       },
       "uuid": {
         "label": "Spell to Cast"

--- a/lang/en.json
+++ b/lang/en.json
@@ -1398,8 +1398,8 @@
         "hint": "Spell components & tags to ignore while casting."
       },
       "spellbook": {
-        "label": "Display in Spellbook",
-        "hint": "Display spell in the Spells tab of the character sheet."
+        "label": "Display in Spells Tab",
+        "hint": "Display spell in the Spells tab of the character sheet. Equippable items must have the Magical property and be attuned if they require attunement."
       },
       "uuid": {
         "label": "Spell to Cast"


### PR DESCRIPTION
- Rename the label from "Display in Spellbook" to "Display in Spells Tab"
- Note the display requirements (Magical property, attunement) in the hint

Closes #5926