### PR TITLE
[#5455] Autofocus Critical button for critical damage rolls

### DIFF
--- a/module/applications/dice/damage-configuration-dialog.mjs
+++ b/module/applications/dice/damage-configuration-dialog.mjs
@@ -39,7 +39,9 @@ export default class DamageRollConfigurationDialog extends RollConfigurationDial
   async _prepareButtonsContext(context, options) {
     const allowCritical = this.config.critical?.allow !== false;
     let defaultButton = this.options.defaultButton;
-    if ( !defaultButton && this.rolls.some(roll => roll.options?.isCritical) ) defaultButton = "critical";
+    if ( !defaultButton && (this.config.isCritical || this.rolls.some(roll => roll.options?.isCritical)) ) {
+      defaultButton = "critical";
+    }
     const defaultCritical = allowCritical && (defaultButton === "critical");
     context.buttons = {
       critical: {

--- a/module/applications/dice/damage-configuration-dialog.mjs
+++ b/module/applications/dice/damage-configuration-dialog.mjs
@@ -38,7 +38,9 @@ export default class DamageRollConfigurationDialog extends RollConfigurationDial
   /** @override */
   async _prepareButtonsContext(context, options) {
     const allowCritical = this.config.critical?.allow !== false;
-    const defaultCritical = allowCritical && (this.options.defaultButton === "critical");
+    let defaultButton = this.options.defaultButton;
+    if ( !defaultButton && this.rolls.some(roll => roll.options?.isCritical) ) defaultButton = "critical";
+    const defaultCritical = allowCritical && (defaultButton === "critical");
     context.buttons = {
       critical: {
         default: defaultCritical,


### PR DESCRIPTION
- Fall back to inspecting roll critical state when no defaultButton is set
- Default the damage dialog to Critical when a roll is already flagged critical
- Mirror the existing D20 configuration dialog pattern

Closes #5455