### PR TITLE
[#5891] Add tooltips to active effects in the chat effect tray

### DIFF
--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -120,7 +120,14 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       effect.updateDuration();
       const li = document.createElement("li");
       li.classList.add("effect");
-      li.dataset.id = effect.id;
+      Object.assign(li.dataset, {
+        id: effect.id,
+        tooltip: `
+          <section class="loading" data-uuid="${effect.uuid}"><i class="fas fa-spinner fa-spin-pulse"></i></section>
+        `,
+        tooltipClass: "dnd5e2 dnd5e-tooltip item-tooltip themed theme-light",
+        tooltipDirection: "LEFT"
+      });
       li.innerHTML = `
         <img class="gold-icon">
         <div class="name-stacked">
@@ -134,11 +141,6 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       `;
       Object.assign(li.querySelector(".gold-icon"), { alt: effect.name, src: effect.img });
       li.querySelector(".name-stacked .title").append(effect.name);
-      li.dataset.tooltip = `
-        <section class="loading" data-uuid="${effect.uuid}"><i class="fas fa-spinner fa-spin-pulse"></i></section>
-      `;
-      li.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip themed theme-light";
-      li.dataset.tooltipDirection = "LEFT";
       this.effectsList.append(li);
       li.addEventListener("click", this._onApplyEffect.bind(this));
     }

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -134,6 +134,11 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       `;
       Object.assign(li.querySelector(".gold-icon"), { alt: effect.name, src: effect.img });
       li.querySelector(".name-stacked .title").append(effect.name);
+      li.dataset.tooltip = `
+        <section class="loading" data-uuid="${effect.uuid}"><i class="fas fa-spinner fa-spin-pulse"></i></section>
+      `;
+      li.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip themed theme-light";
+      li.dataset.tooltipDirection = "LEFT";
       this.effectsList.append(li);
       li.addEventListener("click", this._onApplyEffect.bind(this));
     }


### PR DESCRIPTION
- Attach a rich effect tooltip to each effect row in the chat tray, matching actor sheets

Closes #5891