### PR TITLE
Swap to using `modifyBatch` in places where bulk updates are used

### DIFF
--- a/module/applications/advancement/advancement-manager.mjs
+++ b/module/applications/advancement/advancement-manager.mjs
@@ -910,7 +910,7 @@ export default class AdvancementManager extends Application5e {
     }
 
     // Apply changes from clone to original actor
-    this.actor.performBulkUpdate(
+    await this.actor.performBulkUpdate(
       { actor: updates, create: toCreate, delete: toDelete, item: toUpdate },
       { isAdvancement: true, updateOptions: { diff: false, recursive: false } }
     );

--- a/module/applications/advancement/advancement-manager.mjs
+++ b/module/applications/advancement/advancement-manager.mjs
@@ -910,12 +910,10 @@ export default class AdvancementManager extends Application5e {
     }
 
     // Apply changes from clone to original actor
-    await Promise.all([
-      this.actor.update(updates, { isAdvancement: true }),
-      this.actor.createEmbeddedDocuments("Item", toCreate, { keepId: true, isAdvancement: true }),
-      this.actor.updateEmbeddedDocuments("Item", toUpdate, { diff: false, recursive: false, isAdvancement: true }),
-      this.actor.deleteEmbeddedDocuments("Item", toDelete, { isAdvancement: true })
-    ]);
+    this.actor.performBulkUpdate(
+      { actor: updates, create: toCreate, delete: toDelete, item: toUpdate },
+      { isAdvancement: true, updateOptions: { diff: false, recursive: false } }
+    );
 
     /**
      * A hook event that fires when an AdvancementManager is done modifying an actor.

--- a/module/data/chat-message/fields/_types.mjs
+++ b/module/data/chat-message/fields/_types.mjs
@@ -11,14 +11,6 @@
  */
 
 /**
- * @typedef ActorUpdatesDescription
- * @property {object} actor       Updates applied to the actor.
- * @property {object[]} [create]  Full data for Items to create (with IDs maintained).
- * @property {string[]} [delete]  IDs of items to be deleted from the actor.
- * @property {object[]} item      Updates applied to items on the actor.
- */
-
-/**
  * @typedef IndividualDeltaData
  * @property {number} delta    The change in the specified field.
  * @property {string} keyPath  Path to the changed field on the document.

--- a/module/data/chat-message/fields/deltas-field.mjs
+++ b/module/data/chat-message/fields/deltas-field.mjs
@@ -4,6 +4,7 @@ import MappingField from "../../fields/mapping-field.mjs";
 const { ArrayField, NumberField, ObjectField, SchemaField, StringField } = foundry.data.fields;
 
 /**
+ * @import { ActorUpdatesDescription } from "../../../documents/_types.mjs";
  * @import { ActorDeltasData, DeltaDisplayContext, IndividualDeltaData } from "./_types.mjs";
  */
 

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -1,8 +1,17 @@
 /**
  * @import { SpellScrollValues } from "../_types.mjs";
- * @import { ActorUpdatesDescription } from "../data/chat-message/fields/_types.mjs";
  * @import { WeaponAttackMode } from "../dice/_types.mjs";
  */
+
+/**
+ * @typedef ActorUpdatesDescription
+ * @property {object} actor       Updates applied to the actor.
+ * @property {object[]} [create]  Full data for Items to create (with IDs maintained).
+ * @property {string[]} [delete]  IDs of items to be deleted from the actor.
+ * @property {object[]} item      Updates applied to items on the actor.
+ */
+
+/* -------------------------------------------- */
 
 /**
  * @typedef BastionTurnResult

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -619,6 +619,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @param {object} options  Options passed to the effect creation.
    */
   async createRiderEnchantments(options={}) {
+    const batchedUpdates = [];
     let item;
     let profile;
     const { chatMessageOrigin } = options;
@@ -655,11 +656,13 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       riderActivities[activityData._id] = activityData;
     }
     if ( !foundry.utils.isEmpty(riderActivities) ) {
-      await this.item.update({ "system.activities": riderActivities });
-      const createdActivities = Object.keys(riderActivities).map(id => this.item.system.activities?.get(id));
-      createdActivities.forEach(a => a.effects?.forEach(e => {
-        if ( !this.item.effects.has(e._id) ) riderEffects.push(item.effects.get(e._id)?.toObject());
-      }));
+      batchedUpdates.push({
+        action: "update", documentName: "Item", parent: this.item.actor,
+        updates: [{ _id: this.item.id, "system.activities": riderActivities }]
+      });
+      riderEffects = Object.values(riderActivities).flatMap(a =>
+        a.effects?.map(e => item.effects.get(e._id)?.toObject())
+      ).filter(e => e && !this.item.effects.has(e._id));
     }
 
     // Create Effects
@@ -674,7 +677,9 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     }));
     riderEffects = riderEffects.filter(_ => _);
     riderEffects.forEach(e => foundry.utils.setProperty(e, "flags.dnd5e.dependentOn", this.id));
