### PR TITLE
[#7021] Set `keepId: false` when autoimporting a compendium actor

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -417,7 +417,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       return game.actors.importFromCompendium(game.packs.get(actor.pack), actor.id, {
         "flags.dnd5e.isAutoImported": true,
         folder: game.folders.get(folderId) ?? null
-      });
+      }, { keepId: false });
     } else {
       // A linked world actor was found. Create a copy to avoid affecting the original.
       return actor.clone({


### PR DESCRIPTION
This prevents a conflict when two different players summon the same actor from a compendium.
I'm trying to think of any issue arising from not keeping the original id here and I'm coming up blank. Let me know if I am in fact missing something.

Closes #7021