### PR TITLE
[#1943, #2907] Reset actor state when copying items to the sidebar

### DIFF
--- a/module/applications/item/item-directory.mjs
+++ b/module/applications/item/item-directory.mjs
@@ -58,7 +58,7 @@ export default class ItemDirectory5e extends DragDropApplicationMixin(foundry.ap
     // Create item and its contents if it doesn't already exist here
     if ( (behavior === "copy") || !this._entryAlreadyExists(item) ) {
       const toCreate = await Item5e.createWithContents([item]);
-      toCreate.forEach(d => Item5e.resetActorContextData(d));
+      toCreate.forEach(d => CONFIG.Item.dataModels[d.type]?.resetActorContextData?.(d.system));
       const folder = target?.closest("[data-folder-id]")?.dataset.folderId;
       if ( folder ) toCreate.map(d => d.folder = folder);
       [item] = await Item5e.createDocuments(toCreate, {keepId: true});

--- a/module/applications/item/item-directory.mjs
+++ b/module/applications/item/item-directory.mjs
@@ -58,6 +58,7 @@ export default class ItemDirectory5e extends DragDropApplicationMixin(foundry.ap
     // Create item and its contents if it doesn't already exist here
     if ( (behavior === "copy") || !this._entryAlreadyExists(item) ) {
       const toCreate = await Item5e.createWithContents([item]);
+      toCreate.forEach(d => Item5e.resetActorContextData(d));
       const folder = target?.closest("[data-folder-id]")?.dataset.folderId;
       if ( folder ) toCreate.map(d => d.folder = folder);
       [item] = await Item5e.createDocuments(toCreate, {keepId: true});

--- a/module/applications/item/item-directory.mjs
+++ b/module/applications/item/item-directory.mjs
@@ -58,7 +58,7 @@ export default class ItemDirectory5e extends DragDropApplicationMixin(foundry.ap
     // Create item and its contents if it doesn't already exist here
     if ( (behavior === "copy") || !this._entryAlreadyExists(item) ) {
       const toCreate = await Item5e.createWithContents([item]);
-      toCreate.forEach(d => CONFIG.Item.dataModels[d.type]?.resetActorContextData?.(d.system));
+      toCreate.forEach(d => CONFIG.Item.dataModels[d.type]?.resetData?.(d.system));
       const folder = target?.closest("[data-folder-id]")?.dataset.folderId;
       if ( folder ) toCreate.map(d => d.folder = folder);
       [item] = await Item5e.createDocuments(toCreate, {keepId: true});

--- a/module/data/abstract/system-data-model.mjs
+++ b/module/data/abstract/system-data-model.mjs
@@ -68,7 +68,7 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
    */
   static _immiscible = new Set(["length", "mixed", "name", "prototype", "cleanData", "_cleanData",
     "_initializationOrder", "validateJoint", "_validateJoint", "migrateData", "_migrateData",
-    "shimData", "_shimData", "defineSchema"]);
+    "shimData", "_shimData", "defineSchema", "resetActorContextData", "_resetActorContextData"]);
 
   /* -------------------------------------------- */
 
@@ -253,6 +253,33 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
   static _migrateData(source) {
     for ( const template of this._schemaTemplates ) {
       template._migrateData(source);
+    }
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Copying                                */
+  /* -------------------------------------------- */
+
+  /**
+   * Reset actor-specific state on source data copied out of an actor (e.g. dropped to the items sidebar).
+   * @param {object} source  The source data, modified in place.
+   * @returns {object}       The cleaned source data.
+   */
+  static resetActorContextData(source) {
+    this._resetActorContextData(source);
+    return source;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Reset actor-specific state across the type's templates.
+   * @param {object} source  The source data, modified in place.
+   * @protected
+   */
+  static _resetActorContextData(source) {
+    for ( const template of this._schemaTemplates ) {
+      template._resetActorContextData(source);
     }
   }
 

--- a/module/data/abstract/system-data-model.mjs
+++ b/module/data/abstract/system-data-model.mjs
@@ -68,7 +68,7 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
    */
   static _immiscible = new Set(["length", "mixed", "name", "prototype", "cleanData", "_cleanData",
     "_initializationOrder", "validateJoint", "_validateJoint", "migrateData", "_migrateData",
-    "shimData", "_shimData", "defineSchema", "resetActorContextData", "_resetActorContextData"]);
+    "shimData", "_shimData", "defineSchema", "resetData", "_resetData"]);
 
   /* -------------------------------------------- */
 
@@ -257,33 +257,6 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
   }
 
   /* -------------------------------------------- */
-  /*  Data Copying                                */
-  /* -------------------------------------------- */
-
-  /**
-   * Reset actor-specific state on source data copied out of an actor (e.g. dropped to the items sidebar).
-   * @param {object} source  The source data, modified in place.
-   * @returns {object}       The cleaned source data.
-   */
-  static resetActorContextData(source) {
-    this._resetActorContextData(source);
-    return source;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Reset actor-specific state across the type's templates.
-   * @param {object} source  The source data, modified in place.
-   * @protected
-   */
-  static _resetActorContextData(source) {
-    for ( const template of this._schemaTemplates ) {
-      template._resetActorContextData(source);
-    }
-  }
-
-  /* -------------------------------------------- */
 
   /** @inheritDoc */
   static shimData(data, options) {
@@ -302,6 +275,31 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
   static _shimData(data, options) {
     for ( const template of this._schemaTemplates ) {
       template._shimData(data, options);
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Reset user-modified state.
+   * @param {object} source  The source data, modified in place.
+   * @returns {object}       The cleaned source data.
+   */
+  static resetData(source) {
+    this._resetData(source);
+    return source;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Reset user-modified state across the type's templates.
+   * @param {object} source  The source data, modified in place.
+   * @protected
+   */
+  static _resetData(source) {
+    for ( const template of this._schemaTemplates ) {
+      template._resetData(source);
     }
   }
 

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -194,12 +194,10 @@ export default class ClassData extends ItemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
-  /*  Data Copying                                */
-  /* -------------------------------------------- */
 
   /** @inheritDoc */
-  static _resetActorContextData(source) {
-    super._resetActorContextData(source);
+  static _resetData(source) {
+    super._resetData(source);
     delete source.levels;
     delete source.hd?.spent;
   }

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -194,6 +194,17 @@ export default class ClassData extends ItemDataModel.mixin(
   }
 
   /* -------------------------------------------- */
+  /*  Data Copying                                */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static _resetActorContextData(source) {
+    super._resetActorContextData(source);
+    delete source.levels;
+    delete source.hd?.spent;
+  }
+
+  /* -------------------------------------------- */
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 

--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -110,6 +110,22 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
   }
 
   /* -------------------------------------------- */
+
+  static _resetData(source) {
+    super._resetData(source);
+    delete source.building;
+    delete source.craft;
+    delete source.defenders?.value;
+    delete source.disabled;
+    delete source.hirelings?.value;
+    delete source.progress;
+    delete source.trade?.creatures?.value;
+    delete source.trade?.pending;
+    delete source.trade?.stock?.stocked;
+    delete source.trade?.stocked?.value;
+  }
+
+  /* -------------------------------------------- */
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -433,6 +433,16 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   }
 
   /* -------------------------------------------- */
+  /*  Data Copying                                */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static _resetActorContextData(source) {
+    super._resetActorContextData(source);
+    delete source.preparation?.prepared;
+  }
+
+  /* -------------------------------------------- */
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -433,13 +433,11 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   }
 
   /* -------------------------------------------- */
-  /*  Data Copying                                */
-  /* -------------------------------------------- */
 
   /** @inheritDoc */
-  static _resetActorContextData(source) {
-    super._resetActorContextData(source);
-    delete source.preparation?.prepared;
+  static _resetData(source) {
+    super._resetData(source);
+    delete source.prepared;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -300,12 +300,10 @@ export default class ActivitiesTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
-  /*  Data Copying                                */
-  /* -------------------------------------------- */
 
   /** @inheritDoc */
-  static _resetActorContextData(source) {
-    super._resetActorContextData(source);
+  static _resetData(source) {
+    super._resetData(source);
     delete source.uses?.spent;
     for ( const activity of Object.values(source.activities ?? {}) ) delete activity.uses?.spent;
   }

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -300,6 +300,17 @@ export default class ActivitiesTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Data Copying                                */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static _resetActorContextData(source) {
+    super._resetActorContextData(source);
+    delete source.uses?.spent;
+    for ( const activity of Object.values(source.activities ?? {}) ) delete activity.uses?.spent;
+  }
+
+  /* -------------------------------------------- */
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 

--- a/module/data/item/templates/advancement.mjs
+++ b/module/data/item/templates/advancement.mjs
@@ -46,6 +46,16 @@ export default class AdvancementTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Data Copying                                */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static _resetActorContextData(source) {
+    super._resetActorContextData(source);
+    for ( const advancement of Object.values(source.advancement ?? {}) ) delete advancement.value;
+  }
+
+  /* -------------------------------------------- */
   /*  Socket Event Handlers                       */
   /* -------------------------------------------- */
 

--- a/module/data/item/templates/advancement.mjs
+++ b/module/data/item/templates/advancement.mjs
@@ -46,12 +46,10 @@ export default class AdvancementTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
-  /*  Data Copying                                */
-  /* -------------------------------------------- */
 
   /** @inheritDoc */
-  static _resetActorContextData(source) {
-    super._resetActorContextData(source);
+  static _resetData(source) {
+    super._resetData(source);
     for ( const advancement of Object.values(source.advancement ?? {}) ) delete advancement.value;
   }
 

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -117,12 +117,10 @@ export default class EquippableItemTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
-  /*  Data Copying                                */
-  /* -------------------------------------------- */
 
   /** @inheritDoc */
-  static _resetActorContextData(source) {
-    super._resetActorContextData(source);
+  static _resetData(source) {
+    super._resetData(source);
     delete source.equipped;
     delete source.attuned;
   }

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -117,6 +117,17 @@ export default class EquippableItemTemplate extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Data Copying                                */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static _resetActorContextData(source) {
+    super._resetActorContextData(source);
+    delete source.equipped;
+    delete source.attuned;
+  }
+
+  /* -------------------------------------------- */
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1313,7 +1313,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       if ( newItemData instanceof Item ) newItemData = game.items.fromCompendium(newItemData, {
         clearSort: false, keepId: true, clearOwnership: false
       });
-      foundry.utils.mergeObject(newItemData, {"system.container": containerId} );
+      foundry.utils.mergeObject(newItemData, {"system.container": containerId ?? null} );
       if ( !keepId ) newItemData._id = foundry.utils.randomID();
 
       created.push(newItemData);
@@ -1327,6 +1327,25 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const created = [];
     for ( const item of items ) await createItemData(item, container?.id, initialDepth);
     return created;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Reset actor-specific state on item data copied out of an actor.
+   * @param {object} data  Item source data to clean in place.
+   * @returns {object}     The cleaned data.
+   */
+  static resetActorContextData(data) {
+    const system = data.system ?? {};
+    foundry.utils.mergeObject(system, {
+      equipped: false, attuned: false, levels: 1, hd: { spent: 0 }, uses: { spent: 0 }, preparation: { prepared: 0 }
+    }, { insertKeys: false, insertValues: false });
+    for ( const activity of Object.values(system.activities ?? {}) ) {
+      if ( activity.uses ) activity.uses.spent = 0;
+    }
+    for ( const advancement of Object.values(system.advancement ?? {}) ) advancement.value = {};
+    return data;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1313,7 +1313,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       if ( newItemData instanceof Item ) newItemData = game.items.fromCompendium(newItemData, {
         clearSort: false, keepId: true, clearOwnership: false
       });
-      foundry.utils.mergeObject(newItemData, {"system.container": containerId ?? null} );
+      foundry.utils.mergeObject(newItemData, { "system.container": containerId ?? null } );
       if ( !keepId ) newItemData._id = foundry.utils.randomID();
 
       created.push(newItemData);
@@ -1327,25 +1327,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const created = [];
     for ( const item of items ) await createItemData(item, container?.id, initialDepth);
     return created;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Reset actor-specific state on item data copied out of an actor.
-   * @param {object} data  Item source data to clean in place.
-   * @returns {object}     The cleaned data.
-   */
-  static resetActorContextData(data) {
-    const system = data.system ?? {};
-    foundry.utils.mergeObject(system, {
-      equipped: false, attuned: false, levels: 1, hd: { spent: 0 }, uses: { spent: 0 }, preparation: { prepared: 0 }
-    }, { insertKeys: false, insertValues: false });
-    for ( const activity of Object.values(system.activities ?? {}) ) {
-      if ( activity.uses ) activity.uses.spent = 0;
-    }
-    for ( const advancement of Object.values(system.advancement ?? {}) ) advancement.value = {};
-    return data;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
- Clear equipped, attuned, and spent uses
- Reset class levels, hit dice spent, and applied advancement values
- Reset spell preparation and orphaned container references

Closes #2907, Closes #1943