### PR TITLE
[#7079] Allow selecting attack ability in roll dialog

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1128,6 +1128,9 @@
   "FIELDS": {
     "attack": {
       "label": "Attack Details",
+      "abilities": {
+        "label": "Ability Options"
+      },
       "ability": {
         "label": "Attack Ability",
         "hint": "Ability used for make the attack and determine damage. Available using @mod in formulas."

--- a/module/applications/activity/attack-sheet.mjs
+++ b/module/applications/activity/attack-sheet.mjs
@@ -69,7 +69,7 @@ export default class AttackSheet extends ActivitySheet {
 
   /* -------------------------------------------- */
 
-/** @inheritDoc */
+  /** @inheritDoc */
   async _prepareIdentityContext(context, options) {
     context = await super._prepareIdentityContext(context, options);
 

--- a/module/applications/activity/attack-sheet.mjs
+++ b/module/applications/activity/attack-sheet.mjs
@@ -45,7 +45,7 @@ export default class AttackSheet extends ActivitySheet {
     const availableAbilities = this.activity.availableAbilities;
     context.abilityOptions = [
       {
-        value: "default", label: _loc("DND5E.DefaultSpecific", {
+        value: "", label: _loc("DND5E.DefaultSpecific", {
           default: this.activity.attack.type.classification === "spell"
             ? _loc("DND5E.Spellcasting").toLowerCase()
             : availableAbilities.size
@@ -53,7 +53,7 @@ export default class AttackSheet extends ActivitySheet {
                 Array.from(availableAbilities).map(a => CONFIG.DND5E.abilities[a].label.toLowerCase())
               )
               : _loc("DND5E.None").toLowerCase()
-        })
+        }), rule: true
       },
       { value: "none", label: _loc("DND5E.None") },
       { value: "spellcasting", label: _loc("DND5E.Spellcasting") },

--- a/module/applications/activity/attack-sheet.mjs
+++ b/module/applications/activity/attack-sheet.mjs
@@ -69,17 +69,7 @@ export default class AttackSheet extends ActivitySheet {
 
   /* -------------------------------------------- */
 
-  /** @inheritDoc */
-  _prepareSubmitData(event, formData) {
-    const submitData = super._prepareSubmitData(event, formData);
-    const ability = submitData.attack?.ability;
-    if ( ability ) submitData.attack.ability = Array.from(new Set([ability].flat().filter(a => a)));
-    return submitData;
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
+/** @inheritDoc */
   async _prepareIdentityContext(context, options) {
     context = await super._prepareIdentityContext(context, options);
 

--- a/module/applications/activity/attack-sheet.mjs
+++ b/module/applications/activity/attack-sheet.mjs
@@ -45,7 +45,7 @@ export default class AttackSheet extends ActivitySheet {
     const availableAbilities = this.activity.availableAbilities;
     context.abilityOptions = [
       {
-        value: "", label: _loc("DND5E.DefaultSpecific", {
+        value: "default", label: _loc("DND5E.DefaultSpecific", {
           default: this.activity.attack.type.classification === "spell"
             ? _loc("DND5E.Spellcasting").toLowerCase()
             : availableAbilities.size
@@ -55,7 +55,6 @@ export default class AttackSheet extends ActivitySheet {
               : _loc("DND5E.None").toLowerCase()
         })
       },
-      { rule: true },
       { value: "none", label: _loc("DND5E.None") },
       { value: "spellcasting", label: _loc("DND5E.Spellcasting") },
       ...Object.entries(CONFIG.DND5E.abilities).map(([value, config]) => ({
@@ -66,6 +65,16 @@ export default class AttackSheet extends ActivitySheet {
     context.hasBaseDamage = this.item.system.offersBaseDamage;
 
     return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _prepareSubmitData(event, formData) {
+    const submitData = super._prepareSubmitData(event, formData);
+    const ability = submitData.attack?.ability;
+    if ( ability ) submitData.attack.ability = Array.from(new Set([ability].flat().filter(a => a)));
+    return submitData;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/dice/attack-configuration-dialog.mjs
+++ b/module/applications/dice/attack-configuration-dialog.mjs
@@ -12,6 +12,7 @@ export default class AttackRollConfigurationDialog extends D20RollConfigurationD
   /** @override */
   static DEFAULT_OPTIONS = {
     ammunitionOptions: [],
+    abilityOptions: [],
     attackModeOptions: [],
     masteryOptions: []
   };
@@ -23,7 +24,9 @@ export default class AttackRollConfigurationDialog extends D20RollConfigurationD
   /** @inheritDoc */
   async _prepareConfigurationContext(context, options) {
     context = await super._prepareConfigurationContext(context, options);
+    const abilityOptions = this.config.abilityOptions?.length > 1 ? this.config.abilityOptions : [];
     const optionsFields = [
+      { key: "ability", label: "DND5E.Ability", options: abilityOptions },
       { key: "attackMode", label: "DND5E.ATTACK.Mode.Label", options: this.options.attackModeOptions },
       { key: "ammunition", label: "DND5E.CONSUMABLE.Type.Ammunition.Label", options: this.options.ammunitionOptions },
       { key: "mastery", label: "DND5E.WEAPON.Mastery.Label", options: this.options.masteryOptions }

--- a/module/applications/dice/attack-configuration-dialog.mjs
+++ b/module/applications/dice/attack-configuration-dialog.mjs
@@ -11,8 +11,8 @@ import D20RollConfigurationDialog from "./d20-configuration-dialog.mjs";
 export default class AttackRollConfigurationDialog extends D20RollConfigurationDialog {
   /** @override */
   static DEFAULT_OPTIONS = {
-    ammunitionOptions: [],
     abilityOptions: [],
+    ammunitionOptions: [],
     attackModeOptions: [],
     masteryOptions: []
   };

--- a/module/applications/dice/attack-configuration-dialog.mjs
+++ b/module/applications/dice/attack-configuration-dialog.mjs
@@ -24,7 +24,7 @@ export default class AttackRollConfigurationDialog extends D20RollConfigurationD
   /** @inheritDoc */
   async _prepareConfigurationContext(context, options) {
     context = await super._prepareConfigurationContext(context, options);
-    const abilityOptions = this.config.abilityOptions?.length > 1 ? this.config.abilityOptions : [];
+    const abilityOptions = this.options.abilityOptions?.length > 1 ? this.options.abilityOptions : [];
     const optionsFields = [
       { key: "ability", label: "DND5E.Ability", options: abilityOptions },
       { key: "attackMode", label: "DND5E.ATTACK.Mode.Label", options: this.options.attackModeOptions },

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -87,36 +87,8 @@ export default class EnchantmentData extends ActiveEffectDataModel {
     switch ( change.key ) {
       case "system.ability":
         for ( const activity of item.system.activities?.getByTypes("attack") ?? [] ) {
-          const useDefault = (change.type === "add") && !activity.attack.ability.size;
-          let abilities;
-          if ( useDefault ) {
-            const added = [];
-            const removed = [];
-            for ( const value of [change.value].flat().filter(a => a) ) {
-              const neg = value.replace(/^\s*-\s*/, "");
-              if ( neg === value ) added.push(value);
-              else removed.push(neg);
-            }
-            abilities = removed.length ? Array.from(activity.availableAbilities) : ["default"];
-            abilities.push(...added);
-            abilities = abilities.filter(a => !removed.includes(a));
-            for ( const ability of abilities ) activity.attack.ability.add(ability);
-          }
-          else if ( change.type === "subtract" ) {
-            const values = new Set(activity.attack.ability.size ? activity.attack.ability : activity.availableAbilities);
-            if ( values.delete("default") ) {
-              for ( const ability of activity.availableAbilities ) values.add(ability);
-            }
-            for ( const ability of [change.value].flat().filter(a => a) ) values.delete(ability);
-            activity.attack.ability.clear();
-            for ( const ability of values ) activity.attack.ability.add(ability);
-            abilities = Array.from(values);
-          }
-          else {
-            const ability = applyField(activity, { ...change, key: "attack.ability" });
-            abilities = foundry.utils.getType(ability) === "string" ? ability ? [ability] : [] : ability;
-          }
-          changes[`system.activities.${activity.id}.attack.ability`] = abilities;
+          const field = change.type === "override" ? "attack.ability" : "attack.abilities";
+          changes[`system.activities.${activity.id}.${field}`] = applyField(activity, { ...change, key: field });
         }
         return false;
       case "system.attack.bonus":

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -87,9 +87,10 @@ export default class EnchantmentData extends ActiveEffectDataModel {
     switch ( change.key ) {
       case "system.ability":
         for ( const activity of item.system.activities?.getByTypes("attack") ?? [] ) {
-          changes[`system.activities.${activity.id}.attack.ability`] = applyField(
-            activity, { ...change, key: "attack.ability" }
-          );
+          const ability = applyField(activity, { ...change, key: "attack.ability" });
+          changes[`system.activities.${activity.id}.attack.ability`] = foundry.utils.getType(ability) === "string"
+            ? ability ? [ability] : []
+            : ability;
         }
         return false;
       case "system.attack.bonus":

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -87,8 +87,9 @@ export default class EnchantmentData extends ActiveEffectDataModel {
     switch ( change.key ) {
       case "system.ability":
         for ( const activity of item.system.activities?.getByTypes("attack") ?? [] ) {
-          const field = change.type === "override" ? "attack.ability" : "attack.abilities";
-          changes[`system.activities.${activity.id}.${field}`] = applyField(activity, { ...change, key: field });
+          changes[`system.activities.${activity.id}.attack.abilities`] = applyField(
+            activity, { ...change, key: "attack.abilities" }
+          );
         }
         return false;
       case "system.attack.bonus":

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -87,10 +87,36 @@ export default class EnchantmentData extends ActiveEffectDataModel {
     switch ( change.key ) {
       case "system.ability":
         for ( const activity of item.system.activities?.getByTypes("attack") ?? [] ) {
-          const ability = applyField(activity, { ...change, key: "attack.ability" });
-          changes[`system.activities.${activity.id}.attack.ability`] = foundry.utils.getType(ability) === "string"
-            ? ability ? [ability] : []
-            : ability;
+          const useDefault = (change.type === "add") && !activity.attack.ability.size;
+          let abilities;
+          if ( useDefault ) {
+            const added = [];
+            const removed = [];
+            for ( const value of [change.value].flat().filter(a => a) ) {
+              const neg = value.replace(/^\s*-\s*/, "");
+              if ( neg === value ) added.push(value);
+              else removed.push(neg);
+            }
+            abilities = removed.length ? Array.from(activity.availableAbilities) : ["default"];
+            abilities.push(...added);
+            abilities = abilities.filter(a => !removed.includes(a));
+            for ( const ability of abilities ) activity.attack.ability.add(ability);
+          }
+          else if ( change.type === "subtract" ) {
+            const values = new Set(activity.attack.ability.size ? activity.attack.ability : activity.availableAbilities);
+            if ( values.delete("default") ) {
+              for ( const ability of activity.availableAbilities ) values.add(ability);
+            }
+            for ( const ability of [change.value].flat().filter(a => a) ) values.delete(ability);
+            activity.attack.ability.clear();
+            for ( const ability of values ) activity.attack.ability.add(ability);
+            abilities = Array.from(values);
+          }
+          else {
+            const ability = applyField(activity, { ...change, key: "attack.ability" });
+            abilities = foundry.utils.getType(ability) === "string" ? ability ? [ability] : [] : ability;
+          }
+          changes[`system.activities.${activity.id}.attack.ability`] = abilities;
         }
         return false;
       case "system.attack.bonus":

--- a/module/data/activity/_types.mjs
+++ b/module/data/activity/_types.mjs
@@ -51,7 +51,7 @@
 /**
  * @typedef {ActivityData} AttackActivityData
  * @property {object} attack
- * @property {Set<string>} attack.ability         Abilities used to make the attack and determine damage.
+ * @property {string} attack.ability              Ability used to make the attack and determine damage.
  * @property {string} attack.bonus                Arbitrary bonus added to the attack.
  * @property {object} attack.critical
  * @property {number} attack.critical.threshold   Minimum value on the D20 needed to roll a critical hit.

--- a/module/data/activity/_types.mjs
+++ b/module/data/activity/_types.mjs
@@ -51,7 +51,7 @@
 /**
  * @typedef {ActivityData} AttackActivityData
  * @property {object} attack
- * @property {string} attack.ability              Ability used to make the attack and determine damage.
+ * @property {Set<string>} attack.ability         Abilities used to make the attack and determine damage.
  * @property {string} attack.bonus                Arbitrary bonus added to the attack.
  * @property {object} attack.critical
  * @property {number} attack.critical.threshold   Minimum value on the D20 needed to roll a critical hit.

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -278,9 +278,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
    */
   getAttackData({ ammunition, ability, attackMode, situational }={}) {
     const rollData = this.getRollData({ ability, roll: { attackMode } });
-    if ( ability && (ability in CONFIG.DND5E.abilities) ) {
-      rollData.roll.ability = ability;
-    }
+    if ( ability && (ability in CONFIG.DND5E.abilities) ) rollData.roll.ability = ability;
     if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);
 
     const weapon = this.item.system;

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -163,7 +163,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
     return this.item.system.validAttackTypes ?? new Set();
   }
 
-/* -------------------------------------------- */
+  /* -------------------------------------------- */
 
   /** @override */
   static transformTypeData(source, activityData, options) {
@@ -206,6 +206,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
   /** @inheritDoc */
   prepareData() {
+    this.#abilities = undefined;
     super.prepareData();
     this.attack.type.value ||= this.item.system.attackType ?? "melee";
     this.attack.type.classification ||= this.item.system.attackClassification ?? "weapon";

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -5,7 +5,7 @@ import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
-const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { AttackDamageRollProcessConfiguration } from "../../dice/_types.mjs";
@@ -23,7 +23,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
     return {
       ...super.defineSchema(),
       attack: new SchemaField({
-        ability: new StringField(),
+        ability: new SetField(new StringField()),
         bonus: new FormulaField(),
         critical: new SchemaField({
           threshold: new NumberField({ integer: true, positive: true })
@@ -50,17 +50,37 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
   /** @override */
   get ability() {
-    if ( this.attack.ability === "none" ) return null;
-    if ( this.attack.ability === "spellcasting" ) return this.spellcastingAbility;
-    if ( this.attack.ability in CONFIG.DND5E.abilities ) return this.attack.ability;
+    const configuredAbilities = this.abilities;
+    if ( (configuredAbilities.size === 1) && configuredAbilities.has("none") ) return null;
+    if ( configuredAbilities.size === 1 ) return configuredAbilities.first();
 
-    const availableAbilities = this.availableAbilities;
+    const availableAbilities = configuredAbilities.size ? configuredAbilities : new Set(this.availableAbilities);
+    availableAbilities.delete("none");
     if ( !availableAbilities?.size ) return null;
     if ( availableAbilities?.size === 1 ) return availableAbilities.first();
     const abilities = this.actor?.system.abilities ?? {};
     return availableAbilities.reduce((largest, ability) =>
       (abilities[ability]?.mod ?? -Infinity) > (abilities[largest]?.mod ?? -Infinity) ? ability : largest
     , availableAbilities.first());
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Configured abilities that can be used with this attack.
+   * @type {Set<string>}
+   */
+  get abilities() {
+    const values = foundry.utils.getType(this.attack.ability) === "string"
+      ? [this.attack.ability]
+      : this.attack.ability;
+    const abilities = new Set(values);
+    abilities.delete("");
+    if ( abilities.delete("default") ) {
+      for ( const ability of this.availableAbilities ) abilities.add(ability);
+    }
+    if ( abilities.delete("spellcasting") && this.spellcastingAbility ) abilities.add(this.spellcastingAbility);
+    return abilities;
   }
 
   /* -------------------------------------------- */
@@ -149,6 +169,18 @@ export default class BaseAttackActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @override */
+  static migrateData(source) {
+    super.migrateData(source);
+    if ( foundry.utils.getType(source.attack?.ability) === "string" ) {
+      if ( source.attack.ability ) source.attack.ability = [source.attack.ability];
+      else source.attack.ability = [];
+    }
+    return source;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   static transformTypeData(source, activityData, options) {
     // For weapons and ammunition, separate the first part from the rest to be used as the base damage and keep the rest
     let damageParts = source.system.damage?.parts ?? [];
@@ -162,7 +194,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
     return foundry.utils.mergeObject(activityData, {
       attack: {
-        ability: source.system.ability ?? "",
+        ability: source.system.ability ? [source.system.ability] : [],
         bonus: source.system.attack?.bonus ?? "",
         critical: {
           threshold: source.system.critical?.threshold
@@ -269,7 +301,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
     const weapon = this.item.system;
     const ammo = this.actor?.items.get(ammunition)?.system;
     const { parts, data } = CONFIG.Dice.BasicRoll.constructParts({
-      mod: this.attack.ability !== "none" ? rollData.mod : null,
+      mod: ability !== "none" ? rollData.mod : null,
       prof: weapon.prof?.term,
       bonus: this.attack.bonus,
       weaponMagic: weapon.magicAvailable ? weapon.magicalBonus : null,

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -5,7 +5,7 @@ import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
-const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
  * @import { AttackDamageRollProcessConfiguration } from "../../dice/_types.mjs";
@@ -18,12 +18,13 @@ const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringFiel
  * @mixes AttackActivityData
  */
 export default class BaseAttackActivityData extends BaseActivityData {
+  #abilities;
   /** @inheritDoc */
   static defineSchema() {
     return {
       ...super.defineSchema(),
       attack: new SchemaField({
-        ability: new SetField(new StringField()),
+        ability: new StringField(),
         bonus: new FormulaField(),
         critical: new SchemaField({
           threshold: new NumberField({ integer: true, positive: true })
@@ -71,10 +72,8 @@ export default class BaseAttackActivityData extends BaseActivityData {
    * @type {Set<string>}
    */
   get abilities() {
-    const values = foundry.utils.getType(this.attack.ability) === "string"
-      ? [this.attack.ability]
-      : this.attack.ability;
-    const abilities = new Set(values);
+    if ( this.#abilities ) return this.#abilities;
+    const abilities = this.#abilities = new Set([this.attack.ability]);
     abilities.delete("");
     if ( abilities.delete("default") ) {
       for ( const ability of this.availableAbilities ) abilities.add(ability);
@@ -164,21 +163,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
     return this.item.system.validAttackTypes ?? new Set();
   }
 
-  /* -------------------------------------------- */
-  /*  Data Migration                              */
-  /* -------------------------------------------- */
-
-  /** @override */
-  static migrateData(source) {
-    super.migrateData(source);
-    if ( foundry.utils.getType(source.attack?.ability) === "string" ) {
-      if ( source.attack.ability ) source.attack.ability = [source.attack.ability];
-      else source.attack.ability = [];
-    }
-    return source;
-  }
-
-  /* -------------------------------------------- */
+/* -------------------------------------------- */
 
   /** @override */
   static transformTypeData(source, activityData, options) {
@@ -194,7 +179,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
     return foundry.utils.mergeObject(activityData, {
       attack: {
-        ability: source.system.ability ? [source.system.ability] : [],
+        ability: source.system.ability ?? "",
         bonus: source.system.attack?.bonus ?? "",
         critical: {
           threshold: source.system.critical?.threshold

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -276,10 +276,9 @@ export default class BaseAttackActivityData extends BaseActivityData {
    * @returns {{ data: object, parts: string[] }}
    */
   getAttackData({ ammunition, ability, attackMode, situational }={}) {
-    const rollData = this.getRollData({ roll: { attackMode } });
+    const rollData = this.getRollData({ ability, roll: { attackMode } });
     if ( ability && (ability in CONFIG.DND5E.abilities) ) {
       rollData.roll.ability = ability;
-      rollData.mod = this.actor?.system.abilities?.[ability]?.mod ?? 0;
     }
     if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);
 
@@ -310,15 +309,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
    * @returns {AttackDamageRollProcessConfiguration}
    */
   getDamageConfig(config={}, options={}) {
-    const ability = config.ability;
-    let { rollData } = options;
-    rollData ??= ability !== undefined ? this.getRollData({ roll: { attackMode: config.attackMode } }) : null;
-    if ( rollData ) {
-      rollData.roll ??= {};
-      rollData.roll.ability = ability;
-      rollData.mod = ability in CONFIG.DND5E.abilities ? this.actor?.system.abilities?.[ability]?.mod ?? 0 : null;
-    }
-    const rollConfig = super.getDamageConfig(config, { ...options, rollData });
+    const rollConfig = super.getDamageConfig(config, options);
 
     // Copy properties from selected ammunition
     const ammo = config.ammunition?.system;

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -1,5 +1,4 @@
 import simplifyRollFormula from "../../dice/simplify-roll-formula.mjs";
-import AppliedRules from "../../documents/applied-rules.mjs";
 import { convertLength, formatLength, formatNumber, simplifyBonus } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import D20RollModificationField from "../shared/d20-roll-modification-field.mjs";
@@ -9,7 +8,6 @@ import BaseActivityData from "./base-activity.mjs";
 const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
- * @import { AttackDamageRollProcessConfiguration } from "../../dice/_types.mjs";
  * @import { AttackActivityData } from "./_types.mjs";
  */
 
@@ -192,11 +190,8 @@ export default class BaseAttackActivityData extends BaseActivityData {
     this.attack.type.value ||= this.item.system.attackType ?? "melee";
     this.attack.type.classification ||= this.item.system.attackClassification ?? "weapon";
 
-    if ( this.attack.ability === "spellcasting" ) {
-      this.attack.abilities.add(this.spellcastingAbility);
-    } else if ( this.attack.ability in CONFIG.DND5E.abilities ) {
-      this.attack.abilities.add(this.attack.ability);
-    } else if ( !this.attack.ability ) {
+    if ( this.attack.ability in CONFIG.DND5E.abilities ) this.attack.abilities.add(this.attack.ability);
+    else if ( !this.attack.ability ) {
       for ( const ability of this.availableAbilities ) this.attack.abilities.add(ability);
     }
   }
@@ -205,6 +200,12 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
   /** @inheritDoc */
   prepareFinalData(rollData) {
+    // Must be resolved here because we do not know all spellcasting classes and their spellcasting abilities until
+    // class items have finished preparing.
+    if ( (this.attack.ability === "spellcasting") && this.spellcastingAbility ) {
+      this.attack.abilities.add(this.spellcastingAbility);
+    }
+
     if ( this.damage.includeBase && this.item.system.offersBaseDamage && this.item.system.damage.base.formula ) {
       const basePart = this.item.system.damage.base.clone(this.item.system.damage.base.toObject(false));
       basePart.base = true;
@@ -266,8 +267,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
    * @returns {{ data: object, parts: string[] }}
    */
   getAttackData({ ability, ammunition, attackMode, situational }={}) {
-    const rollData = this.getRollData({ ability, roll: { attackMode } });
-    if ( ability && (ability in CONFIG.DND5E.abilities) ) rollData.roll.ability = ability;
+    const rollData = this.getRollData({ roll: { ability, attackMode } });
     if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);
 
     const weapon = this.item.system;
@@ -276,7 +276,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
       "rolls.attack", `rolls.attack.${this.getActionType(attackMode)}`
     ], { rules: { category: "attack", actor: this.actor, item: this.item, rollData } }) : {};
     const { parts, data } = CONFIG.Dice.BasicRoll.constructParts({
-      mod: ability !== "none" ? rollData.mod : null,
+      mod: rollData.roll.ability ? rollData.mod : null,
       prof: weapon.prof?.term,
       bonus: this.attack.bonus,
       weaponMagic: weapon.magicAvailable ? weapon.magicalBonus : null,
@@ -382,8 +382,9 @@ export default class BaseAttackActivityData extends BaseActivityData {
   getRollData(options={}) {
     const rollData = super.getRollData(options);
     if ( options.roll ) {
+      const ability = options.roll.ability ?? this.ability;
       rollData.roll ??= {};
-      rollData.roll.ability = this.ability;
+      rollData.roll.ability = ability === "none" ? null : ability;
       rollData.roll.attack ??= {};
       rollData.roll.attack.classification = this.attack.type.classification;
       rollData.roll.attack.mode = options.roll.attackMode;

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -5,7 +5,7 @@ import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
-const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { AttackDamageRollProcessConfiguration } from "../../dice/_types.mjs";
@@ -18,13 +18,14 @@ const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foun
  * @mixes AttackActivityData
  */
 export default class BaseAttackActivityData extends BaseActivityData {
-  #abilities;
+
   /** @inheritDoc */
   static defineSchema() {
     return {
       ...super.defineSchema(),
       attack: new SchemaField({
         ability: new StringField(),
+        abilities: new SetField(new StringField(), { persisted: false }),
         bonus: new FormulaField(),
         critical: new SchemaField({
           threshold: new NumberField({ integer: true, positive: true })
@@ -52,34 +53,15 @@ export default class BaseAttackActivityData extends BaseActivityData {
   /** @override */
   get ability() {
     const configuredAbilities = this.abilities;
-    if ( (configuredAbilities.size === 1) && configuredAbilities.has("none") ) return null;
-    if ( configuredAbilities.size === 1 ) return configuredAbilities.first();
+    if ( this.attack.ability === "none" ) return null;
 
-    const availableAbilities = configuredAbilities.size ? configuredAbilities : new Set(this.availableAbilities);
-    availableAbilities.delete("none");
+    const availableAbilities = this.attack.abilities.size ? this.attack.abilities : new Set(this.availableAbilities);
     if ( !availableAbilities?.size ) return null;
     if ( availableAbilities?.size === 1 ) return availableAbilities.first();
     const abilities = this.actor?.system.abilities ?? {};
     return availableAbilities.reduce((largest, ability) =>
       (abilities[ability]?.mod ?? -Infinity) > (abilities[largest]?.mod ?? -Infinity) ? ability : largest
     , availableAbilities.first());
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Configured abilities that can be used with this attack.
-   * @type {Set<string>}
-   */
-  get abilities() {
-    if ( this.#abilities ) return this.#abilities;
-    const abilities = this.#abilities = new Set([this.attack.ability]);
-    abilities.delete("");
-    if ( abilities.delete("default") ) {
-      for ( const ability of this.availableAbilities ) abilities.add(ability);
-    }
-    if ( abilities.delete("spellcasting") && this.spellcastingAbility ) abilities.add(this.spellcastingAbility);
-    return abilities;
   }
 
   /* -------------------------------------------- */
@@ -164,6 +146,8 @@ export default class BaseAttackActivityData extends BaseActivityData {
   }
 
   /* -------------------------------------------- */
+  /*  Data Migration                              */
+  /* -------------------------------------------- */
 
   /** @override */
   static transformTypeData(source, activityData, options) {
@@ -206,10 +190,17 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
   /** @inheritDoc */
   prepareData() {
-    this.#abilities = undefined;
     super.prepareData();
     this.attack.type.value ||= this.item.system.attackType ?? "melee";
     this.attack.type.classification ||= this.item.system.attackClassification ?? "weapon";
+
+    if ( this.attack.ability === "spellcasting" ) {
+      this.attack.abilities.add(this.spellcastingAbility);
+    } else if ( this.attack.ability in CONFIG.DND5E.abilities ) {
+      this.attack.abilities.add(this.attack.ability);
+    } else if ( !this.attack.ability ) {
+      for ( const ability of this.availableAbilities ) this.attack.abilities.add(ability);
+    }
   }
 
   /* -------------------------------------------- */
@@ -302,14 +293,8 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
   /* -------------------------------------------- */
 
-  /**
-   * Get the roll parts used to create the damage rolls.
-   * @param {Partial<AttackDamageRollProcessConfiguration>} [config={}]
-   * @returns {AttackDamageRollProcessConfiguration}
-   */
+  /** @inheritDoc */
   getDamageConfig(config={}, options={}) {
-    const rollConfig = super.getDamageConfig(config, options);
-
     // Copy properties from selected ammunition
     const ammo = config.ammunition?.system;
     if ( ammo ) {
@@ -320,6 +305,8 @@ export default class BaseAttackActivityData extends BaseActivityData {
         if ( !config.properties.includes(property) ) config.properties.push(property);
       }
     }
+
+    const rollConfig = super.getDamageConfig(config, options);
 
     if ( this.damage.critical.bonus && rollConfig.rolls[0] && !rollConfig.rolls[0].options?.critical?.bonusDamage ) {
       foundry.utils.setProperty(rollConfig.rolls[0], "options.critical.bonusDamage", this.damage.critical.bonus);

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -18,7 +18,6 @@ const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringFiel
  * @mixes AttackActivityData
  */
 export default class BaseAttackActivityData extends BaseActivityData {
-
   /** @inheritDoc */
   static defineSchema() {
     return {
@@ -52,16 +51,14 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
   /** @override */
   get ability() {
-    const configuredAbilities = this.abilities;
     if ( this.attack.ability === "none" ) return null;
 
-    const availableAbilities = this.attack.abilities.size ? this.attack.abilities : new Set(this.availableAbilities);
-    if ( !availableAbilities?.size ) return null;
-    if ( availableAbilities?.size === 1 ) return availableAbilities.first();
+    if ( !this.attack.abilities?.size ) return null;
+    if ( this.attack.abilities?.size === 1 ) return this.attack.abilities.first();
     const abilities = this.actor?.system.abilities ?? {};
-    return availableAbilities.reduce((largest, ability) =>
+    return this.attack.abilities.reduce((largest, ability) =>
       (abilities[ability]?.mod ?? -Infinity) > (abilities[largest]?.mod ?? -Infinity) ? ability : largest
-    , availableAbilities.first());
+    , this.attack.abilities.first());
   }
 
   /* -------------------------------------------- */
@@ -261,13 +258,13 @@ export default class BaseAttackActivityData extends BaseActivityData {
   /**
    * Get the roll parts used to create the attack roll.
    * @param {object} [config={}]
-   * @param {string} [config.ammunition]
    * @param {string} [config.ability]
+   * @param {string} [config.ammunition]
    * @param {string} [config.attackMode]
    * @param {string} [config.situational]
    * @returns {{ data: object, parts: string[] }}
    */
-  getAttackData({ ammunition, ability, attackMode, situational }={}) {
+  getAttackData({ ability, ammunition, attackMode, situational }={}) {
     const rollData = this.getRollData({ ability, roll: { attackMode } });
     if ( ability && (ability in CONFIG.DND5E.abilities) ) rollData.roll.ability = ability;
     if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -253,12 +253,17 @@ export default class BaseAttackActivityData extends BaseActivityData {
    * Get the roll parts used to create the attack roll.
    * @param {object} [config={}]
    * @param {string} [config.ammunition]
+   * @param {string} [config.ability]
    * @param {string} [config.attackMode]
    * @param {string} [config.situational]
    * @returns {{ data: object, parts: string[] }}
    */
-  getAttackData({ ammunition, attackMode, situational }={}) {
+  getAttackData({ ammunition, ability, attackMode, situational }={}) {
     const rollData = this.getRollData({ roll: { attackMode } });
+    if ( ability && (ability in CONFIG.DND5E.abilities) ) {
+      rollData.roll.ability = ability;
+      rollData.mod = this.actor?.system.abilities?.[ability]?.mod ?? 0;
+    }
     if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);
 
     const weapon = this.item.system;
@@ -282,8 +287,22 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
   /* -------------------------------------------- */
 
-  /** @override */
+  /**
+   * Get the roll parts used to create the damage rolls.
+   * @param {Partial<AttackDamageRollProcessConfiguration>} [config={}]
+   * @returns {AttackDamageRollProcessConfiguration}
+   */
   getDamageConfig(config={}, options={}) {
+    const ability = config.ability;
+    let { rollData } = options;
+    rollData ??= ability !== undefined ? this.getRollData({ roll: { attackMode: config.attackMode } }) : null;
+    if ( rollData ) {
+      rollData.roll ??= {};
+      rollData.roll.ability = ability;
+      rollData.mod = ability in CONFIG.DND5E.abilities ? this.actor?.system.abilities?.[ability]?.mod ?? 0 : null;
+    }
+    const rollConfig = super.getDamageConfig(config, { ...options, rollData });
+
     // Copy properties from selected ammunition
     const ammo = config.ammunition?.system;
     if ( ammo ) {
@@ -294,8 +313,6 @@ export default class BaseAttackActivityData extends BaseActivityData {
         if ( !config.properties.includes(property) ) config.properties.push(property);
       }
     }
-
-    const rollConfig = super.getDamageConfig(config, options);
 
     if ( this.damage.critical.bonus && rollConfig.rolls[0] && !rollConfig.rolls[0].options?.critical?.bonusDamage ) {
       foundry.utils.setProperty(rollConfig.rolls[0], "options.critical.bonusDamage", this.damage.critical.bonus);

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -776,7 +776,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     if ( !this.damage?.parts ) return foundry.utils.mergeObject({ rolls: [] }, config);
 
     const rollConfig = foundry.utils.deepClone(config);
-    rollData ??= this.getRollData({ roll: { attackMode: config.attackMode } });
+    rollData ??= this.getRollData({ ability: config.ability, roll: { attackMode: config.attackMode } });
     rollData.roll ??= {};
     Object.assign(rollData.roll, {
       isCritical: rollConfig.isCritical,
@@ -818,7 +818,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     const rollData = this.item.getRollData(options);
     rollData.activity = { ...this };
     rollData.consumed = this.item.flags.dnd5e?.consumed;
-    rollData.mod = this.actor?.system.abilities?.[this.ability]?.mod ?? 0;
+    rollData.mod = this.actor?.system.abilities?.[options.ability ?? this.ability]?.mod ?? 0;
     return rollData;
   }
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -20,7 +20,7 @@ const {
 
 /**
  * @import { DamageRollConfiguration, DamageRollProcessConfiguration } from "../../dice/_types.mjs";
- * @import { ActivityRollData, ActivityRollDataOptions } from "../../documents/_types.mjs";
+ * @import { ActivityRollData, RollDataOptions } from "../../documents/_types.mjs";
  * @import { DamageFormulaOptions } from "../shared/_types.mjs";
  * @import { ActivityData, BehaviorApplicationData, EffectApplicationData } from "./_types.mjs";
  */
@@ -776,7 +776,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     if ( !this.damage?.parts ) return foundry.utils.mergeObject({ rolls: [] }, config);
 
     const rollConfig = foundry.utils.deepClone(config);
-    rollData ??= this.getRollData({ ability: config.ability, roll: { attackMode: config.attackMode } });
+    rollData ??= this.getRollData({ roll: { ability: config.ability, attackMode: config.attackMode } });
     rollData.roll ??= {};
     Object.assign(rollData.roll, {
       isCritical: rollConfig.isCritical,
@@ -811,14 +811,14 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
   /**
    * Prepare a data object which defines the data schema used by dice roll commands against this Activity.
-   * @param {ActivityRollDataOptions} [options]
+   * @param {RollDataOptions} [options]
    * @returns {ActivityRollData}
    */
   getRollData(options={}) {
     const rollData = this.item.getRollData(options);
     rollData.activity = { ...this };
     rollData.consumed = this.item.flags.dnd5e?.consumed;
-    rollData.mod = this.actor?.system.abilities?.[options.ability ?? this.ability]?.mod ?? 0;
+    rollData.mod = this.actor?.system.abilities?.[options.roll?.ability ?? this.ability]?.mod ?? 0;
     return rollData;
   }
 

--- a/module/dice/_types.mjs
+++ b/module/dice/_types.mjs
@@ -74,6 +74,7 @@
 
 /**
  * @typedef {D20RollProcessConfiguration} AttackRollProcessConfiguration
+ * @property {string} [ability]               Ability to use with the attack.
  * @property {Item5e|boolean} [ammunition]    Specific ammunition to consume, or `false` to prevent any ammo usage.
  * @property {WeaponAttackMode} [attackMode]  Mode to use for making the attack and rolling damage.
  * @property {string} [mastery]               Weapon mastery option to use.

--- a/module/dice/_types.mjs
+++ b/module/dice/_types.mjs
@@ -38,7 +38,6 @@
  * @typedef {BasicRollProcessConfiguration} D20RollProcessConfiguration
  * @property {boolean} [advantage]             Apply advantage to each roll.
  * @property {boolean} [disadvantage]          Apply disadvantage to each roll.
- * @property {boolean} [elvenAccuracy]         Use three dice when rolling with advantage.
  * @property {boolean} [halflingLucky]         Add a re-roll once modifier to the d20 die.
  * @property {boolean} [reliableTalent]        Set the minimum for the d20 roll to 10.
  * @property {D20RollConfiguration[]} rolls    Configuration data for individual rolls.
@@ -106,6 +105,7 @@
  *
  * @typedef {BasicRollProcessConfiguration} DamageRollProcessConfiguration
  * @property {DamageRollConfiguration[]} rolls         Configuration data for individual rolls.
+ * @property {string} [ability]                        Ability used to calculate the damage modifier.
  * @property {CriticalDamageConfiguration} [critical]  Critical configuration for all rolls.
  * @property {string[]} [properties]                   Properties applied to all rolls.
  * @property {boolean} [isCritical]                    Treat each roll as a critical unless otherwise specified.

--- a/module/dice/_types.mjs
+++ b/module/dice/_types.mjs
@@ -76,6 +76,8 @@
  * @typedef {D20RollProcessConfiguration} AttackRollProcessConfiguration
  * @property {Item5e|boolean} [ammunition]    Specific ammunition to consume, or `false` to prevent any ammo usage.
  * @property {WeaponAttackMode} [attackMode]  Mode to use for making the attack and rolling damage.
+ * @property {string} [ability]               ID of the ability to roll as found in `CONFIG.DND5E.abilities`.
+ * @property {FormSelectOption[]} [abilityOptions]  Ability options that can be selected for this attack.
  * @property {string} [mastery]               Weapon mastery option to use.
  */
 

--- a/module/dice/_types.mjs
+++ b/module/dice/_types.mjs
@@ -76,8 +76,6 @@
  * @typedef {D20RollProcessConfiguration} AttackRollProcessConfiguration
  * @property {Item5e|boolean} [ammunition]    Specific ammunition to consume, or `false` to prevent any ammo usage.
  * @property {WeaponAttackMode} [attackMode]  Mode to use for making the attack and rolling damage.
- * @property {string} [ability]               ID of the ability to roll as found in `CONFIG.DND5E.abilities`.
- * @property {FormSelectOption[]} [abilityOptions]  Ability options that can be selected for this attack.
  * @property {string} [mastery]               Weapon mastery option to use.
  */
 
@@ -197,6 +195,7 @@
 
 /**
  * @typedef {BasicRollConfigurationDialogOptions} AttackRollConfigurationDialogOptions
+ * @property {FormSelectOption[]} abilityOptions     Ability options that can be selected for this attack.
  * @property {FormSelectOption[]} ammunitionOptions  Ammunition that can be used with the attack.
  * @property {FormSelectOption[]} attackModeOptions  Different modes of attack.
  * @property {FormSelectOption[]} masteryOptions     Available masteries for the attacking weapon.

--- a/module/dice/d20-roll.mjs
+++ b/module/dice/d20-roll.mjs
@@ -50,7 +50,6 @@ export default class D20Roll extends BasicRoll {
     const formula = [new CONFIG.Dice.D20Die().formula].concat(config.parts ?? []).join(" + ");
     config.options.criticalSuccess ??= CONFIG.Dice.D20Die.CRITICAL_SUCCESS_TOTAL;
     config.options.criticalFailure ??= CONFIG.Dice.D20Die.CRITICAL_FAILURE_TOTAL;
-    config.options.elvenAccuracy ??= process.elvenAccuracy;
     config.options.halflingLucky ??= process.halflingLucky;
     config.options.reliableTalent ??= process.reliableTalent;
     config.options.target ??= process.target;

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -155,11 +155,6 @@
  */
 
 /**
- * @typedef {RollDataOptions} ActivityRollDataOptions
- * @property {string} [ability]  Ability used to calculate the roll modifier.
- */
-
-/**
  * @typedef {RollData} ActorRollData
  * @property {object} flags                     Flags set on the actor.
  * @property {string} name                      Name of the actor.
@@ -179,8 +174,8 @@
 
 /**
  * @typedef {RollData} JournalEntryPageRollData
- * @param {object} flags          Flags set on the journal entry.
- * @param {string} name           Name of the journal entry.
+ * @property {object} flags       Flags set on the journal entry.
+ * @property {string} name        Name of the journal entry.
  * @property {object} page        Object containing the page's system data.
  * @property {object} page.flags  Flags set on the page.
  * @property {string} page.name   Name of the page.
@@ -193,24 +188,31 @@
 
 /**
  * @typedef RollDescription
- * @param {string} [ability]                Ability associated with a D20 roll.
- * @param {object} [attack]
- * @param {"spell"|"unarmed"|"weapon"} [attack.classification]  Source of the attack.
- * @param {WeaponAttackMode} [attack.mode]  Selected weapon attack mode.
- * @param {"melee"|"ranged"} [attack.type]  Whether this is a melee or ranged attack.
- * @param {boolean} [proficient]            Whether proficiency was added to the roll.
- * @param {string} [skill]                  ID of skill associated with the roll.
- * @param {string} [tool]                   ID of tool associated with the roll.
- * @param {string} type                     Type of roll being performed (e.g. "attack", "skill", "tool", etc.).
+ * @property {string} [ability]                Ability associated with a D20 roll.
+ * @property {object} [attack]
+ * @property {"spell"|"unarmed"|"weapon"} [attack.classification]  Source of the attack.
+ * @property {WeaponAttackMode} [attack.mode]  Selected weapon attack mode.
+ * @property {"melee"|"ranged"} [attack.type]  Whether this is a melee or ranged attack.
+ * @property {boolean} [proficient]            Whether proficiency was added to the roll.
+ * @property {string} [skill]                  ID of skill associated with the roll.
+ * @property {string} [tool]                   ID of tool associated with the roll.
+ * @property {string} type                     Type of roll being performed (e.g. "attack", "skill", "tool", etc.).
  */
 
 /**
  * @typedef RollDataOptions
- * @property {boolean} [deterministic]  Whether to force deterministic values for data properties that could
- *                                      be either a die term or a flat term.
- * @property {object} [data]            Arbitrary data assigned to the roll data object.
- * @property {boolean|object} [roll]               Configuration for a roll or true to indicate data is for a roll.
- * @property {WeaponAttackMode} [roll.attackMode]  Selected weapon attack mode.
+ * @property {boolean} [deterministic]             Whether to force deterministic values for data properties that
+ *                                                 could be either a die term or a flat term.
+ * @property {boolean|RollDataRollOptions} [roll]  Options describing the roll being performed, or true to indicate the
+ *                                                 data is for a roll without any further configuration.
+ */
+
+/**
+ * Roll-specific options that roll data preparation can respond to.
+ *
+ * @typedef RollDataRollOptions
+ * @property {string} [ability]               Ability used to calculate the roll modifier.
+ * @property {WeaponAttackMode} [attackMode]  Selected weapon attack mode.
  */
 
 /* -------------------------------------------- */

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -147,6 +147,7 @@
 
 /**
  * @typedef {RollDataOptions} ActivityRollDataOptions
+ * @property {string} [ability]  Ability used to calculate the roll modifier.
  */
 
 /**

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -332,33 +332,14 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     const changes = {};
     const apply = (activity, key) => {
       if ( (key === "attack.ability") && (activity.type === "attack") ) {
-        let abilities;
-        if ( (change.type === "add") && !activity.attack.ability.size ) {
-          const added = [];
-          const removed = [];
-          for ( const value of [change.value].flat().filter(a => a) ) {
-            const neg = value.replace(/^\s*-\s*/, "");
-            if ( neg === value ) added.push(value);
-            else removed.push(neg);
-          }
-          abilities = removed.length ? Array.from(activity.availableAbilities) : ["default"];
-          abilities.push(...added);
-          abilities = abilities.filter(a => !removed.includes(a));
-          for ( const ability of abilities ) activity.attack.ability.add(ability);
-        } else if ( change.type === "subtract" ) {
-          const values = new Set(activity.attack.ability.size ? activity.attack.ability : activity.availableAbilities);
-          if ( values.delete("default") ) {
-            for ( const ability of activity.availableAbilities ) values.add(ability);
-          }
-          for ( const ability of [change.value].flat().filter(a => a) ) values.delete(ability);
-          activity.attack.ability.clear();
-          for ( const ability of values ) activity.attack.ability.add(ability);
-          abilities = Array.from(values);
+        const abilities = activity.abilities;
+        if ( change.type === "override" ) abilities.clear();
+        for ( const value of [change.value].flat().filter(a => a) ) {
+          const ability = value.replace(/^\s*-\s*/, "");
+          if ( (change.type === "subtract") || (ability !== value) ) abilities.delete(ability);
+          else abilities.add(ability);
         }
-        if ( abilities ) {
-          changes[`system.activities.${activity.id}.${key}`] = abilities;
-          return;
-        }
+        return;
       }
       const c = this.constructor.applyChange(activity, { ...change, key }, options);
       Object.entries(c).forEach(([k, v]) => changes[`system.activities.${activity.id}.${k}`] = v);

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -331,6 +331,35 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   applyActivity(item, change, options) {
     const changes = {};
     const apply = (activity, key) => {
+      if ( (key === "attack.ability") && (activity.type === "attack") ) {
+        let abilities;
+        if ( (change.type === "add") && !activity.attack.ability.size ) {
+          const added = [];
+          const removed = [];
+          for ( const value of [change.value].flat().filter(a => a) ) {
+            const neg = value.replace(/^\s*-\s*/, "");
+            if ( neg === value ) added.push(value);
+            else removed.push(neg);
+          }
+          abilities = removed.length ? Array.from(activity.availableAbilities) : ["default"];
+          abilities.push(...added);
+          abilities = abilities.filter(a => !removed.includes(a));
+          for ( const ability of abilities ) activity.attack.ability.add(ability);
+        } else if ( change.type === "subtract" ) {
+          const values = new Set(activity.attack.ability.size ? activity.attack.ability : activity.availableAbilities);
+          if ( values.delete("default") ) {
+            for ( const ability of activity.availableAbilities ) values.add(ability);
+          }
+          for ( const ability of [change.value].flat().filter(a => a) ) values.delete(ability);
+          activity.attack.ability.clear();
+          for ( const ability of values ) activity.attack.ability.add(ability);
+          abilities = Array.from(values);
+        }
+        if ( abilities ) {
+          changes[`system.activities.${activity.id}.${key}`] = abilities;
+          return;
+        }
+      }
       const c = this.constructor.applyChange(activity, { ...change, key }, options);
       Object.entries(c).forEach(([k, v]) => changes[`system.activities.${activity.id}.${k}`] = v);
     };

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -331,16 +331,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   applyActivity(item, change, options) {
     const changes = {};
     const apply = (activity, key) => {
-      if ( (key === "attack.ability") && (activity.type === "attack") ) {
-        const abilities = activity.abilities;
-        if ( change.type === "override" ) abilities.clear();
-        for ( const value of [change.value].flat().filter(a => a) ) {
-          const ability = value.replace(/^\s*-\s*/, "");
-          if ( (change.type === "subtract") || (ability !== value) ) abilities.delete(ability);
-          else abilities.add(ability);
-        }
-        return;
-      }
       const c = this.constructor.applyChange(activity, { ...change, key }, options);
       Object.entries(c).forEach(([k, v]) => changes[`system.activities.${activity.id}.${k}`] = v);
     };

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -15,6 +15,7 @@ const { NumberField, ObjectField, SchemaField, SetField, StringField } = foundry
  */
 
 const BONUS_SHIM_REGEX = new RegExp(/system\.(abilities|skills|tools)\.(\w+)\.bonuses\.(check|save)/);
+const ATTACK_ABILITY_SHIM_REGEX = new RegExp(/system\.activities\.\w+\.attack\.ability/);
 
 /**
  * Extend the base ActiveEffect class to implement system-specific logic.
@@ -95,7 +96,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     "system.bonuses.rsak.damage": { key: "system.rolls.damage.rsak.bonus" },
     "system.bonuses.abilities.check": { key: "system.rolls.ability.check.bonus" },
     "system.bonuses.abilities.save": { key: "system.rolls.ability.save.bonus" },
-    "system.bonuses.abilities.skill": { key: "system.rolls.ability.skill.bonus" }
+    "system.bonuses.abilities.skill": { key: "system.rolls.ability.skill.bonus" },
+    "activities[attack].attack.ability": { key: "activities[attack].attack.abilities" }
   };
 
   /* -------------------------------------------- */
@@ -469,6 +471,9 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    */
   _applyChangeShim(change) {
     let shim = ActiveEffect5e.SHIM_FIELDS[change.key];
+    if ( !shim && ATTACK_ABILITY_SHIM_REGEX.test(change.key) ) {
+      shim = { key: change.key.replace(/\.ability$/, ".abilities") };
+    }
     if ( !shim ) {
       const [, category, key, type] = change.key.match(BONUS_SHIM_REGEX) ?? [];
       if ( !category ) return change;

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -1,10 +1,8 @@
 import AttackSheet from "../../applications/activity/attack-sheet.mjs";
 import AttackRollConfigurationDialog from "../../applications/dice/attack-configuration-dialog.mjs";
 import BaseAttackActivityData from "../../data/activity/attack-data.mjs";
-import AdvantageModeField from "../../data/fields/advantage-mode-field.mjs";
 import D20RollModificationField from "../../data/shared/d20-roll-modification-field.mjs";
 import { getTargetDescriptors } from "../../utils.mjs";
-import AppliedRules from "../applied-rules.mjs";
 import ActivityMixin from "./mixin.mjs";
 
 /**
@@ -122,7 +120,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
       rollConfig.mastery = masteryOptions?.[0]?.value;
     }
 
-    const rollData = this.getRollData({ roll: { attackMode: rollConfig.attackMode } });
+    const rollData = this.getRollData({ roll: { ability: rollConfig.ability, attackMode: rollConfig.attackMode } });
     const { advantage, disadvantage } = this.actor ? D20RollModificationField.combineFields(this.actor.system, [
       "rolls.attack", `rolls.attack.${this.getActionType(rollConfig.attackMode)}`
     ], { rules: { category: "attack", actor: this.actor, item: this.item, rollData } }) : {};
@@ -343,11 +341,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const actorAbilities = this.actor?.system.abilities ?? {};
     const options = Array.from(this.attack.abilities)
       .filter(ability => ability in CONFIG.DND5E.abilities)
-      .sort((ability, largest) => {
-        const abilityMod = actorAbilities[ability]?.mod ?? -Infinity;
-        const largestMod = actorAbilities[largest]?.mod ?? -Infinity;
-        return largestMod - abilityMod;
-      })
+      .sort((a, b) => (actorAbilities[b]?.mod ?? 0) - (actorAbilities[a]?.mod ?? 0))
       .map(value => ({ value, label: CONFIG.DND5E.abilities[value].label }));
     if ( this.attack.ability === "none" ) options.push({ value: "none", label: _loc("DND5E.None") });
     return options;

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -103,12 +103,10 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     }, config);
 
     const ammunitionOptions = this.item.system.ammunitionOptions ?? [];
-    rollConfig.abilityOptions = this._prepareAbilityOptions();
-    if ( rollConfig.abilityOptions.length && !rollConfig.abilityOptions.some(a => a.value === rollConfig.ability) ) {
-      rollConfig.ability = rollConfig.abilityOptions[0]?.value;
+    const abilityOptions = this._prepareAbilityOptions();
+    if ( abilityOptions.length && !abilityOptions.some(a => a.value === rollConfig.ability) ) {
+      rollConfig.ability = abilityOptions[0]?.value;
     }
-    rollConfig.elvenAccuracy = this.actor?.getFlag("dnd5e", "elvenAccuracy")
-      && CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(rollConfig.ability);
     if ( ammunitionOptions.length ) ammunitionOptions.unshift({ value: "", label: "" });
     if ( rollConfig.ammunition === undefined ) rollConfig.ammunition = ammunitionOptions?.[1]?.value;
     else if ( !ammunitionOptions?.find(m => m.value === rollConfig.ammunition) ) {
@@ -144,7 +142,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const dialogConfig = foundry.utils.mergeObject({
       applicationClass: AttackRollConfigurationDialog,
       options: {
-        abilityOptions: rollConfig.abilityOptions,
+        abilityOptions,
         ammunitionOptions: rollConfig.ammunition !== false ? ammunitionOptions : [],
         attackModeOptions,
         buildConfig,
@@ -179,7 +177,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const rolls = await CONFIG.Dice.D20Roll.buildConfigure(rollConfig, dialogConfig, messageConfig);
     await CONFIG.Dice.D20Roll.buildEvaluate(rolls, rollConfig, messageConfig);
     if ( !rolls.length ) return null;
-    for ( const key of ["ammunition", "attackMode", "mastery"] ) {
+    for ( const key of ["ability", "ammunition", "attackMode", "mastery"] ) {
       if ( !rolls[0].options[key] ) continue;
       foundry.utils.setProperty(messageConfig.data, `flags.dnd5e.roll.${key}`, rolls[0].options[key]);
     }
@@ -267,7 +265,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const mastery = formData?.get("mastery") ?? process.mastery;
 
     process.ability = ability;
-    let { parts, data } = this.getAttackData({ ammunition, ability, attackMode });
+    let { parts, data } = this.getAttackData({ ability, ammunition, attackMode });
     const options = foundry.utils.mergeObject({
       maximum: this.actor
         ? AppliedRules.collect("attack:maximum", this.actor, this.item).filterWith(data).resolve(data).toSmallest()

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -144,6 +144,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const dialogConfig = foundry.utils.mergeObject({
       applicationClass: AttackRollConfigurationDialog,
       options: {
+        abilityOptions: rollConfig.abilityOptions,
         ammunitionOptions: rollConfig.ammunition !== false ? ammunitionOptions : [],
         attackModeOptions,
         buildConfig,

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -311,7 +311,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
    */
   static #rollDamage(event, target, message) {
     const lastAttack = message.getAssociatedRolls("attack").pop();
-    const ability = lastAttack?.rolls[0]?.options.ability ?? lastAttack?.getFlag("dnd5e", "roll.ability");
+    const ability = lastAttack?.getFlag("dnd5e", "roll.ability");
     const attackMode = lastAttack?.getFlag("dnd5e", "roll.attackMode");
 
     // Fetch the ammunition used with the last attack roll
@@ -341,9 +341,8 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
    * @protected
    */
   _getAbilityOptions() {
-    const abilities = this.attack.abilities.size ? new Set(this.attack.abilities) : new Set(this.availableAbilities);
     const actorAbilities = this.actor?.system.abilities ?? {};
-    const options = Array.from(abilities)
+    const options = Array.from(this.attack.abilities)
       .filter(ability => ability in CONFIG.DND5E.abilities)
       .sort((ability, largest) => {
         const abilityMod = actorAbilities[ability]?.mod ?? -Infinity;

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -94,19 +94,19 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const buildConfig = this._buildAttackConfig.bind(this);
 
     const rollConfig = foundry.utils.mergeObject({
+      ability: this.item.getFlag("dnd5e", `last.${this.id}.ability`),
       ammunition: this.item.getFlag("dnd5e", `last.${this.id}.ammunition`),
-      ability: this.ability,
       attackMode: this.item.getFlag("dnd5e", `last.${this.id}.attackMode`),
       halflingLucky: this.actor?.getFlag("dnd5e", "halflingLucky"),
       mastery: this.item.getFlag("dnd5e", `last.${this.id}.mastery`),
       target: targets.length === 1 ? targets[0].ac : undefined
     }, config);
 
-    const ammunitionOptions = this.item.system.ammunitionOptions ?? [];
-    const abilityOptions = this._prepareAbilityOptions();
-    if ( abilityOptions.length && !abilityOptions.some(a => a.value === rollConfig.ability) ) {
+    const abilityOptions = this._getAbilityOptions();
+    if ( abilityOptions.length && !abilityOptions.find(a => a.value === rollConfig.ability) ) {
       rollConfig.ability = abilityOptions[0]?.value;
     }
+    const ammunitionOptions = this.item.system.ammunitionOptions ?? [];
     if ( ammunitionOptions.length ) ammunitionOptions.unshift({ value: "", label: "" });
     if ( rollConfig.ammunition === undefined ) rollConfig.ammunition = ammunitionOptions?.[1]?.value;
     else if ( !ammunitionOptions?.find(m => m.value === rollConfig.ammunition) ) {
@@ -181,13 +181,13 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
       if ( !rolls[0].options[key] ) continue;
       foundry.utils.setProperty(messageConfig.data, `flags.dnd5e.roll.${key}`, rolls[0].options[key]);
     }
-    if ( rolls[0].options.ability ) foundry.utils.setProperty(messageConfig.data, "flags.dnd5e.roll.ability", rolls[0].options.ability);
     await CONFIG.Dice.D20Roll.buildPost(rolls, rollConfig, messageConfig);
 
     const flags = {};
     let ammoUpdate = null;
 
     const canUpdate = this.item.isOwner && !this.item.inCompendium;
+    if ( rolls[0].options.ability ) flags.ability = rolls[0].options.ability;
     if ( rolls[0].options.ammunition ) {
       const ammo = this.actor?.items.get(rolls[0].options.ammunition);
       if ( ammo ) {
@@ -259,14 +259,15 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
    * @param {number} index                                 Index of the roll within all rolls being prepared.
    */
   _buildAttackConfig(process, config, formData, index) {
-    const ammunition = formData?.get("ammunition") ?? process.ammunition;
     const ability = formData?.get("ability") ?? process.ability;
+    const ammunition = formData?.get("ammunition") ?? process.ammunition;
     const attackMode = formData?.get("attackMode") ?? process.attackMode;
     const mastery = formData?.get("mastery") ?? process.mastery;
 
-    process.ability = ability;
     let { parts, data } = this.getAttackData({ ability, ammunition, attackMode });
     const options = foundry.utils.mergeObject({
+      elvenAccuracy: this.actor?.getFlag("dnd5e", "elvenAccuracy") &&
+        CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(ability),
       maximum: this.actor
         ? AppliedRules.collect("attack:maximum", this.actor, this.item).filterWith(data).resolve(data).toSmallest()
         : undefined,
@@ -274,12 +275,10 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
         ? AppliedRules.collect("attack:minimum", this.actor, this.item).filterWith(data).resolve(data).toLargest()
         : undefined,
     }, config.options ?? {});
-    if ( ammunition !== undefined ) options.ammunition = ammunition;
     if ( ability !== undefined ) options.ability = ability;
+    if ( ammunition !== undefined ) options.ammunition = ammunition;
     if ( attackMode !== undefined ) options.attackMode = attackMode;
     if ( mastery !== undefined ) options.mastery = mastery;
-    if ( ability !== undefined ) options.elvenAccuracy = this.actor?.getFlag("dnd5e", "elvenAccuracy")
-      && CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(ability);
 
     config.parts = [...(config.parts ?? []), ...parts];
     config.data = { ...data, ...(config.data ?? {}) };
@@ -341,9 +340,8 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
    * @returns {FormSelectOption[]}
    * @protected
    */
-  _prepareAbilityOptions() {
-    const abilities = this.abilities.size ? new Set(this.abilities) : new Set(this.availableAbilities);
-    const hasNone = abilities.delete("none");
+  _getAbilityOptions() {
+    const abilities = this.attack.abilities.size ? new Set(this.attack.abilities) : new Set(this.availableAbilities);
     const actorAbilities = this.actor?.system.abilities ?? {};
     const options = Array.from(abilities)
       .filter(ability => ability in CONFIG.DND5E.abilities)
@@ -353,9 +351,11 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
         return largestMod - abilityMod;
       })
       .map(value => ({ value, label: CONFIG.DND5E.abilities[value].label }));
-    if ( hasNone ) options.push({ value: "none", label: _loc("DND5E.None") });
+    if ( this.attack.ability === "none" ) options.push({ value: "none", label: _loc("DND5E.None") });
     return options;
   }
+
+  /* -------------------------------------------- */
 
   /** @inheritDoc */
   async getFavoriteData() {

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -95,15 +95,20 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
 
     const rollConfig = foundry.utils.mergeObject({
       ammunition: this.item.getFlag("dnd5e", `last.${this.id}.ammunition`),
+      ability: this.ability,
       attackMode: this.item.getFlag("dnd5e", `last.${this.id}.attackMode`),
-      elvenAccuracy: this.actor?.getFlag("dnd5e", "elvenAccuracy")
-        && CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(this.ability),
       halflingLucky: this.actor?.getFlag("dnd5e", "halflingLucky"),
       mastery: this.item.getFlag("dnd5e", `last.${this.id}.mastery`),
       target: targets.length === 1 ? targets[0].ac : undefined
     }, config);
 
     const ammunitionOptions = this.item.system.ammunitionOptions ?? [];
+    rollConfig.abilityOptions = this._prepareAbilityOptions();
+    if ( rollConfig.abilityOptions.length && !rollConfig.abilityOptions.some(a => a.value === rollConfig.ability) ) {
+      rollConfig.ability = rollConfig.abilityOptions[0]?.value;
+    }
+    rollConfig.elvenAccuracy = this.actor?.getFlag("dnd5e", "elvenAccuracy")
+      && CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(rollConfig.ability);
     if ( ammunitionOptions.length ) ammunitionOptions.unshift({ value: "", label: "" });
     if ( rollConfig.ammunition === undefined ) rollConfig.ammunition = ammunitionOptions?.[1]?.value;
     else if ( !ammunitionOptions?.find(m => m.value === rollConfig.ammunition) ) {
@@ -177,6 +182,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
       if ( !rolls[0].options[key] ) continue;
       foundry.utils.setProperty(messageConfig.data, `flags.dnd5e.roll.${key}`, rolls[0].options[key]);
     }
+    if ( rolls[0].options.ability ) foundry.utils.setProperty(messageConfig.data, "flags.dnd5e.roll.ability", rolls[0].options.ability);
     await CONFIG.Dice.D20Roll.buildPost(rolls, rollConfig, messageConfig);
 
     const flags = {};
@@ -255,10 +261,11 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
    */
   _buildAttackConfig(process, config, formData, index) {
     const ammunition = formData?.get("ammunition") ?? process.ammunition;
+    const ability = formData?.get("ability") ?? process.ability;
     const attackMode = formData?.get("attackMode") ?? process.attackMode;
     const mastery = formData?.get("mastery") ?? process.mastery;
 
-    let { parts, data } = this.getAttackData({ ammunition, attackMode });
+    let { parts, data } = this.getAttackData({ ammunition, ability, attackMode });
     const options = foundry.utils.mergeObject({
       maximum: this.actor
         ? AppliedRules.collect("attack:maximum", this.actor, this.item).filterWith(data).resolve(data).toSmallest()
@@ -268,8 +275,11 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
         : undefined,
     }, config.options ?? {});
     if ( ammunition !== undefined ) options.ammunition = ammunition;
+    if ( ability !== undefined ) options.ability = ability;
     if ( attackMode !== undefined ) options.attackMode = attackMode;
     if ( mastery !== undefined ) options.mastery = mastery;
+    if ( ability !== undefined ) options.elvenAccuracy = this.actor?.getFlag("dnd5e", "elvenAccuracy")
+      && CONFIG.DND5E.characterFlags.elvenAccuracy.abilities.includes(ability);
 
     config.parts = [...(config.parts ?? []), ...parts];
     config.data = { ...data, ...(config.data ?? {}) };
@@ -302,6 +312,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
    */
   static #rollDamage(event, target, message) {
     const lastAttack = message.getAssociatedRolls("attack").pop();
+    const ability = lastAttack?.getFlag("dnd5e", "roll.ability");
     const attackMode = lastAttack?.getFlag("dnd5e", "roll.attackMode");
 
     // Fetch the ammunition used with the last attack roll
@@ -318,12 +329,32 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const dialogConfig = {};
     if ( isCritical ) dialogConfig.options = { defaultButton: "critical" };
 
-    this.rollDamage({ event, ammunition, attackMode, isCritical }, dialogConfig);
+    this.rollDamage({ event, ability, ammunition, attackMode, isCritical }, dialogConfig);
   }
 
   /* -------------------------------------------- */
   /*  Helpers                                     */
   /* -------------------------------------------- */
+
+  /**
+   * Prepare ability options for this attack.
+   * @returns {FormSelectOption[]}
+   * @protected
+   */
+  _prepareAbilityOptions() {
+    if ( this.attack.ability === "none" ) return [];
+    const abilities = new Set(this.availableAbilities);
+    if ( this.ability ) abilities.add(this.ability);
+    const actorAbilities = this.actor?.system.abilities ?? {};
+    return Array.from(abilities)
+      .filter(ability => ability in CONFIG.DND5E.abilities)
+      .sort((ability, largest) => {
+        const abilityMod = actorAbilities[ability]?.mod ?? -Infinity;
+        const largestMod = actorAbilities[largest]?.mod ?? -Infinity;
+        return largestMod - abilityMod;
+      })
+      .map(value => ({ value, label: CONFIG.DND5E.abilities[value].label }));
+  }
 
   /** @inheritDoc */
   async getFavoriteData() {

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -265,6 +265,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const attackMode = formData?.get("attackMode") ?? process.attackMode;
     const mastery = formData?.get("mastery") ?? process.mastery;
 
+    process.ability = ability;
     let { parts, data } = this.getAttackData({ ammunition, ability, attackMode });
     const options = foundry.utils.mergeObject({
       maximum: this.actor
@@ -312,7 +313,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
    */
   static #rollDamage(event, target, message) {
     const lastAttack = message.getAssociatedRolls("attack").pop();
-    const ability = lastAttack?.getFlag("dnd5e", "roll.ability");
+    const ability = lastAttack?.rolls[0]?.options.ability ?? lastAttack?.getFlag("dnd5e", "roll.ability");
     const attackMode = lastAttack?.getFlag("dnd5e", "roll.attackMode");
 
     // Fetch the ammunition used with the last attack roll
@@ -342,11 +343,10 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
    * @protected
    */
   _prepareAbilityOptions() {
-    if ( this.attack.ability === "none" ) return [];
-    const abilities = new Set(this.availableAbilities);
-    if ( this.ability ) abilities.add(this.ability);
+    const abilities = this.abilities.size ? new Set(this.abilities) : new Set(this.availableAbilities);
+    const hasNone = abilities.delete("none");
     const actorAbilities = this.actor?.system.abilities ?? {};
-    return Array.from(abilities)
+    const options = Array.from(abilities)
       .filter(ability => ability in CONFIG.DND5E.abilities)
       .sort((ability, largest) => {
         const abilityMod = actorAbilities[ability]?.mod ?? -Infinity;
@@ -354,6 +354,8 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
         return largestMod - abilityMod;
       })
       .map(value => ({ value, label: CONFIG.DND5E.abilities[value].label }));
+    if ( hasNone ) options.push({ value: "none", label: _loc("DND5E.None") });
+    return options;
   }
 
   /** @inheritDoc */


### PR DESCRIPTION
Closes #7079 

Commits:
- https://github.com/foundryvtt/dnd5e/pull/7080/commits/985922b4c32d234ec2e93f31490c13c14e142c41
  - [x] Adds attack ability options to the attack roll configuration so attacks with multiple valid abilities can expose a selector in the roll dialog.
  - [x] Stores ability options on the roll config before pre-roll hooks run, so modules can extend or replace the available choices during roll configuration.
  - [x] Carries the selected ability into attack roll construction (would trigger Elven Accuracy checks), and follow-up damage rolls, allowing the chosen ability modifier to be used consistently across the attack workflow.
- https://github.com/foundryvtt/dnd5e/pull/7080/commits/ede41e0c2633ba6bb8d62550caedbf1f816b6775
  - [x] Changes attack activity ability configuration to a multi-select field. 
  - [x] Adds migration handling for existing attack activity ability strings.
- https://github.com/foundryvtt/dnd5e/pull/7080/commits/5ead3abba980415a86d5486e38504f84461f9520
  - [x] Preserves legacy `system.ability` enchantment handling for the new multi-select attack ability field.
  - [x] Supports enchantments targeting `activities[attack].attack.ability` and `system.activities.<activityID>.attack.ability`.
  - [x] Supports `Add`, `Override`, and `Subtract` enchantment changes for attack ability multi-select fields, including default attack abilities such as finesse weapon Strength/Dexterity defaults.
  

Stacked work:
- [ ] If this PR is merged, I can rebase the follow-up from here: <https://github.com/thatlonelybugbear/dnd5e/pull/1>
  
Not handled yet:
- [ ] Array-valued enchantment changes such as `["wis", "cha"]` are not supported yet. That should probably be handled separately as part of a broader enchantment refactor for Set-backed ability fields.

```js
Hooks.on('dnd5e.preRollAttack', (config) => {
	config.abilityOptions ??= [];

	for (const ability of ['wis', 'int']) {
		if (config.abilityOptions.some((option) => option.value === ability)) continue;
		config.abilityOptions.push({
			value: ability,
			label: CONFIG.DND5E.abilities[ability].label,
		});
	}
});
```
<img width="703" height="802" alt="image" src="https://github.com/user-attachments/assets/ee8adf51-1088-4c13-afe5-c250ab881962" />