-    await this.item.createEmbeddedDocuments("ActiveEffect", riderEffects, { keepId: true });
+    batchedUpdates.push({
+      action: "create", documentName: "ActiveEffect", data: riderEffects, parent: this.item, keepId: true
+    });
 
     // Create Items
     if ( this.item.isEmbedded ) {
@@ -688,8 +693,12 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
           }
         }
       );
-      await this.actor.createEmbeddedDocuments("Item", riderItems, { keepId: true });
+      batchedUpdates.push({
+        action: "create", documentName: "Item", data: riderItems, parent: this.actor, keepId: true
+      });
     }
+
+    await foundry.documents.modifyBatch(batchedUpdates);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/_types.mjs
+++ b/module/documents/activity/_types.mjs
@@ -1,7 +1,7 @@
 /**
  * @import { TransformationConfiguration } from "../../_types.mjs";
  * @import { TokenPlacementData } from "../../canvas/_types.mjs";
- * @import { ActorUpdatesDescription } from "../../data/chat-message/fields/_types.mjs";
+ * @import { ActorUpdatesDescription } from "../../documents/actor/_types.mjs";
  * @import { PseudoDocumentsMetadata } from "../mixins/_types.mjs";
  */
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -404,7 +404,7 @@ export default function ActivityMixin(Base) {
       const consumed = ActorDeltasField.getDeltas(this.actor, updates);
 
       // Update documents with consumption
-      this.actor.performBulkUpdate(updates);
+      await this.actor.performBulkUpdate(updates);
 
       return consumed;
     }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -404,12 +404,7 @@ export default function ActivityMixin(Base) {
       const consumed = ActorDeltasField.getDeltas(this.actor, updates);
 
       // Update documents with consumption
-      if ( !foundry.utils.isEmpty(updates.actor) ) await this.actor.update(updates.actor);
-      if ( !foundry.utils.isEmpty(updates.create) ) {
-        await this.actor.createEmbeddedDocuments("Item", updates.create, { keepId: true });
-      }
-      if ( !foundry.utils.isEmpty(updates.delete) ) await this.actor.deleteEmbeddedDocuments("Item", updates.delete);
-      if ( !foundry.utils.isEmpty(updates.item) ) await this.actor.updateEmbeddedDocuments("Item", updates.item);
+      this.actor.performBulkUpdate(updates);
 
       return consumed;
     }

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -520,22 +520,25 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
     delete placement.prototypeToken;
     const tokenDocument = await actor.getTokenDocument(foundry.utils.mergeObject(placement, tokenUpdates));
 
-    // Linked summons require more explicit updates before token creation.
-    // Unlinked summons can take actor delta directly.
+    // Linked summons require more explicit updates before token creation
     if ( tokenDocument.actorLink ) {
       const { effects, items, ...rest } = actorUpdates;
-      await tokenDocument.actor.update(rest);
-      await tokenDocument.actor.updateEmbeddedDocuments("Item", items);
-
       const { newEffects, oldEffects } = effects.reduce((acc, curr) => {
         const target = tokenDocument.actor.effects.get(curr._id) ? "oldEffects" : "newEffects";
         acc[target].push(curr);
         return acc;
       }, { newEffects: [], oldEffects: [] });
 
-      await tokenDocument.actor.updateEmbeddedDocuments("ActiveEffect", oldEffects);
-      await tokenDocument.actor.createEmbeddedDocuments("ActiveEffect", newEffects, { keepId: true });
-    } else {
+      await foundry.documents.modifyBatch([
+        { action: "update", documentName: "Actor", updates: [{ _id: tokenDocument.actor.id, ...rest }] },
+        { action: "update", documentName: "Item", updates: items, parent: tokenDocument.actor },
+        { action: "update", documentName: "ActiveEffect", updates: oldEffects, parent: tokenDocument.actor },
+        { action: "create", documentName: "ActiveEffect", data: newEffects, parent: tokenDocument.actor, keepId: true }
+      ]);
+    }
+
+    // Unlinked summons can take actor delta directly
+    else {
       tokenDocument.updateSource({ delta: actorUpdates });
       if ( actor.prototypeToken.appendNumber ) TokenPlacement.adjustAppendedNumber(tokenDocument, placement);
     }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2417,13 +2417,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      */
     if ( Hooks.call("dnd5e.preRestCompleted", this, result, config) === false ) return result;
 
