### PR TITLE
[#4443] Use page icons for journal subtype content links

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -125,6 +125,7 @@ Hooks.once("init", function() {
   CONFIG.ChatMessage.dataModels = dataModels.chatMessage.config;
   CONFIG.Item.dataModels = dataModels.item.config;
   CONFIG.JournalEntryPage.dataModels = dataModels.journal.config;
+  Object.assign(CONFIG.JournalEntryPage.typeIcons, dataModels.journal.icons);
   Object.assign(CONFIG.RegionBehavior.dataModels, dataModels.regionBehavior.config);
   Object.assign(CONFIG.RegionBehavior.typeIcons, dataModels.regionBehavior.icons);
 

--- a/module/data/journal/_module.mjs
+++ b/module/data/journal/_module.mjs
@@ -19,3 +19,11 @@ export const config = {
   spells: SpellListJournalPageData,
   subclass: SubclassJournalPageData
 };
+
+export const icons = {
+  class: "fa-solid fa-file-lines",
+  map: "fa-solid fa-file-lines",
+  rule: "fa-solid fa-file-lines",
+  spells: "fa-solid fa-file-lines",
+  subclass: "fa-solid fa-file-lines"
+};

--- a/module/data/journal/_module.mjs
+++ b/module/data/journal/_module.mjs
@@ -21,9 +21,9 @@ export const config = {
 };
 
 export const icons = {
-  class: "fa-solid fa-file-lines",
-  map: "fa-solid fa-file-lines",
-  rule: "fa-solid fa-file-lines",
-  spells: "fa-solid fa-file-lines",
-  subclass: "fa-solid fa-file-lines"
+  class: "fa-solid fa-file-shield",
+  map: "fa-solid fa-map",
+  rule: "fa-solid fa-book-section",
+  spells: "fa-solid fa-book-sparkles",
+  subclass: "fa-solid fa-diagram-subtask"
 };


### PR DESCRIPTION
- Add an icons map for the dnd5e journal page subtypes (class, subclass, map, rule, spells)
- Assign them to CONFIG.JournalEntryPage.typeIcons at init, mirroring the regionBehavior.typeIcons pattern
- Content links and the page tree now show the text-page icon instead of the journal book fallback

Closes #4443