### PR TITLE
[#3993] Hide the attunement icon on unidentified items from players

### DIFF
--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -876,7 +876,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
     ctx.concealDetails = !game.user.isGM && (item.system.identified === false);
     ctx.isStack = Number.isNumeric(item.system.quantity) && (item.system.quantity !== 1);
 
-    if ( item.system.attunement ) ctx.attunement = item.system.attuned ? {
+    if ( item.system.attunement && !ctx.concealDetails ) ctx.attunement = item.system.attuned ? {
       icon: "fa-sun",
       cls: "attuned",
       title: "DND5E.AttunementAttuned"

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -325,6 +325,7 @@ export default class InventoryElement extends (foundry.applications.elements.Ado
   _getContextOptions(item, element) {
     const compendiumLocked = game.packs.get(item.pack)?.locked;
     const inFavorites = !!element.closest(".favorites");
+    const concealDetails = !game.user.isGM && (item.system.identified === false);
 
     // Standard options.
     const options = [{
@@ -391,7 +392,7 @@ export default class InventoryElement extends (foundry.applications.elements.Ado
       label: `DND5E.ContextMenuAction${item.system.attuned ? "Unattune" : "Attune"}`,
       icon: '<i class="fa-solid fa-sun fa-fw"></i>',
       group: "state",
-      visible: () => item.system.attunement && item.isOwner && !compendiumLocked,
+      visible: () => !concealDetails && item.system.attunement && item.isOwner && !compendiumLocked,
       onClick: (event, target) => this._onAction(target, "attune", { event })
     }, {
       label: `DND5E.ContextMenuAction${item.system.equipped ? "Unequip" : "Equip"}`,

--- a/module/applications/components/inventory.mjs
+++ b/module/applications/components/inventory.mjs
@@ -325,7 +325,6 @@ export default class InventoryElement extends (foundry.applications.elements.Ado
   _getContextOptions(item, element) {
     const compendiumLocked = game.packs.get(item.pack)?.locked;
     const inFavorites = !!element.closest(".favorites");
-    const concealDetails = !game.user.isGM && (item.system.identified === false);
 
     // Standard options.
     const options = [{
@@ -392,7 +391,7 @@ export default class InventoryElement extends (foundry.applications.elements.Ado
       label: `DND5E.ContextMenuAction${item.system.attuned ? "Unattune" : "Attune"}`,
       icon: '<i class="fa-solid fa-sun fa-fw"></i>',
       group: "state",
-      visible: () => !concealDetails && item.system.attunement && item.isOwner && !compendiumLocked,
+      visible: () => ItemSheet5e.isItemIdentified(item) && item.system.attunement && item.isOwner && !compendiumLocked,
       onClick: (event, target) => this._onAction(target, "attune", { event })
     }, {
       label: `DND5E.ContextMenuAction${item.system.equipped ? "Unequip" : "Equip"}`,

--- a/templates/inventory/columns/controls.hbs
+++ b/templates/inventory/columns/controls.hbs
@@ -17,7 +17,6 @@
     {{/if}}
     {{else if @root.owner}}
     {{!-- Attuning --}}
-    {{#unless ctx.concealDetails}}
     {{#with ctx.attunement}}
     {{#if applicable}}
     <button type="button" class="unbutton config-button item-control item-action {{ cls }}" data-action="attune"
@@ -26,7 +25,6 @@
     </button>
     {{/if}}
     {{/with}}
-    {{/unless}}
 
     {{!-- Equipping --}}
     {{#with ctx.equip}}

--- a/templates/inventory/columns/controls.hbs
+++ b/templates/inventory/columns/controls.hbs
@@ -17,6 +17,7 @@
     {{/if}}
     {{else if @root.owner}}
     {{!-- Attuning --}}
+    {{#unless ctx.concealDetails}}
     {{#with ctx.attunement}}
     {{#if applicable}}
     <button type="button" class="unbutton config-button item-control item-action {{ cls }}" data-action="attune"
@@ -25,6 +26,7 @@
     </button>
     {{/if}}
     {{/with}}
+    {{/unless}}
 
     {{!-- Equipping --}}
     {{#with ctx.equip}}


### PR DESCRIPTION
- Gate the attunement control on ctx.concealDetails so it no longer reveals the item's magical status

Closes #3993