-    // Perform updates
-    await this.performBulkUpdate(
-      { actor: result.updateData, delete: result.deleteItems, item: result.updateItems }, { isRest: true }
-    );
-
     // Expire active effects
     const expiryEvents = CONFIG.DND5E.restTypes[config.type ?? "long"]?.expiryEvents ?? [];
+    let operations = [];
     if ( expiryEvents.length ) {
       const expired = new Map();
       const expireEffect = effect => {
@@ -2441,10 +2437,15 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
           if ( effect.isAppliedEnchantment ) expireEffect(effect);
         }
       }
-      const operations = expired.entries()
-        .map(([parent, ids]) => ({ action: "delete", documentName: "ActiveEffect", ids, parent }));
-      await foundry.documents.modifyBatch(operations.toArray());
+      operations = expired.entries()
+        .map(([parent, ids]) => ({ action: "delete", documentName: "ActiveEffect", ids, parent }))
+        .toArray();
     }
+
+    // Perform updates
+    await this.performBulkUpdate(
+      { actor: result.updateData, delete: result.deleteItems, item: result.updateItems, operations }, { isRest: true }
+    );
 
     // Advance the game clock
     if ( config.advanceTime && (config.duration > 0) && game.user.isGM ) await game.time.advance(60 * config.duration);
@@ -3780,15 +3781,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   /**
    * Perform bulk updates on the actor and its embedded documents.
    * @param {ActorUpdatesDescription} updates
+   * @param {DatabaseUpdateOperation[]} [updates.operations=[]]    Additional database operations to perform.
    * @param {object} [options]                                     Options passed to all database operations.
-   * @param {Partial<DatabaseCreateOperation>} [createOptions={}]  Options passed to item creation operation.
-   *                                                               By default the `keepId` option is set to `true`.
-   * @param {Partial<DatabaseDeleteOperation>} [deleteOptions={}]  Options passed to item deletion operation.
-   * @param {Partial<DatabaseUpdateOperation>} [updateOptions={}]  Options passed to item update operation.
+   * @param {Partial<DatabaseCreateOperation>} [options.createOptions={}]  Options passed to item creation operation. By
+   *                                                                       default the `keepId` option is set to `true`.
+   * @param {Partial<DatabaseDeleteOperation>} [options.deleteOptions={}]  Options passed to item deletion operation.
+   * @param {Partial<DatabaseUpdateOperation>} [options.updateOptions={}]  Options passed to item update operation.
    * @returns {Promise<Document[][]>}
    */
