### PR TITLE
[#7132] Add options to move embed name to header or inline

### DIFF
--- a/less/v2/typography.less
+++ b/less/v2/typography.less
@@ -150,11 +150,21 @@
   }
 
   /* Embed Captions */
-  .content-embed figcaption cite {
-    display: block;
-    text-align: right;
+  .content-embed {
+    figcaption cite {
+      display: block;
+      text-align: right;
 
-    &::before { content: "-"; }
+      &::before { content: "-"; }
+    }
+
+    p > .embed-name {
+      font-style: italic;
+      font-weight: bold;
+
+      &:has(> a) > a::after { content: "."; }
+      &:not(:has(> a))::after { content: ". "; }
+    }
   }
 
   /* Embedded Roll Tables */

--- a/module/documents/journal-entry-page.mjs
+++ b/module/documents/journal-entry-page.mjs
@@ -1,3 +1,5 @@
+import EmbeddableDocumentMixin from "./mixins/embeddable.mjs";
+
 /**
  * @import { JournalEntryPageRollData } from "./_types.mjs";
  */
@@ -5,7 +7,7 @@
 /**
  * Custom implementation of journal entry pages for providing roll data.
  */
-export default class JournalEntryPage5e extends JournalEntryPage {
+export default class JournalEntryPage5e extends EmbeddableDocumentMixin(JournalEntryPage) {
   /**
    * Return a data object regarding this page and from the containing journal entry.
    * @returns {JournalEntryPageRollData}

--- a/module/documents/mixins/document.mjs
+++ b/module/documents/mixins/document.mjs
@@ -1,5 +1,6 @@
 import AppliedRules from "../applied-rules.mjs";
 import DependentDocumentMixin from "./dependent.mjs";
+import EmbeddableDocumentMixin from "./embeddable.mjs";
 import SystemFlagsMixin from "./flags.mjs";
 
 /**
@@ -10,7 +11,7 @@ import SystemFlagsMixin from "./flags.mjs";
  * @mixin
  */
 export default function SystemDocumentMixin(Base) {
-  class SystemDocument extends DependentDocumentMixin(SystemFlagsMixin(Base)) {
+  class SystemDocument extends DependentDocumentMixin(EmbeddableDocumentMixin(SystemFlagsMixin(Base))) {
 
     /* -------------------------------------------- */
     /*  Properties                                  */

--- a/module/documents/mixins/embeddable.mjs
+++ b/module/documents/mixins/embeddable.mjs
@@ -13,13 +13,15 @@ export default function EmbeddableDocumentMixin(Base) {
       if ( !config.nameStyle ) return element;
 
       // Use citation if present, use caption if it equals the document's name, otherwise create a new element
-      const figcaption = element.querySelector("figcaption:has(cite, .embed-caption)");
-      const citation = figcaption.querySelector(":scope > cite");
-      const caption = figcaption.querySelector(":scope > .embed-caption");
+      const figcaption = element.querySelector(":scope > figure.content-embed > figcaption:has(cite, .embed-caption)");
+      const citation = figcaption?.querySelector(":scope > cite")
+        ?? element.querySelector(":scope > figure.content-embed > cite");
+      const caption = figcaption?.querySelector(":scope > .embed-caption");
       const originalElement = caption && (caption.innerText === this.name) ? caption : citation;
 
       // Headers use tag provided, inline uses <span>, any others are invalid
-      const tagName = config.nameStyle.match(/h\d/i) ? config.nameStyle : config.nameStyle === "inline" ? "span" : null;
+      const nameStyle = String(config.nameStyle);
+      const tagName = /^h[1-6]$/i.test(nameStyle) ? nameStyle : nameStyle === "inline" ? "span" : null;
       if ( !tagName ) return element;
 
       // Create the new name element
@@ -33,11 +35,13 @@ export default function EmbeddableDocumentMixin(Base) {
 
       // Place headers as the first child, place inline names inside first paragraph
       let prepend = element.querySelector("figure.content-embed") ?? element;
-      if ( config.nameStyle === "inline" ) prepend = element.querySelector(".content-embed p") ?? prepend;
+      if ( config.nameStyle === "inline" ) {
+        prepend = element.querySelector(":scope > figure.content-embed p") ?? prepend;
+      }
       prepend.prepend(nameElement);
 
       // Remove original <figcaption> if empty
-      if ( !figcaption.hasChildNodes() ) figcaption.remove();
+      if ( figcaption && !figcaption.hasChildNodes() ) figcaption.remove();
 
       return element;
     }

--- a/module/documents/mixins/embeddable.mjs
+++ b/module/documents/mixins/embeddable.mjs
@@ -43,7 +43,8 @@ export default function EmbeddableDocumentMixin(Base) {
       // Place headers as the first child, place inline names inside first paragraph
       let prepend = element.querySelector("figure.content-embed") ?? element;
       if ( config.nameStyle === "inline" ) {
-        prepend = element.querySelector(":scope > figure.content-embed p") ?? prepend;
+        prepend = element
+          .querySelector(":scope > figure.content-embed > div > p, :scope > figure.content-embed > p") ?? prepend;
       }
       prepend.prepend(nameElement);
 

--- a/module/documents/mixins/embeddable.mjs
+++ b/module/documents/mixins/embeddable.mjs
@@ -17,7 +17,8 @@ export default function EmbeddableDocumentMixin(Base) {
       const citation = figcaption?.querySelector(":scope > cite")
         ?? element.querySelector(":scope > figure.content-embed > cite");
       const caption = figcaption?.querySelector(":scope > .embed-caption");
-      const originalElement = caption && (caption.innerText === this.name) ? caption : citation;
+      const originalElement = caption && ((caption.innerText === this.name) || (caption.innerText === config.label))
+        ? caption : citation;
 
       // Headers use tag provided, inline uses <span>, any others are invalid
       const nameStyle = String(config.nameStyle);
@@ -28,10 +29,16 @@ export default function EmbeddableDocumentMixin(Base) {
       const nameElement = document.createElement(tagName);
       nameElement.classList.add("embed-name");
       if ( originalElement ) {
+        if ( (originalElement === citation) && config.label ) {
+          const link = originalElement.querySelector("a");
+          const icon = originalElement.querySelector("i");
+          link.innerText = config.label;
+          link.prepend(icon);
+        }
         nameElement.replaceChildren(...originalElement.childNodes);
         originalElement.remove();
       }
-      else nameElement.innerText = this.name;
+      else nameElement.innerText = config.label || this.name;
 
       // Place headers as the first child, place inline names inside first paragraph
       let prepend = element.querySelector("figure.content-embed") ?? element;

--- a/module/documents/mixins/embeddable.mjs
+++ b/module/documents/mixins/embeddable.mjs
@@ -1,0 +1,46 @@
+/**
+ * Mixin used to add additional embedding options.
+ * @template {foundry.abstract.Document|PseudoDocument} T
+ * @param {typeof T} Base  The base document class to wrap.
+ * @returns {typeof EmbeddableDocument}
+ * @mixin
+ */
+export default function EmbeddableDocumentMixin(Base) {
+  class EmbeddableDocument extends Base {
+    /** @inheritDoc */
+    async _createFigureEmbed(content, config, options) {
+      const element = await super._createFigureEmbed(content, config, options);
+      if ( !config.nameStyle ) return element;
+
+      // Use citation if present, use caption if it equals the document's name, otherwise create a new element
+      const figcaption = element.querySelector("figcaption:has(cite, .embed-caption)");
+      const citation = figcaption.querySelector(":scope > cite");
+      const caption = figcaption.querySelector(":scope > .embed-caption");
+      const originalElement = caption && (caption.innerText === this.name) ? caption : citation;
+
+      // Headers use tag provided, inline uses <span>, any others are invalid
+      const tagName = config.nameStyle.match(/h\d/i) ? config.nameStyle : config.nameStyle === "inline" ? "span" : null;
+      if ( !tagName ) return element;
+
+      // Create the new name element
+      const nameElement = document.createElement(tagName);
+      nameElement.classList.add("embed-name");
+      if ( originalElement ) {
+        nameElement.replaceChildren(...originalElement.childNodes);
+        originalElement.remove();
+      }
+      else nameElement.innerText = this.name;
+
+      // Place headers as the first child, place inline names inside first paragraph
+      let prepend = element.querySelector("figure.content-embed") ?? element;
+      if ( config.nameStyle === "inline" ) prepend = element.querySelector(".content-embed p") ?? prepend;
+      prepend.prepend(nameElement);
+
+      // Remove original <figcaption> if empty
+      if ( !figcaption.hasChildNodes() ) figcaption.remove();
+
+      return element;
+    }
+  }
+  return EmbeddableDocument;
+}


### PR DESCRIPTION
Adds a new `nameStyle` option to the `@Embed` enricher for actors and items that allows them to place the document's name inline with the first paragraph of text or as a header. This option accepts an HTML header tag (e.g. `h2`) or `inline` as its value.

<img width="1427" height="1161" alt="Embed Name Styles" src="https://github.com/user-attachments/assets/1e6ce752-048c-4492-92de-db180f7233c9" />

This change is implemented in a new `EmbeddableDocumentMixin` so that it can be easily be added to Activity and Advancement when those types get embedding support.

### Future Work
- Adding an `nameAction` option for Items and Activities that changes the link to activate the item or activity rather than opening its sheet

Closes #7132