### PR TITLE
Added level-gated item choice advancement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -558,6 +558,53 @@
       "SpellList": "Only spells available on the {lists} spell list can be chosen for this advancement."
     }
   },
+  "LevelGatedItemChoice": {
+    "AvailableFromLevel": "Available from Level {level}+",
+    "DropHere": "Drop items here for level {level}+",
+    "Hint": "Present the player with item choices from a pool that expands as their advancement level increases.",
+    "LevelLabel": "Level {level}",
+    "Notification": {
+      "Moved": "Moved {name} to level {level}."
+    },
+    "PoolHeading": "Level-Gated Item Pool",
+    "PoolHint": "Drop items into the level where they first become available.",
+    "PoolRole": {
+      "Child": "Child Pool",
+      "Parent": "Parent Pool",
+      "Standalone": "Standalone"
+    },
+    "Title": "Choose Items by Level",
+    "FIELDS": {
+      "parentPoolId": {
+        "hint": "For a child pool, enter the parent Pool ID to merge into. Child advancements do not prompt for choices.",
+        "label": "Parent Pool ID"
+      },
+      "pool": {
+        "FIELDS": {
+          "minLevel": {
+            "label": "Minimum Level"
+          }
+        },
+        "label": "Level Gated Item Pool"
+      },
+      "poolId": {
+        "hint": "For a parent pool, enter an ID that child pools can target.",
+        "label": "Pool ID"
+      },
+      "poolRole": {
+        "hint": "Standalone pools behave independently. Parent pools can merge child pools with matching IDs.",
+        "label": "Pool Role"
+      },
+      "sectionTitles": {
+        "label": "Section Title"
+      }
+    },
+    "Warning": {
+      "DropOnLevel": "Drop the item onto one of the level sections.",
+      "InvalidSelection": "One or more selected items are not available at level {level}.",
+      "Unavailable": "{name} is not available from this advancement at level {level}."
+    }
+  },
   "ItemGrant": {
     "Details": "Grant Details",
     "DropHint": "Drop Items here to add them to the list granted by this advancement.",

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -176,6 +176,164 @@
   }
 }
 
