### PR TITLE
[#5139] Allow checking prerequisites within compendium browser

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -558,6 +558,7 @@ Hooks.once("ready", function() {
   dnd5e.registry.classes.initialize();
   dnd5e.registry.species.initialize();
   dnd5e.registry.subclasses.initialize();
+  dnd5e.registry.identifiers.initialize();
 
   // Chat message listeners
   documents.ChatMessage5e.activateListeners();

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -554,11 +554,7 @@ Hooks.once("ready", function() {
   inserts.registerProseMirrorInserts();
 
   // Register items by type
-  dnd5e.registry.backgrounds.initialize();
-  dnd5e.registry.classes.initialize();
-  dnd5e.registry.species.initialize();
-  dnd5e.registry.subclasses.initialize();
-  dnd5e.registry.identifiers.initialize();
+  dnd5e.registry.items.initialize();
 
   // Chat message listeners
   documents.ChatMessage5e.activateListeners();

--- a/lang/en.json
+++ b/lang/en.json
@@ -3997,19 +3997,28 @@
   "FIELDS": {
     "prerequisites": {
       "items": {
+        "display": "{items}",
         "hint": "Identifiers for items that the character must have before selecting this item.",
         "label": "Required Items"
       },
       "label": "Prerequisites",
       "level": {
+        "display": "Level {level}+",
+        "displayLegacy": "{levelOrdinal} level",
         "hint": "Character or class level required to select this feature when levelling up.",
         "label": "Required Level"
       },
       "repeatable": {
+        "display": "Not already taken",
         "hint": "This feature can be chosen more than once.",
         "label": "Repeatable"
       }
     }
+  },
+  "Status": {
+    "Invalid": "Prerequisite Validation Failed",
+    "Unknown": "Prerequisite Validation Incomplete",
+    "Valid": "Prerequisite Validation Succeeded"
   },
   "Warning": {
     "InvalidLevel": "must be at least level {level}",

--- a/less/v2/compendium-browser.less
+++ b/less/v2/compendium-browser.less
@@ -238,6 +238,15 @@
       z-index: 1;
     }
 
+    .items-section .item-prerequisites {
+      width: 20px;
+
+      .prerequisites-result {
+        &.fa-circle-check { color: var(--dnd5e-color-success); }
+        &.fa-circle-xmark { color: var(--dnd5e-color-failure); }
+      }
+    }
+
     .items-section .item-controls {
       width: 50px;
       align-items: center;

--- a/less/v2/tooltips.less
+++ b/less/v2/tooltips.less
@@ -148,6 +148,11 @@
     }
 
     .extras {
+      font-family: var(--dnd5e-font-roboto-condensed);
+      font-size: var(--font-size-12);
+      margin: 0;
+      text-align: center;
+
       .prerequisite::after {
         font-family: var(--font-awesome);
         font-weight: 900;

--- a/less/v2/tooltips.less
+++ b/less/v2/tooltips.less
@@ -147,6 +147,22 @@
       &:empty { margin-bottom: .5rem; }
     }
 
+    .extras {
+      .prerequisite::after {
+        font-family: var(--font-awesome);
+        font-weight: 900;
+        padding-inline-start: 4px;
+      }
+      .prerequisite.valid::after {
+        content: "\f00c";
+        color: var(--dnd5e-color-success);
+      }
+      .prerequisite.invalid::after {
+        content: "\f00d";
+        color: var(--dnd5e-color-failure);
+      }
+    }
+
     &.locked-tooltip {
       .description {
         overflow-y: scroll;

--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -444,10 +444,10 @@
 
 /**
  * @typedef RegisteredItemData
- * @property {string} name        Name of the item.
- * @property {string} identifier  Item identifier.
- * @property {string} img         Item's icon.
- * @property {string[]} sources   UUIDs of different compendium items matching this identifier.
+ * @property {string} name         Name of the item.
+ * @property {string} identifier   Item identifier.
+ * @property {string} [img]        Item's icon.
+ * @property {string[]} [sources]  UUIDs of different compendium items matching this identifier.
  */
 
 /* -------------------------------------------- */

--- a/module/applications/_types.mjs
+++ b/module/applications/_types.mjs
@@ -12,6 +12,8 @@
  * @property {number|null} xp                        Amount of experience points to award.
  */
 
+/* -------------------------------------------- */
+
 /**
  * @typedef CurrencyUpdateOptions
  * @property {boolean} [exact=true]                    Prioritize deducting the requested denomination first.
@@ -30,7 +32,11 @@
  *                                              Locked filters won't be able to be changed by the user. Initial filters
  *                                              will be set to start but can be changed.
  * @property {string|null} hint                 Hint displayed in the interface.
- * @property {CompendiumBrowserSelectionConfiguration} selection  Configuration used to define document selections.
+ * @property {CompendiumBrowserSelectionConfiguration} selection     Configuration used to define document selections.
+ * @property {object} prerequisites
+ * @property {boolean} prerequisites.enforce        Prevent selection of results that fail validation.
+ * @property {boolean} prerequisites.fullDocuments  Require the full documents to be fetched for evaluation.
+ * @property {ValidatePrerequisitesCallback} prerequisites.validate  Callback used to evaluate prerequisites.
  */
 
 /**
@@ -80,6 +86,25 @@
  *                                   class are assumed.
  * @property {boolean} [advanced]    Is this tab only available in the advanced browsing mode.
  */
+
+/**
+ * @typedef PrerequisiteValidationResult
+ * @param {string} label           Label describing the prerequisite.
+ * @param {boolean} [quiet=false]  Only display in mark compendium browser if invalid.
+ * @param {boolean|null} valid     Whether the prerequisite is valid or not, or `null` if it couldn't be evaluated.
+ */
+
+/**
+ * @typedef {Map<string, PrerequisiteValidationResult>} PrerequisiteValidationResults
+ */
+
+/**
+ * @callback ValidatePrerequisitesCallback
+ * @param {Document|object} doc  Document for which to evaluate the prerequisites.
+ * @returns {PrerequisiteValidationResults}
+ */
+
+/* -------------------------------------------- */
 
 /**
  * Description for a single part of a property attribution.

--- a/module/applications/_types.mjs
+++ b/module/applications/_types.mjs
@@ -89,9 +89,9 @@
 
 /**
  * @typedef PrerequisiteValidationResult
- * @param {string} label           Label describing the prerequisite.
- * @param {boolean} [quiet=false]  Only display in mark compendium browser if invalid.
- * @param {boolean|null} valid     Whether the prerequisite is valid or not, or `null` if it couldn't be evaluated.
+ * @property {string} label           Label describing the prerequisite.
+ * @property {boolean} [quiet=false]  Only display in mark compendium browser if invalid.
+ * @property {boolean|null} valid     Whether the prerequisite is valid or not, or `null` if it couldn't be evaluated.
  */
 
 /**
@@ -101,7 +101,7 @@
 /**
  * @callback ValidatePrerequisitesCallback
  * @param {Document|object} doc  Document for which to evaluate the prerequisites.
- * @returns {PrerequisiteValidationResults}
+ * @returns {PrerequisiteValidationResults|void}
  */
 
 /* -------------------------------------------- */

--- a/module/applications/advancement/ability-score-improvement-flow.mjs
+++ b/module/applications/advancement/ability-score-improvement-flow.mjs
@@ -185,7 +185,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
 
     // TODO: Remove this unnecessary check when https://github.com/foundryvtt/dnd5e/issues/5139 is implemented
     const item = await fromUuid(result);
-    const isValid = item.system.validatePrerequisites?.(this.advancement.actor, { showMessage: true });
+    const isValid = item.system.assertPrerequisites?.(this.advancement.actor, { showMessage: true });
     if ( isValid === true ) {
       await this.advancement.apply(this.level, {
         retainedItems: this.retainedData?.retainedItems, type: "feat", uuid: result
@@ -290,7 +290,7 @@ export default class AbilityScoreImprovementFlow extends AdvancementFlow {
       return null;
     }
 
-    const isValid = item.system.validatePrerequisites?.(this.advancement.actor, { showMessage: true });
+    const isValid = item.system.assertPrerequisites?.(this.advancement.actor, { showMessage: true });
     if ( isValid !== true ) return null;
 
     await this.advancement.apply(this.level, {

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -349,6 +349,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
 
     try {
       this.advancement._validateItemType(item);
+      item.system.assertPrerequisites?.(this.advancement.actor, { level: this.featureLevel, throwError: true });
     } catch(err) {
       ui.notifications.error(err.message);
       return null;

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -233,7 +233,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
       return;
     }
 
-    const filters = { locked: { additional: {}, documentClass: "Item" } };
+    const filters = { locked: { additional: {}, documentClass: "Item", exclusive: true } };
 
     // Apply restrictions based on type
     if ( config.type ) {
@@ -273,7 +273,14 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     }
 
     const result = await CompendiumBrowser.select({
-      filters, selection: { min: 1, max: max - current }
+      filters,
+      prerequisites: {
+        validate: item => {
+          if ( !item.system.prerequisiteLabels ) return [];
+          return item.system.prerequisiteLabels({ actor: this.advancement.actor, level: this.level });
+        }
+      },
+      selection: { min: 1, max: max - current }
     }, this.manager?._detachOptions());
     if ( !result?.size ) return;
 

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -154,7 +154,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
       items: [...this.pool, ...dropped].reduce((arr, item) => {
         const { id, name, img } = item;
         const uuid = item.flags.dnd5e?.sourceId ?? item.uuid;
-        const validFeature = !item.system.validatePrerequisites || (item.system.validatePrerequisites(
+        const validFeature = !item.system.assertPrerequisites || (item.system.assertPrerequisites(
           this.advancement.actor, { added, removed, level: this.featureLevel }
         ) === true);
         const validSpell = !validateSpellLevel
@@ -276,8 +276,8 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
       filters,
       prerequisites: {
         validate: item => {
-          if ( !item.system.prerequisiteLabels ) return;
-          return item.system.prerequisiteLabels({ actor: this.advancement.actor, level: this.featureLevel });
+          if ( !item.system.validatePrerequisites ) return;
+          return item.system.validatePrerequisites({ actor: this.advancement.actor, level: this.featureLevel });
         }
       },
       selection: { min: 1, max: max - current }

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -276,8 +276,8 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
       filters,
       prerequisites: {
         validate: item => {
-          if ( !item.system.prerequisiteLabels ) return [];
-          return item.system.prerequisiteLabels({ actor: this.advancement.actor, level: this.level });
+          if ( !item.system.prerequisiteLabels ) return;
+          return item.system.prerequisiteLabels({ actor: this.advancement.actor, level: this.featureLevel });
         }
       },
       selection: { min: 1, max: max - current }

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -1,6 +1,6 @@
 import * as Filter from "../filter.mjs";
 import SourceField from "../data/shared/source-field.mjs";
-import { getPluralRules, loadingTooltip } from "../utils.mjs";
+import { bulkFromUuid, getPluralRules, loadingTooltip } from "../utils.mjs";
 import Application5e from "./api/application.mjs";
 import CompendiumBrowserSettingsConfig from "./settings/compendium-browser-settings.mjs";
 
@@ -676,9 +676,9 @@ export default class CompendiumBrowser extends Application5e {
     };
     if ( this.options.prerequisites.validate ) {
       const results = this.options.prerequisites.validate(entry);
-      if ( results.size ) {
+      if ( results?.size ) {
         context.prerequisites = results.values().reduce((r, result) => {
-          if ( result.valid === false) {
+          if ( result.valid === false ) {
             r.disabled = this.options.prerequisites.enforce;
             r.invalid = true;
             r.valid = false;
@@ -1162,13 +1162,13 @@ export default class CompendiumBrowser extends Application5e {
             && (!p.metadata.flags.dnd5e?.types || p.metadata.flags.dnd5e.types.includes(i.type))))
             && (!filters.length || Filter.performCheck(i, filters))
         )
-
-        // If full documents are required, retrieve those, otherwise stick with the indices
-        .map(async i => index ? i : await fromUuid(i.uuid))
       ));
 
     // Wait for everything to finish loading and flatten the arrays
     documents = (await Promise.all(documents)).flat();
+
+    // If full documents are required, retrieve those, otherwise stick with the indices
+    if ( !index ) documents = (await bulkFromUuid(documents.map(d => d.uuid))).values().toArray();
 
     if ( sort ) {
       if ( sort === true ) sort = "name";

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -71,6 +71,11 @@ export default class CompendiumBrowser extends Application5e {
         types: new Set(["class"])
       }
     },
+    prerequisites: {
+      enforce: true,
+      fullDocuments: true,
+      validate: null
+    },
     selection: {
       min: null,
       max: null
@@ -256,6 +261,16 @@ export default class CompendiumBrowser extends Application5e {
    */
   get displaySelection() {
     return !!this.options.selection.min || !!this.options.selection.max;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Should the prerequisites column be displayed?
+   * @type {boolean}
+   */
+  get displayPrerequisites() {
+    return !!this.options.prerequisites.validate;
   }
 
   /* -------------------------------------------- */
@@ -591,8 +606,10 @@ export default class CompendiumBrowser extends Application5e {
     this.#results = CompendiumBrowser.fetch(CONFIG[context.filters.documentClass].documentClass, {
       filters,
       types: context.filters.types,
+      index: !this.options.prerequisites.validate || !this.options.prerequisites.fullDocuments,
       indexFields: new Set(["system.source"])
     });
+    context.displayPrerequisites = this.displayPrerequisites;
     context.displaySelection = this.displaySelection;
     context.hint = this.options.hint;
     return context;
@@ -653,9 +670,27 @@ export default class CompendiumBrowser extends Application5e {
     const source = system?.source?.value ?? "";
     const context = {
       entry: { img, name, subtitle, uuid, source },
+      displayPrerequisites: this.displayPrerequisites,
       displaySelection: this.displaySelection,
       selected: this.#selected.has(uuid)
     };
+    if ( this.options.prerequisites.validate ) {
+      const results = this.options.prerequisites.validate(entry);
+      if ( results.size ) {
+        context.prerequisites = results.values().reduce((r, result) => {
+          if ( result.valid === false) {
+            r.disabled = this.options.prerequisites.enforce;
+            r.invalid = true;
+            r.valid = false;
+          } else if ( result.valid === null ) {
+            r.indeterminate = true;
+          }
+          r.display ||= (result.quiet !== true) || (r.valid === false);
+          return r;
+        }, { disabled: false, display: false, indeterminate: false, invalid: false, valid: true });
+        context.prerequisites.results = results;
+      }
+    }
     const html = await foundry.applications.handlebars.renderTemplate(
       "systems/dnd5e/templates/compendium/browser-entry.hbs", context
     );
@@ -664,6 +699,11 @@ export default class CompendiumBrowser extends Application5e {
     element.dataset.tooltipHtml = loadingTooltip({ uuid });
     element.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip";
     element.dataset.tooltipDirection ??= "RIGHT";
+    if ( context.prerequisites ) element.dataset.tooltipExtras = game.i18n.getListFormatter({ type: "unit" }).format(
+      context.prerequisites.results.values().map(r =>
+        `<span class="prerequisite${r.valid ? " valid" : r.valid === false ? " invalid" : ""}">${r.label}</span>`
+      )
+    );
     return element;
   }
 

--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -171,6 +171,8 @@ export default class ItemDataModel extends SystemDataModel {
   /**
    * Render a rich tooltip for this item.
    * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
+   * @param {Activity} [enrichmentOptions.activity]     Specific activity on item to use for customizing the data.
+   * @param {string} [enrichmentOptions.extras]         Extra HTML displayed with the tooltip.
    * @returns {{content: string, classes: string[]}}
    */
   async richTooltip(enrichmentOptions={}) {
@@ -188,9 +190,10 @@ export default class ItemDataModel extends SystemDataModel {
    * Prepare item card template data.
    * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
    * @param {Activity} [enrichmentOptions.activity]     Specific activity on item to use for customizing the data.
+   * @param {string} [enrichmentOptions.extras]         Extra HTML displayed with the tooltip.
    * @returns {Promise<object>}
    */
-  async getCardData({ activity, ...enrichmentOptions }={}) {
+  async getCardData({ activity, extras, ...enrichmentOptions }={}) {
     const { name, type, img } = this.parent;
     let {
       price, weight, uses, identified, unidentified, description, school, materials
@@ -202,7 +205,7 @@ export default class ItemDataModel extends SystemDataModel {
 
     enrichmentOptions = { rollData, relativeTo: this.parent, ...enrichmentOptions };
     const context = {
-      name, type, img, price, weight, uses, school, materials,
+      name, type, img, price, weight, uses, school, materials, extras,
       config: CONFIG.DND5E,
       controlHints: game.settings.get("dnd5e", "controlHints"),
       labels: foundry.utils.deepClone((activity ?? this.parent).labels),

--- a/module/data/actor/encounter.mjs
+++ b/module/data/actor/encounter.mjs
@@ -1,5 +1,6 @@
-import GroupTemplate from "./templates/group.mjs";
+import { bulkFromUuid } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
+import GroupTemplate from "./templates/group.mjs";
 
 const { ArrayField, DocumentUUIDField, NumberField, SchemaField } = foundry.data.fields;
 
@@ -127,31 +128,10 @@ export default class EncounterData extends GroupTemplate {
 
   /** @override */
   async getMembers() {
-    // Batch compendium lookups when retrieving members.
-    const collections = new Map();
-    const members = new Map();
-
-    for ( const { uuid, ...rest } of this.members ) {
-      const { collection, id } = foundry.utils.parseUuid(uuid);
-      let ids = collections.get(collection);
-      if ( !ids ) {
-        ids = [];
-        collections.set(collection, ids);
-      }
-      ids.push(id);
-      rest.collection = collection;
-      members.set(id, rest);
-    }
-
-    for ( const [collection, ids] of collections.entries() ) {
-      if ( collection instanceof foundry.documents.collections.CompendiumCollection ) {
-        await collection.getDocuments({ _id__in: ids });
-      }
-    }
-
-    return Array.from(members.entries().map(([id, { collection, ...data }]) => {
-      return { actor: collection.get(id), ...foundry.utils.deepClone(data) };
-    }).filter(d => d.actor));
+    const members = await bulkFromUuid(this.members.map(m => m.uuid));
+    return this.members.map(data => ({
+      actor: members.get(data.uuid), ...foundry.utils.deepClone(data)
+    })).filter(d => d.actor);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -314,13 +314,73 @@ export default class FeatData extends ItemDataModel.mixin(
 
   /**
    * Validate the prerequisites specified on this item.
+   * @param {Actor5e} actor                        Actor against which the prerequisites should be checked.
+   * @param {object} [options={}]
+   * @param {Item5e[]} [options.added]             Items that are pending addition to the Actor.
+   * @param {number} [options.level]               Level to validate. Falls back to character level.
+   * @param {Item5e[]} [options.removed]           Items that are pending removal from the Actor.
+   * @param {boolean} [options.showMessage=false]  Show a UI message if the validation fails.
+   * @param {boolean} [options.throwError=false]   Throw an error if validation fails.
+   * @returns {true|string[]}  True if the item is valid or a list of invalid descriptions if validation failed.
+   */
+  assertPrerequisites(actor, {
+    added=[], level=actor.system?.details?.level, removed=[], showMessage=false, throwError=false
+  }={}) {
+    const results = this.validatePrerequisites({ actor, added, level });
+    const messages = [];
+
+    if ( results.get("items")?.valid === false ) {
+      messages.push(_loc("DND5E.Prerequisites.Warning.MissingItem", {
+        items: game.i18n.getListFormatter({ type: "disjunction" }).format(
+          Array.from(this.prerequisites.items).map(i => dnd5e.registry.identifiers.get(i) ?? i)
+        )
+      }));
+    }
+
+    if ( results.get("repeatable")?.valid === false ) {
+      messages.push(_loc("DND5E.Prerequisites.Warning.NotRepeatable", { name: this.parent.name }));
+    }
+
+    if ( results.get("level")?.valid === false ) {
+      messages.push(_loc("DND5E.Prerequisites.Warning.InvalidLevel", { level: this.prerequisites.level }));
+    }
+
+    if ( !messages.length ) return true;
+
+    if ( showMessage || throwError ) {
+      const message = _loc("DND5E.Prerequisites.Warning.Message", {
+        actor: actor.name,
+        requirements: game.i18n.getListFormatter().format(messages),
+        type: _loc(CONFIG.Item.typeLabels[this.parent.type]).toLowerCase()
+      });
+      if ( showMessage ) ui.notifications.warn(message);
+      if ( throwError ) throw new Error(message);
+    }
+
+    return messages;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Validate the prerequisites specified on this item.
    * @param {object} [context={}]
    * @param {Actor5e} [context.actor]   Actor against which the prerequisites should be checked.
    * @param {Item5e[]} [context.added]  Items that are pending addition to the Actor.
    * @param {number} [context.level]    Level to validate. Falls back to character level if actor is provided.
+   * @param {object} [_options]
    * @returns {PrerequisiteValidationResults}
    */
-  prerequisiteLabels({ actor, added=[], level=actor?.system?.details?.level }) {
+  validatePrerequisites(context={}, _options) {
+    if ( context instanceof Actor ) {
+      foundry.utils.logCompatibilityWarning(
+        "`FeatData#validatePrerequisites` has been renamed `assertPrerequisites`.",
+        { since: "DnD5e 6.0", until: "DnD5e 7.0" }
+      );
+      return this.assertPrerequisites(context, _options);
+    }
+
+    const { actor, added=[], level=actor?.system?.details?.level } = context;
     const prerequisites = new Map();
     const legacy = this.source.rules === "2014" || dnd5e.settings.rulesVersion === "legacy" ? "Legacy" : "";
 
@@ -352,54 +412,6 @@ export default class FeatData extends ItemDataModel.mixin(
     });
 
     return prerequisites;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Validate the prerequisites specified on this item.
-   * @param {Actor5e} actor                        Actor against which the prerequisites should be checked.
-   * @param {object} [options={}]
-   * @param {Item5e[]} [options.added]             Items that are pending addition to the Actor.
-   * @param {number} [options.level]               Level to validate. Falls back to character level.
-   * @param {Item5e[]} [options.removed]           Items that are pending removal from the Actor.
-   * @param {boolean} [options.showMessage=false]  Show a UI message if the validation fails.
-   * @param {boolean} [options.throwError=false]   Throw an error if validation fails.
-   * @returns {true|string[]}  True if the item is valid or a list of invalid descriptions if validation failed.
-   */
-  validatePrerequisites(actor, {
-    added=[], level=actor.system?.details?.level, removed=[], showMessage=false, throwError=false
-  }={}) {
-    const results = this.prerequisiteLabels({ actor, added, level });
-    const messages = [];
-
-    if ( results.get("items")?.valid === false ) {
-      messages.push(_loc("DND5E.Prerequisites.Warning.MissingItem", {
-        items: game.i18n.getListFormatter({ type: "disjunction" }).format(Array.from(this.prerequisites.items))
-      }));
-    }
-
-    if ( results.get("repeatable")?.valid === false ) {
-      messages.push(_loc("DND5E.Prerequisites.Warning.NotRepeatable", { name: this.parent.name }));
-    }
-
-    if ( results.get("level")?.valid === false ) {
-      messages.push(_loc("DND5E.Prerequisites.Warning.InvalidLevel", { level: this.prerequisites.level }));
-    }
-
-    if ( !messages.length ) return true;
-
-    if ( showMessage || throwError ) {
-      const message = _loc("DND5E.Prerequisites.Warning.Message", {
-        actor: actor.name,
-        requirements: game.i18n.getListFormatter().format(messages),
-        type: _loc(CONFIG.Item.typeLabels[this.parent.type]).toLowerCase()
-      });
-      if ( showMessage ) ui.notifications.warn(message);
-      if ( throwError ) throw new Error(message);
-    }
-
-    return messages;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -332,7 +332,7 @@ export default class FeatData extends ItemDataModel.mixin(
     if ( results.get("items")?.valid === false ) {
       messages.push(_loc("DND5E.Prerequisites.Warning.MissingItem", {
         items: game.i18n.getListFormatter({ type: "disjunction" }).format(
-          Array.from(this.prerequisites.items).map(i => dnd5e.registry.identifiers.get(i) ?? i)
+          Array.from(this.prerequisites.items).map(i => dnd5e.registry.items.get(i)?.name ?? i)
         )
       }));
     }
@@ -398,7 +398,7 @@ export default class FeatData extends ItemDataModel.mixin(
     if ( this.prerequisites.items.size ) prerequisites.set("items", {
       label: _loc("DND5E.Prerequisites.FIELDS.prerequisites.items.display", {
         items: game.i18n.getListFormatter({ type: "disjunction" }).format(
-          Array.from(this.prerequisites.items).map(i => dnd5e.registry.identifiers.get(i) ?? i)
+          Array.from(this.prerequisites.items).map(i => dnd5e.registry.items.get(i)?.name ?? i)
         )
       }),
       valid: actor ? Array.from(this.prerequisites.items).some(i => actor.identifiedItems.get(i)?.size) : null

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -382,7 +382,7 @@ export default class FeatData extends ItemDataModel.mixin(
 
     const { actor, added=[], level=actor?.system?.details?.level } = context;
     const prerequisites = new Map();
-    const legacy = this.source.rules === "2014" || dnd5e.settings.rulesVersion === "legacy" ? "Legacy" : "";
+    const legacy = (this.source.rules === "2014") || (dnd5e.settings.rulesVersion === "legacy") ? "Legacy" : "";
 
     // If a feature has a level pre-requisite, make sure it is less than or equal to current level
     if ( Number.isFinite(this.prerequisites.level) ) prerequisites.set("level", {

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -337,7 +337,7 @@ export default class FeatData extends ItemDataModel.mixin(
     // If a feature has item pre-requisites, make sure the other items exist on the actor
     if ( this.prerequisites.items.size ) prerequisites.set("items", {
       label: _loc("DND5E.Prerequisites.FIELDS.prerequisites.items.display", {
-        items:  game.i18n.getListFormatter({ type: "disjunction" }).format(
+        items: game.i18n.getListFormatter({ type: "disjunction" }).format(
           Array.from(this.prerequisites.items).map(i => dnd5e.registry.identifiers.get(i) ?? i)
         )
       }),

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -1,3 +1,4 @@
+import { formatNumber } from "../../utils.mjs";
 import ItemDataModel from "../abstract/item-data-model.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import IdentifierField from "../fields/identifier-field.mjs";
@@ -313,6 +314,50 @@ export default class FeatData extends ItemDataModel.mixin(
 
   /**
    * Validate the prerequisites specified on this item.
+   * @param {object} [context={}]
+   * @param {Actor5e} [context.actor]   Actor against which the prerequisites should be checked.
+   * @param {Item5e[]} [context.added]  Items that are pending addition to the Actor.
+   * @param {number} [context.level]    Level to validate. Falls back to character level if actor is provided.
+   * @returns {PrerequisiteValidationResults}
+   */
+  prerequisiteLabels({ actor, added=[], level=actor?.system?.details?.level }) {
+    const prerequisites = new Map();
+    const legacy = this.source.rules === "2014" || dnd5e.settings.rulesVersion === "legacy" ? "Legacy" : "";
+
+    // If a feature has a level pre-requisite, make sure it is less than or equal to current level
+    if ( Number.isFinite(this.prerequisites.level) ) prerequisites.set("level", {
+      label: _loc(`DND5E.Prerequisites.FIELDS.prerequisites.level.display${legacy}`, {
+        level: formatNumber(this.prerequisites.level),
+        levelOrdinal: formatNumber(this.prerequisites.level, { ordinal: true })
+      }),
+      quiet: true,
+      valid: Number.isFinite(level) ? level >= this.prerequisites.level : null
+    });
+
+    // If a feature has item pre-requisites, make sure the other items exist on the actor
+    if ( this.prerequisites.items.size ) prerequisites.set("items", {
+      label: _loc("DND5E.Prerequisites.FIELDS.prerequisites.items.display", {
+        items:  game.i18n.getListFormatter({ type: "disjunction" }).format(
+          Array.from(this.prerequisites.items).map(i => dnd5e.registry.identifiers.get(i) ?? i)
+        )
+      }),
+      valid: actor ? Array.from(this.prerequisites.items).some(i => actor.identifiedItems.get(i)?.size) : null
+    });
+
+    // Check to ensure the item doesn't already exist on actor if it is not repeatable
+    if ( actor && !this.prerequisites.repeatable && actor.sourcedItems?.get(this.parent.uuid)?.size
+      && !added.find(a => a.uuid === this.parent.uuid) ) prerequisites.set("repeatable", {
+      label: _loc("DND5E.Prerequisites.FIELDS.prerequisites.repeatable.display"),
+      valid: false
+    });
+
+    return prerequisites;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Validate the prerequisites specified on this item.
    * @param {Actor5e} actor                        Actor against which the prerequisites should be checked.
    * @param {object} [options={}]
    * @param {Item5e[]} [options.added]             Items that are pending addition to the Actor.
@@ -325,27 +370,21 @@ export default class FeatData extends ItemDataModel.mixin(
   validatePrerequisites(actor, {
     added=[], level=actor.system?.details?.level, removed=[], showMessage=false, throwError=false
   }={}) {
+    const results = this.prerequisiteLabels({ actor, added, level });
     const messages = [];
 
-    // If a feature has item pre-requisites, make sure the other items exist on the actor
-    if ( this.prerequisites.items.size
-      && !Array.from(this.prerequisites.items).some(i => actor.identifiedItems.get(i)?.size) ) {
+    if ( results.get("items")?.valid === false ) {
       messages.push(_loc("DND5E.Prerequisites.Warning.MissingItem", {
         items: game.i18n.getListFormatter({ type: "disjunction" }).format(Array.from(this.prerequisites.items))
       }));
     }
 
-    // Check to ensure the item doesn't already exist on actor if it is not repeatable
-    if ( !this.prerequisites.repeatable && actor.sourcedItems?.get(this.parent.uuid)?.size
-      && !added.find(a => a.uuid === this.parent.uuid) ) {
+    if ( results.get("repeatable")?.valid === false ) {
       messages.push(_loc("DND5E.Prerequisites.Warning.NotRepeatable", { name: this.parent.name }));
     }
 
-    // If a feature has a level pre-requisite, make sure it is less than or equal to current level
-    if ( (this.prerequisites.level ?? -Infinity) > (level ?? Infinity) ) {
-      messages.push(_loc("DND5E.Prerequisites.Warning.InvalidLevel", {
-        level: this.prerequisites.level
-      }));
+    if ( results.get("level")?.valid === false ) {
+      messages.push(_loc("DND5E.Prerequisites.Warning.InvalidLevel", { level: this.prerequisites.level }));
     }
 
     if ( !messages.length ) return true;

--- a/module/data/journal/rule.mjs
+++ b/module/data/journal/rule.mjs
@@ -25,9 +25,10 @@ export default class RuleJournalPageData extends foundry.abstract.TypeDataModel 
   /**
    * Render a rich tooltip for this page.
    * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
+   * @param {string} [enrichmentOptions.extras]         Extra HTML displayed with the tooltip.
    * @returns {{content: string, classes: string[]}}
    */
-  async richTooltip(enrichmentOptions={}) {
+  async richTooltip({ extras, ...enrichmentOptions }={}) {
     const context = {
       page: this.parent,
       type: CONFIG.DND5E.ruleTypes[this.type].label,

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -1106,9 +1106,10 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /**
    * Prepare an object of chat data used to display a card for the Item in the chat log.
    * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
+   * @param {string} [enrichmentOptions.extras]         Extra HTML displayed with the tooltip.
    * @returns {object}              An object of chat data to render.
    */
-  async getPreviewContext(enrichmentOptions={}) {
+  async getPreviewContext({ extras, ...enrichmentOptions }={}) {
     let properties = [];
     if ( this.isSuppressed ) properties.push("DND5E.EFFECT.Status.Unavailable");
     else if ( this.disabled ) properties.push("DND5E.EFFECT.Status.Inactive");
@@ -1120,7 +1121,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     properties.unshift(...this.statuses.map(id => CONFIG.statusEffects[id]?.name).filter(_ => _));
 
     return {
-      properties,
+      extras, properties,
       description: await TextEditor.enrichHTML(this.description ?? "", {
         ...enrichmentOptions,
         relativeTo: this
@@ -1172,6 +1173,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /**
    * Render a rich tooltip for this effect.
    * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
+   * @param {string} [enrichmentOptions.extras]         Extra HTML displayed with the tooltip.
    * @returns {Promise<{content: string, classes: string[]}>}
    */
   async richTooltip(enrichmentOptions={}) {

--- a/module/documents/advancement/_types.mjs
+++ b/module/documents/advancement/_types.mjs
@@ -90,6 +90,7 @@
  *                                  data is present, it will be used rather than fetching new data from the source.
  * @property {string[]} [selected]  UUIDs of items to add. If none provided, then will fall back to the items
  *                                  provided in the `items` object.
+ * @property {boolean} [skipExisting=true]  Don't add items if item with same source UUID has already been added.
  */
 
 /**

--- a/module/documents/advancement/item-choice.mjs
+++ b/module/documents/advancement/item-choice.mjs
@@ -107,7 +107,7 @@ export default class ItemChoiceAdvancement extends ItemGrantAdvancement {
     let replacement;
     if ( retainedData.replaced ) ({ original, replacement } = retainedData.replaced);
 
-    await super.apply(level, { ...data, retainedData }, options);
+    await super.apply(level, { ...data, retainedData, skipExisting: false }, options);
 
     if ( original ) {
       const replaced = this.value.replaced[level] ?? {};
@@ -227,7 +227,7 @@ export default class ItemChoiceAdvancement extends ItemGrantAdvancement {
       for ( const [id, uuid] of Object.entries(this.value.added[level] ?? {}) ) {
         const item = this.actor.items.get(id);
         if ( !item ) continue;
-        const isValid = item.system.validatePrerequisites?.(this.actor, {
+        const isValid = item.system.assertPrerequisites?.(this.actor, {
           added, removed, level: level || this.actor.system.details?.level, showMessage
         }) ?? true;
         if ( isValid !== true ) await this.reverse(level, { skipEvaluation: true, uuid });

--- a/module/documents/advancement/item-choice.mjs
+++ b/module/documents/advancement/item-choice.mjs
@@ -152,7 +152,7 @@ export default class ItemChoiceAdvancement extends ItemGrantAdvancement {
     for ( const item of data.items ?? [] ) {
       const original = await fromUuid(item.flags.dnd5e.sourceId);
       try {
-        original?.system.validatePrerequisites?.(this.actor, {
+        original?.system.assertPrerequisites?.(this.actor, {
           level: level || this.actor.system.details?.level, throwError: true
         });
         items.push(item);

--- a/module/documents/advancement/item-grant.mjs
+++ b/module/documents/advancement/item-grant.mjs
@@ -88,7 +88,7 @@ export default class ItemGrantAdvancement extends Advancement {
   /* -------------------------------------------- */
 
   /** @override */
-  async apply(level, { ability, retainedData={}, selected }={}, options={}) {
+  async apply(level, { ability, retainedData={}, selected, skipExisting=true }={}, options={}) {
     if ( options.initial ) {
       ability ??= retainedData.ability ?? this.value.ability ?? this.configuration.spell?.ability?.first();
       selected ??= this.configuration.items?.reduce((arr, { optional, uuid }) => {
@@ -110,7 +110,7 @@ export default class ItemGrantAdvancement extends Advancement {
     const itemUpdates = {};
     const existing = new Set(Object.values(added));
     for ( const uuid of selected ) {
-      if ( existing.has(uuid) ) continue;
+      if ( existing.has(uuid) && skipExisting ) continue;
       let itemData = retainedData.items?.find(i => i.flags?.dnd5e?.sourceId ?? i._stats?.compendiumSource);
       if ( !itemData ) {
         itemData = await this.createItemData(uuid);

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -721,10 +721,11 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /**
    * Render a rich tooltip for this item.
    * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
+   * @param {string} [enrichmentOptions.extras]         Extra HTML displayed with the tooltip.
    * @returns {Promise<{content: string, classes: string[]}>|null}
    */
   richTooltip(enrichmentOptions={}) {
-    return this.system.richTooltip?.() ?? null;
+    return this.system.richTooltip?.(enrichmentOptions) ?? null;
   }
 
   /* -------------------------------------------- */

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -222,7 +222,7 @@ class ItemRegistry {
    * @type {Iterator<FormSelectOption>}
    */
   get #options() {
-    return ItemRegistry.#items.get(this.#itemType).entries()
+    return (ItemRegistry.#items.get(this.#itemType)?.entries() ?? [].values())
       .map(([value, data]) => ({ value, label: data.name }));
   }
 
@@ -254,7 +254,7 @@ class ItemRegistry {
   /* -------------------------------------------- */
 
   /**
-   * Get the name of an item based on identifier. Accepts optional type as either separate option or using
+   * Get an item descriptor based on identifier. Accepts optional type as either separate option or using
    * the colon-separated format (e.g. `spell:blade-ward`).
    * @param {string} key             Identifier to find.
    * @param {object} [options={}]

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -5,6 +5,12 @@ import { formatIdentifier } from "./utils.mjs";
  * @import { RegisteredItemData } from "./_types.mjs";
  */
 
+const STATUS_STATES = Object.freeze({
+  NONE: 0,
+  LOADING: 1,
+  READY: 2
+});
+
 /* -------------------------------------------- */
 /*  Dependents                                  */
 /* -------------------------------------------- */
@@ -142,6 +148,81 @@ class EnchantmentRegisty {
 }
 
 /* -------------------------------------------- */
+/*  Identifiers Registry                        */
+/* -------------------------------------------- */
+
+class IdentifierRegistry {
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Identifiers mapped to their names grouped by type.
+   * @type {Map<string, Map<string, string>>}
+   */
+  static #identifiers = new Map([["*", new Map()]]);
+
+  /* -------------------------------------------- */
+
+  /**
+   * Has initial loading been completed?
+   * @type {number}
+   */
+  static #status = STATUS_STATES.NONE;
+
+  /* -------------------------------------------- */
+  /*  Methods                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Get the name of an item based on identifier. Accepts optional type as either separate option or using
+   * the colon-separated format (e.g. `spell:blade-ward`).
+   * @param {string} key             Identifier to find.
+   * @param {object} [options={}]
+   * @param {string} [options.type]  Type of items to check.
+   * @returns {string|void}
+   */
+  static get(key, { type }={}) {
+    if ( !key ) return;
+    if ( key.includes(":") && !type ) [type, key] = key.split(":", 2);
+    return this.#identifiers.get(type ?? "*")?.get(key);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Scan compendium packs to register item identifiers.
+   */
+  static async initialize() {
+    if ( this.#status > STATUS_STATES.NONE ) return;
+    RegistryStatus.set("identifiers", false);
+    if ( game.modules.get("babele")?.active && (game.babele?.initialized === false) ) {
+      Hooks.once("babele.ready", () => this.initialize());
+      return;
+    } else if ( !game.ready ) {
+      Hooks.once("ready", () => this.initialize());
+      return;
+    }
+    this.#status = STATUS_STATES.LOADING;
+
+    const indexes = await CompendiumBrowser.fetch(Item, {
+      // types: new Set([this.#itemType]),
+      indexFields: new Set(["system.identifier"]),
+      sort: false
+    });
+    for ( const item of indexes ) {
+      const identifier = item.system?.identifier ?? formatIdentifier(item.name);
+      if ( !this.#identifiers.has(item.type) ) this.#identifiers.set(item.type, new Map());
+      this.#identifiers.get("*").set(identifier, item.name);
+      this.#identifiers.get(item.type).set(identifier, item.name);
+    }
+
+    this.#status = STATUS_STATES.READY;
+    RegistryStatus.set("identifiers", true);
+  }
+}
+
+/* -------------------------------------------- */
 /*  Item Registry                               */
 /* -------------------------------------------- */
 
@@ -174,17 +255,7 @@ class ItemRegistry {
    * Has initial loading been completed?
    * @type {number}
    */
-  #status = ItemRegistry.#STATUS_STATES.NONE;
-
-  /**
-   * Possible preparation states for the item registry.
-   * @enum {number}
-   */
-  static #STATUS_STATES = Object.freeze({
-    NONE: 0,
-    LOADING: 1,
-    READY: 2
-  });
+  #status = STATUS_STATES.NONE;
 
   /* -------------------------------------------- */
 
@@ -251,7 +322,7 @@ class ItemRegistry {
    * Scan compendium packs to register matching items of this type.
    */
   async initialize() {
-    if ( this.#status > ItemRegistry.#STATUS_STATES.NONE ) return;
+    if ( this.#status > STATUS_STATES.NONE ) return;
     RegistryStatus.set(this.#itemType, false);
     if ( game.modules.get("babele")?.active && (game.babele?.initialized === false) ) {
       Hooks.once("babele.ready", () => this.initialize());
@@ -260,7 +331,7 @@ class ItemRegistry {
       Hooks.once("ready", () => this.initialize());
       return;
     }
-    this.#status = ItemRegistry.#STATUS_STATES.LOADING;
+    this.#status = STATUS_STATES.LOADING;
 
     const indexes = await CompendiumBrowser.fetch(Item, {
       types: new Set([this.#itemType]),
@@ -277,7 +348,7 @@ class ItemRegistry {
       itemData.sources.push(item.uuid);
     }
 
-    this.#status = ItemRegistry.#STATUS_STATES.READY;
+    this.#status = STATUS_STATES.READY;
     RegistryStatus.set(this.#itemType, true);
   }
 }
@@ -739,6 +810,7 @@ export default {
   classes: new ItemRegistry("class"),
   dependents: DependentsRegistry,
   enchantments: EnchantmentRegisty,
+  identifiers: IdentifierRegistry,
   messages: MessageRegistry,
   ready: RegistryStatus.ready,
   species: new ItemRegistry("race"),

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -206,12 +206,11 @@ class IdentifierRegistry {
     this.#status = STATUS_STATES.LOADING;
 
     const indexes = await CompendiumBrowser.fetch(Item, {
-      // types: new Set([this.#itemType]),
       indexFields: new Set(["system.identifier"]),
       sort: false
     });
     for ( const item of indexes ) {
-      const identifier = item.system?.identifier ?? formatIdentifier(item.name);
+      const identifier = item.system?.identifier || formatIdentifier(item.name);
       if ( !this.#identifiers.has(item.type) ) this.#identifiers.set(item.type, new Map());
       this.#identifiers.get("*").set(identifier, item.name);
       this.#identifiers.get(item.type).set(identifier, item.name);
@@ -339,7 +338,7 @@ class ItemRegistry {
       sort: false
     });
     for ( const item of indexes ) {
-      const identifier = item.system?.identifier ?? formatIdentifier(item.name);
+      const identifier = item.system?.identifier || formatIdentifier(item.name);
       if ( !this.#items.has(identifier) ) this.#items.set(identifier, { sources: [] });
       const itemData = this.#items.get(identifier);
       itemData.name = item.name;

--- a/module/registry.mjs
+++ b/module/registry.mjs
@@ -148,80 +148,6 @@ class EnchantmentRegisty {
 }
 
 /* -------------------------------------------- */
-/*  Identifiers Registry                        */
-/* -------------------------------------------- */
-
-class IdentifierRegistry {
-  /* -------------------------------------------- */
-  /*  Properties                                  */
-  /* -------------------------------------------- */
-
-  /**
-   * Identifiers mapped to their names grouped by type.
-   * @type {Map<string, Map<string, string>>}
-   */
-  static #identifiers = new Map([["*", new Map()]]);
-
-  /* -------------------------------------------- */
-
-  /**
-   * Has initial loading been completed?
-   * @type {number}
-   */
-  static #status = STATUS_STATES.NONE;
-
-  /* -------------------------------------------- */
-  /*  Methods                                     */
-  /* -------------------------------------------- */
-
-  /**
-   * Get the name of an item based on identifier. Accepts optional type as either separate option or using
-   * the colon-separated format (e.g. `spell:blade-ward`).
-   * @param {string} key             Identifier to find.
-   * @param {object} [options={}]
-   * @param {string} [options.type]  Type of items to check.
-   * @returns {string|void}
-   */
-  static get(key, { type }={}) {
-    if ( !key ) return;
-    if ( key.includes(":") && !type ) [type, key] = key.split(":", 2);
-    return this.#identifiers.get(type ?? "*")?.get(key);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Scan compendium packs to register item identifiers.
-   */
-  static async initialize() {
-    if ( this.#status > STATUS_STATES.NONE ) return;
-    RegistryStatus.set("identifiers", false);
-    if ( game.modules.get("babele")?.active && (game.babele?.initialized === false) ) {
-      Hooks.once("babele.ready", () => this.initialize());
-      return;
-    } else if ( !game.ready ) {
-      Hooks.once("ready", () => this.initialize());
-      return;
-    }
-    this.#status = STATUS_STATES.LOADING;
-
-    const indexes = await CompendiumBrowser.fetch(Item, {
-      indexFields: new Set(["system.identifier"]),
-      sort: false
-    });
-    for ( const item of indexes ) {
-      const identifier = item.system?.identifier || formatIdentifier(item.name);
-      if ( !this.#identifiers.has(item.type) ) this.#identifiers.set(item.type, new Map());
-      this.#identifiers.get("*").set(identifier, item.name);
-      this.#identifiers.get(item.type).set(identifier, item.name);
-    }
-
-    this.#status = STATUS_STATES.READY;
-    RegistryStatus.set("identifiers", true);
-  }
-}
-
-/* -------------------------------------------- */
 /*  Item Registry                               */
 /* -------------------------------------------- */
 
@@ -235,10 +161,26 @@ class ItemRegistry {
   /* -------------------------------------------- */
 
   /**
-   * Items grouped by identifiers.
-   * @type {Map<string, RegisteredItemData>}
+   * Item types that track icon and a list of sources in addition to the name and identifier.
+   * @type {Set<string>}
    */
-  #items = new Map();
+  static #extendedData = new Set(["background", "class", "race", "subclass"]);
+
+  /* -------------------------------------------- */
+
+  /**
+   * Core registry of item data, shared across types.
+   * @type {Map<string, Map<string, RegisteredItemData>>}
+   */
+  static #items = new Map([["*", new Map()]]);
+
+  /* -------------------------------------------- */
+
+  /**
+   * Has initial loading been completed?
+   * @type {number}
+   */
+  static #status = STATUS_STATES.NONE;
 
   /* -------------------------------------------- */
 
@@ -247,14 +189,6 @@ class ItemRegistry {
    * @type {string}
    */
   #itemType;
-
-  /* -------------------------------------------- */
-
-  /**
-   * Has initial loading been completed?
-   * @type {number}
-   */
-  #status = STATUS_STATES.NONE;
 
   /* -------------------------------------------- */
 
@@ -285,13 +219,25 @@ class ItemRegistry {
 
   /**
    * All items formatted for a select input.
+   * @type {Iterator<FormSelectOption>}
+   */
+  get #options() {
+    return ItemRegistry.#items.get(this.#itemType).entries()
+      .map(([value, data]) => ({ value, label: data.name }));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * All items formatted for a select input.
    * @type {FormSelectOption[]}
    */
   get options() {
-    return Array.from(this.#items.entries())
-      .map(([value, data]) => ({ value, label: data.name }))
+    return this.#options.toArray()
       .sort((lhs, rhs) => lhs.label.localeCompare(rhs.label, game.i18n.lang));
   }
+
+  /* -------------------------------------------- */
 
   /**
    * All items formatted for a select input with grouping.
@@ -299,11 +245,28 @@ class ItemRegistry {
    */
   get groupedOptions() {
     // TODO: Group subclasses by parent class
-    return this.options.map(o => ({ ...o, group: this.label }));
+    return this.#options.map(o => ({ ...o, group: this.label }))
+      .sort((lhs, rhs) => lhs.label.localeCompare(rhs.label, game.i18n.lang));
   }
 
   /* -------------------------------------------- */
   /*  Methods                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Get the name of an item based on identifier. Accepts optional type as either separate option or using
+   * the colon-separated format (e.g. `spell:blade-ward`).
+   * @param {string} key             Identifier to find.
+   * @param {object} [options={}]
+   * @param {string} [options.type]  Type of items to check.
+   * @returns {RegisteredItemData|void}
+   */
+  static get(key, { type }={}) {
+    if ( !key ) return;
+    if ( key.includes(":") && !type ) [type, key] = key.split(":", 2);
+    return this.#items.get(type ?? "*")?.get(key);
+  }
+
   /* -------------------------------------------- */
 
   /**
@@ -312,17 +275,17 @@ class ItemRegistry {
    * @returns {RegisteredItemData|void}
    */
   get(identifier) {
-    return this.#items.get(identifier);
+    return ItemRegistry.get(identifier, { type: this.#itemType });
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Scan compendium packs to register matching items of this type.
+   * Scan compendium packs to register item identifiers.
    */
-  async initialize() {
+  static async initialize() {
     if ( this.#status > STATUS_STATES.NONE ) return;
-    RegistryStatus.set(this.#itemType, false);
+    RegistryStatus.set("items", false);
     if ( game.modules.get("babele")?.active && (game.babele?.initialized === false) ) {
       Hooks.once("babele.ready", () => this.initialize());
       return;
@@ -333,22 +296,27 @@ class ItemRegistry {
     this.#status = STATUS_STATES.LOADING;
 
     const indexes = await CompendiumBrowser.fetch(Item, {
-      types: new Set([this.#itemType]),
       indexFields: new Set(["system.identifier", "system.source"]),
       sort: false
     });
     for ( const item of indexes ) {
       const identifier = item.system?.identifier || formatIdentifier(item.name);
-      if ( !this.#items.has(identifier) ) this.#items.set(identifier, { sources: [] });
-      const itemData = this.#items.get(identifier);
-      itemData.name = item.name;
-      itemData.img = item.img;
-      itemData.identifier = identifier;
-      itemData.sources.push(item.uuid);
+      const generalCollection = this.#items.get("*");
+      const typeCollection = this.#items.getOrInsert(item.type, new Map());
+      for ( const collection of [generalCollection, typeCollection] ) {
+        const itemData = collection.getOrInsert(identifier, {});
+        itemData.name = item.name;
+        itemData.identifier = identifier;
+        if ( this.#extendedData.has(item.type) ) {
+          itemData.img = item.img;
+          itemData.sources ??= [];
+          itemData.sources.push(item.uuid);
+        }
+      }
     }
 
     this.#status = STATUS_STATES.READY;
-    RegistryStatus.set(this.#itemType, true);
+    RegistryStatus.set("items", true);
   }
 }
 
@@ -809,7 +777,7 @@ export default {
   classes: new ItemRegistry("class"),
   dependents: DependentsRegistry,
   enchantments: EnchantmentRegisty,
-  identifiers: IdentifierRegistry,
+  items: ItemRegistry,
   messages: MessageRegistry,
   ready: RegistryStatus.ready,
   species: new ItemRegistry("race"),

--- a/module/tooltips.mjs
+++ b/module/tooltips.mjs
@@ -64,10 +64,13 @@ export default class Tooltips5e {
    * @returns {Promise}
    */
   async _onTooltipActivate() {
+    const dataset = game.tooltip.element?.dataset ?? {};
+    const extras = dataset.tooltipExtras;
+
     // General content links
     if ( game.tooltip.element?.classList.contains("content-link") ) {
       const doc = await fromUuid(game.tooltip.element.dataset.uuid);
-      return this._onHoverContentLink(doc);
+      return this._onHoverContentLink(doc, { extras });
     }
 
     const loading = this.tooltip.querySelector(".loading");
@@ -76,12 +79,11 @@ export default class Tooltips5e {
     if ( loading?.dataset.uuid ) {
       const doc = await fromUuid(loading.dataset.uuid);
       if ( doc instanceof dnd5e.documents.Actor5e ) return this._onHoverActor(doc);
-      return this._onHoverContentLink(doc);
+      return this._onHoverContentLink(doc, { extras });
     }
 
     // Passive checks
     else if ( loading?.dataset.passive !== undefined ) {
-      const dataset = game.tooltip.element?.dataset ?? {};
       switch ( dataset.type ) {
         case "language":
           return this._onHoverPassiveLanguage(dataset.language);
@@ -109,11 +111,14 @@ export default class Tooltips5e {
 
   /**
    * Handle hovering over a content link and showing rich tooltips if possible.
-   * @param {Document} doc  The document linked by the content link.
+   * @param {Document} doc             The document linked by the content link.
+   * @param {object} [options={}]
+   * @param {string} [options.extras]  Extra HTML displayed with the tooltip.
    * @protected
    */
-  async _onHoverContentLink(doc) {
-    const { content, classes } = await (doc.richTooltip?.() ?? doc.system?.richTooltip?.() ?? {});
+  async _onHoverContentLink(doc, { extras }={}) {
+    if ( extras ) extras = foundry.utils.cleanHTML(extras);
+    const { content, classes } = await (doc.richTooltip?.({ extras }) ?? doc.system?.richTooltip?.({ extras }) ?? {});
     if ( !content ) return;
     this.tooltip.innerHTML = content;
     this.tooltip.classList.remove("theme-dark");

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -50,6 +50,41 @@ export function roundCurrency(value, denomination) {
 }
 
 /* -------------------------------------------- */
+/*  Documents                                   */
+/* -------------------------------------------- */
+
+/**
+ * Bulk version of `fromUuid` that performs only a single fetch per compendium.
+ * @param {string[]} uuids           UUIDs of documents to retrieve.
+ * @returns {Map<string, Document>}  Documents mapped to the provided UUID.
+ */
+export async function bulkFromUuid(uuids) {
+  const collections = new Map();
+  const redirected = new Map();
+
+  for ( const uuid of uuids ) {
+    const { collection, id, uuid: redirectedUuid } = foundry.utils.parseUuid(uuid);
+    if ( !collections.has(collection) ) collections.set(collection, []);
+    collections.get(collection).push(id);
+    redirected.set(redirectedUuid, uuid);
+  }
+
+  const fetches = [];
+  for ( const [collection, ids] of collections.entries() ) {
+    if ( collection instanceof foundry.documents.collections.CompendiumCollection ) {
+      fetches.push(collection.getDocuments({ _id__in: ids }));
+    } else {
+      fetches.push(ids.map(id => collection.get(id)));
+    }
+  }
+
+  return (await Promise.all(fetches)).flat().reduce((map, doc) => {
+    map.set(redirected.get(doc.uuid), doc);
+    return map;
+  }, new Map());
+}
+
+/* -------------------------------------------- */
 /*  Formatters                                  */
 /* -------------------------------------------- */
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -79,7 +79,7 @@ export async function bulkFromUuid(uuids) {
   }
 
   return (await Promise.all(fetches)).flat().reduce((map, doc) => {
-    map.set(redirected.get(doc.uuid), doc);
+    if ( doc ) map.set(redirected.get(doc.uuid), doc);
     return map;
   }, new Map());
 }

--- a/templates/compendium/browser-entry.hbs
+++ b/templates/compendium/browser-entry.hbs
@@ -24,10 +24,22 @@
             {{/if}}
         </div>
 
+        {{#if displayPrerequisites}}
+        <div class="item-detail item-prerequisites">
+            {{#with prerequisites}}
+            {{#if display}}
+            <i class="prerequisites-result fa-solid fa-circle-{{ ifThen indeterminate 'question' (ifThen valid 'check' 'xmark') }}"
+               aria-label="{{ localize (concat 'DND5E.Prerequisites.Status.' (ifThen indeterminate 'Unknown' (ifThen valid 'Valid' 'Invalid' ))) }}"></i>
+            {{/if}}
+            {{/with}}
+        </div>
+        {{/if}}
+
         <div class="item-detail item-controls">
 
             {{#if displaySelection}}
-            <dnd5e-checkbox name="selected" value="{{ entry.uuid }}" {{ checked selected }}></dnd5e-checkbox>
+            <dnd5e-checkbox name="selected" value="{{ entry.uuid }}" {{ checked selected }}
+                            {{ disabled prerequisites.disabled }}></dnd5e-checkbox>
             {{/if}}
 
         </div>

--- a/templates/compendium/browser-results.hbs
+++ b/templates/compendium/browser-results.hbs
@@ -10,6 +10,7 @@
 
                 <h3 class="item-name">{{ localize "DND5E.CompendiumBrowser.Column.Results" }}</h3>
                 <div class="item-header item-source">{{ localize "DND5E.CompendiumBrowser.Column.Source" }}</div>
+                {{#if displayPrerequisites}}<div class="item-header item-prerequisites"></div>{{/if}}
                 <div class="item-header item-controls"></div>
 
             </div>

--- a/templates/items/parts/item-tooltip.hbs
+++ b/templates/items/parts/item-tooltip.hbs
@@ -38,9 +38,8 @@
             </div>
         </div>
     </section>
-    {{#if isSpell}}
-        {{> "dnd5e.spell-block" }}
-    {{/if}}
+    {{#if extras}}<p class="extras">{{{ extras }}}</p>{{/if}}
+    {{#if isSpell}}{{> "dnd5e.spell-block" }}{{/if}}
     <section class="description">{{{ description.value }}}</section>
     <ul class="pills">
         {{#each properties}}


### PR DESCRIPTION
Introduces some new options to the compendium browser options that allow passing in a method for each item to determine whether it can be selected or not. This callback returns a map with a `valid` value that can be `true`, `false`, or `null` as well as a label. The compendium browser will display a checkmark if all conditions are valid, x-mark if any condition is invalid, or a question mark if there conditions that couldn't not be checked fully (this is to allow conditions that players should take into account but cannot be fully evaluated in code, such as certain feats that require a specific faction or to be part of a specific campaign).

<img width="1182" height="1136" alt="Compendium Browser Prerequisites" src="https://github.com/user-attachments/assets/e12272df-4311-4b27-8010-5fc9afad70cb" />

The prerequisite checking on features has been modified with a new method that returns this mapping for each prerequisite defined on the feature item.

Uses can hover over the row in the compendium browser to view more details on the evaluation in the tooltip. Rather than adding a new tooltip, this adds support for `data-tooltip-extras` which adds more information into an existing item tooltip.

In order to produce human-readable labels for the items conditions on features, a new `IdentifierRegistry` has been added. This scans all items in compendiums on world load and creates a mapping to those item's localized names.

```javascript
dnd5e.registry.identifiers.get("pact-of-the-blade"); // Pact of the Blade
dnd5e.registry.identifiers.get("spell:blade-ward"); // Blade Ward
dnd5e.registry.identifiers.get("cleric", { type: "class" }); // Cleric
```

Closes #5139