### PR TITLE
[#4393] Inherit the item's base damage type for untyped activity damage

### DIFF
--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -906,7 +906,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     const lastType = this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`);
     // Fall back to the item's base damage type when this part specifies none (e.g. weapon/ammo base damage).
     let { types } = damage;
-    if ( !types.size && this.item.system.offersBaseDamage ) types = this.item.system.damage.base.types;
+    if ( !types.size && this.item.system.offersBaseDamage && (this.constructor.damageRuleCategory !== "healing") ) {
+      types = this.item.system.damage.base.types;
+    }
     const data = { ...rollData, roll: foundry.utils.deepClone(rollData.roll ?? {}) };
     data.roll.damage ??= {};
     data.roll.damage.type = (types.has(lastType) ? lastType : null) ?? types.first();

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -904,9 +904,12 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     const scaledFormula = damage.scaledFormula(rollConfig.scaling ?? rollData.scaling, formulaOptions);
     const parts = scaledFormula ? [scaledFormula] : [];
     const lastType = this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`);
+    // Fall back to the item's base damage type when this part specifies none (e.g. weapon/ammo base damage).
+    let { types } = damage;
+    if ( !types.size && this.item.system.offersBaseDamage ) types = this.item.system.damage.base.types;
     const data = { ...rollData, roll: foundry.utils.deepClone(rollData.roll ?? {}) };
     data.roll.damage ??= {};
-    data.roll.damage.type = (damage.types.has(lastType) ? lastType : null) ?? damage.types.first();
+    data.roll.damage.type = (types.has(lastType) ? lastType : null) ?? types.first();
 
     if ( index === 0 ) {
       const actionType = this.getActionType(rollConfig.attackMode);
@@ -929,7 +932,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       data, parts,
       options: {
         type: data.roll.damage.type,
-        types: Array.from(damage.types),
+        types: Array.from(types),
         properties: data.roll.properties
       }
     };


### PR DESCRIPTION
- Fall back to the host item's base damage type in `_processDamagePart` when a damage part specifies none
- Gate the fallback on `offersBaseDamage` so it only applies to weapon and ammunition items

Closes #4393