+.dnd5e2.advancement.level-gated-item-choice.sheet {
+  --grid-column-left-size: .8fr;
+  --grid-column-center-size: 1.15fr;
+  --grid-column-right-size: .55fr;
+
+  .level-gated-pool {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .level-gated-pool-settings {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+    border: 1px solid var(--dnd5e-color-card-border);
+    border-radius: 4px;
+    background: var(--dnd5e-background-card);
+
+    .form-group { margin: 0; }
+    input, select { width: 100%; }
+  }
+
+  .level-gated-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .level-gated-section {
+    overflow: hidden;
+    border: 1px solid var(--dnd5e-color-card-border);
+    border-radius: 4px;
+    background: var(--dnd5e-background-card);
+
+    &.level-gated-drop-active {
+      border-color: var(--color-border-highlight);
+    }
+  }
+
+  .level-gated-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 6px;
+    cursor: pointer;
+    list-style: none;
+
+    &::-webkit-details-marker { display: none; }
+  }
+
+  .level-gated-title {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .level-gated-header-right {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .level-gated-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    border-radius: 10px;
+    background: var(--dnd5e-color-gold);
+    color: var(--color-text-light-primary);
+    font-size: var(--font-size-10);
+    font-weight: bold;
+  }
+
+  .level-gated-toggle-icon {
+    width: 12px;
+    text-align: center;
+    transition: transform 120ms ease;
+  }
+
+  .level-gated-section:not([open]) .level-gated-toggle-icon {
+    transform: rotate(-90deg);
+  }
+
+  .level-gated-body {
+    padding: 6px;
+    border-top: 1px solid var(--dnd5e-color-card-border);
+  }
+
+  .level-gated-items-list {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .level-gated-section-title-input {
+    width: 100%;
+    min-height: 22px;
+    padding: 0 6px;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    background: transparent;
+    font-weight: bold;
+
+    &:focus {
+      border-color: var(--color-border-highlight);
+      background: var(--color-bg-option);
+      outline: none;
+    }
+  }
+
+  .level-gated-hidden {
+    display: none !important;
+  }
+}
+
+.advancement.flow[data-type="LGICLevelGatedItemChoice"] {
+  [data-application-part="content"] { gap: 12px; }
+
+  .level-gated-choice-flow,
+  .level-gated-choice-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .level-gated-current-heading {
+    margin: 0;
+    text-align: center;
+  }
+
+  .items-header {
+    align-items: center;
+  }
+
+  .level-gated-count {
+    flex: 0 0 auto;
+    min-width: 20px;
+    text-align: center;
+  }
+
+  .item-list {
+    .item-controls {
+      flex: 0 0 50px;
+      align-items: center;
+      padding: 0;
+
+      .item-control { font-size: var(--font-size-12); }
+    }
+
+    .replaced .title {
+      text-decoration: rgb(200 0 0) line-through 2px;
+    }
+  }
+}
+
 /* ----------------------------------------- */
 /*  Grant Items Advancement                  */
 /* ----------------------------------------- */

--- a/module/applications/advancement/_module.mjs
+++ b/module/applications/advancement/_module.mjs
@@ -12,6 +12,8 @@ export {default as HitPointsConfig} from "./hit-points-config.mjs";
 export {default as HitPointsFlow} from "./hit-points-flow.mjs";
 export {default as ItemChoiceConfig} from "./item-choice-config.mjs";
 export {default as ItemChoiceFlow} from "./item-choice-flow.mjs";
+export {default as LevelGatedItemChoiceConfig} from "./level-gated-item-choice-config.mjs";
+export {default as LevelGatedItemChoiceFlow} from "./level-gated-item-choice-flow.mjs";
 export {default as ItemGrantConfig} from "./item-grant-config.mjs";
 export {default as ItemGrantFlow} from "./item-grant-flow.mjs";
 export {default as ItemGrantFlowV2} from "./item-grant-flow-v2.mjs";

--- a/module/applications/advancement/level-gated-item-choice-config.mjs
+++ b/module/applications/advancement/level-gated-item-choice-config.mjs
@@ -1,0 +1,275 @@
+import ItemChoiceConfig from "./item-choice-config.mjs";
+import {
+  clampLevel,
+  cleanPoolId,
+  cleanSectionTitle,
+  getMaxSectionLevel,
+  getSectionTitle,
+  MAX_LEVEL_GATED_CHOICE_LEVEL,
+  normalizePoolRole,
+  sortItemsByName
+} from "../../documents/advancement/level-gated-item-choice-helpers.mjs";
+
+/**
+ * Configuration application for level-gated item choices.
+ */
+export default class LevelGatedItemChoiceConfig extends ItemChoiceConfig {
+
+  /** @override */
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(ItemChoiceConfig.DEFAULT_OPTIONS, {
+    classes: [...new Set([...(ItemChoiceConfig.DEFAULT_OPTIONS.classes ?? []), "level-gated-item-choice"])],
+    position: { width: 980 }
+  }, { inplace: false });
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static PARTS = foundry.utils.mergeObject(ItemChoiceConfig.PARTS, {
+    items: {
+      container: { classes: ["column-container"], id: "column-center" },
+      template: "systems/dnd5e/templates/advancement/level-gated-item-choice-config-items.hbs"
+    }
+  }, { inplace: false });
+
+  /* -------------------------------------------- */
+
+  get collapseStorageKey() {
+    const itemKey = this.item?.uuid ?? this.item?.id ?? "item";
+    const advancementKey = this.advancement?.id ?? this.advancement?._id ?? "advancement";
+    return `dnd5e.level-gated-item-choice.collapsed-levels.${itemKey}.${advancementKey}`;
+  }
+
+  /* -------------------------------------------- */
+
+  loadCollapsedLevels() {
+    if ( this._collapsedLevels instanceof Set ) return this._collapsedLevels;
+    try {
+      const stored = JSON.parse(localStorage.getItem(this.collapseStorageKey) ?? "[]");
+      this._collapsedLevels = new Set(Array.isArray(stored) ? stored.map(String) : []);
+    } catch(err) {
+      this._collapsedLevels = new Set();
+    }
+    return this._collapsedLevels;
+  }
+
+  /* -------------------------------------------- */
+
+  saveCollapsedLevels() {
+    if ( !(this._collapsedLevels instanceof Set) ) return;
+    localStorage.setItem(this.collapseStorageKey, JSON.stringify(Array.from(this._collapsedLevels)));
+  }
+
+  /* -------------------------------------------- */
+
+  setLevelCollapsed(level, collapsed) {
+    const collapsedLevels = this.loadCollapsedLevels();
+    const key = String(level);
+    if ( collapsed ) collapsedLevels.add(key);
+    else collapsedLevels.delete(key);
+    this.saveCollapsedLevels();
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const maxLevel = getMaxSectionLevel();
+    const collapsedLevels = this.loadCollapsedLevels();
+    const sections = new Map();
+
+    for ( let level = 1; level <= maxLevel; level++ ) {
+      const defaultLabel = _loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.LevelLabel", { level });
+      const titleValue = getSectionTitle(this.advancement.configuration, level, { fallback: false });
+      sections.set(level, {
+        level,
+        label: titleValue || defaultLabel,
+        defaultLabel,
+        titleValue,
+        dropLabel: _loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.DropHere", { level }),
+        open: !collapsedLevels.has(String(level)),
+        items: []
+      });
+    }
+
+    const poolItems = this.advancement.configuration.pool ?? [];
+    context.items = poolItems.map((poolEntry, poolIndex) => {
+      const min = [undefined, null, ""].includes(poolEntry.minLevel) ? 1 : Number(poolEntry.minLevel);
+      const minLevel = clampLevel(Number.isFinite(min) ? min : 1, maxLevel);
+      return {
+        data: { uuid: poolEntry.uuid },
+        uuid: poolEntry.uuid,
+        poolIndex,
+        minLevel,
+        index: fromUuidSync(poolEntry.uuid)
+      };
+    });
+
+    for ( const item of context.items ) sections.get(item.minLevel)?.items.push(item);
+    context.levelSections = Array.from(sections.values());
+    for ( const section of context.levelSections ) sortItemsByName(section.items);
+
+    const poolRole = normalizePoolRole(this.advancement.configuration.poolRole);
+    context.poolRole = poolRole;
+    context.isPoolParent = poolRole === "parent";
+    context.isPoolChild = poolRole === "child";
+    context.poolId = this.advancement.configuration.poolId ?? "";
+    context.parentPoolId = this.advancement.configuration.parentPoolId ?? "";
+    context.poolRoleOptions = [
+      {
+        value: "standalone",
+        label: _loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.PoolRole.Standalone"),
+        selected: poolRole === "standalone"
+      },
+      {
+        value: "parent",
+        label: _loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.PoolRole.Parent"),
+        selected: poolRole === "parent"
+      },
+      {
+        value: "child",
+        label: _loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.PoolRole.Child"),
+        selected: poolRole === "child"
+      }
+    ];
+    context.showContainerWarning = context.items.some(i => i.index?.type === "container");
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async prepareConfigurationUpdate(configuration) {
+    if ( configuration.pool ) {
+      const maxLevel = getMaxSectionLevel();
+      configuration.pool = Object.values(configuration.pool).map(entry => ({
+        uuid: entry.uuid,
+        minLevel: clampLevel(entry.minLevel, maxLevel)
+      }));
+    }
+
+    configuration.poolRole = normalizePoolRole(configuration.poolRole);
+    configuration.poolId = cleanPoolId(configuration.poolId);
+    configuration.parentPoolId = cleanPoolId(configuration.parentPoolId);
+    if ( configuration.poolRole !== "parent" ) configuration.poolId = "";
+    if ( configuration.poolRole !== "child" ) configuration.parentPoolId = "";
+
+    const sectionTitles = configuration.sectionTitles ?? {};
+    configuration.sectionTitles = Object.fromEntries(
+      Array.from({ length: MAX_LEVEL_GATED_CHOICE_LEVEL }, (_, index) => {
+        const level = index + 1;
+        return [level, cleanSectionTitle(sectionTitles[level])];
+      })
+    );
+
+    return super.prepareConfigurationUpdate(configuration);
+  }
+
+  /* -------------------------------------------- */
+  /*  Life-Cycle Handlers                         */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    if ( !this.isEditable ) return;
+
+    for ( const zone of this.element.querySelectorAll("[data-level-gated-level]") ) {
+      zone.addEventListener("toggle", () => {
+        this.setLevelCollapsed(zone.dataset.levelGatedLevel, !zone.open);
+      });
+      zone.addEventListener("dragenter", () => zone.classList.add("level-gated-drop-active"));
+      zone.addEventListener("dragover", event => {
+        event.preventDefault();
+        zone.classList.add("level-gated-drop-active");
+      });
+      zone.addEventListener("dragleave", event => {
+        if ( !zone.contains(event.relatedTarget) ) zone.classList.remove("level-gated-drop-active");
+      });
+      zone.addEventListener("drop", () => zone.classList.remove("level-gated-drop-active"));
+    }
+
+    for ( const input of this.element.querySelectorAll("[data-level-gated-section-title]") ) {
+      input.addEventListener("click", event => event.stopPropagation());
+      input.addEventListener("pointerdown", event => event.stopPropagation());
+      input.addEventListener("keydown", event => event.stopPropagation());
+    }
+
+    const roleSelect = this.element.querySelector("[data-level-gated-pool-role]");
+    const updateRoleFields = () => {
+      const role = normalizePoolRole(roleSelect?.value);
+      for ( const field of this.element.querySelectorAll("[data-level-gated-role-field]") ) {
+        field.classList.toggle("level-gated-hidden", field.dataset.levelGatedRoleField !== role);
+      }
+    };
+    roleSelect?.addEventListener("change", updateRoleFields);
+    updateRoleFields();
+  }
+
+  /* -------------------------------------------- */
+  /*  Drag & Drop                                 */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onDragStart(event) {
+    const row = event.target.closest?.("[data-item-uuid]");
+    const uuid = row?.dataset.itemUuid;
+    if ( !uuid ) return;
+    event.dataTransfer.setData("text/plain", JSON.stringify({ type: "Item", uuid }));
+    event.dataTransfer.effectAllowed = "move";
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onDrop(event) {
+    const levelSection = event.target.closest?.("[data-level-gated-level]");
+    if ( !levelSection ) {
+      ui.notifications.warn(_loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.Warning.DropOnLevel"));
+      return;
+    }
+
+    const minLevel = Number(levelSection.dataset.levelGatedLevel);
+    if ( !Number.isFinite(minLevel) ) return;
+
+    if ( "open" in levelSection ) {
+      levelSection.open = true;
+      this.setLevelCollapsed(minLevel, false);
+    }
+
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+    if ( data?.type !== "Item" ) return;
+    const item = await Item.implementation.fromDropData(data);
+
+    try {
+      this._validateDroppedItem(event, item);
+    } catch(err) {
+      ui.notifications.error(err.message);
+      return;
+    }
+
+    if ( item.uuid === this.item.uuid ) {
+      ui.notifications.error("DND5E.ADVANCEMENT.ItemGrant.Warning.Recursive");
+      return;
+    }
+
+    const existingItems = foundry.utils.deepClone(this.advancement.configuration.pool ?? []);
+    const existingIndex = existingItems.findIndex(entry => entry.uuid === item.uuid);
+
+    if ( existingIndex >= 0 ) {
+      existingItems[existingIndex].minLevel = minLevel;
+      ui.notifications.info(_loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.Notification.Moved", {
+        name: item.name,
+        level: minLevel
+      }));
+    } else {
+      existingItems.push({ uuid: item.uuid, minLevel });
+    }
+
+    await this.submit({ updateData: { "configuration.pool": existingItems } });
+  }
+}

--- a/module/applications/advancement/level-gated-item-choice-flow.mjs
+++ b/module/applications/advancement/level-gated-item-choice-flow.mjs
@@ -1,0 +1,225 @@
+import ItemChoiceFlow from "./item-choice-flow.mjs";
+import {
+  clampLevel,
+  getMaxSectionLevel,
+  sortItemsByName
+} from "../../documents/advancement/level-gated-item-choice-helpers.mjs";
+
+/**
+ * Flow application for level-gated item choices.
+ */
+export default class LevelGatedItemChoiceFlow extends ItemChoiceFlow {
+
+  /** @override */
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(ItemChoiceFlow.DEFAULT_OPTIONS, {
+    classes: [
+      ...(ItemChoiceFlow.DEFAULT_OPTIONS.classes ?? []),
+      "level-gated-item-choice"
+    ]
+  }, { inplace: false });
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static PARTS = foundry.utils.mergeObject(ItemChoiceFlow.PARTS, {
+    content: {
+      template: "systems/dnd5e/templates/advancement/level-gated-item-choice-flow.hbs"
+    }
+  }, { inplace: false });
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContentContext(context, options) {
+    this.manager?.clone?.reset?.();
+    this.advancement.actor?.reset?.();
+    await this.advancement.preparePendingChildPools?.({ manager: this.manager });
+
+    if ( this.advancement.isPoolChild ) {
+      this.pool = [];
+    } else {
+      this.pool = (
+        await Promise.all(this.advancement.getPoolForLevel(this.level, { manager: this.manager })
+          .map(entry => fromUuid(entry.uuid)))
+      ).filter(Boolean);
+    }
+
+    context = await super._prepareContentContext(context, options);
+    context.showBrowseButton = false;
+    this._prepareLevelSections(context);
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  _prepareLevelSections(context) {
+    const sections = Array.from(context.sections ?? []);
+    const maxLevel = getMaxSectionLevel();
+    const entryLevels = new Map();
+    const mergedPool = this.advancement.getMergedPool?.({ manager: this.manager })
+      ?? this.advancement.getPoolForLevel(this.level, { manager: this.manager });
+
+    for ( const entry of mergedPool ) {
+      const minLevel = clampLevel(entry.minLevel ?? 1, maxLevel);
+      entryLevels.set(entry.uuid, minLevel);
+    }
+
+    for ( const item of this.pool ?? [] ) {
+      const sourceUuid = item.flags?.dnd5e?.sourceId ?? item.uuid;
+      const entry = mergedPool.find(e => (e.uuid === sourceUuid) || (e.uuid === item.uuid));
+      if ( !entry ) continue;
+
+      const minLevel = clampLevel(entry.minLevel ?? 1, maxLevel);
+      entryLevels.set(sourceUuid, minLevel);
+      entryLevels.set(item.uuid, minLevel);
+    }
+
+    const levelForItem = item => {
+      const uuid = item?.uuid;
+      if ( entryLevels.has(uuid) ) return entryLevels.get(uuid);
+
+      const actorItem = item?.id ? this.advancement.actor?.items?.get(item.id) : null;
+      const sourceUuid = actorItem?.flags?.dnd5e?.sourceId ?? actorItem?._stats?.compendiumSource ?? actorItem?.uuid;
+      if ( entryLevels.has(sourceUuid) ) return entryLevels.get(sourceUuid);
+
+      return clampLevel(this.level ?? 1, maxLevel);
+    };
+
+    const selectedSections = new Map();
+    const choiceSections = new Map();
+
+    const addToSection = (map, item, sourceSection) => {
+      const minLevel = levelForItem(item);
+      const header = this.advancement.getRegionTitle(minLevel, { flow: true });
+      const key = `${minLevel}.${header}`;
+
+      if ( !map.has(key) ) {
+        map.set(key, {
+          ...sourceSection,
+          level: minLevel,
+          header,
+          items: []
+        });
+      }
+
+      map.get(key).items.push(item);
+    };
+
+    const selectedItems = [];
+    const choiceItems = [];
+    for ( const section of sections ) {
+      for ( const item of section.items ?? [] ) {
+        if ( section.isCurrentLevel ) choiceItems.push({ item, section });
+        else selectedItems.push({ item, section });
+      }
+    }
+
+    const selectedUuids = new Set();
+    for ( const { item, section } of selectedItems ) {
+      selectedUuids.add(item.uuid);
+      addToSection(selectedSections, { ...item, disabled: true }, { ...section, isCurrentLevel: false });
+    }
+
+    for ( const { item, section } of choiceItems ) {
+      if ( selectedUuids.has(item.uuid) ) continue;
+      addToSection(choiceSections, item, section);
+    }
+
+    const prepareSections = map => {
+      return Array.from(map.values()).sort((a, b) => a.level - b.level).map(section => {
+        sortItemsByName(section.items);
+        return section;
+      });
+    };
+
+    context.previousSections = prepareSections(selectedSections);
+    context.choiceLevelSections = prepareSections(choiceSections);
+    context.currentChoiceHeader = sections.find(section => section.isCurrentLevel)?.header;
+    context.sections = [
+      ...context.previousSections,
+      ...context.choiceLevelSections
+    ];
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _handleForm(event, form, formData) {
+    const target = event.target;
+    const isChoiceCheckbox = target?.tagName === "DND5E-CHECKBOX";
+    await super._handleForm(event, form, formData);
+
+    if ( isChoiceCheckbox ) {
+      this.pool = null;
+      this.manager?.clone?.reset?.();
+      this.advancement.actor?.reset?.();
+      await this.advancement.preparePendingChildPools?.({
+        manager: this.manager,
+        extraUuids: target.checked ? [target.name] : []
+      });
+    }
+  }
+
+  /* -------------------------------------------- */
+  /*  Drag & Drop                                 */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onDrop(event) {
+    if ( this.counts.full ) return false;
+
+    let data;
+    try {
+      data = JSON.parse(event.dataTransfer.getData("text/plain"));
+    } catch(err) {
+      return false;
+    }
+
+    if ( data.type !== "Item" ) return false;
+    const item = await Item.implementation.fromDropData(data);
+
+    try {
+      this.advancement._validateItemType(item);
+    } catch(err) {
+      ui.notifications.error(err.message);
+      return null;
+    }
+
+    const sourceUuid = item.flags?.dnd5e?.sourceId ?? item.uuid;
+    const poolEntry = this.advancement.getPoolForLevel(this.level, { manager: this.manager }).find(entry => {
+      return (entry.uuid === item.uuid) || (entry.uuid === sourceUuid);
+    });
+
+    if ( !poolEntry ) {
+      ui.notifications.error(_loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.Warning.Unavailable", {
+        name: item.name,
+        level: this.level
+      }));
+      return null;
+    }
+
+    const spellLevel = this.advancement.configuration.restriction.level;
+    if ( (this.advancement.configuration.type === "spell") && ["available", "availableNoCantrips"].includes(spellLevel) ) {
+      const maxSlot = this._maxSpellSlotLevel();
+      const minSlot = spellLevel === "availableNoCantrips" ? 1 : 0;
+      if ( (item.system.level < minSlot) || (item.system.level > maxSlot) ) {
+        ui.notifications.error("DND5E.ADVANCEMENT.ItemChoice.Warning.SpellLevelAvailable", {
+          format: { level: CONFIG.DND5E.spellLevels[maxSlot] }
+        });
+        return null;
+      }
+    }
+
+    await this.advancement.apply(this.level, { selected: [poolEntry.uuid] });
+    this.pool = null;
+    this.manager?.clone?.reset?.();
+    this.advancement.actor?.reset?.();
+    await this.advancement.preparePendingChildPools?.({
+      manager: this.manager,
+      extraUuids: [poolEntry.uuid]
+    });
+    this.render();
+  }
+}

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4424,6 +4424,10 @@ DND5E.advancementTypes = {
     documentClass: advancement.ItemChoiceAdvancement,
     validItemTypes: new Set(_ALL_ITEM_TYPES)
   },
+  LevelGatedItemChoice: {
+    documentClass: advancement.LevelGatedItemChoiceAdvancement,
+    validItemTypes: new Set(_ALL_ITEM_TYPES)
+  },
   ItemGrant: {
     documentClass: advancement.ItemGrantAdvancement,
     validItemTypes: new Set(_ALL_ITEM_TYPES)

--- a/module/data/advancement/_module.mjs
+++ b/module/data/advancement/_module.mjs
@@ -3,6 +3,7 @@ export {default as SpellConfigurationData} from "./spell-config.mjs";
 
 export * from "./ability-score-improvement-data.mjs";
 export * from "./item-choice-data.mjs";
+export * from "./level-gated-item-choice-data.mjs";
 export {default as ItemGrantConfigurationData} from "./item-grant-data.mjs";
 export * from "./modify-item-data.mjs";
 export * as scaleValue from "./scale-value-data.mjs";

--- a/module/data/advancement/level-gated-item-choice-data.mjs
+++ b/module/data/advancement/level-gated-item-choice-data.mjs
@@ -1,0 +1,116 @@
+import { ItemChoiceConfigurationData } from "./item-choice-data.mjs";
+import {
+  cleanPoolId,
+  cleanSectionTitle,
+  MAX_LEVEL_GATED_CHOICE_LEVEL,
+  normalizePoolRole
+} from "../../documents/advancement/level-gated-item-choice-helpers.mjs";
+
+const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * Configuration data for Level-Gated Item Choice advancement.
+ * @extends {ItemChoiceConfigurationData}
+ */
+export class LevelGatedItemChoiceConfigurationData extends ItemChoiceConfigurationData {
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = [
+    "DND5E.ADVANCEMENT.LevelGatedItemChoice",
+    ...ItemChoiceConfigurationData.LOCALIZATION_PREFIXES
+  ];
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static defineSchema() {
+    const schema = super.defineSchema();
+
+    schema.pool = new ArrayField(new SchemaField({
+      uuid: new StringField({ required: true, nullable: false, blank: false }),
+      minLevel: new NumberField({
+        required: false,
+        integer: true,
+        min: 0,
+        nullable: true,
+        initial: null,
+        label: "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.pool.FIELDS.minLevel.label"
+      })
+    }));
+
+    schema.poolRole = new StringField({
+      required: false,
+      nullable: false,
+      blank: false,
+      initial: "standalone",
+      label: "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.poolRole.label"
+    });
+
+    schema.poolId = new StringField({
+      required: false,
+      nullable: false,
+      blank: true,
+      initial: "",
+      label: "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.poolId.label"
+    });
+
+    schema.parentPoolId = new StringField({
+      required: false,
+      nullable: false,
+      blank: true,
+      initial: "",
+      label: "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.parentPoolId.label"
+    });
+
+    schema.sectionTitles = new SchemaField(Object.fromEntries(
+      Array.from({ length: MAX_LEVEL_GATED_CHOICE_LEVEL }, (_, index) => {
+        const level = index + 1;
+        return [level, new StringField({
+          required: false,
+          nullable: false,
+          blank: true,
+          initial: "",
+          label: "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.sectionTitles.label"
+        })];
+      })
+    ), {
+      required: false,
+      nullable: false,
+      label: "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.sectionTitles.label"
+    });
+
+    return schema;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static migrateData(source) {
+    super.migrateData(source);
+    if ( !source ) return source;
+
+    const pool = Array.isArray(source.pool) ? source.pool : Object.values(source.pool ?? {});
+    if ( pool.length ) {
+      let lastMin = 1;
+      source.pool = pool.map(entry => {
+        if ( foundry.utils.getType(entry) === "string" ) return { uuid: entry, minLevel: lastMin };
+
+        const rawMin = entry.minLevel;
+        const min = [undefined, null, ""].includes(rawMin) ? lastMin : Number(rawMin);
+        const minLevel = Number.isFinite(min) ? min : lastMin;
+        lastMin = minLevel;
+        return { uuid: entry.uuid, minLevel };
+      });
+    }
+
+    source.poolRole = normalizePoolRole(source.poolRole);
+    source.poolId = cleanPoolId(source.poolId);
+    source.parentPoolId = cleanPoolId(source.parentPoolId);
+    source.sectionTitles = Object.fromEntries(Array.from({ length: MAX_LEVEL_GATED_CHOICE_LEVEL }, (_, index) => {
+      const level = index + 1;
+      return [level, cleanSectionTitle(source.sectionTitles?.[level])];
+    }));
+
+    return source;
+  }
+}

--- a/module/documents/advancement/_module.mjs
+++ b/module/documents/advancement/_module.mjs
@@ -3,6 +3,7 @@ export {default as Advancement} from "./advancement.mjs";
 export {default as AbilityScoreImprovementAdvancement} from "./ability-score-improvement.mjs";
 export {default as HitPointsAdvancement} from "./hit-points.mjs";
 export {default as ItemChoiceAdvancement} from "./item-choice.mjs";
+export {default as LevelGatedItemChoiceAdvancement} from "./level-gated-item-choice.mjs";
 export {default as ItemGrantAdvancement} from "./item-grant.mjs";
 export {default as ModifyItemAdvancement} from "./modify-item.mjs";
 export {default as ScaleValueAdvancement} from "./scale-value.mjs";

--- a/module/documents/advancement/level-gated-item-choice-helpers.mjs
+++ b/module/documents/advancement/level-gated-item-choice-helpers.mjs
@@ -1,0 +1,371 @@
+/* eslint-disable jsdoc/require-jsdoc */
+
+export const LEVEL_GATED_ITEM_CHOICE_TYPE = "LevelGatedItemChoice";
+export const MAX_LEVEL_GATED_CHOICE_LEVEL = 20;
+
+/* -------------------------------------------- */
+
+export function clampLevel(value, maxLevel=getMaxSectionLevel()) {
+  const numeric = Number(value);
+  if ( !Number.isFinite(numeric) ) return 1;
+  return Math.min(Math.max(Math.trunc(numeric), 1), maxLevel);
+}
+
+/* -------------------------------------------- */
+
+export function getMaxSectionLevel() {
+  return Math.min(Number(CONFIG.DND5E?.maxLevel ?? MAX_LEVEL_GATED_CHOICE_LEVEL), MAX_LEVEL_GATED_CHOICE_LEVEL)
+    || MAX_LEVEL_GATED_CHOICE_LEVEL;
+}
+
+/* -------------------------------------------- */
+
+export function sortItemsByName(items) {
+  return items.sort((a, b) => {
+    const nameA = String(a.item?.name ?? a.name ?? a.label ?? a.uuid ?? "");
+    const nameB = String(b.item?.name ?? b.name ?? b.label ?? b.uuid ?? "");
+    return nameB.localeCompare(nameA, game.i18n.lang, { sensitivity: "base", numeric: true });
+  });
+}
+
+/* -------------------------------------------- */
+
+export function normalizePoolRole(value) {
+  return ["standalone", "parent", "child"].includes(value) ? value : "standalone";
+}
+
+/* -------------------------------------------- */
+
+export function cleanPoolId(value) {
+  return String(value ?? "").trim();
+}
+
+/* -------------------------------------------- */
+
+export function cleanSectionTitle(value) {
+  return String(value ?? "").trim();
+}
+
+/* -------------------------------------------- */
+
+export function getSectionTitles(configuration) {
+  const titles = configuration?.sectionTitles ?? {};
+  return titles?.toObject?.() ?? titles;
+}
+
+/* -------------------------------------------- */
+
+export function getSectionTitle(configuration, level, { flow=false, fallback=true }={}) {
+  const title = cleanSectionTitle(getSectionTitles(configuration)?.[level]);
+  if ( title ) return title;
+  if ( !fallback ) return "";
+  return flow
+    ? _loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.AvailableFromLevel", { level })
+    : _loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.LevelLabel", { level });
+}
+
+/* -------------------------------------------- */
+
+export function normalizePoolEntry(entry, maxLevel=getMaxSectionLevel()) {
+  if ( typeof entry === "string" ) entry = { uuid: entry };
+  if ( !entry?.uuid ) return null;
+
+  const min = [undefined, null, ""].includes(entry.minLevel) ? 1 : Number(entry.minLevel);
+  return {
+    uuid: entry.uuid,
+    minLevel: clampLevel(Number.isFinite(min) ? min : 1, maxLevel)
+  };
+}
+
+/* -------------------------------------------- */
+
+export function mergePools(pools, maxLevel=getMaxSectionLevel()) {
+  const merged = new Map();
+  for ( const pool of pools ) {
+    for ( const rawEntry of pool ?? [] ) {
+      const entry = normalizePoolEntry(rawEntry, maxLevel);
+      if ( !entry ) continue;
+
+      const existing = merged.get(entry.uuid);
+      if ( existing ) existing.minLevel = Math.min(existing.minLevel, entry.minLevel);
+      else merged.set(entry.uuid, entry);
+    }
+  }
+  return Array.from(merged.values()).sort((a, b) => (a.minLevel - b.minLevel) || a.uuid.localeCompare(b.uuid));
+}
+
+/* -------------------------------------------- */
+
+export function getSelectedSourceUuids(advancement) {
+  const value = advancement?.value ?? advancement?.data?.value ?? advancement?.toObject?.()?.value ?? {};
+  const uuids = new Set();
+
+  const collect = source => {
+    if ( !source ) return;
+    if ( typeof source === "string" ) {
+      uuids.add(source);
+      return;
+    }
+    if ( Array.isArray(source) ) {
+      for ( const entry of source ) collect(entry);
+      return;
+    }
+    if ( typeof source === "object" ) {
+      for ( const entry of Object.values(source) ) collect(entry);
+    }
+  };
+
+  collect(value.added ?? {});
+  return Array.from(uuids);
+}
+
+/* -------------------------------------------- */
+
+export function getAdvancementId(advancement) {
+  return advancement?.id ?? advancement?._id ?? advancement?.data?._id ?? advancement?.toObject?.()?._id ?? null;
+}
+
+/* -------------------------------------------- */
+
+export function getAdvancementType(advancement) {
+  return advancement?.type ?? advancement?.constructor?.typeName ?? advancement?.data?.type
+    ?? advancement?.toObject?.()?.type ?? null;
+}
+
+/* -------------------------------------------- */
+
+export function getAdvancementConfiguration(advancement) {
+  return advancement?.configuration ?? advancement?.data?.configuration
+    ?? advancement?.toObject?.()?.configuration ?? {};
+}
+
+/* -------------------------------------------- */
+
+export function getAdvancementPool(advancement) {
+  const pool = getAdvancementConfiguration(advancement).pool ?? [];
+  return Array.isArray(pool) ? pool : Object.values(pool);
+}
+
+/* -------------------------------------------- */
+
+export function getItemAdvancements(item) {
+  if ( !item ) return [];
+
+  const parsed = item.advancement;
+  if ( parsed?.contents ) return Array.from(parsed.contents);
+  if ( parsed?.byId ) {
+    if ( typeof parsed.byId.values === "function" ) return Array.from(parsed.byId.values());
+    return Object.values(parsed.byId);
+  }
+  if ( typeof parsed?.values === "function" ) return Array.from(parsed.values());
+  if ( Array.isArray(parsed) ) return parsed;
+
+  const advancements = item.system?.advancement;
+  if ( !advancements ) return [];
+  if ( Array.isArray(advancements) ) return advancements;
+  if ( typeof advancements.values === "function" ) return Array.from(advancements.values());
+  return Object.values(advancements);
+}
+
+/* -------------------------------------------- */
+
+export function getSelectedSourceUuidsFromActor(actor) {
+  const uuids = new Set();
+  for ( const item of actor?.items ?? [] ) {
+    for ( const advancement of getItemAdvancements(item) ) {
+      for ( const uuid of getSelectedSourceUuids(advancement) ) uuids.add(uuid);
+    }
+  }
+  return Array.from(uuids);
+}
+
+/* -------------------------------------------- */
+
+export function getSelectedSourceUuidsFromManager(manager) {
+  const uuids = new Set();
+  for ( const step of manager?.steps ?? [] ) {
+    const advancement = step?.flow?.advancement;
+    for ( const uuid of getSelectedSourceUuids(advancement) ) uuids.add(uuid);
+  }
+  return Array.from(uuids);
+}
+
+/* -------------------------------------------- */
+
+export function getCandidateActors(advancement, manager) {
+  const actors = [];
+  if ( advancement?.actor ) actors.push(advancement.actor);
+  if ( manager?.clone && !actors.includes(manager.clone) ) actors.push(manager.clone);
+  return actors;
+}
+
+/* -------------------------------------------- */
+
+export function getChildAdvancementsFromActor(actor, parentPoolId, currentAdvancement) {
+  if ( !actor || !parentPoolId ) return [];
+
+  const children = [];
+  const currentId = getAdvancementId(currentAdvancement);
+
+  for ( const item of actor.items ?? [] ) {
+    for ( const advancement of getItemAdvancements(item) ) {
+      if ( getAdvancementType(advancement) !== LEVEL_GATED_ITEM_CHOICE_TYPE ) continue;
+      if ( getAdvancementId(advancement) === currentId ) continue;
+
+      const configuration = getAdvancementConfiguration(advancement);
+      if ( normalizePoolRole(configuration.poolRole) !== "child" ) continue;
+      if ( cleanPoolId(configuration.parentPoolId) !== parentPoolId ) continue;
+
+      children.push(advancement);
+    }
+  }
+
+  return children;
+}
+
+/* -------------------------------------------- */
+
+export function looksLikeUuid(value) {
+  if ( typeof value !== "string" ) return false;
+  return /^(Actor|Item|Compendium|Scene|JournalEntry|Macro|RollTable)\./.test(value);
+}
+
+/* -------------------------------------------- */
+
+export function collectUuidsDeep(value, { maxDepth=6, seen=new WeakSet() }={}) {
+  const uuids = new Set();
+
+  const collect = (entry, depth) => {
+    if ( depth > maxDepth || entry == null ) return;
+
+    if ( typeof entry === "string" ) {
+      if ( looksLikeUuid(entry) ) uuids.add(entry);
+      return;
+    }
+
+    if ( typeof entry !== "object" ) return;
+    if ( seen.has(entry) ) return;
+    seen.add(entry);
+
+    if ( looksLikeUuid(entry.uuid) ) uuids.add(entry.uuid);
+
+    if ( entry instanceof Map ) {
+      for ( const [key, value] of entry.entries() ) {
+        collect(key, depth + 1);
+        collect(value, depth + 1);
+      }
+      return;
+    }
+
+    if ( entry instanceof Set ) {
+      for ( const value of entry.values() ) collect(value, depth + 1);
+      return;
+    }
+
+    if ( Array.isArray(entry) ) {
+      for ( const value of entry ) collect(value, depth + 1);
+      return;
+    }
+
+    for ( const [key, value] of Object.entries(entry) ) {
+      if ( key.startsWith("_") && key !== "_id" ) continue;
+      collect(value, depth + 1);
+    }
+  };
+
+  collect(value, 0);
+  return Array.from(uuids);
+}
+
+/* -------------------------------------------- */
+
+export function collectGrantEntryUuids(entries) {
+  const uuids = new Set();
+  const collect = entry => {
+    if ( !entry ) return;
+    if ( typeof entry === "string" ) {
+      if ( looksLikeUuid(entry) ) uuids.add(entry);
+      return;
+    }
+    if ( Array.isArray(entry) ) {
+      for ( const value of entry ) collect(value);
+      return;
+    }
+    if ( typeof entry !== "object" ) return;
+    if ( looksLikeUuid(entry.uuid) ) uuids.add(entry.uuid);
+  };
+
+  collect(entries);
+  return Array.from(uuids);
+}
+
+/* -------------------------------------------- */
+
+export function getFollowUpItemUuidsFromAdvancement(advancement) {
+  const configuration = getAdvancementConfiguration(advancement);
+  const type = getAdvancementType(advancement);
+  const uuids = new Set();
+
+  for ( const uuid of getSelectedSourceUuids(advancement) ) uuids.add(uuid);
+  for ( const uuid of collectGrantEntryUuids(configuration.items) ) uuids.add(uuid);
+
+  if ( type !== LEVEL_GATED_ITEM_CHOICE_TYPE ) {
+    for ( const uuid of collectGrantEntryUuids(configuration.pool) ) uuids.add(uuid);
+  }
+
+  return Array.from(uuids);
+}
+
+/* -------------------------------------------- */
+
+export async function collectMatchingChildPoolsFromItem(item, parentPoolId, {
+  currentAdvancement=null,
+  depth=0,
+  maxDepth=10,
+  seenItems=new Set(),
+  seenPoolKeys=new Set()
+}={}) {
+  const pools = [];
+  if ( !item || !parentPoolId || depth > maxDepth ) return pools;
+
+  const itemKey = item.uuid ?? item.id ?? item.name;
+  if ( !itemKey || seenItems.has(itemKey) ) return pools;
+  seenItems.add(itemKey);
+
+  const currentId = getAdvancementId(currentAdvancement);
+  const nextUuids = new Set();
+
+  for ( const advancement of getItemAdvancements(item) ) {
+    const configuration = getAdvancementConfiguration(advancement);
+    const type = getAdvancementType(advancement);
+    const role = normalizePoolRole(configuration.poolRole);
+    const childParentPoolId = cleanPoolId(configuration.parentPoolId);
+    const advancementId = getAdvancementId(advancement);
+
+    if ( (type === LEVEL_GATED_ITEM_CHOICE_TYPE) && (role === "child") && (childParentPoolId === parentPoolId) ) {
+      if ( advancementId !== currentId ) {
+        const key = `${item.uuid ?? item.id ?? "item"}.${advancementId ?? foundry.utils.randomID()}`;
+        if ( !seenPoolKeys.has(key) ) {
+          seenPoolKeys.add(key);
+          pools.push(getAdvancementPool(advancement));
+        }
+      }
+    }
+
+    for ( const uuid of getFollowUpItemUuidsFromAdvancement(advancement) ) nextUuids.add(uuid);
+  }
+
+  for ( const uuid of nextUuids ) {
+    const nextItem = await fromUuid(uuid);
+    const nestedPools = await collectMatchingChildPoolsFromItem(nextItem, parentPoolId, {
+      currentAdvancement,
+      depth: depth + 1,
+      maxDepth,
+      seenItems,
+      seenPoolKeys
+    });
+    pools.push(...nestedPools);
+  }
+
+  return pools;
+}

--- a/module/documents/advancement/level-gated-item-choice.mjs
+++ b/module/documents/advancement/level-gated-item-choice.mjs
@@ -1,0 +1,222 @@
+import LevelGatedItemChoiceConfig from "../../applications/advancement/level-gated-item-choice-config.mjs";
+import LevelGatedItemChoiceFlow from "../../applications/advancement/level-gated-item-choice-flow.mjs";
+import { ItemChoiceValueData } from "../../data/advancement/item-choice-data.mjs";
+import { LevelGatedItemChoiceConfigurationData } from "../../data/advancement/level-gated-item-choice-data.mjs";
+import ItemChoiceAdvancement from "./item-choice.mjs";
+import {
+  cleanPoolId,
+  collectMatchingChildPoolsFromItem,
+  collectUuidsDeep,
+  getAdvancementId,
+  getAdvancementPool,
+  getCandidateActors,
+  getChildAdvancementsFromActor,
+  getMaxSectionLevel,
+  getSectionTitle,
+  getSelectedSourceUuids,
+  getSelectedSourceUuidsFromActor,
+  getSelectedSourceUuidsFromManager,
+  LEVEL_GATED_ITEM_CHOICE_TYPE,
+  mergePools,
+  normalizePoolRole
+} from "./level-gated-item-choice-helpers.mjs";
+
+/**
+ * Advancement that presents item choices from a pool gated by minimum advancement level.
+ */
+export default class LevelGatedItemChoiceAdvancement extends ItemChoiceAdvancement {
+
+  /** @inheritDoc */
+  static get typeName() {
+    return LEVEL_GATED_ITEM_CHOICE_TYPE;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      dataModels: {
+        configuration: LevelGatedItemChoiceConfigurationData,
+        value: ItemChoiceValueData
+      },
+      order: 51,
+      title: _loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.Title"),
+      hint: _loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.Hint"),
+      apps: {
+        config: LevelGatedItemChoiceConfig,
+        flow: LevelGatedItemChoiceFlow
+      }
+    });
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  get poolRole() {
+    return normalizePoolRole(this.configuration.poolRole);
+  }
+
+  get isPoolParent() {
+    return this.poolRole === "parent";
+  }
+
+  get isPoolChild() {
+    return this.poolRole === "child";
+  }
+
+  get poolId() {
+    return cleanPoolId(this.configuration.poolId);
+  }
+
+  get parentPoolId() {
+    return cleanPoolId(this.configuration.parentPoolId);
+  }
+
+  /** @inheritDoc */
+  get levels() {
+    if ( this.isPoolChild ) return [];
+    return super.levels;
+  }
+
+  /* -------------------------------------------- */
+  /*  Display Methods                             */
+  /* -------------------------------------------- */
+
+  getRegionTitle(level, { flow=false }={}) {
+    return getSectionTitle(this.configuration, level, { flow, fallback: true });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  configuredForLevel(level) {
+    if ( this.isPoolChild ) return true;
+    return super.configuredForLevel(level);
+  }
+
+  /* -------------------------------------------- */
+  /*  Pool Management                             */
+  /* -------------------------------------------- */
+
+  async preparePendingChildPools({ manager=null, extraUuids=[] }={}) {
+    this._levelGatedPendingChildPools = [];
+    if ( !this.isPoolParent || !this.poolId ) return [];
+
+    manager?.clone?.reset?.();
+    this.actor?.reset?.();
+
+    const pools = [];
+    const seenPoolKeys = new Set();
+    const pendingUuids = new Set([
+      ...getSelectedSourceUuids(this),
+      ...getSelectedSourceUuidsFromManager(manager),
+      ...collectUuidsDeep(manager, { maxDepth: 6 }),
+      ...extraUuids
+    ]);
+
+    for ( const actor of getCandidateActors(this, manager) ) {
+      for ( const uuid of getSelectedSourceUuidsFromActor(actor) ) pendingUuids.add(uuid);
+
+      for ( const child of getChildAdvancementsFromActor(actor, this.poolId, this) ) {
+        const key = `${child.item?.uuid ?? child.item?.id ?? "item"}.${getAdvancementId(child)
+          ?? foundry.utils.randomID()}`;
+        if ( seenPoolKeys.has(key) ) continue;
+        seenPoolKeys.add(key);
+        pools.push(getAdvancementPool(child));
+      }
+
+      for ( const item of actor.items ?? [] ) {
+        const nestedPools = await collectMatchingChildPoolsFromItem(item, this.poolId, {
+          currentAdvancement: this,
+          seenPoolKeys
+        });
+        pools.push(...nestedPools);
+      }
+    }
+
+    for ( const uuid of pendingUuids ) {
+      const item = await fromUuid(uuid);
+      const nestedPools = await collectMatchingChildPoolsFromItem(item, this.poolId, {
+        currentAdvancement: this,
+        seenPoolKeys
+      });
+      pools.push(...nestedPools);
+    }
+
+    this._levelGatedPendingChildPools = pools;
+    return pools;
+  }
+
+  /* -------------------------------------------- */
+
+  getLinkedChildAdvancements({ manager=null }={}) {
+    if ( !this.isPoolParent || !this.poolId ) return [];
+
+    const children = [];
+    const seen = new Set();
+    for ( const actor of getCandidateActors(this, manager) ) {
+      for ( const child of getChildAdvancementsFromActor(actor, this.poolId, this) ) {
+        const key = `${child.item?.uuid ?? child.item?.id ?? "item"}.${getAdvancementId(child)
+          ?? foundry.utils.randomID()}`;
+        if ( seen.has(key) ) continue;
+        seen.add(key);
+        children.push(child);
+      }
+    }
+    return children;
+  }
+
+  /* -------------------------------------------- */
+
+  getMergedPool({ manager=null }={}) {
+    const maxLevel = getMaxSectionLevel();
+    const pools = [this.configuration.pool ?? []];
+
+    if ( this.isPoolParent ) {
+      for ( const child of this.getLinkedChildAdvancements({ manager }) ) pools.push(getAdvancementPool(child));
+      for ( const pendingPool of this._levelGatedPendingChildPools ?? [] ) pools.push(pendingPool);
+    }
+
+    return mergePools(pools, maxLevel);
+  }
+
+  /* -------------------------------------------- */
+
+  getPoolForLevel(level, { manager=null }={}) {
+    if ( this.isPoolChild ) return [];
+    const numericLevel = Number(level);
+    return this.getMergedPool({ manager }).filter(entry => numericLevel >= Number(entry.minLevel ?? 0));
+  }
+
+  /* -------------------------------------------- */
+
+  isUuidAvailableAtLevel(uuid, level) {
+    return this.getPoolForLevel(level).some(entry => entry.uuid === uuid);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async apply(level, data={}, options={}) {
+    if ( this.isPoolChild ) return;
+
+    if ( data.selected?.length ) await this.preparePendingChildPools({ extraUuids: data.selected });
+    if ( data.selected?.length ) {
+      const invalid = data.selected.filter(uuid => !this.isUuidAvailableAtLevel(uuid, level));
+      if ( invalid.length ) {
+        throw new this.constructor.ERROR(_loc("DND5E.ADVANCEMENT.LevelGatedItemChoice.Warning.InvalidSelection", {
+          level
+        }));
+      }
+    }
+
+    const result = await super.apply(level, data, options);
+    if ( data.selected?.length ) {
+      this.actor?.reset?.();
+      await this.preparePendingChildPools({ extraUuids: data.selected });
+    }
+    return result;
+  }
+}

--- a/templates/advancement/level-gated-item-choice-config-items.hbs
+++ b/templates/advancement/level-gated-item-choice-config-items.hbs
@@ -1,0 +1,85 @@
+<fieldset class="card items level-gated-pool">
+    <legend>{{ localize "DND5E.ADVANCEMENT.LevelGatedItemChoice.PoolHeading" }}</legend>
+    <p class="hint">{{ localize "DND5E.ADVANCEMENT.LevelGatedItemChoice.PoolHint" }}</p>
+
+    <div class="level-gated-pool-settings">
+        <div class="form-group">
+            <label>{{ localize "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.poolRole.label" }}</label>
+            <div class="form-fields">
+                <select name="configuration.poolRole" data-level-gated-pool-role>
+                    {{#each poolRoleOptions}}
+                    <option value="{{ value }}" {{#if selected}}selected{{/if}}>{{ label }}</option>
+                    {{/each}}
+                </select>
+            </div>
+            <p class="hint">{{ localize "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.poolRole.hint" }}</p>
+        </div>
+
+        <div class="form-group {{#unless isPoolParent}}level-gated-hidden{{/unless}}"
+             data-level-gated-role-field="parent">
+            <label>{{ localize "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.poolId.label" }}</label>
+            <div class="form-fields">
+                <input type="text" name="configuration.poolId" value="{{ poolId }}"
+                       placeholder="eldritch-invocations">
+            </div>
+            <p class="hint">{{ localize "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.poolId.hint" }}</p>
+        </div>
+
+        <div class="form-group {{#unless isPoolChild}}level-gated-hidden{{/unless}}"
+             data-level-gated-role-field="child">
+            <label>{{ localize "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.parentPoolId.label" }}</label>
+            <div class="form-fields">
+                <input type="text" name="configuration.parentPoolId" value="{{ parentPoolId }}"
+                       placeholder="eldritch-invocations">
+            </div>
+            <p class="hint">{{ localize "DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.parentPoolId.hint" }}</p>
+        </div>
+    </div>
+
+    <div class="level-gated-grid">
+        {{#each levelSections}}
+        <details class="level-gated-section" data-level-gated-level="{{ level }}" {{#if open}}open{{/if}}>
+            <summary class="level-gated-header">
+                <span class="level-gated-title">
+                    <input type="text" class="level-gated-section-title-input"
+                           name="configuration.sectionTitles.{{ level }}" value="{{ titleValue }}"
+                           placeholder="{{ defaultLabel }}"
+                           aria-label="{{ localize 'DND5E.ADVANCEMENT.LevelGatedItemChoice.FIELDS.sectionTitles.label' }}"
+                           data-level-gated-section-title>
+                </span>
+                <span class="level-gated-header-right">
+                    <span class="level-gated-count">{{ items.length }}</span>
+                    <i class="fa-solid fa-chevron-down level-gated-toggle-icon" inert></i>
+                </span>
+            </summary>
+
+            <div class="level-gated-body">
+                <ol class="items-list unlist level-gated-items-list">
+                    {{#each items}}
+                    <li class="item flexrow draggable" draggable="true" data-index="{{ poolIndex }}"
+                        data-item-uuid="{{ data.uuid }}">
+                        <div class="item-name">
+                            {{{ dnd5e-linkForUuid data.uuid renderBroken=true }}}
+                            <input type="hidden" name="configuration.pool.{{ poolIndex }}.uuid" value="{{ data.uuid }}">
+                            <input type="hidden" name="configuration.pool.{{ poolIndex }}.minLevel" value="{{ minLevel }}">
+                        </div>
+                        <div class="item-controls flexrow">
+                            <a class="item-control item-action" data-action="deleteItem" data-tooltip
+                               aria-label="{{ localize 'DND5E.ItemDelete' }}">
+                                <i class="fas fa-trash" inert></i>
+                            </a>
+                        </div>
+                    </li>
+                    {{/each}}
+                </ol>
+
+                <p class="hint centered drop-area">{{ dropLabel }}</p>
+            </div>
+        </details>
+        {{/each}}
+    </div>
+
+    {{#if showContainerWarning}}
+    <p class="hint centered warning">{{ localize "DND5E.ADVANCEMENT.ItemGrant.Warning.Container" }}</p>
+    {{/if}}
+</fieldset>

--- a/templates/advancement/level-gated-item-choice-flow.hbs
+++ b/templates/advancement/level-gated-item-choice-flow.hbs
@@ -1,0 +1,85 @@
+<div class="standard-form level-gated-choice-flow">
+    {{#if (or abilities replaceable)}}
+    <fieldset>
+        <legend>{{ localize "DND5E.ADVANCEMENT.ItemChoice.Options" }}</legend>
+
+        {{#if abilities}}
+        {{ formGroup abilities.field name="ability" value=abilities.value disabled=abilities.disabled
+                     options=abilities.options rootId=partId }}
+        {{/if}}
+
+        {{#if replaceable}}
+        <div class="form-group">
+            <label for="{{ partId }}-replace">{{ localize "DND5E.ADVANCEMENT.ItemChoice.Replacement.None" }}</label>
+            <div class="form-fields">
+                <input type="radio" name="replace" value="" id="{{ partId }}-replace" {{ checked noReplacement }}>
+            </div>
+        </div>
+        {{/if}}
+    </fieldset>
+    {{/if}}
+
+    {{#each previousSections}}
+    <div class="items-section card level-gated-flow-section">
+        <div class="items-header header">
+            <h4 class="item-name">{{ header }}</h4>
+            <span class="level-gated-count">{{ items.length }}</span>
+        </div>
+        <ul class="item-list unlist">
+            {{#each items}}
+            <li class="item flexrow {{~#if replaced}} replaced{{/if}}" data-uuid="{{ uuid }}">
+                <div class="item-name flexrow" data-action="viewItem">
+                    <img class="gold-icon" src="{{ img }}" alt="{{ name }}">
+                    <div class="name-stacked">
+                        <div class="title">{{ name }}</div>
+                    </div>
+                </div>
+                {{#if (and @root.replaceable (not previouslyReplaced))}}
+                <div class="item-controls flexrow">
+                    <input type="radio" name="replace" value="{{ id }}" {{ checked replaced }}>
+                </div>
+                {{/if}}
+            </li>
+            {{/each}}
+        </ul>
+    </div>
+    {{/each}}
+
+    {{#if currentChoiceHeader}}
+    <h4 class="level-gated-current-heading">{{ currentChoiceHeader }}</h4>
+    {{/if}}
+
+    <div class="level-gated-choice-grid">
+        {{#each choiceLevelSections}}
+        <div class="items-section card level-gated-flow-section">
+            <div class="items-header header">
+                <h4 class="item-name">{{ header }}</h4>
+                <span class="level-gated-count">{{ items.length }}</span>
+            </div>
+            <ul class="item-list unlist current-level">
+                {{#each items}}
+                <li class="item flexrow {{~#if replaced}} replaced{{/if}}" data-uuid="{{ uuid }}">
+                    <div class="item-name flexrow" data-action="viewItem">
+                        <img class="gold-icon" src="{{ img }}" alt="{{ name }}">
+                        <div class="name-stacked">
+                            <div class="title">{{ name }}</div>
+                        </div>
+                    </div>
+                    <div class="item-controls flexrow">
+                        {{#if dropped}}
+                        <button type="button" class="unbutton control-button item-control" data-action="deleteItem"
+                                data-tooltip aria-label="{{ localize 'DND5E.ItemDelete' }}">
+                            <i class="fa-solid fa-trash" inert></i>
+                        </button>
+                        <input type="hidden" name="{{ uuid }}" value="true" data-dtype="Boolean">
+                        {{else}}
+                        <dnd5e-checkbox name="{{ uuid }}" {{ checked checked }} {{ disabled disabled }}></dnd5e-checkbox>
+                        {{/if}}
+                    </div>
+                </li>
+                {{/each}}
+            </ul>
+        </div>
+        {{/each}}
+    </div>
+</div>


### PR DESCRIPTION
Added LevelGatedItemChoice as a first-class dnd5e advancement type, ported from my standalone module into the system
source structure.

This adds:
- A new advancement document class extending ItemChoiceAdvancement
- A dedicated configuration data model with per-pool-entry minLevel data
- Config and flow applications using native dnd5e advancement V2 patterns
- Templates for level-section pool editing and level-grouped choice flow
- Parent/child pool linking support via poolRole, poolId, and parentPoolId
- Pool merging and pending child-pool discovery during advancement flows
- Level-gated availability checks when applying selected items
- Localization strings for the new advancement type and UI
- LESS styles for the config sheet and advancement flow
- Registration in CONFIG.DND5E.advancementTypes
- Barrel exports for documents, applications, and data models

Closes #7145 

Creation UI
<img width="983" height="936" alt="LevelGateAdvancementCreation" src="https://github.com/user-attachments/assets/902564a6-8b5e-4c71-8572-2b76ade95fd0" />

Selection UI
<img width="464" height="937" alt="LevelGateItemSelection" src="https://github.com/user-attachments/assets/b466276d-08f6-4d8e-a8cf-68051ec7e646" />
