### PR TITLE
[#3285] Hide death saves when the character's max HP is 0

### DIFF
--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -921,12 +921,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
       this._renderSpellbook(context, options);
     }
 
-    // Show death tray at 0 HP
-    const renderContext = options.renderContext ?? options.action;
-    const renderData = options.renderData ?? options.data;
-    const isUpdate = (renderContext === "update") || (renderContext === "updateActor");
-    const hp = foundry.utils.getProperty(renderData ?? {}, "system.attributes.hp.value");
-    if ( isUpdate && (hp === 0) ) this._toggleDeathTray(true);
+    if ( options.openDeathTray ) this._toggleDeathTray(true);
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -141,9 +141,9 @@ export default class CharacterActorSheet extends BaseActorSheet {
   /* -------------------------------------------- */
 
   /**
-   * Whether the user has manually opened the death save tray.
+   * Death save tray state.
    * @type {boolean}
-   * @protected
+   * @internal
    */
   _deathTrayOpen = false;
 
@@ -915,13 +915,10 @@ export default class CharacterActorSheet extends BaseActorSheet {
   /** @inheritDoc */
   async _onRender(context, options) {
     await super._onRender(context, options);
-
     if ( !this.actor.limited ) {
       this._renderAttunement(context, options);
       this._renderSpellbook(context, options);
     }
-
-    if ( options.openDeathTray ) this._toggleDeathTray(true);
   }
 
   /* -------------------------------------------- */
@@ -1054,8 +1051,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
     const tab = tray.querySelector(".death-tab");
     tray.classList.toggle("open", open);
     this._deathTrayOpen = tray.classList.contains("open");
-    tab.dataset.tooltip = `DND5E.DeathSave${this._deathTrayOpen ? "Hide" : "Show"}`;
-    tab.setAttribute("aria-label", _loc(tab.dataset.tooltip));
+    tab.setAttribute("aria-label", _loc(`DND5E.DeathSave${this._deathTrayOpen ? "Hide" : "Show"}`));
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -296,7 +296,7 @@ export default class CharacterData extends CreatureTemplate {
 
     const hp = foundry.utils.getProperty(changed, "system.attributes.hp.value");
     if ( !options.isAdvancement && (hp === 0) && (this.attributes.hp.max > 0) && this.parent.sheet?.rendered ) {
-      this.parent.sheet.render(false, { openDeathTray: true });
+      this.parent.sheet._deathTrayOpen = true;
     }
   }
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -293,6 +293,11 @@ export default class CharacterData extends CreatureTemplate {
     super._onUpdate(changed, options, userId);
     AttributesFields.onUpdateHP.call(this, changed, options, userId);
     AttributesFields.onUpdateDeathSaves.call(this, changed, options, userId);
+
+    const hp = foundry.utils.getProperty(changed, "system.attributes.hp.value");
+    if ( !options.isAdvancement && (hp === 0) && (this.attributes.hp.max > 0) && this.parent.sheet?.rendered ) {
+      this.parent.sheet.render(false, { openDeathTray: true });
+    }
   }
 
   /* -------------------------------------------- */

--- a/templates/actors/character-sidebar.hbs
+++ b/templates/actors/character-sidebar.hbs
@@ -226,9 +226,9 @@
             </div>
 
             <button type="button" class="death-tab card-tab horizontal unbutton always-interactive"
-                    data-action="toggleDeathTray" {{#if death.open~}}
-                    data-tooltip="DND5E.DeathSaveShow" aria-label="{{ localize 'DND5E.DeathSaveShow' }}"{{else~}}
-                    data-tooltip="DND5E.DeathSaveHide" aria-label="{{ localize 'DND5E.DeathSaveHide' }}"{{/if}}>
+                    data-action="toggleDeathTray" data-tooltip {{#if death.open~}}
+                    aria-label="{{ localize 'DND5E.DeathSaveHide' }}"{{else~}}
+                    aria-label="{{ localize 'DND5E.DeathSaveShow' }}"{{/if}}>
                 <i class="fas fa-skull" inert></i>
             </button>
         </div>


### PR DESCRIPTION
- Gate the death-save tray on a max-HP check so it no longer shows for a 0/0 character (e.g. after removing all classes)
- Guard _toggleDeathTray against the tray being absent, since it is auto-opened on a 0-HP update

Closes #3285