### PR TITLE
[#3991] Remove stray whitespace around the award enricher button

### DIFF
--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -316,9 +316,9 @@ export async function enrichAward(config, label, options) {
     entries.push(`<span class="award-entry">${amount} <i class="currency ${
       key}" data-tooltip aria-label="${label}"></i></span>`);
   }
-  if ( parsed.xp ) {
-    entries.push(`<span class="award-entry">${formatNumber(parsed.xp)} ${_loc("DND5E.ExperiencePoints.Abbreviation")}</span>`);
-  }
+  if ( parsed.xp ) entries.push(
+    `<span class="award-entry">${formatNumber(parsed.xp)} ${_loc("DND5E.ExperiencePoints.Abbreviation")}</span>`
+  );
 
   let award = game.i18n.getListFormatter({ type: "unit" }).format(entries);
   if ( parsed.each ) award = _loc("EDITOR.DND5E.Inline.AwardEach", { award });

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -313,27 +313,17 @@ export async function enrichAward(config, label, options) {
   for ( let [key, amount] of Object.entries(parsed.currency) ) {
     const label = CONFIG.DND5E.currencies[key].label;
     amount = Number.isNumeric(amount) ? formatNumber(amount) : amount;
-    entries.push(`
-      <span class="award-entry">
-        ${amount} <i class="currency ${key}" data-tooltip aria-label="${label}"></i>
-      </span>
-    `);
+    entries.push(`<span class="award-entry">${amount} <i class="currency ${key}" data-tooltip aria-label="${label}"></i></span>`);
   }
-  if ( parsed.xp ) entries.push(`
-    <span class="award-entry">
-      ${formatNumber(parsed.xp)} ${_loc("DND5E.ExperiencePoints.Abbreviation")}
-    </span>
-  `);
+  if ( parsed.xp ) {
+    entries.push(`<span class="award-entry">${formatNumber(parsed.xp)} ${_loc("DND5E.ExperiencePoints.Abbreviation")}</span>`);
+  }
 
   let award = game.i18n.getListFormatter({ type: "unit" }).format(entries);
   if ( parsed.each ) award = _loc("EDITOR.DND5E.Inline.AwardEach", { award });
 
-  block.innerHTML += `
-    ${award}
-    <a class="award-link" data-action="awardRequest">
-      <i class="fa-solid fa-trophy"></i> ${label ?? _loc("DND5E.Award.Action")}
-    </a>
-  `;
+  block.innerHTML += `${award}<a class="award-link" data-action="awardRequest">`
+    + `<i class="fa-solid fa-trophy"></i> ${label ?? _loc("DND5E.Award.Action")}</a>`;
 
   return block;
 }

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -313,7 +313,8 @@ export async function enrichAward(config, label, options) {
   for ( let [key, amount] of Object.entries(parsed.currency) ) {
     const label = CONFIG.DND5E.currencies[key].label;
     amount = Number.isNumeric(amount) ? formatNumber(amount) : amount;
-    entries.push(`<span class="award-entry">${amount} <i class="currency ${key}" data-tooltip aria-label="${label}"></i></span>`);
+    entries.push(`<span class="award-entry">${amount} <i class="currency ${
+      key}" data-tooltip aria-label="${label}"></i></span>`);
   }
   if ( parsed.xp ) {
     entries.push(`<span class="award-entry">${formatNumber(parsed.xp)} ${_loc("DND5E.ExperiencePoints.Abbreviation")}</span>`);


### PR DESCRIPTION
Before:
<img width="121" height="31" alt="msedge_mEiw25tP3m" src="https://github.com/user-attachments/assets/60252076-4418-47db-9d74-5cebbf4c0e8b" />

After:
<img width="118" height="33" alt="msedge_AznPIsZKss" src="https://github.com/user-attachments/assets/a09bf298-075c-46ea-816c-aa49a7545af5" />

Closes #3991