-  performBulkUpdate(updates, { createOptions={}, deleteOptions={}, updateOptions={}, ...options }={}) {
-    const operations = [];
+  performBulkUpdate(
+    { operations=[], ...updates }, { createOptions={}, deleteOptions={}, updateOptions={}, ...options }={}
+  ) {
     if ( !foundry.utils.isEmpty(updates.actor) ) operations.push(this.parent
       ? {
         action: "update", documentName: "ActorDelta", parent: this.parent,

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -32,8 +32,9 @@ import ConditionData from "../../data/active-effect/condition.mjs";
  *   SkillToolRollDialogConfiguration, SkillToolRollProcessConfiguration
  * } from "../../dice/_types.mjs";
  * @import {
- *   ActorRollData, DamageAffectCategory, DamageApplicationOptions, DamageDescription, DamageSummary,
- *   RestConfiguration, RestResult, RollDataOptions, SpellcastingDescription
+ *   ActorRollData, ActorUpdatesDescription, DamageAffectCategory, DamageApplicationOptions,
+ *   DamageDescription, DamageSummary, RestConfiguration, RestResult, RollDataOptions,
+ *   SpellcastingDescription
  * } from "../_types.mjs";
  */
 
@@ -2417,9 +2418,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( Hooks.call("dnd5e.preRestCompleted", this, result, config) === false ) return result;
 
     // Perform updates
-    await this.update(result.updateData, { isRest: true });
-    await this.deleteEmbeddedDocuments("Item", result.deleteItems, { isRest: true });
-    await this.updateEmbeddedDocuments("Item", result.updateItems, { isRest: true });
+    await this.performBulkUpdate(
+      { actor: result.updateData, delete: result.deleteItems, item: result.updateItems }, { isRest: true }
+    );
 
     // Expire active effects
     const expiryEvents = CONFIG.DND5E.restTypes[config.type ?? "long"]?.expiryEvents ?? [];
@@ -3770,6 +3771,44 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
   static getDefaultArtwork(actorData={}) {
     const img = CONFIG.DND5E.defaultArtwork.Actor[actorData.type];
     return img ? { img, texture: { src: img } } : super.getDefaultArtwork(actorData);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Perform bulk updates on the actor and its embedded documents.
+   * @param {ActorUpdatesDescription} updates
+   * @param {object} [options]                                     Options passed to all database operations.
+   * @param {Partial<DatabaseCreateOperation>} [createOptions={}]  Options passed to item creation operation.
+   *                                                               By default the `keepId` option is set to `true`.
+   * @param {Partial<DatabaseDeleteOperation>} [deleteOptions={}]  Options passed to item deletion operation.
+   * @param {Partial<DatabaseUpdateOperation>} [updateOptions={}]  Options passed to item update operation.
+   * @returns {Promise<Document[][]>}
+   */
+  performBulkUpdate(updates, { createOptions={}, deleteOptions={}, updateOptions={}, ...options }={}) {
+    const operations = [];
+    if ( !foundry.utils.isEmpty(updates.actor) ) operations.push(this.parent
+      ? {
+        action: "update", documentName: "ActorDelta", parent: this.parent,
+        updates: [{ _id: this.parent.delta.id, ...updates.actor }], ...options
+      }
+      : { action: "update", documentName: "Actor", updates: [{ _id: this.id, ...updates.actor }], ...options }
+    );
+    if ( !foundry.utils.isEmpty(updates.create) ) operations.push({
+      action: "create", documentName: "Item", data: updates.create, parent: this, keepId: true,
+      ...options, ...createOptions
+    });
+    if ( !foundry.utils.isEmpty(updates.delete) ) operations.push({
+      action: "delete", documentName: "Item", ids: updates.delete, parent: this,
+      ...options, ...updateOptions
+    });
+    if ( !foundry.utils.isEmpty(updates.item) ) operations.push({
+      action: "update", documentName: "Item", updates: updates.item, parent: this,
+      ...options, ...deleteOptions
+    });
+    return foundry.documents.modifyBatch(operations);
   }
 }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3805,11 +3805,11 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     });
     if ( !foundry.utils.isEmpty(updates.delete) ) operations.push({
       action: "delete", documentName: "Item", ids: updates.delete, parent: this,
-      ...options, ...updateOptions
+      ...options, ...deleteOptions
     });
     if ( !foundry.utils.isEmpty(updates.item) ) operations.push({
       action: "update", documentName: "Item", updates: updates.item, parent: this,
-      ...options, ...deleteOptions
+      ...options, ...updateOptions
     });
     return foundry.documents.modifyBatch(operations);
   }

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -148,9 +148,7 @@ export default class Combatant5e extends Combatant {
 
     const deltas = ActorDeltasField.getDeltas(this.actor, results);
 
-    if ( !foundry.utils.isEmpty(results.actor) ) await this.actor.update(results.actor);
-    if ( results.delete.length ) await this.actor.deleteEmbeddedDocuments("Item", results.delete);
-    if ( results.item.length ) await this.actor.updateEmbeddedDocuments("Item", results.item);
+    await this.actor.performBulkUpdate(results);
 
     const message = await this.createTurnMessage({ deltas, periods, rolls: results.rolls });
 


### PR DESCRIPTION
Start using `foundry.documents.modifyBatch` in several places in the system where mulitple update operations are handled including:

- Advancement application
- Enchantment rider creation
- Activity consumption/recovery
- Actor rests
- Linked summoning changes
- Combatant recovery

In order to simplify the common pattern of updating actors as well as their embedded items and to resolve issues with those updates on synthetic actors, a new `performBulkUpdate` method was added that takes `ActorUpdatesDescription` and transforms it into the needed `DatbaseOperation`s.

One place that this doesn't modify is `Actor#transformInto` on unlinked actors since there is currently some special handling to deal with tombstoning items. If that extra work is no longer required due to core changes we should be able to make that change.