### PR TITLE
[#4266] Keep expanded roll damage type labels on one line

### DIFF
--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -263,6 +263,7 @@
           color: var(--color-text-secondary);
           text-transform: uppercase;
           text-align: center;
+          white-space: nowrap;
         }
 
         .value {


### PR DESCRIPTION
Closes #4266