### PR TITLE
[#6665] Prevent hidden items from being used, recovering uses

### DIFF
--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -97,6 +97,7 @@ export default function ActivityMixin(Base) {
      */
     get canUse() {
       if ( this.isRider ) return false;
+      if ( !this.item.canUse ) return false;
       if ( this.dependentOrigin?.active === false ) return false;
       if ( this.visibility?.requireAttunement && !this.item.system.attuned ) return false;
       if ( this.visibility?.requireMagic && (this.item.system.magicAvailable === false) ) return false;
@@ -175,7 +176,7 @@ export default function ActivityMixin(Base) {
      * @returns {Promise<ActivityUsageResults|void>}  Details on the usage process if not canceled.
      */
     async use(usage={}, dialog={}, message={}) {
-      if ( !this.item.isEmbedded || this.item.pack ) return;
+      if ( !this.item.isEmbedded ) return;
       if ( !this.item.isOwner ) {
         ui.notifications.error("DND5E.DocumentUseWarn");
         return;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2581,8 +2581,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     result.updateItems ??= [];
     result.rolls ??= [];
     for ( const item of this.items ) {
-      if ( (item.dependentOrigin?.active === false)
-        || (foundry.utils.getType(item.system.recoverUses) !== "function") ) continue;
+      if ( item.isHidden || (foundry.utils.getType(item.system.recoverUses) !== "function") ) continue;
       const rollData = item.getRollData();
       const { updates, rolls, destroy } = await item.system.recoverUses(recovery, rollData);
       if ( destroy ) {

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -121,8 +121,7 @@ export default class Combatant5e extends Combatant {
     await this.actor?.system.recoverCombatUses?.(periods, results);
 
     for ( const item of this.actor?.items ?? [] ) {
-      if ( (item.dependentOrigin?.active === false)
-        || (foundry.utils.getType(item.system.recoverUses) !== "function") ) continue;
+      if ( item.isHidden || (foundry.utils.getType(item.system.recoverUses) !== "function") ) continue;
       const rollData = item.getRollData();
       const { updates, rolls, destroy } = await item.system.recoverUses(Array.from(periods), rollData);
       if ( destroy ) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -166,6 +166,16 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* --------------------------------------------- */
 
   /**
+   * Should this item be able to be used?
+   * @type {boolean}
+   */
+  get canUse() {
+    return !this.inCompendium && !this.isHidden;
+  }
+
+  /* --------------------------------------------- */
+
+  /**
    * The item that contains this item, if it is in a container. Returns a promise if the item is located
    * in a compendium pack.
    * @type {Item5e|Promise<Item5e>|void}
@@ -283,6 +293,18 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   get isHealing() {
     return this.system.isHealing ?? false;
+  }
+
+  /* --------------------------------------------- */
+
+  /**
+   * Is this item hidden, preventing it from being used or recovering uses?
+   * @type {boolean}
+   */
+  get isHidden() {
+    if ( this.actor?.hiddenItems.has(this.id) ) return true;
+    if ( this.dependentOrigin?.active === false ) return true;
+    return false;
   }
 
   /* -------------------------------------------- */
@@ -481,7 +503,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @type {boolean}
    */
   get areEffectsSuppressed() {
-    if ( this.parent?.hiddenItems?.has(this.id) ) return true;
+    if ( this.isHidden ) return true;
     const requireEquipped = (this.type !== "consumable")
       || ["rod", "trinket", "wand"].includes(this.system.type.value);
     if ( requireEquipped && (this.system.equipped === false) ) return true;
@@ -708,8 +730,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    *                                                                   activities and was posted directly to chat.
    */
   async use(config={}, dialog={}, message={}) {
-    if ( this.pack ) return;
-
     let event = config.event;
     const activities = this.system.activities?.filter(a => a.canUse);
     if ( activities?.length ) {


### PR DESCRIPTION
Adds `Item#isHidden` that is used to determine whether item or activity uses can be recovered. Adds `Item#canUse` which uses `isHidden` combined with `inCompendium` to determine if an activity on an item can be used.

Removes the explicit check for whether an item is in a pack in `Item#use` and defer that to the activity filtering. This means calling `use` on items in compendiums will just fall through to posting to chat.