### PR TITLE
[#5434] Show an equipped indicator on containers in the inventory panel

### DIFF
--- a/less/v2/actors.less
+++ b/less/v2/actors.less
@@ -524,14 +524,15 @@
         background-color: var(--dnd5e-background-alt-1);
 
         .equipped {
-          position: absolute;
-          bottom: 3px;
-          inset-inline-end: 3px;
-          z-index: 1;
+          background: var(--dnd5e-color-black);
+          border: 1px solid var(--dnd5e-color-gold);
+          border-radius: 50%;
+          box-shadow: 0 0 8px var(--dnd5e-shadow-15);
+          color: var(--dnd5e-color-gold);
           font-size: var(--font-size-14);
-          color: var(--item-control-active-color);
-          cursor: var(--cursor-pointer);
-          filter: drop-shadow(0 0 2px var(--dnd5e-shadow-45));
+          inset: auto -3px -3px auto;
+          padding: 2px;
+          position: absolute;
         }
 
         a {

--- a/less/v2/actors.less
+++ b/less/v2/actors.less
@@ -514,6 +514,7 @@
       gap: .5rem;
 
       .container {
+        position: relative;
         max-width: 78px;
         max-height: 78px;
         aspect-ratio: 1;
@@ -521,6 +522,17 @@
         border-radius: 4px;
         box-shadow: 0 0 6px var(--dnd5e-shadow-45);
         background-color: var(--dnd5e-background-alt-1);
+
+        .equipped {
+          position: absolute;
+          bottom: 3px;
+          inset-inline-end: 3px;
+          z-index: 1;
+          font-size: var(--font-size-14);
+          color: var(--item-control-active-color);
+          cursor: var(--cursor-pointer);
+          filter: drop-shadow(0 0 2px var(--dnd5e-shadow-45));
+        }
 
         a {
           display: flex;

--- a/templates/inventory/containers.hbs
+++ b/templates/inventory/containers.hbs
@@ -10,10 +10,10 @@
             {{/with}}
             {{/dnd5e-itemContext}}
             <img src="{{ img }}" alt="{{ name }}" draggable="false">
+            {{#if system.equipped}}
+            <i class="equipped fa-solid fa-shield-halved" data-tooltip aria-label="{{ localize "DND5E.Equipped" }}"></i>
+            {{/if}}
         </a>
-        {{#if system.equipped}}
-        <i class="equipped fa-solid fa-shield-halved" data-tooltip aria-label="{{ localize "DND5E.Equipped" }}"></i>
-        {{/if}}
     </li>
     {{/each}}
 </ul>

--- a/templates/inventory/containers.hbs
+++ b/templates/inventory/containers.hbs
@@ -11,6 +11,9 @@
             {{/dnd5e-itemContext}}
             <img src="{{ img }}" alt="{{ name }}" draggable="false">
         </a>
+        {{#if system.equipped}}
+        <i class="equipped fa-solid fa-shield-halved" data-tooltip aria-label="{{ localize "DND5E.Equipped" }}"></i>
+        {{/if}}
     </li>
     {{/each}}
 </ul>


### PR DESCRIPTION
- Add a shield badge to equipped containers in the icon-grid panel
- Position it bottom-right clear of the capacity meter, matching the equip control's active accent and tooltip

Closes #5434