### PR TITLE
[#6598] Widen the inventory uses column to fit up to four digits

### DIFF
--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -262,7 +262,7 @@
       .item-uses, .item-charges {
         gap: unset;
         &.item-detail { font-weight: bold; }
-        .max, input { width: 20px; }
+        .max, input { width: 26px; }
         .separator { color: var(--dnd5e-color-gold); }
         .max {
           color: var(--color-text-secondary);

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -262,7 +262,7 @@
       .item-uses, .item-charges {
         gap: unset;
         &.item-detail { font-weight: bold; }
-        .max, input { width: 26px; }
+        .max, input { width: 24px; }
         .separator { color: var(--dnd5e-color-gold); }
         .max {
           color: var(--color-text-secondary);


### PR DESCRIPTION
- Bump the uses/charges column and its value/max fields
- Keep the column registry width in sync with the CSS

Closes #6598

(Note, if wanted, we can drop all these changes except `less/v2/inventory.less:266` if we just want to allow 3 digits nicely. I went with  4 for redundancy)