### PR TITLE
[#7009] Prevent duplicate Compendium Browser sidebar buttons

### DIFF
--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -1244,6 +1244,7 @@ export default class CompendiumBrowser extends Application5e {
    * @param {HTMLElement} html  HTML of the sidebar being rendered.
    */
   static injectSidebarButton(html) {
+    if ( html.querySelector(".open-compendium-browser") ) return;
     const button = document.createElement("button");
     button.type = "button";
     button.classList.add("open-compendium-browser");


### PR DESCRIPTION
- Skip injecting the button if one already exists, so sidebar re-renders (detach/reattach) don't stack duplicates

Closes #7009